### PR TITLE
Rename ngraph with ov in common_test_utils

### DIFF
--- a/src/common/low_precision_transformations/tests/add_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/add_transformation.cpp
@@ -99,7 +99,7 @@ public:
                                                   testValues.postops_configuration);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::AddTransformation, ngraph::opset1::Add>(testValues.params);
+        transform.add<ngraph::pass::low_precision::AddTransformation, ov::op::v1::Add>(testValues.params);
         transform.transform(actualFunction);
 
         auto inputShape1Ref = inputShapes.first;

--- a/src/common/low_precision_transformations/tests/align_concat_quantization_parameters_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/align_concat_quantization_parameters_transformation.cpp
@@ -84,9 +84,8 @@ public:
         transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
         transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(
             testValues.params);
-        transform
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
-                testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
+            testValues.params);
         transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/align_concat_quantization_parameters_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/align_concat_quantization_parameters_transformation.cpp
@@ -72,22 +72,22 @@ public:
             testValues.actual.dequantization);
 
         auto supportedPrecisions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>(
-            {ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Convolution>(
+            {ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Convolution>(
                 {{{0}, {ngraph::element::u8}}, {{1}, {ngraph::element::i8}}})});
 
         auto perTensorQuantization = std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-            ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::Convolution>({0}),
+            ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::Convolution>({0}),
         });
 
         SimpleLowPrecisionTransformer transform(supportedPrecisions, perTensorQuantization);
-        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ngraph::opset1::AvgPool>(testValues.params);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(
+        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ov::op::v1::AvgPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(
             testValues.params);
         transform
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(
+            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
                 testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::AlignConcatQuantizationParametersFunction::getReference(

--- a/src/common/low_precision_transformations/tests/assign_and_read_value_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/assign_and_read_value_transformation.cpp
@@ -74,7 +74,7 @@ public:
             testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transformer({}, {}, { ngraph::element::f32, defaultPrecisions });
-        transformer.add<ngraph::pass::low_precision::AssignAndReadValueTransformation, ngraph::opset6::Assign>(actualFunction, params);
+        transformer.add<ngraph::pass::low_precision::AssignAndReadValueTransformation, ov::op::v6::Assign>(actualFunction, params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::AssignAndReadValueFunction::getReference(

--- a/src/common/low_precision_transformations/tests/avg_pool_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/avg_pool_transformation.cpp
@@ -67,8 +67,8 @@ public:
                                                                                  testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ngraph::opset1::AvgPool>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ov::op::v1::AvgPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction =

--- a/src/common/low_precision_transformations/tests/avg_pool_with_child_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/avg_pool_with_child_transformation.cpp
@@ -63,8 +63,8 @@ public:
                                                                                  testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ngraph::opset1::AvgPool>(testValues.params);
-        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(
+        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ov::op::v1::AvgPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(
             testValues.params);
         transform.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/clamp_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/clamp_transformation.cpp
@@ -60,7 +60,7 @@ public:
                                                                         testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::ClampTransformation, ngraph::opset1::Clamp>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::ClampTransformation, ov::op::v0::Clamp>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = testValues.nonDequantizationMultiply

--- a/src/common/low_precision_transformations/tests/compose_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/compose_fake_quantize_transformation.cpp
@@ -58,7 +58,7 @@ public:
         const auto input = actualFunction->get_parameters()[0];
         const auto fakeQuantizes = input->output(0).get_target_inputs();
         const auto it = fakeQuantizes.begin();
-        const auto fakeQuantize = ngraph::as_type_ptr<ngraph::opset1::FakeQuantize>(it->get_node()->shared_from_this());
+        const auto fakeQuantize = ngraph::as_type_ptr<ov::op::v0::FakeQuantize>(it->get_node()->shared_from_this());
         low_precision::NetworkHelper::composeFakeQuantize(fakeQuantize);
 
         referenceFunction = ngraph::builder::subgraph::ComposeFakeQuantizeFunction::get(

--- a/src/common/low_precision_transformations/tests/concat_selection_with_intermediate_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_selection_with_intermediate_transformation.cpp
@@ -86,15 +86,15 @@ public:
             testValues.actual.fakeQuantize2);
 
         auto supportedPrecisions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-            ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Convolution>({
+            ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Convolution>({
                 {{0}, {ngraph::element::u8}}
             })
         });
 
         SimpleLowPrecisionTransformer transform(supportedPrecisions);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceSelectionWithIntermediate(

--- a/src/common/low_precision_transformations/tests/concat_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_transformation.cpp
@@ -65,7 +65,7 @@ public:
             testValues.concatAxis);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ConcatFunction::get(

--- a/src/common/low_precision_transformations/tests/concat_with_different_precision_on_children.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_different_precision_on_children.cpp
@@ -94,13 +94,13 @@ public:
         auto quantizationRestrictions = testValues.multiChannels ?
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>() :
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::AvgPool>()
+                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::AvgPool>()
             });
 
         SimpleLowPrecisionTransformer transform({}, quantizationRestrictions);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithDifferentPrecisionOnChildren(

--- a/src/common/low_precision_transformations/tests/concat_with_fq_tranformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_fq_tranformation.cpp
@@ -131,14 +131,14 @@ public:
                                                                         testValues.axis,
                                                                         testValues.addNotPrecisionPreservedOperation);
         auto supportedPrecisionsOnActivation = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>(
-            {ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::AvgPool>(
+            {ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::AvgPool>(
                 {{{0}, testValues.params.precisionsOnActivations}})});
 
         auto quantizationRestrictions =
             testValues.multiChannels ? std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>()
                                      : std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>(
                                            {ngraph::pass::low_precision::QuantizationGranularityRestriction::create<
-                                               ngraph::opset1::AvgPool>()});
+                                               ov::op::v1::AvgPool>()});
 
         const auto params = TestTransformationParams::toParams(testValues.params);
         SimpleLowPrecisionTransformer transformer(supportedPrecisionsOnActivation, quantizationRestrictions);
@@ -213,13 +213,13 @@ TEST_P(ConcatWithFQTransformation, CompareFunctions) {
     ASSERT_TRUE(LayerTransformation::allNamesAreUnique(actualFunction)) << "Not all names are unique";
 
     ConcatTransformationTestValues testValues = std::get<2>(GetParam());
-    const auto actualFakeQuantizes = LayerTransformation::get<opset1::FakeQuantize>(actualFunction);
+    const auto actualFakeQuantizes = LayerTransformation::get<ov::op::v0::FakeQuantize>(actualFunction);
     if (testValues.axis == 1) {
         ASSERT_TRUE(checkIfOutputAttributesSharedValuesAreTheSame<PrecisionsAttribute>(actualFakeQuantizes))
             << "PrecisionsAttribute are not the same";
 
         if (testValues.checkIntervalsAlignmentAttributes) {
-            auto operations = LayerTransformation::get<opset1::Concat>(actualFunction);
+            auto operations = LayerTransformation::get<ov::op::v0::Concat>(actualFunction);
             operations.insert(operations.end(), actualFakeQuantizes.begin(), actualFakeQuantizes.end());
             ASSERT_TRUE(checkIfAttributesSharedValuesAreTheSame<IntervalsAlignmentAttribute>(operations))
                 << "IntervalsAlignmentAttribute are not the same";

--- a/src/common/low_precision_transformations/tests/concat_with_fq_tranformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_fq_tranformation.cpp
@@ -135,10 +135,10 @@ public:
                 {{{0}, testValues.params.precisionsOnActivations}})});
 
         auto quantizationRestrictions =
-            testValues.multiChannels ? std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>()
-                                     : std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>(
-                                           {ngraph::pass::low_precision::QuantizationGranularityRestriction::create<
-                                               ov::op::v1::AvgPool>()});
+            testValues.multiChannels
+                ? std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>()
+                : std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>(
+                      {ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::AvgPool>()});
 
         const auto params = TestTransformationParams::toParams(testValues.params);
         SimpleLowPrecisionTransformer transformer(supportedPrecisionsOnActivation, quantizationRestrictions);

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_precision_selection_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_precision_selection_transformation.cpp
@@ -90,20 +90,20 @@ public:
             testValues.actual.fakeQuantize2);
 
         auto supportedPrecisionsOnActivation = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-            ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::AvgPool>({{{0}, testValues.params.precisionsOnActivations}})
+            ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::AvgPool>({{{0}, testValues.params.precisionsOnActivations}})
         });
 
         auto quantizationRestrictions = testValues.multiChannels ?
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>() :
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::AvgPool>()
+                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::AvgPool>()
             });
 
         SimpleLowPrecisionTransformer transform(supportedPrecisionsOnActivation, quantizationRestrictions);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
-        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ngraph::opset1::AvgPool>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ov::op::v1::AvgPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithIntermediateAvgPool(

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_reshape_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_reshape_transformation.cpp
@@ -78,9 +78,9 @@ public:
             testValues.actual.fakeQuantize2);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::ReshapeTransformation, ngraph::opset1::Reshape>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ReshapeTransformation, ov::op::v1::Reshape>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithIntermediateReshape(

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_transformation.cpp
@@ -93,13 +93,13 @@ public:
         auto quantizationRestrictions = testValues.multiChannels ?
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>() :
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::Convolution>()
+                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::Convolution>()
             });
 
         SimpleLowPrecisionTransformer transform({}, quantizationRestrictions);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithIntermediate(

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_with_constant_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_with_constant_transformation.cpp
@@ -94,14 +94,14 @@ public:
         auto quantizationRestrictions = testValues.multiChannels ?
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>() :
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::AvgPool>()
+                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::AvgPool>()
             });
 
         SimpleLowPrecisionTransformer transform({}, quantizationRestrictions);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
-        transform.add<ngraph::pass::low_precision::InterpolateTransformation, ngraph::opset1::Interpolate>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::InterpolateTransformation, ov::op::v0::Interpolate>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithIntermediateWithConstant(

--- a/src/common/low_precision_transformations/tests/concat_with_neighbors_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_neighbors_transformation.cpp
@@ -103,7 +103,7 @@ public:
             testValues.additionalLayer);
 
         auto supportedPrecisionsOnActivation = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-            ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Convolution>({
+            ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Convolution>({
                 {{0}, testValues.params.precisionsOnActivations},
                 {{1}, testValues.params.precisionsOnWeights}
             })
@@ -112,13 +112,13 @@ public:
         auto quantizationRestrictions = testValues.multiChannels ?
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>() :
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::Convolution>()
+                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::Convolution>()
         });
 
         SimpleLowPrecisionTransformer transform(supportedPrecisionsOnActivation, quantizationRestrictions);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithNeighbors(

--- a/src/common/low_precision_transformations/tests/concat_with_neighbors_transformation_with_convolution.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_neighbors_transformation_with_convolution.cpp
@@ -120,8 +120,8 @@ public:
         SimpleLowPrecisionTransformer transform(supportedPrecisionsOnActivation, quantizationRestrictions);
         transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::opset1::Concat>(testValues.params);
         transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::opset1::Convolution>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::opset1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::PrecisionPropagationFunction::getReferenceWithNeighbors(
@@ -157,7 +157,7 @@ TEST_P(ConcatWithNeighborsWithConvolutionTransformation, CompareFunctions) {
     //auto res = compare_functions(actualFunction, referenceFunction, true, false, false);
     //ASSERT_TRUE(res.first) << res.second;
 
-    auto actualFakeQuantizes = LayerTransformation::get<ov::opset1::FakeQuantize>(actualFunction);
+    auto actualFakeQuantizes = LayerTransformation::get<ov::op::v0::FakeQuantize>(actualFunction);
     ASSERT_EQ(3ul, actualFakeQuantizes.size()) << "unexpected FakeQuantize operations count " << actualFakeQuantizes.size();
 
     ASSERT_TRUE(checkIfOutputAttributesSharedValuesAreTheSame<PrecisionsAttribute>(actualFakeQuantizes)) <<

--- a/src/common/low_precision_transformations/tests/concat_with_not_quantized_parent_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_not_quantized_parent_transformation.cpp
@@ -156,15 +156,15 @@ public:
             testValues.addNotPrecisionPreservedOperation);
 
         auto precisionsRestrictions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-            ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Convolution>({
+            ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Convolution>({
                 {{0}, {ngraph::element::u8}},
                 {{1}, {ngraph::element::i8}}
             }),
-            ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::AvgPool>({{{0}, testValues.params.precisionsOnActivations}})
+            ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::AvgPool>({{{0}, testValues.params.precisionsOnActivations}})
         });
 
         auto quantizationRestrictions = std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-            ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::Convolution>({0})
+            ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::Convolution>({0})
         });
 
         const auto params = TestTransformationParams(testValues.params.updatePrecisions);
@@ -250,7 +250,7 @@ TEST_P(ConcatWithNotQuantizedParentTransformation, CompareFunctions) {
     auto res = compare_functions(actualFunction, referenceFunction, true, true, false, true, false);
     ASSERT_TRUE(res.first) << res.second;
 
-    auto actualFakeQuantizes = LayerTransformation::get<opset1::FakeQuantize>(actualFunction);
+    auto actualFakeQuantizes = LayerTransformation::get<ov::op::v0::FakeQuantize>(actualFunction);
     for (auto it = actualFakeQuantizes.begin(); it != actualFakeQuantizes.end(); it++) {
         const auto actualFakeQuantize = *it;
         if (actualFakeQuantize->output(0).get_target_inputs().begin()->get_index() == 1ul) {
@@ -263,7 +263,7 @@ TEST_P(ConcatWithNotQuantizedParentTransformation, CompareFunctions) {
 
     ConcatWithNotQuantizedParentTransformationTestValues testValues = std::get<2>(GetParam());
     if (testValues.checkIntervalsAlignmentAttributes) {
-        auto operations = LayerTransformation::get<opset1::Concat>(actualFunction);
+        auto operations = LayerTransformation::get<ov::op::v0::Concat>(actualFunction);
         operations.insert(operations.end(), actualFakeQuantizes.begin(), actualFakeQuantizes.end());
         ASSERT_TRUE(checkIfAttributesSharedValuesAreTheSame<IntervalsAlignmentAttribute>(operations)) <<
             "IntervalsAlignmentAttribute are not the same";

--- a/src/common/low_precision_transformations/tests/concat_with_reshape_at_the_end_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_reshape_at_the_end_transformation.cpp
@@ -85,10 +85,10 @@ public:
             testValues.actual.fakeQuantize3);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
-        transform.add<ngraph::pass::low_precision::ReshapeTransformation, ngraph::opset1::Reshape>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ReshapeTransformation, ov::op::v1::Reshape>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithReshapeAtTheEndTransformation(

--- a/src/common/low_precision_transformations/tests/concat_with_split_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_split_transformation.cpp
@@ -100,7 +100,7 @@ public:
             addConvolution);
 
         auto supportedPrecisions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-               ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Convolution>({
+               ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Convolution>({
                    {{0}, testValues.params.precisionsOnActivations},
                    {{1}, testValues.params.precisionsOnWeights},
                })
@@ -109,13 +109,13 @@ public:
         auto quantizationRestrictions = testValues.multiChannels ?
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>() :
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::Convolution>()
+                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::Convolution>()
             });
 
         SimpleLowPrecisionTransformer transform(supportedPrecisions, quantizationRestrictions);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::SplitTransformation, ngraph::opset1::Split>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::SplitTransformation, ov::op::v1::Split>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithSplitedIntermediate(

--- a/src/common/low_precision_transformations/tests/concat_with_strided_slice_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_strided_slice_transformation.cpp
@@ -93,7 +93,7 @@ public:
             testValues.ssAfterConcat);
 
         auto supportedPrecisions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-           ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Convolution>({
+           ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Convolution>({
                {{0}, testValues.params.precisionsOnActivations},
                {{1}, testValues.params.precisionsOnWeights},
            })
@@ -102,14 +102,14 @@ public:
         auto quantizationRestrictions = testValues.multiChannels ?
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>() :
             std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::Convolution>()
+                ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::Convolution>()
             });
 
         SimpleLowPrecisionTransformer transform(supportedPrecisions, quantizationRestrictions);
-        transform.add<ngraph::pass::low_precision::ConcatTransformation, ngraph::opset1::Concat>(testValues.params);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
-        transform.add<ngraph::pass::low_precision::StridedSliceTransformation, ngraph::opset1::StridedSlice>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConcatTransformation, ov::op::v0::Concat>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::StridedSliceTransformation, ov::op::v1::StridedSlice>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithStridedSlice(

--- a/src/common/low_precision_transformations/tests/convolution_backprop_data_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_backprop_data_transformation.cpp
@@ -40,7 +40,7 @@ public:
         ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
         builder::subgraph::DequantizationOperations dequantizationOnWeights;
-        std::shared_ptr<ngraph::opset1::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> weights;
         callback_function_type callback;
 
         Actual() = default;
@@ -49,7 +49,7 @@ public:
             const DequantizationOperations& dequantizationOnActivations,
             const FakeQuantizeOnWeights& fakeQuantizeOnWeights,
             const DequantizationOperations& dequantizationOnWeights,
-            const std::shared_ptr<ngraph::opset1::Constant>& weights,
+            const std::shared_ptr<ov::op::v0::Constant>& weights,
             const callback_function_type& callback = empty_callback) :
                 precisionBeforeDequantization(precisionBeforeDequantization),
                 dequantizationOnActivations(dequantizationOnActivations),
@@ -61,7 +61,7 @@ public:
             const ngraph::element::Type& precisionBeforeDequantization,
             const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
             const builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
-            const std::shared_ptr<ngraph::opset1::Constant>& weights,
+            const std::shared_ptr<ov::op::v0::Constant>& weights,
             const callback_function_type& callback = empty_callback) :
                 precisionBeforeDequantization(precisionBeforeDequantization),
                 dequantizationOnActivations(dequantizationOnActivations),
@@ -72,7 +72,7 @@ public:
             const ngraph::element::Type& precisionBeforeDequantization,
             const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
             const builder::subgraph::DequantizationOperations& dequantizationOnWeights,
-            const std::shared_ptr<ngraph::opset1::Constant>& weights,
+            const std::shared_ptr<ov::op::v0::Constant>& weights,
             const callback_function_type& callback = empty_callback) :
                 precisionBeforeDequantization(precisionBeforeDequantization),
                 dequantizationOnActivations(dequantizationOnActivations),
@@ -87,7 +87,7 @@ public:
         ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
         builder::subgraph::DequantizationOperations dequantizationOnWeights;
         ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
-        std::shared_ptr<ngraph::opset1::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> weights;
         bool transformed;
     };
 
@@ -123,7 +123,7 @@ public:
 
         std::shared_ptr<Node> actualWeights = pass::low_precision::fold<opset1::Broadcast>(
                 testValues.actual.weights,
-                opset1::Constant::create(
+                ov::op::v0::Constant::create(
                         element::i64,
                         Shape{ outputShape.size() },
                         Shape{ inputChannels, outputShape[1], 1, 1 }));
@@ -133,19 +133,19 @@ public:
                     netPrecision,
                     testValues.actual.fakeQuantizeOnWeights,
                     testValues.actual.dequantizationOnWeights,
-                    ov::as_type_ptr<opset1::Constant>(actualWeights));
+                    ov::as_type_ptr<ov::op::v0::Constant>(actualWeights));
         } else if (!testValues.actual.fakeQuantizeOnWeights.empty()) {
             actualWeights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
                     outputShape,
                     netPrecision,
                     testValues.actual.fakeQuantizeOnWeights,
-                    ov::as_type_ptr<opset1::Constant>(actualWeights));
+                    ov::as_type_ptr<ov::op::v0::Constant>(actualWeights));
         } else {
             actualWeights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
                     outputShape,
                     netPrecision,
                     testValues.actual.dequantizationOnWeights,
-                    ov::as_type_ptr<opset1::Constant>(actualWeights));
+                    ov::as_type_ptr<ov::op::v0::Constant>(actualWeights));
         }
 
         actualFunction = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getOriginal(
@@ -163,7 +163,7 @@ public:
 
         std::shared_ptr<Node> refWeights = low_precision::fold<opset1::Broadcast>(
                 testValues.expected.weights,
-                opset1::Constant::create(
+                ov::op::v0::Constant::create(
                         element::i64,
                         Shape{ outputShape.size() },
                         Shape{ inputChannels, outputShape[1], 1, 1 }));
@@ -174,13 +174,13 @@ public:
                 netPrecision,
                 testValues.actual.fakeQuantizeOnWeights,
                 testValues.actual.dequantizationOnWeights,
-                ov::as_type_ptr<opset1::Constant>(refWeights));
+                ov::as_type_ptr<ov::op::v0::Constant>(refWeights));
         } else {
             refWeights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
                 outputShape,
                 netPrecision,
                 testValues.expected.dequantizationOnWeights,
-                ov::as_type_ptr<opset1::Constant>(refWeights));
+                ov::as_type_ptr<ov::op::v0::Constant>(refWeights));
         }
 
         referenceFunction = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getReference(

--- a/src/common/low_precision_transformations/tests/convolution_qdq_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_qdq_transformation.cpp
@@ -63,7 +63,7 @@ public:
             testValues.actual.dequantizationAfter);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(

--- a/src/common/low_precision_transformations/tests/convolution_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_transformation.cpp
@@ -28,7 +28,7 @@ public:
     public:
         ngraph::element::Type precisionBeforeDequantization;
         ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-        std::shared_ptr<ngraph::opset1::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> weights;
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     };
 
@@ -36,7 +36,7 @@ public:
     public:
         ngraph::element::Type precisionBeforeDequantization;
         ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
-        std::shared_ptr<ngraph::opset1::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> weights;
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
         ngraph::element::Type precisionAfterOperation;
         ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
@@ -83,7 +83,7 @@ public:
             OutputVector convertedOutput(1);
             convertOnWeights->constant_fold(convertedOutput, convertOnWeights->input_values());
             const auto convertedWeights = convertedOutput[0].get_node_shared_ptr();
-            testValues.expected.weights = ov::as_type_ptr<opset1::Constant>(convertedWeights);
+            testValues.expected.weights = ov::as_type_ptr<ov::op::v0::Constant>(convertedWeights);
         }
 
         referenceFunction = ngraph::builder::subgraph::ConvolutionFunction::getReference(

--- a/src/common/low_precision_transformations/tests/convolution_with_incorrect_weights.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_with_incorrect_weights.cpp
@@ -62,9 +62,8 @@ public:
         SimpleLowPrecisionTransformer transform;
         transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(
             testValues.params);
-        transform
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
-                testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
+            testValues.params);
         transform.transform(actualFunction);
 
         ngraph::pass::Manager cleanupManager;

--- a/src/common/low_precision_transformations/tests/convolution_with_incorrect_weights.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_with_incorrect_weights.cpp
@@ -63,7 +63,7 @@ public:
         transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(
             testValues.params);
         transform
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(
+            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
                 testValues.params);
         transform.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/elementwise_with_multi_parent_dequantization_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/elementwise_with_multi_parent_dequantization_transformation.cpp
@@ -67,7 +67,7 @@ public:
             testValues.actual.dequantization2);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::AddTransformation, ngraph::opset1::Add>(testValues.params);
+        transform.add<ngraph::pass::low_precision::AddTransformation, ov::op::v1::Add>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ElementwiseWithMultiParentDequantizationFunction::get(

--- a/src/common/low_precision_transformations/tests/eliminate_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/eliminate_fake_quantize_transformation.cpp
@@ -57,12 +57,12 @@ public:
                                                                                   {});
         SimpleLowPrecisionTransformer transformer;
         transformer
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(
+            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
                 testValues.params);
-        transformer.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
-        transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(
+        transformer.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ov::op::v0::FakeQuantize>(
             testValues.params);
-        transformer.add<ngraph::pass::low_precision::EliminateFakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(
+        transformer.add<ngraph::pass::low_precision::EliminateFakeQuantizeTransformation, ov::op::v0::FakeQuantize>(
             testValues.params);
         transformer.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/eliminate_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/eliminate_fake_quantize_transformation.cpp
@@ -56,9 +56,8 @@ public:
                                                                                   testValues.actual.fakeQuantizeOnData2,
                                                                                   {});
         SimpleLowPrecisionTransformer transformer;
-        transformer
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
-                testValues.params);
+        transformer.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
+            testValues.params);
         transformer.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ov::op::v0::FakeQuantize>(
             testValues.params);

--- a/src/common/low_precision_transformations/tests/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -75,8 +75,8 @@ public:
             testValues.actual.fqOnWeights2);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
-        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndTwoOutputBranchesWithConvolutionFunction::getReference(

--- a/src/common/low_precision_transformations/tests/fake_quantize_on_weights_with_unsupported_child.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_on_weights_with_unsupported_child.cpp
@@ -27,13 +27,13 @@ class FakeQuantizeOnWeightsWithUnsupportedChildTestValues {
 public:
     class Actual {
     public:
-        std::shared_ptr<ngraph::opset1::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> weights;
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     };
 
     class Expected {
     public:
-        std::shared_ptr<ngraph::opset1::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> weights;
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     };
 
@@ -62,7 +62,7 @@ public:
             testValues.actual.fakeQuantizeOnWeights);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
         transform.transform(actualFunction);
 
         ngraph::pass::Manager cleanupManager;

--- a/src/common/low_precision_transformations/tests/fake_quantize_precision_selection_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_precision_selection_transformation.cpp
@@ -90,17 +90,17 @@ public:
             });
 
         auto supportedPrecisions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-           ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Convolution>({
+           ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Convolution>({
                {{0}, testValues.precisionsOnActivationForLimitedOperation},
                {{1}, { element::i8 }}
            })
         });
 
         SimpleLowPrecisionTransformer transform(supportedPrecisions);
-        transform.add<ngraph::pass::low_precision::PReluTransformation, ngraph::opset1::PRelu>(params);
-        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(precisionLimitedOperationParams);
-        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(params);
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(params);
+        transform.add<ngraph::pass::low_precision::PReluTransformation, ov::op::v0::PRelu>(params);
+        transform.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(precisionLimitedOperationParams);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FakeQuantizePrecisionSelectionFunction::getReference(

--- a/src/common/low_precision_transformations/tests/fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_transformation.cpp
@@ -88,9 +88,8 @@ public:
                 {{{0}, params.precisionsOnActivations}})});
 
         SimpleLowPrecisionTransformer transform(supportedPrecisions, {}, {ngraph::element::f32, defaultPrecisions});
-        transform
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
-                params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
+            params);
         transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ov::op::v1::AvgPool>(params);
         transform.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_transformation.cpp
@@ -84,14 +84,14 @@ public:
             fakeQuantizeOnData.addNotPrecisionPreservedOperation);
 
         auto supportedPrecisions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>(
-            {ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::AvgPool>(
+            {ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::AvgPool>(
                 {{{0}, params.precisionsOnActivations}})});
 
         SimpleLowPrecisionTransformer transform(supportedPrecisions, {}, {ngraph::element::f32, defaultPrecisions});
         transform
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(
+            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
                 params);
-        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ngraph::opset1::AvgPool>(params);
+        transform.add<ngraph::pass::low_precision::AvgPoolTransformation, ov::op::v1::AvgPool>(params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FakeQuantizeFunction::getReference(

--- a/src/common/low_precision_transformations/tests/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -81,20 +81,20 @@ public:
             testValues.actual.dequantizationAfter);
 
         auto precisionsRestrictions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-            ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Convolution>({
+            ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Convolution>({
                 {{0}, {ngraph::element::u8}},
                 {{1}, {ngraph::element::i8}}
             })
         });
 
         auto quantizationRestrictions = std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>({
-            ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ngraph::opset1::Convolution>()
+            ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::Convolution>()
         });
 
         SimpleLowPrecisionTransformer transformer(precisionsRestrictions, quantizationRestrictions);
-        transformer.add<ngraph::pass::low_precision::ConvolutionTransformation, ngraph::opset1::Convolution>(
+        transformer.add<ngraph::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(
             TestTransformationParams(params).setPrecisionsOnActivations({ element::u8 }));
-        transformer.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(params);
+        transformer.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(

--- a/src/common/low_precision_transformations/tests/fake_quantize_with_dynamic_intervals_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_with_dynamic_intervals_transformation.cpp
@@ -63,7 +63,7 @@ public:
         actualFunction = get(precision, shape, testValues.inputLowConst, testValues.inpuHighConst, testValues.outputLowConst, testValues.outputHighConst);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ov::op::v0::FakeQuantize>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = get(precision, shape, testValues.inputLowConst, testValues.inpuHighConst, testValues.outputLowConst, testValues.outputHighConst);
@@ -88,7 +88,7 @@ private:
         const bool inpuHighConst,
         const bool outputLowConst,
         const bool outputHighConst) {
-        const auto input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
+        const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
         input->set_friendly_name("input");
 
         const auto constantPresition = element::f32;
@@ -97,40 +97,40 @@ private:
         const std::vector<float> high = { 1.f };
 
         const auto inputLow = inputLowConst ?
-            std::dynamic_pointer_cast<ngraph::Node>(std::make_shared<opset1::Constant>(constantPresition, constantShape, low)) :
-            std::make_shared<ngraph::opset1::Parameter>(constantPresition, constantShape);
+            std::dynamic_pointer_cast<ngraph::Node>(std::make_shared<ov::op::v0::Constant>(constantPresition, constantShape, low)) :
+            std::make_shared<ov::op::v0::Parameter>(constantPresition, constantShape);
 
         const auto inputHigh = inputLowConst ?
-            std::dynamic_pointer_cast<ngraph::Node>(std::make_shared<opset1::Constant>(constantPresition, constantShape, high)) :
-            std::make_shared<ngraph::opset1::Parameter>(constantPresition, constantShape);
+            std::dynamic_pointer_cast<ngraph::Node>(std::make_shared<ov::op::v0::Constant>(constantPresition, constantShape, high)) :
+            std::make_shared<ov::op::v0::Parameter>(constantPresition, constantShape);
 
         const auto outputLow = outputLowConst ?
-            std::dynamic_pointer_cast<ngraph::Node>(std::make_shared<opset1::Constant>(constantPresition, constantShape, low)) :
-            std::make_shared<ngraph::opset1::Parameter>(constantPresition, constantShape);
+            std::dynamic_pointer_cast<ngraph::Node>(std::make_shared<ov::op::v0::Constant>(constantPresition, constantShape, low)) :
+            std::make_shared<ov::op::v0::Parameter>(constantPresition, constantShape);
 
         const auto outputHigh = outputHighConst ?
-            std::dynamic_pointer_cast<ngraph::Node>(std::make_shared<opset1::Constant>(constantPresition, constantShape, high)) :
-            std::make_shared<ngraph::opset1::Parameter>(constantPresition, constantShape);
+            std::dynamic_pointer_cast<ngraph::Node>(std::make_shared<ov::op::v0::Constant>(constantPresition, constantShape, high)) :
+            std::make_shared<ov::op::v0::Parameter>(constantPresition, constantShape);
 
         const auto levels = 256ul;
 
-        auto fakeQuantize = std::make_shared<ngraph::opset1::FakeQuantize>(input, inputLow, inputHigh, outputLow, outputHigh, levels);
+        auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, inputLow, inputHigh, outputLow, outputHigh, levels);
         fakeQuantize->set_friendly_name("fakeQuantize");
 
-        ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(fakeQuantize) };
+        ngraph::ResultVector results{ std::make_shared<ov::op::v0::Result>(fakeQuantize) };
 
         ngraph::ParameterVector inputs{ input };
-        if (as_type_ptr<ngraph::opset1::Parameter>(inputLow)) {
-            inputs.push_back(as_type_ptr<ngraph::opset1::Parameter>(inputLow));
+        if (as_type_ptr<ov::op::v0::Parameter>(inputLow)) {
+            inputs.push_back(as_type_ptr<ov::op::v0::Parameter>(inputLow));
         }
-        if (as_type_ptr<ngraph::opset1::Parameter>(inputHigh)) {
-            inputs.push_back(as_type_ptr<ngraph::opset1::Parameter>(inputHigh));
+        if (as_type_ptr<ov::op::v0::Parameter>(inputHigh)) {
+            inputs.push_back(as_type_ptr<ov::op::v0::Parameter>(inputHigh));
         }
-        if (as_type_ptr<ngraph::opset1::Parameter>(outputLow)) {
-            inputs.push_back(as_type_ptr<ngraph::opset1::Parameter>(outputLow));
+        if (as_type_ptr<ov::op::v0::Parameter>(outputLow)) {
+            inputs.push_back(as_type_ptr<ov::op::v0::Parameter>(outputLow));
         }
-        if (as_type_ptr<ngraph::opset1::Parameter>(outputHigh)) {
-            inputs.push_back(as_type_ptr<ngraph::opset1::Parameter>(outputHigh));
+        if (as_type_ptr<ov::op::v0::Parameter>(outputHigh)) {
+            inputs.push_back(as_type_ptr<ov::op::v0::Parameter>(outputHigh));
         }
 
         return std::make_shared<ngraph::Function>(results, inputs, "FakeQuantizeWithDynamicIntervalsTransformation");

--- a/src/common/low_precision_transformations/tests/fold_convert_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fold_convert_transformation.cpp
@@ -49,19 +49,19 @@ public:
             const ngraph::element::Type precision,
             const ngraph::PartialShape& inputShape,
             const ngraph::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ngraph::Function> {
-            auto input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
+            auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
             std::shared_ptr<ngraph::Node> output = makeDequantization(input, dequantization);
             output->set_friendly_name("output");
 
             return std::make_shared<ngraph::Function>(
-                ngraph::ResultVector{ std::make_shared<ngraph::opset1::Result>(output) },
+                ngraph::ResultVector{ std::make_shared<ov::op::v0::Result>(output) },
                 ngraph::ParameterVector{ input },
                 "FoldConvertTransformation");
         };
         actualFunction = createFunction(testValues.precision, inputShape, testValues.dequantizationActual);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::FoldConvertTransformation, ngraph::opset1::Add>(testValues.params);
+        transform.add<ngraph::pass::low_precision::FoldConvertTransformation, ov::op::v1::Add>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = createFunction(testValues.precision, inputShape, testValues.dequantizationExpected);

--- a/src/common/low_precision_transformations/tests/fold_fake_quantize_in_transformations.cpp
+++ b/src/common/low_precision_transformations/tests/fold_fake_quantize_in_transformations.cpp
@@ -68,16 +68,16 @@ public:
         const auto params = TestTransformationParams(testValues.params).setUpdatePrecisions(testValues.updatePrecision);
 
         std::shared_ptr<ngraph::Node> dataSource;
-        std::shared_ptr<ngraph::opset1::Parameter> parameter;
+        std::shared_ptr<ov::op::v0::Parameter> parameter;
         bool useParameterAsDataSource = (testValues.actual.constValues.size() == 0);
 
         if (useParameterAsDataSource) {
             // for data-independent const folding
             parameter =
-                std::make_shared<ngraph::opset1::Parameter>(testValues.actual.constPrecision, testValues.constShape);
+                std::make_shared<ov::op::v0::Parameter>(testValues.actual.constPrecision, testValues.constShape);
             dataSource = parameter;
         } else {
-            dataSource = std::make_shared<ngraph::opset1::Constant>(testValues.actual.constPrecision,
+            dataSource = std::make_shared<ov::op::v0::Constant>(testValues.actual.constPrecision,
                                                                     testValues.constShape,
                                                                     testValues.actual.constValues);
         }
@@ -86,11 +86,11 @@ public:
             ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(dataSource,
                                                                    element::f32,
                                                                    testValues.actual.fakeQuantize);
-        ngraph::pass::low_precision::NetworkHelper::setOutDataPrecision(as_type_ptr<opset1::FakeQuantize>(fq),
+        ngraph::pass::low_precision::NetworkHelper::setOutDataPrecision(as_type_ptr<ov::op::v0::FakeQuantize>(fq),
                                                                         testValues.actual.fqOutPrecision);
-        fq = ngraph::pass::low_precision::NetworkHelper::fold_fake_quantize(as_type_ptr<opset1::FakeQuantize>(fq),
+        fq = ngraph::pass::low_precision::NetworkHelper::fold_fake_quantize(as_type_ptr<ov::op::v0::FakeQuantize>(fq),
                                                                             testValues.roundValues);
-        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(fq)};
+        ngraph::ResultVector results{std::make_shared<ov::op::v0::Result>(fq)};
         actualFunction = std::make_shared<ngraph::Function>(
             results,
             parameter ? ngraph::ParameterVector{parameter} : ngraph::ParameterVector{},

--- a/src/common/low_precision_transformations/tests/fold_fake_quantize_in_transformations.cpp
+++ b/src/common/low_precision_transformations/tests/fold_fake_quantize_in_transformations.cpp
@@ -78,8 +78,8 @@ public:
             dataSource = parameter;
         } else {
             dataSource = std::make_shared<ov::op::v0::Constant>(testValues.actual.constPrecision,
-                                                                    testValues.constShape,
-                                                                    testValues.actual.constValues);
+                                                                testValues.constShape,
+                                                                testValues.actual.constValues);
         }
 
         std::shared_ptr<Node> fq =

--- a/src/common/low_precision_transformations/tests/fuse_convert_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_convert_transformation.cpp
@@ -64,7 +64,7 @@ public:
                 testValues.constInput);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::FuseConvertTransformation, ngraph::opset1::Convert>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::FuseConvertTransformation, ov::op::v0::Convert>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FuseConvertFunction::get(

--- a/src/common/low_precision_transformations/tests/fuse_dequantize_to_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_dequantize_to_fake_quantize_transformation.cpp
@@ -74,11 +74,11 @@ public:
 
         SimpleLowPrecisionTransformer transformer;
         transformer
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ngraph::opset1::FakeQuantize>(
+            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
                 testValues.params);
         transformer.transform(actualFunction);
 
-        transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(
+        transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ov::op::v0::FakeQuantize>(
             testValues.params);
         transformer.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/fuse_dequantize_to_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_dequantize_to_fake_quantize_transformation.cpp
@@ -73,9 +73,8 @@ public:
             testValues.actual.fakeQuantizeOnData);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer
-            .add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
-                testValues.params);
+        transformer.add<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
+            testValues.params);
         transformer.transform(actualFunction);
 
         transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ov::op::v0::FakeQuantize>(

--- a/src/common/low_precision_transformations/tests/fuse_fake_quantize_with_multi_inputs_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_fake_quantize_with_multi_inputs_transformation.cpp
@@ -62,7 +62,7 @@ public:
             testValues.actual.fakeQuantizeOnData);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ngraph::opset1::FakeQuantize>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::FakeQuantizeTransformation, ov::op::v0::FakeQuantize>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FuseFakeQuantizeFunction::get(

--- a/src/common/low_precision_transformations/tests/fuse_multiply_to_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_multiply_to_fake_quantize_transformation.cpp
@@ -68,7 +68,7 @@ public:
             testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::FuseMultiplyToFakeQuantizeTransformation, ngraph::opset1::Multiply>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::FuseMultiplyToFakeQuantizeTransformation, ov::op::v1::Multiply>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::FuseMultiplyToFakeQuantizeFunction::get(

--- a/src/common/low_precision_transformations/tests/fuse_subtract_to_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_subtract_to_fake_quantize_transformation.cpp
@@ -86,7 +86,7 @@ public:
                 testValues.actual.dequantization2);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::FuseSubtractToFakeQuantizeTransformation, ngraph::opset1::Subtract>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::FuseSubtractToFakeQuantizeTransformation, ov::op::v1::Subtract>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = testValues.expected.fakeQuantizeOnData2.empty() ?

--- a/src/common/low_precision_transformations/tests/gather_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/gather_transformation.cpp
@@ -68,7 +68,7 @@ public:
                                                                    opset_version);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::GatherTransformation, ngraph::opset1::Gather>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::GatherTransformation, ov::op::v1::Gather>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction =

--- a/src/common/low_precision_transformations/tests/group_convolution_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/group_convolution_transformation.cpp
@@ -28,7 +28,7 @@ public:
     public:
         ngraph::element::Type precisionBeforeDequantization;
         ngraph::builder::subgraph::DequantizationOperations dequantization;
-        std::shared_ptr<ngraph::opset1::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> weights;
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
         ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
     };
@@ -37,7 +37,7 @@ public:
     public:
         ngraph::element::Type precisionBeforeDequantization;
         ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
-        std::shared_ptr<ngraph::opset1::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> weights;
         builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
         ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
         ngraph::element::Type precisionAfterOperation;

--- a/src/common/low_precision_transformations/tests/interpolate_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/interpolate_transformation.cpp
@@ -112,7 +112,7 @@ public:
                 testValues.actual.dequantization);
 
             SimpleLowPrecisionTransformer transformer;
-            transformer.add<ngraph::pass::low_precision::InterpolateTransformation, ngraph::opset1::Interpolate>(testValues.params);
+            transformer.add<ngraph::pass::low_precision::InterpolateTransformation, ov::op::v0::Interpolate>(testValues.params);
             transformer.transform(actualFunction);
 
             referenceFunction = ngraph::builder::subgraph::InterpolateFunction::getReference(

--- a/src/common/low_precision_transformations/tests/is_asymmetric_on_weights_dequantization.cpp
+++ b/src/common/low_precision_transformations/tests/is_asymmetric_on_weights_dequantization.cpp
@@ -23,7 +23,7 @@ public:
     TestTransformationParams params;
     ngraph::element::Type precisionBeforeDequantization;
     ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-    std::shared_ptr<ngraph::opset1::Constant> weights;
+    std::shared_ptr<ov::op::v0::Constant> weights;
     builder::subgraph::DequantizationOperations dequantizationOnWeights;
     bool isAsymmetricOnWeights;
 };

--- a/src/common/low_precision_transformations/tests/is_asymmetric_on_weights_fq.cpp
+++ b/src/common/low_precision_transformations/tests/is_asymmetric_on_weights_fq.cpp
@@ -24,7 +24,7 @@ public:
     TestTransformationParams params;
     ngraph::element::Type precisionBeforeDequantization;
     ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-    std::shared_ptr<ngraph::opset1::Constant> weights;
+    std::shared_ptr<ov::op::v0::Constant> weights;
     builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
 };
 

--- a/src/common/low_precision_transformations/tests/is_constant_path_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/is_constant_path_transformation.cpp
@@ -18,7 +18,7 @@ using namespace ngraph::pass;
 using namespace ngraph::builder::subgraph;
 
 TEST(LPT, isConstantPathFQAfterInputTransformation) {
-    const auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
     const auto fqOnActivations = makeFakeQuantize(input, ngraph::element::f32,
         FakeQuantizeOnData{ 256ul, {}, {0.f}, {2.55f}, {0.f}, {2.55f} });
 
@@ -28,7 +28,7 @@ TEST(LPT, isConstantPathFQAfterInputTransformation) {
 }
 
 TEST(LPT, isConstantPathFQAfterWeightsTransformation) {
-    const auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 1, 1 }, { 1.f });
+    const auto weights = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 1, 1 }, { 1.f });
     const auto fqOnWeights = makeFakeQuantize(weights, ngraph::element::f32,
         FakeQuantizeOnWeights{ 255ul, {}, {0.f}, {254.f}, {-1.27f}, {1.27f} });
 
@@ -38,7 +38,7 @@ TEST(LPT, isConstantPathFQAfterWeightsTransformation) {
 }
 
 TEST(LPT, isConstantPathDqAfterInputTransformation) {
-    const auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
     const auto dqOnActivations = makeDequantization(input, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
 
     const bool result = low_precision::NetworkHelper::isConstantPath(dqOnActivations);
@@ -47,7 +47,7 @@ TEST(LPT, isConstantPathDqAfterInputTransformation) {
 }
 
 TEST(LPT, isConstantPathDqAfterWeightsTransformation) {
-    const auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 1, 1 }, { 1.f });
+    const auto weights = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 1, 1 }, { 1.f });
     const auto dqOnWeights = makeDequantization(weights, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
 
     const bool result = low_precision::NetworkHelper::isConstantPath(dqOnWeights);
@@ -56,8 +56,8 @@ TEST(LPT, isConstantPathDqAfterWeightsTransformation) {
 }
 
 TEST(LPT, isConstantPathTwoInputsTransformation) {
-    const auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-    const auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto input1 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto input2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
     const auto dq1 = makeDequantization(input1, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
     const auto dq2 = makeDequantization(input2, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
     const auto matmul = std::make_shared<ngraph::opset1::MatMul>(dq1, dq2);
@@ -68,8 +68,8 @@ TEST(LPT, isConstantPathTwoInputsTransformation) {
 }
 
 TEST(LPT, isConstantPathTwoConsantsTransformation) {
-    const auto constant1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 1, 1 }, { 1.f });
-    const auto constant2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 1, 1 }, { 1.f });
+    const auto constant1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 1, 1 }, { 1.f });
+    const auto constant2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 1, 1 }, { 1.f });
     const auto dq1 = makeDequantization(constant1, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
     const auto dq2 = makeDequantization(constant2, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
     const auto eltwise = std::make_shared<ngraph::opset1::Add>(dq1, dq2);
@@ -80,8 +80,8 @@ TEST(LPT, isConstantPathTwoConsantsTransformation) {
 }
 
 TEST(LPT, isConstantPathMatMulParentFQTransformation) {
-    const auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-    const auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto input1 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto input2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
     const auto dq1 = makeDequantization(input1, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
     const auto dq2 = makeDequantization(input2, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
     const auto matmul = std::make_shared<ngraph::opset1::MatMul>(dq1, dq2);
@@ -94,8 +94,8 @@ TEST(LPT, isConstantPathMatMulParentFQTransformation) {
 }
 
 TEST(LPT, isConstantPathMatMulParentDqTransformation) {
-    const auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-    const auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto input1 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto input2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
     const auto dq1 = makeDequantization(input1, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
     const auto dq2 = makeDequantization(input2, DequantizationOperations{ ngraph::element::f32, {128.f}, {0.1f} });
     const auto matmul = std::make_shared<ngraph::opset1::MatMul>(dq1, dq2);
@@ -107,8 +107,8 @@ TEST(LPT, isConstantPathMatMulParentDqTransformation) {
 }
 
 TEST(LPT, isConstantPathConvParentDqTransformation) {
-    const auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 72, 16 });
-    const auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 6, 3, 1, 1 }, { 1.f });
+    const auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 72, 16 });
+    const auto weights = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{ 6, 3, 1, 1 }, { 1.f });
     const auto conv = std::make_shared<ngraph::opset1::Convolution>(
         input,
         weights,
@@ -124,8 +124,8 @@ TEST(LPT, isConstantPathConvParentDqTransformation) {
 }
 
 TEST(LPT, isConstantPathGroupConvParentDqTransformation) {
-    const auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-    const auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 6, 3, 1, 1 }, { 1.f });
+    const auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+    const auto weights = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 6, 3, 1, 1 }, { 1.f });
     const auto groupConv = std::make_shared<ngraph::opset1::GroupConvolution>(
         input,
         weights,

--- a/src/common/low_precision_transformations/tests/is_function_quantized_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/is_function_quantized_transformation.cpp
@@ -33,7 +33,7 @@ public:
     void SetUp() override {
         const auto testValues = GetParam();
 
-        const auto input = std::make_shared<ov::opset1::Parameter>(testValues.precision, ngraph::Shape(testValues.shape));
+        const auto input = std::make_shared<ov::op::v0::Parameter>(testValues.precision, ngraph::Shape(testValues.shape));
         const auto fakeQuantize = ngraph::builder::subgraph::makeFakeQuantize(
             input,
             testValues.precision,
@@ -44,7 +44,7 @@ public:
             replace_node(fakeQuantize->get_input_node_shared_ptr(3), input);
         }
 
-        ngraph::ResultVector results{ std::make_shared<ov::opset1::Result>(fakeQuantize) };
+        ngraph::ResultVector results{ std::make_shared<ov::op::v0::Result>(fakeQuantize) };
         function = std::make_shared<ngraph::Function>(results, ngraph::ParameterVector{ input }, "IsFunctionQuantizedFunction");
         function->validate_nodes_and_infer_types();
     }

--- a/src/common/low_precision_transformations/tests/low_precision_transformations_test.cpp
+++ b/src/common/low_precision_transformations/tests/low_precision_transformations_test.cpp
@@ -53,7 +53,7 @@ TEST_F(smoke_LPT_LowPrecisionTransformationsTests, DISABLED_removeAll) {
 //    ASSERT_NE(0, transformation.size());
 //    const size_t originalSize = transformation.size();
 //
-//    transformations.removeCleanup<ngraph::pass::low_precision::FuseConvertTransformation, ngraph::opset1::Multiply>();
+//    transformations.removeCleanup<ngraph::pass::low_precision::FuseConvertTransformation, ov::op::v1::Multiply>();
 //    transformation = transformations.find("Multiply");
 //    ASSERT_EQ(originalSize - 1, transformation.size());
 //}
@@ -64,7 +64,7 @@ TEST_F(smoke_LPT_LowPrecisionTransformationsTests, DISABLED_removeAll) {
 //    ASSERT_NE(0, transformation.size());
 //    const size_t originalSize = transformation.size();
 //
-//    transformations.removeStandaloneCleanup<ngraph::pass::low_precision::SubtractMultiplyToMultiplyAddTransformation, ngraph::opset1::Multiply>();
+//    transformations.removeStandaloneCleanup<ngraph::pass::low_precision::SubtractMultiplyToMultiplyAddTransformation, ov::op::v1::Multiply>();
 //    transformation = transformations.find("Multiply");
 //    ASSERT_EQ(originalSize - 1, transformation.size());
 //}

--- a/src/common/low_precision_transformations/tests/lpt_avoid_shapeof_propagation_test.cpp
+++ b/src/common/low_precision_transformations/tests/lpt_avoid_shapeof_propagation_test.cpp
@@ -77,7 +77,8 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationAvgPoolTransformation) {
     auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
     auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto avgPool = std::make_shared<ov::op::v1::AvgPool>(mul, Strides{1, 1}, Shape{1, 1}, Shape{0, 0}, Shape{2, 2}, true);
+    auto avgPool =
+        std::make_shared<ov::op::v1::AvgPool>(mul, Strides{1, 1}, Shape{1, 1}, Shape{0, 0}, Shape{2, 2}, true);
     auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(avgPool);
 
     auto result1 = std::make_shared<ov::op::v0::Result>(avgPool);
@@ -148,11 +149,11 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationConvolutionTransformation) {
         std::make_shared<ov::op::v1::Multiply>(convertOnWeights, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
 
     auto convolution = std::make_shared<ov::op::v1::Convolution>(mul,
-                                                             mulOnWeights,
-                                                             ngraph::Strides{1, 1},
-                                                             ngraph::CoordinateDiff{0, 0},
-                                                             ngraph::CoordinateDiff{0, 0},
-                                                             ngraph::Strides{1, 1});
+                                                                 mulOnWeights,
+                                                                 ngraph::Strides{1, 1},
+                                                                 ngraph::CoordinateDiff{0, 0},
+                                                                 ngraph::CoordinateDiff{0, 0},
+                                                                 ngraph::Strides{1, 1});
 
     auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(convolution);
 
@@ -178,11 +179,11 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationConvolutionBackpropDataTransfor
         std::make_shared<ov::op::v1::Multiply>(convertOnWeights, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
 
     auto convolutionBackpropData = std::make_shared<ov::op::v1::ConvolutionBackpropData>(mul,
-                                                                                     mulOnWeights,
-                                                                                     ngraph::Strides{1, 1},
-                                                                                     ngraph::CoordinateDiff{0, 0},
-                                                                                     ngraph::CoordinateDiff{0, 0},
-                                                                                     ngraph::Strides{1, 1});
+                                                                                         mulOnWeights,
+                                                                                         ngraph::Strides{1, 1},
+                                                                                         ngraph::CoordinateDiff{0, 0},
+                                                                                         ngraph::CoordinateDiff{0, 0},
+                                                                                         ngraph::Strides{1, 1});
 
     auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(convolutionBackpropData);
 
@@ -253,11 +254,11 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationGroupConvolutionTransformation)
     auto reshapeOnWeights = std::make_shared<ov::op::v1::Reshape>(mulOnWeights, reshapeConst, true);
 
     auto groupConvolution = std::make_shared<ov::op::v1::GroupConvolution>(mul,
-                                                                       reshapeOnWeights,
-                                                                       ngraph::Strides{1, 1},
-                                                                       ngraph::CoordinateDiff{0, 0},
-                                                                       ngraph::CoordinateDiff{0, 0},
-                                                                       ngraph::Strides{1, 1});
+                                                                           reshapeOnWeights,
+                                                                           ngraph::Strides{1, 1},
+                                                                           ngraph::CoordinateDiff{0, 0},
+                                                                           ngraph::CoordinateDiff{0, 0},
+                                                                           ngraph::Strides{1, 1});
     auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(groupConvolution);
 
     auto result1 = std::make_shared<ov::op::v0::Result>(groupConvolution);
@@ -649,11 +650,11 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationStridedSliceTransformation) {
     auto endParam = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 2, 1, 1});
     auto stridesParam = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 1, 1, 1});
     auto stridedSlice = std::make_shared<ov::op::v1::StridedSlice>(mul,
-                                                                       beginParam,
-                                                                       endParam,
-                                                                       stridesParam,
-                                                                       std::vector<std::int64_t>{1, 0, 1, 1},
-                                                                       std::vector<std::int64_t>{1, 0, 1, 1});
+                                                                   beginParam,
+                                                                   endParam,
+                                                                   stridesParam,
+                                                                   std::vector<std::int64_t>{1, 0, 1, 1},
+                                                                   std::vector<std::int64_t>{1, 0, 1, 1});
     auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(stridedSlice);
 
     auto result1 = std::make_shared<ov::op::v0::Result>(stridedSlice);

--- a/src/common/low_precision_transformations/tests/lpt_avoid_shapeof_propagation_test.cpp
+++ b/src/common/low_precision_transformations/tests/lpt_avoid_shapeof_propagation_test.cpp
@@ -48,20 +48,20 @@ using namespace ngraph;
 using namespace ngraph::pass;
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationAddTransformation) {
-    auto input1 = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto input2 = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto input1 = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto input2 = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
 
-    auto convert1 = std::make_shared<opset1::Convert>(input1, element::f32);
-    auto convert2 = std::make_shared<opset1::Convert>(input2, element::f32);
+    auto convert1 = std::make_shared<ov::op::v0::Convert>(input1, element::f32);
+    auto convert2 = std::make_shared<ov::op::v0::Convert>(input2, element::f32);
 
-    auto mul1 = std::make_shared<opset1::Multiply>(convert1, opset1::Constant::create(element::f32, {}, {2.f}));
-    auto mul2 = std::make_shared<opset1::Multiply>(convert2, opset1::Constant::create(element::f32, {}, {4.f}));
+    auto mul1 = std::make_shared<ov::op::v1::Multiply>(convert1, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
+    auto mul2 = std::make_shared<ov::op::v1::Multiply>(convert2, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
 
-    auto add = std::make_shared<opset1::Add>(mul1, mul2);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(add);
+    auto add = std::make_shared<ov::op::v1::Add>(mul1, mul2);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(add);
 
-    auto result1 = std::make_shared<opset1::Result>(add);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(add);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input1, input2});
     pass::Manager m;
@@ -73,15 +73,15 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationAddTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationAvgPoolTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto avgPool = std::make_shared<opset1::AvgPool>(mul, Strides{1, 1}, Shape{1, 1}, Shape{0, 0}, Shape{2, 2}, true);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(avgPool);
+    auto avgPool = std::make_shared<ov::op::v1::AvgPool>(mul, Strides{1, 1}, Shape{1, 1}, Shape{0, 0}, Shape{2, 2}, true);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(avgPool);
 
-    auto result1 = std::make_shared<opset1::Result>(avgPool);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(avgPool);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -93,15 +93,15 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationAvgPoolTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationClampTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto clamp = std::make_shared<opset1::Clamp>(mul, 0.0, 6.0);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(clamp);
+    auto clamp = std::make_shared<ov::op::v0::Clamp>(mul, 0.0, 6.0);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(clamp);
 
-    auto result1 = std::make_shared<opset1::Result>(clamp);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(clamp);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -113,20 +113,20 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationClampTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationConcatTransformation) {
-    auto input1 = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto input2 = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto input1 = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto input2 = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
 
-    auto convert1 = std::make_shared<opset1::Convert>(input1, element::f32);
-    auto convert2 = std::make_shared<opset1::Convert>(input2, element::f32);
+    auto convert1 = std::make_shared<ov::op::v0::Convert>(input1, element::f32);
+    auto convert2 = std::make_shared<ov::op::v0::Convert>(input2, element::f32);
 
-    auto mul1 = std::make_shared<opset1::Multiply>(convert1, opset1::Constant::create(element::f32, {}, {2.f}));
-    auto mul2 = std::make_shared<opset1::Multiply>(convert2, opset1::Constant::create(element::f32, {}, {4.f}));
+    auto mul1 = std::make_shared<ov::op::v1::Multiply>(convert1, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
+    auto mul2 = std::make_shared<ov::op::v1::Multiply>(convert2, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
 
-    auto concat = std::make_shared<opset1::Concat>(OutputVector{mul1, mul2}, 1);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(concat);
+    auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{mul1, mul2}, 1);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(concat);
 
-    auto result1 = std::make_shared<opset1::Result>(concat);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(concat);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input1, input2});
     pass::Manager m;
@@ -138,26 +138,26 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationConcatTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationConvolutionTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto weights = opset1::Constant::create(element::i8, {6, 3, 1, 1}, {3});
-    auto convertOnWeights = std::make_shared<opset1::Convert>(weights, element::f32);
+    auto weights = ov::op::v0::Constant::create(element::i8, {6, 3, 1, 1}, {3});
+    auto convertOnWeights = std::make_shared<ov::op::v0::Convert>(weights, element::f32);
     auto mulOnWeights =
-        std::make_shared<opset1::Multiply>(convertOnWeights, opset1::Constant::create(element::f32, {}, {4.f}));
+        std::make_shared<ov::op::v1::Multiply>(convertOnWeights, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
 
-    auto convolution = std::make_shared<opset1::Convolution>(mul,
+    auto convolution = std::make_shared<ov::op::v1::Convolution>(mul,
                                                              mulOnWeights,
                                                              ngraph::Strides{1, 1},
                                                              ngraph::CoordinateDiff{0, 0},
                                                              ngraph::CoordinateDiff{0, 0},
                                                              ngraph::Strides{1, 1});
 
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(convolution);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(convolution);
 
-    auto result1 = std::make_shared<opset1::Result>(convolution);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(convolution);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -168,26 +168,26 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationConvolutionTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationConvolutionBackpropDataTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 8, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 8, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto weights = opset1::Constant::create(element::i8, {8, 2, 1, 1}, {3});
-    auto convertOnWeights = std::make_shared<opset1::Convert>(weights, element::f32);
+    auto weights = ov::op::v0::Constant::create(element::i8, {8, 2, 1, 1}, {3});
+    auto convertOnWeights = std::make_shared<ov::op::v0::Convert>(weights, element::f32);
     auto mulOnWeights =
-        std::make_shared<opset1::Multiply>(convertOnWeights, opset1::Constant::create(element::f32, {}, {4.f}));
+        std::make_shared<ov::op::v1::Multiply>(convertOnWeights, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
 
-    auto convolutionBackpropData = std::make_shared<opset1::ConvolutionBackpropData>(mul,
+    auto convolutionBackpropData = std::make_shared<ov::op::v1::ConvolutionBackpropData>(mul,
                                                                                      mulOnWeights,
                                                                                      ngraph::Strides{1, 1},
                                                                                      ngraph::CoordinateDiff{0, 0},
                                                                                      ngraph::CoordinateDiff{0, 0},
                                                                                      ngraph::Strides{1, 1});
 
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(convolutionBackpropData);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(convolutionBackpropData);
 
-    auto result1 = std::make_shared<opset1::Result>(convolutionBackpropData);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(convolutionBackpropData);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -198,15 +198,15 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationConvolutionBackpropDataTransfor
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationDepthToSpaceTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto d2s = std::make_shared<opset1::DepthToSpace>(mul, op::v0::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(d2s);
+    auto d2s = std::make_shared<ov::op::v0::DepthToSpace>(mul, op::v0::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(d2s);
 
-    auto result1 = std::make_shared<opset1::Result>(d2s);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(d2s);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -218,18 +218,18 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationDepthToSpaceTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationFakeQuantizeDecompositionTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::f32, PartialShape{1, 3, 16, 16});
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{1, 3, 16, 16});
 
     ngraph::builder::subgraph::FakeQuantizeOnData fqValues{256ul, {}, {0.f}, {2.55f}, {0.f}, {2.55f}};
     auto fakeQuantize = ngraph::builder::subgraph::makeFakeQuantize(input, element::f32, fqValues);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(fakeQuantize);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(fakeQuantize);
 
     auto& outInfo = fakeQuantize->output(0).get_rt_info();
     outInfo.emplace(PrecisionsAttribute::get_type_info_static(),
                     PrecisionsAttribute(element::TypeVector{element::u8, element::i8}));
 
-    auto result1 = std::make_shared<opset1::Result>(fakeQuantize);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(fakeQuantize);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -241,27 +241,27 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationFakeQuantizeDecompositionTransf
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationGroupConvolutionTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 2 * 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 2 * 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto weights = opset1::Constant::create(element::i8, {6, 3, 7, 7}, {2});
-    auto convertOnWeights = std::make_shared<opset1::Convert>(weights, element::f32);
+    auto weights = ov::op::v0::Constant::create(element::i8, {6, 3, 7, 7}, {2});
+    auto convertOnWeights = std::make_shared<ov::op::v0::Convert>(weights, element::f32);
     auto mulOnWeights =
-        std::make_shared<opset1::Multiply>(convertOnWeights, opset1::Constant::create(element::f32, {}, {4.f}));
-    auto reshapeConst = opset1::Constant::create(element::i32, {5}, {2, 3, 3, 7, 7});
-    auto reshapeOnWeights = std::make_shared<opset1::Reshape>(mulOnWeights, reshapeConst, true);
+        std::make_shared<ov::op::v1::Multiply>(convertOnWeights, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
+    auto reshapeConst = ov::op::v0::Constant::create(element::i32, {5}, {2, 3, 3, 7, 7});
+    auto reshapeOnWeights = std::make_shared<ov::op::v1::Reshape>(mulOnWeights, reshapeConst, true);
 
-    auto groupConvolution = std::make_shared<opset1::GroupConvolution>(mul,
+    auto groupConvolution = std::make_shared<ov::op::v1::GroupConvolution>(mul,
                                                                        reshapeOnWeights,
                                                                        ngraph::Strides{1, 1},
                                                                        ngraph::CoordinateDiff{0, 0},
                                                                        ngraph::CoordinateDiff{0, 0},
                                                                        ngraph::Strides{1, 1});
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(groupConvolution);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(groupConvolution);
 
-    auto result1 = std::make_shared<opset1::Result>(groupConvolution);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(groupConvolution);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -272,11 +272,11 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationGroupConvolutionTransformation)
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationInterpolateTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto outShape = opset1::Constant::create(element::i32, {4}, {1, 3, 18, 18});
+    auto outShape = ov::op::v0::Constant::create(element::i32, {4}, {1, 3, 18, 18});
     op::v0::InterpolateAttrs attributes;
     attributes.align_corners = false;
     attributes.antialias = false;
@@ -284,11 +284,11 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationInterpolateTransformation) {
     attributes.mode = "nearest";
     attributes.pads_begin = {0};
     attributes.pads_end = {0};
-    auto interpolate = std::make_shared<opset1::Interpolate>(mul, outShape, attributes);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(interpolate);
+    auto interpolate = std::make_shared<ov::op::v0::Interpolate>(mul, outShape, attributes);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(interpolate);
 
-    auto result1 = std::make_shared<opset1::Result>(interpolate);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(interpolate);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -300,20 +300,20 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationInterpolateTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationMatMulTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 1024});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 1024});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto weights = opset1::Constant::create(element::i8, {2048, 1024}, {3});
-    auto convertOnWeights = std::make_shared<opset1::Convert>(weights, element::f32);
+    auto weights = ov::op::v0::Constant::create(element::i8, {2048, 1024}, {3});
+    auto convertOnWeights = std::make_shared<ov::op::v0::Convert>(weights, element::f32);
     auto mulOnWeights =
-        std::make_shared<opset1::Multiply>(convertOnWeights, opset1::Constant::create(element::f32, {}, {4.f}));
+        std::make_shared<ov::op::v1::Multiply>(convertOnWeights, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
 
-    auto matmul = std::make_shared<opset1::MatMul>(mul, mulOnWeights, false, true);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(matmul);
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(mul, mulOnWeights, false, true);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(matmul);
 
-    auto result1 = std::make_shared<opset1::Result>(matmul);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(matmul);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -324,15 +324,15 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationMatMulTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationMaxPoolTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto maxPool = std::make_shared<opset1::MaxPool>(mul, Strides{1, 1}, Shape{1, 1}, Shape{0, 0}, Shape{2, 2});
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(maxPool);
+    auto maxPool = std::make_shared<ov::op::v1::MaxPool>(mul, Strides{1, 1}, Shape{1, 1}, Shape{0, 0}, Shape{2, 2});
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(maxPool);
 
-    auto result1 = std::make_shared<opset1::Result>(maxPool);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(maxPool);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -343,20 +343,20 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationMaxPoolTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationMultiplyTransformation) {
-    auto input1 = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto input2 = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto input1 = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto input2 = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
 
-    auto convert1 = std::make_shared<opset1::Convert>(input1, element::f32);
-    auto convert2 = std::make_shared<opset1::Convert>(input2, element::f32);
+    auto convert1 = std::make_shared<ov::op::v0::Convert>(input1, element::f32);
+    auto convert2 = std::make_shared<ov::op::v0::Convert>(input2, element::f32);
 
-    auto mul1 = std::make_shared<opset1::Multiply>(convert1, opset1::Constant::create(element::f32, {}, {2.f}));
-    auto mul2 = std::make_shared<opset1::Multiply>(convert2, opset1::Constant::create(element::f32, {}, {4.f}));
+    auto mul1 = std::make_shared<ov::op::v1::Multiply>(convert1, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
+    auto mul2 = std::make_shared<ov::op::v1::Multiply>(convert2, ov::op::v0::Constant::create(element::f32, {}, {4.f}));
 
-    auto mul = std::make_shared<opset1::Multiply>(mul1, mul2);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(mul);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(mul1, mul2);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(mul);
 
-    auto result1 = std::make_shared<opset1::Result>(mul);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(mul);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input1, input2});
     pass::Manager m;
@@ -368,15 +368,15 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationMultiplyTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationMVNTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
     auto MVN = std::make_shared<ov::op::TypeRelaxed<op::v0::MVN>>(mul);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(MVN);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(MVN);
 
-    auto result1 = std::make_shared<opset1::Result>(MVN);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(MVN);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -388,16 +388,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationMVNTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationNormalizeL2Transformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axes = opset1::Constant::create(element::i32, {2}, {2, 3});
-    auto normalize = std::make_shared<opset1::NormalizeL2>(mul, axes, 0.01f, ov::op::EpsMode::ADD);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(normalize);
+    auto axes = ov::op::v0::Constant::create(element::i32, {2}, {2, 3});
+    auto normalize = std::make_shared<ov::op::v0::NormalizeL2>(mul, axes, 0.01f, ov::op::EpsMode::ADD);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(normalize);
 
-    auto result1 = std::make_shared<opset1::Result>(normalize);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(normalize);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -409,17 +409,17 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationNormalizeL2Transformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationPadTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto pads_begin = opset1::Constant::create(element::i32, {4}, {0, 0, 1, 1});
-    auto pads_end = opset1::Constant::create(element::i32, {4}, {0, 0, 1, 1});
-    auto pad = std::make_shared<opset1::Pad>(mul, pads_begin, pads_end, op::PadMode::CONSTANT);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(pad);
+    auto pads_begin = ov::op::v0::Constant::create(element::i32, {4}, {0, 0, 1, 1});
+    auto pads_end = ov::op::v0::Constant::create(element::i32, {4}, {0, 0, 1, 1});
+    auto pad = std::make_shared<ov::op::v1::Pad>(mul, pads_begin, pads_end, op::PadMode::CONSTANT);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(pad);
 
-    auto result1 = std::make_shared<opset1::Result>(pad);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(pad);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -431,16 +431,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationPadTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationPReluTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto slope = opset1::Constant::create(element::f32, {1, 3, 1, 1}, {0.01f});
-    auto prelu = std::make_shared<opset1::PRelu>(mul, slope);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(prelu);
+    auto slope = ov::op::v0::Constant::create(element::f32, {1, 3, 1, 1}, {0.01f});
+    auto prelu = std::make_shared<ov::op::v0::PRelu>(mul, slope);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(prelu);
 
-    auto result1 = std::make_shared<opset1::Result>(prelu);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(prelu);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -452,16 +452,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationPReluTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMaxTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axes = opset1::Constant::create(element::i32, {2}, {2, 3});
-    auto reduce = std::make_shared<opset1::ReduceMax>(mul, axes);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(reduce);
+    auto axes = ov::op::v0::Constant::create(element::i32, {2}, {2, 3});
+    auto reduce = std::make_shared<ov::op::v1::ReduceMax>(mul, axes);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(reduce);
 
-    auto result1 = std::make_shared<opset1::Result>(reduce);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(reduce);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -473,16 +473,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMaxTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMeanTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axes = opset1::Constant::create(element::i32, {2}, {2, 3});
-    auto reduce = std::make_shared<opset1::ReduceMean>(mul, axes);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(reduce);
+    auto axes = ov::op::v0::Constant::create(element::i32, {2}, {2, 3});
+    auto reduce = std::make_shared<ov::op::v1::ReduceMean>(mul, axes);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(reduce);
 
-    auto result1 = std::make_shared<opset1::Result>(reduce);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(reduce);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -494,16 +494,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMeanTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMinTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axes = opset1::Constant::create(element::i32, {2}, {2, 3});
-    auto reduce = std::make_shared<opset1::ReduceMin>(mul, axes);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(reduce);
+    auto axes = ov::op::v0::Constant::create(element::i32, {2}, {2, 3});
+    auto reduce = std::make_shared<ov::op::v1::ReduceMin>(mul, axes);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(reduce);
 
-    auto result1 = std::make_shared<opset1::Result>(reduce);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(reduce);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -515,16 +515,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMinTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceSumTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axes = opset1::Constant::create(element::i32, {2}, {2, 3});
-    auto reduce = std::make_shared<opset1::ReduceSum>(mul, axes);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(reduce);
+    auto axes = ov::op::v0::Constant::create(element::i32, {2}, {2, 3});
+    auto reduce = std::make_shared<ov::op::v1::ReduceSum>(mul, axes);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(reduce);
 
-    auto result1 = std::make_shared<opset1::Result>(reduce);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(reduce);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -536,16 +536,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceSumTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationReshapeTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto outShape = opset1::Constant::create(element::i32, {3}, {1, 3, -1});
-    auto reshape = std::make_shared<opset1::Reshape>(mul, outShape, true);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(reshape);
+    auto outShape = ov::op::v0::Constant::create(element::i32, {3}, {1, 3, -1});
+    auto reshape = std::make_shared<ov::op::v1::Reshape>(mul, outShape, true);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(reshape);
 
-    auto result1 = std::make_shared<opset1::Result>(reshape);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(reshape);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -557,15 +557,15 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReshapeTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationReluTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto relu = std::make_shared<opset1::Relu>(mul);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(relu);
+    auto relu = std::make_shared<ov::op::v0::Relu>(mul);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(relu);
 
-    auto result1 = std::make_shared<opset1::Result>(relu);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(relu);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -577,16 +577,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReluTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationSqueezeTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axes = opset1::Constant::create(element::i32, {1}, {0});
-    auto squeeze = std::make_shared<opset1::Squeeze>(mul, axes);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(squeeze);
+    auto axes = ov::op::v0::Constant::create(element::i32, {1}, {0});
+    auto squeeze = std::make_shared<ov::op::v0::Squeeze>(mul, axes);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(squeeze);
 
-    auto result1 = std::make_shared<opset1::Result>(squeeze);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(squeeze);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -598,18 +598,18 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationSqueezeTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationSplitTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axis = opset1::Constant::create(element::i32, {}, {1});
-    auto split = std::make_shared<opset1::Split>(mul, axis, 3);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(split);
+    auto axis = ov::op::v0::Constant::create(element::i32, {}, {1});
+    auto split = std::make_shared<ov::op::v1::Split>(mul, axis, 3);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(split);
 
-    auto result1 = std::make_shared<opset1::Result>(split->output(0));
-    auto result2 = std::make_shared<opset1::Result>(split->output(1));
-    auto result3 = std::make_shared<opset1::Result>(split->output(2));
-    auto result4 = std::make_shared<opset1::Result>(shapeOf->output(0));
+    auto result1 = std::make_shared<ov::op::v0::Result>(split->output(0));
+    auto result2 = std::make_shared<ov::op::v0::Result>(split->output(1));
+    auto result3 = std::make_shared<ov::op::v0::Result>(split->output(2));
+    auto result4 = std::make_shared<ov::op::v0::Result>(shapeOf->output(0));
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2, result3, result4}, ParameterVector{input});
     pass::Manager m;
@@ -621,15 +621,15 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationSplitTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationShuffleChannelsTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto shuffleChannels = std::make_shared<opset1::ShuffleChannels>(mul);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(shuffleChannels);
+    auto shuffleChannels = std::make_shared<ov::op::v0::ShuffleChannels>(mul);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(shuffleChannels);
 
-    auto result1 = std::make_shared<opset1::Result>(shuffleChannels);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(shuffleChannels);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -641,23 +641,23 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationShuffleChannelsTransformation) 
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationStridedSliceTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
     auto beginParam = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 0, 0, 0});
     auto endParam = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 2, 1, 1});
     auto stridesParam = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 1, 1, 1});
-    auto stridedSlice = std::make_shared<ngraph::opset1::StridedSlice>(mul,
+    auto stridedSlice = std::make_shared<ov::op::v1::StridedSlice>(mul,
                                                                        beginParam,
                                                                        endParam,
                                                                        stridesParam,
                                                                        std::vector<std::int64_t>{1, 0, 1, 1},
                                                                        std::vector<std::int64_t>{1, 0, 1, 1});
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(stridedSlice);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(stridedSlice);
 
-    auto result1 = std::make_shared<opset1::Result>(stridedSlice);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(stridedSlice);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -669,16 +669,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationStridedSliceTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationTransposeTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
     auto constant = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 1, 3, 2});
-    auto transpose = std::make_shared<ngraph::opset1::Transpose>(mul, constant);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(transpose);
+    auto transpose = std::make_shared<ov::op::v1::Transpose>(mul, constant);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(transpose);
 
-    auto result1 = std::make_shared<opset1::Result>(transpose);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(transpose);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -690,16 +690,16 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationTransposeTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationUnsqueezeTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axes = opset1::Constant::create(element::i32, {1}, {3});
-    auto unsqueeze = std::make_shared<opset1::Unsqueeze>(mul, axes);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(unsqueeze);
+    auto axes = ov::op::v0::Constant::create(element::i32, {1}, {3});
+    auto unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(mul, axes);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(unsqueeze);
 
-    auto result1 = std::make_shared<opset1::Result>(unsqueeze);
-    auto result2 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(unsqueeze);
+    auto result2 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2}, ParameterVector{input});
     pass::Manager m;
@@ -711,18 +711,18 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationUnsqueezeTransformation) {
 }
 
 TEST(LPT, AvoidDequantizationToShapeOfPropagationVariadicSplitTransformation) {
-    auto input = std::make_shared<opset1::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
-    auto convert = std::make_shared<opset1::Convert>(input, element::f32);
-    auto mul = std::make_shared<opset1::Multiply>(convert, opset1::Constant::create(element::f32, {}, {2.f}));
+    auto input = std::make_shared<ov::op::v0::Parameter>(element::u8, PartialShape{1, 3, 16, 16});
+    auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(convert, ov::op::v0::Constant::create(element::f32, {}, {2.f}));
 
-    auto axis = opset1::Constant::create(element::i32, {}, {1});
-    auto lengths = opset1::Constant::create(element::i32, {2}, {1, 2});
-    auto variadicSplit = std::make_shared<opset1::VariadicSplit>(mul, axis, lengths);
-    auto shapeOf = std::make_shared<opset1::ShapeOf>(variadicSplit->output(0));
+    auto axis = ov::op::v0::Constant::create(element::i32, {}, {1});
+    auto lengths = ov::op::v0::Constant::create(element::i32, {2}, {1, 2});
+    auto variadicSplit = std::make_shared<ov::op::v1::VariadicSplit>(mul, axis, lengths);
+    auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(variadicSplit->output(0));
 
-    auto result1 = std::make_shared<opset1::Result>(variadicSplit->output(0));
-    auto result2 = std::make_shared<opset1::Result>(variadicSplit->output(1));
-    auto result3 = std::make_shared<opset1::Result>(shapeOf);
+    auto result1 = std::make_shared<ov::op::v0::Result>(variadicSplit->output(0));
+    auto result2 = std::make_shared<ov::op::v0::Result>(variadicSplit->output(1));
+    auto result3 = std::make_shared<ov::op::v0::Result>(shapeOf);
 
     auto f = std::make_shared<Function>(ResultVector{result1, result2, result3}, ParameterVector{input});
     pass::Manager m;

--- a/src/common/low_precision_transformations/tests/lpt_public_methods_test.cpp
+++ b/src/common/low_precision_transformations/tests/lpt_public_methods_test.cpp
@@ -14,7 +14,7 @@
 
 using namespace testing;
 using namespace ngraph;
-using namespace ngraph::pass;
+using namespace ov::pass;
 
 // TODO: LPT: not implemented
 TEST(DISABLED_LPT, isQuantizedTransformation) {

--- a/src/common/low_precision_transformations/tests/lpt_public_methods_test.cpp
+++ b/src/common/low_precision_transformations/tests/lpt_public_methods_test.cpp
@@ -18,11 +18,11 @@ using namespace ov::pass;
 
 // TODO: LPT: not implemented
 TEST(DISABLED_LPT, isQuantizedTransformation) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{ 1, 3, 16, 16 });
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{ 1, 3, 16, 16 });
     const auto mulConst = op::v0::Constant::create(element::f32, Shape{}, { 1.f });
-    const auto mul = std::make_shared<ngraph::opset1::Multiply>(input, mulConst);
+    const auto mul = std::make_shared<ov::op::v1::Multiply>(input, mulConst);
     const auto shapeConst = op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 1, 3, 16, 16 });
-    const auto layer = std::make_shared<opset1::Reshape>(mul, shapeConst, true);
+    const auto layer = std::make_shared<ov::op::v1::Reshape>(mul, shapeConst, true);
 
     // TODO: FIXME
     EXPECT_EQ(1, 0);

--- a/src/common/low_precision_transformations/tests/markup_avg_pool_precisions_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/markup_avg_pool_precisions_transformation.cpp
@@ -132,7 +132,7 @@ TEST_P(MarkupAvgPoolPrecisionsTransformation, CompareFunctions) {
     ov::pass::InitNodeInfo().run_on_model(actualFunction);
     actualFunction->validate_nodes_and_infer_types();
 
-    const auto avgPoolOperations = LayerTransformation::get<ov::opset1::AvgPool>(actualFunction);
+    const auto avgPoolOperations = LayerTransformation::get<ov::op::v1::AvgPool>(actualFunction);
     ASSERT_EQ(1ul, avgPoolOperations.size()) << "unexpected avgPoolOperations size: " << avgPoolOperations.size();
 
     {
@@ -142,7 +142,7 @@ TEST_P(MarkupAvgPoolPrecisionsTransformation, CompareFunctions) {
         ASSERT_EQ(true, avgPoolPrecisioinPreservedAttribute.as<AvgPoolPrecisionPreservedAttribute>().value());
     }
 
-    const auto precisionPreserved = LayerTransformation::get<ov::opset1::MaxPool>(actualFunction);
+    const auto precisionPreserved = LayerTransformation::get<ov::op::v1::MaxPool>(actualFunction);
     ASSERT_TRUE(checkIfAttributesAreTheSame<AvgPoolPrecisionPreservedAttribute>(precisionPreserved))
         << "AvgPoolPrecisionPreservedAttribute are not the same";
 

--- a/src/common/low_precision_transformations/tests/markup_bias_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/markup_bias_transformation.cpp
@@ -58,7 +58,7 @@ protected:
 TEST_P(MarkupBiasTests, CompareFunctions) {
     actualFunction->validate_nodes_and_infer_types();
 
-    const auto addOps = LayerTransformation::get<opset1::Add>(actualFunction);
+    const auto addOps = LayerTransformation::get<ov::op::v1::Add>(actualFunction);
     EXPECT_EQ(1ul, addOps.size()) << "unexpected addOps size";
 
     const bool is_bias = std::get<1>(GetParam()).is_bias;

--- a/src/common/low_precision_transformations/tests/max_pool_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/max_pool_transformation.cpp
@@ -64,7 +64,7 @@ public:
             testValues.actual.dequantization2);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ngraph::opset1::MaxPool>(testValues.params);
+        transform.add<ngraph::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::MaxPoolFunction::get(

--- a/src/common/low_precision_transformations/tests/move_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/move_fake_quantize_transformation.cpp
@@ -139,10 +139,10 @@ public:
                 {{{0}, testValues.params.precisionsOnActivations}})});
 
         auto quantizationRestrictions =
-            testValues.multiChannels ? std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>()
-                                     : std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>(
-                                           {ngraph::pass::low_precision::QuantizationGranularityRestriction::create<
-                                               ov::op::v1::AvgPool>()});
+            testValues.multiChannels
+                ? std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>()
+                : std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>(
+                      {ngraph::pass::low_precision::QuantizationGranularityRestriction::create<ov::op::v1::AvgPool>()});
 
         const auto params = TestTransformationParams::toParams(testValues.params);
         ov::pass::Manager manager;

--- a/src/common/low_precision_transformations/tests/move_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/move_fake_quantize_transformation.cpp
@@ -135,14 +135,14 @@ public:
                                                                           oneInputWithSplit);
 
         auto supportedPrecisionsOnActivation = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>(
-            {ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::AvgPool>(
+            {ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::AvgPool>(
                 {{{0}, testValues.params.precisionsOnActivations}})});
 
         auto quantizationRestrictions =
             testValues.multiChannels ? std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>()
                                      : std::vector<ngraph::pass::low_precision::QuantizationGranularityRestriction>(
                                            {ngraph::pass::low_precision::QuantizationGranularityRestriction::create<
-                                               ngraph::opset1::AvgPool>()});
+                                               ov::op::v1::AvgPool>()});
 
         const auto params = TestTransformationParams::toParams(testValues.params);
         ov::pass::Manager manager;
@@ -199,7 +199,7 @@ TEST_P(MoveFakeQuantizeTransformation, CompareFunctions) {
 
     ASSERT_TRUE(LayerTransformation::allNamesAreUnique(actualFunction)) << "Not all names are unique";
 
-    const auto actualFakeQuantizes = LayerTransformation::get<opset1::FakeQuantize>(actualFunction);
+    const auto actualFakeQuantizes = LayerTransformation::get<ov::op::v0::FakeQuantize>(actualFunction);
     ASSERT_TRUE(checkIfOutputAttributesSharedValuesAreTheSame<PrecisionsAttribute>(actualFakeQuantizes))
         << "PrecisionsAttribute are not the same";
 }

--- a/src/common/low_precision_transformations/tests/multiply_to_group_convolution_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/multiply_to_group_convolution_transformation.cpp
@@ -35,8 +35,8 @@ public:
     class Expected {
     public:
         ngraph::element::Type inputPrecision;
-        std::shared_ptr<ngraph::opset1::Constant> weights;
-        std::shared_ptr<ngraph::opset1::Constant> biases;
+        std::shared_ptr<ov::op::v0::Constant> weights;
+        std::shared_ptr<ov::op::v0::Constant> biases;
         ngraph::builder::subgraph::DequantizationOperations dequantization;
     };
 
@@ -62,14 +62,14 @@ public:
             testValues.haveMultiplyWithNoConstBeforeDequantization);
 
         auto precisionRestrictions = std::vector<ngraph::pass::low_precision::PrecisionsRestriction>({
-            ngraph::pass::low_precision::PrecisionsRestriction::create<ngraph::opset1::Multiply>({
+            ngraph::pass::low_precision::PrecisionsRestriction::create<ov::op::v1::Multiply>({
                 {{0}, {ngraph::element::u8}},
                 {{1}, {ngraph::element::i8}}
             })
         });
 
         SimpleLowPrecisionTransformer transformer(precisionRestrictions);
-        transformer.add<ngraph::pass::low_precision::MultiplyToGroupConvolutionTransformation, ngraph::opset1::Multiply>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::MultiplyToGroupConvolutionTransformation, ov::op::v1::Multiply>(testValues.params);
         transformer.transform(actualFunction);
 
         if (testValues.transformed) {
@@ -127,7 +127,7 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
             nullptr,
             {
                 {},
@@ -152,7 +152,7 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
             nullptr,
             {
                 {},
@@ -193,8 +193,8 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1}, std::vector<float>{0.77f, -0.8f, -0.1f, -1.5f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1}, std::vector<float>{0.77f, -0.8f, -0.1f, -1.5f}),
             {
                 {},
                 {},
@@ -218,8 +218,8 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1}, std::vector<float>{0.77f, -0.8f, -0.1f, -1.5f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1}, std::vector<float>{0.77f, -0.8f, -0.1f, -1.5f}),
             {
                 {},
                 {},
@@ -259,8 +259,8 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1}, std::vector<float>{-1.f, -2.f, -3.f, -4.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1}, std::vector<float>{-1.f, -2.f, -3.f, -4.f}),
             {
                 {},
                 {},
@@ -284,8 +284,8 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1}, std::vector<float>{-1.f, -2.f, -3.f, -4.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1}, std::vector<float>{-1.f, -2.f, -3.f, -4.f}),
             {
                 {},
                 {},
@@ -309,8 +309,8 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1, 1}, std::vector<float>{-1.f, -2.f, -3.f, -4.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::f32, Shape{1, 4, 1, 1, 1}, std::vector<float>{-1.f, -2.f, -3.f, -4.f}),
             {
                 {},
                 {},
@@ -382,7 +382,7 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
             nullptr,
             {
                 {},
@@ -406,7 +406,7 @@ const std::vector<MultiplyToGroupConvolutionTransformationTestValues> testValues
         },
         {
             ngraph::element::u8,
-            std::make_shared<ngraph::opset1::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
+            std::make_shared<ov::op::v0::Constant>(ngraph::element::i8, Shape{4, 1, 1, 1, 1}, std::vector<float>{1.f, 1.f, 1.f, 1.f}),
             nullptr,
             {
                 {},

--- a/src/common/low_precision_transformations/tests/multiply_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/multiply_transformation.cpp
@@ -55,7 +55,7 @@ public:
 
         actualFunction = MultiplyFunction::get(precision, testParams.actual);
         SimpleLowPrecisionTransformer transform;
-        transform.add<low_precision::MultiplyTransformation, ngraph::opset1::Multiply>(testParams.transformationParams);
+        transform.add<low_precision::MultiplyTransformation, ov::op::v1::Multiply>(testParams.transformationParams);
         transform.transform(actualFunction);
 
         referenceFunction = MultiplyFunction::get(precision, testParams.expected);

--- a/src/common/low_precision_transformations/tests/mvn_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mvn_transformation.cpp
@@ -73,7 +73,7 @@ public:
             opset_version);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::MVNTransformation, ngraph::opset1::Interpolate>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::MVNTransformation, ov::op::v0::Interpolate>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::MVNFunction::getReference(

--- a/src/common/low_precision_transformations/tests/normalize_l2_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/normalize_l2_transformation.cpp
@@ -70,7 +70,7 @@ public:
             params.actual.dequantization);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<low_precision::NormalizeL2Transformation, ngraph::opset1::NormalizeL2>(params.transformationParams);
+        transform.add<low_precision::NormalizeL2Transformation, ov::op::v0::NormalizeL2>(params.transformationParams);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::NormalizeL2Function::getReference(

--- a/src/common/low_precision_transformations/tests/pad_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/pad_transformation.cpp
@@ -74,7 +74,7 @@ public:
             { {}, {}, {} });
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::PadTransformation, ngraph::opset1::Pad>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::PadTransformation, ov::op::v1::Pad>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::PadFunction::get(

--- a/src/common/low_precision_transformations/tests/prelu_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/prelu_transformation.cpp
@@ -58,7 +58,7 @@ public:
                                                                   testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::PReluTransformation, ngraph::opset1::PRelu>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::PReluTransformation, ov::op::v0::PRelu>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction =

--- a/src/common/low_precision_transformations/tests/reduce_max_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reduce_max_transformation.cpp
@@ -27,13 +27,13 @@ using namespace ngraph;
 using namespace ngraph::pass;
 using namespace ngraph::builder::subgraph;
 
-class ReduceMaxTransformation : public ReduceTransformation<opset1::ReduceMax> {
+class ReduceMaxTransformation : public ReduceTransformation<ov::op::v1::ReduceMax> {
     void SetUp() override {
         ReduceTransformation::SetUp();
         const auto transformationParams = std::get<1>(GetParam()).params;
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ReduceMaxTransformation, ngraph::opset1::ReduceMax>(transformationParams);
+        transform.add<ngraph::pass::low_precision::ReduceMaxTransformation, ov::op::v1::ReduceMax>(transformationParams);
         transform.transform(actualFunction);
     }
 };

--- a/src/common/low_precision_transformations/tests/reduce_mean_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reduce_mean_transformation.cpp
@@ -27,13 +27,13 @@ using namespace ngraph;
 using namespace ngraph::pass;
 using namespace ngraph::builder::subgraph;
 
-class ReduceMeanTransformation : public ReduceTransformation<opset1::ReduceMean> {
+class ReduceMeanTransformation : public ReduceTransformation<ov::op::v1::ReduceMean> {
     void SetUp() override {
         ReduceTransformation::SetUp();
         const auto transformationParams = std::get<1>(GetParam()).params;
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ReduceMeanTransformation, ngraph::opset1::ReduceMean>(transformationParams);
+        transform.add<ngraph::pass::low_precision::ReduceMeanTransformation, ov::op::v1::ReduceMean>(transformationParams);
         transform.transform(actualFunction);
     }
 };

--- a/src/common/low_precision_transformations/tests/reduce_min_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reduce_min_transformation.cpp
@@ -27,13 +27,13 @@ using namespace ngraph;
 using namespace ngraph::pass;
 using namespace ngraph::builder::subgraph;
 
-class ReduceMinTransformation : public ReduceTransformation<opset1::ReduceMin> {
+class ReduceMinTransformation : public ReduceTransformation<ov::op::v1::ReduceMin> {
     void SetUp() override {
         ReduceTransformation::SetUp();
         const auto transformationParams = std::get<1>(GetParam()).params;
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ReduceMinTransformation, ngraph::opset1::ReduceMin>(transformationParams);
+        transform.add<ngraph::pass::low_precision::ReduceMinTransformation, ov::op::v1::ReduceMin>(transformationParams);
         transform.transform(actualFunction);
     }
 };

--- a/src/common/low_precision_transformations/tests/reduce_sum_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reduce_sum_transformation.cpp
@@ -27,13 +27,13 @@ using namespace ngraph;
 using namespace ngraph::pass;
 using namespace ngraph::builder::subgraph;
 
-class ReduceSumTransformation : public ReduceTransformation<opset1::ReduceSum> {
+class ReduceSumTransformation : public ReduceTransformation<ov::op::v1::ReduceSum> {
     void SetUp() override {
         ReduceTransformation::SetUp();
         const auto transformationParams = std::get<1>(GetParam()).params;
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ReduceSumTransformation, ngraph::opset1::ReduceSum>(transformationParams);
+        transform.add<ngraph::pass::low_precision::ReduceSumTransformation, ov::op::v1::ReduceSum>(transformationParams);
         transform.transform(actualFunction);
     }
 };

--- a/src/common/low_precision_transformations/tests/relu_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/relu_transformation.cpp
@@ -62,7 +62,7 @@ public:
             testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::ReluTransformation, ngraph::opset1::Relu>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::ReluTransformation, ov::op::v0::PRelu>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ReluFunction::getReference(

--- a/src/common/low_precision_transformations/tests/reshape_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reshape_transformation.cpp
@@ -59,7 +59,7 @@ public:
                                                                     testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::ReshapeTransformation, ngraph::opset1::Reshape>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::ReshapeTransformation, ov::op::v1::Reshape>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction =

--- a/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
@@ -55,26 +55,26 @@ public:
             const ngraph::element::Type precision,
             const ngraph::Shape& inputShape,
             const ngraph::builder::subgraph::DequantizationOperations& dequantizations) -> std::shared_ptr<ngraph::Function> {
-            const std::shared_ptr<ngraph::opset1::Parameter> input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
-            const auto relu = std::make_shared<ngraph::opset1::Relu>(input);
+            const std::shared_ptr<ov::op::v0::Parameter> input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
+            const auto relu = std::make_shared<ov::op::v0::Relu>(input);
             const auto dequantizationsNode = ngraph::builder::subgraph::makeDequantization(relu, dequantizations);
 
-            const std::shared_ptr<ngraph::Node> reshape1 = std::make_shared<ngraph::opset1::Reshape>(
+            const std::shared_ptr<ngraph::Node> reshape1 = std::make_shared<ov::op::v1::Reshape>(
                 dequantizationsNode,
-                std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
+                std::make_shared<ov::op::v0::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
                 true);
             reshape1->set_friendly_name("reshape1");
 
-            const std::shared_ptr<ngraph::Node> reshape2 = std::make_shared<ngraph::opset1::Reshape>(
+            const std::shared_ptr<ngraph::Node> reshape2 = std::make_shared<ov::op::v1::Reshape>(
                 dequantizationsNode,
-                std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
+                std::make_shared<ov::op::v0::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
                 true);
             reshape2->set_friendly_name("reshape2");
 
             return std::make_shared<ngraph::Function>(
                 ngraph::ResultVector{
-                    std::make_shared<ngraph::opset1::Result>(reshape1),
-                    std::make_shared<ngraph::opset1::Result>(reshape2)
+                    std::make_shared<ov::op::v0::Result>(reshape1),
+                    std::make_shared<ov::op::v0::Result>(reshape2)
                 },
                 std::vector<std::shared_ptr<ngraph::op::Parameter>> { input },
                 "SeparateInStandaloneBranchTransformation");
@@ -87,25 +87,25 @@ public:
             const ngraph::element::Type precision,
             const ngraph::Shape& inputShape,
             const ngraph::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ngraph::Function> {
-            const std::shared_ptr<ngraph::opset1::Parameter> input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
-            const auto relu = std::make_shared<ngraph::opset1::Relu>(input);
+            const std::shared_ptr<ov::op::v0::Parameter> input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
+            const auto relu = std::make_shared<ov::op::v0::Relu>(input);
 
-            const std::shared_ptr<ngraph::Node> reshape1 = std::make_shared<ngraph::opset1::Reshape>(
+            const std::shared_ptr<ngraph::Node> reshape1 = std::make_shared<ov::op::v1::Reshape>(
                 ngraph::builder::subgraph::makeDequantization(relu, dequantization),
-                std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
+                std::make_shared<ov::op::v0::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
                 true);
             reshape1->set_friendly_name("reshape1");
 
-            const std::shared_ptr<ngraph::Node> reshape2 = std::make_shared<ngraph::opset1::Reshape>(
+            const std::shared_ptr<ngraph::Node> reshape2 = std::make_shared<ov::op::v1::Reshape>(
                 ngraph::builder::subgraph::makeDequantization(relu, dequantization),
-                std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
+                std::make_shared<ov::op::v0::Constant>(ngraph::element::i32, ngraph::Shape{ 2 }, std::vector<double>({0, -1})),
                 true);
             reshape2->set_friendly_name("reshape2");
 
             return std::make_shared<ngraph::Function>(
                 ngraph::ResultVector{
-                    std::make_shared<ngraph::opset1::Result>(reshape1),
-                    std::make_shared<ngraph::opset1::Result>(reshape2)
+                    std::make_shared<ov::op::v0::Result>(reshape1),
+                    std::make_shared<ov::op::v0::Result>(reshape2)
                 },
                 std::vector<std::shared_ptr<ngraph::op::Parameter>> { input },
                 "SeparateInStandaloneBranchTransformation");

--- a/src/common/low_precision_transformations/tests/shuffle_channels_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/shuffle_channels_transformation.cpp
@@ -64,7 +64,7 @@ public:
             testValues.group);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::ShuffleChannelsTransformation, ngraph::opset1::ShuffleChannels>(testValues.params);
+        transform.add<ngraph::pass::low_precision::ShuffleChannelsTransformation, ov::op::v0::ShuffleChannels>(testValues.params);
         transform.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::ShuffleChannelsFunction::getReference(

--- a/src/common/low_precision_transformations/tests/split_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/split_transformation.cpp
@@ -61,7 +61,7 @@ public:
                                                                   testValues.numSplits);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::SplitTransformation, ngraph::opset1::Split>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::SplitTransformation, ov::op::v1::Split>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction =

--- a/src/common/low_precision_transformations/tests/squeeze_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/squeeze_transformation.cpp
@@ -59,7 +59,7 @@ public:
             testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::SqueezeTransformation, ngraph::opset1::Squeeze>(testValues.params);
+        transform.add<ngraph::pass::low_precision::SqueezeTransformation, ov::op::v0::Squeeze>(testValues.params);
 
         transform.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/strided_slice_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/strided_slice_transformation.cpp
@@ -83,7 +83,7 @@ public:
             testValues.layerParams.elipsisMask);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::StridedSliceTransformation, ngraph::opset1::StridedSlice>(testValues.params);
+        transformer.add<ngraph::pass::low_precision::StridedSliceTransformation, ov::op::v1::StridedSlice>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::StridedSliceFunction::getReference(

--- a/src/common/low_precision_transformations/tests/subgraph/src/fq_decomposition_with_shared_constants.cpp
+++ b/src/common/low_precision_transformations/tests/subgraph/src/fq_decomposition_with_shared_constants.cpp
@@ -30,33 +30,33 @@ public:
         const auto input_precision = ngraph::element::f32;
 
         {
-            auto input = std::make_shared<opset1::Parameter>(input_precision, shape);
-            auto shared_il = opset1::Constant::create(input_precision, {}, {0.f});
-            auto shared_ih = opset1::Constant::create(input_precision, {}, {25.5f});
-            auto shared_ol = opset1::Constant::create(input_precision, {}, {0.f});
-            auto shared_oh = opset1::Constant::create(input_precision, {}, {25.5f});
+            auto input = std::make_shared<ov::op::v0::Parameter>(input_precision, shape);
+            auto shared_il = ov::op::v0::Constant::create(input_precision, {}, {0.f});
+            auto shared_ih = ov::op::v0::Constant::create(input_precision, {}, {25.5f});
+            auto shared_ol = ov::op::v0::Constant::create(input_precision, {}, {0.f});
+            auto shared_oh = ov::op::v0::Constant::create(input_precision, {}, {25.5f});
             auto fq_before =
-                std::make_shared<opset1::FakeQuantize>(input, shared_il, shared_ih, shared_ol, shared_oh, 256);
+                std::make_shared<ov::op::v0::FakeQuantize>(input, shared_il, shared_ih, shared_ol, shared_oh, 256);
             auto fq_after =
-                std::make_shared<opset1::FakeQuantize>(fq_before, shared_il, shared_ih, shared_ol, shared_oh, 256);
-            auto relu = std::make_shared<opset1::Relu>(fq_after);
+                std::make_shared<ov::op::v0::FakeQuantize>(fq_before, shared_il, shared_ih, shared_ol, shared_oh, 256);
+            auto relu = std::make_shared<ov::op::v0::Relu>(fq_after);
             if (addIntervalsAlignment) {
                 addAttributes(
                     {fq_before, fq_after},
                     {IntervalsAlignmentAttribute(IntervalsAlignmentSharedValue::Interval{0.f, 2.55f}, 256ul)});
                 addAttributes({fq_after, relu}, {QuantizationAlignmentAttribute(true)});
             }
-            ResultVector results{std::make_shared<opset1::Result>(relu)};
+            ResultVector results{std::make_shared<ov::op::v0::Result>(relu)};
             actualFunction = std::make_shared<Function>(results, ParameterVector{input}, "FakeQuantizeFunction");
         }
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<pass::low_precision::FakeQuantizeDecompositionTransformation, opset1::FakeQuantize>(
+        transform.add<pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(
             LayerTransformation::createParamsU8I8());
         transform.transform(actualFunction);
 
         {
-            auto input = std::make_shared<opset1::Parameter>(input_precision, shape);
+            auto input = std::make_shared<ov::op::v0::Parameter>(input_precision, shape);
             auto fqStructure =
                 FakeQuantizeOnData{256ul, Shape({}), {0.f}, {25.5f}, {0.f}, {255.f}, ngraph::element::u8};
             auto deqStructure = DequantizationOperations{{element::f32}, {}, {0.1f}};
@@ -64,8 +64,8 @@ public:
             auto dq_before = makeDequantization(fq_before, deqStructure);
             auto fq_after = makeFakeQuantizeTypeRelaxed(dq_before, input_precision, fqStructure);
             auto dq_after = makeDequantization(fq_after, deqStructure);
-            auto relu = std::make_shared<opset1::Relu>(dq_after);
-            ResultVector results{std::make_shared<opset1::Result>(relu)};
+            auto relu = std::make_shared<ov::op::v0::Relu>(dq_after);
+            ResultVector results{std::make_shared<ov::op::v0::Result>(relu)};
             referenceFunction = std::make_shared<Function>(results, ParameterVector{input}, "FakeQuantizeFunction");
         }
     }
@@ -88,7 +88,7 @@ TEST_P(FQDecompositionWithSharedConstants, FQDecompositionWithSharedConstants) {
 
     // additional check: FQ constants after transformation mustn't be shared
     for (const auto& n : actualFunction->get_ordered_ops()) {
-        if (ov::is_type<opset1::Constant>(n)) {
+        if (ov::is_type<ov::op::v0::Constant>(n)) {
             EXPECT_EQ(n->get_output_target_inputs(0).size(), 1);
         }
     }

--- a/src/common/low_precision_transformations/tests/transformations_after_split_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/transformations_after_split_transformation.cpp
@@ -56,43 +56,43 @@ void getTransformerWithTransformationByName(
     using namespace pass::low_precision;
 
     if (name == "AddTransformationWithoutConcat" || name == "AddTransformationWithConcat") {
-        transformer.add<AddTransformation, ngraph::opset1::Add>(params);
+        transformer.add<AddTransformation, ov::op::v1::Add>(params);
         return;
     }
     if (name == "AvgPoolTransformation") {
-        transformer.add<AvgPoolTransformation, opset1::AvgPool>(params);
+        transformer.add<AvgPoolTransformation, ov::op::v1::AvgPool>(params);
         return;
     }
     if (name == "ClampTransformation") {
-        transformer.add<ClampTransformation, opset1::Clamp>(params);
+        transformer.add<ClampTransformation, ov::op::v0::Clamp>(params);
         return;
     }
     if (name == "ConvolutionTransformation" || name == "AsymmetricConvolutionTransformation") {
-        transformer.add<ConvolutionTransformation, opset1::Convolution>(params);
+        transformer.add<ConvolutionTransformation, ov::op::v1::Convolution>(params);
         return;
     }
     if (name == "DepthToSpaceTransformation") {
-        transformer.add<DepthToSpaceTransformation, opset1::DepthToSpace>(params);
+        transformer.add<DepthToSpaceTransformation, ov::op::v0::DepthToSpace>(params);
         return;
     }
     if (name == "FakeQuantizeTransformation") {
-        transformer.add<FakeQuantizeTransformation, opset1::FakeQuantize>(params);
+        transformer.add<FakeQuantizeTransformation, ov::op::v0::FakeQuantize>(params);
         return;
     }
     if (name == "InterpolateTransformation") {
-        transformer.add<InterpolateTransformation, ngraph::opset1::Interpolate>(params);
+        transformer.add<InterpolateTransformation, ov::op::v0::Interpolate>(params);
         return;
     }
     if (name == "MatMulTransformation") {
-        transformer.add<MatMulTransformation, ngraph::opset1::MatMul>(params);
+        transformer.add<MatMulTransformation, ov::op::v0::MatMul>(params);
         return;
     }
     if (name == "MaxPoolTransformation") {
-        transformer.add<MaxPoolTransformation, ngraph::opset1::MaxPool>(params);
+        transformer.add<MaxPoolTransformation, ov::op::v1::MaxPool>(params);
         return;
     }
     if (name == "MultiplyTransformation") {
-        transformer.add<MultiplyTransformation, ngraph::opset1::Multiply>(params);
+        transformer.add<MultiplyTransformation, ov::op::v1::Multiply>(params);
         return;
     }
     if (name == "MVNTransformation") {
@@ -100,51 +100,51 @@ void getTransformerWithTransformationByName(
         return;
     }
     if (name == "NormalizeL2Transformation") {
-        transformer.add<NormalizeL2Transformation, ngraph::opset1::NormalizeL2>(params);
+        transformer.add<NormalizeL2Transformation, ov::op::v0::NormalizeL2>(params);
         return;
     }
     if (name == "PReluTransformation") {
-        transformer.add<PReluTransformation, ngraph::opset1::PRelu>(params);
+        transformer.add<PReluTransformation, ov::op::v0::PRelu>(params);
         return;
     }
     if (name == "ReluTransformation") {
-        transformer.add<ReluTransformation, ngraph::opset1::Relu>(params);
+        transformer.add<ReluTransformation, ov::op::v0::PRelu>(params);
         return;
     }
     if (name == "ReshapeTransformation") {
-        transformer.add<ReshapeTransformation, ngraph::opset1::Reshape>(params);
+        transformer.add<ReshapeTransformation, ov::op::v1::Reshape>(params);
         return;
     }
     if (name == "SqueezeTransformation") {
-        transformer.add<SqueezeTransformation, ngraph::opset1::Squeeze>(params);
+        transformer.add<SqueezeTransformation, ov::op::v0::Squeeze>(params);
         return;
     }
     if (name == "StridedSliceTransformation") {
-        transformer.add<StridedSliceTransformation, ngraph::opset1::StridedSlice>(params);
+        transformer.add<StridedSliceTransformation, ov::op::v1::StridedSlice>(params);
         return;
     }
     if (name == "TransposeTransformation") {
-        transformer.add<TransposeTransformation, ngraph::opset1::Transpose>(params);
+        transformer.add<TransposeTransformation, ov::op::v1::Transpose>(params);
         return;
     }
     if (name == "UnsqueezeTransformation") {
-        transformer.add<UnsqueezeTransformation, ngraph::opset1::Unsqueeze>(params);
+        transformer.add<UnsqueezeTransformation, ov::op::v0::Unsqueeze>(params);
         return;
     }
     if (name == "FuseConvertTransformation") {
-        transformer.add<FuseConvertTransformation, ngraph::opset1::Multiply>(params);
+        transformer.add<FuseConvertTransformation, ov::op::v1::Multiply>(params);
         return;
     }
     if (name == "FuseSubtractToFakeQuantizeTransformation") {
-        transformer.add<FuseSubtractToFakeQuantizeTransformation, ngraph::opset1::Subtract>(params);
+        transformer.add<FuseSubtractToFakeQuantizeTransformation, ov::op::v1::Subtract>(params);
         return;
     }
     if (name == "FuseMultiplyToFakeQuantizeTransformation") {
-        transformer.add<FuseMultiplyToFakeQuantizeTransformation, ngraph::opset1::Multiply>(params);
+        transformer.add<FuseMultiplyToFakeQuantizeTransformation, ov::op::v1::Multiply>(params);
         return;
     }
     if (name == "MultiplyToGroupConvolutionTransformation") {
-        transformer.add<MultiplyToGroupConvolutionTransformation, ngraph::opset1::Multiply>(params);
+        transformer.add<MultiplyToGroupConvolutionTransformation, ov::op::v1::Multiply>(params);
         return;
     }
     throw std::runtime_error("unexpected transformation name");

--- a/src/common/low_precision_transformations/tests/transpose_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/transpose_transformation.cpp
@@ -60,7 +60,7 @@ public:
                                                                       testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::TransposeTransformation, ngraph::opset1::Transpose>(
+        transformer.add<ngraph::pass::low_precision::TransposeTransformation, ov::op::v1::Transpose>(
             testValues.params);
         transformer.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/transpose_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/transpose_transformation.cpp
@@ -60,8 +60,7 @@ public:
                                                                       testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::TransposeTransformation, ov::op::v1::Transpose>(
-            testValues.params);
+        transformer.add<ngraph::pass::low_precision::TransposeTransformation, ov::op::v1::Transpose>(testValues.params);
         transformer.transform(actualFunction);
 
         referenceFunction = ngraph::builder::subgraph::TransposeFunction::getReference(

--- a/src/common/low_precision_transformations/tests/unit/get_data_precision.cpp
+++ b/src/common/low_precision_transformations/tests/unit/get_data_precision.cpp
@@ -12,10 +12,10 @@
 using namespace ngraph;
 
 TEST(LPT_GetDataPrecision, getDataPrecision_reqU8_U8_to_U8) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 299, 299});
-    const auto low = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
-    const auto high = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{2.55f});
-    const auto fakeQuantize = std::make_shared<opset1::FakeQuantize>(input, low, high, low, high, 256);
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 299, 299});
+    const auto low = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
+    const auto high = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{2.55f});
+    const auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, low, high, low, high, 256);
 
     auto const dequantization = pass::low_precision::QuantizationDetails::getDetails(fakeQuantize);
 
@@ -28,10 +28,10 @@ TEST(LPT_GetDataPrecision, getDataPrecision_reqU8_U8_to_U8) {
 }
 
 TEST(LPT_GetDataPrecision, getDataPrecision_reqI8_I8_to_I8) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 299, 299});
-    const auto low = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{-1.28f});
-    const auto high = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{1.27f});
-    const auto fakeQuantize = std::make_shared<opset1::FakeQuantize>(input, low, high, low, high, 256);
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 299, 299});
+    const auto low = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{-1.28f});
+    const auto high = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{1.27f});
+    const auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, low, high, low, high, 256);
 
     auto const dequantization = pass::low_precision::QuantizationDetails::getDetails(fakeQuantize);
 
@@ -45,10 +45,10 @@ TEST(LPT_GetDataPrecision, getDataPrecision_reqI8_I8_to_I8) {
 }
 
 TEST(LPT_GetDataPrecision, getDataPrecision_reqU8_I8_to_U8zp) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 299, 299});
-    const auto low = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{-1.28f});
-    const auto high = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{1.27f});
-    const auto fakeQuantize = std::make_shared<opset1::FakeQuantize>(input, low, high, low, high, 256);
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 299, 299});
+    const auto low = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{-1.28f});
+    const auto high = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{1.27f});
+    const auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, low, high, low, high, 256);
 
     auto const dequantization = pass::low_precision::QuantizationDetails::getDetails(fakeQuantize);
 
@@ -61,10 +61,10 @@ TEST(LPT_GetDataPrecision, getDataPrecision_reqU8_I8_to_U8zp) {
 }
 
 TEST(LPT_GetDataPrecision, getDataPrecision_reqI8_U8_to_I8zp) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 299, 299});
-    const auto low = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
-    const auto high = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{2.55f});
-    const auto fakeQuantize = std::make_shared<opset1::FakeQuantize>(input, low, high, low, high, 256);
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 299, 299});
+    const auto low = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{0.f});
+    const auto high = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{2.55f});
+    const auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, low, high, low, high, 256);
 
     auto const dequantization = pass::low_precision::QuantizationDetails::getDetails(fakeQuantize);
 
@@ -77,10 +77,10 @@ TEST(LPT_GetDataPrecision, getDataPrecision_reqI8_U8_to_I8zp) {
 }
 
 TEST(LPT_GetDataPrecision, getDataPrecision_reqU8_I8zp_to_U8zp) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 299, 299});
-    const auto low = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{-0.875227511f});
-    const auto high = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.882119000f});
-    const auto fakeQuantize = std::make_shared<opset1::FakeQuantize>(input, low, high, low, high, 256);
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 299, 299});
+    const auto low = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{-0.875227511f});
+    const auto high = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{0.882119000f});
+    const auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, low, high, low, high, 256);
 
     auto const dequantization = pass::low_precision::QuantizationDetails::getDetails(fakeQuantize);
 
@@ -93,10 +93,10 @@ TEST(LPT_GetDataPrecision, getDataPrecision_reqU8_I8zp_to_U8zp) {
 }
 
 TEST(LPT_GetDataPrecision, getDataPrecision_reqI8_U8zp_to_I8zp) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 299, 299});
-    const auto low = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.875227511f});
-    const auto high = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.882119000f});
-    const auto fakeQuantize = std::make_shared<opset1::FakeQuantize>(input, low, high, low, high, 256);
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 299, 299});
+    const auto low = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{0.875227511f});
+    const auto high = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{0.882119000f});
+    const auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, low, high, low, high, 256);
 
     auto const dequantization = pass::low_precision::QuantizationDetails::getDetails(fakeQuantize);
 
@@ -109,10 +109,10 @@ TEST(LPT_GetDataPrecision, getDataPrecision_reqI8_U8zp_to_I8zp) {
 }
 
 TEST(LPT_GetDataPrecision, getDataPrecision_reqNone_I8zp_to_undefzp) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 299, 299});
-    const auto low = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{-0.875227511f});
-    const auto high = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.882119000f});
-    const auto fakeQuantize = std::make_shared<opset1::FakeQuantize>(input, low, high, low, high, 256);
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 299, 299});
+    const auto low = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{-0.875227511f});
+    const auto high = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{0.882119000f});
+    const auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, low, high, low, high, 256);
 
     auto const dequantization = pass::low_precision::QuantizationDetails::getDetails(fakeQuantize);
 
@@ -125,10 +125,10 @@ TEST(LPT_GetDataPrecision, getDataPrecision_reqNone_I8zp_to_undefzp) {
 }
 
 TEST(LPT_GetDataPrecision, getDataPrecision_reqNone_U8zp_to_undefzp) {
-    const auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 3, 299, 299});
-    const auto low = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.875227511f});
-    const auto high = std::make_shared<opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.882119000f});
-    const auto fakeQuantize = std::make_shared<opset1::FakeQuantize>(input, low, high, low, high, 256);
+    const auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 299, 299});
+    const auto low = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{0.875227511f});
+    const auto high = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{0.882119000f});
+    const auto fakeQuantize = std::make_shared<ov::op::v0::FakeQuantize>(input, low, high, low, high, 256);
 
     auto const dequantization = pass::low_precision::QuantizationDetails::getDetails(fakeQuantize);
 

--- a/src/common/low_precision_transformations/tests/unsqueeze_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/unsqueeze_transformation.cpp
@@ -59,7 +59,7 @@ public:
             testValues.actual.dequantization);
 
         SimpleLowPrecisionTransformer transform;
-        transform.add<ngraph::pass::low_precision::UnsqueezeTransformation, ngraph::opset1::Unsqueeze>(testValues.params);
+        transform.add<ngraph::pass::low_precision::UnsqueezeTransformation, ov::op::v0::Unsqueeze>(testValues.params);
 
         transform.transform(actualFunction);
 

--- a/src/common/low_precision_transformations/tests/variadic_split_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/variadic_split_transformation.cpp
@@ -58,7 +58,7 @@ public:
             testValues.splitLengths);
 
         SimpleLowPrecisionTransformer transformer;
-        transformer.add<ngraph::pass::low_precision::VariadicSplitTransformation, ngraph::opset1::VariadicSplit>(
+        transformer.add<ngraph::pass::low_precision::VariadicSplitTransformation, ov::op::v1::VariadicSplit>(
             testValues.params);
         transformer.transform(actualFunction);
 

--- a/src/common/transformations/tests/common_optimizations/clamp_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/clamp_fusion.cpp
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, ClampFusion) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto clamp = std::make_shared<opset5::Clamp>(data, 0.1, 5);
         function_ref = std::make_shared<Function>(NodeVector{clamp}, ParameterVector{data});
     }
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, ClampFusionScalars) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto clamp = std::make_shared<opset5::Clamp>(data, 0.1, 5);
         function_ref = std::make_shared<Function>(NodeVector{clamp}, ParameterVector{data});
     }
@@ -94,7 +94,7 @@ TEST_F(TransformationTestsF, ClampFusionMinMax) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto clamp = std::make_shared<opset5::Clamp>(data, 0.1, 5);
         function_ref = std::make_shared<Function>(NodeVector{clamp}, ParameterVector{data});
     }
@@ -113,7 +113,7 @@ TEST_F(TransformationTestsF, ClampFusionMinMaxScalars) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto clamp = std::make_shared<opset5::Clamp>(data, 0.1, 5);
         function_ref = std::make_shared<Function>(NodeVector{clamp}, ParameterVector{data});
     }

--- a/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
@@ -147,25 +147,25 @@ TEST_F(TransformationTestsF, CompressConstants_f32_If) {
                                                                 default_scales_node,
                                                                 axes_node,
                                                                 interpolate4_attr);
-        auto then_op_result = std::make_shared<ngraph::opset1::Result>(resize);
+        auto then_op_result = std::make_shared<ov::op::v0::Result>(resize);
         auto body_then_function =
             std::make_shared<ov::Model>(ov::NodeVector{then_op_result}, ov::ParameterVector{input_then});
 
         // create else body
         auto input_else = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
-        auto else_op_result = std::make_shared<ngraph::opset1::Result>(input_else);
+        auto else_op_result = std::make_shared<ov::op::v0::Result>(input_else);
         auto body_else_function =
             std::make_shared<ov::Model>(ov::NodeVector{else_op_result}, ov::ParameterVector{input_else});
 
         // create main graph
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
-        auto cond = std::make_shared<ngraph::opset1::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
+        auto cond = std::make_shared<ov::op::v0::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
         auto if_op = std::make_shared<ov::opset8::If>(cond);
         if_op->set_then_body(body_then_function);
         if_op->set_else_body(body_else_function);
         if_op->set_input(input, input_then, input_else);
         if_op->set_output(then_op_result, else_op_result);
-        auto if_result = std::make_shared<ngraph::opset1::Result>(if_op);
+        auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{if_result}, ngraph::ParameterVector{input});
 
@@ -212,25 +212,25 @@ TEST_F(TransformationTestsF, CompressConstants_f32_If) {
                                                                 default_scales_node,
                                                                 axes_node,
                                                                 interpolate4_attr);
-        auto then_op_result = std::make_shared<ngraph::opset1::Result>(resize);
+        auto then_op_result = std::make_shared<ov::op::v0::Result>(resize);
         auto body_then_function =
             std::make_shared<ov::Model>(ov::NodeVector{then_op_result}, ov::ParameterVector{input_then});
 
         // create else body
         auto input_else = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
-        auto else_op_result = std::make_shared<ngraph::opset1::Result>(input_else);
+        auto else_op_result = std::make_shared<ov::op::v0::Result>(input_else);
         auto body_else_function =
             std::make_shared<ov::Model>(ov::NodeVector{else_op_result}, ov::ParameterVector{input_else});
 
         // create main graph
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
-        auto cond = std::make_shared<ngraph::opset1::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
+        auto cond = std::make_shared<ov::op::v0::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
         auto if_op = std::make_shared<ov::opset8::If>(cond);
         if_op->set_then_body(body_then_function);
         if_op->set_else_body(body_else_function);
         if_op->set_input(input, input_then, input_else);
         if_op->set_output(then_op_result, else_op_result);
-        auto if_result = std::make_shared<ngraph::opset1::Result>(if_op);
+        auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
         function_ref =
             std::make_shared<ngraph::Function>(ngraph::NodeVector{if_result}, ngraph::ParameterVector{input});

--- a/src/common/transformations/tests/common_optimizations/concat_reduce_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/concat_reduce_fusion.cpp
@@ -13,6 +13,14 @@
 #include <transformations/init_node_info.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/reduce_max.hpp"
+#include "openvino/op/reduce_min.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/squeeze.hpp"
 
 using namespace testing;
 using namespace ov;
@@ -21,28 +29,28 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionDynamicShape) {
     PartialShape shape{-1, -1, -1, -1};
     std::int64_t reduce_axis = 2;
     {
-        auto left_input = std::make_shared<ov::opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        auto concat = std::make_shared<opset8::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
+        auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<opset8::ReduceMax>(concat, opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v1::ReduceMax>(concat, ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto maximum = std::make_shared<opset8::Maximum>(left_input, right_input);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto maximum = std::make_shared<ov::op::v1::Maximum>(left_input, right_input);
         function_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
@@ -51,37 +59,37 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionKeepDimsDynamicShape) {
     PartialShape shape{-1, -1, -1, -1};
     std::int64_t reduce_axis = 2;
     {
-        auto left_input = std::make_shared<ov::opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        auto concat = std::make_shared<opset8::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
+        auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<opset8::ReduceMax>(concat,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}),
+            std::make_shared<ov::op::v1::ReduceMax>(concat,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}),
                                                 true);
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
-        auto left_input = std::make_shared<ov::opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
-        auto maximum = std::make_shared<opset8::Maximum>(left_unsqueeze, right_unsqueeze);
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+        auto maximum = std::make_shared<ov::op::v1::Maximum>(left_unsqueeze, right_unsqueeze);
         function_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
@@ -90,28 +98,28 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionDynamicRank) {
     PartialShape shape = PartialShape::dynamic();
     std::int64_t reduce_axis = 3;
     {
-        auto left_input = std::make_shared<ov::opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        auto concat = std::make_shared<opset8::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
+        auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<opset8::ReduceMax>(concat, opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v1::ReduceMax>(concat, ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto maximum = std::make_shared<opset8::Maximum>(left_input, right_input);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto maximum = std::make_shared<ov::op::v1::Maximum>(left_input, right_input);
         function_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
@@ -120,28 +128,28 @@ TEST_F(TransformationTestsF, ConcatReduceMinFusionDynamicShape) {
     PartialShape shape{-1, -1, -1, -1};
     std::int64_t reduce_axis = 2;
     {
-        auto left_input = std::make_shared<ov::opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        auto concat = std::make_shared<opset8::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
+        auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<opset8::ReduceMin>(concat, opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v1::ReduceMin>(concat, ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto maximum = std::make_shared<opset8::Minimum>(left_input, right_input);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto maximum = std::make_shared<ov::op::v1::Minimum>(left_input, right_input);
         function_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
@@ -150,28 +158,28 @@ TEST_F(TransformationTestsF, ConcatReduceMinFusionDynamicRank) {
     PartialShape shape = PartialShape::dynamic();
     std::int64_t reduce_axis = 3;
     {
-        auto left_input = std::make_shared<ov::opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input,
-                                                opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        auto concat = std::make_shared<opset8::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
+        auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<opset8::ReduceMin>(concat, opset8::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v1::ReduceMin>(concat, ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto maximum = std::make_shared<opset8::Minimum>(left_input, right_input);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto maximum = std::make_shared<ov::op::v1::Minimum>(left_input, right_input);
         function_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
@@ -179,36 +187,36 @@ TEST_F(TransformationTestsF, ConcatReduceMinFusionDynamicRank) {
 TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseStaticShape) {
     PartialShape shape{224, 224, 1, 1};
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        auto add = std::make_shared<opset8::Add>(left_unsqueeze, right_unsqueeze);
+        auto add = std::make_shared<ov::op::v1::Add>(left_unsqueeze, right_unsqueeze);
 
-        auto squeeze = std::make_shared<opset8::Squeeze>(add, opset8::Constant::create(element::i64, Shape{}, {0}));
+        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         function = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::PullSqueezeThroughEltwise>();
     }
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto left_squeeze =
-            std::make_shared<opset8::Squeeze>(left_unsqueeze, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Squeeze>(left_unsqueeze, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_squeeze =
-            std::make_shared<opset8::Squeeze>(right_unsqueeze, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Squeeze>(right_unsqueeze, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        auto add = std::make_shared<opset8::Add>(left_squeeze, right_squeeze);
+        auto add = std::make_shared<ov::op::v1::Add>(left_squeeze, right_squeeze);
 
         function_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{left_input, right_input});
     }
@@ -217,26 +225,26 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseStaticShape) {
 TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationStaticShape) {
     PartialShape shape{224, 224, 1, 1};
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        auto add = std::make_shared<opset8::Add>(left_unsqueeze, right_unsqueeze);
+        auto add = std::make_shared<ov::op::v1::Add>(left_unsqueeze, right_unsqueeze);
 
-        auto squeeze = std::make_shared<opset8::Squeeze>(add, opset8::Constant::create(element::i64, Shape{}, {0}));
+        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         function = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
-        auto add = std::make_shared<opset8::Add>(left_input, right_input);
+        auto add = std::make_shared<ov::op::v1::Add>(left_input, right_input);
 
         function_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{left_input, right_input});
     }
@@ -245,26 +253,26 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationStaticSh
 TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicShape) {
     PartialShape shape{-1, -1, -1, -1};
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        auto add = std::make_shared<opset8::Add>(left_unsqueeze, right_unsqueeze);
+        auto add = std::make_shared<ov::op::v1::Add>(left_unsqueeze, right_unsqueeze);
 
-        auto squeeze = std::make_shared<opset8::Squeeze>(add, opset8::Constant::create(element::i64, Shape{}, {0}));
+        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         function = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
-        auto add = std::make_shared<opset8::Add>(left_input, right_input);
+        auto add = std::make_shared<ov::op::v1::Add>(left_input, right_input);
 
         function_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{left_input, right_input});
     }
@@ -273,26 +281,26 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicS
 TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicRank) {
     PartialShape shape = PartialShape::dynamic();
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(left_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_unsqueeze =
-            std::make_shared<opset8::Unsqueeze>(right_input, opset8::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        auto add = std::make_shared<opset8::Add>(left_unsqueeze, right_unsqueeze);
+        auto add = std::make_shared<ov::op::v1::Add>(left_unsqueeze, right_unsqueeze);
 
-        auto squeeze = std::make_shared<opset8::Squeeze>(add, opset8::Constant::create(element::i64, Shape{}, {0}));
+        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         function = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
-        auto left_input = std::make_shared<opset8::Parameter>(element::f32, shape);
-        auto right_input = std::make_shared<opset8::Parameter>(element::f32, shape);
+        auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
+        auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
-        auto add = std::make_shared<opset8::Add>(left_input, right_input);
+        auto add = std::make_shared<ov::op::v1::Add>(left_input, right_input);
 
         function_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{left_input, right_input});
     }

--- a/src/common/transformations/tests/common_optimizations/concat_reduce_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/concat_reduce_fusion.cpp
@@ -13,14 +13,14 @@
 #include <transformations/init_node_info.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
-#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"
-#include "openvino/op/reduce_max.hpp"
-#include "openvino/op/reduce_min.hpp"
 #include "openvino/op/maximum.hpp"
 #include "openvino/op/minimum.hpp"
-#include "openvino/op/add.hpp"
+#include "openvino/op/reduce_max.hpp"
+#include "openvino/op/reduce_min.hpp"
 #include "openvino/op/squeeze.hpp"
+#include "openvino/op/unsqueeze.hpp"
 
 using namespace testing;
 using namespace ov;
@@ -34,15 +34,16 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionDynamicShape) {
 
         auto left_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(left_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(right_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<ov::op::v1::ReduceMax>(concat, ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v1::ReduceMax>(concat,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
@@ -64,17 +65,17 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionKeepDimsDynamicShape) {
 
         auto left_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(left_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(right_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
             std::make_shared<ov::op::v1::ReduceMax>(concat,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}),
-                                                true);
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}),
+                                                    true);
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
@@ -85,10 +86,10 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionKeepDimsDynamicShape) {
 
         auto left_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(left_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(right_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto maximum = std::make_shared<ov::op::v1::Maximum>(left_unsqueeze, right_unsqueeze);
         function_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
     }
@@ -103,15 +104,16 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionDynamicRank) {
 
         auto left_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(left_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(right_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<ov::op::v1::ReduceMax>(concat, ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v1::ReduceMax>(concat,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
@@ -133,15 +135,16 @@ TEST_F(TransformationTestsF, ConcatReduceMinFusionDynamicShape) {
 
         auto left_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(left_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(right_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<ov::op::v1::ReduceMin>(concat, ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v1::ReduceMin>(concat,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
@@ -163,15 +166,16 @@ TEST_F(TransformationTestsF, ConcatReduceMinFusionDynamicRank) {
 
         auto left_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(left_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto right_unsqueeze =
             std::make_shared<ov::op::v0::Unsqueeze>(right_input,
-                                                ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         auto concat = std::make_shared<ov::op::v0::Concat>(NodeVector{left_unsqueeze, right_unsqueeze}, reduce_axis);
 
         auto reduce_max =
-            std::make_shared<ov::op::v1::ReduceMin>(concat, ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
+            std::make_shared<ov::op::v1::ReduceMin>(concat,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
         function = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
@@ -191,13 +195,16 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseStaticShape) {
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         auto add = std::make_shared<ov::op::v1::Add>(left_unsqueeze, right_unsqueeze);
 
-        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+        auto squeeze =
+            std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         function = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::PullSqueezeThroughEltwise>();
@@ -207,14 +214,18 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseStaticShape) {
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto left_squeeze =
-            std::make_shared<ov::op::v0::Squeeze>(left_unsqueeze, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Squeeze>(left_unsqueeze,
+                                                  ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         auto right_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_squeeze =
-            std::make_shared<ov::op::v0::Squeeze>(right_unsqueeze, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Squeeze>(right_unsqueeze,
+                                                  ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         auto add = std::make_shared<ov::op::v1::Add>(left_squeeze, right_squeeze);
 
@@ -229,13 +240,16 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationStaticSh
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         auto add = std::make_shared<ov::op::v1::Add>(left_unsqueeze, right_unsqueeze);
 
-        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+        auto squeeze =
+            std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         function = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
@@ -257,13 +271,16 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicS
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         auto add = std::make_shared<ov::op::v1::Add>(left_unsqueeze, right_unsqueeze);
 
-        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+        auto squeeze =
+            std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         function = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
@@ -285,13 +302,16 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicR
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
 
         auto left_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(left_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(left_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
         auto right_unsqueeze =
-            std::make_shared<ov::op::v0::Unsqueeze>(right_input, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+            std::make_shared<ov::op::v0::Unsqueeze>(right_input,
+                                                    ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         auto add = std::make_shared<ov::op::v1::Add>(left_unsqueeze, right_unsqueeze);
 
-        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
+        auto squeeze =
+            std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
         function = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();

--- a/src/common/transformations/tests/common_optimizations/convert_nms_gather_path_to_unsigned_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_nms_gather_path_to_unsigned_test.cpp
@@ -204,5 +204,5 @@ TEST(TransformationTests, test_convert_to_unsigned_nms_gather_3) {
     manager.register_pass<ov::pass::ConvertNmsGatherPathToUnsigned>();
     manager.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
-    ASSERT_EQ(count_ops_of_type<opset1::Convert>(f), 0);
+    ASSERT_EQ(count_ops_of_type<ov::op::v0::Convert>(f), 0);
 }

--- a/src/common/transformations/tests/common_optimizations/fq_mul_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/fq_mul_fusion_test.cpp
@@ -73,12 +73,12 @@ public:
 };
 
 TEST_P(FQMulFusion, ExpectFusion) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ov::pass::FakeQuantizeMulFusion>();
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh);
 
     manager.run_passes(m_function);
     ASSERT_NO_THROW(check_rt_info(m_function));

--- a/src/common/transformations/tests/common_optimizations/fq_reshape_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/fq_reshape_fusion.cpp
@@ -123,12 +123,12 @@ private:
 };
 
 TEST_P(nGraphFQReshapeFusionTests, ReshapeMatMul) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ov::pass::FakeQuantizeReshapeFusion>();
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh);
 
     manager.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));

--- a/src/common/transformations/tests/common_optimizations/gelu_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/gelu_fusion.cpp
@@ -45,7 +45,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternOne) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<opset7::Gelu>(data);
         function_ref = std::make_shared<Function>(NodeVector{gelu}, ParameterVector{data});
     }
@@ -71,7 +71,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternOneF16) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f16, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{2, 2});
         auto gelu = std::make_shared<opset7::Gelu>(data);
         function_ref = std::make_shared<Function>(NodeVector{gelu}, ParameterVector{data});
     }
@@ -97,7 +97,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternTwo) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<opset7::Gelu>(data);
         function_ref = std::make_shared<Function>(NodeVector{gelu}, ParameterVector{data});
     }
@@ -123,7 +123,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternTwoF16) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f16, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{2, 2});
         auto gelu = std::make_shared<opset7::Gelu>(data);
         function_ref = std::make_shared<Function>(NodeVector{gelu}, ParameterVector{data});
     }
@@ -149,7 +149,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternThree) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<opset7::Gelu>(data);
         function_ref = std::make_shared<Function>(NodeVector{gelu}, ParameterVector{data});
     }
@@ -175,7 +175,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternThreeF16) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f16, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{2, 2});
         auto gelu = std::make_shared<opset7::Gelu>(data);
         function_ref = std::make_shared<Function>(NodeVector{gelu}, ParameterVector{data});
     }
@@ -201,7 +201,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternFour) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<opset9::Gelu>(data);
         function_ref = std::make_shared<Function>(NodeVector{gelu}, ParameterVector{data});
     }
@@ -227,7 +227,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternFourF16) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f16, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{2, 2});
         auto gelu = std::make_shared<opset9::Gelu>(data);
         function_ref = std::make_shared<Function>(NodeVector{gelu}, ParameterVector{data});
     }

--- a/src/common/transformations/tests/common_optimizations/hsigmoid_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/hsigmoid_fusion_test.cpp
@@ -146,8 +146,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithClampMul) {
 
 TEST_F(TransformationTestsF, HSigmoidFusionWithClampDiv) {
     {
-        auto input =
-            std::make_shared<ov::op::v0::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
         auto add_constant = ov::op::v0::Constant::create(ngraph::element::f16, ngraph::Shape{}, {3.0});
         auto add = std::make_shared<ov::op::v1::Add>(input, add_constant);
         auto clamp = std::make_shared<ov::op::v0::Clamp>(add, 0.0f, 6.0f);

--- a/src/common/transformations/tests/common_optimizations/hsigmoid_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/hsigmoid_fusion_test.cpp
@@ -147,12 +147,12 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithClampMul) {
 TEST_F(TransformationTestsF, HSigmoidFusionWithClampDiv) {
     {
         auto input =
-            std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
-        auto add_constant = ngraph::opset6::Constant::create(ngraph::element::f16, ngraph::Shape{}, {3.0});
-        auto add = std::make_shared<ngraph::opset6::Add>(input, add_constant);
-        auto clamp = std::make_shared<ngraph::opset6::Clamp>(add, 0.0f, 6.0f);
-        auto div_constant = ngraph::opset6::Constant::create(ngraph::element::f16, ngraph::Shape{}, {6.0});
-        auto div = std::make_shared<ngraph::opset6::Divide>(clamp, div_constant);
+            std::make_shared<ov::op::v0::Parameter>(ngraph::element::f16, ngraph::PartialShape::dynamic(1));
+        auto add_constant = ov::op::v0::Constant::create(ngraph::element::f16, ngraph::Shape{}, {3.0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, add_constant);
+        auto clamp = std::make_shared<ov::op::v0::Clamp>(add, 0.0f, 6.0f);
+        auto div_constant = ov::op::v0::Constant::create(ngraph::element::f16, ngraph::Shape{}, {6.0});
+        auto div = std::make_shared<ov::op::v1::Divide>(clamp, div_constant);
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{div}, ngraph::ParameterVector{input});
 

--- a/src/common/transformations/tests/common_optimizations/leaky_relu_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/leaky_relu_fusion.cpp
@@ -32,7 +32,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionConstant) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto alpha = opset8::Constant::create(element::f32, Shape{1}, {0.1});
         auto leaky_relu = std::make_shared<opset8::PRelu>(data, alpha);
         function_ref = std::make_shared<Function>(NodeVector{leaky_relu}, ParameterVector{data});
@@ -51,7 +51,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionScalar) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto alpha = opset8::Constant::create(element::f32, Shape{}, {0.1});
         auto leaky_relu = std::make_shared<opset8::PRelu>(data, alpha);
         function_ref = std::make_shared<Function>(NodeVector{leaky_relu}, ParameterVector{data});
@@ -70,7 +70,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionParameter) {
     }
 
     {
-        auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{2, 2});
+        auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto alpha = std::make_shared<opset8::Parameter>(element::f32, Shape{});
         auto leaky_relu = std::make_shared<opset8::PRelu>(data, alpha);
         function_ref = std::make_shared<Function>(NodeVector{leaky_relu}, ParameterVector{data, alpha});

--- a/src/common/transformations/tests/common_optimizations/low_latency_v2_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/low_latency_v2_test.cpp
@@ -594,7 +594,7 @@ TEST(TransformationTests, LowLatency2_LSTM_Loop_Reshape) {
         auto results = body->get_results();
 
         auto shape_of = std::make_shared<ShapeOf>(X);
-        const auto trip_count = std::make_shared<ov::opset8::Gather>(shape_of,
+        const auto trip_count = std::make_shared<ov::op::v8::Gather>(shape_of,
                                                                      Constant::create(ngraph::element::i64, {1}, {0}),
                                                                      Constant::create(ngraph::element::i64, {1}, {0}));
         auto exec_condition = std::make_shared<Constant>(element::boolean, Shape{}, true);

--- a/src/common/transformations/tests/common_optimizations/ngraph_fq_transpose_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/ngraph_fq_transpose_test.cpp
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, FQTransposeTest1) {
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{transpose}, ngraph::ParameterVector{});
 
         manager.register_pass<ov::pass::PullTransposeThroughFQUp>();
-        manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+        manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
             check_rt_info(f);
         });
         manager.register_pass<ngraph::pass::ConstantFolding>();
@@ -76,7 +76,7 @@ TEST_F(TransformationTestsF, FQTransposeNegativeCase) {
 
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ov::pass::PullTransposeThroughFQUp>();
-    manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+    manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
         check_rt_info(f);
     });
 

--- a/src/common/transformations/tests/common_optimizations/ngraph_fq_transpose_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/ngraph_fq_transpose_test.cpp
@@ -20,20 +20,21 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "common_test_utils/test_common.hpp"
+#include "openvino/op/sigmoid.hpp"
 
 using namespace testing;
 
 TEST_F(TransformationTestsF, FQTransposeTest1) {
     {
-        auto data = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 3}, {1, 2, 3});
-        auto input_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
-        auto input_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
-        auto output_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
-        auto output_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
-        auto transpose_order = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {0, 2, 1});
+        auto data = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 3}, {1, 2, 3});
+        auto input_low = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
+        auto input_high = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
+        auto output_low = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
+        auto output_high = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
+        auto transpose_order = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {0, 2, 1});
 
-        auto fq = std::make_shared<ngraph::op::FakeQuantize>(data, input_low, input_high, output_low, output_high, 1);
-        auto transpose = std::make_shared<ngraph::op::Transpose>(fq, transpose_order);
+        auto fq = std::make_shared<ov::op::v0::FakeQuantize>(data, input_low, input_high, output_low, output_high, 1);
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(fq, transpose_order);
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{transpose}, ngraph::ParameterVector{});
 
@@ -44,13 +45,13 @@ TEST_F(TransformationTestsF, FQTransposeTest1) {
         manager.register_pass<ngraph::pass::ConstantFolding>();
     }
     {
-        auto data = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 1}, {1, 2, 3});
-        auto input_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 1}, {2});
-        auto input_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 1}, {3});
-        auto output_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 1}, {2});
-        auto output_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 1}, {3});
+        auto data = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 1}, {1, 2, 3});
+        auto input_low = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 1}, {2});
+        auto input_high = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 1}, {3});
+        auto output_low = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 1}, {2});
+        auto output_high = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 1}, {3});
 
-        auto fq = std::make_shared<ngraph::op::FakeQuantize>(data, input_low, input_high, output_low, output_high, 1);
+        auto fq = std::make_shared<ov::op::v0::FakeQuantize>(data, input_low, input_high, output_low, output_high, 1);
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{fq}, ngraph::ParameterVector{});
     }
@@ -58,17 +59,17 @@ TEST_F(TransformationTestsF, FQTransposeTest1) {
 
 TEST_F(TransformationTestsF, FQTransposeNegativeCase) {
     auto create_graph = []() -> std::shared_ptr<ngraph::Function> {
-        auto data = std::make_shared<ngraph::op::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 3, 1});
-        auto sigmoid = std::make_shared<ngraph::op::Sigmoid>(data);
-        auto input_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
-        auto input_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
-        auto output_low = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
-        auto output_high = ngraph::op::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
-        auto transpose_order = ngraph::op::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {0, 2, 1});
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 3, 1});
+        auto sigmoid = std::make_shared<ov::op::v0::Sigmoid>(data);
+        auto input_low = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
+        auto input_high = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
+        auto output_low = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {2});
+        auto output_high = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {3});
+        auto transpose_order = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {0, 2, 1});
 
         auto fq =
-            std::make_shared<ngraph::op::FakeQuantize>(sigmoid, input_low, input_high, output_low, output_high, 1);
-        auto transpose = std::make_shared<ngraph::op::Transpose>(fq, transpose_order);
+            std::make_shared<ov::op::v0::FakeQuantize>(sigmoid, input_low, input_high, output_low, output_high, 1);
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(fq, transpose_order);
 
         return std::make_shared<ngraph::Function>(ngraph::NodeVector{transpose}, ngraph::ParameterVector{data});
     };

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -28,13 +28,13 @@ using namespace ngraph;
 using namespace std;
 
 TEST(nop_elimination, eliminate_convert) {
-    std::shared_ptr<Function> f;
+    std::shared_ptr<ov::Model> f;
     {
         Shape shape{};
         auto type = element::f32;
         auto A = make_shared<op::Parameter>(type, shape);
         auto c = make_shared<op::v0::Convert>(A, element::f32);
-        f = make_shared<Function>(make_shared<op::v0::Abs>(c), ParameterVector{A});
+        f = make_shared<ov::Model>(make_shared<op::v0::Abs>(c), ParameterVector{A});
     }
 
     pass::Manager pass_manager;
@@ -46,14 +46,13 @@ TEST(nop_elimination, eliminate_convert) {
 
 TEST(nop_elimination, convert_type_agnostic) {
     Shape shape{};
-    std::shared_ptr<Function> f;
+    std::shared_ptr<ov::Model> f;
     {
-        auto type = element::from<int8_t>();
-        auto A = make_shared<op::Parameter>(type, shape);
-        auto c1 = make_shared<op::v0::Convert>(A, element::from<uint8_t>());
-        auto c = make_shared<op::v0::Convert>(c1, element::f32);
+        auto A = make_shared<op::Parameter>(ov::element::i8, shape);
+        auto c1 = make_shared<op::v0::Convert>(A, ov::element::u8);
+        auto c = make_shared<op::v0::Convert>(c1, ov::element::f32);
         auto z = make_shared<op::v3::NonZero>(c);
-        f = make_shared<Function>(make_shared<op::v0::Abs>(z), ParameterVector{A});
+        f = make_shared<ov::Model>(make_shared<op::v0::Abs>(z), ParameterVector{A});
     }
 
     pass::Manager pass_manager;
@@ -66,12 +65,12 @@ TEST(nop_elimination, convert_type_agnostic) {
 
 template <typename Op>
 void test_nop_eliminate_broadcast() {
-    std::shared_ptr<Function> f;
+    std::shared_ptr<ov::Model> f;
     {
         Shape shape{1};
         auto A = make_shared<op::Parameter>(element::f32, shape);
         auto b = make_shared<Op>(A, op::Constant::create(element::u64, Shape{1}, {1}));
-        f = make_shared<Function>(make_shared<op::v0::Abs>(b), ParameterVector{A});
+        f = make_shared<ov::Model>(make_shared<op::v0::Abs>(b), ParameterVector{A});
     }
 
     pass::Manager pass_manager;
@@ -102,7 +101,7 @@ TEST(nop_elimination, reshape_elimination_v1) {
         auto reshape_v1_org = std::make_shared<op::v1::Reshape>(arg, pattern_org, zero);
         auto reshape_v1 = std::make_shared<op::v1::Reshape>(reshape_v1_org, pattern, zero);
         auto abs = std::make_shared<op::v0::Abs>(reshape_v1);
-        return std::make_shared<Function>(NodeVector{abs}, ParameterVector{arg});
+        return std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg});
     };
 
     auto func = generate_func(false);
@@ -145,7 +144,7 @@ TEST(nop_elimination, reshape_v1_1D) {
 }
 
 TEST(nop_elimination, squeeze_reshape_elimination_check_info) {
-    std::shared_ptr<Function> f;
+    std::shared_ptr<ov::Model> f;
     {
         auto arg = std::make_shared<opset4::Parameter>(element::f32, PartialShape{8, 16, 1, 3});
 
@@ -162,7 +161,7 @@ TEST(nop_elimination, squeeze_reshape_elimination_check_info) {
 
         auto abs = std::make_shared<opset4::Abs>(reshape);
 
-        f = std::make_shared<Function>(NodeVector{abs}, ParameterVector{arg});
+        f = std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg});
     }
 
     pass::Manager pass_manager;
@@ -180,7 +179,7 @@ TEST(nop_elimination, squeeze_reshape_elimination_check_info) {
 }
 
 TEST(nop_elimination, squeeze_unsqueeze_elimination) {
-    std::shared_ptr<Function> f;
+    std::shared_ptr<ov::Model> f;
     {
         auto arg = std::make_shared<opset4::Parameter>(element::f32, PartialShape{8, 16, 1, 3});
 
@@ -197,7 +196,7 @@ TEST(nop_elimination, squeeze_unsqueeze_elimination) {
 
         auto abs = std::make_shared<opset4::Abs>(unsqueeze);
 
-        f = std::make_shared<Function>(NodeVector{abs}, ParameterVector{arg});
+        f = std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg});
     }
 
     pass::Manager pass_manager;
@@ -219,7 +218,7 @@ TEST(nop_elimination, reshape_elimination_v1_dynamic) {
     auto pattern = make_shared<op::Parameter>(element::i64, PartialShape::dynamic(1));
     auto reshape_v1 = std::make_shared<op::v1::Reshape>(arg, pattern, false);
     auto abs = std::make_shared<op::v0::Abs>(reshape_v1);
-    auto f = std::make_shared<Function>(NodeVector{abs}, ParameterVector{arg, pattern});
+    auto f = std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg, pattern});
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::NopElimination>();
     pass_manager.run_passes(f);
@@ -227,7 +226,7 @@ TEST(nop_elimination, reshape_elimination_v1_dynamic) {
 }
 
 TEST(nop_elimination, reshape_elimination_v1_check_consumer_count) {
-    std::shared_ptr<Function> f;
+    std::shared_ptr<ov::Model> f;
     {
         auto arg = std::make_shared<opset4::Parameter>(element::f32, PartialShape{8, 16, 1, 3});
 
@@ -242,7 +241,7 @@ TEST(nop_elimination, reshape_elimination_v1_check_consumer_count) {
         auto relu = std::make_shared<opset4::Relu>(reshape_1);
         relu->set_friendly_name("relu");
 
-        f = std::make_shared<Function>(NodeVector{reshape_2, relu}, ParameterVector{arg});
+        f = std::make_shared<ov::Model>(NodeVector{reshape_2, relu}, ParameterVector{arg});
     }
 
     pass::Manager pass_manager;
@@ -256,7 +255,7 @@ TEST(nop_elimination, reshape_elimination_v1_check_consumer_count) {
 TEST(nop_elimination, concat_elimination_single_node) {
     int64_t a = 0;
     auto A = make_shared<op::Parameter>(element::f32, Shape{2, 3});
-    auto f = make_shared<Function>(make_shared<op::v0::Concat>(NodeVector{A}, a), ParameterVector{A});
+    auto f = make_shared<ov::Model>(make_shared<op::v0::Concat>(NodeVector{A}, a), ParameterVector{A});
 
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::Validate>();
@@ -270,7 +269,7 @@ TEST(nop_elimination, concat_elimination_single_input) {
     int64_t a = 0;
     auto A = make_shared<op::Parameter>(element::f32, Shape{2, 3});
     auto B = make_shared<op::v0::Concat>(NodeVector{A}, a);
-    auto f = make_shared<Function>(make_shared<op::v0::Abs>(B), ParameterVector{A});
+    auto f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B), ParameterVector{A});
 
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::Validate>();
@@ -284,7 +283,7 @@ TEST(nop_elimination, concat_elimination_single_input_dynamic) {
     int64_t a = 0;
     auto A = make_shared<op::Parameter>(element::f32, PartialShape{Dimension::dynamic(), 3});
     auto B = make_shared<op::v0::Concat>(NodeVector{A}, a);
-    auto f = make_shared<Function>(make_shared<op::v0::Abs>(B), ParameterVector{A});
+    auto f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B), ParameterVector{A});
 
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::Validate>();
@@ -299,7 +298,7 @@ TEST(nop_elimination, unsqueeze_elimination) {
     const auto A =
         make_shared<op::Parameter>(element::f32, PartialShape{3, Dimension::dynamic(), Dimension::dynamic()});
     const auto unsqueeze = make_shared<op::v0::Unsqueeze>(A, axis);
-    auto f = make_shared<Function>(unsqueeze, ParameterVector{A});
+    auto f = make_shared<ov::Model>(unsqueeze, ParameterVector{A});
 
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::Validate>();
@@ -369,8 +368,8 @@ TEST(nop_elimination, squeeze_unsqueeze_overlap_elimination) {
             B1 = make_shared<op::v0::Squeeze>(B, sq_axes);
         }
 
-        auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+        auto optimized_f = baseline_f->clone();
 
         pass::Manager pass_manager;
         pass_manager.register_pass<ov::pass::Validate>();
@@ -561,8 +560,8 @@ TEST(nop_elimination, squeeze_squeeze_overlap_elimination) {
         auto A1 = make_shared<op::v0::Abs>(A);
         auto B = make_shared<op::v0::Squeeze>(A1, sq_axes_1);
         auto B1 = make_shared<op::v0::Squeeze>(B, sq_axes_2);
-        auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+        auto optimized_f = baseline_f->clone();
 
         pass::Manager pass_manager;
         pass_manager.register_pass<ov::pass::Validate>();
@@ -595,8 +594,8 @@ TEST(nop_elimination, unsqueeze_unsqueeze_overlap_elimination) {
         auto A1 = make_shared<op::v0::Abs>(A);
         auto B = make_shared<op::v0::Unsqueeze>(A1, unsq_axes_1);
         auto B1 = make_shared<op::v0::Unsqueeze>(B, unsq_axes_2);
-        auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+        auto optimized_f = baseline_f->clone();
 
         pass::Manager pass_manager;
         pass_manager.register_pass<ov::pass::Validate>();
@@ -623,7 +622,7 @@ TEST(nop_elimination, unsqueeze_squeeze_elimination) {
         auto A1 = make_shared<op::v0::Abs>(A);
         auto B = make_shared<op::v0::Unsqueeze>(A1, axes);
         auto B1 = make_shared<op::v0::Squeeze>(B, axes);
-        return make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+        return make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
     };
 
     auto check_usecase = [&](const Shape& shape, const std::vector<int64_t>& axes_val) {
@@ -656,8 +655,8 @@ TEST(nop_elimination, reshape_unsqueeze_elimination) {
             auto B = make_shared<op::v1::Reshape>(A1, pat, zero);
             auto pat2 = op::Constant::create<int64_t>(element::i64, Shape{2}, std::vector<int64_t>{0, -1});
             auto B1 = make_shared<op::v0::Unsqueeze>(B, axes);
-            auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
-            auto optimized_f = clone_function(*baseline_f);
+            auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+            auto optimized_f = baseline_f->clone();
             ngraph::pass::Manager manager;
             manager.register_pass<ov::pass::NopElimination>();
             manager.run_passes(optimized_f);
@@ -684,8 +683,8 @@ TEST(nop_elimination, reshape_squeeze_elimination) {
             auto B = make_shared<op::v1::Reshape>(A1, pat, zero);
             auto pat2 = op::Constant::create<int64_t>(element::i64, Shape{2}, std::vector<int64_t>{0, -1});
             auto B1 = make_shared<op::v0::Squeeze>(B, axes);
-            auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
-            auto optimized_f = clone_function(*baseline_f);
+            auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+            auto optimized_f = baseline_f->clone();
             ngraph::pass::Manager manager;
             manager.register_pass<ov::pass::NopElimination>();
             manager.run_passes(optimized_f);
@@ -711,8 +710,8 @@ TEST(nop_elimination, reshape_reshape_elimination) {
         auto B = make_shared<op::v1::Reshape>(A1, pat, zero);
         auto pat2 = op::Constant::create<int64_t>(element::i64, Shape{2}, std::vector<int64_t>{0, -1});
         auto B1 = make_shared<op::v1::Reshape>(B, pat2, true);
-        auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+        auto optimized_f = baseline_f->clone();
         ngraph::pass::Manager manager;
         manager.register_pass<ov::pass::NopElimination>();
         manager.run_passes(optimized_f);
@@ -737,8 +736,8 @@ TEST(nop_elimination, squeeze_reshape_elimination) {
         auto B = make_shared<op::v0::Squeeze>(A1, indices);
         auto pat2 = op::Constant::create<int64_t>(element::i64, Shape{1}, std::vector<int64_t>{-1});
         auto B1 = make_shared<op::v1::Reshape>(B, pat2, false);
-        auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+        auto optimized_f = baseline_f->clone();
         ngraph::pass::Manager manager;
         manager.register_pass<ov::pass::NopElimination>();
         manager.run_passes(optimized_f);
@@ -764,8 +763,8 @@ TEST(nop_elimination, unsqueeze_reshape_elimination) {
         auto B = make_shared<op::v0::Unsqueeze>(A1, indices);
         auto pat2 = op::Constant::create<int64_t>(element::i64, Shape{1}, std::vector<int64_t>{-1});
         auto B1 = make_shared<op::v1::Reshape>(B, pat2, false);
-        auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(B1), ParameterVector{A});
+        auto optimized_f = baseline_f->clone();
         ngraph::pass::Manager manager;
         manager.register_pass<ov::pass::NopElimination>();
         manager.run_passes(optimized_f);
@@ -787,8 +786,8 @@ TEST(nop_elimination, squeeze_unsqueeze_elimination_negative) {
         auto indices = op::Constant::create(element::i64, Shape{indices_val.size()}, indices_val);
         auto input = make_shared<op::Parameter>(element::f32, shape);
         auto squeeze = make_shared<ngraph::opset1::Squeeze>(input, indices);
-        auto baseline_f = make_shared<Function>(squeeze, ParameterVector{input});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(squeeze, ParameterVector{input});
+        auto optimized_f = baseline_f->clone();
         ngraph::pass::Manager manager;
         manager.register_pass<ov::pass::NopElimination>();
         manager.run_passes(optimized_f);
@@ -809,8 +808,8 @@ TEST(nop_elimination, topk_convert_elimination) {
                                            op::v1::TopK::Mode::MAX,
                                            op::v1::TopK::SortType::NONE);
         auto C = make_shared<op::Convert>(B->output(0), B->output(0).get_element_type());
-        auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(C), ParameterVector{A});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(C), ParameterVector{A});
+        auto optimized_f = baseline_f->clone();
         ngraph::pass::Manager manager;
         manager.register_pass<ov::pass::NopElimination>();
         manager.run_passes(optimized_f);
@@ -860,8 +859,8 @@ TEST(nop_elimination, gather_3d_indices_constant_axis_1) {
         }
         auto G = make_shared<op::v1::Gather>((multiout ? A1->output(0) : A1), indices, axis);
 
-        auto baseline_f = make_shared<Function>(make_shared<op::v0::Abs>(G), ParameterVector{A});
-        auto optimized_f = clone_function(*baseline_f);
+        auto baseline_f = make_shared<ov::Model>(make_shared<op::v0::Abs>(G), ParameterVector{A});
+        auto optimized_f = baseline_f->clone();
 
         pass::Manager pass_manager;
         pass_manager.register_pass<ov::pass::Validate>();
@@ -1049,13 +1048,13 @@ TEST_P(EliminateEltwiseTests, eliminate_eltwise) {
         ASSERT_FALSE(true) << "Invalid OpType";
     }
     auto abs = make_shared<opset8::Abs>(node);
-    function = make_shared<Function>(abs, ParameterVector{parameter});
+    function = make_shared<ov::Model>(abs, ParameterVector{parameter});
 
     manager.register_pass<ov::pass::NopElimination>();
 
     if (can_fuse) {
         auto abs = make_shared<opset8::Abs>(parameter);
-        function_ref = make_shared<Function>(abs, ParameterVector{parameter});
+        function_ref = make_shared<ov::Model>(abs, ParameterVector{parameter});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -1131,13 +1130,13 @@ TEST_F(TransformationTestsF, eliminate_eltwise_dequantization_subgraph) {
         auto convert = make_shared<opset8::Convert>(constant, element::f32);
         auto sub = make_shared<opset8::Subtract>(convert, opset8::Constant::create(element::f32, Shape{}, {0}));
         auto mul = make_shared<opset8::Multiply>(sub, opset8::Constant::create(element::f32, Shape{}, {1}));
-        function = make_shared<Function>(mul, ParameterVector{});
+        function = make_shared<ov::Model>(mul, ParameterVector{});
     }
     {
         auto constant = opset8::Constant::create(element::i8, Shape{}, {2});
         auto convert = make_shared<opset8::Convert>(constant, element::f32);
         auto mul = make_shared<opset8::Multiply>(convert, opset8::Constant::create(element::f32, Shape{}, {1}));
-        function_ref = make_shared<Function>(mul, ParameterVector{});
+        function_ref = make_shared<ov::Model>(mul, ParameterVector{});
     }
 
     manager.register_pass<ov::pass::NopElimination>();
@@ -1320,7 +1319,7 @@ TEST(nop_elimination, gather_to_squeeze) {
         auto indices = op::Constant::create(element::i64, Shape{}, vector<int64_t>{0});
         auto axis = op::Constant::create(element::i64, Shape{}, vector<int64_t>{gather_axis});
         auto gather = std::make_shared<op::v8::Gather>(arg, indices, axis);
-        return std::make_shared<Function>(NodeVector{gather}, ParameterVector{arg});
+        return std::make_shared<ov::Model>(NodeVector{gather}, ParameterVector{arg});
     };
 
     auto func_axis_0 = generate_func(0);
@@ -1329,7 +1328,7 @@ TEST(nop_elimination, gather_to_squeeze) {
     auto func_axis_3 = generate_func(3);
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::NopElimination>();
-    auto run_and_check = [&](std::shared_ptr<Function>& func) {
+    auto run_and_check = [&](std::shared_ptr<ov::Model>& func) {
         pass_manager.run_passes(func);
         EXPECT_EQ(count_ops_of_type<op::v8::Gather>(func), 0);
         EXPECT_EQ(count_ops_of_type<op::v0::Squeeze>(func), 1);

--- a/src/common/transformations/tests/common_optimizations/preprocessing_fusion_tests.cpp
+++ b/src/common/transformations/tests/common_optimizations/preprocessing_fusion_tests.cpp
@@ -691,10 +691,10 @@ TEST_F(TransformationTestsF, RICFusionSplitConcatDetectionNegative3) {
 
 TEST_F(TransformationTestsF, FuseConvertLayout) {
     {
-        auto input = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 64});
-        auto order = ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {1, 2, 0});
-        auto transpose = std::make_shared<ngraph::opset6::Transpose>(input, order);
-        auto relu = std::make_shared<ngraph::opset6::Relu>(transpose);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 64});
+        auto order = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {1, 2, 0});
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
+        auto relu = std::make_shared<ov::op::v0::Relu>(transpose);
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{relu}, ngraph::ParameterVector{input});
 
@@ -708,9 +708,9 @@ TEST_F(TransformationTestsF, FuseConvertLayout) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f16, ngraph::Shape{3, 64, 1});
-        auto convert = std::make_shared<ngraph::opset6::Convert>(input, element::f32);
-        auto relu = std::make_shared<ngraph::opset6::Relu>(convert);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f16, ngraph::Shape{3, 64, 1});
+        auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
+        auto relu = std::make_shared<ov::op::v0::Relu>(convert);
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{relu}, ngraph::ParameterVector{input});
     }
@@ -719,8 +719,8 @@ TEST_F(TransformationTestsF, FuseConvertLayout) {
 TEST_F(TransformationTestsF, FuseScaleValue) {
     {
         auto input = create_param({1, 64, 64, 3});
-        auto order = ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2});
-        auto transpose = std::make_shared<ngraph::opset6::Transpose>(input, order);
+        auto order = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2});
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto conv = create_conv(transpose, {6, 3, 3, 3});
 
         function = std::make_shared<Function>(NodeVector{conv}, ParameterVector{input});
@@ -736,8 +736,8 @@ TEST_F(TransformationTestsF, FuseScaleValue) {
 
     {
         auto input = create_param({1, 64, 64, 3});
-        auto order = ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2});
-        auto transpose = std::make_shared<ngraph::opset6::Transpose>(input, order);
+        auto order = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2});
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto conv = create_conv(transpose, {6, 3, 3, 3});
         function_ref = std::make_shared<Function>(NodeVector{conv}, ParameterVector{input});
     }
@@ -748,8 +748,8 @@ TEST_F(TransformationTestsF, FuseScaleValue) {
 TEST_F(TransformationTestsF, FuseScaleValues) {
     {
         auto input = create_param({1, 64, 64, 3});
-        auto order = ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2});
-        auto transpose = std::make_shared<ngraph::opset6::Transpose>(input, order);
+        auto order = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2});
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto conv = create_conv(transpose, {6, 3, 3, 3});
 
         function = std::make_shared<Function>(NodeVector{conv}, ParameterVector{input});
@@ -765,8 +765,8 @@ TEST_F(TransformationTestsF, FuseScaleValues) {
 
     {
         auto input = create_param({1, 64, 64, 3});
-        auto order = ngraph::opset6::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2});
-        auto transpose = std::make_shared<ngraph::opset6::Transpose>(input, order);
+        auto order = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2});
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto conv = create_conv(transpose, {6, 3, 3, 3});
         function_ref = std::make_shared<Function>(NodeVector{conv}, ParameterVector{input});
     }

--- a/src/common/transformations/tests/common_optimizations/shuffle_channels_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/shuffle_channels_fusion_test.cpp
@@ -64,13 +64,13 @@ public:
             f_ref = f;
         }
 
-        auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+        auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         ngraph::pass::Manager manager;
         auto pass_config = manager.get_pass_config();
-        manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+        manager.register_pass<ov::pass::InitUniqueNames>(unh);
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<ov::pass::ShuffleChannelsFusion>(values.check_values);
-        manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+        manager.register_pass<ov::pass::CheckUniqueNames>(unh);
         manager.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }

--- a/src/common/transformations/tests/common_optimizations/simplify_second_input_of_reshape_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/simplify_second_input_of_reshape_test.cpp
@@ -368,7 +368,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest14) {
     {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
 
-        auto shape_of = std::make_shared<opset1::ShapeOf>(data);
+        auto shape_of = std::make_shared<ov::op::v0::ShapeOf>(data);
         auto gather_op = gather(shape_of, std::vector<int64_t>{0, 1});
         auto constant = opset7::Constant::create(element::i64, Shape{1}, {768});
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);

--- a/src/common/transformations/tests/common_optimizations/softmax_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/softmax_fusion.cpp
@@ -36,12 +36,12 @@ TEST_P(SoftmaxFusionFixture, SoftmaxFusion) {
         auto div = std::make_shared<opset6::Divide>(exp, reduce_sum);
         f = std::make_shared<Function>(NodeVector{div}, ParameterVector{data});
 
-        auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+        auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         pass::Manager m;
-        m.register_pass<pass::InitUniqueNames>(unh);
+        m.register_pass<ov::pass::InitUniqueNames>(unh);
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ov::pass::SoftmaxFusion>();
-        m.register_pass<pass::CheckUniqueNames>(unh);
+        m.register_pass<ov::pass::CheckUniqueNames>(unh);
         m.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
@@ -81,12 +81,12 @@ TEST_P(SoftmaxFusionSimplePatternFixture, SoftmaxFusionSimplePatternTest) {
         auto div = std::make_shared<opset6::Divide>(exp, reduce_sum);
         f = std::make_shared<Function>(NodeVector{div}, ParameterVector{data});
 
-        auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+        auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         pass::Manager m;
-        m.register_pass<pass::InitUniqueNames>(unh);
+        m.register_pass<ov::pass::InitUniqueNames>(unh);
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ov::pass::SoftmaxFusion>();
-        m.register_pass<pass::CheckUniqueNames>(unh);
+        m.register_pass<ov::pass::CheckUniqueNames>(unh);
         m.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
@@ -136,12 +136,12 @@ TEST_P(NegativeSoftmaxFusionFixture, NegativeSoftmaxFusion) {
     auto div = std::make_shared<opset6::Divide>(exp, reduce_sum);
     f = std::make_shared<Function>(NodeVector{div}, ParameterVector{data});
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     pass::Manager m;
-    m.register_pass<pass::InitUniqueNames>(unh);
+    m.register_pass<ov::pass::InitUniqueNames>(unh);
     m.register_pass<ov::pass::InitNodeInfo>();
     m.register_pass<ov::pass::SoftmaxFusion>();
-    m.register_pass<pass::CheckUniqueNames>(unh);
+    m.register_pass<ov::pass::CheckUniqueNames>(unh);
     m.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
     ASSERT_EQ(count_ops_of_type<opset6::ReduceMax>(f), 1);

--- a/src/common/transformations/tests/common_optimizations/strides_optimization.cpp
+++ b/src/common/transformations/tests/common_optimizations/strides_optimization.cpp
@@ -24,18 +24,18 @@ TEST_F(TransformationTestsF, StridesOptimization1) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
@@ -44,18 +44,18 @@ TEST_F(TransformationTestsF, StridesOptimization1) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
     }
@@ -67,18 +67,18 @@ TEST_F(TransformationTestsF, StridesOptimization2) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
@@ -87,18 +87,18 @@ TEST_F(TransformationTestsF, StridesOptimization2) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{4, 4},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{4, 4},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
     }
@@ -110,18 +110,18 @@ TEST_F(TransformationTestsF, StridesOptimization3) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
@@ -130,18 +130,18 @@ TEST_F(TransformationTestsF, StridesOptimization3) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
     }
@@ -154,28 +154,28 @@ TEST_F(TransformationTestsF, StridesOptimization4) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto relu_2 = std::make_shared<ngraph::opset7::Relu>(conv_2);
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, relu_2);
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add,
-                                                                    weights_3,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3}, ngraph::ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
@@ -184,28 +184,28 @@ TEST_F(TransformationTestsF, StridesOptimization4) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{4, 4},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{4, 4},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_2,
-                                                                    ngraph::Strides{4, 4},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{4, 4},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto relu_2 = std::make_shared<ngraph::opset7::Relu>(conv_2);
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, relu_2);
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add,
-                                                                    weights_3,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3}, ngraph::ParameterVector{data});
     }
@@ -218,21 +218,21 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{0, 0},
-                                                                    ngraph::CoordinateDiff{0, 0},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{0, 0},
+                                                                ngraph::CoordinateDiff{0, 0},
+                                                                ngraph::Strides{});
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
         auto relu_2 = std::make_shared<ngraph::opset7::Relu>(data);
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, relu_2);
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
@@ -241,11 +241,11 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
         auto pool = std::make_shared<ngraph::opset7::MaxPool>(data,
                                                               ngraph::Strides{2, 2},
@@ -256,11 +256,11 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, relu_2);
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add,
-                                                                    weights_2,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
     }
@@ -274,32 +274,32 @@ TEST_F(TransformationTestsF, StridesOptimization6) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(conv_2,
-                                                                    weights_3,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_4 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_4 = std::make_shared<ov::op::v1::Convolution>(conv_3,
-                                                                    weights_4,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_4,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_4}, ngraph::ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
@@ -308,32 +308,32 @@ TEST_F(TransformationTestsF, StridesOptimization6) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(conv_2,
-                                                                    weights_3,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_4 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_4 = std::make_shared<ov::op::v1::Convolution>(conv_3,
-                                                                    weights_4,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_4,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_4}, ngraph::ParameterVector{data});
     }
@@ -349,33 +349,33 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(conv_2,
-                                                                    weights_3,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto relu = std::make_shared<ngraph::opset7::Relu>(conv_1);
         auto weights_4 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_4 = std::make_shared<ov::op::v1::Convolution>(relu,
-                                                                    weights_4,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_4,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function =
             std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3, conv_4}, ngraph::ParameterVector{data});
@@ -385,25 +385,25 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
-                                                                    weights_2,
-                                                                    ngraph::Strides{4, 4},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{4, 4},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(conv_2,
-                                                                    weights_3,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto pool = std::make_shared<ngraph::opset7::MaxPool>(conv_1,
                                                               ngraph::Strides{2, 2},
                                                               ngraph::Shape{0, 0},
@@ -412,11 +412,11 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
         auto relu = std::make_shared<ngraph::opset7::Relu>(pool);
         auto weights_4 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_4 = std::make_shared<ov::op::v1::Convolution>(relu,
-                                                                    weights_4,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_4,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref =
             std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3, conv_4}, ngraph::ParameterVector{data});
@@ -433,11 +433,11 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{0, 0},
-                                                                    ngraph::CoordinateDiff{0, 0},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{0, 0},
+                                                                ngraph::CoordinateDiff{0, 0},
+                                                                ngraph::Strides{});
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
         ngraph::Shape const_shape{1, 3, 224, 224};
         auto constant = ngraph::opset7::Constant::create(ngraph::element::f32,
@@ -446,20 +446,20 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, constant);
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{3, 112, 112});
         auto add_2 = std::make_shared<ngraph::opset7::Add>(conv_2, data_2);
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add_2,
-                                                                    weights_3,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function =
             std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3}, ngraph::ParameterVector{data, data_2});
@@ -469,11 +469,11 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{4, 4},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{4, 4},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
         ngraph::Shape const_shape{1, 3, 56, 56};
         auto constant = ngraph::opset7::Constant::create(ngraph::element::f32,
@@ -482,11 +482,11 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, constant);
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add,
-                                                                    weights_2,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{3, 112, 112});
         auto reshape = std::make_shared<ngraph::opset7::Reshape>(
             data_2,
@@ -503,11 +503,11 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
         auto add_2 = std::make_shared<ngraph::opset7::Add>(conv_2, squeeze);
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add_2,
-                                                                    weights_3,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref =
             std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3}, ngraph::ParameterVector{data, data_2});
@@ -526,11 +526,11 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{0, 0},
-                                                                    ngraph::CoordinateDiff{0, 0},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{0, 0},
+                                                                ngraph::CoordinateDiff{0, 0},
+                                                                ngraph::Strides{});
 
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{224});
         auto add_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{224}, {128});
@@ -541,11 +541,11 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         auto add_3 = std::make_shared<ngraph::opset7::Add>(conv_1, add_2);
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add_3,
-                                                                    weights_2,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         auto data_3 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{});
         auto add_4_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{}, {128});
@@ -555,11 +555,11 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         auto add_6 = std::make_shared<ngraph::opset7::Add>(conv_2, add_5);
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add_6,
-                                                                    weights_3,
-                                                                    ngraph::Strides{2, 2},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{2, 2},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3},
                                                       ngraph::ParameterVector{data, data_2, data_3});
@@ -569,11 +569,11 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
         auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
-                                                                    weights_1,
-                                                                    ngraph::Strides{4, 4},
-                                                                    ngraph::CoordinateDiff{0, 0},
-                                                                    ngraph::CoordinateDiff{0, 0},
-                                                                    ngraph::Strides{});
+                                                                weights_1,
+                                                                ngraph::Strides{4, 4},
+                                                                ngraph::CoordinateDiff{0, 0},
+                                                                ngraph::CoordinateDiff{0, 0},
+                                                                ngraph::Strides{});
 
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{224});
         auto reshape = std::make_shared<ngraph::opset7::Reshape>(
@@ -596,11 +596,11 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         auto add_3 = std::make_shared<ngraph::opset7::Add>(conv_1, add_2);
         auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add_3,
-                                                                    weights_2,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_2,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         auto data_3 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{});
         auto new_shape = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 1, 1, 1});
@@ -620,11 +620,11 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         auto add_6 = std::make_shared<ngraph::opset7::Add>(conv_2, add_5);
         auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
         auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add_6,
-                                                                    weights_3,
-                                                                    ngraph::Strides{1, 1},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::CoordinateDiff{},
-                                                                    ngraph::Strides{});
+                                                                weights_3,
+                                                                ngraph::Strides{1, 1},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::CoordinateDiff{},
+                                                                ngraph::Strides{});
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3},
                                                           ngraph::ParameterVector{data, data_2, data_3});

--- a/src/common/transformations/tests/common_optimizations/strides_optimization.cpp
+++ b/src/common/transformations/tests/common_optimizations/strides_optimization.cpp
@@ -21,16 +21,16 @@ using namespace testing;
 // Pl->Conv(1x1,1x1)->Conv(1x1,2x2) => Pl->Conv(1x1,2x2)->Conv(1x1,1x1)
 TEST_F(TransformationTestsF, StridesOptimization1) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -41,16 +41,16 @@ TEST_F(TransformationTestsF, StridesOptimization1) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{},
                                                                     ngraph::CoordinateDiff{},
@@ -64,16 +64,16 @@ TEST_F(TransformationTestsF, StridesOptimization1) {
 // Pl->Conv(3x3,2x2)->Conv(1x1,2x2) => Pl->Conv(3x3,4x4)->Conv(1x1,1x1)
 TEST_F(TransformationTestsF, StridesOptimization2) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -84,16 +84,16 @@ TEST_F(TransformationTestsF, StridesOptimization2) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{4, 4},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{},
                                                                     ngraph::CoordinateDiff{},
@@ -107,16 +107,16 @@ TEST_F(TransformationTestsF, StridesOptimization2) {
 // Pl->Conv(3x3,2x2)->Conv(3x3,2x2) => Same
 TEST_F(TransformationTestsF, StridesOptimization3) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -127,16 +127,16 @@ TEST_F(TransformationTestsF, StridesOptimization3) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -151,17 +151,17 @@ TEST_F(TransformationTestsF, StridesOptimization3) {
 //   `-->Conv(3x3,2x2)->ReLU---`                             `-->Conv(3x3,4x4)->ReLU---`
 TEST_F(TransformationTestsF, StridesOptimization4) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -169,8 +169,8 @@ TEST_F(TransformationTestsF, StridesOptimization4) {
                                                                     ngraph::Strides{});
         auto relu_2 = std::make_shared<ngraph::opset7::Relu>(conv_2);
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, relu_2);
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(add,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add,
                                                                     weights_3,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -181,17 +181,17 @@ TEST_F(TransformationTestsF, StridesOptimization4) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{4, 4},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_2,
                                                                     ngraph::Strides{4, 4},
                                                                     ngraph::CoordinateDiff{},
@@ -199,8 +199,8 @@ TEST_F(TransformationTestsF, StridesOptimization4) {
                                                                     ngraph::Strides{});
         auto relu_2 = std::make_shared<ngraph::opset7::Relu>(conv_2);
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, relu_2);
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(add,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add,
                                                                     weights_3,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
@@ -215,9 +215,9 @@ TEST_F(TransformationTestsF, StridesOptimization4) {
 //   `----------------->ReLU---`                             `-->Pool(1x1,2x2)->ReLU---`
 TEST_F(TransformationTestsF, StridesOptimization5) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{0, 0},
@@ -226,8 +226,8 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
         auto relu_1 = std::make_shared<ngraph::opset7::Relu>(conv_1);
         auto relu_2 = std::make_shared<ngraph::opset7::Relu>(data);
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, relu_2);
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(add,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -238,9 +238,9 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -254,8 +254,8 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
                                                               ngraph::Shape{1, 1});
         auto relu_2 = std::make_shared<ngraph::opset7::Relu>(pool);
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, relu_2);
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(add,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add,
                                                                     weights_2,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
@@ -271,30 +271,30 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
 // Pl->Conv(1x1,2x2)->Conv(1x1,1x1)->Conv(3x3,2x2)->Conv(1x1,1x1)
 TEST_F(TransformationTestsF, StridesOptimization6) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(conv_2,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(conv_2,
                                                                     weights_3,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_4 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_4 = std::make_shared<ngraph::opset7::Convolution>(conv_3,
+        auto weights_4 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_4 = std::make_shared<ov::op::v1::Convolution>(conv_3,
                                                                     weights_4,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -305,30 +305,30 @@ TEST_F(TransformationTestsF, StridesOptimization6) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(conv_2,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 3, 3}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(conv_2,
                                                                     weights_3,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_4 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_4 = std::make_shared<ngraph::opset7::Convolution>(conv_3,
+        auto weights_4 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_4 = std::make_shared<ov::op::v1::Convolution>(conv_3,
                                                                     weights_4,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
@@ -346,31 +346,31 @@ TEST_F(TransformationTestsF, StridesOptimization6) {
 //                   `--> Pool(1x1, 2x2) -> Relu --> Conv(1x1,1x1)
 TEST_F(TransformationTestsF, StridesOptimization7) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(conv_2,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(conv_2,
                                                                     weights_3,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
         auto relu = std::make_shared<ngraph::opset7::Relu>(conv_1);
-        auto weights_4 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_4 = std::make_shared<ngraph::opset7::Convolution>(relu,
+        auto weights_4 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_4 = std::make_shared<ov::op::v1::Convolution>(relu,
                                                                     weights_4,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -382,23 +382,23 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(conv_1,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(conv_1,
                                                                     weights_2,
                                                                     ngraph::Strides{4, 4},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(conv_2,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(conv_2,
                                                                     weights_3,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
@@ -410,8 +410,8 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
                                                               ngraph::Shape{0, 0},
                                                               ngraph::Shape{1, 1});
         auto relu = std::make_shared<ngraph::opset7::Relu>(pool);
-        auto weights_4 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_4 = std::make_shared<ngraph::opset7::Convolution>(relu,
+        auto weights_4 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_4 = std::make_shared<ov::op::v1::Convolution>(relu,
                                                                     weights_4,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
@@ -430,9 +430,9 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
 // Const-->MaxPool(1x1,4x4)-->Squeeze`  Pl--->MaxPool(1x1,2x2)-->Squeeze`
 TEST_F(TransformationTestsF, StridesOptimization8) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{0, 0},
@@ -444,17 +444,17 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
                                                          const_shape,
                                                          std::vector<float>(shape_size(const_shape), 1));
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, constant);
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(add,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto data_2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 112, 112});
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{3, 112, 112});
         auto add_2 = std::make_shared<ngraph::opset7::Add>(conv_2, data_2);
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(add_2,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add_2,
                                                                     weights_3,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -466,9 +466,9 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{4, 4},
                                                                     ngraph::CoordinateDiff{},
@@ -480,14 +480,14 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
                                                          const_shape,
                                                          std::vector<float>(shape_size(const_shape), 1));
         auto add = std::make_shared<ngraph::opset7::Add>(relu_1, constant);
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(add,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add,
                                                                     weights_2,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
-        auto data_2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 112, 112});
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{3, 112, 112});
         auto reshape = std::make_shared<ngraph::opset7::Reshape>(
             data_2,
             ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 3, 112, 112}),
@@ -501,8 +501,8 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
             pool_2,
             ngraph::op::Constant::create(ngraph::element::u64, ngraph::Shape{1}, {0}));
         auto add_2 = std::make_shared<ngraph::opset7::Add>(conv_2, squeeze);
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(add_2,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add_2,
                                                                     weights_3,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
@@ -523,38 +523,38 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
 // Const--`      Const-`        Const--`     Const-`
 TEST_F(TransformationTestsF, StridesOptimization9) {
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{0, 0},
                                                                     ngraph::CoordinateDiff{0, 0},
                                                                     ngraph::Strides{});
 
-        auto data_2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{224});
-        auto add_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{224}, {128});
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{224});
+        auto add_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{224}, {128});
         auto add = std::make_shared<ngraph::opset7::Add>(data_2, add_const);
-        auto add_2_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{224}, {128});
+        auto add_2_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{224}, {128});
         auto add_2 = std::make_shared<ngraph::opset7::Add>(add, add_2_const);
 
         auto add_3 = std::make_shared<ngraph::opset7::Add>(conv_1, add_2);
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(add_3,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add_3,
                                                                     weights_2,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
 
-        auto data_3 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{});
-        auto add_4_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, {128});
+        auto data_3 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{});
+        auto add_4_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{}, {128});
         auto add_4 = std::make_shared<ngraph::opset7::Add>(data_3, add_4_const);
-        auto add_5_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {128});
+        auto add_5_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {128});
         auto add_5 = std::make_shared<ngraph::opset7::Add>(add_4, add_5_const);
         auto add_6 = std::make_shared<ngraph::opset7::Add>(conv_2, add_5);
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(add_6,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add_6,
                                                                     weights_3,
                                                                     ngraph::Strides{2, 2},
                                                                     ngraph::CoordinateDiff{},
@@ -566,16 +566,16 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
-        auto weights_1 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_1 = std::make_shared<ngraph::opset7::Convolution>(data,
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 224, 224});
+        auto weights_1 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_1 = std::make_shared<ov::op::v1::Convolution>(data,
                                                                     weights_1,
                                                                     ngraph::Strides{4, 4},
                                                                     ngraph::CoordinateDiff{0, 0},
                                                                     ngraph::CoordinateDiff{0, 0},
                                                                     ngraph::Strides{});
 
-        auto data_2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{224});
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{224});
         auto reshape = std::make_shared<ngraph::opset7::Reshape>(
             data_2,
             ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 1, 1, 224}),
@@ -588,22 +588,22 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         auto squeeze = std::make_shared<ngraph::opset7::Squeeze>(
             pool,
             ngraph::op::Constant::create(ngraph::element::u64, ngraph::Shape{3}, {0, 1, 2}));
-        auto add_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{56}, {128});
+        auto add_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{56}, {128});
         auto add = std::make_shared<ngraph::opset7::Add>(squeeze, add_const);
-        auto add_2_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{56}, {128});
+        auto add_2_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{56}, {128});
         auto add_2 = std::make_shared<ngraph::opset7::Add>(add, add_2_const);
 
         auto add_3 = std::make_shared<ngraph::opset7::Add>(conv_1, add_2);
-        auto weights_2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_2 = std::make_shared<ngraph::opset7::Convolution>(add_3,
+        auto weights_2 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_2 = std::make_shared<ov::op::v1::Convolution>(add_3,
                                                                     weights_2,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::CoordinateDiff{},
                                                                     ngraph::Strides{});
 
-        auto data_3 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{});
-        auto new_shape = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 1, 1, 1});
+        auto data_3 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{});
+        auto new_shape = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {1, 1, 1, 1});
         auto reshape_2 = std::make_shared<ngraph::opset7::Reshape>(data_3, new_shape, false);
         auto pool_2 = std::make_shared<ngraph::opset7::MaxPool>(reshape_2,
                                                                 ngraph::Strides{2, 2},
@@ -613,13 +613,13 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
         auto squeeze_2 = std::make_shared<ngraph::opset7::Squeeze>(
             pool_2,
             ngraph::op::Constant::create(ngraph::element::u64, ngraph::Shape{4}, {0, 1, 2, 3}));
-        auto add_4_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, {128});
+        auto add_4_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{}, {128});
         auto add_4 = std::make_shared<ngraph::opset7::Add>(squeeze_2, add_4_const);
-        auto add_5_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {128});
+        auto add_5_const = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{1}, {128});
         auto add_5 = std::make_shared<ngraph::opset7::Add>(add_4, add_5_const);
         auto add_6 = std::make_shared<ngraph::opset7::Add>(conv_2, add_5);
-        auto weights_3 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
-        auto conv_3 = std::make_shared<ngraph::opset7::Convolution>(add_6,
+        auto weights_3 = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 1}, {128});
+        auto conv_3 = std::make_shared<ov::op::v1::Convolution>(add_6,
                                                                     weights_3,
                                                                     ngraph::Strides{1, 1},
                                                                     ngraph::CoordinateDiff{},

--- a/src/common/transformations/tests/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
@@ -22,25 +22,25 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul) {
     Shape data_shape_1{10, 2};
     Shape data_shape_2{10, 2, 25};
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
-        auto const_transpose_before = opset1::Constant::create(element::i32, Shape{3}, {1, 2, 0});
-        auto transpose_before = std::make_shared<opset1::Transpose>(data_2, const_transpose_before);
-        auto const_reshape_before = opset1::Constant::create(element::i32, Shape{2}, {2, 250});
-        auto reshape_before = std::make_shared<opset1::Reshape>(transpose_before, const_reshape_before, false);
-        auto matmul = std::make_shared<opset1::MatMul>(data_1, reshape_before);
-        auto const_reshape_after = opset1::Constant::create(element::i32, Shape{3}, {10, 10, 25});
-        auto reshape_after = std::make_shared<opset1::Reshape>(matmul, const_reshape_after, false);
-        auto const_tranpose_after = opset1::Constant::create(element::i32, Shape{3}, {2, 0, 1});
-        auto tranpose_after = std::make_shared<opset1::Transpose>(reshape_after, const_tranpose_after);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
+        auto const_transpose_before = ov::op::v0::Constant::create(element::i32, Shape{3}, {1, 2, 0});
+        auto transpose_before = std::make_shared<ov::op::v1::Transpose>(data_2, const_transpose_before);
+        auto const_reshape_before = ov::op::v0::Constant::create(element::i32, Shape{2}, {2, 250});
+        auto reshape_before = std::make_shared<ov::op::v1::Reshape>(transpose_before, const_reshape_before, false);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, reshape_before);
+        auto const_reshape_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {10, 10, 25});
+        auto reshape_after = std::make_shared<ov::op::v1::Reshape>(matmul, const_reshape_after, false);
+        auto const_tranpose_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {2, 0, 1});
+        auto tranpose_after = std::make_shared<ov::op::v1::Transpose>(reshape_after, const_tranpose_after);
         function = std::make_shared<Function>(NodeVector{tranpose_after}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
-        auto matmul = std::make_shared<opset1::MatMul>(data_1, data_2);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, data_2);
         function_ref = std::make_shared<Function>(NodeVector{matmul}, ParameterVector{data_1, data_2});
     }
 }
@@ -49,24 +49,24 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_TransposedA) {
     Shape data_shape_1{2, 10};
     Shape data_shape_2{10, 2, 25};
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
-        auto const_transpose_before = opset1::Constant::create(element::i32, Shape{3}, {1, 2, 0});
-        auto transpose_before = std::make_shared<opset1::Transpose>(data_2, const_transpose_before);
-        auto const_reshape_before = opset1::Constant::create(element::i32, Shape{2}, {2, 250});
-        auto reshape_before = std::make_shared<opset1::Reshape>(transpose_before, const_reshape_before, false);
-        auto matmul = std::make_shared<opset1::MatMul>(data_1, reshape_before, true, false);
-        auto const_reshape_after = opset1::Constant::create(element::i32, Shape{3}, {10, 10, 25});
-        auto reshape_after = std::make_shared<opset1::Reshape>(matmul, const_reshape_after, false);
-        auto const_tranpose_after = opset1::Constant::create(element::i32, Shape{3}, {2, 0, 1});
-        auto tranpose_after = std::make_shared<opset1::Transpose>(reshape_after, const_tranpose_after);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
+        auto const_transpose_before = ov::op::v0::Constant::create(element::i32, Shape{3}, {1, 2, 0});
+        auto transpose_before = std::make_shared<ov::op::v1::Transpose>(data_2, const_transpose_before);
+        auto const_reshape_before = ov::op::v0::Constant::create(element::i32, Shape{2}, {2, 250});
+        auto reshape_before = std::make_shared<ov::op::v1::Reshape>(transpose_before, const_reshape_before, false);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, reshape_before, true, false);
+        auto const_reshape_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {10, 10, 25});
+        auto reshape_after = std::make_shared<ov::op::v1::Reshape>(matmul, const_reshape_after, false);
+        auto const_tranpose_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {2, 0, 1});
+        auto tranpose_after = std::make_shared<ov::op::v1::Transpose>(reshape_after, const_tranpose_after);
         function = std::make_shared<Function>(NodeVector{tranpose_after}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
-        auto matmul = std::make_shared<opset1::MatMul>(data_1, data_2, true, false);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, data_2, true, false);
         function_ref = std::make_shared<Function>(NodeVector{matmul}, ParameterVector{data_1, data_2});
     }
 }
@@ -75,24 +75,24 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_TransposedB) {
     Shape data_shape_1{10, 2};
     Shape data_shape_2{10, 2, 25};
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
-        auto const_transpose_before = opset1::Constant::create(element::i32, Shape{3}, {0, 2, 1});
-        auto transpose_before = std::make_shared<opset1::Transpose>(data_2, const_transpose_before);
-        auto const_reshape_before = opset1::Constant::create(element::i32, Shape{2}, {250, 2});
-        auto reshape_before = std::make_shared<opset1::Reshape>(transpose_before, const_reshape_before, false);
-        auto matmul = std::make_shared<opset1::MatMul>(data_1, reshape_before, false, true);
-        auto const_reshape_after = opset1::Constant::create(element::i32, Shape{3}, {10, 10, 25});
-        auto reshape_after = std::make_shared<opset1::Reshape>(matmul, const_reshape_after, false);
-        auto const_tranpose_after = opset1::Constant::create(element::i32, Shape{3}, {1, 0, 2});
-        auto tranpose_after = std::make_shared<opset1::Transpose>(reshape_after, const_tranpose_after);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
+        auto const_transpose_before = ov::op::v0::Constant::create(element::i32, Shape{3}, {0, 2, 1});
+        auto transpose_before = std::make_shared<ov::op::v1::Transpose>(data_2, const_transpose_before);
+        auto const_reshape_before = ov::op::v0::Constant::create(element::i32, Shape{2}, {250, 2});
+        auto reshape_before = std::make_shared<ov::op::v1::Reshape>(transpose_before, const_reshape_before, false);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, reshape_before, false, true);
+        auto const_reshape_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {10, 10, 25});
+        auto reshape_after = std::make_shared<ov::op::v1::Reshape>(matmul, const_reshape_after, false);
+        auto const_tranpose_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {1, 0, 2});
+        auto tranpose_after = std::make_shared<ov::op::v1::Transpose>(reshape_after, const_tranpose_after);
         function = std::make_shared<Function>(NodeVector{tranpose_after}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
-        auto matmul = std::make_shared<opset1::MatMul>(data_1, data_2);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, data_2);
         function_ref = std::make_shared<Function>(NodeVector{matmul}, ParameterVector{data_1, data_2});
     }
 }
@@ -101,24 +101,24 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_TransposedAB) 
     Shape data_shape_1{2, 10};
     Shape data_shape_2{10, 2, 25};
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
-        auto const_transpose_before = opset1::Constant::create(element::i32, Shape{3}, {0, 2, 1});
-        auto transpose_before = std::make_shared<opset1::Transpose>(data_2, const_transpose_before);
-        auto const_reshape_before = opset1::Constant::create(element::i32, Shape{2}, {250, 2});
-        auto reshape_before = std::make_shared<opset1::Reshape>(transpose_before, const_reshape_before, false);
-        auto matmul = std::make_shared<opset1::MatMul>(data_1, reshape_before, true, true);
-        auto const_reshape_after = opset1::Constant::create(element::i32, Shape{3}, {10, 10, 25});
-        auto reshape_after = std::make_shared<opset1::Reshape>(matmul, const_reshape_after, false);
-        auto const_tranpose_after = opset1::Constant::create(element::i32, Shape{3}, {1, 0, 2});
-        auto tranpose_after = std::make_shared<opset1::Transpose>(reshape_after, const_tranpose_after);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
+        auto const_transpose_before = ov::op::v0::Constant::create(element::i32, Shape{3}, {0, 2, 1});
+        auto transpose_before = std::make_shared<ov::op::v1::Transpose>(data_2, const_transpose_before);
+        auto const_reshape_before = ov::op::v0::Constant::create(element::i32, Shape{2}, {250, 2});
+        auto reshape_before = std::make_shared<ov::op::v1::Reshape>(transpose_before, const_reshape_before, false);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, reshape_before, true, true);
+        auto const_reshape_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {10, 10, 25});
+        auto reshape_after = std::make_shared<ov::op::v1::Reshape>(matmul, const_reshape_after, false);
+        auto const_tranpose_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {1, 0, 2});
+        auto tranpose_after = std::make_shared<ov::op::v1::Transpose>(reshape_after, const_tranpose_after);
         function = std::make_shared<Function>(NodeVector{tranpose_after}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
-        auto matmul = std::make_shared<opset1::MatMul>(data_1, data_2, true, false);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, data_2, true, false);
         function_ref = std::make_shared<Function>(NodeVector{matmul}, ParameterVector{data_1, data_2});
     }
 }
@@ -127,21 +127,21 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_Einsum) {
     Shape data_shape_1{5, 2};
     Shape data_shape_2{10, 2, 25};
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto einsum = std::make_shared<opset7::Einsum>(OutputVector{data_1, data_2}, "kl,mlj->mkj");
         function = std::make_shared<Function>(NodeVector{einsum}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::EinsumDecomposition>();
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
     {
-        auto data_1 = std::make_shared<opset1::Parameter>(element::f32, data_shape_1);
-        auto data_2 = std::make_shared<opset1::Parameter>(element::f32, data_shape_2);
+        auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
+        auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         // for some cases Reshape may be first input for Matmul
         auto shape_constant =
-            std::make_shared<opset1::Constant>(element::i64, Shape{data_shape_1.size()}, data_shape_1);
-        auto reshape = std::make_shared<opset1::Reshape>(data_1, shape_constant, false);
-        auto matmul = std::make_shared<opset1::MatMul>(reshape, data_2, false, false);
+            std::make_shared<ov::op::v0::Constant>(element::i64, Shape{data_shape_1.size()}, data_shape_1);
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(data_1, shape_constant, false);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, data_2, false, false);
         function_ref = std::make_shared<Function>(NodeVector{matmul}, ParameterVector{data_1, data_2});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -96,13 +96,13 @@ public:
 };
 
 TEST_P(TransposeSinkingFQ, TransposeFQReduce) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ov::pass::TransposeFQReduction>();
     manager.register_pass<ov::pass::TransposeReduction>();
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh);
     manager.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
 
@@ -215,12 +215,12 @@ private:
 };
 
 TEST_P(TransposeSinking, TransposeReduction) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ov::pass::TransposeReduction>();
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh);
     manager.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
 

--- a/src/common/transformations/tests/common_optimizations/transpose_to_reshape_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_to_reshape_test.cpp
@@ -211,7 +211,7 @@ TEST(TransformationTests, replace_transpose_with_reshape) {
         pass::Manager m;
         m.register_pass<ov::pass::InitUniqueNames>(unh);
         m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ngraph::pass::Validate>();
+        m.register_pass<ov::pass::Validate>();
         m.register_pass<ov::pass::TransposeToReshape>();
         m.register_pass<ov::pass::CheckUniqueNames>(unh);
         m.run_passes(optimized_f);

--- a/src/common/transformations/tests/common_optimizations/transpose_to_reshape_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_to_reshape_test.cpp
@@ -107,12 +107,12 @@ private:
 };
 
 TEST_P(TransposeToReshapeTests, CompareFunctions) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     pass::Manager m;
-    m.register_pass<pass::InitUniqueNames>(unh);
+    m.register_pass<ov::pass::InitUniqueNames>(unh);
     m.register_pass<ov::pass::InitNodeInfo>();
     m.register_pass<ov::pass::TransposeToReshape>();
-    m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    m.register_pass<ov::pass::CheckUniqueNames>(unh);
     m.run_passes(f);
     f->validate_nodes_and_infer_types();
     ASSERT_NO_THROW(check_rt_info(f));
@@ -207,13 +207,13 @@ TEST(TransformationTests, replace_transpose_with_reshape) {
         auto baseline_f = make_shared<Function>(transpose1, ParameterVector{param});
         auto optimized_f = baseline_f->clone();
 
-        auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+        auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         pass::Manager m;
-        m.register_pass<pass::InitUniqueNames>(unh);
+        m.register_pass<ov::pass::InitUniqueNames>(unh);
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ngraph::pass::Validate>();
         m.register_pass<ov::pass::TransposeToReshape>();
-        m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+        m.register_pass<ov::pass::CheckUniqueNames>(unh);
         m.run_passes(optimized_f);
 
         auto ps = baseline_f->get_results()[0]->get_output_partial_shape(0);

--- a/src/common/transformations/tests/common_optimizations/weights_dequantize_to_fake_quantize.cpp
+++ b/src/common/transformations/tests/common_optimizations/weights_dequantize_to_fake_quantize.cpp
@@ -93,12 +93,12 @@ public:
 };
 
 TEST_P(TranslateNewWeightFormatToOldOne, ReshapeMatMul) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    m.register_pass<ov::pass::InitUniqueNames>(unh);
     m.register_pass<ov::pass::InitNodeInfo>();
     m.register_pass<ov::pass::WeightsDequantizeToFakeQuantize>();
-    m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    m.register_pass<ov::pass::CheckUniqueNames>(unh);
     m.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
 

--- a/src/common/transformations/tests/control_flow/unroll_if_test.cpp
+++ b/src/common/transformations/tests/control_flow/unroll_if_test.cpp
@@ -202,7 +202,7 @@ TEST(TransformationTests, UnrollIfCondIsTrueMultiOutput) {
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{if_result}, ngraph::ParameterVector{data});
 
-        ngraph::pass::Manager manager;
+        ov::pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<ov::pass::UnrollIf>();
         manager.run_passes(f);

--- a/src/common/transformations/tests/control_flow/unroll_if_test.cpp
+++ b/src/common/transformations/tests/control_flow/unroll_if_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <memory>
-#include <openvino/opsets/opset9.hpp>
 #include <openvino/pass/constant_folding.hpp>
 #include <openvino/pass/manager.hpp>
 #include <transformations/common_optimizations/push_constant_to_subgraph.hpp>
@@ -13,32 +12,39 @@
 #include <transformations/init_node_info.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/if.hpp"
+#include "openvino/op/split.hpp"
+#include "openvino/op/variadic_split.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/logical_not.hpp"
 
 using namespace testing;
 
 std::shared_ptr<ov::Model> get_then_body() {
-    auto Xt = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-    auto Yt = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-    auto add_op = std::make_shared<ov::opset9::Add>(Xt, Yt);
-    auto then_op_result = std::make_shared<ov::opset9::Result>(add_op);
+    auto Xt = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+    auto Yt = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+    auto add_op = std::make_shared<ov::op::v1::Add>(Xt, Yt);
+    auto then_op_result = std::make_shared<ov::op::v0::Result>(add_op);
     auto then_body = std::make_shared<ov::Model>(ov::OutputVector{then_op_result}, ov::ParameterVector{Xt, Yt});
     return then_body;
 }
 
 std::shared_ptr<ov::Model> get_else_body() {
-    auto Xe = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-    auto Ye = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-    auto mul_op = std::make_shared<ov::opset9::Multiply>(Xe, Ye);
-    auto else_op_result = std::make_shared<ov::opset9::Result>(mul_op);
+    auto Xe = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+    auto Ye = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+    auto mul_op = std::make_shared<ov::op::v1::Multiply>(Xe, Ye);
+    auto else_op_result = std::make_shared<ov::op::v0::Result>(mul_op);
     auto else_body = std::make_shared<ov::Model>(ov::OutputVector{else_op_result}, ov::ParameterVector{Xe, Ye});
     return else_body;
 }
 
 std::shared_ptr<ov::Model> create_if_model(bool condition) {
-    auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-    auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-    auto cond = std::make_shared<ov::opset9::Constant>(ov::element::boolean, ov::Shape{1}, condition);
-    auto if_op = std::make_shared<ov::opset8::If>(cond);
+    auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+    auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+    auto cond = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{1}, condition);
+    auto if_op = std::make_shared<ov::op::v8::If>(cond);
     const auto& then_body = get_then_body();
     const auto& else_body = get_else_body();
 
@@ -49,7 +55,7 @@ std::shared_ptr<ov::Model> create_if_model(bool condition) {
     if_op->set_input(X, then_p[0], else_p[0]);
     if_op->set_input(Y, then_p[1], else_p[1]);
     if_op->set_output(then_body->get_results()[0], else_body->get_results()[0]);
-    auto if_result = std::make_shared<ov::opset9::Result>(if_op);
+    auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
     return std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
 }
@@ -95,12 +101,12 @@ TEST(TransformationTests, UnrollIfCondIsFalse) {
 TEST(TransformationTests, UnrollIfWithSplitInput) {
     std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
     {
-        auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{2, 3});
-        auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
+        auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 3});
+        auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
         auto split =
-            std::make_shared<ov::opset9::Split>(X, ov::opset9::Constant::create(ov::element::i32, ov::Shape{}, {0}), 2);
-        auto cond = std::make_shared<ov::opset9::Constant>(ov::element::boolean, ov::Shape{1}, false);
-        auto if_op = std::make_shared<ov::opset8::If>(cond);
+            std::make_shared<ov::op::v1::Split>(X, ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0}), 2);
+        auto cond = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{1}, false);
+        auto if_op = std::make_shared<ov::op::v8::If>(cond);
         const auto& then_body = get_then_body();
         const auto& else_body = get_else_body();
 
@@ -113,7 +119,7 @@ TEST(TransformationTests, UnrollIfWithSplitInput) {
         if_op->set_input(split->output(1), nullptr, else_p[0]);
         if_op->set_input(Y, then_p[1], else_p[1]);
         if_op->set_output(then_body->get_results()[0], else_body->get_results()[0]);
-        auto if_result = std::make_shared<ov::opset9::Result>(if_op);
+        auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
         f = std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
 
@@ -126,12 +132,12 @@ TEST(TransformationTests, UnrollIfWithSplitInput) {
     }
 
     {
-        auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{2, 3});
-        auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
+        auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 3});
+        auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
         auto split =
-            std::make_shared<ov::opset9::Split>(X, ov::opset9::Constant::create(ov::element::i32, ov::Shape{}, {0}), 2);
-        auto mul_op = std::make_shared<ov::opset9::Multiply>(split->output(1), Y);
-        auto if_result = std::make_shared<ov::opset9::Result>(mul_op);
+            std::make_shared<ov::op::v1::Split>(X, ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0}), 2);
+        auto mul_op = std::make_shared<ov::op::v1::Multiply>(split->output(1), Y);
+        auto if_result = std::make_shared<ov::op::v0::Result>(mul_op);
         f_ref = std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
     }
 
@@ -142,14 +148,14 @@ TEST(TransformationTests, UnrollIfWithSplitInput) {
 TEST(TransformationTests, UnrollNestedIfThenBody) {
     std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
     {
-        auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-        auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
+        auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+        auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
 
         auto then_body = create_if_model(true);
         auto else_body = create_if_model(false);
 
-        auto cond = std::make_shared<ov::opset9::Constant>(ov::element::boolean, ov::Shape{1}, true);
-        auto if_op = std::make_shared<ov::opset8::If>(cond);
+        auto cond = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{1}, true);
+        auto if_op = std::make_shared<ov::op::v8::If>(cond);
 
         if_op->set_then_body(then_body);
         if_op->set_else_body(else_body);
@@ -158,7 +164,7 @@ TEST(TransformationTests, UnrollNestedIfThenBody) {
         if_op->set_input(X, then_p[0], else_p[0]);
         if_op->set_input(Y, then_p[1], else_p[1]);
         if_op->set_output(then_body->get_results()[0], else_body->get_results()[0]);
-        auto if_result = std::make_shared<ov::opset9::Result>(if_op);
+        auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
         f = std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
         ov::pass::Manager manager;
@@ -177,20 +183,20 @@ TEST(TransformationTests, UnrollNestedIfThenBody) {
 TEST(TransformationTests, UnrollIfCondIsTrueMultiOutput) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto data = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{3});
-        auto X = std::make_shared<ngraph::opset6::VariadicSplit>(
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{3});
+        auto X = std::make_shared<ov::op::v1::VariadicSplit>(
             data,
-            ngraph::opset6::Constant::create(ngraph::element::i32, {1}, {0}),
-            ngraph::opset6::Constant::create(ngraph::element::i32, {2}, {1, 2}));
-        auto cond = std::make_shared<ngraph::opset1::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
-        auto if_op = std::make_shared<ov::opset9::If>(cond);
-        auto Xt = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{2});
-        auto then_op_result = std::make_shared<ngraph::opset1::Result>(Xt);
+            ov::op::v0::Constant::create(ngraph::element::i32, {1}, {0}),
+            ov::op::v0::Constant::create(ngraph::element::i32, {2}, {1, 2}));
+        auto cond = std::make_shared<ov::op::v0::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
+        auto if_op = std::make_shared<ov::op::v8::If>(cond);
+        auto Xt = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{2});
+        auto then_op_result = std::make_shared<ov::op::v0::Result>(Xt);
         auto then_body =
             std::make_shared<ngraph::Function>(ngraph::OutputVector{then_op_result}, ngraph::ParameterVector{Xt});
 
-        auto Xe = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{2});
-        auto else_op_result = std::make_shared<ngraph::opset1::Result>(Xe);
+        auto Xe = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{2});
+        auto else_op_result = std::make_shared<ov::op::v0::Result>(Xe);
         auto else_body =
             std::make_shared<ngraph::Function>(ngraph::OutputVector{else_op_result}, ngraph::ParameterVector{Xe});
 
@@ -198,7 +204,7 @@ TEST(TransformationTests, UnrollIfCondIsTrueMultiOutput) {
         if_op->set_else_body(else_body);
         if_op->set_input(X->output(1), Xt, Xe);
         if_op->set_output(then_op_result, else_op_result);
-        auto if_result = std::make_shared<ngraph::opset1::Result>(if_op);
+        auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{if_result}, ngraph::ParameterVector{data});
 
@@ -211,12 +217,12 @@ TEST(TransformationTests, UnrollIfCondIsTrueMultiOutput) {
     }
 
     {
-        auto data = std::make_shared<ngraph::opset6::Parameter>(ngraph::element::f32, ngraph::Shape{3});
-        auto X = std::make_shared<ngraph::opset6::VariadicSplit>(
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{3});
+        auto X = std::make_shared<ov::op::v1::VariadicSplit>(
             data,
-            ngraph::opset6::Constant::create(ngraph::element::i32, {1}, {0}),
-            ngraph::opset6::Constant::create(ngraph::element::i32, {2}, {1, 2}));
-        auto if_result = std::make_shared<ngraph::opset1::Result>(X->output(1));
+            ov::op::v0::Constant::create(ngraph::element::i32, {1}, {0}),
+            ov::op::v0::Constant::create(ngraph::element::i32, {2}, {1, 2}));
+        auto if_result = std::make_shared<ov::op::v0::Result>(X->output(1));
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{if_result}, ngraph::ParameterVector{data});
     }
 
@@ -227,32 +233,32 @@ TEST(TransformationTests, UnrollIfCondIsTrueMultiOutput) {
 TEST(TransformationTests, UnrollIfInsideIf) {
     std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
     {
-        auto cond = std::make_shared<ov::opset9::Constant>(ov::element::boolean, ov::Shape{1}, true);
-        auto not_cond = std::make_shared<ov::opset9::LogicalNot>(cond);
-        auto if_op = std::make_shared<ov::opset8::If>(cond);
+        auto cond = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{1}, true);
+        auto not_cond = std::make_shared<ov::op::v1::LogicalNot>(cond);
+        auto if_op = std::make_shared<ov::op::v8::If>(cond);
 
         std::shared_ptr<ov::Model> then_body;
         {
-            auto cond_inside = std::make_shared<ov::opset9::Parameter>(ov::element::boolean, ov::Shape{1});
-            auto if_inside = std::make_shared<ov::opset8::If>(cond_inside);
+            auto cond_inside = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, ov::Shape{1});
+            auto if_inside = std::make_shared<ov::op::v8::If>(cond_inside);
 
             std::shared_ptr<ov::Model> then_body_inside;
             {
-                auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-                auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-                auto add = std::make_shared<ov::opset9::Add>(X, Y);
+                auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+                auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+                auto add = std::make_shared<ov::op::v1::Add>(X, Y);
                 then_body_inside = std::make_shared<ov::Model>(add, ov::ParameterVector{X, Y});
             }
             std::shared_ptr<ov::Model> else_body_inside;
             {
-                auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-                auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-                auto mul = std::make_shared<ov::opset9::Multiply>(X, Y);
+                auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+                auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+                auto mul = std::make_shared<ov::op::v1::Multiply>(X, Y);
                 else_body_inside = std::make_shared<ov::Model>(mul, ov::ParameterVector{X, Y});
             }
 
-            auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-            auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
+            auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+            auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
             if_inside->set_then_body(then_body_inside);
             if_inside->set_else_body(else_body_inside);
             auto then_p = then_body_inside->get_parameters();
@@ -260,21 +266,21 @@ TEST(TransformationTests, UnrollIfInsideIf) {
             if_inside->set_input(X, then_p[0], else_p[0]);
             if_inside->set_input(Y, then_p[1], else_p[1]);
             if_inside->set_output(then_body_inside->get_results()[0], else_body_inside->get_results()[0]);
-            auto if_result = std::make_shared<ov::opset9::Result>(if_inside);
+            auto if_result = std::make_shared<ov::op::v0::Result>(if_inside);
 
             then_body = std::make_shared<ov::Model>(if_result, ov::ParameterVector{cond_inside, X, Y});
         }
 
         std::shared_ptr<ov::Model> else_body;
         {
-            auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-            auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-            auto sub = std::make_shared<ov::opset9::Subtract>(X, Y);
+            auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+            auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+            auto sub = std::make_shared<ov::op::v1::Subtract>(X, Y);
             else_body = std::make_shared<ov::Model>(sub, ov::ParameterVector{X, Y});
         }
 
-        auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-        auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
+        auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+        auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
         if_op->set_then_body(then_body);
         if_op->set_else_body(else_body);
         auto then_p = then_body->get_parameters();
@@ -283,7 +289,7 @@ TEST(TransformationTests, UnrollIfInsideIf) {
         if_op->set_input(X, then_p[1], else_p[0]);
         if_op->set_input(Y, then_p[2], else_p[1]);
         if_op->set_output(then_body->get_results()[0], else_body->get_results()[0]);
-        auto if_result = std::make_shared<ov::opset9::Result>(if_op);
+        auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
         f = std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
         ov::pass::Manager manager;
@@ -296,9 +302,9 @@ TEST(TransformationTests, UnrollIfInsideIf) {
     }
 
     {
-        auto X = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-        auto Y = std::make_shared<ov::opset9::Parameter>(ov::element::f32, ov::Shape{3});
-        auto mul = std::make_shared<ov::opset9::Multiply>(X, Y);
+        auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+        auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
+        auto mul = std::make_shared<ov::op::v1::Multiply>(X, Y);
         f_ref = std::make_shared<ov::Model>(mul, ov::ParameterVector{X, Y});
     }
 

--- a/src/common/transformations/tests/control_flow/unroll_if_test.cpp
+++ b/src/common/transformations/tests/control_flow/unroll_if_test.cpp
@@ -13,12 +13,12 @@
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "openvino/op/add.hpp"
-#include "openvino/op/multiply.hpp"
 #include "openvino/op/if.hpp"
-#include "openvino/op/split.hpp"
-#include "openvino/op/variadic_split.hpp"
-#include "openvino/op/subtract.hpp"
 #include "openvino/op/logical_not.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/split.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/variadic_split.hpp"
 
 using namespace testing;
 

--- a/src/common/transformations/tests/op_conversions/convert_nms9_to_nms_ie_internal_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_nms9_to_nms_ie_internal_test.cpp
@@ -24,12 +24,12 @@ using namespace ngraph;
 
 TEST_F(TransformationTestsF, ConvertPreviousNMSToNMSIEInternal) {
     {
-        auto boxes = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1000, 4});
-        auto scores = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1, 1000});
-        auto max_output_boxes_per_class = opset1::Constant::create(element::i64, Shape{}, {10});
-        auto iou_threshold = opset1::Constant::create(element::f32, Shape{}, {0.75});
-        auto score_threshold = opset1::Constant::create(element::f32, Shape{}, {0.7});
-        auto nms = std::make_shared<opset1::NonMaxSuppression>(boxes,
+        auto boxes = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 1000, 4});
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 1, 1000});
+        auto max_output_boxes_per_class = ov::op::v0::Constant::create(element::i64, Shape{}, {10});
+        auto iou_threshold = ov::op::v0::Constant::create(element::f32, Shape{}, {0.75});
+        auto score_threshold = ov::op::v0::Constant::create(element::f32, Shape{}, {0.7});
+        auto nms = std::make_shared<ov::op::v1::NonMaxSuppression>(boxes,
                                                                scores,
                                                                max_output_boxes_per_class,
                                                                iou_threshold,
@@ -49,11 +49,11 @@ TEST_F(TransformationTestsF, ConvertPreviousNMSToNMSIEInternal) {
     }
 
     {
-        auto boxes = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1000, 4});
-        auto scores = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1, 1000});
-        auto max_output_boxes_per_class = opset1::Constant::create(element::i64, Shape{1}, {10});
-        auto iou_threshold = opset1::Constant::create(element::f32, Shape{1}, {0.75});
-        auto score_threshold = opset1::Constant::create(element::f32, Shape{1}, {0.7});
+        auto boxes = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 1000, 4});
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 1, 1000});
+        auto max_output_boxes_per_class = ov::op::v0::Constant::create(element::i64, Shape{1}, {10});
+        auto iou_threshold = ov::op::v0::Constant::create(element::f32, Shape{1}, {0.75});
+        auto score_threshold = ov::op::v0::Constant::create(element::f32, Shape{1}, {0.7});
         auto nms = std::make_shared<ov::op::internal::NonMaxSuppressionIEInternal>(boxes,
                                                                                    scores,
                                                                                    max_output_boxes_per_class,
@@ -62,7 +62,7 @@ TEST_F(TransformationTestsF, ConvertPreviousNMSToNMSIEInternal) {
                                                                                    0,
                                                                                    true,
                                                                                    element::i32);
-        auto convert = std::make_shared<opset1::Convert>(nms->output(0), element::i64);
+        auto convert = std::make_shared<ov::op::v0::Convert>(nms->output(0), element::i64);
 
         function_ref = std::make_shared<Function>(NodeVector{convert}, ParameterVector{boxes, scores});
     }
@@ -70,12 +70,12 @@ TEST_F(TransformationTestsF, ConvertPreviousNMSToNMSIEInternal) {
 
 TEST_F(TransformationTestsF, ConvertNMS9ToNMSIEInternal) {
     {
-        auto boxes = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1000, 4});
-        auto scores = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1, 1000});
-        auto max_output_boxes_per_class = opset1::Constant::create(element::i32, Shape{}, {10});
-        auto iou_threshold = opset1::Constant::create(element::f32, Shape{}, {0.75});
-        auto score_threshold = opset1::Constant::create(element::f32, Shape{}, {0.7});
-        auto soft_nms_sigma = opset1::Constant::create(element::f32, Shape{}, {0.5});
+        auto boxes = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 1000, 4});
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 1, 1000});
+        auto max_output_boxes_per_class = ov::op::v0::Constant::create(element::i32, Shape{}, {10});
+        auto iou_threshold = ov::op::v0::Constant::create(element::f32, Shape{}, {0.75});
+        auto score_threshold = ov::op::v0::Constant::create(element::f32, Shape{}, {0.7});
+        auto soft_nms_sigma = ov::op::v0::Constant::create(element::f32, Shape{}, {0.5});
         auto nms = std::make_shared<opset9::NonMaxSuppression>(boxes,
                                                                scores,
                                                                max_output_boxes_per_class,
@@ -93,12 +93,12 @@ TEST_F(TransformationTestsF, ConvertNMS9ToNMSIEInternal) {
     }
 
     {
-        auto boxes = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1000, 4});
-        auto scores = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1, 1000});
-        auto max_output_boxes_per_class = opset1::Constant::create(element::i32, Shape{1}, {10});
-        auto iou_threshold = opset1::Constant::create(element::f32, Shape{1}, {0.75});
-        auto score_threshold = opset1::Constant::create(element::f32, Shape{1}, {0.7});
-        auto soft_nms_sigma = opset1::Constant::create(element::f32, Shape{1}, {0.5});
+        auto boxes = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 1000, 4});
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 1, 1000});
+        auto max_output_boxes_per_class = ov::op::v0::Constant::create(element::i32, Shape{1}, {10});
+        auto iou_threshold = ov::op::v0::Constant::create(element::f32, Shape{1}, {0.75});
+        auto score_threshold = ov::op::v0::Constant::create(element::f32, Shape{1}, {0.7});
+        auto soft_nms_sigma = ov::op::v0::Constant::create(element::f32, Shape{1}, {0.5});
         auto nms = std::make_shared<ov::op::internal::NonMaxSuppressionIEInternal>(boxes,
                                                                                    scores,
                                                                                    max_output_boxes_per_class,

--- a/src/common/transformations/tests/op_conversions/convert_nms9_to_nms_ie_internal_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_nms9_to_nms_ie_internal_test.cpp
@@ -30,12 +30,12 @@ TEST_F(TransformationTestsF, ConvertPreviousNMSToNMSIEInternal) {
         auto iou_threshold = ov::op::v0::Constant::create(element::f32, Shape{}, {0.75});
         auto score_threshold = ov::op::v0::Constant::create(element::f32, Shape{}, {0.7});
         auto nms = std::make_shared<ov::op::v1::NonMaxSuppression>(boxes,
-                                                               scores,
-                                                               max_output_boxes_per_class,
-                                                               iou_threshold,
-                                                               score_threshold,
-                                                               op::v1::NonMaxSuppression::BoxEncodingType::CORNER,
-                                                               true);
+                                                                   scores,
+                                                                   max_output_boxes_per_class,
+                                                                   iou_threshold,
+                                                                   score_threshold,
+                                                                   op::v1::NonMaxSuppression::BoxEncodingType::CORNER,
+                                                                   true);
 
         function = std::make_shared<Function>(NodeVector{nms}, ParameterVector{boxes, scores});
 

--- a/src/common/transformations/tests/op_conversions/convert_reduce_to_pooling_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_reduce_to_pooling_test.cpp
@@ -135,12 +135,12 @@ public:
 };
 
 TEST_P(ConvertReduceToPoolingTests, CompareFunctions) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    m.register_pass<ov::pass::InitUniqueNames>(unh);
     m.register_pass<ov::pass::InitNodeInfo>();
     m.register_pass<ov::pass::ConvertReduceToPooling>();
-    m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    m.register_pass<ov::pass::CheckUniqueNames>(unh);
     m.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
 

--- a/src/common/transformations/tests/op_conversions/convert_scatter_elements_to_scatter_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_scatter_elements_to_scatter_test.cpp
@@ -81,13 +81,13 @@ std::shared_ptr<ngraph::Function> get_reference_function(const ngraph::PartialSh
 }
 
 void test(std::shared_ptr<ngraph::Function> f, std::shared_ptr<ngraph::Function> f_ref) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ov::pass::ConvertScatterElementsToScatter>();
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
-    manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh);
+    manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
         check_rt_info(f);
     });
     manager.register_pass<ngraph::pass::ConstantFolding>();

--- a/src/common/transformations/tests/op_conversions/ngraph_depth_to_space_transform_test.cpp
+++ b/src/common/transformations/tests/op_conversions/ngraph_depth_to_space_transform_test.cpp
@@ -43,7 +43,7 @@ TEST(TransformationTests, TestDepthToSpaceTransformBlockFirst) {
     ASSERT_EQ(consumers.size(), 1);
 
     auto reshape_begin = consumers.begin()->get_node();
-    auto shape_begin = std::dynamic_pointer_cast<ngraph::op::Constant>(
+    auto shape_begin = std::dynamic_pointer_cast<ov::op::v0::Constant>(
         reshape_begin->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> shape_begin_value = shape_begin->get_vector<int64_t>();
     std::vector<int64_t> shape_begin_value_ref{1, 2, 2, 3, 1080, 1616};
@@ -54,14 +54,14 @@ TEST(TransformationTests, TestDepthToSpaceTransformBlockFirst) {
 
     auto transpose = consumers.begin()->get_node();
     auto order =
-        std::dynamic_pointer_cast<ngraph::op::Constant>(transpose->input(1).get_source_output().get_node_shared_ptr());
+        std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> order_value = order->get_vector<int64_t>();
     std::vector<int64_t> order_value_ref{0, 3, 4, 1, 5, 2};
     ASSERT_EQ(order_value, order_value_ref);
 
     consumers = transpose->output(0).get_target_inputs();
     auto reshape_end = consumers.begin()->get_node();
-    auto shape_end = std::dynamic_pointer_cast<ngraph::op::Constant>(
+    auto shape_end = std::dynamic_pointer_cast<ov::op::v0::Constant>(
         reshape_end->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> shape_end_value = shape_end->get_vector<int64_t>();
     std::vector<int64_t> shape_end_value_ref{1, 3, 2 * 1080, 2 * 1616};
@@ -89,7 +89,7 @@ TEST(TransformationTests, TestDepthToSpaceTransformDepthFirst) {
     ASSERT_EQ(consumers.size(), 1);
 
     auto reshape_begin = consumers.begin()->get_node();
-    auto shape_begin = std::dynamic_pointer_cast<ngraph::op::Constant>(
+    auto shape_begin = std::dynamic_pointer_cast<ov::op::v0::Constant>(
         reshape_begin->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> shape_begin_value = shape_begin->get_vector<int64_t>();
     std::vector<int64_t> shape_begin_value_ref{1, 3, 2, 2, 1080, 1616};
@@ -100,14 +100,14 @@ TEST(TransformationTests, TestDepthToSpaceTransformDepthFirst) {
 
     auto transpose = consumers.begin()->get_node();
     auto order =
-        std::dynamic_pointer_cast<ngraph::op::Constant>(transpose->input(1).get_source_output().get_node_shared_ptr());
+        std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> order_value = order->get_vector<int64_t>();
     std::vector<int64_t> order_value_ref{0, 1, 4, 2, 5, 3};
     ASSERT_EQ(order_value, order_value_ref);
 
     consumers = transpose->output(0).get_target_inputs();
     auto reshape_end = consumers.begin()->get_node();
-    auto shape_end = std::dynamic_pointer_cast<ngraph::op::Constant>(
+    auto shape_end = std::dynamic_pointer_cast<ov::op::v0::Constant>(
         reshape_end->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> shape_end_value = shape_end->get_vector<int64_t>();
     std::vector<int64_t> shape_end_value_ref{1, 3, 2 * 1080, 2 * 1616};
@@ -135,7 +135,7 @@ TEST(TransformationTests, TestSpaceToDepthTransformBlockFirst) {
     ASSERT_EQ(consumers.size(), 1);
 
     auto reshape_begin = consumers.begin()->get_node();
-    auto shape_begin = std::dynamic_pointer_cast<ngraph::op::Constant>(
+    auto shape_begin = std::dynamic_pointer_cast<ov::op::v0::Constant>(
         reshape_begin->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> shape_begin_value = shape_begin->get_vector<int64_t>();
     std::vector<int64_t> shape_begin_value_ref{1, 12, 1080 / 2, 2, 1616 / 2, 2};
@@ -146,14 +146,14 @@ TEST(TransformationTests, TestSpaceToDepthTransformBlockFirst) {
 
     auto transpose = consumers.begin()->get_node();
     auto order =
-        std::dynamic_pointer_cast<ngraph::op::Constant>(transpose->input(1).get_source_output().get_node_shared_ptr());
+        std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> order_value = order->get_vector<int64_t>();
     std::vector<int64_t> order_value_ref{0, 3, 5, 1, 2, 4};
     ASSERT_EQ(order_value, order_value_ref);
 
     consumers = transpose->output(0).get_target_inputs();
     auto reshape_end = consumers.begin()->get_node();
-    auto shape_end = std::dynamic_pointer_cast<ngraph::op::Constant>(
+    auto shape_end = std::dynamic_pointer_cast<ov::op::v0::Constant>(
         reshape_end->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> shape_end_value = shape_end->get_vector<int64_t>();
     std::vector<int64_t> shape_end_value_ref{1, 12 * 4, 1080 / 2, 1616 / 2};
@@ -181,7 +181,7 @@ TEST(TransformationTests, TestSpaceToDepthTransformDepthFirst) {
     ASSERT_EQ(consumers.size(), 1);
 
     auto reshape_begin = consumers.begin()->get_node();
-    auto shape_begin = std::dynamic_pointer_cast<ngraph::op::Constant>(
+    auto shape_begin = std::dynamic_pointer_cast<ov::op::v0::Constant>(
         reshape_begin->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> shape_begin_value = shape_begin->get_vector<int64_t>();
     std::vector<int64_t> shape_begin_value_ref{1, 12, 1080 / 2, 2, 1616 / 2, 2};
@@ -192,14 +192,14 @@ TEST(TransformationTests, TestSpaceToDepthTransformDepthFirst) {
 
     auto transpose = consumers.begin()->get_node();
     auto order =
-        std::dynamic_pointer_cast<ngraph::op::Constant>(transpose->input(1).get_source_output().get_node_shared_ptr());
+        std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> order_value = order->get_vector<int64_t>();
     std::vector<int64_t> order_value_ref{0, 1, 3, 5, 2, 4};
     ASSERT_EQ(order_value, order_value_ref);
 
     consumers = transpose->output(0).get_target_inputs();
     auto reshape_end = consumers.begin()->get_node();
-    auto shape_end = std::dynamic_pointer_cast<ngraph::op::Constant>(
+    auto shape_end = std::dynamic_pointer_cast<ov::op::v0::Constant>(
         reshape_end->input(1).get_source_output().get_node_shared_ptr());
     std::vector<int64_t> shape_end_value = shape_end->get_vector<int64_t>();
     std::vector<int64_t> shape_end_value_ref{1, 12 * 4, 1080 / 2, 1616 / 2};

--- a/src/common/transformations/tests/op_conversions/ngraph_mode_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/ngraph_mode_decomposition_test.cpp
@@ -31,12 +31,12 @@ TEST(TransformationTests, ModDecompositionTests) {
         auto mod = std::make_shared<ngraph::op::v1::Mod>(data1, data2);
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{mod}, ngraph::ParameterVector{});
-        auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+        auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         ngraph::pass::Manager m;
-        m.register_pass<ngraph::pass::InitUniqueNames>(unh);
+        m.register_pass<ov::pass::InitUniqueNames>(unh);
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ov::pass::ConvertMod>();
-        m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+        m.register_pass<ov::pass::CheckUniqueNames>(unh);
         m.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }

--- a/src/common/transformations/tests/smart_reshape/sr_mimicking_sbs.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_mimicking_sbs.cpp
@@ -23,7 +23,7 @@ TEST(SmartReshapeTests, MimickingSBS) {
 
     InferenceEngine::CNNNetwork network(f);
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -45,7 +45,7 @@ TEST(SmartReshapeTests, MimickingSBS_1) {
 
     InferenceEngine::CNNNetwork network(f);
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -67,7 +67,7 @@ TEST(SmartReshapeTests, MimickingSBS_2) {
 
     InferenceEngine::CNNNetwork network(f);
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(1));
     check_unique_names(f, unh);

--- a/src/common/transformations/tests/smart_reshape/sr_proposal_scales.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_proposal_scales.cpp
@@ -42,7 +42,7 @@ TEST(SmartReshapeTests, Proposal1Scales) {
     }
 
     InferenceEngine::CNNNetwork network(f);
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -81,7 +81,7 @@ TEST(SmartReshapeTests, Proposal1Scales_WithConvert) {
     }
 
     InferenceEngine::CNNNetwork network(f);
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -120,7 +120,7 @@ TEST(SmartReshapeTests, Proposal4Scales) {
 
     InferenceEngine::CNNNetwork network(f);
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -161,7 +161,7 @@ TEST(SmartReshapeTests, Proposal4Scales_WithConvert) {
 
     InferenceEngine::CNNNetwork network(f);
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);

--- a/src/common/transformations/tests/smart_reshape/sr_reshape_1d.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_reshape_1d.cpp
@@ -27,7 +27,7 @@ TEST(SmartReshapeTests, Reshape1d) {
         ngraph::PartialShape::dynamic()));
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({5}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.reshape(
         InferenceEngine::ICNNNetwork::InputShapes{{f->get_parameters()[0]->get_friendly_name(), {1, 3, 300, 300}}}));
@@ -52,7 +52,7 @@ TEST(SmartReshapeTests, Reshape1d_negative) {
         ngraph::PartialShape::dynamic()));
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().is_dynamic());
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.reshape(
         InferenceEngine::ICNNNetwork::InputShapes{{f->get_parameters()[0]->get_friendly_name(), {1, 3, 300, 300}}}));

--- a/src/common/transformations/tests/smart_reshape/sr_strided_slice_squeeze.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_strided_slice_squeeze.cpp
@@ -34,7 +34,7 @@ TEST(SmartReshapeTests, SS_Squeeze) {
         << network.getFunction()->get_results()[0]->get_output_partial_shape(0);
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 3}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -69,7 +69,7 @@ TEST(SmartReshapeTests, SS_Squeeze_partial_begin_end_mask) {
         << network.getFunction()->get_results()[0]->get_output_partial_shape(0);
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 128, 768}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     auto inputname = network.getFunction()->get_parameters()[0]->get_friendly_name();
     ASSERT_NO_THROW(network.reshape(InferenceEngine::ICNNNetwork::InputShapes{{inputname, {2, 128, 768}}}));
@@ -107,7 +107,7 @@ TEST(SmartReshapeTests, SS_Squeeze_partial_begin_end) {
         << network.getFunction()->get_results()[0]->get_output_partial_shape(0);
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 1, 768}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     auto inputname = network.getFunction()->get_parameters()[0]->get_friendly_name();
     ASSERT_NO_THROW(network.reshape(InferenceEngine::ICNNNetwork::InputShapes{{inputname, {2, 1, 768}}}));
@@ -143,7 +143,7 @@ TEST(SmartReshapeTests, SS_Squeeze_mask_use_negative) {
         << network.getFunction()->get_results()[0]->get_output_partial_shape(0);
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 3}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_ANY_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -174,7 +174,7 @@ TEST(SmartReshapeTests, SS_Squeeze_negative_stride_negative) {
         << network.getFunction()->get_results()[0]->get_output_partial_shape(0);
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 3}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_ANY_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -208,7 +208,7 @@ TEST(SmartReshapeTests, SS_SharedSqueezes) {
         << network.getFunction()->get_results()[0]->get_output_partial_shape(0);
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 3}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -243,7 +243,7 @@ TEST(SmartReshapeTests, SS_SqueezeNegativeAxes) {
         << network.getFunction()->get_results()[0]->get_output_partial_shape(0);
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 3, 1, 8, 1, 2}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);
@@ -277,7 +277,7 @@ TEST(SmartReshapeTests, Squeeze_SSNegativeAxes) {
         << network.getFunction()->get_results()[0]->get_output_partial_shape(0);
     ASSERT_TRUE(network.getFunction()->get_parameters()[0]->get_partial_shape().compatible({1, 3, 1, 8, 1, 2}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.setBatchSize(2));
     check_unique_names(f, unh);

--- a/src/common/transformations/tests/smart_reshape/sr_sub_graph_ops.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_sub_graph_ops.cpp
@@ -59,7 +59,7 @@ TEST(SmartReshapeTests, TensorIteratorStaticParameters) {
     ASSERT_TRUE(network.getFunction()->get_results()[2]->get_output_partial_shape(0).compatible({1, 1, 1}));
     ASSERT_TRUE(network.getFunction()->get_results()[3]->get_output_partial_shape(0).compatible({1, 1, 1}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.reshape(
         InferenceEngine::ICNNNetwork::InputShapes{{f->get_parameters()[0]->get_friendly_name(), {32, 1, 10}},
@@ -121,7 +121,7 @@ TEST(SmartReshapeTests, TensorIteratorDynamicParameters) {
     ASSERT_TRUE(network.getFunction()->get_results()[2]->get_output_partial_shape(0).compatible({1, 1, 1}));
     ASSERT_TRUE(network.getFunction()->get_results()[3]->get_output_partial_shape(0).compatible({1, 1, 1}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.reshape(
         InferenceEngine::ICNNNetwork::InputShapes{{f->get_parameters()[0]->get_friendly_name(), {32, 1, 10}},
@@ -191,7 +191,7 @@ TEST(SmartReshapeTests, LoopStaticParameters) {
     ASSERT_TRUE(
         network.getFunction()->get_results()[3]->get_output_partial_shape(0).compatible(PartialShape::dynamic()));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.reshape(
         InferenceEngine::ICNNNetwork::InputShapes{{f->get_parameters()[0]->get_friendly_name(), {32, 1, 10}},
@@ -261,7 +261,7 @@ TEST(SmartReshapeTests, LoopDynamicParameters) {
     ASSERT_TRUE(
         network.getFunction()->get_results()[3]->get_output_partial_shape(0).compatible(PartialShape::dynamic()));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.reshape(
         InferenceEngine::ICNNNetwork::InputShapes{{f->get_parameters()[0]->get_friendly_name(), {32, 1, 10}},
@@ -335,7 +335,7 @@ TEST(SmartReshapeTests, LoopParentParametersUsedInBody) {
     ASSERT_TRUE(
         network.getFunction()->get_results()[3]->get_output_partial_shape(0).compatible(PartialShape::dynamic()));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.reshape(
         InferenceEngine::ICNNNetwork::InputShapes{{f->get_parameters()[0]->get_friendly_name(), {4, 3, 2}},
@@ -401,7 +401,7 @@ TEST(SmartReshapeTests, TensorIteratorParentParameterUsedInBody) {
     ASSERT_TRUE(network.getFunction()->get_results()[2]->get_output_partial_shape(0).compatible({1, 1, 1}));
     ASSERT_TRUE(network.getFunction()->get_results()[3]->get_output_partial_shape(0).compatible({1, 1, 1}));
 
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     init_unique_names(f, unh);
     ASSERT_NO_THROW(network.reshape(
         InferenceEngine::ICNNNetwork::InputShapes{{f->get_parameters()[0]->get_friendly_name(), {32, 1, 10}},

--- a/src/common/transformations/tests/utils/compare_functions_test.cpp
+++ b/src/common/transformations/tests/utils/compare_functions_test.cpp
@@ -483,7 +483,7 @@ TEST(TransformationTests, ReorgYoloNegativeDifferentMax) {
         auto param = std::make_shared<Parameter>(ngraph::element::f32, ngraph::Shape{10, 10, 10, 10});
         auto reorg_yolo = std::make_shared<ReorgYolo>(param, stride);
 
-        return std::make_shared<ngraph::Function>(std::make_shared<ngraph::opset1::Result>(reorg_yolo),
+        return std::make_shared<ngraph::Function>(std::make_shared<ov::op::v0::Result>(reorg_yolo),
                                                   ngraph::ParameterVector{param});
     };
 

--- a/src/core/tests/pass/serialization/custom_ops.cpp
+++ b/src/core/tests/pass/serialization/custom_ops.cpp
@@ -29,10 +29,10 @@ protected:
     }
 };
 
-class TemplateOp : public ov::op::Op {
+class TemplateOpExtension : public ov::op::Op {
 public:
     OPENVINO_OP("Template", "custom_opset");
-    TemplateOp() = default;
+    TemplateOpExtension() = default;
 
     bool visit_attributes(ov::AttributeVisitor& visitor) override {
         return true;
@@ -100,7 +100,7 @@ TEST_F(CustomOpsSerializationTest, CustomOpNoExtensions) {
 )V0G0N";
 
     ov::Core core;
-    auto extension = std::make_shared<ov::OpExtension<TemplateOp>>();
+    auto extension = std::make_shared<ov::OpExtension<TemplateOpExtension>>();
     core.add_extension(extension);
     auto expected = core.read_model(model, ov::Tensor());
     ov::pass::Manager manager;

--- a/src/core/tests/pass/serialization/custom_ops.cpp
+++ b/src/core/tests/pass/serialization/custom_ops.cpp
@@ -29,25 +29,23 @@ protected:
     }
 };
 
-class FrameworkNodeExtension : public InferenceEngine::IExtension {
+class TemplateOp : public ov::op::Op {
 public:
-    void GetVersion(const InferenceEngine::Version*& versionInfo) const noexcept override {
-        static InferenceEngine::Version ExtensionDescription = {{1, 0}, "1.0", "framework_node_ext"};
+    OPENVINO_OP("Template", "custom_opset");
+    TemplateOp() = default;
 
-        versionInfo = &ExtensionDescription;
+    bool visit_attributes(ov::AttributeVisitor& visitor) override {
+        return true;
     }
 
-    std::map<std::string, ngraph::OpSet> getOpSets() override {
-        static std::map<std::string, ngraph::OpSet> opsets;
-        if (opsets.empty()) {
-            ngraph::OpSet opset;
-            opset.insert<ov::op::util::FrameworkNode>();
-            opsets["util"] = opset;
-        }
-        return opsets;
+    void validate_and_infer_types() override {
+        set_output_size(1);
+        set_output_type(0, get_input_element_type(0), get_input_partial_shape(0));
     }
 
-    void Unload() noexcept override {}
+    std::shared_ptr<Node> clone_with_new_inputs(const ov::OutputVector& inputs) const override {
+        return nullptr;
+    }
 };
 
 TEST_F(CustomOpsSerializationTest, CustomOpNoExtensions) {
@@ -66,9 +64,8 @@ TEST_F(CustomOpsSerializationTest, CustomOpNoExtensions) {
             </output>
         </layer>
         <layer name="operation" id="1" type="Template" version="custom_opset">
-            <data num_bodies="0" add="11"/>
             <input>
-                <port id="1" precision="FP32">
+                <port id="0" precision="FP32">
                     <dim>2</dim>
                     <dim>2</dim>
                     <dim>2</dim>
@@ -76,7 +73,7 @@ TEST_F(CustomOpsSerializationTest, CustomOpNoExtensions) {
                 </port>
             </input>
             <output>
-                <port id="2" precision="FP32">
+                <port id="1" precision="FP32">
                     <dim>2</dim>
                     <dim>2</dim>
                     <dim>2</dim>
@@ -96,21 +93,18 @@ TEST_F(CustomOpsSerializationTest, CustomOpNoExtensions) {
         </layer>
     </layers>
     <edges>
-        <edge from-layer="0" from-port="0" to-layer="1" to-port="1"/>
-        <edge from-layer="1" from-port="2" to-layer="2" to-port="0"/>
+        <edge from-layer="0" from-port="0" to-layer="1" to-port="0"/>
+        <edge from-layer="1" from-port="1" to-layer="2" to-port="0"/>
     </edges>
 </net>
 )V0G0N";
 
     ov::Core core;
-    auto extension = std::make_shared<FrameworkNodeExtension>();
+    auto extension = std::make_shared<ov::OpExtension<TemplateOp>>();
     core.add_extension(extension);
     auto expected = core.read_model(model, ov::Tensor());
     ov::pass::Manager manager;
-    manager.register_pass<ov::pass::Serialize>(m_out_xml_path,
-                                               m_out_bin_path,
-                                               extension->getOpSets(),
-                                               ov::pass::Serialize::Version::IR_V10);
+    manager.register_pass<ov::pass::Serialize>(m_out_xml_path, m_out_bin_path, ov::pass::Serialize::Version::IR_V10);
     manager.run_passes(expected);
     auto result = core.read_model(m_out_xml_path, m_out_bin_path);
 

--- a/src/core/tests/pass/serialization/custom_ops.cpp
+++ b/src/core/tests/pass/serialization/custom_ops.cpp
@@ -50,7 +50,7 @@ public:
 
 TEST_F(CustomOpsSerializationTest, CustomOpNoExtensions) {
     const std::string model = R"V0G0N(
-<net name="Network" version="10">
+<net name="Network" version="11">
     <layers>
         <layer name="in1" type="Parameter" id="0" version="opset1">
             <data element_type="f32" shape="2,2,2,1"/>
@@ -104,7 +104,7 @@ TEST_F(CustomOpsSerializationTest, CustomOpNoExtensions) {
     core.add_extension(extension);
     auto expected = core.read_model(model, ov::Tensor());
     ov::pass::Manager manager;
-    manager.register_pass<ov::pass::Serialize>(m_out_xml_path, m_out_bin_path, ov::pass::Serialize::Version::IR_V10);
+    manager.register_pass<ov::pass::Serialize>(m_out_xml_path, m_out_bin_path, ov::pass::Serialize::Version::IR_V11);
     manager.run_passes(expected);
     auto result = core.read_model(m_out_xml_path, m_out_bin_path);
 

--- a/src/core/tests/pass/serialization/deterministicity.cpp
+++ b/src/core/tests/pass/serialization/deterministicity.cpp
@@ -295,6 +295,6 @@ TEST_P(SerializationDeterministicityInputOutputTest, FromIrModel) {
     EXPECT_TRUE(files_equal(xml_2, xml_1));
 }
 
-INSTANTIATE_TEST_CASE_P(DeterministicityInputOutput,
-                        SerializationDeterministicityInputOutputTest,
-                        ::testing::Values(ov::pass::Serialize::Version::IR_V10, ov::pass::Serialize::Version::IR_V11));
+INSTANTIATE_TEST_SUITE_P(DeterministicityInputOutput,
+                         SerializationDeterministicityInputOutputTest,
+                         ::testing::Values(ov::pass::Serialize::Version::IR_V10, ov::pass::Serialize::Version::IR_V11));

--- a/src/core/tests/pass/serialization/from_model.cpp
+++ b/src/core/tests/pass/serialization/from_model.cpp
@@ -8,15 +8,15 @@
 
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/graph_comparator.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/if.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/split.hpp"
+#include "openvino/op/subtract.hpp"
 #include "openvino/pass/serialize.hpp"
 #include "openvino/util/file_util.hpp"
 #include "read_ir.hpp"
 #include "util/test_common.hpp"
-#include "openvino/op/split.hpp"
-#include "openvino/op/subtract.hpp"
-#include "openvino/op/relu.hpp"
-#include "openvino/op/if.hpp"
-#include "openvino/op/add.hpp"
 
 using ModelBuilder = std::function<std::shared_ptr<ov::Model>()>;
 using SerializationFromModelParams = std::tuple<ModelBuilder, std::string>;

--- a/src/core/tests/pass/serialization/from_model.cpp
+++ b/src/core/tests/pass/serialization/from_model.cpp
@@ -12,6 +12,11 @@
 #include "openvino/util/file_util.hpp"
 #include "read_ir.hpp"
 #include "util/test_common.hpp"
+#include "openvino/op/split.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/if.hpp"
+#include "openvino/op/add.hpp"
 
 using ModelBuilder = std::function<std::shared_ptr<ov::Model>()>;
 using SerializationFromModelParams = std::tuple<ModelBuilder, std::string>;
@@ -73,12 +78,12 @@ std::shared_ptr<ov::Model> create_model_if_mixed_inputs() {
     Ze->output(0).get_tensor().set_names({"Z_else"});
     auto cond = std::make_shared<op::v0::Constant>(element::boolean, Shape{1}, true);
     auto axis_then = std::make_shared<op::v0::Constant>(element::i32, Shape{}, 0);
-    auto split_y = std::make_shared<opset8::Split>(Yt, axis_then, 2);
-    auto then_op = std::make_shared<opset8::Subtract>(Xt, split_y->output(0));
+    auto split_y = std::make_shared<op::v1::Split>(Yt, axis_then, 2);
+    auto then_op = std::make_shared<op::v1::Subtract>(Xt, split_y->output(0));
     auto res0 = std::make_shared<op::v0::Result>(then_op);
     auto axis_else = std::make_shared<op::v0::Constant>(element::i32, Shape{}, 0);
-    auto split_z = std::make_shared<opset8::Split>(Ze, axis_else, 4);
-    auto else_op = std::make_shared<opset8::Relu>(split_z);
+    auto split_z = std::make_shared<op::v1::Split>(Ze, axis_else, 4);
+    auto else_op = std::make_shared<op::v0::Relu>(split_z);
     auto res1 = std::make_shared<op::v0::Result>(else_op);
     auto then_body = std::make_shared<ov::Model>(OutputVector{res0}, ParameterVector{Yt, Xt}, "then_body");
     auto else_body = std::make_shared<ov::Model>(OutputVector{res1}, ParameterVector{Ze}, "else_body");
@@ -105,7 +110,7 @@ std::vector<SerializationFromModelParams> get_models() {
             p1->output(0).set_names({"X"});
             auto p2 = std::make_shared<op::v0::Parameter>(element::f32, Shape{2});
             p2->output(0).set_names({"Y"});
-            auto op = std::make_shared<opset8::Add>(p1, p2);
+            auto op = std::make_shared<op::v1::Add>(p1, p2);
             auto res = std::make_shared<op::v0::Result>(op);
             return std::make_shared<Model>(OutputVector{res}, ParameterVector{p1, p2});
         };
@@ -125,7 +130,7 @@ std::vector<SerializationFromModelParams> get_models() {
                 p1->output(0).set_names({"X"});
                 auto c1 = std::make_shared<op::v0::Constant>(element::u8, shape, data.data());
                 c1->output(0).set_names({"C"});
-                auto op = std::make_shared<opset8::Add>(p1, c1);
+                auto op = std::make_shared<op::v1::Add>(p1, c1);
                 auto res = std::make_shared<op::v0::Result>(op);
                 return std::make_shared<Model>(OutputVector{res}, ParameterVector{p1});
             };
@@ -178,7 +183,7 @@ TEST_P(SerializationFromModelTest_large, DISABLED_Model_very_large) {
         p1->output(0).set_names({"X"});
         auto c1 = std::make_shared<op::v0::Constant>(element::u8, shape, data.data());
         c1->output(0).set_names({"C"});
-        auto op = std::make_shared<opset8::Add>(p1, c1);
+        auto op = std::make_shared<op::v1::Add>(p1, c1);
         auto res = std::make_shared<op::v0::Result>(op);
         auto model = std::make_shared<Model>(OutputVector{res}, ParameterVector{p1});
         ov::pass::Serialize(m_out_xml_path, m_out_bin_path).run_on_model(model);

--- a/src/frontends/ir/tests/rt_info_deserialization.cpp
+++ b/src/frontends/ir/tests/rt_info_deserialization.cpp
@@ -16,6 +16,12 @@
 #include "transformations/rt_info/fused_names_attribute.hpp"
 #include "transformations/rt_info/old_api_map_element_type_attribute.hpp"
 #include "transformations/rt_info/old_api_map_order_attribute.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/round.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/transpose.hpp"
 
 class RTInfoDeserialization : public testing::Test {
 protected:
@@ -148,20 +154,20 @@ TEST_F(RTInfoDeserialization, node_v10) {
     {
         ov::Shape shape{1, 3, 22, 22};
         auto type = ov::element::f32;
-        auto param = std::make_shared<ov::opset8::Parameter>(type, shape);
+        auto param = std::make_shared<ov::op::v0::Parameter>(type, shape);
         param->set_friendly_name("in1");
         param->get_output_tensor(0).set_names({"input_tensor", param->get_friendly_name()});
 
         // TODO: No guarantee that exactly 'Convert' will be added
-        auto convert_param = std::make_shared<ov::opset8::Convert>(param, ov::element::f16);
+        auto convert_param = std::make_shared<ov::op::v0::Convert>(param, ov::element::f16);
 
-        auto round = std::make_shared<ov::opset8::Round>(convert_param, ov::opset8::Round::RoundMode::HALF_TO_EVEN);
+        auto round = std::make_shared<ov::op::v5::Round>(convert_param, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
 
-        auto convert_result = std::make_shared<ov::opset8::Convert>(round, type);
+        auto convert_result = std::make_shared<ov::op::v0::Convert>(round, type);
         convert_result->set_friendly_name("Round");
         convert_result->get_output_tensor(0).set_names({"output_tensor", convert_result->get_friendly_name()});
 
-        auto result = std::make_shared<ov::opset8::Result>(convert_result);
+        auto result = std::make_shared<ov::op::v0::Result>(convert_result);
         result->set_friendly_name("output");
 
         auto f_10_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param});
@@ -393,18 +399,18 @@ TEST_F(RTInfoDeserialization, input_and_output_v10) {
     {
         const ov::Shape shape{1, 3, 22, 22};
         const auto type = ov::element::i64;
-        auto param = std::make_shared<ov::opset8::Parameter>(type, shape);
+        auto param = std::make_shared<ov::op::v0::Parameter>(type, shape);
         param->set_friendly_name("in1");
         param->get_output_tensor(0).set_names({"input_tensor", param->get_friendly_name()});
 
-        auto sum = std::make_shared<ov::opset8::Add>(param, param);
+        auto sum = std::make_shared<ov::op::v1::Add>(param, param);
 
         // TODO: No guarantee that exactly 'convert' will be added by post-processing
-        auto convert_result = std::make_shared<ov::opset8::Convert>(sum, ov::element::i32);
+        auto convert_result = std::make_shared<ov::op::v0::Convert>(sum, ov::element::i32);
         convert_result->set_friendly_name("sum");
         convert_result->get_output_tensor(0).set_names({"output_tensor", convert_result->get_friendly_name()});
 
-        auto result = std::make_shared<ov::opset8::Result>(convert_result);
+        auto result = std::make_shared<ov::op::v0::Result>(convert_result);
         result->set_friendly_name("output");
 
         auto f_10_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param});
@@ -554,31 +560,31 @@ TEST_F(RTInfoDeserialization, node_v11) {
     {
         const ov::PartialShape shape{1, 3, 22, 22};
         auto type = ov::element::f16;
-        auto param = std::make_shared<ov::opset8::Parameter>(type, shape);
+        auto param = std::make_shared<ov::op::v0::Parameter>(type, shape);
         param->set_friendly_name("in1");
         param->get_output_tensor(0).set_names({"input_tensor"});
 
         // TODO: No guarantee that Transpose will use exactly 'uint64_t' constant
         auto constant_param =
-            std::make_shared<ov::opset8::Constant>(ov::element::u64, ov::Shape{4}, std::vector<uint64_t>{0, 2, 3, 1});
-        auto transpose_param = std::make_shared<ov::opset8::Transpose>(param, constant_param);
+            std::make_shared<ov::op::v0::Constant>(ov::element::u64, ov::Shape{4}, std::vector<uint64_t>{0, 2, 3, 1});
+        auto transpose_param = std::make_shared<ov::op::v1::Transpose>(param, constant_param);
 
         // TODO: No guarantee that only 'convert' will be added by implicit pre-processing
-        auto convert_param = std::make_shared<ov::opset8::Convert>(transpose_param, ov::element::f32);
+        auto convert_param = std::make_shared<ov::op::v0::Convert>(transpose_param, ov::element::f32);
 
-        auto round = std::make_shared<ov::opset8::Round>(convert_param, ov::opset8::Round::RoundMode::HALF_TO_EVEN);
+        auto round = std::make_shared<ov::op::v5::Round>(convert_param, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
         // TODO: runtime information should migrate as well?
         round->get_rt_info()[ov::FusedNames::get_type_info_static()] = ov::FusedNames("Round1,Round2");
 
         // TODO: No guarantee that exactly 'convert, then transpose' will be added by implicit post-processing
         auto constant_result =
-            std::make_shared<ov::opset8::Constant>(ov::element::u64, ov::Shape{4}, std::vector<uint64_t>{0, 3, 1, 2});
-        auto transpose_result = std::make_shared<ov::opset8::Transpose>(round, constant_result);
+            std::make_shared<ov::op::v0::Constant>(ov::element::u64, ov::Shape{4}, std::vector<uint64_t>{0, 3, 1, 2});
+        auto transpose_result = std::make_shared<ov::op::v1::Transpose>(round, constant_result);
 
         transpose_result->set_friendly_name("Round");
         transpose_result->get_output_tensor(0).set_names({"output_tensor"});
 
-        auto result = std::make_shared<ov::opset8::Result>(transpose_result);
+        auto result = std::make_shared<ov::op::v0::Result>(transpose_result);
         result->set_friendly_name("output");
 
         auto f_10_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param});
@@ -697,24 +703,24 @@ TEST_F(RTInfoDeserialization, node_v11_uint8) {
     // read IR v11 with old API and check that old_api_map is applied
     const ov::PartialShape shape{1, 3, 22, 22};
     auto type = ov::element::f16;
-    auto param = std::make_shared<ov::opset8::Parameter>(type, shape);
+    auto param = std::make_shared<ov::op::v0::Parameter>(type, shape);
     param->set_friendly_name("in1");
     param->get_output_tensor(0).set_names({"input_tensor"});
 
     auto constant_param =
-        std::make_shared<ov::opset8::Constant>(ov::element::u64, ov::Shape{4}, std::vector<uint64_t>{0, 2, 3, 1});
-    auto transpose_param = std::make_shared<ov::opset8::Transpose>(param, constant_param);
+        std::make_shared<ov::op::v0::Constant>(ov::element::u64, ov::Shape{4}, std::vector<uint64_t>{0, 2, 3, 1});
+    auto transpose_param = std::make_shared<ov::op::v1::Transpose>(param, constant_param);
 
-    auto round = std::make_shared<ov::opset8::Round>(transpose_param, ov::opset8::Round::RoundMode::HALF_TO_EVEN);
+    auto round = std::make_shared<ov::op::v5::Round>(transpose_param, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
     round->get_rt_info()[ov::FusedNames::get_type_info_static()] = ov::FusedNames("Round1,Round2");
     auto constant_result =
-        std::make_shared<ov::opset8::Constant>(ov::element::u64, ov::Shape{4}, std::vector<uint64_t>{0, 3, 1, 2});
-    auto transpose_result = std::make_shared<ov::opset8::Transpose>(round, constant_result);
+        std::make_shared<ov::op::v0::Constant>(ov::element::u64, ov::Shape{4}, std::vector<uint64_t>{0, 3, 1, 2});
+    auto transpose_result = std::make_shared<ov::op::v1::Transpose>(round, constant_result);
 
     transpose_result->set_friendly_name("Round");
     transpose_result->get_output_tensor(0).set_names({"output_tensor"});
 
-    auto result = std::make_shared<ov::opset8::Result>(transpose_result);
+    auto result = std::make_shared<ov::op::v0::Result>(transpose_result);
     result->set_friendly_name("output");
 
     auto f_10_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param});

--- a/src/frontends/ir/tests/rt_info_deserialization.cpp
+++ b/src/frontends/ir/tests/rt_info_deserialization.cpp
@@ -12,16 +12,16 @@
 #include "ie/ie_core.hpp"
 #include "openvino/core/preprocess/input_tensor_info.hpp"
 #include "openvino/frontend/manager.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/round.hpp"
+#include "openvino/op/transpose.hpp"
 #include "openvino/runtime/core.hpp"
 #include "transformations/rt_info/fused_names_attribute.hpp"
 #include "transformations/rt_info/old_api_map_element_type_attribute.hpp"
 #include "transformations/rt_info/old_api_map_order_attribute.hpp"
-#include "openvino/op/parameter.hpp"
-#include "openvino/op/convert.hpp"
-#include "openvino/op/round.hpp"
-#include "openvino/op/result.hpp"
-#include "openvino/op/add.hpp"
-#include "openvino/op/transpose.hpp"
 
 class RTInfoDeserialization : public testing::Test {
 protected:

--- a/src/frontends/onnx/tests/onnx_editor_topological_sort.cpp
+++ b/src/frontends/onnx/tests/onnx_editor_topological_sort.cpp
@@ -19,31 +19,30 @@ using namespace ngraph::test;
 static std::string s_manifest = "${MANIFEST}";
 
 NGRAPH_TEST(onnx_editor, topological_sort_two_nodes_swap) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
-                                                        SERIALIZED_ZOO,
-                                                        "onnx/model_editor/topological_sort/two_nodes_swap.onnx")};
+    ONNXModelEditor editor{ov::util::path_join({CommonTestUtils::getExecutableDirectory(),
+                                                SERIALIZED_ZOO,
+                                                "onnx/model_editor/topological_sort/two_nodes_swap.onnx"})};
     ASSERT_NO_THROW(editor.get_function());
 }
 
 NGRAPH_TEST(onnx_editor, topological_sort_completely_unsorted) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
-                                                        SERIALIZED_ZOO,
-                                                        "onnx/model_editor/topological_sort/completely_unsorted.onnx")};
+    ONNXModelEditor editor{ov::util::path_join({CommonTestUtils::getExecutableDirectory(),
+                                                SERIALIZED_ZOO,
+                                                "onnx/model_editor/topological_sort/completely_unsorted.onnx"})};
     ASSERT_NO_THROW(editor.get_function());
 }
 
 NGRAPH_TEST(onnx_editor, topological_sort_completely_unsorted_2) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
-                                     SERIALIZED_ZOO,
-                                     "onnx/model_editor/topological_sort/completely_unsorted_2.onnx")};
+    ONNXModelEditor editor{ov::util::path_join({CommonTestUtils::getExecutableDirectory(),
+                                                SERIALIZED_ZOO,
+                                                "onnx/model_editor/topological_sort/completely_unsorted_2.onnx"})};
     ASSERT_NO_THROW(editor.get_function());
 }
 
 NGRAPH_TEST(onnx_editor, topological_sort_constant_node_in_the_graph) {
     const std::string rel_path_to_model = "onnx/model_editor/topological_sort/add_abc_const_node_unsorted.onnx";
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model)};
+        ov::util::path_join({CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model})};
 
     ASSERT_NO_THROW(editor.get_function());
 }
@@ -51,7 +50,7 @@ NGRAPH_TEST(onnx_editor, topological_sort_constant_node_in_the_graph) {
 NGRAPH_TEST(onnx_editor, topological_sort_multioutput_node) {
     const std::string rel_path_to_model = "onnx/model_editor/topological_sort/multioutput_split_unsorted.onnx";
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model)};
+        ov::util::path_join({CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model})};
 
     ASSERT_NO_THROW(editor.get_function());
 }
@@ -60,11 +59,11 @@ NGRAPH_TEST(onnx_editor, topological_sort_graph_not_changed_if_the_same_name_of_
     const std::string rel_path_to_model =
         "onnx/model_editor/topological_sort/same_name_of_unsorted_node_and_initializer.onnx";
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model)};
+        ov::util::path_join({CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model})};
 
     // topological sorting is called only via Editor importing
     const auto ref_model =
-        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model);
+        ov::util::path_join({CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model});
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
     EXPECT_TRUE(result.is_ok) << result.error_message;
@@ -73,11 +72,11 @@ NGRAPH_TEST(onnx_editor, topological_sort_graph_not_changed_if_the_same_name_of_
 NGRAPH_TEST(onnx_editor, topological_sort_graph_not_changed_if_empty_input_name) {
     const std::string rel_path_to_model = "onnx/model_editor/topological_sort/empty_input_name.onnx";
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model)};
+        ov::util::path_join({CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model})};
 
     // topological sorting is called only via Editor importing
     const auto ref_model =
-        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model);
+        ov::util::path_join({CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, rel_path_to_model});
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
     EXPECT_TRUE(result.is_ok) << result.error_message;

--- a/src/frontends/onnx/tests/onnx_ops_registration.cpp
+++ b/src/frontends/onnx/tests/onnx_ops_registration.cpp
@@ -23,7 +23,7 @@ static std::string s_manifest = "${MANIFEST}";
 
 NGRAPH_TEST(ops_registration, check_importing_abs_in_all_opset_versions) {
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/abs.onnx")};
+        ov::util::path_join({CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/abs.onnx"})};
     for (int version = 1; version <= ONNX_OPSET_VERSION; ++version) {
         const auto changed_opset_model = change_opset_version(editor.model_string(), {version});
         std::stringstream model_stream{changed_opset_model};
@@ -37,9 +37,8 @@ NGRAPH_TEST(ops_registration, check_importing_add_in_different_opsets) {
                    return std::string{op->get_type_name()} == "Reshape";
                }) != std::end(ops);
     };
-    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
-                                                        SERIALIZED_ZOO,
-                                                        "onnx/add_v6_broadcast_dynamic.onnx")};
+    ONNXModelEditor editor{ov::util::path_join(
+        {CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/add_v6_broadcast_dynamic.onnx"})};
     for (int version = 1; version <= ONNX_OPSET_VERSION; ++version) {
         const auto changed_opset_model = change_opset_version(editor.model_string(), {version});
         std::stringstream model_stream{changed_opset_model};

--- a/src/frontends/onnx/tests/op_extension.cpp
+++ b/src/frontends/onnx/tests/op_extension.cpp
@@ -177,6 +177,9 @@ TEST(ONNXOpExtensionViaCommonConstructor, onnx_op_extension_via_ov_type_name_wit
     EXPECT_NO_THROW(fe->convert(input_model));
 }
 
+OPENVINO_SUPPRESS_DEPRECATED_START
+// Old API test
+
 namespace {
 class OldApiNode : public InferenceEngine::IExtension {
     void GetVersion(const InferenceEngine::Version*& versionInfo) const noexcept override {
@@ -206,3 +209,5 @@ TEST(ONNXOpExtensionViaCommonConstructor, onnx_op_extension_mixed_legacy_and_new
     core.add_extension(new_api_ext);
     EXPECT_NO_THROW(core.read_model(input_model_path));
 }
+
+OPENVINO_SUPPRESS_DEPRECATED_END

--- a/src/frontends/tests/frontend/shared/src/library_extension.cpp
+++ b/src/frontends/tests/frontend/shared/src/library_extension.cpp
@@ -8,10 +8,9 @@
 #include <ostream>
 
 #include "common_test_utils/file_utils.hpp"
-#include "utils.hpp"
-
 #include "openvino/op/relu.hpp"
 #include "openvino/op/swish.hpp"
+#include "utils.hpp"
 
 using namespace ov::frontend;
 

--- a/src/frontends/tests/frontend/shared/src/library_extension.cpp
+++ b/src/frontends/tests/frontend/shared/src/library_extension.cpp
@@ -10,6 +10,9 @@
 #include "common_test_utils/file_utils.hpp"
 #include "utils.hpp"
 
+#include "openvino/op/relu.hpp"
+#include "openvino/op/swish.hpp"
+
 using namespace ov::frontend;
 
 std::string FrontendLibraryExtensionTest::getTestCaseName(
@@ -52,7 +55,7 @@ TEST_P(FrontendLibraryExtensionTest, verifyFunctions) {
         ASSERT_NE(std::find_if(nodes.begin(),
                                nodes.end(),
                                [](const std::shared_ptr<ov::Node>& n) {
-                                   return ov::is_type<ov::opset8::Relu>(n);
+                                   return ov::is_type<ov::op::v0::Relu>(n);
                                }),
                   nodes.end());
     }
@@ -76,13 +79,13 @@ TEST_P(FrontendLibraryExtensionTest, verifyFunctions) {
         ASSERT_EQ(std::find_if(nodes.begin(),
                                nodes.end(),
                                [](const std::shared_ptr<ov::Node>& n) {
-                                   return ov::is_type<ov::opset8::Relu>(n);
+                                   return ov::is_type<ov::op::v0::Relu>(n);
                                }),
                   nodes.end());
         ASSERT_NE(std::find_if(nodes.begin(),
                                nodes.end(),
                                [](const std::shared_ptr<ov::Node>& n) {
-                                   return ov::is_type<ov::opset8::Swish>(n);
+                                   return ov::is_type<ov::op::v4::Swish>(n);
                                }),
                   nodes.end());
     }

--- a/src/inference/tests/functional/CMakeLists.txt
+++ b/src/inference/tests/functional/CMakeLists.txt
@@ -46,6 +46,7 @@ ov_add_test_target(
             funcTestUtils
         INCLUDES
             $<TARGET_PROPERTY:inference_engine_obj,SOURCE_DIR>/src
+            ${CMAKE_CURRENT_SOURCE_DIR}
         ADD_CLANG_FORMAT
         LABELS
             OV

--- a/src/inference/tests/functional/legacy/ov_extension_test.cpp
+++ b/src/inference/tests/functional/legacy/ov_extension_test.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ov_extension_test.hpp"
+
+#include "common_test_utils/file_utils.hpp"
+#include "ie_iextension.h"
+#include "openvino/op/op.hpp"
+#include "openvino/runtime/core.hpp"
+
+OPENVINO_SUPPRESS_DEPRECATED_START
+
+class CustomOldIdentity : public ov::op::Op {
+public:
+    OPENVINO_OP("Identity");
+
+    CustomOldIdentity() = default;
+    CustomOldIdentity(const ov::Output<ov::Node>& arg) : Op({arg}) {
+        constructor_validate_and_infer_types();
+    }
+
+    void validate_and_infer_types() override {
+        set_output_type(0, get_input_element_type(0), get_input_partial_shape(0));
+    }
+
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override {
+        if (new_args.size() != 1) {
+            OPENVINO_THROW("Incorrect number of new arguments");
+        }
+
+        return std::make_shared<CustomOldIdentity>(new_args.at(0));
+    }
+
+    bool visit_attributes(ov::AttributeVisitor& visitor) override {
+        return true;
+    }
+};
+
+class TestTileOldExtension : public InferenceEngine::IExtension {
+public:
+    void GetVersion(const InferenceEngine::Version*& versionInfo) const noexcept override {}
+
+    void Unload() noexcept override {}
+
+    std::map<std::string, ngraph::OpSet> getOpSets() override {
+        static std::map<std::string, ngraph::OpSet> opsets;
+        if (opsets.empty()) {
+            ngraph::OpSet opset;
+            opset.insert<CustomOldIdentity>();
+            opsets["extension"] = opset;
+        }
+        return opsets;
+    }
+};
+
+TEST_F(OVExtensionTests, ReshapeIRWithOldExtension) {
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    core.add_extension(std::make_shared<TestTileOldExtension>());
+    OPENVINO_SUPPRESS_DEPRECATED_END
+    test();
+}
+
+OPENVINO_SUPPRESS_DEPRECATED_END

--- a/src/inference/tests/functional/ov_extension_test.cpp
+++ b/src/inference/tests/functional/ov_extension_test.cpp
@@ -225,23 +225,6 @@ public:
     }
 };
 
-class TestTileOldExtension : public InferenceEngine::IExtension {
-public:
-    void GetVersion(const InferenceEngine::Version*& versionInfo) const noexcept override {}
-
-    void Unload() noexcept override {}
-
-    std::map<std::string, ngraph::OpSet> getOpSets() override {
-        static std::map<std::string, ngraph::OpSet> opsets;
-        if (opsets.empty()) {
-            ngraph::OpSet opset;
-            opset.insert<CustomOldIdentity>();
-            opsets["extension"] = opset;
-        }
-        return opsets;
-    }
-};
-
 class CustomNewIdentity : public ov::op::Op {
 public:
     OPENVINO_OP("Identity")
@@ -291,13 +274,6 @@ public:
 };
 
 #if defined(ENABLE_OV_IR_FRONTEND)
-TEST_F(OVExtensionTests, ReshapeIRWithOldExtension) {
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    core.add_extension(std::make_shared<TestTileOldExtension>());
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    test();
-}
-
 TEST_F(OVExtensionTests, ReshapeIRWithNewExtensionsLib) {
     core.add_extension(getOVExtensionPath());
     test();

--- a/src/inference/tests/functional/ov_extension_test.cpp
+++ b/src/inference/tests/functional/ov_extension_test.cpp
@@ -2,176 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <gtest/gtest.h>
-
-#include <map>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "ov_extension_test.hpp"
 
 #include "common_test_utils/file_utils.hpp"
-#include "common_test_utils/test_common.hpp"
-#include "ie_iextension.h"
-#include "ngraph/op/op.hpp"
-#include "openvino/core/except.hpp"
-#include "openvino/core/op_extension.hpp"
-#include "openvino/runtime/core.hpp"
 #include "openvino/util/file_util.hpp"
 
 using namespace testing;
 using namespace InferenceEngine;
 using namespace CommonTestUtils;
-
-class OVExtensionTests : public TestsCommon {
-public:
-    ov::Core core;
-
-    void test() {
-        std::string model = R"V0G0N(
-<net name="Activation" version="10">
-    <layers>
-        <layer name="in1" type="Parameter" id="0" version="opset1">
-            <data shape="1,3,22,22" element_type="f32"/>
-            <output>
-                <port id="0" precision="FP32" names="in_data">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </output>
-        </layer>
-        <layer name="activation" id="1" type="Identity" version="extension">
-            <input>
-                <port id="1" precision="FP32">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </input>
-            <output>
-                <port id="2" precision="FP32" names="out_data">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </output>
-        </layer>
-        <layer name="output" type="Result" id="2" version="opset1">
-            <input>
-                <port id="0" precision="FP32">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </input>
-        </layer>
-    </layers>
-    <edges>
-        <edge from-layer="0" from-port="0" to-layer="1" to-port="1"/>
-        <edge from-layer="1" from-port="2" to-layer="2" to-port="0"/>
-    </edges>
-</net>
-)V0G0N";
-        ov::Tensor weights;
-        ov::PartialShape refBeforeReshape{1, 3, 22, 22};
-        ov::PartialShape refAfterReshape{8, 9, 33, 66};
-
-        auto network = core.read_model(model, weights);
-        std::map<std::string, ov::PartialShape> newShapes;
-        newShapes["in_data"] = refAfterReshape;
-
-        EXPECT_EQ(refBeforeReshape, network->output().get_partial_shape());
-        EXPECT_NO_THROW(network->reshape(newShapes));
-        EXPECT_EQ(refAfterReshape, network->output().get_partial_shape());
-    }
-
-    void test_two_op() {
-        std::string model = R"V0G0N(
-<net name="Activation" version="10">
-    <layers>
-        <layer name="in1" type="Parameter" id="0" version="opset1">
-            <data shape="1,3,22,22" element_type="f32"/>
-            <output>
-                <port id="0" precision="FP32" names="in_data">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </output>
-        </layer>
-        <layer name="activation" id="1" type="Identity" version="extension">
-            <input>
-                <port id="1" precision="FP32">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </input>
-            <output>
-                <port id="2" precision="FP32" names="out_data">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </output>
-        </layer>
-        <layer name="activation2" id="2" type="CustomReLU" version="extension">
-            <input>
-                <port id="1" precision="FP32">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </input>
-            <output>
-                <port id="2" precision="FP32" names="out_relu_data">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </output>
-        </layer>
-        <layer name="output" type="Result" id="3" version="opset1">
-            <input>
-                <port id="0" precision="FP32">
-                    <dim>1</dim>
-                    <dim>3</dim>
-                    <dim>22</dim>
-                    <dim>22</dim>
-                </port>
-            </input>
-        </layer>
-    </layers>
-    <edges>
-        <edge from-layer="0" from-port="0" to-layer="1" to-port="1"/>
-        <edge from-layer="1" from-port="2" to-layer="2" to-port="1"/>
-        <edge from-layer="2" from-port="2" to-layer="3" to-port="0"/>
-    </edges>
-</net>
-)V0G0N";
-        ov::Tensor weights;
-        ov::PartialShape refBeforeReshape{1, 3, 22, 22};
-        ov::PartialShape refAfterReshape{8, 9, 33, 66};
-
-        auto network = core.read_model(model, weights);
-        std::map<std::string, ov::PartialShape> newShapes;
-        newShapes["in_data"] = refAfterReshape;
-
-        EXPECT_EQ(refBeforeReshape, network->output().get_partial_shape());
-        EXPECT_NO_THROW(network->reshape(newShapes));
-        EXPECT_EQ(refAfterReshape, network->output().get_partial_shape());
-    }
-};
 
 namespace {
 
@@ -199,31 +37,6 @@ std::string getRelativeOVExtensionPath() {
 
 }  // namespace
 
-class CustomOldIdentity : public ngraph::op::Op {
-public:
-    OPENVINO_OP("Identity");
-
-    CustomOldIdentity() = default;
-    CustomOldIdentity(const ngraph::Output<ngraph::Node>& arg) : Op({arg}) {
-        constructor_validate_and_infer_types();
-    }
-
-    void validate_and_infer_types() override {
-        set_output_type(0, get_input_element_type(0), get_input_partial_shape(0));
-    }
-
-    std::shared_ptr<ngraph::Node> clone_with_new_inputs(const ngraph::OutputVector& new_args) const override {
-        if (new_args.size() != 1) {
-            OPENVINO_THROW("Incorrect number of new arguments");
-        }
-
-        return std::make_shared<CustomOldIdentity>(new_args.at(0));
-    }
-
-    bool visit_attributes(ngraph::AttributeVisitor& visitor) override {
-        return true;
-    }
-};
 
 class CustomNewIdentity : public ov::op::Op {
 public:

--- a/src/inference/tests/functional/ov_extension_test.cpp
+++ b/src/inference/tests/functional/ov_extension_test.cpp
@@ -37,7 +37,6 @@ std::string getRelativeOVExtensionPath() {
 
 }  // namespace
 
-
 class CustomNewIdentity : public ov::op::Op {
 public:
     OPENVINO_OP("Identity")
@@ -87,6 +86,7 @@ public:
 };
 
 #if defined(ENABLE_OV_IR_FRONTEND)
+
 TEST_F(OVExtensionTests, ReshapeIRWithNewExtensionsLib) {
     core.add_extension(getOVExtensionPath());
     test();

--- a/src/inference/tests/functional/ov_extension_test.hpp
+++ b/src/inference/tests/functional/ov_extension_test.hpp
@@ -1,0 +1,157 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "common_test_utils/test_common.hpp"
+#include "openvino/runtime/core.hpp"
+
+class OVExtensionTests : public CommonTestUtils::TestsCommon {
+public:
+    ov::Core core;
+
+    void test() {
+        std::string model = R"V0G0N(
+<net name="Activation" version="10">
+    <layers>
+        <layer name="in1" type="Parameter" id="0" version="opset1">
+            <data shape="1,3,22,22" element_type="f32"/>
+            <output>
+                <port id="0" precision="FP32" names="in_data">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </output>
+        </layer>
+        <layer name="activation" id="1" type="Identity" version="extension">
+            <input>
+                <port id="1" precision="FP32">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </input>
+            <output>
+                <port id="2" precision="FP32" names="out_data">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </output>
+        </layer>
+        <layer name="output" type="Result" id="2" version="opset1">
+            <input>
+                <port id="0" precision="FP32">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </input>
+        </layer>
+    </layers>
+    <edges>
+        <edge from-layer="0" from-port="0" to-layer="1" to-port="1"/>
+        <edge from-layer="1" from-port="2" to-layer="2" to-port="0"/>
+    </edges>
+</net>
+)V0G0N";
+        ov::Tensor weights;
+        ov::PartialShape refBeforeReshape{1, 3, 22, 22};
+        ov::PartialShape refAfterReshape{8, 9, 33, 66};
+
+        auto network = core.read_model(model, weights);
+        std::map<std::string, ov::PartialShape> newShapes;
+        newShapes["in_data"] = refAfterReshape;
+
+        EXPECT_EQ(refBeforeReshape, network->output().get_partial_shape());
+        EXPECT_NO_THROW(network->reshape(newShapes));
+        EXPECT_EQ(refAfterReshape, network->output().get_partial_shape());
+    }
+
+    void test_two_op() {
+        std::string model = R"V0G0N(
+<net name="Activation" version="10">
+    <layers>
+        <layer name="in1" type="Parameter" id="0" version="opset1">
+            <data shape="1,3,22,22" element_type="f32"/>
+            <output>
+                <port id="0" precision="FP32" names="in_data">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </output>
+        </layer>
+        <layer name="activation" id="1" type="Identity" version="extension">
+            <input>
+                <port id="1" precision="FP32">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </input>
+            <output>
+                <port id="2" precision="FP32" names="out_data">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </output>
+        </layer>
+        <layer name="activation2" id="2" type="CustomReLU" version="extension">
+            <input>
+                <port id="1" precision="FP32">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </input>
+            <output>
+                <port id="2" precision="FP32" names="out_relu_data">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </output>
+        </layer>
+        <layer name="output" type="Result" id="3" version="opset1">
+            <input>
+                <port id="0" precision="FP32">
+                    <dim>1</dim>
+                    <dim>3</dim>
+                    <dim>22</dim>
+                    <dim>22</dim>
+                </port>
+            </input>
+        </layer>
+    </layers>
+    <edges>
+        <edge from-layer="0" from-port="0" to-layer="1" to-port="1"/>
+        <edge from-layer="1" from-port="2" to-layer="2" to-port="1"/>
+        <edge from-layer="2" from-port="2" to-layer="3" to-port="0"/>
+    </edges>
+</net>
+)V0G0N";
+        ov::Tensor weights;
+        ov::PartialShape refBeforeReshape{1, 3, 22, 22};
+        ov::PartialShape refAfterReshape{8, 9, 33, 66};
+
+        auto network = core.read_model(model, weights);
+        std::map<std::string, ov::PartialShape> newShapes;
+        newShapes["in_data"] = refAfterReshape;
+
+        EXPECT_EQ(refBeforeReshape, network->output().get_partial_shape());
+        EXPECT_NO_THROW(network->reshape(newShapes));
+        EXPECT_EQ(refAfterReshape, network->output().get_partial_shape());
+    }
+};

--- a/src/inference/tests/unit/add_preprocessing.cpp
+++ b/src/inference/tests/unit/add_preprocessing.cpp
@@ -13,6 +13,7 @@
 #include "common_test_utils/test_common.hpp"
 #include "dev/preprocessing/preprocessing.hpp"
 #include "openvino/runtime/common.hpp"
+#include "openvino/op/add.hpp"
 
 using namespace testing;
 

--- a/src/inference/tests/unit/add_preprocessing.cpp
+++ b/src/inference/tests/unit/add_preprocessing.cpp
@@ -12,8 +12,8 @@
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "dev/preprocessing/preprocessing.hpp"
-#include "openvino/runtime/common.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/runtime/common.hpp"
 
 using namespace testing;
 

--- a/src/inference/tests/unit/ie_extension_test.cpp
+++ b/src/inference/tests/unit/ie_extension_test.cpp
@@ -19,6 +19,8 @@ using ExtensionTests = ::testing::Test;
 
 #ifndef OPENVINO_STATIC_LIBRARY
 
+OPENVINO_SUPPRESS_DEPRECATED_START
+
 static std::string getExtensionPath() {
     return FileUtils::makePluginLibraryName<char>(CommonTestUtils::getExecutableDirectory(),
                                                   std::string("template_extension") + IE_BUILD_POSTFIX);
@@ -54,5 +56,7 @@ TEST(ExtensionTests, testGetImplementationThrowsIfNgraphNodeIsNullPtr) {
     IExtensionPtr extension = std::make_shared<Extension>(getExtensionPath());
     ASSERT_THROW(extension->getImplementation(std::shared_ptr<ngraph::Node>(), ""), InferenceEngine::Exception);
 }
+
+OPENVINO_SUPPRESS_DEPRECATED_END
 
 #endif  // OPENVINO_STATIC_LIBRARY

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_non0_output_port.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_non0_output_port.cpp
@@ -26,7 +26,7 @@ class FuseNon0OuputPort : public SubgraphBaseTest {
         params[2] = ngraph::builder::makeParams(ov::element::i32, {z_shape})[0];
 
         // make a sub function
-        const auto cond = ov::opset8::Constant::create(ov::element::boolean, {1}, {true});
+        const auto cond = ov::op::v0::Constant::create(ov::element::boolean, {1}, {true});
         ngraph::ParameterVector sub_params(3);
         sub_params[0] = ngraph::builder::makeParams(ov::element::f32, {x_shape})[0];
         sub_params[1] = ngraph::builder::makeParams(ov::element::i32, {y_shape})[0];
@@ -38,8 +38,8 @@ class FuseNon0OuputPort : public SubgraphBaseTest {
         const auto sub_model = std::make_shared<ov::Model>(sub_results, sub_params);
 
         // loop ops
-        const auto trip = ov::opset8::Constant::create(ov::element::i64, {1}, {2});
-        const auto loop = std::make_shared<ov::opset8::Loop>(trip, cond);
+        const auto trip = ov::op::v0::Constant::create(ov::element::i64, {1}, {2});
+        const auto loop = std::make_shared<ov::op::v5::Loop>(trip, cond);
         loop->set_function(sub_model);
         loop->set_invariant_input(sub_params[0], params[0]);
         loop->set_invariant_input(sub_params[1], params[1]);
@@ -50,9 +50,9 @@ class FuseNon0OuputPort : public SubgraphBaseTest {
         const auto out2 = loop->get_iter_value(sub_results[2]->output(0), -1);
 
         // main function
-        const auto c = ov::opset8::Constant::create(ov::element::i32, {1}, {1});
-        const auto z1 = std::make_shared<ov::opset8::Add>(params[2], c);
-        const auto d = std::make_shared<ov::opset8::Add>(out1, z1);
+        const auto c = ov::op::v0::Constant::create(ov::element::i32, {1}, {1});
+        const auto z1 = std::make_shared<ov::op::v1::Add>(params[2], c);
+        const auto d = std::make_shared<ov::op::v1::Add>(out1, z1);
         function = std::make_shared<ov::Model>(ov::OutputVector{d->output(0), out0, out2}, params, "FuseNon0OuputPort");
     }
 };

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_transpose_reorder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_transpose_reorder.cpp
@@ -318,19 +318,19 @@ void FuseTransposeAndReorderTest4::CreateGraph() {
     auto memFmt = nhwc;
 
     auto inputParams = ngraph::builder::makeParams(ngPrc, {inputShape});
-    const auto relu = std::make_shared<ov::opset8::Relu>(inputParams[0]);
-    const auto transposeOrder = ov::opset8::Constant::create(ov::element::i32, {4}, {0, 3, 1, 2});
-    const auto transpose1 = std::make_shared<ov::opset8::Transpose>(relu, transposeOrder);
+    const auto relu = std::make_shared<ov::op::v0::Relu>(inputParams[0]);
+    const auto transposeOrder = ov::op::v0::Constant::create(ov::element::i32, {4}, {0, 3, 1, 2});
+    const auto transpose1 = std::make_shared<ov::op::v1::Transpose>(relu, transposeOrder);
     const auto conv1 = ngraph::builder::makeConvolution(transpose1, ngPrc, kernel, stride, padBegin,
                                                     padEnd, dilation, ngraph::op::PadType::AUTO, convOutChannels);
     conv1->get_rt_info() = makeCPUInfo({memFmt}, {memFmt}, {});
-    const auto transpose2 = std::make_shared<ov::opset8::Transpose>(relu, transposeOrder);
+    const auto transpose2 = std::make_shared<ov::op::v1::Transpose>(relu, transposeOrder);
     const auto conv2 = ngraph::builder::makeConvolution(transpose2, ngPrc, kernel, stride, padBegin,
                                                     padEnd, dilation, ngraph::op::PadType::AUTO, convOutChannels);
     conv2->get_rt_info() = makeCPUInfo({memFmt}, {memFmt}, {});
-    const auto add = std::make_shared<ov::opset8::Add>(conv1, conv2);
+    const auto add = std::make_shared<ov::op::v1::Add>(conv1, conv2);
 
-    ov::ResultVector results{std::make_shared<ov::opset8::Result>(add->output(0))};
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(add->output(0))};
     function = std::make_shared<ov::Model>(results, inputParams, "TransposeReorder");
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/interaction.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/interaction.cpp
@@ -54,7 +54,7 @@ static std::shared_ptr<ov::Model> makeInteraction(const ElementType inType, cons
         features.push_back(sparse_feat);
         inputsParams.push_back(sparse_input);
     }
-    auto shapeof = std::make_shared<opset8::ShapeOf>(dense_feature);
+    auto shapeof = std::make_shared<ov::op::v3::ShapeOf>(dense_feature);
     auto gather_batch_indices =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{1}, std::vector<int32_t>{0});
     auto gather_batch_axis =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{}, 0);
     auto gather_batch = std::make_shared<opset8::Gather>(shapeof, gather_batch_indices, gather_batch_axis);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_inplace.cpp
@@ -46,10 +46,10 @@ protected:
         targetDevice = CommonTestUtils::DEVICE_CPU;
         params[0] = ngraph::builder::makeParams(rtPrc, {inpShape})[0];
         params[1] = ngraph::builder::makeParams(ov::element::i32, {secShape})[0];
-        auto shape = std::make_shared<ov::opset8::ShapeOf>(params[0]);
+        auto shape = std::make_shared<ov::op::v3::ShapeOf>(params[0]);
         auto c = ngraph::builder::makeConstant<float>(rtPrc, {}, {1.0f});
-        auto broadcast = std::make_shared<ov::opset8::Broadcast>(c, shape);
-        auto reshape = std::make_shared<ov::opset8::Reshape>(broadcast, params[1], false);
+        auto broadcast = std::make_shared<ov::op::v3::Broadcast>(c, shape);
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(broadcast, params[1], false);
         ov::ResultVector results{std::make_shared<ngraph::opset1::Result>(reshape->output(0))};
         function = std::make_shared<ngraph::Function>(results, params, "reshape_check");
     }

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/subgraph_with_blocked_format.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/subgraph_with_blocked_format.cpp
@@ -20,10 +20,10 @@ protected:
         auto weights = builder::makeConstant(type, Shape{32, 32, 1, 1}, std::vector<float>{}, true);
         auto conv = std::make_shared<opset8::Convolution>(param, weights, Strides{1, 1}, CoordinateDiff{0, 0}, CoordinateDiff{0, 0}, Strides{1, 1});
         auto mean = std::make_shared<opset8::ReduceMean>(conv, opset8::Constant::create(element::i32, Shape{2}, {2, 3}), true);
-        auto reshape_before = std::make_shared<opset8::Reshape>(mean, opset8::Constant::create(element::i32, Shape{3}, {0, 16, -1}), true);
+        auto reshape_before = std::make_shared<ov::op::v1::Reshape>(mean, opset8::Constant::create(element::i32, Shape{3}, {0, 16, -1}), true);
         auto mvn = std::make_shared<opset8::MVN>(reshape_before, opset8::Constant::create(element::i32, Shape{1}, {2}),
                 false, 0.1, op::MVNEpsMode::INSIDE_SQRT);
-        auto reshape_after = std::make_shared<opset8::Reshape>(mvn, std::make_shared<opset8::ShapeOf>(mean), false);
+        auto reshape_after = std::make_shared<ov::op::v1::Reshape>(mvn, std::make_shared<ov::op::v3::ShapeOf>(mean), false);
         auto mul = std::make_shared<opset8::Multiply>(reshape_after, builder::makeConstant(type, Shape{32, 1, 1}, std::vector<float>{}, true));
         auto add = std::make_shared<opset8::Add>(mul, builder::makeConstant(type, Shape{32, 1, 1}, std::vector<float>{}, true));
         auto sigmoid = std::make_shared<opset8::Sigmoid>(add);

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/x64/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/x64/convert_to_interaction.cpp
@@ -140,12 +140,12 @@ TEST(TransformationTests, ConvertToInteractionTest1) {
         }
         //construct ref interaction
         {
-            auto dense_feature = std::make_shared<ngraph::opset1::Parameter>(element::f32, inputShape);
+            auto dense_feature = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
             NodeVector features{dense_feature};
             ParameterVector inputsParams{dense_feature};
             const size_t sparse_feature_num = 26;
             for (size_t i = 0; i < sparse_feature_num; i++) {
-                auto sparse_feat = std::make_shared<ngraph::opset1::Parameter>(element::f32, inputShape);
+                auto sparse_feat = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
                 features.push_back(sparse_feat);
                 inputsParams.push_back(sparse_feat);
             }
@@ -175,12 +175,12 @@ TEST(TransformationTests, FuseFQtoInteractionTest1) {
         }
         //construct ref interaction
         {
-            auto dense_feature = std::make_shared<ngraph::opset1::Parameter>(element::f32, inputShape);
+            auto dense_feature = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
             NodeVector features{dense_feature};
             ParameterVector inputsParams{dense_feature};
             const size_t sparse_feature_num = 26;
             for (size_t i = 0; i < sparse_feature_num; i++) {
-                auto sparse_feat = std::make_shared<ngraph::opset1::Parameter>(element::f32, inputShape);
+                auto sparse_feat = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
                 features.push_back(sparse_feat);
                 inputsParams.push_back(sparse_feat);
             }
@@ -210,13 +210,13 @@ TEST(TransformationTests, FuseFQtoInteractionTest2) {
         }
         //construct ref interaction
         {
-            auto dense_input = std::make_shared<ngraph::opset1::Parameter>(element::f32, inputShape);
+            auto dense_input = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
             auto dense_feature = createFQ(dense_input);
             NodeVector features{dense_feature};
             ParameterVector inputsParams{dense_input};
             const size_t sparse_feature_num = 26;
             for (size_t i = 0; i < sparse_feature_num; i++) {
-                auto sparse_input = std::make_shared<ngraph::opset1::Parameter>(element::f32, inputShape);
+                auto sparse_input = std::make_shared<ov::op::v0::Parameter>(element::f32, inputShape);
                 auto sparse_feat = createFQ(sparse_input);
                 features.push_back(sparse_feat);
                 inputsParams.push_back(sparse_input);

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/fake_quantize_tokenization_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/fake_quantize_tokenization_test.cpp
@@ -12,7 +12,6 @@
 #include "snippets/op/subgraph.hpp"
 #include "transformations/snippets/x64/pass/snippets_mark_skipped.hpp"
 #include "function_helper.hpp"
-
 namespace ov {
 namespace test {
 namespace snippets {
@@ -90,7 +89,7 @@ TEST_F(FakeQuantizeTokenizationTest, smoke_Snippets_ConvolutionWithFakeQuantize)
         {{}, {}, {}, {}},
         true,
         FunctionHelper::makePrerequisitesOriginal(),
-        std::make_shared<ngraph::opset1::Convolution>());
+        std::make_shared<ov::op::v1::Convolution>());
 
     function_ref = FakeQuantizeFunction::getOperationAndFakeQuantize(
         {{1, 3, 16, 16}},
@@ -98,7 +97,7 @@ TEST_F(FakeQuantizeTokenizationTest, smoke_Snippets_ConvolutionWithFakeQuantize)
         {{}, {}, {}, {}},
         true,
         FunctionHelper::makePrerequisitesOriginal(),
-        std::make_shared<ngraph::opset1::Convolution>());
+        std::make_shared<ov::op::v1::Convolution>());
 
     register_passes();
 }

--- a/src/plugins/intel_gna/legacy/tests/conv_fusion_test.cpp
+++ b/src/plugins/intel_gna/legacy/tests/conv_fusion_test.cpp
@@ -130,13 +130,13 @@ private:
 };
 
 TEST_P(ConvFusionTests, CompareFunctions) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ngraph::pass::ConvFusion>();
     manager.register_pass<ngraph::pass::ConstantFolding>();
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh);
     manager.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
 

--- a/src/plugins/intel_gna/legacy/tests/convert_nms5_test.cpp
+++ b/src/plugins/intel_gna/legacy/tests/convert_nms5_test.cpp
@@ -812,7 +812,7 @@ TEST_F(TransformationTestsF, ConvertNMS5ToNMSIEDynamic2TwoInputs) {
                                                               true,
                                                               element::i32);
 
-        auto convert_0 = std::make_shared<opset1::Convert>(nms->output(0), element::i64);
+        auto convert_0 = std::make_shared<ov::op::v0::Convert>(nms->output(0), element::i64);
 
         function_ref = std::make_shared<Function>(NodeVector{convert_0}, ParameterVector{boxes, scores});
     }

--- a/src/plugins/intel_gna/legacy/tests/convert_topk_test.cpp
+++ b/src/plugins/intel_gna/legacy/tests/convert_topk_test.cpp
@@ -30,7 +30,7 @@ TEST_F(TransformationTestsF, ConvertTopKToTopKIEStatic) {
             std::make_shared<ngraph::Function>(ngraph::OutputVector{topk->output(0)}, ngraph::ParameterVector{input});
 
         manager.register_pass<ngraph::pass::ConvertTopKToTopKIEMatcher>();
-        manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+        manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
             check_rt_info(f);
         });
         manager.register_pass<ngraph::pass::ConstantFolding>();

--- a/src/plugins/intel_gna/legacy/tests/fc_bias_fusion_test.cpp
+++ b/src/plugins/intel_gna/legacy/tests/fc_bias_fusion_test.cpp
@@ -36,7 +36,7 @@ TEST_F(TransformationTestsF, FullyConnectedBiasFusionTest3D) {
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input1});
 
         manager.register_pass<ngraph::pass::FullyConnectedBiasFusion>();
-        manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+        manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
             check_rt_info(f);
         });
         manager.register_pass<ngraph::pass::ConstantFolding>();
@@ -64,7 +64,7 @@ TEST_F(TransformationTestsF, FullyConnectedBiasFusionTest2D) {
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input1});
         manager.register_pass<ngraph::pass::FullyConnectedBiasFusion>();
-        manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+        manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
             check_rt_info(f);
         });
         manager.register_pass<ngraph::pass::ConstantFolding>();
@@ -94,7 +94,7 @@ TEST_F(TransformationTestsF, FullyConnectedBiasFusionTestBias1x1) {
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input1});
 
         manager.register_pass<ngraph::pass::FullyConnectedBiasFusion>();
-        manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> function) {
+        manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> function) {
             check_rt_info(function);
         });
         manager.register_pass<ngraph::pass::ConstantFolding>();

--- a/src/plugins/intel_gna/legacy/tests/mul_add_conversion_test.cpp
+++ b/src/plugins/intel_gna/legacy/tests/mul_add_conversion_test.cpp
@@ -145,14 +145,14 @@ public:
 class MulOrAddConversionTests : public MulAddConversionTests {};
 
 TEST_P(MulAddConversionTests, CompareFunctions) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
 
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ngraph::pass::ConvertMulAddToScaleShiftOrPower>();
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
-    manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh);
+    manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
         check_rt_info(f);
     });
     manager.register_pass<ngraph::pass::ConstantFolding>();
@@ -166,14 +166,14 @@ TEST_P(MulAddConversionTests, CompareFunctions) {
 }
 
 TEST_P(MulOrAddConversionTests, CompareFunctions) {
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
 
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ngraph::pass::ConvertMulOrAddFinally>();
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh);
-    manager.register_pass<ngraph::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh);
+    manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ngraph::Function> f) {
         check_rt_info(f);
     });
     manager.register_pass<ngraph::pass::ConstantFolding>();

--- a/src/plugins/intel_gna/legacy/tests/reshape_fc_fusion_test.cpp
+++ b/src/plugins/intel_gna/legacy/tests/reshape_fc_fusion_test.cpp
@@ -35,12 +35,12 @@ TEST(TransformationTests, ReshapeFCFusiuonTest1) {
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{});
 
-        auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+        auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         ngraph::pass::Manager m;
-        m.register_pass<ngraph::pass::InitUniqueNames>(unh);
+        m.register_pass<ov::pass::InitUniqueNames>(unh);
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ngraph::pass::ReshapeFullyConnectedFusion>();
-        m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+        m.register_pass<ov::pass::CheckUniqueNames>(unh);
         m.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
@@ -59,12 +59,12 @@ TEST(TransformationTests, ReshapeFCFusiuonTest2) {
         auto fc = std::make_shared<ngraph::op::FullyConnected>(reshape, fc_weights, fc_biases, ngraph::Shape{1, 6});
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{});
-        auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+        auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         ngraph::pass::Manager m;
-        m.register_pass<ngraph::pass::InitUniqueNames>(unh);
+        m.register_pass<ov::pass::InitUniqueNames>(unh);
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ngraph::pass::ReshapeFullyConnectedFusion>();
-        m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+        m.register_pass<ov::pass::CheckUniqueNames>(unh);
         m.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
@@ -83,12 +83,12 @@ TEST(TransformationTests, ReshapeFCFusiuonTest3) {
         auto fc = std::make_shared<ngraph::op::FullyConnected>(reshape, fc_weights, fc_biases, ngraph::Shape{2, 6});
 
         f = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{});
-        auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+        auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         ngraph::pass::Manager m;
-        m.register_pass<ngraph::pass::InitUniqueNames>(unh);
+        m.register_pass<ov::pass::InitUniqueNames>(unh);
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ngraph::pass::ReshapeFullyConnectedFusion>();
-        m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+        m.register_pass<ov::pass::CheckUniqueNames>(unh);
         m.run_passes(f);
         ASSERT_NO_THROW(check_rt_info(f));
     }
@@ -105,12 +105,12 @@ TEST(TransformationTests, ReshapeFCFusiuonDynamic) {
     auto fc = std::make_shared<ngraph::op::FullyConnected>(reshape, fc_weights, fc_biases, ngraph::Shape{1, 6});
 
     auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{});
-    auto unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    m.register_pass<ov::pass::InitUniqueNames>(unh);
     m.register_pass<ov::pass::InitNodeInfo>();
     m.register_pass<ngraph::pass::ReshapeFullyConnectedFusion>();
-    m.register_pass<ngraph::pass::CheckUniqueNames>(unh);
+    m.register_pass<ov::pass::CheckUniqueNames>(unh);
     m.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
 }

--- a/src/plugins/intel_gna/tests/deprecated/helpers/tests_file_utils.cpp
+++ b/src/plugins/intel_gna/tests/deprecated/helpers/tests_file_utils.cpp
@@ -27,10 +27,10 @@ using namespace std;
 void FileUtils::readAllFile(const std::string &file_name, void *buffer, size_t maxSize) {
     std::ifstream inputFile;
     inputFile.open(file_name, std::ios::binary | std::ios::in);
-    if (!inputFile.is_open()) IE_THROW() << "cannot open file " << file_name;
+    if (!inputFile.is_open()) OPENVINO_THROW("cannot open file ", file_name);
     if (!inputFile.read(static_cast<char *> (buffer), maxSize)) {
         inputFile.close();
-        IE_THROW() << "cannot read " << maxSize << " bytes from file " << file_name;
+        OPENVINO_THROW("cannot read ", maxSize, " bytes from file ", file_name);
     }
 
     inputFile.close();

--- a/src/plugins/intel_gna/tests/deprecated/unit/inference_engine_tests/cnn_ngraph_impl_tests.cpp
+++ b/src/plugins/intel_gna/tests/deprecated/unit/inference_engine_tests/cnn_ngraph_impl_tests.cpp
@@ -763,11 +763,11 @@ TEST(CNNNGraphImplTests, ReadMeanImageFromCNNNetReader) {
     auto f = network.getFunction();
 
     std::shared_ptr<ngraph::Function> f_ref;
-    auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 22, 22});
+    auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 22, 22});
     {
-        auto mean_image = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 22, 22}, {1});
-        auto sub = std::make_shared<ngraph::opset1::Subtract>(data, mean_image);
-        auto relu = std::make_shared<ngraph::opset1::Relu>(sub);
+        auto mean_image = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 22, 22}, {1});
+        auto sub = std::make_shared<ov::op::v1::Subtract>(data, mean_image);
+        auto relu = std::make_shared<ov::op::v0::Relu>(sub);
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{relu}, ngraph::ParameterVector{data});
     }
 
@@ -846,11 +846,11 @@ TEST(CNNNGraphImplTests, ReadMeanValueFromCNNNetReader) {
 
     std::shared_ptr<ngraph::Function> f_ref;
     {
-        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 22, 22});
+        auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 22, 22});
         auto mean_image =
-            ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 1, 1}, {1.1, 2.2, 3.3});
-        auto sub = std::make_shared<ngraph::opset1::Subtract>(data, mean_image);
-        auto relu = std::make_shared<ngraph::opset1::Relu>(sub);
+            ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 1, 1}, {1.1, 2.2, 3.3});
+        auto sub = std::make_shared<ov::op::v1::Subtract>(data, mean_image);
+        auto relu = std::make_shared<ov::op::v0::Relu>(sub);
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{relu}, ngraph::ParameterVector{data});
     }
 
@@ -1988,38 +1988,38 @@ TEST(CNNNGraphImplTests, CheckNonUniqueNewResultName) {
 TEST(CNNNGraphImplTests, RemoveLoopDanglingParametersIfConcatEmptyTensor) {
     CNNNetwork network;
 
-    auto trip_count = std::make_shared<ov::opset8::Constant>(ov::element::i64, ov::Shape{}, 10);
-    auto condition = std::make_shared<ov::opset8::Constant>(ov::element::boolean, ov::Shape{}, true);
+    auto trip_count = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{}, 10);
+    auto condition = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{}, true);
 
-    auto a = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{2, 2});
-    auto ai = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{2, 2});
-    auto b = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{2});
+    auto a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 2});
+    auto ai = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 2});
+    auto b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2});
     auto b_broadcast =
-        std::make_shared<ov::opset8::Broadcast>(b, ov::opset8::Constant::create(ngraph::element::i64, {2}, {0, 2}));
-    auto bi = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{0, 2});
+        std::make_shared<ov::op::v3::Broadcast>(b, ov::op::v0::Constant::create(ngraph::element::i64, {2}, {0, 2}));
+    auto bi = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{0, 2});
     {
-        auto concat = std::make_shared<ov::opset8::Concat>(ov::NodeVector{ai, bi}, 0);
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::NodeVector{ai, bi}, 0);
         auto body = std::make_shared<ov::Model>(ov::OutputVector{condition, concat}, ov::ParameterVector{ai, bi});
-        auto loop = std::make_shared<ov::opset8::Loop>(trip_count, condition);
+        auto loop = std::make_shared<ov::op::v5::Loop>(trip_count, condition);
         loop->set_special_body_ports({-1, 0});
         loop->set_function(body);
         loop->set_invariant_input(ai, a);
         loop->set_invariant_input(bi, b_broadcast);
 
-        auto loop_res = std::make_shared<ov::opset8::Result>(loop->get_iter_value(concat));
+        auto loop_res = std::make_shared<ov::op::v0::Result>(loop->get_iter_value(concat));
         auto model = std::make_shared<ov::Model>(ov::OutputVector{loop_res}, ov::ParameterVector{a, b});
 
         network = CNNNetwork(model);
     }
     {
-        auto concat = std::make_shared<ov::opset8::Concat>(ov::NodeVector{ai}, 0);
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::NodeVector{ai}, 0);
         auto body = std::make_shared<ov::Model>(ov::OutputVector{condition, concat}, ov::ParameterVector{ai});
-        auto loop = std::make_shared<ov::opset8::Loop>(trip_count, condition);
+        auto loop = std::make_shared<ov::op::v5::Loop>(trip_count, condition);
         loop->set_special_body_ports({-1, 0});
         loop->set_function(body);
         loop->set_invariant_input(ai, a);
 
-        auto loop_res = std::make_shared<ov::opset8::Result>(loop->get_iter_value(concat));
+        auto loop_res = std::make_shared<ov::op::v0::Result>(loop->get_iter_value(concat));
         auto model_ref = std::make_shared<ov::Model>(ov::OutputVector{loop_res}, ov::ParameterVector{a, b});
 
         const auto fc = FunctionsComparator::with_default()

--- a/src/plugins/intel_gna/tests/deprecated/unit/inference_engine_tests/cnn_ngraph_impl_tests.cpp
+++ b/src/plugins/intel_gna/tests/deprecated/unit/inference_engine_tests/cnn_ngraph_impl_tests.cpp
@@ -35,11 +35,11 @@
 #include <string>
 
 #include "cnn_network_ngraph_impl.hpp"
+#include "cnnlayer_utils.hpp"
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/file_utils.hpp"
 #include "ie_precision.hpp"
 #include "transformations/rt_info/primitives_priority_attribute.hpp"
-#include "cnnlayer_utils.hpp"
 
 using namespace testing;
 using namespace InferenceEngine;
@@ -847,8 +847,7 @@ TEST(CNNNGraphImplTests, ReadMeanValueFromCNNNetReader) {
     std::shared_ptr<ngraph::Function> f_ref;
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 22, 22});
-        auto mean_image =
-            ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 1, 1}, {1.1, 2.2, 3.3});
+        auto mean_image = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{3, 1, 1}, {1.1, 2.2, 3.3});
         auto sub = std::make_shared<ov::op::v1::Subtract>(data, mean_image);
         auto relu = std::make_shared<ov::op::v0::Relu>(sub);
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{relu}, ngraph::ParameterVector{data});

--- a/src/plugins/template/tests/functional/subgraph_reference/preprocess.cpp
+++ b/src/plugins/template/tests/functional/subgraph_reference/preprocess.cpp
@@ -836,11 +836,11 @@ static RefPreprocessParams set_shape_custom_crop() {
         p.input().preprocess().custom([](const Output<Node>& node) {
             // Add custom crop to model's dimensions using 'Slice' operation
             // Middle part 2x2x2x2 of original user's 4x4x4x4 input tensor will be extracted
-            auto start = opset8::Constant::create(element::i32, {4}, {1, 1, 1, 1});
-            auto stop = opset8::Constant::create(element::i32, {4}, {3, 3, 3, 3});
-            auto step = opset8::Constant::create(element::i32, {4}, {1, 1, 1, 1});
-            auto axis = opset8::Constant::create(element::i32, {4}, {0, 1, 2, 3});
-            auto slice = std::make_shared<opset8::Slice>(node, start, stop, step, axis);
+            auto start = ov::op::v0::Constant::create(element::i32, {4}, {1, 1, 1, 1});
+            auto stop = ov::op::v0::Constant::create(element::i32, {4}, {3, 3, 3, 3});
+            auto step = ov::op::v0::Constant::create(element::i32, {4}, {1, 1, 1, 1});
+            auto axis = ov::op::v0::Constant::create(element::i32, {4}, {0, 1, 2, 3});
+            auto slice = std::make_shared<ov::op::v8::Slice>(node, start, stop, step, axis);
             return slice;
         });
         p.build();

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/matchers/convolutions.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/matchers/convolutions.cpp
@@ -4,6 +4,9 @@
 
 #include "matchers/convolutions.hpp"
 
+#include "openvino/op/convolution.hpp"
+#include "openvino/op/group_conv.hpp"
+
 using namespace SubgraphsDumper;
 ConvolutionsMatcher::ConvolutionsMatcher() {
     default_configs = {

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/matchers/single_op.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/matchers/single_op.cpp
@@ -181,7 +181,7 @@ bool SingleOpMatcher::match(const std::shared_ptr<ov::Node> &node,
 SingleOpMatcher::SingleOpMatcher() {
     default_configs = {
             std::make_shared<MatcherConfig<>>(std::vector<std::string>{}, std::vector<size_t>{0}),
-            std::make_shared<MatcherConfig<ov::opset8::FakeQuantize>>(std::vector<std::string>{},
+            std::make_shared<MatcherConfig<ov::op::v0::FakeQuantize>>(std::vector<std::string>{},
                                                                       std::vector<size_t>{0, 1, 2, 3, 4}),
             std::make_shared<MatcherConfig<
                     ov::op::v0::MatMul,

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/tests/matchers/convolutions_matcher.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/tests/matchers/convolutions_matcher.cpp
@@ -21,13 +21,13 @@ protected:
 
 // Check that two convolutions with different input ov::Shapes but same kernel size are match each other
 TEST_F(ConvolutionMatcherTest, ConvsSameKernelSize) {
-    const auto param = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 3, 10, 10}));
-    const auto weights = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({10, 3, 3, 3}), 1);
+    const auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 3, 10, 10}));
+    const auto weights = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({10, 3, 3, 3}), 1);
     const auto op1 = std::make_shared<ov::op::v1::Convolution>(param, weights, ov::Strides(0, 0), ov::CoordinateDiff(0, 0),
                                                        ov::CoordinateDiff(0, 0), ov::Strides(0, 0));
 
-    const auto param2 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 5, 20, 20}));
-    const auto weights2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({10, 5, 3, 3}), 1);
+    const auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 5, 20, 20}));
+    const auto weights2 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({10, 5, 3, 3}), 1);
     const auto op2 = std::make_shared<ov::op::v1::Convolution>(param2, weights2, ov::Strides(0, 0), ov::CoordinateDiff(0, 0),
                                                        ov::CoordinateDiff(0, 0), ov::Strides(0, 0));
     ASSERT_TRUE(matcher.match(op1, op2, op_info));
@@ -35,13 +35,13 @@ TEST_F(ConvolutionMatcherTest, ConvsSameKernelSize) {
 
 // Check that two convolutions with different input ov::Shapes but same kernel size are match each other
 TEST_F(ConvolutionMatcherTest, ConvsDifferentKernelSize) {
-    const auto param = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 3, 10, 10}));
-    const auto weights = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({10, 3, 3, 5}), 1);
+    const auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 3, 10, 10}));
+    const auto weights = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({10, 3, 3, 5}), 1);
     const auto op1 = std::make_shared<ov::op::v1::Convolution>(param, weights, ov::Strides(0, 0), ov::CoordinateDiff(0, 0),
                                                        ov::CoordinateDiff(0, 0), ov::Strides(0, 0));
 
-    const auto param2 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 5, 20, 20}));
-    const auto weights2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({10, 5, 3, 3}), 1);
+    const auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 5, 20, 20}));
+    const auto weights2 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({10, 5, 3, 3}), 1);
     const auto op2 = std::make_shared<ov::op::v1::Convolution>(param2, weights2, ov::Strides(0, 0), ov::CoordinateDiff(0, 0),
                                                        ov::CoordinateDiff(0, 0), ov::Strides(0, 0));
     ASSERT_FALSE(matcher.match(op1, op2, op_info));
@@ -49,13 +49,13 @@ TEST_F(ConvolutionMatcherTest, ConvsDifferentKernelSize) {
 
 // Check that two group convolutions with different input ov::Shapes but same kernel size are match each other
 TEST_F(ConvolutionMatcherTest, GroupConvsSameKernelSize) {
-    const auto param = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 4, 10, 10}));
-    const auto weights = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2, 10, 2, 3, 3}), 1);
+    const auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 4, 10, 10}));
+    const auto weights = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({2, 10, 2, 3, 3}), 1);
     const auto op1 = std::make_shared<ov::op::v1::GroupConvolution>(param, weights, ov::Strides(0, 0), ov::CoordinateDiff(0, 0),
                                                        ov::CoordinateDiff(0, 0), ov::Strides(0, 0));
 
-    const auto param2 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 6, 20, 20}));
-    const auto weights2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2, 10, 3, 3, 3}), 1);
+    const auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 6, 20, 20}));
+    const auto weights2 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({2, 10, 3, 3, 3}), 1);
     const auto op2 = std::make_shared<ov::op::v1::GroupConvolution>(param2, weights2, ov::Strides(0, 0), ov::CoordinateDiff(0, 0),
                                                        ov::CoordinateDiff(0, 0), ov::Strides(0, 0));
     ASSERT_TRUE(matcher.match(op1, op2, op_info));
@@ -63,13 +63,13 @@ TEST_F(ConvolutionMatcherTest, GroupConvsSameKernelSize) {
 
 // Check that two group convolutions with different input ov::Shapes but same kernel size are match each other
 TEST_F(ConvolutionMatcherTest, GroupConvsDifferentKernelSize) {
-    const auto param = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 4, 10, 10}));
-    const auto weights = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2, 10, 2, 3, 5}), 1);
+    const auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 4, 10, 10}));
+    const auto weights = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({2, 10, 2, 3, 5}), 1);
     const auto op1 = std::make_shared<ov::op::v1::GroupConvolution>(param, weights, ov::Strides(0, 0), ov::CoordinateDiff(0, 0),
                                                        ov::CoordinateDiff(0, 0), ov::Strides(0, 0));
 
-    const auto param2 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 6, 20, 20}));
-    const auto weights2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2, 10, 3, 3, 3}), 1);
+    const auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 6, 20, 20}));
+    const auto weights2 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({2, 10, 3, 3, 3}), 1);
     const auto op2 = std::make_shared<ov::op::v1::GroupConvolution>(param2, weights2, ov::Strides(0, 0), ov::CoordinateDiff(0, 0),
                                                        ov::CoordinateDiff(0, 0), ov::Strides(0, 0));
     ASSERT_FALSE(matcher.match(op1, op2, op_info));

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/tests/matchers/generic_single_op.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/tests/matchers/generic_single_op.cpp
@@ -21,19 +21,19 @@ protected:
 
 // Check that different values of constant nodes on port 0 (default value) are ignored in match()
 TEST_F(SingleOpMatcherTest, AllPortsAreConsts_IgnoreConstPortVals) {
-    const auto const1 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 1);
-    const auto shape_pattern = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::i64, ov::Shape({2}), std::vector<int>{1, 25});
+    const auto const1 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 1);
+    const auto shape_pattern = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i64, ov::Shape({2}), std::vector<int>{1, 25});
     const auto op1 = std::make_shared<ov::op::v1::Reshape>(const1, shape_pattern, false);
 
-    const auto const2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 2);
+    const auto const2 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 2);
     const auto op2 = std::make_shared<ov::op::v1::Reshape>(const2, shape_pattern, false);
     ASSERT_TRUE(matcher.match(op1, op2, op_info));
 }
 
 // Check match of equal nodes
 TEST_F(SingleOpMatcherTest, AllPortsAreParams_NodesEqual) {
-    const auto param1 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10}));
-    const auto param2 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 20}));
+    const auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10}));
+    const auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 20}));
     const auto op1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector({param1, param2}), 1);
     const auto op2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector({param1, param2}), 1);
     ASSERT_TRUE(matcher.match(op1, op2, op_info));
@@ -41,48 +41,48 @@ TEST_F(SingleOpMatcherTest, AllPortsAreParams_NodesEqual) {
 
 // Check nodes doesn't match - different input ranks
 TEST_F(SingleOpMatcherTest, AllPortsAreParams_RanksNotEqual) {
-    const auto param1 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10}));
-    const auto param2 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 20}));
+    const auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10}));
+    const auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 20}));
     const auto op1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector({param1, param2}), 1);
 
-    const auto param3 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 40, 10}));
-    const auto param4 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 40, 10}));
+    const auto param3 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 40, 10}));
+    const auto param4 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 40, 10}));
     const auto op2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector({param3, param4}), 1);
     ASSERT_FALSE(matcher.match(op1, op2, op_info));
 }
 
 // Check nodes doesn't match - different input element types
 TEST_F(SingleOpMatcherTest, AllPortsAreParams_TypesNotEqual) {
-    const auto param1 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10}));
-    const auto param2 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 20}));
+    const auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10}));
+    const auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 20}));
     const auto op1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector({param1, param2}), 1);
 
-    const auto param3 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f16, ov::Shape({10, 10}));
-    const auto param4 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f16, ov::Shape({10, 20}));
+    const auto param3 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f16, ov::Shape({10, 10}));
+    const auto param4 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f16, ov::Shape({10, 20}));
     const auto op2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector({param3, param4}), 1);
     ASSERT_FALSE(matcher.match(op1, op2, op_info));
 }
 
 // Check nodes doesn't match - different input element types
 TEST_F(SingleOpMatcherTest, AllPortsAreParams_AttrsNotEqual) {
-    const auto param1 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10, 10}));
-    const auto param2 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10, 10}));
+    const auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10, 10}));
+    const auto param2 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10, 10}));
     const auto op1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector({param1, param2}), 1);
 
-    const auto param3 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10, 10}));
-    const auto param4 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10, 10}));
+    const auto param3 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10, 10}));
+    const auto param4 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({10, 10, 10}));
     const auto op2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector({param3, param4}), 2);
     ASSERT_FALSE(matcher.match(op1, op2, op_info));
 }
 
 // Check nodes Add OPs match with different constants on ports
 TEST_F(SingleOpMatcherTest, ChecAddOpConfiguration) {
-    const auto const1 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 1);
-    const auto const2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 2);
+    const auto const1 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 1);
+    const auto const2 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 2);
     const auto op1 = std::make_shared<ov::op::v1::Add>(const1, const2);
 
-    const auto const3 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 3);
-    const auto const4 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 4);
+    const auto const3 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 3);
+    const auto const4 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({5, 5}), 4);
     const auto op2  = std::make_shared<ov::op::v1::Add>(const1, const2);
     ASSERT_TRUE(matcher.match(op1, op2, op_info));
 }

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/compiled_model_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/compiled_model_base.hpp
@@ -525,16 +525,16 @@ TEST_P(OVCompiledModelBaseTest, loadIncorrectV10Model) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto param2 = std::make_shared<ov::opset8::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
+        auto param2 = std::make_shared<ov::op::v0::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
         param2->set_friendly_name("param2");
         param2->output(0).get_tensor().set_names({"data2"});
-        auto concat = std::make_shared<ov::opset8::Concat>(OutputVector{param1, param2}, 1);
+        auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{param1, param2}, 1);
         concat->set_friendly_name("data1");
         concat->output(0).get_tensor().set_names({"concat"});
-        auto result = std::make_shared<ov::opset8::Result>(concat);
+        auto result = std::make_shared<ov::op::v0::Result>(concat);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{param1, param2});
         function->get_rt_info()["version"] = int64_t(10);
@@ -548,16 +548,16 @@ TEST_P(OVCompiledModelBaseTest, loadIncorrectV11Model) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto param2 = std::make_shared<ov::opset8::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
+        auto param2 = std::make_shared<ov::op::v0::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
         param2->set_friendly_name("param2");
         param2->output(0).get_tensor().set_names({"data2"});
-        auto concat = std::make_shared<ov::opset8::Concat>(OutputVector{param1, param2}, 1);
+        auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{param1, param2}, 1);
         concat->set_friendly_name("data1");
         concat->output(0).get_tensor().set_names({"concat"});
-        auto result = std::make_shared<ov::opset8::Result>(concat);
+        auto result = std::make_shared<ov::op::v0::Result>(concat);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{param1, param2});
         function->get_rt_info()["version"] = int64_t(11);

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/import_export.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/import_export.hpp
@@ -74,21 +74,21 @@ TEST_P(OVCompiledGraphImportExportTest, importExportedFunction) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto param2 = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param2 = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param2->set_friendly_name("param2");
         param2->output(0).get_tensor().set_names({"data2"});
-        auto relu = std::make_shared<ov::opset8::Relu>(param1);
+        auto relu = std::make_shared<ov::op::v0::Relu>(param1);
         relu->set_friendly_name("relu_op");
         relu->output(0).get_tensor().set_names({"relu"});
-        auto result1 = std::make_shared<ov::opset8::Result>(relu);
+        auto result1 = std::make_shared<ov::op::v0::Result>(relu);
         result1->set_friendly_name("result1");
-        auto concat = std::make_shared<ov::opset8::Concat>(OutputVector{relu, param2}, 1);
+        auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{relu, param2}, 1);
         concat->set_friendly_name("concat_op");
         concat->output(0).get_tensor().set_names({"concat"});
-        auto result2 = std::make_shared<ov::opset8::Result>(concat);
+        auto result2 = std::make_shared<ov::op::v0::Result>(concat);
         result2->set_friendly_name("result2");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
                                                       ngraph::ParameterVector{param1, param2});
@@ -151,10 +151,10 @@ TEST_P(OVCompiledGraphImportExportTest, importExportedFunction) {
 TEST_P(OVCompiledGraphImportExportTest, importExportedFunctionParameterResultOnly) {
     // Create a simple function
     {
-        auto param = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param->set_friendly_name("param");
         param->output(0).get_tensor().set_names({"data"});
-        auto result = std::make_shared<ov::opset8::Result>(param);
+        auto result = std::make_shared<ov::op::v0::Result>(param);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                       ngraph::ParameterVector{param});
@@ -187,10 +187,10 @@ TEST_P(OVCompiledGraphImportExportTest, importExportedFunctionParameterResultOnl
 TEST_P(OVCompiledGraphImportExportTest, importExportedFunctionConstantResultOnly) {
     // Create a simple function
     {
-        auto constant = std::make_shared<ov::opset8::Constant>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto constant = std::make_shared<ov::op::v0::Constant>(elementType, ngraph::Shape({1, 3, 24, 24}));
         constant->set_friendly_name("constant");
         constant->output(0).get_tensor().set_names({"data"});
-        auto result = std::make_shared<ov::opset8::Result>(constant);
+        auto result = std::make_shared<ov::op::v0::Result>(constant);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                       ngraph::ParameterVector{});
@@ -318,21 +318,21 @@ TEST_P(OVCompiledGraphImportExportTest, importExportedIENetwork) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto param2 = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param2 = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param2->set_friendly_name("param2");
         param2->output(0).get_tensor().set_names({"data2"});
-        auto relu = std::make_shared<ov::opset8::Relu>(param1);
+        auto relu = std::make_shared<ov::op::v0::Relu>(param1);
         relu->set_friendly_name("relu_op");
         relu->output(0).get_tensor().set_names({"relu"});
-        auto result1 = std::make_shared<ov::opset8::Result>(relu);
+        auto result1 = std::make_shared<ov::op::v0::Result>(relu);
         result1->set_friendly_name("result1");
-        auto concat = std::make_shared<ov::opset8::Concat>(OutputVector{relu, param2}, 1);
+        auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{relu, param2}, 1);
         concat->set_friendly_name("concat_op");
         concat->output(0).get_tensor().set_names({"concat"});
-        auto result2 = std::make_shared<ov::opset8::Result>(concat);
+        auto result2 = std::make_shared<ov::op::v0::Result>(concat);
         result2->set_friendly_name("result2");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
                                                       ngraph::ParameterVector{param1, param2});
@@ -380,10 +380,10 @@ TEST_P(OVCompiledGraphImportExportTest, importExportedIENetworkParameterResultOn
 
     // Create a simple function
     {
-        auto param = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param->set_friendly_name("param");
         param->output(0).get_tensor().set_names({"data"});
-        auto result = std::make_shared<ov::opset8::Result>(param);
+        auto result = std::make_shared<ov::op::v0::Result>(param);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
         function->set_friendly_name("ParamResult");
@@ -418,10 +418,10 @@ TEST_P(OVCompiledGraphImportExportTest, importExportedIENetworkConstantResultOnl
 
     // Create a simple function
     {
-        auto constant = std::make_shared<ov::opset8::Constant>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto constant = std::make_shared<ov::op::v0::Constant>(elementType, ngraph::Shape({1, 3, 24, 24}));
         constant->set_friendly_name("constant");
         constant->output(0).get_tensor().set_names({"data"});
-        auto result = std::make_shared<ov::opset8::Result>(constant);
+        auto result = std::make_shared<ov::op::v0::Result>(constant);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                       ngraph::ParameterVector{});
@@ -459,21 +459,21 @@ TEST_P(OVCompiledGraphImportExportTest, ovImportExportedFunction) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto param2 = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param2 = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param2->set_friendly_name("param2");
         param2->output(0).get_tensor().set_names({"data2"});
-        auto relu = std::make_shared<ov::opset8::Relu>(param1);
+        auto relu = std::make_shared<ov::op::v0::Relu>(param1);
         relu->set_friendly_name("relu_op");
         relu->output(0).get_tensor().set_names({"relu"});
-        auto result1 = std::make_shared<ov::opset8::Result>(relu);
+        auto result1 = std::make_shared<ov::op::v0::Result>(relu);
         result1->set_friendly_name("result1");
-        auto concat = std::make_shared<ov::opset8::Concat>(OutputVector{relu, param2}, 1);
+        auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{relu, param2}, 1);
         concat->set_friendly_name("concat_op");
         concat->output(0).get_tensor().set_names({"concat"});
-        auto result2 = std::make_shared<ov::opset8::Result>(concat);
+        auto result2 = std::make_shared<ov::op::v0::Result>(concat);
         result2->set_friendly_name("result2");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
                                                       ngraph::ParameterVector{param1, param2});

--- a/src/tests/functional/plugin/shared/include/behavior/executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/executable_network/exec_network_base.hpp
@@ -334,13 +334,13 @@ TEST_P(ExecutableNetworkBaseTest, loadIncorrectV10Model) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto relu = std::make_shared<ov::opset8::Relu>(param1);
+        auto relu = std::make_shared<ov::op::v0::Relu>(param1);
         relu->set_friendly_name("data1");
         relu->output(0).get_tensor().set_names({"relu"});
-        auto result = std::make_shared<ov::opset8::Result>(relu);
+        auto result = std::make_shared<ov::op::v0::Result>(relu);
         result->set_friendly_name("result");
         function = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param1});
         function->get_rt_info()["version"] = int64_t(10);
@@ -357,13 +357,13 @@ TEST_P(ExecutableNetworkBaseTest, loadIncorrectV11Model) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto relu = std::make_shared<ov::opset8::Relu>(param1);
+        auto relu = std::make_shared<ov::op::v0::Relu>(param1);
         relu->set_friendly_name("data1");
         relu->output(0).get_tensor().set_names({"relu"});
-        auto result = std::make_shared<ov::opset8::Result>(relu);
+        auto result = std::make_shared<ov::op::v0::Result>(relu);
         result->set_friendly_name("result");
         function = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param1});
         function->get_rt_info()["version"] = int64_t(11);

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_graph_info.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_graph_info.hpp
@@ -138,10 +138,10 @@ TEST_P(OVExecGraphImportExportTest, importExportedFunctionParameterResultOnly) {
 
     // Create a simple function
     {
-        auto param = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param->set_friendly_name("param");
         param->output(0).get_tensor().set_names({"data"});
-        auto result = std::make_shared<ov::opset8::Result>(param);
+        auto result = std::make_shared<ov::op::v0::Result>(param);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                       ngraph::ParameterVector{param});
@@ -178,10 +178,10 @@ TEST_P(OVExecGraphImportExportTest, importExportedFunctionConstantResultOnly) {
 
     // Create a simple function
     {
-        auto constant = std::make_shared<ov::opset8::Constant>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto constant = std::make_shared<ov::op::v0::Constant>(elementType, ngraph::Shape({1, 3, 24, 24}));
         constant->set_friendly_name("constant");
         constant->output(0).get_tensor().set_names({"data"});
-        auto result = std::make_shared<ov::opset8::Result>(constant);
+        auto result = std::make_shared<ov::op::v0::Result>(constant);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                       ngraph::ParameterVector{});
@@ -385,10 +385,10 @@ TEST_P(OVExecGraphImportExportTest, importExportedIENetworkParameterResultOnly) 
 
     // Create a simple function
     {
-        auto param = std::make_shared<ov::opset8::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto param = std::make_shared<ov::op::v0::Parameter>(elementType, ngraph::Shape({1, 3, 24, 24}));
         param->set_friendly_name("param");
         param->output(0).get_tensor().set_names({"data"});
-        auto result = std::make_shared<ov::opset8::Result>(param);
+        auto result = std::make_shared<ov::op::v0::Result>(param);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
         function->set_friendly_name("ParamResult");
@@ -427,10 +427,10 @@ TEST_P(OVExecGraphImportExportTest, importExportedIENetworkConstantResultOnly) {
 
     // Create a simple function
     {
-        auto constant = std::make_shared<ov::opset8::Constant>(elementType, ngraph::Shape({1, 3, 24, 24}));
+        auto constant = std::make_shared<ov::op::v0::Constant>(elementType, ngraph::Shape({1, 3, 24, 24}));
         constant->set_friendly_name("constant");
         constant->output(0).get_tensor().set_names({"data"});
-        auto result = std::make_shared<ov::opset8::Result>(constant);
+        auto result = std::make_shared<ov::op::v0::Result>(constant);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
                                                       ngraph::ParameterVector{});

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -574,16 +574,16 @@ TEST_P(OVExecutableNetworkBaseTest, loadIncorrectV10Model) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto param2 = std::make_shared<ov::opset8::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
+        auto param2 = std::make_shared<ov::op::v0::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
         param2->set_friendly_name("param2");
         param2->output(0).get_tensor().set_names({"data2"});
-        auto concat = std::make_shared<ov::opset8::Concat>(OutputVector{param1, param2}, 1);
+        auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{param1, param2}, 1);
         concat->set_friendly_name("data1");
         concat->output(0).get_tensor().set_names({"concat"});
-        auto result = std::make_shared<ov::opset8::Result>(concat);
+        auto result = std::make_shared<ov::op::v0::Result>(concat);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{param1, param2});
         function->get_rt_info()["version"] = int64_t(10);
@@ -597,16 +597,16 @@ TEST_P(OVExecutableNetworkBaseTest, loadIncorrectV11Model) {
 
     // Create simple function
     {
-        auto param1 = std::make_shared<ov::opset8::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
         param1->set_friendly_name("param1");
         param1->output(0).get_tensor().set_names({"data1"});
-        auto param2 = std::make_shared<ov::opset8::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
+        auto param2 = std::make_shared<ov::op::v0::Parameter>(element::Type_t::f32, ngraph::Shape({1, 3, 24, 24}));
         param2->set_friendly_name("param2");
         param2->output(0).get_tensor().set_names({"data2"});
-        auto concat = std::make_shared<ov::opset8::Concat>(OutputVector{param1, param2}, 1);
+        auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{param1, param2}, 1);
         concat->set_friendly_name("data1");
         concat->output(0).get_tensor().set_names({"concat"});
-        auto result = std::make_shared<ov::opset8::Result>(concat);
+        auto result = std::make_shared<ov::op::v0::Result>(concat);
         result->set_friendly_name("result");
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{param1, param2});
         function->get_rt_info()["version"] = int64_t(11);

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/infer_correctness.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/infer_correctness.cpp
@@ -11,13 +11,13 @@ namespace ov {
 namespace test {
 namespace behavior {
 std::shared_ptr<ngraph::Function> GetDefaultGraph() {
-    auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 224, 224});
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 224, 224});
     size_t spatialDims = 2;
     std::vector<ptrdiff_t> padBegin(spatialDims, 0), padEnd(spatialDims, 0);
     ngraph::Shape strides(spatialDims, 1);
     auto weights = ngraph::builder::makeConstant<float>(ov::element::f32, {64, 3, 7, 7}, {},
             true);
-    auto conv1 = std::make_shared<ov::opset8::Convolution>(input, weights, strides,
+    auto conv1 = std::make_shared<ov::op::v1::Convolution>(input, weights, strides,
             padBegin, padEnd, strides);
     auto gamma = ngraph::builder::makeConstant<float>(ov::element::f32, {64}, {},
             true);
@@ -27,10 +27,10 @@ std::shared_ptr<ngraph::Function> GetDefaultGraph() {
             true);
     auto variance = ngraph::builder::makeConstant<float>(ov::element::f32, {64}, {},
             true);
-    auto batchNorm1 = std::make_shared<ov::opset8::BatchNormInference>(conv1, gamma,
+    auto batchNorm1 = std::make_shared<ov::op::v0::BatchNormInference>(conv1, gamma,
             beta, mean, variance, 1e-5);
-    auto relu1 = std::make_shared<ov::opset8::Relu>(batchNorm1);
-    auto pool = std::make_shared<ov::opset8::AvgPool>(relu1, strides, ov::Shape{1, 1},
+    auto relu1 = std::make_shared<ov::op::v0::Relu>(batchNorm1);
+    auto pool = std::make_shared<ov::op::v1::AvgPool>(relu1, strides, ov::Shape{1, 1},
             ov::Shape{1, 1}, ov::Shape{4, 4}, true);
     return std::make_shared<ngraph::Function>(ngraph::OutputVector{pool},
             ngraph::ParameterVector{input},

--- a/src/tests/functional/plugin/shared/src/snippets/check_broadcast.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/check_broadcast.cpp
@@ -19,19 +19,19 @@ public:
         const PartialShape& input_shape2,
         const ov::element::Type input_type,
         const ov::op::AutoBroadcastSpec broadcast) {
-        const auto parameter1 = std::make_shared<ngraph::opset1::Parameter>(input_type, input_shape1);
+        const auto parameter1 = std::make_shared<ov::op::v0::Parameter>(input_type, input_shape1);
         parameter1->set_friendly_name("parameter1");
 
-        const auto parameter2 = std::make_shared<ngraph::opset1::Parameter>(input_type, input_shape2);
+        const auto parameter2 = std::make_shared<ov::op::v0::Parameter>(input_type, input_shape2);
         parameter2->set_friendly_name("parameter2");
 
-        std::shared_ptr<Node> parent = std::make_shared<ngraph::opset1::Multiply>(
+        std::shared_ptr<Node> parent = std::make_shared<ov::op::v1::Multiply>(
             parameter1,
             parameter2,
             broadcast);
         parent->set_friendly_name("multiply");
 
-        const auto result = std::make_shared<ngraph::opset1::Result>(parent);
+        const auto result = std::make_shared<ov::op::v0::Result>(parent);
         result->set_friendly_name("result");
 
         return std::make_shared<ngraph::Function>(

--- a/src/tests/functional/shared_test_classes/src/single_layer/random_uniform.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/random_uniform.cpp
@@ -63,7 +63,7 @@ void RandomUniformLayerTest::SetUp() {
     std::string targetName;
     std::tie(output_shape, randomUniformParams, global_seed, op_seed, targetDevice) = this->GetParam();
     const auto precision = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(randomUniformParams.precision);
-    auto out_shape_ = std::make_shared<ov::opset8::Constant>(ov::element::i64,
+    auto out_shape_ = std::make_shared<ov::op::v0::Constant>(ov::element::i64,
                                                              ov::Shape{output_shape.size()},
                                                              output_shape);
 

--- a/src/tests/ie_test_utils/common_test_utils/common_utils.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/common_utils.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "common_test_utils/common_utils.hpp"
+#include "openvino/core/except.hpp"
 
 #include <gtest/gtest.h>
 
@@ -20,7 +21,7 @@ std::ostream& operator<<(std::ostream& os, OpType type) {
         os << "VECTOR";
         break;
     default:
-        IE_THROW() << "NOT_SUPPORTED_OP_TYPE";
+        OPENVINO_THROW("NOT_SUPPORTED_OP_TYPE");
     }
     return os;
 }

--- a/src/tests/ie_test_utils/common_test_utils/common_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/common_utils.hpp
@@ -4,13 +4,12 @@
 
 #pragma once
 
-#include <cpp/ie_cnn_network.h>
+#include "openvino/core/partial_shape.hpp"
 
 #include <algorithm>
 #include <chrono>
 #include <iterator>
 #include <memory>
-#include <ngraph/function.hpp>
 #include <ostream>
 #include <set>
 #include <sstream>
@@ -45,7 +44,7 @@ inline void replaceSubstringInString(std::string& str, const std::string& from, 
     }
 }
 
-inline std::string partialShape2str(const std::vector<ngraph::PartialShape>& partialShapes) {
+inline std::string partialShape2str(const std::vector<ov::PartialShape>& partialShapes) {
     std::ostringstream result;
     for (const auto& partialShape : partialShapes) {
         result << partialShape;

--- a/src/tests/ie_test_utils/common_test_utils/common_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/common_utils.hpp
@@ -16,10 +16,6 @@
 #include <string>
 #include <vector>
 
-namespace InferenceEngine {
-class CNNLayer;
-}
-
 namespace CommonTestUtils {
 
 enum class OpType { SCALAR, VECTOR };

--- a/src/tests/ie_test_utils/common_test_utils/data_utils.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/data_utils.cpp
@@ -8,10 +8,13 @@
 
 #include <ie_blob.h>
 #include <blob_factory.hpp>
+#include "openvino/core/deprecated.hpp"
 
 using namespace InferenceEngine::details;
 
 namespace CommonTestUtils {
+
+OPENVINO_SUPPRESS_DEPRECATED_START
 
 bool isDenseBlob(const InferenceEngine::Blob::Ptr& blob) {
     auto blk_desc = blob->getTensorDesc().getBlockingDesc();
@@ -251,4 +254,6 @@ void fill_data_const(InferenceEngine::Blob::Ptr& blob, const std::vector<float> 
 void fill_data_const(InferenceEngine::Blob::Ptr& blob, float val) {
     fill_data_const(blob, std::vector<float> {val});
 }
+
+OPENVINO_SUPPRESS_DEPRECATED_END
 }  // namespace CommonTestUtils

--- a/src/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -18,6 +18,7 @@
 #include <random>
 
 namespace CommonTestUtils {
+OPENVINO_SUPPRESS_DEPRECATED_START
 
 inline void fill_data(float *data, size_t size, size_t duty_ratio = 10) {
     for (size_t i = 0; i < size; i++) {
@@ -507,5 +508,7 @@ inline ngraph::bfloat16 ie_abs(const ngraph::bfloat16 &val) {
 inline ngraph::float16 ie_abs(const ngraph::float16 &val) {
     return ngraph::float16::from_bits(val.to_bits() & 0x7FFF);
 }
+
+OPENVINO_SUPPRESS_DEPRECATED_END
 
 }  // namespace CommonTestUtils

--- a/src/tests/ie_test_utils/common_test_utils/graph_comparator.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/graph_comparator.cpp
@@ -5,7 +5,6 @@
 #include "common_test_utils/graph_comparator.hpp"
 
 #include <gtest/gtest.h>
-#include "ie_common.h"
 
 #include <algorithm>
 #include <cassert>
@@ -20,16 +19,15 @@
 #include <typeinfo>
 #include <vector>
 
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "ie_common.h"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/loop.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/tensor_iterator.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
-
-#include "common_test_utils/ov_tensor_utils.hpp"
-#include "ngraph_functions/utils/ngraph_helpers.hpp"
-
-#include "openvino/op/constant.hpp"
-#include "openvino/op/result.hpp"
-#include "openvino/op/loop.hpp"
-#include "openvino/op/tensor_iterator.hpp"
 
 namespace {
 inline namespace tools {
@@ -38,14 +36,15 @@ bool is_type_relaxed(const std::string& type) {
 }
 
 bool compare_type_info(const ov::DiscreteTypeInfo& info1, const ov::DiscreteTypeInfo& info2) {
-    if (!is_type_relaxed(info1.name) && !is_type_relaxed(info2.name) && (std::strcmp(info1.version_id, info2.version_id) != 0)) {
+    if (!is_type_relaxed(info1.name) && !is_type_relaxed(info2.name) &&
+        (std::strcmp(info1.version_id, info2.version_id) != 0)) {
         return false;
     }
 
     const std::string info1Name =
-            is_type_relaxed(info1.name) && (info1.parent != nullptr) ? info1.parent->name : info1.name;
+        is_type_relaxed(info1.name) && (info1.parent != nullptr) ? info1.parent->name : info1.name;
     const std::string info2Name =
-            is_type_relaxed(info2.name) && (info2.parent != nullptr) ? info2.parent->name : info2.name;
+        is_type_relaxed(info2.name) && (info2.parent != nullptr) ? info2.parent->name : info2.name;
     return info1Name == info2Name;
 }
 
@@ -77,19 +76,19 @@ bool compare_rt_keys(const T& node1, const T& node2, std::ostream& err_log) {
     return true;
 }
 
-bool has_more_than_1_tensor_names(const std::shared_ptr<ov::Node> &node) {
+bool has_more_than_1_tensor_names(const std::shared_ptr<ov::Node>& node) {
     return node->input_value(0).get_tensor_ptr()->get_names().size() > 1;
 }
 
 ov::ResultVector intersect_results(const ov::ResultVector& results_1, const ov::ResultVector& results_2) {
     ov::ResultVector out_results(results_2.size());
     for (size_t idx_1 = 0; idx_1 < results_1.size(); ++idx_1) {
-        const auto &names_mp_1 = results_1[idx_1]->input(0).get_tensor().get_names();
+        const auto& names_mp_1 = results_1[idx_1]->input(0).get_tensor().get_names();
 
-        for (const auto & res_2 : results_2) {
-            const auto &names_mp_2 = res_2->input(0).get_tensor().get_names();
+        for (const auto& res_2 : results_2) {
+            const auto& names_mp_2 = res_2->input(0).get_tensor().get_names();
 
-            for (const auto &element : names_mp_1) {
+            for (const auto& element : names_mp_1) {
                 if (names_mp_2.count(element) > 0) {
                     out_results[idx_1] = res_2;
                     break;
@@ -112,7 +111,7 @@ bool less_by_friendly_name(const std::shared_ptr<ov::op::v0::Result>& l, const s
 }
 
 bool less_by_parent_friendly_name(const std::shared_ptr<ov::op::v0::Result>& l,
-                         const std::shared_ptr<ov::op::v0::Result>& r) {
+                                  const std::shared_ptr<ov::op::v0::Result>& r) {
     const auto& l_name = l->get_input_node_shared_ptr(0)->get_friendly_name();
     const auto& r_name = r->get_input_node_shared_ptr(0)->get_friendly_name();
     return l_name.size() < r_name.size() || (l_name.size() == r_name.size() && l_name < r_name);
@@ -150,7 +149,8 @@ bool equal_type_and_partial_shape(const InOut1& lhs, const InOut2& rhs) {
 
 template <typename InOut1, typename InOut2>
 bool equal_type_and_partial_shape_compatible(const InOut1& lhs, const InOut2& rhs) {
-    return lhs.get_element_type() == rhs.get_element_type() && lhs.get_partial_shape().compatible(rhs.get_partial_shape());
+    return lhs.get_element_type() == rhs.get_element_type() &&
+           lhs.get_partial_shape().compatible(rhs.get_partial_shape());
 }
 
 class NodeAndInputDescription {
@@ -163,9 +163,9 @@ public:
     explicit NodeAndInputDescription(const InputNode& input,
                                      const Parameter* parameter,
                                      const InputDescripton* description)
-            : m_input(input),
-              m_parameter(not_null(parameter)),
-              m_description(not_null(description)) {}
+        : m_input(input),
+          m_parameter(not_null(parameter)),
+          m_description(not_null(description)) {}
 
     static bool equal_descriptions(const InputDescripton* lhs, const InputDescripton* rhs) {
         if (!lhs || !rhs || lhs->get_type_info() != rhs->get_type_info()) {
@@ -214,7 +214,7 @@ public:
             }
             for (size_t i = 0; i != param_shape.size(); ++i) {
                 const auto expected_axis_size =
-                        i == slice_description->m_axis ? slice_description->m_part_size * num_iterations : param_shape[i];
+                    i == slice_description->m_axis ? slice_description->m_part_size * num_iterations : param_shape[i];
                 if (input_shape[i] != expected_axis_size) {
                     return false;
                 }
@@ -222,7 +222,8 @@ public:
             return true;
         } else if (m_description->get_type_info() == SubGraphOp::MergedInputDescription::get_type_info_static() ||
                    m_description->get_type_info() == SubGraphOp::InvariantInputDescription::get_type_info_static()) {
-            // If loop op has back edge it may change the parameter to dynamic. The shape will be different with the initial op
+            // If loop op has back edge it may change the parameter to dynamic. The shape will be different with the
+            // initial op
             return equal_type_and_partial_shape_compatible(*m_parameter, m_input);
         }
 
@@ -258,9 +259,9 @@ public:
     explicit NodeAndOutputDescription(const OutputNode& output,
                                       const Result* result,
                                       const OutputDescription* description)
-            : m_output(output),
-              m_result(not_null(result)),
-              m_description(not_null(description)) {}
+        : m_output(output),
+          m_result(not_null(result)),
+          m_description(not_null(description)) {}
 
     static bool equal_descriptions(const OutputDescription* lhs, const OutputDescription* rhs) {
         if (!lhs || !rhs || lhs->get_type_info() != rhs->get_type_info()) {
@@ -345,8 +346,8 @@ public:
     using Id = uint64_t;
 
     explicit BackEdge(const Parameter* parameter, const Result* result)
-            : m_parameter(not_null(parameter)),
-              m_result(not_null(result)) {}
+        : m_parameter(not_null(parameter)),
+          m_result(not_null(result)) {}
 
     bool result_and_parameter_match() const {
         if (m_parameter->get_element_type() != m_result->output(0).get_element_type()) {
@@ -363,9 +364,10 @@ public:
             if (param_rank.get_length() != result_rank.get_length()) {
                 return false;
             }
-            for (int i=0; i < param_rank.get_length(); ++i) {
+            for (int i = 0; i < param_rank.get_length(); ++i) {
                 if (param_shape[i].is_static() && param_shape[i].get_length() == 0) {
-                    continue; // zero-dim-shape is acceptable for subgraph op param and can be not compatible with a result shape
+                    continue;  // zero-dim-shape is acceptable for subgraph op param and can be not compatible with a
+                               // result shape
                 }
                 if (!param_shape[i].compatible(result_shape[i])) {
                     return false;
@@ -597,8 +599,7 @@ Comparator::Result compare_io(ov::op::util::SubGraphOp* sub_lhs,
 }
 }  // namespace subgraph
 }  // namespace
-Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f,
-                                       const std::shared_ptr<ov::Model>& f_ref) {
+Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::Model>& f_ref) {
     /*
      * This function compares two ov::Model and requires them to have exactly one output
      * + Check nodes types
@@ -624,8 +625,8 @@ Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f,
 
         if (new_ref_results.empty()) {
             auto cmp = less_by_friendly_name;
-            // In case if Result source output has more than one name so the Result may have any of this names as a friendly
-            // name An in case of multiple names we sort Result operation using their parent node names
+            // In case if Result source output has more than one name so the Result may have any of this names as a
+            // friendly name An in case of multiple names we sort Result operation using their parent node names
 
             if (std::any_of(f_results.begin(), f_results.end(), has_more_than_1_tensor_names) ||
                 std::any_of(f_ref_results.begin(), f_ref_results.end(), has_more_than_1_tensor_names)) {
@@ -637,8 +638,8 @@ Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f,
             f_ref_results = new_ref_results;
         }
 
-        const auto &f_sinks = f->get_sinks();
-        const auto &f_ref_sinks = f_ref->get_sinks();
+        const auto& f_sinks = f->get_sinks();
+        const auto& f_ref_sinks = f_ref->get_sinks();
         if (f_sinks.size() != f_ref_sinks.size()) {
             return Result::error("Number of sinks is different: " + to_str(f_sinks.size()) + " and " +
                                  to_str(f_ref_sinks.size()));
@@ -650,7 +651,7 @@ Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f,
             used.insert(f_sinks[0].get());
         } else {
             // Cast to Assign and find those that have same variable_id suffix
-            for (const auto &sink1 : f_sinks) {
+            for (const auto& sink1 : f_sinks) {
                 auto assign1 = std::dynamic_pointer_cast<ov::op::util::VariableExtension>(sink1);
                 if (!assign1) {
                     return Result::error("Sink '" + name(sink1) +
@@ -658,7 +659,7 @@ Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f,
                 }
                 auto name1 = assign1->get_variable_id();
                 std::shared_ptr<ov::op::Sink> found_sink2;
-                for (const auto &sink2 : f_ref_sinks) {
+                for (const auto& sink2 : f_ref_sinks) {
                     auto assign2 = std::dynamic_pointer_cast<ov::op::util::VariableExtension>(sink2);
                     if (!assign2) {
                         return Result::error("Sink '" + name(sink2) +
@@ -683,9 +684,8 @@ Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f,
                 if (name(f_results[i]->get_input_node_shared_ptr(0)) !=
                     name(f_ref_results[i]->get_input_node_shared_ptr(0))) {
                     return Result::error(
-                            "Different output node names: " + name(f_results[i]->get_input_node_shared_ptr(0)) +
-                            " and " +
-                            name(f_ref_results[i]->get_input_node_shared_ptr(0)));
+                        "Different output node names: " + name(f_results[i]->get_input_node_shared_ptr(0)) + " and " +
+                        name(f_ref_results[i]->get_input_node_shared_ptr(0)));
                 }
             }
             q.push({f_results[i].get(), f_ref_results[i].get()});
@@ -695,8 +695,8 @@ Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f,
         std::stringstream errors;
 
         while (!q.empty()) {
-            ov::Node *const node1 = q.front().first;
-            ov::Node *const node2 = q.front().second;
+            ov::Node* const node1 = q.front().first;
+            ov::Node* const node2 = q.front().second;
             q.pop();
 
             const auto result = compare(node1, node2, errors);
@@ -839,8 +839,9 @@ void Comparator::compare_outputs(ov::Node* node1, ov::Node* node2, std::ostream&
         if (should_compare(CmpValues::CONSUMERS_COUNT)) {
             if (node1->output(i).get_target_inputs().size() != node2->output(i).get_target_inputs().size()) {
                 err_log << "Different consumers number detected\n"
-                        << name(node1) << " Output(" << i << ") " << node1->output(i).get_target_inputs().size() << " and "
-                        << name(node2) << " Output(" << i << ") " << node2->output(i).get_target_inputs().size() << std::endl;
+                        << name(node1) << " Output(" << i << ") " << node1->output(i).get_target_inputs().size()
+                        << " and " << name(node2) << " Output(" << i << ") "
+                        << node2->output(i).get_target_inputs().size() << std::endl;
             }
         }
     }
@@ -849,7 +850,7 @@ void Comparator::compare_outputs(ov::Node* node1, ov::Node* node2, std::ostream&
 void Comparator::compare_nodes(ov::Node* node1, ov::Node* node2, std::ostream& err_log) {
     if (should_compare(CmpValues::RUNTIME_KEYS) && !compare_rt_keys(*node1, *node2, err_log)) {
         err_log << "Different runtime info detected\n" + name(node1) + " and " + name(node2) +
-                   " not equal runtime info.\n";
+                       " not equal runtime info.\n";
     }
 
     if (should_compare(CmpValues::ATTRIBUTES)) {
@@ -895,113 +896,111 @@ void check_rt_info(const std::shared_ptr<ov::Model>& f) {
 
 namespace attributes {
 namespace detail {
-    void ReadAndStoreAttributes::on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) {
-        if (auto inputs = ov::as_type<ov::AttributeAdapter<SubGraphOpInputDescription>>(&adapter)) {
-            insert(name, inputs->get());
-        } else if (auto outputs = ov::as_type<ov::AttributeAdapter<SubGraphOpOutputDescription>>(&adapter)) {
-            insert(name, outputs->get());
-        } else if (ov::is_type<ov::AttributeAdapter<SpecialBodyPorts>>(&adapter)) {
-            // drop comparison, no more info than port indexes which will be check in
-            // subgraph::compare_io
-        } else if (auto a = ov::as_type<ov::AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(
-                &adapter)) {
-            const auto beg = static_cast<unsigned char*>(a->get()->get_ptr());
-            const auto end = beg + a->get()->size();
-            insert(name, storage::MemoryChunk{storage::MemoryChunk::Data(beg, end)});
-        } else if (auto framework_node_attr =
-                ov::as_type<ov::AttributeAdapter<ov::op::util::FrameworkNodeAttrs>>(&adapter)) {
-            insert(name, framework_node_attr->get());
-        } else if (auto variable_ptr =
-                ov::as_type<ov::AttributeAdapter<std::shared_ptr<ov::op::util::Variable>>>(&adapter)) {
-            insert(name, variable_ptr->get());
-        } else if (auto shape_ptr = ov::as_type<ov::AttributeAdapter<ov::PartialShape>>(&adapter)) {
-            insert(name, shape_ptr->get());
-        } else if (auto dim_ptr = ov::as_type<ov::AttributeAdapter<ov::Dimension>>(&adapter)) {
-            insert(name, dim_ptr->get());
-        } else {
-            m_read_result += "store   attr [ ERR ]: " + name + " [drop `void` comparison which is '" +
-                             adapter.get_type_info().name + "']";
-        }
+void ReadAndStoreAttributes::on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) {
+    if (auto inputs = ov::as_type<ov::AttributeAdapter<SubGraphOpInputDescription>>(&adapter)) {
+        insert(name, inputs->get());
+    } else if (auto outputs = ov::as_type<ov::AttributeAdapter<SubGraphOpOutputDescription>>(&adapter)) {
+        insert(name, outputs->get());
+    } else if (ov::is_type<ov::AttributeAdapter<SpecialBodyPorts>>(&adapter)) {
+        // drop comparison, no more info than port indexes which will be check in
+        // subgraph::compare_io
+    } else if (auto a = ov::as_type<ov::AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(&adapter)) {
+        const auto beg = static_cast<unsigned char*>(a->get()->get_ptr());
+        const auto end = beg + a->get()->size();
+        insert(name, storage::MemoryChunk{storage::MemoryChunk::Data(beg, end)});
+    } else if (auto framework_node_attr =
+                   ov::as_type<ov::AttributeAdapter<ov::op::util::FrameworkNodeAttrs>>(&adapter)) {
+        insert(name, framework_node_attr->get());
+    } else if (auto variable_ptr =
+                   ov::as_type<ov::AttributeAdapter<std::shared_ptr<ov::op::util::Variable>>>(&adapter)) {
+        insert(name, variable_ptr->get());
+    } else if (auto shape_ptr = ov::as_type<ov::AttributeAdapter<ov::PartialShape>>(&adapter)) {
+        insert(name, shape_ptr->get());
+    } else if (auto dim_ptr = ov::as_type<ov::AttributeAdapter<ov::Dimension>>(&adapter)) {
+        insert(name, dim_ptr->get());
+    } else {
+        m_read_result += "store   attr [ ERR ]: " + name + " [drop `void` comparison which is '" +
+                         adapter.get_type_info().name + "']";
     }
-    template <typename AttrValue>
-    void ReadAndCompareAttributes::verify(const std::string& name, const AttrValue& attr_value) {
-        if (should_return()) {
-            return;
-        }
-        m_visited_attributes.insert(name);
-        const auto ref_value = m_attr_ref.get<AttrValue>(name);
-        if (!ref_value) {
-            m_cmp_result += "missing attribute name: '" + name + "'";
-            return;
-        }
-
-        if (!equal::Equal<AttrValue>::equal_value(*ref_value, attr_value)) {
-            m_cmp_result += "mismatch in value: '" + name + "' : " + str::Get<AttrValue>::value(*ref_value) + " vs " +
-                            str::Get<AttrValue>::value(attr_value);
-        }
+}
+template <typename AttrValue>
+void ReadAndCompareAttributes::verify(const std::string& name, const AttrValue& attr_value) {
+    if (should_return()) {
+        return;
+    }
+    m_visited_attributes.insert(name);
+    const auto ref_value = m_attr_ref.get<AttrValue>(name);
+    if (!ref_value) {
+        m_cmp_result += "missing attribute name: '" + name + "'";
+        return;
     }
 
-    void ReadAndCompareAttributes::verify_mem_buf(const std::string& name,
-                                                  const std::shared_ptr<ngraph::runtime::AlignedBuffer>& buffer) {
-        if (should_return()) {
-            return;
-        }
-        m_visited_attributes.insert(name);
-        const auto ref_value = m_attr_ref.get<storage::MemoryChunk>(name);
-        if (!ref_value) {
-            m_cmp_result += "missing attribute name: '" + name + "'";
-            return;
-        }
+    if (!equal::Equal<AttrValue>::equal_value(*ref_value, attr_value)) {
+        m_cmp_result += "mismatch in value: '" + name + "' : " + str::Get<AttrValue>::value(*ref_value) + " vs " +
+                        str::Get<AttrValue>::value(attr_value);
+    }
+}
 
-        if (buffer->size() != ref_value->size() ||
-            std::memcmp(ref_value->data(), buffer->get_ptr(), ref_value->size()) != 0) {
-            m_cmp_result += "mismatch in value: '" + name + "' : look in to the mem buffer";
-            return;
-        }
+void ReadAndCompareAttributes::verify_mem_buf(const std::string& name,
+                                              const std::shared_ptr<ngraph::runtime::AlignedBuffer>& buffer) {
+    if (should_return()) {
+        return;
+    }
+    m_visited_attributes.insert(name);
+    const auto ref_value = m_attr_ref.get<storage::MemoryChunk>(name);
+    if (!ref_value) {
+        m_cmp_result += "missing attribute name: '" + name + "'";
+        return;
     }
 
-    void ReadAndCompareAttributes::verify_function(const std::string& name, ModelAccessor& adapter) {
-        if (should_return()) {
-            return;
-        }
-        m_visited_attributes.insert(name);
-        const auto ref_value = m_attr_ref.get<std::shared_ptr<ov::Model>>(name);
-        if (!ref_value) {
-            m_cmp_result += "missing attribute name: '" + name + "'";
-            return;
-        }
-        Comparator c(m_check_flags);
-        const auto result = c.compare(*ref_value, adapter.get());
-        if (!result.valid) {
-            m_cmp_result += result.message;
-        }
+    if (buffer->size() != ref_value->size() ||
+        std::memcmp(ref_value->data(), buffer->get_ptr(), ref_value->size()) != 0) {
+        m_cmp_result += "mismatch in value: '" + name + "' : look in to the mem buffer";
+        return;
     }
+}
 
-    void ReadAndCompareAttributes::verify_others(const std::string& name, ov::ValueAccessor<void>& adapter) {
-        if (auto inputs = ov::as_type<ov::AttributeAdapter<SubGraphOpInputDescription>>(&adapter)) {
-            verify(name, inputs->get());
-        } else if (auto outputs = ov::as_type<ov::AttributeAdapter<SubGraphOpOutputDescription>>(&adapter)) {
-            verify(name, outputs->get());
-        } else if (ov::is_type<ov::AttributeAdapter<SpecialBodyPorts>>(&adapter)) {
-            // drop comparison, no more info than port indexes which will be check in
-            // subgraph::compare_io
-        } else if (auto a = ov::as_type<ov::AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(
-                &adapter)) {
-            verify_mem_buf(name, a->get());
-        } else if (auto attrs = ov::as_type<ov::AttributeAdapter<ov::op::util::FrameworkNodeAttrs>>(&adapter)) {
-            verify(name, attrs->get());
-        } else if (auto variable_ptr =
-                ov::as_type<ov::AttributeAdapter<std::shared_ptr<ov::op::util::Variable>>>(&adapter)) {
-            verify(name, variable_ptr->get());
-        } else if (auto shape_ptr = ov::as_type<ov::AttributeAdapter<ov::PartialShape>>(&adapter)) {
-            verify(name, shape_ptr->get());
-        } else if (auto dim_ptr = ov::as_type<ov::AttributeAdapter<ov::Dimension>>(&adapter)) {
-            verify(name, dim_ptr->get());
-        } else {
-            m_cmp_result += "compare attr [ ERR ]: " + name + " [drop `void` comparison which is '" +
-                            adapter.get_type_info().name + "']";
-        }
+void ReadAndCompareAttributes::verify_function(const std::string& name, ModelAccessor& adapter) {
+    if (should_return()) {
+        return;
     }
+    m_visited_attributes.insert(name);
+    const auto ref_value = m_attr_ref.get<std::shared_ptr<ov::Model>>(name);
+    if (!ref_value) {
+        m_cmp_result += "missing attribute name: '" + name + "'";
+        return;
+    }
+    Comparator c(m_check_flags);
+    const auto result = c.compare(*ref_value, adapter.get());
+    if (!result.valid) {
+        m_cmp_result += result.message;
+    }
+}
+
+void ReadAndCompareAttributes::verify_others(const std::string& name, ov::ValueAccessor<void>& adapter) {
+    if (auto inputs = ov::as_type<ov::AttributeAdapter<SubGraphOpInputDescription>>(&adapter)) {
+        verify(name, inputs->get());
+    } else if (auto outputs = ov::as_type<ov::AttributeAdapter<SubGraphOpOutputDescription>>(&adapter)) {
+        verify(name, outputs->get());
+    } else if (ov::is_type<ov::AttributeAdapter<SpecialBodyPorts>>(&adapter)) {
+        // drop comparison, no more info than port indexes which will be check in
+        // subgraph::compare_io
+    } else if (auto a = ov::as_type<ov::AttributeAdapter<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(&adapter)) {
+        verify_mem_buf(name, a->get());
+    } else if (auto attrs = ov::as_type<ov::AttributeAdapter<ov::op::util::FrameworkNodeAttrs>>(&adapter)) {
+        verify(name, attrs->get());
+    } else if (auto variable_ptr =
+                   ov::as_type<ov::AttributeAdapter<std::shared_ptr<ov::op::util::Variable>>>(&adapter)) {
+        verify(name, variable_ptr->get());
+    } else if (auto shape_ptr = ov::as_type<ov::AttributeAdapter<ov::PartialShape>>(&adapter)) {
+        verify(name, shape_ptr->get());
+    } else if (auto dim_ptr = ov::as_type<ov::AttributeAdapter<ov::Dimension>>(&adapter)) {
+        verify(name, dim_ptr->get());
+    } else {
+        m_cmp_result += "compare attr [ ERR ]: " + name + " [drop `void` comparison which is '" +
+                        adapter.get_type_info().name + "']";
+    }
+}
 
 }  // namespace detail
 
@@ -1029,9 +1028,9 @@ AccuracyCheckResult accuracy_check(const std::shared_ptr<ov::Model>& ref_functio
         std::map<std::shared_ptr<ov::Node>, ov::Tensor> ref_input_data;
         std::map<std::shared_ptr<ov::Node>, ov::Tensor> cur_input_data;
         for (size_t i = 0; i < ref_function->get_parameters().size(); i++) {
-            const auto &tensor = ov::test::utils::create_and_fill_tensor(
-                    ref_function->get_parameters()[i]->get_element_type(),
-                    ref_function->get_parameters()[i]->get_shape());
+            const auto& tensor =
+                ov::test::utils::create_and_fill_tensor(ref_function->get_parameters()[i]->get_element_type(),
+                                                        ref_function->get_parameters()[i]->get_shape());
             ref_input_data[ref_function->get_parameters()[i]] = tensor;
             cur_input_data[cur_function->get_parameters()[i]] = tensor;
         }
@@ -1044,10 +1043,9 @@ AccuracyCheckResult accuracy_check(const std::shared_ptr<ov::Model>& ref_functio
         for (int i = 0; i < ref_outputs.size(); i++) {
             ov::test::utils::compare(ref_outputs[i], outputs[i], 5e-4, 1e-3);
         }
-    }
-    catch (const std::runtime_error &re) {
+    } catch (const std::runtime_error& re) {
         return AccuracyCheckResult{false, re.what()};
-    } catch (const std::exception &ex) {
+    } catch (const std::exception& ex) {
         return AccuracyCheckResult{false, ex.what()};
     } catch (...) {
         return AccuracyCheckResult{false, ""};

--- a/src/tests/ie_test_utils/common_test_utils/graph_comparator.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/graph_comparator.cpp
@@ -13,15 +13,15 @@
 #include <iostream>
 #include <map>
 #include <memory>
-#include <openvino/op/util/op_types.hpp>
-#include <openvino/op/util/sub_graph_base.hpp>
-#include <openvino/opsets/opset8.hpp>
 #include <queue>
 #include <sstream>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
 #include <vector>
+
+#include "openvino/op/util/op_types.hpp"
+#include "openvino/op/util/sub_graph_base.hpp"
 
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "ngraph_functions/utils/ngraph_helpers.hpp"

--- a/src/tests/ie_test_utils/common_test_utils/graph_comparator.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/graph_comparator.hpp
@@ -12,6 +12,7 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/util/framework_node.hpp"
+#include "openvino/opsets/opset1.hpp"
 #include "openvino/opsets/opset8.hpp"
 #include "openvino/pass/pass.hpp"
 #include "openvino/pass/serialize.hpp"
@@ -69,10 +70,10 @@ public:
     bool should_compare(CmpValues f) const noexcept {
         return m_comparison_flags & f;
     }
-    Result compare(const std::shared_ptr<ngraph::Function>& f, const std::shared_ptr<ngraph::Function>& f_ref) const;
+    Result compare(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::Model>& f_ref) const;
 
-    Result operator()(const std::shared_ptr<ngraph::Function>& f,
-                      const std::shared_ptr<ngraph::Function>& f_ref) const {
+    Result operator()(const std::shared_ptr<ov::Model>& f,
+                      const std::shared_ptr<ov::Model>& f_ref) const {
         return compare(f, f_ref);
     }
 
@@ -85,8 +86,8 @@ private:
 /// \deprecated
 /// \brief compare_functions is obsolete function use FunctionsComparator instead.
 ///
-inline std::pair<bool, std::string> compare_functions(const std::shared_ptr<ngraph::Function>& f,
-                                                      const std::shared_ptr<ngraph::Function>& f_ref,
+inline std::pair<bool, std::string> compare_functions(const std::shared_ptr<ov::Model>& f,
+                                                      const std::shared_ptr<ov::Model>& f_ref,
                                                       const bool compareConstValues = false,
                                                       const bool compareNames = false,
                                                       const bool compareRuntimeKeys = false,
@@ -114,17 +115,17 @@ inline std::pair<bool, std::string> compare_functions(const std::shared_ptr<ngra
     return {r.valid, r.message};
 }
 
-void check_rt_info(const std::shared_ptr<ngraph::Function>& f);
+void check_rt_info(const std::shared_ptr<ov::Model>& f);
 
-namespace ngraph {
+namespace ov {
 namespace pass {
 class InjectionPass : public ov::pass::ModelPass {
 public:
-    using injection_callback = std::function<void(std::shared_ptr<ngraph::Function>)>;
+    using injection_callback = std::function<void(std::shared_ptr<ov::Model>)>;
 
     explicit InjectionPass(injection_callback callback) : ModelPass(), m_callback(std::move(callback)) {}
 
-    bool run_on_model(const std::shared_ptr<ngraph::Function>& f) override {
+    bool run_on_model(const std::shared_ptr<ov::Model>& f) override {
         m_callback(f);
         return false;
     }
@@ -155,7 +156,7 @@ public:
 
     UniqueNamesHolder() = default;
 
-    void init_names(std::shared_ptr<Function> f) {
+    void init_names(std::shared_ptr<ov::Model> f) {
         // initialize function with unique friendly and tensor names
         for (auto node : f->get_ordered_ops()) {
             const auto& node_name = generate_friendly_name();
@@ -185,7 +186,7 @@ public:
         }
     }
 
-    void check_unique_names(std::shared_ptr<Function> f) {
+    void check_unique_names(std::shared_ptr<ov::Model> f) {
         // Check that all tensor names and friendly names are unique
         names_t unique_tensor_names, unique_friendly_names;
         for (auto node : f->get_ordered_ops()) {
@@ -197,7 +198,7 @@ public:
             }
             unique_friendly_names.insert(node->get_friendly_name());
 
-            if (as_type_ptr<op::Result>(node))
+            if (as_type_ptr<ov::opset1::Result>(node))
                 continue;
             for (auto output : node->outputs()) {
                 const auto& tensor_names = output.get_names();
@@ -262,7 +263,7 @@ class InitUniqueNames : public ov::pass::ModelPass {
 
 public:
     InitUniqueNames(UniqueNamesHolder::Ptr unh) : m_unh(unh) {}
-    bool run_on_model(const std::shared_ptr<Function>& f) override {
+    bool run_on_model(const std::shared_ptr<ov::Model>& f) override {
         m_unh->init_names(f);
         return false;
     }
@@ -278,26 +279,26 @@ public:
         if (!result_friendly_names_check)
             m_unh->disable_result_friendly_names_check();
     }
-    bool run_on_model(const std::shared_ptr<Function>& f) override {
+    bool run_on_model(const std::shared_ptr<ov::Model>& f) override {
         m_unh->check_unique_names(f);
         return false;
     }
 };
 
 }  // namespace pass
-}  // namespace ngraph
+}  // namespace ov
 
 class Comparator {
 public:
     using CmpValues = FunctionsComparator::CmpValues;
     using Result = FunctionsComparator::Result;
-    using ComparedNodes = std::pair<ngraph::Node*, ngraph::Node*>;
+    using ComparedNodes = std::pair<ov::Node*, ov::Node*>;
 
     explicit Comparator(CmpValues f) : m_comparison_flags(f) {}
 
-    Result compare(const std::shared_ptr<ngraph::Function>& f, const std::shared_ptr<ngraph::Function>& f_ref);
+    Result compare(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::Model>& f_ref);
 
-    Result compare(ngraph::Node* node1, ngraph::Node* node2) {
+    Result compare(ov::Node* node1, ov::Node* node2) {
         std::stringstream errors;
         const auto result = compare(node1, node2, errors);
         if (!result.valid) {
@@ -311,11 +312,11 @@ public:
         return Comparator(m_comparison_flags);
     }
 
-    void compare_inputs(ngraph::Node* node1, ngraph::Node* node2, std::ostream& err_log);
+    void compare_inputs(ov::Node* node1, ov::Node* node2, std::ostream& err_log);
 
-    void compare_outputs(ngraph::Node* node1, ngraph::Node* node2, std::ostream& err_log);
+    void compare_outputs(ov::Node* node1, ov::Node* node2, std::ostream& err_log);
 
-    void compare_nodes(ngraph::Node* node1, ngraph::Node* node2, std::ostream& err_log);
+    void compare_nodes(ov::Node* node1, ov::Node* node2, std::ostream& err_log);
 
 private:
     bool should_compare(CmpValues f) const noexcept {
@@ -326,15 +327,15 @@ private:
     /// \param err_log - will be fill by minor errors if happen
     /// \return only fatality error if some minor one appears it will be add to err_log
     ///
-    Result compare(ngraph::Node* node1, ngraph::Node* node2, std::ostream& err_log);
+    Result compare(ov::Node* node1, ov::Node* node2, std::ostream& err_log);
 
-    void add_nodes_inputs_to_queue(ngraph::Node* node1, ngraph::Node* node2);
+    void add_nodes_inputs_to_queue(ov::Node* node1, ov::Node* node2);
 
     //-- DATA --
     CmpValues m_comparison_flags;
 
     std::queue<ComparedNodes> q;
-    std::unordered_set<ngraph::Node*> used;
+    std::unordered_set<ov::Node*> used;
 };
 
 inline namespace tools {
@@ -449,11 +450,11 @@ class Storage : private AttributeStorage<MemoryChunk>,
                 private AttributeStorage<std::vector<float>>,
                 private AttributeStorage<std::vector<double>>,
                 private AttributeStorage<std::vector<std::string>>,
-                private AttributeStorage<std::shared_ptr<ngraph::Function>>,
+                private AttributeStorage<std::shared_ptr<ov::Model>>,
                 private AttributeStorage<SubGraphOpInputDescription>,
                 private AttributeStorage<SubGraphOpOutputDescription>,
                 private AttributeStorage<ov::op::util::FrameworkNodeAttrs>,
-                private AttributeStorage<std::shared_ptr<ngraph::Variable>>,
+                private AttributeStorage<std::shared_ptr<ov::op::util::Variable>>,
                 private AttributeStorage<ov::PartialShape>,
                 private AttributeStorage<ov::Dimension> {
 public:
@@ -484,23 +485,23 @@ public:
                storage<std::vector<float>>().get_attributes_number() +
                storage<std::vector<double>>().get_attributes_number() +
                storage<std::vector<std::string>>().get_attributes_number() +
-               storage<std::shared_ptr<ngraph::Function>>().get_attributes_number() +
+               storage<std::shared_ptr<ov::Model>>().get_attributes_number() +
                storage<SubGraphOpInputDescription>().get_attributes_number() +
                storage<SubGraphOpOutputDescription>().get_attributes_number() +
                storage<ov::op::util::FrameworkNodeAttrs>().get_attributes_number() +
-               storage<std::shared_ptr<ngraph::Variable>>().get_attributes_number() +
+               storage<std::shared_ptr<ov::op::util::Variable>>().get_attributes_number() +
                storage<ov::PartialShape>().get_attributes_number() + storage<ov::Dimension>().get_attributes_number();
     }
 };
 
 }  // namespace storage
 
-class ReadAndStoreAttributes : public ngraph::AttributeVisitor, protected storage::Storage {
+class ReadAndStoreAttributes : public ov::AttributeVisitor, protected storage::Storage {
 public:
-    void on_adapter(const std::string& name, ngraph::ValueAccessor<void>& adapter) override;
+    void on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) override;
 
 #define ON_ADAPTER(TYPE)                                                                      \
-void on_adapter(const std::string& name, ngraph::ValueAccessor<TYPE>& adapter) override { \
+void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { \
 insert(name, adapter.get());                                                          \
 }
 
@@ -527,7 +528,7 @@ insert(name, adapter.get());                                                    
     ON_ADAPTER(std::vector<float>)
     ON_ADAPTER(std::vector<double>)
     ON_ADAPTER(std::vector<std::string>)
-    ON_ADAPTER(std::shared_ptr<ngraph::Function>)
+    ON_ADAPTER(std::shared_ptr<ov::Model>)
 
 #undef ON_ADAPTER
 
@@ -563,8 +564,8 @@ struct Equal {
 };
 
 template <>
-struct Equal<ngraph::bfloat16> {
-    static bool equal_value(ngraph::bfloat16 lhs, ngraph::bfloat16 rhs) {
+struct Equal<ov::bfloat16> {
+    static bool equal_value(ov::bfloat16 lhs, ov::bfloat16 rhs) {
         if (lhs.to_bits() == rhs.to_bits()) {
             return true;
         }
@@ -573,8 +574,8 @@ struct Equal<ngraph::bfloat16> {
 };
 
 template <>
-struct Equal<ngraph::float16> {
-    static bool equal_value(ngraph::float16 lhs, ngraph::float16 rhs) {
+struct Equal<ov::float16> {
+    static bool equal_value(ov::float16 lhs, ov::float16 rhs) {
         if (lhs.to_bits() == rhs.to_bits()) {
             return true;
         }
@@ -686,9 +687,9 @@ struct Equal<SubGraphOpOutputDescription> {
 };
 
 template <>
-struct Equal<std::shared_ptr<ngraph::Variable>> {
-    static bool equal_value(const std::shared_ptr<ngraph::Variable>& lhs,
-                            const std::shared_ptr<ngraph::Variable>& rhs) {
+struct Equal<std::shared_ptr<ov::op::util::Variable>> {
+    static bool equal_value(const std::shared_ptr<ov::op::util::Variable>& lhs,
+                            const std::shared_ptr<ov::op::util::Variable>& rhs) {
         return lhs->get_info() == rhs->get_info();
     }
 };
@@ -730,26 +731,26 @@ struct Equal<std::shared_ptr<Constant>> {
         }
 
         switch (lhs_t) {
-            case ngraph::element::Type_t::u1: {
+            case ov::element::Type_t::u1: {
                 const auto lhs_v = static_cast<const uint8_t*>(lhs->get_data_ptr());
                 const auto rhs_v = static_cast<const uint8_t*>(rhs->get_data_ptr());
                 const auto lhs_bit_size = shape_size(lhs->get_shape());
                 const auto rhs_bit_size = shape_size(rhs->get_shape());
                 return Equal<uint8_t*>::equal_value(lhs_v, rhs_v, lhs_bit_size, rhs_bit_size);
             }
-            case ngraph::element::Type_t::bf16: {
-                auto lhs_v = lhs->cast_vector<ngraph::bfloat16>();
-                auto rhs_v = rhs->cast_vector<ngraph::bfloat16>();
-                return Equal<std::vector<ngraph::bfloat16>>::equal_value(lhs_v, rhs_v);
+            case ov::element::Type_t::bf16: {
+                auto lhs_v = lhs->cast_vector<ov::bfloat16>();
+                auto rhs_v = rhs->cast_vector<ov::bfloat16>();
+                return Equal<std::vector<ov::bfloat16>>::equal_value(lhs_v, rhs_v);
                 break;
             }
-            case ngraph::element::Type_t::f16: {
-                const auto& lhs_v = lhs->cast_vector<ngraph::float16>();
-                const auto& rhs_v = rhs->cast_vector<ngraph::float16>();
-                return Equal<std::vector<ngraph::float16>>::equal_value(lhs_v, rhs_v);
+            case ov::element::Type_t::f16: {
+                const auto& lhs_v = lhs->cast_vector<ov::float16>();
+                const auto& rhs_v = rhs->cast_vector<ov::float16>();
+                return Equal<std::vector<ov::float16>>::equal_value(lhs_v, rhs_v);
                 break;
             }
-            case ngraph::element::Type_t::f32: {
+            case ov::element::Type_t::f32: {
                 const auto& lhs_v = lhs->cast_vector<float>();
                 const auto& rhs_v = rhs->cast_vector<float>();
                 return Equal<std::vector<float>>::equal_value(lhs_v, rhs_v);
@@ -863,8 +864,8 @@ struct Get<ov::PartialShape, void> {
 };
 
 template <>
-struct Get<std::shared_ptr<ngraph::Variable>, void> {
-    static std::string value(const std::shared_ptr<ngraph::Variable>& variable) {
+struct Get<std::shared_ptr<ov::op::util::Variable>, void> {
+    static std::string value(const std::shared_ptr<ov::op::util::Variable>& variable) {
         std::stringstream oss;
         const auto variable_info = variable->get_info();
         oss << "[";
@@ -878,19 +879,19 @@ struct Get<std::shared_ptr<ngraph::Variable>, void> {
 
 }  // namespace str
 
-class ReadAndCompareAttributes : public ngraph::AttributeVisitor {
+class ReadAndCompareAttributes : public ov::AttributeVisitor {
 public:
     ReadAndCompareAttributes(const ReadAndStoreAttributes& ref, Comparator::CmpValues check_flags)
             : m_attr_ref(ref),
               m_cmp_result{ref.read_result()},
               m_check_flags(check_flags) {}
 
-    void on_adapter(const std::string& name, ngraph::ValueAccessor<void>& adapter) override {
+    void on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) override {
         verify_others(name, adapter);
     }
 
 #define ON_ADAPTER(TYPE)                                                                      \
-void on_adapter(const std::string& name, ngraph::ValueAccessor<TYPE>& adapter) override { \
+void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { \
 verify(name, adapter.get());                                                          \
 }
 
@@ -921,7 +922,7 @@ verify(name, adapter.get());                                                    
 #undef ON_ADAPTER
 
     void on_adapter(const std::string& name,
-                    ngraph::ValueAccessor<std::shared_ptr<ngraph::Function>>& adapter) override {
+                    ov::ValueAccessor<std::shared_ptr<ov::Model>>& adapter) override {
         verify_function(name, adapter);
     }
 
@@ -947,11 +948,11 @@ private:
 
     void verify_mem_buf(const std::string& name, const std::shared_ptr<ngraph::runtime::AlignedBuffer>& buffer);
 
-    using ModelAccessor = ngraph::ValueAccessor<std::shared_ptr<ngraph::Function>>;
+    using ModelAccessor = ov::ValueAccessor<std::shared_ptr<ov::Model>>;
 
     void verify_function(const std::string& name, ModelAccessor& adapter);
 
-    void verify_others(const std::string& name, ngraph::ValueAccessor<void>& adapter);
+    void verify_others(const std::string& name, ov::ValueAccessor<void>& adapter);
     //-- DATA --
     const ReadAndStoreAttributes& m_attr_ref;
     Result m_cmp_result;
@@ -997,7 +998,7 @@ private:
 
 }  // namespace detail
 
-Comparator::Result compare(ngraph::Node* node1, ngraph::Node* node2, Comparator::CmpValues comparition_flags);
+Comparator::Result compare(ov::Node* node1, ov::Node* node2, Comparator::CmpValues comparition_flags);
 
 }  // namespace attributes
 

--- a/src/tests/ie_test_utils/common_test_utils/graph_comparator.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/graph_comparator.hpp
@@ -14,8 +14,6 @@
 #include "openvino/op/util/framework_node.hpp"
 #include "openvino/opsets/opset1.hpp"
 #include "openvino/opsets/opset8.hpp"
-#include "openvino/pass/pass.hpp"
-#include "openvino/pass/serialize.hpp"
 
 class FunctionsComparator {
 public:

--- a/src/tests/ie_test_utils/common_test_utils/graph_comparator.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/graph_comparator.hpp
@@ -70,8 +70,7 @@ public:
     }
     Result compare(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::Model>& f_ref) const;
 
-    Result operator()(const std::shared_ptr<ov::Model>& f,
-                      const std::shared_ptr<ov::Model>& f_ref) const {
+    Result operator()(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::Model>& f_ref) const {
         return compare(f, f_ref);
     }
 
@@ -201,8 +200,8 @@ public:
             for (auto output : node->outputs()) {
                 const auto& tensor_names = output.get_names();
                 if (std::any_of(tensor_names.begin(), tensor_names.end(), [&](const std::string& name) {
-                    return unique_tensor_names.count(name);
-                })) {
+                        return unique_tensor_names.count(name);
+                    })) {
                     std::stringstream ss;
                     ss << "Node: " << node->get_type_info() << " with name " << node->get_friendly_name() << " ";
                     ss << "has non unique tensor name.";
@@ -229,8 +228,8 @@ public:
             if (m_result_friendly_names_check) {
                 // Check that result input node names are preserved
                 bool is_multi_output = m_result_node_names.at(r.get()).second;
-                const auto &ref_node_name = m_result_node_names.at(r.get()).first;
-                const auto &cur_node_name = r->input_value(0).get_node()->get_friendly_name();
+                const auto& ref_node_name = m_result_node_names.at(r.get()).first;
+                const auto& cur_node_name = r->input_value(0).get_node()->get_friendly_name();
                 if (is_multi_output || m_soft_names_comparison) {
                     if (cur_node_name.find(ref_node_name) == std::string::npos) {
                         std::stringstream ss;
@@ -271,7 +270,10 @@ class CheckUniqueNames : public ov::pass::ModelPass {
     UniqueNamesHolder::Ptr m_unh;
 
 public:
-    CheckUniqueNames(UniqueNamesHolder::Ptr unh, bool soft_names_comparison = false, bool result_friendly_names_check = true) : m_unh(unh) {
+    CheckUniqueNames(UniqueNamesHolder::Ptr unh,
+                     bool soft_names_comparison = false,
+                     bool result_friendly_names_check = true)
+        : m_unh(unh) {
         if (soft_names_comparison)
             m_unh->enable_soft_names_comparison();
         if (!result_friendly_names_check)
@@ -498,10 +500,10 @@ class ReadAndStoreAttributes : public ov::AttributeVisitor, protected storage::S
 public:
     void on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) override;
 
-#define ON_ADAPTER(TYPE)                                                                      \
-void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { \
-insert(name, adapter.get());                                                          \
-}
+#define ON_ADAPTER(TYPE)                                                                  \
+    void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { \
+        insert(name, adapter.get());                                                      \
+    }
 
     ON_ADAPTER(bool)
     ON_ADAPTER(std::string)
@@ -729,37 +731,37 @@ struct Equal<std::shared_ptr<Constant>> {
         }
 
         switch (lhs_t) {
-            case ov::element::Type_t::u1: {
-                const auto lhs_v = static_cast<const uint8_t*>(lhs->get_data_ptr());
-                const auto rhs_v = static_cast<const uint8_t*>(rhs->get_data_ptr());
-                const auto lhs_bit_size = shape_size(lhs->get_shape());
-                const auto rhs_bit_size = shape_size(rhs->get_shape());
-                return Equal<uint8_t*>::equal_value(lhs_v, rhs_v, lhs_bit_size, rhs_bit_size);
-            }
-            case ov::element::Type_t::bf16: {
-                auto lhs_v = lhs->cast_vector<ov::bfloat16>();
-                auto rhs_v = rhs->cast_vector<ov::bfloat16>();
-                return Equal<std::vector<ov::bfloat16>>::equal_value(lhs_v, rhs_v);
-                break;
-            }
-            case ov::element::Type_t::f16: {
-                const auto& lhs_v = lhs->cast_vector<ov::float16>();
-                const auto& rhs_v = rhs->cast_vector<ov::float16>();
-                return Equal<std::vector<ov::float16>>::equal_value(lhs_v, rhs_v);
-                break;
-            }
-            case ov::element::Type_t::f32: {
-                const auto& lhs_v = lhs->cast_vector<float>();
-                const auto& rhs_v = rhs->cast_vector<float>();
-                return Equal<std::vector<float>>::equal_value(lhs_v, rhs_v);
-                break;
-            }
-            default: {
-                const auto& lhs_v = lhs->cast_vector<double>();
-                const auto& rhs_v = rhs->cast_vector<double>();
-                return Equal<std::vector<double>>::equal_value(lhs_v, rhs_v);
-                break;
-            }
+        case ov::element::Type_t::u1: {
+            const auto lhs_v = static_cast<const uint8_t*>(lhs->get_data_ptr());
+            const auto rhs_v = static_cast<const uint8_t*>(rhs->get_data_ptr());
+            const auto lhs_bit_size = shape_size(lhs->get_shape());
+            const auto rhs_bit_size = shape_size(rhs->get_shape());
+            return Equal<uint8_t*>::equal_value(lhs_v, rhs_v, lhs_bit_size, rhs_bit_size);
+        }
+        case ov::element::Type_t::bf16: {
+            auto lhs_v = lhs->cast_vector<ov::bfloat16>();
+            auto rhs_v = rhs->cast_vector<ov::bfloat16>();
+            return Equal<std::vector<ov::bfloat16>>::equal_value(lhs_v, rhs_v);
+            break;
+        }
+        case ov::element::Type_t::f16: {
+            const auto& lhs_v = lhs->cast_vector<ov::float16>();
+            const auto& rhs_v = rhs->cast_vector<ov::float16>();
+            return Equal<std::vector<ov::float16>>::equal_value(lhs_v, rhs_v);
+            break;
+        }
+        case ov::element::Type_t::f32: {
+            const auto& lhs_v = lhs->cast_vector<float>();
+            const auto& rhs_v = rhs->cast_vector<float>();
+            return Equal<std::vector<float>>::equal_value(lhs_v, rhs_v);
+            break;
+        }
+        default: {
+            const auto& lhs_v = lhs->cast_vector<double>();
+            const auto& rhs_v = rhs->cast_vector<double>();
+            return Equal<std::vector<double>>::equal_value(lhs_v, rhs_v);
+            break;
+        }
         }
         return false;
     }
@@ -880,18 +882,18 @@ struct Get<std::shared_ptr<ov::op::util::Variable>, void> {
 class ReadAndCompareAttributes : public ov::AttributeVisitor {
 public:
     ReadAndCompareAttributes(const ReadAndStoreAttributes& ref, Comparator::CmpValues check_flags)
-            : m_attr_ref(ref),
-              m_cmp_result{ref.read_result()},
-              m_check_flags(check_flags) {}
+        : m_attr_ref(ref),
+          m_cmp_result{ref.read_result()},
+          m_check_flags(check_flags) {}
 
     void on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) override {
         verify_others(name, adapter);
     }
 
-#define ON_ADAPTER(TYPE)                                                                      \
-void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { \
-verify(name, adapter.get());                                                          \
-}
+#define ON_ADAPTER(TYPE)                                                                  \
+    void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { \
+        verify(name, adapter.get());                                                      \
+    }
 
     ON_ADAPTER(bool)
     ON_ADAPTER(std::string)
@@ -919,8 +921,7 @@ verify(name, adapter.get());                                                    
 
 #undef ON_ADAPTER
 
-    void on_adapter(const std::string& name,
-                    ov::ValueAccessor<std::shared_ptr<ov::Model>>& adapter) override {
+    void on_adapter(const std::string& name, ov::ValueAccessor<std::shared_ptr<ov::Model>>& adapter) override {
         verify_function(name, adapter);
     }
 

--- a/src/tests/ie_test_utils/common_test_utils/graph_comparator.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/graph_comparator.hpp
@@ -11,9 +11,9 @@
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/model.hpp"
+#include "openvino/op/loop.hpp"
 #include "openvino/op/util/framework_node.hpp"
-#include "openvino/opsets/opset1.hpp"
-#include "openvino/opsets/opset8.hpp"
+#include "openvino/op/util/sub_graph_base.hpp"
 
 class FunctionsComparator {
 public:
@@ -196,7 +196,7 @@ public:
             }
             unique_friendly_names.insert(node->get_friendly_name());
 
-            if (as_type_ptr<ov::opset1::Result>(node))
+            if (as_type_ptr<ov::op::v0::Result>(node))
                 continue;
             for (auto output : node->outputs()) {
                 const auto& tensor_names = output.get_names();
@@ -380,7 +380,7 @@ using SubGraphOpInputDescription = std::vector<std::shared_ptr<ov::op::util::Sub
 
 using SubGraphOpOutputDescription = std::vector<std::shared_ptr<ov::op::util::SubGraphOp::OutputDescription>>;
 
-using SpecialBodyPorts = ov::opset8::Loop::SpecialBodyPorts;
+using SpecialBodyPorts = ov::op::v5::Loop::SpecialBodyPorts;
 
 namespace storage {
 
@@ -718,7 +718,7 @@ struct Equal<uint8_t*> {
     }
 };
 
-using Constant = ov::opset8::Constant;
+using Constant = ov::op::v0::Constant;
 template <>
 struct Equal<std::shared_ptr<Constant>> {
     static bool equal_value(const std::shared_ptr<Constant>& lhs, const std::shared_ptr<Constant>& rhs) {

--- a/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
@@ -35,7 +35,7 @@ TransformationTestsF::TransformationTestsF()
     : model(function),
       model_ref(function_ref),
       comparator(FunctionsComparator::no_default()) {
-    m_unh = std::make_shared<ngraph::pass::UniqueNamesHolder>();
+    m_unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     comparator.enable(FunctionsComparator::CmpValues::NODES);
     comparator.enable(FunctionsComparator::CmpValues::PRECISIONS);
     comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
@@ -47,7 +47,7 @@ TransformationTestsF::TransformationTestsF()
 }
 
 void TransformationTestsF::SetUp() {
-    manager.register_pass<ngraph::pass::InitUniqueNames>(m_unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(m_unh);
     manager.register_pass<ov::pass::InitNodeInfo>();
     manager.register_pass<ov::pass::CopyTensorNamesToRefModel>(function_ref);
 }
@@ -63,7 +63,7 @@ void TransformationTestsF::TearDown() {
     } else if (acc_enabled) {
         cloned_function = ngraph::clone_function(*function);
     }
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(m_unh, m_soft_names_comparison, m_result_friendly_names_check);
+    manager.register_pass<ov::pass::CheckUniqueNames>(m_unh, m_soft_names_comparison, m_result_friendly_names_check);
     manager.run_passes(function);
 
     if (!m_disable_rt_info_check) {
@@ -94,15 +94,15 @@ void TransformationTestsF::disable_result_friendly_names_check() {
     m_result_friendly_names_check = false;
 }
 
-void init_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ngraph::pass::UniqueNamesHolder>& unh) {
+void init_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::InitUniqueNames>(unh);
+    manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.run_passes(f);
 }
 
-void check_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ngraph::pass::UniqueNamesHolder>& unh) {
+void check_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
     ngraph::pass::Manager manager;
-    manager.register_pass<ngraph::pass::CheckUniqueNames>(unh, true);
+    manager.register_pass<ov::pass::CheckUniqueNames>(unh, true);
     manager.run_passes(f);
 }
 

--- a/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "ngraph_test_utils.hpp"
-#include "openvino/op/constant.hpp"
 
 namespace ov {
 namespace pass {
@@ -95,18 +94,18 @@ void TransformationTestsF::disable_result_friendly_names_check() {
     m_result_friendly_names_check = false;
 }
 
-void init_unique_names(std::shared_ptr<ov::Model> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
+void init_unique_names(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
     ov::pass::Manager manager;
     manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.run_passes(f);
 }
 
-void check_unique_names(std::shared_ptr<ov::Model> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
+void check_unique_names(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
     ov::pass::Manager manager;
     manager.register_pass<ov::pass::CheckUniqueNames>(unh, true);
     manager.run_passes(f);
 }
 
-std::shared_ptr<ov::opset8::Constant> create_zero_constant(const ov::element::Type_t& et, const ov::Shape& shape) {
-    return ov::opset8::Constant::create(et, shape, {0});
+std::shared_ptr<ov::op::v0::Constant> create_zero_constant(const ov::element::Type_t& et, const ov::Shape& shape) {
+    return ov::op::v0::Constant::create(et, shape, {0});
 }

--- a/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "ngraph_test_utils.hpp"
+#include "openvino/op/constant.hpp"
 
 namespace ov {
 namespace pass {
@@ -58,10 +59,10 @@ void TransformationTestsF::TearDown() {
     std::shared_ptr<ov::Model> cloned_function;
     auto acc_enabled = comparator.should_compare(FunctionsComparator::ACCURACY);
     if (!function_ref) {
-        cloned_function = ngraph::clone_function(*function);
+        cloned_function = function->clone();
         function_ref = cloned_function;
     } else if (acc_enabled) {
-        cloned_function = ngraph::clone_function(*function);
+        cloned_function = function->clone();
     }
     manager.register_pass<ov::pass::CheckUniqueNames>(m_unh, m_soft_names_comparison, m_result_friendly_names_check);
     manager.run_passes(function);
@@ -94,14 +95,14 @@ void TransformationTestsF::disable_result_friendly_names_check() {
     m_result_friendly_names_check = false;
 }
 
-void init_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
-    ngraph::pass::Manager manager;
+void init_unique_names(std::shared_ptr<ov::Model> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
+    ov::pass::Manager manager;
     manager.register_pass<ov::pass::InitUniqueNames>(unh);
     manager.run_passes(f);
 }
 
-void check_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
-    ngraph::pass::Manager manager;
+void check_unique_names(std::shared_ptr<ov::Model> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh) {
+    ov::pass::Manager manager;
     manager.register_pass<ov::pass::CheckUniqueNames>(unh, true);
     manager.run_passes(f);
 }

--- a/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.cpp
@@ -23,13 +23,14 @@ public:
         }
         return false;
     }
+
 private:
     // we store a reference to shared_ptr because it will be initialized later in the test body
     const std::shared_ptr<ov::Model>& m_ref_model;
 };
 
-} // namespace pass
-} // namespace ov
+}  // namespace pass
+}  // namespace ov
 
 TransformationTestsF::TransformationTestsF()
     : model(function),
@@ -67,7 +68,7 @@ void TransformationTestsF::TearDown() {
     manager.run_passes(function);
 
     if (!m_disable_rt_info_check) {
-    ASSERT_NO_THROW(check_rt_info(function));
+        ASSERT_NO_THROW(check_rt_info(function));
     }
 
     if (acc_enabled) {

--- a/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.hpp
@@ -8,21 +8,18 @@
 #include <memory>
 #include <queue>
 
-#include <ngraph/dimension.hpp>
-#include <ngraph/function.hpp>
-#include <ngraph/opsets/opset1.hpp>
-#include <ngraph/pass/pass.hpp>
-#include <ngraph/pass/manager.hpp>
-#include <ngraph/opsets/opset6.hpp>
-#include <ngraph/op/util/framework_node.hpp>
-#include <transformations/init_node_info.hpp>
-#include <openvino/core/model.hpp>
-
+#include "openvino/core/dimension.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/pass/pass.hpp"
+#include "openvino/pass/manager.hpp"
+#include "transformations/init_node_info.hpp"
+#include "ngraph/opsets/opset1.hpp"
+#include "ngraph/opsets/opset6.hpp"
 #include "test_common.hpp"
 
 #include "graph_comparator.hpp"
 
-#define DYN ngraph::Dimension::dynamic()
+#define DYN ov::Dimension::dynamic()
 
 using TransformationTests = CommonTestUtils::TestsCommon;
 
@@ -44,7 +41,7 @@ public:
     std::shared_ptr<ov::Model> function, function_ref;
     // Aliases to function and function_ref pointers to be more corresponding with ov namespace.
     std::shared_ptr<ov::Model>&model, &model_ref;
-    ngraph::pass::Manager manager;
+    ov::pass::Manager manager;
     FunctionsComparator comparator;
 
 private:
@@ -54,15 +51,15 @@ private:
     bool m_result_friendly_names_check{true};
 };
 
-void init_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
+void init_unique_names(std::shared_ptr<ov::Model> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
 
-void check_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
+void check_unique_names(std::shared_ptr<ov::Model> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
 
 template <typename T>
-size_t count_ops_of_type(const std::shared_ptr<ngraph::Function>& f) {
+size_t count_ops_of_type(const std::shared_ptr<ov::Model>& f) {
     size_t count = 0;
     for (auto op : f->get_ops()) {
-        if (ngraph::is_type<T>(op)) {
+        if (ov::is_type<T>(op)) {
             count++;
         }
     }

--- a/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.hpp
@@ -8,16 +8,13 @@
 #include <memory>
 #include <queue>
 
+#include "graph_comparator.hpp"
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/pass/pass.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/init_node_info.hpp"
-#include "ngraph/opsets/opset1.hpp"
-#include "ngraph/opsets/opset6.hpp"
 #include "test_common.hpp"
-
-#include "graph_comparator.hpp"
 
 #define DYN ov::Dimension::dynamic()
 
@@ -51,9 +48,9 @@ private:
     bool m_result_friendly_names_check{true};
 };
 
-void init_unique_names(std::shared_ptr<ov::Model> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
+void init_unique_names(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
 
-void check_unique_names(std::shared_ptr<ov::Model> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
+void check_unique_names(const std::shared_ptr<ov::Model>& f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
 
 template <typename T>
 size_t count_ops_of_type(const std::shared_ptr<ov::Model>& f) {
@@ -68,9 +65,9 @@ size_t count_ops_of_type(const std::shared_ptr<ov::Model>& f) {
 }
 
 template<class T>
-std::shared_ptr<ov::opset8::Constant> create_constant(const std::vector<T>& data, const ov::element::Type_t et = ov::element::i64, bool scalar = false) {
+std::shared_ptr<ov::op::v0::Constant> create_constant(const std::vector<T>& data, const ov::element::Type_t et = ov::element::i64, bool scalar = false) {
     ov::Shape shape = scalar ? ov::Shape{} : ov::Shape{data.size()};
-    return ov::opset8::Constant::create(et, shape, data);
+    return ov::op::v0::Constant::create(et, shape, data);
 }
 
-std::shared_ptr<ov::opset8::Constant> create_zero_constant(const ov::element::Type_t& et, const ov::Shape& shape);
+std::shared_ptr<ov::op::v0::Constant> create_zero_constant(const ov::element::Type_t& et, const ov::Shape& shape);

--- a/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.hpp
@@ -48,15 +48,15 @@ public:
     FunctionsComparator comparator;
 
 private:
-    std::shared_ptr<ngraph::pass::UniqueNamesHolder> m_unh;
+    std::shared_ptr<ov::pass::UniqueNamesHolder> m_unh;
     bool m_disable_rt_info_check{false};
     bool m_soft_names_comparison{true};
     bool m_result_friendly_names_check{true};
 };
 
-void init_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ngraph::pass::UniqueNamesHolder>& unh);
+void init_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
 
-void check_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ngraph::pass::UniqueNamesHolder>& unh);
+void check_unique_names(std::shared_ptr<ngraph::Function> f, const std::shared_ptr<ov::pass::UniqueNamesHolder>& unh);
 
 template <typename T>
 size_t count_ops_of_type(const std::shared_ptr<ngraph::Function>& f) {

--- a/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/ngraph_test_utils.hpp
@@ -11,16 +11,16 @@
 #include "graph_comparator.hpp"
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/model.hpp"
-#include "openvino/pass/pass.hpp"
 #include "openvino/pass/manager.hpp"
-#include "transformations/init_node_info.hpp"
+#include "openvino/pass/pass.hpp"
 #include "test_common.hpp"
+#include "transformations/init_node_info.hpp"
 
 #define DYN ov::Dimension::dynamic()
 
 using TransformationTests = CommonTestUtils::TestsCommon;
 
-class TransformationTestsF : public  CommonTestUtils::TestsCommon {
+class TransformationTestsF : public CommonTestUtils::TestsCommon {
 public:
     TransformationTestsF();
 
@@ -64,8 +64,10 @@ size_t count_ops_of_type(const std::shared_ptr<ov::Model>& f) {
     return count;
 }
 
-template<class T>
-std::shared_ptr<ov::op::v0::Constant> create_constant(const std::vector<T>& data, const ov::element::Type_t et = ov::element::i64, bool scalar = false) {
+template <class T>
+std::shared_ptr<ov::op::v0::Constant> create_constant(const std::vector<T>& data,
+                                                      const ov::element::Type_t et = ov::element::i64,
+                                                      bool scalar = false) {
     ov::Shape shape = scalar ? ov::Shape{} : ov::Shape{data.size()};
     return ov::op::v0::Constant::create(et, shape, data);
 }

--- a/src/tests/ie_test_utils/common_test_utils/ov_tensor_utils.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/ov_tensor_utils.cpp
@@ -5,7 +5,6 @@
 #include <queue>
 
 #include "openvino/core/type/element_type_traits.hpp"
-#include "ngraph/coordinate_transform.hpp"
 
 #include "common_test_utils/data_utils.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"

--- a/src/tests/ie_test_utils/common_test_utils/tests/graph_comparator_tests.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/tests/graph_comparator_tests.cpp
@@ -4,15 +4,22 @@
 
 #include <gtest/gtest.h>
 #include <common_test_utils/graph_comparator.hpp>
-
+#include "openvino/op/add.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/convolution.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/tensor_iterator.hpp"
+#include "openvino/op/gru_cell.hpp"
+#include "openvino/op/multiply.hpp"
 
 TEST(GraphComparatorTests, AllEnablePositiveCheck) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add}, ngraph::ParameterVector{ input });
         function = function_ref->clone();
     }
@@ -32,15 +39,15 @@ TEST(GraphComparatorTests, CheckbyDefault) {
     FunctionsComparator comparator(FunctionsComparator::with_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto input2 = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto add = std::make_shared<ov::opset8::Add>(input, input2);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto input2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto add = std::make_shared<ov::op::v1::Add>(input, input2);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input, input2 });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {12});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {12});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     auto res = comparator.compare(function, function_ref);
@@ -51,17 +58,17 @@ TEST(GraphComparatorTests, CheckResultsNumber) {
     FunctionsComparator comparator(FunctionsComparator::with_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto input2 = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto add = std::make_shared<ov::opset8::Add>(input, input2);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto input2 = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto add = std::make_shared<ov::op::v1::Add>(input, input2);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input, input2 });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {12});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
-        auto result1 = std::make_shared<ov::opset8::Result>(constant);
-        auto result2 = std::make_shared<ov::opset8::Result>(add);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {12});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
+        auto result1 = std::make_shared<ov::op::v0::Result>(constant);
+        auto result2 = std::make_shared<ov::op::v0::Result>(add);
         function = std::make_shared<ngraph::Function>(ngraph::ResultVector{ result1, result2 }, ngraph::ParameterVector{ input });
     }
     auto res = comparator.compare(function, function_ref);
@@ -72,20 +79,20 @@ TEST(GraphComparatorTests, NamesCheckPositive) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
         input->set_friendly_name("new_name1");
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
         constant->set_friendly_name("new_name2");
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->set_friendly_name("new_name3");
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
         input->set_friendly_name("new_name1");
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
         constant->set_friendly_name("new_name2");
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->set_friendly_name("new_name3");
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
@@ -99,20 +106,20 @@ TEST(GraphComparatorTests, NamesCheckNegative) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
         input->set_friendly_name("new_name1");
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
         constant->set_friendly_name("new_name2");
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->set_friendly_name("new_name3");
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
         input->set_friendly_name("new_name1");
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
         constant->set_friendly_name("new_name2");
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->set_friendly_name("new_name3_different");
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
@@ -126,15 +133,15 @@ TEST(GraphComparatorTests, ConstCheckWithoutEnable) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {12});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {12});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::NODES);
@@ -146,15 +153,15 @@ TEST(GraphComparatorTests, ConstCheckNegative) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {12});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {12});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::CONST_VALUES)
@@ -167,9 +174,9 @@ TEST(GraphComparatorTests, TensorNamesCheckNegative) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
         function = function_ref->clone();
         add->get_input_tensor(0).set_names({"new_name"});
@@ -184,9 +191,9 @@ TEST(GraphComparatorTests, TensorNamesCheckWithoutEnable) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
         function = function_ref->clone();
         add->get_input_tensor(0).set_names({"new_name"});
@@ -200,12 +207,12 @@ TEST(GraphComparatorTests, CheckAttributesNegative) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 12, 12 });
-        auto const_weights = ov::opset8::Constant::create(ov::element::f16,
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 12, 12 });
+        auto const_weights = ov::op::v0::Constant::create(ov::element::f16,
                                                           ov::Shape{ 1, 3, 3, 3 },
                                                           { 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
-        auto convert_ins1 = std::make_shared<ov::opset8::Convert>(const_weights, ov::element::f32);
-        auto conv = std::make_shared<ov::opset8::Convolution>(input,
+        auto convert_ins1 = std::make_shared<ov::op::v0::Convert>(const_weights, ov::element::f32);
+        auto conv = std::make_shared<ov::op::v1::Convolution>(input,
                                                               convert_ins1,
                                                               ov::Strides{ 1, 1 },
                                                               ov::CoordinateDiff{ 1, 1 },
@@ -214,12 +221,12 @@ TEST(GraphComparatorTests, CheckAttributesNegative) {
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ conv }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 12, 12 });
-        auto const_weights = ov::opset8::Constant::create(ov::element::f16,
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 12, 12 });
+        auto const_weights = ov::op::v0::Constant::create(ov::element::f16,
                                                           ov::Shape{ 1, 3, 3, 3 },
                                                           { 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
-        auto convert_ins1 = std::make_shared<ov::opset8::Convert>(const_weights, ov::element::f32);
-        auto conv = std::make_shared<ov::opset8::Convolution>(input,
+        auto convert_ins1 = std::make_shared<ov::op::v0::Convert>(const_weights, ov::element::f32);
+        auto conv = std::make_shared<ov::op::v1::Convolution>(input,
                                                               convert_ins1,
                                                               ov::Strides{ 1, 1 },
                                                               ov::CoordinateDiff{ 0, 0 },
@@ -237,15 +244,15 @@ TEST(GraphComparatorTests, CheckPrecisionsNegative) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::f32, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::f32, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::f32, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::PRECISIONS)
@@ -258,15 +265,15 @@ TEST(GraphComparatorTests, CheckPrecisionsWithoutEnable) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::f32, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::f32, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::f32, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::NODES);
@@ -278,16 +285,16 @@ TEST(GraphComparatorTests, CheckRTInfo) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->get_rt_info()["my_info"] = 42;
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::RUNTIME_KEYS)
@@ -300,15 +307,15 @@ TEST(GraphComparatorTests, CheckRTInfoReverse) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->get_rt_info()["my_info"] = 42;
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
@@ -322,16 +329,16 @@ TEST(GraphComparatorTests, CheckRTInfoInput) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->input(0).get_rt_info()["my_info"] = 42;
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::RUNTIME_KEYS)
@@ -344,16 +351,16 @@ TEST(GraphComparatorTests, CheckRTInfoOutput) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->output(0).get_rt_info()["my_info"] = 42;
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{3});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {3}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{3});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {3}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::RUNTIME_KEYS)
@@ -366,31 +373,31 @@ TEST(GraphComparatorTests, CheckTensorIteratorPositive) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto X = std::make_shared<ov::opset8::Parameter>(ngraph::element::f32, ngraph::Shape{2, 1, 16});
-        auto Y = std::make_shared<ov::opset8::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
+        auto X = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{2, 1, 16});
+        auto Y = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
 
-        auto Xi = std::make_shared<ov::opset8::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 16});
-        auto Yi = std::make_shared<ov::opset8::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
+        auto Xi = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 16});
+        auto Yi = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, ngraph::Shape{1, 128});
 
         // Body
-        auto axis = ov::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0});
-        auto squeeze = std::make_shared<ov::opset8::Squeeze>(Xi, axis);
+        auto axis = ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0});
+        auto squeeze = std::make_shared<ov::op::v0::Squeeze>(Xi, axis);
 
         auto w_val = std::vector<float>(384*16, 0);
         auto r_val = std::vector<float>(384*128, 0);
         auto b_val = std::vector<float>(384, 0);
-        auto W = ov::opset8::Constant::create(ngraph::element::f32, ngraph::Shape{384, 16}, w_val);
-        auto R = ov::opset8::Constant::create(ngraph::element::f32, ngraph::Shape{384, 128}, r_val);
-        auto B = ov::opset8::Constant::create(ngraph::element::f32, ngraph::Shape{384}, b_val);
+        auto W = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{384, 16}, w_val);
+        auto R = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{384, 128}, r_val);
+        auto B = ov::op::v0::Constant::create(ngraph::element::f32, ngraph::Shape{384}, b_val);
 
-        auto gru_cell = std::make_shared<ov::opset8::GRUCell>(squeeze, Yi, W, R, B, 128);
-        auto res_1 = std::make_shared<ov::opset8::Result>(gru_cell);
-        auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(gru_cell, axis);
-        auto res_2 = std::make_shared<ov::opset8::Result>(unsqueeze);
+        auto gru_cell = std::make_shared<ov::op::v3::GRUCell>(squeeze, Yi, W, R, B, 128);
+        auto res_1 = std::make_shared<ov::op::v0::Result>(gru_cell);
+        auto unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(gru_cell, axis);
+        auto res_2 = std::make_shared<ov::op::v0::Result>(unsqueeze);
         auto body = std::make_shared<ngraph::Function>(ngraph::OutputVector{res_1, res_2},
                                                        ngraph::ParameterVector{Xi, Yi});
 
-        auto tensor_iterator = std::make_shared<ov::opset8::TensorIterator>();
+        auto tensor_iterator = std::make_shared<ov::op::v0::TensorIterator>();
         tensor_iterator->set_body(body);
 
         tensor_iterator->set_sliced_input(Xi, X, 0, 1, 1, -1, 0);
@@ -399,7 +406,7 @@ TEST(GraphComparatorTests, CheckTensorIteratorPositive) {
         auto out0 = tensor_iterator->get_iter_value(res_1, -1);
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 0);
 
-        auto res_ti_1 = std::make_shared<ov::opset8::Result>(tensor_iterator->output(1));
+        auto res_ti_1 = std::make_shared<ov::op::v0::Result>(tensor_iterator->output(1));
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{res_ti_1},
                                                           ngraph::ParameterVector{X, Y});
         function = function_ref->clone();
@@ -413,36 +420,36 @@ TEST(GraphComparatorTests, CheckLoopPositive) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto X = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto Y = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto M = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
+        auto X = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
+        auto Y = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
+        auto M = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
 
         // Set up the cell body, a function from (Xi, Yi) -> (Zo)
         // Body parameters
-        auto Xi = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto Yi = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto M_body = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
-        auto body_condition = std::make_shared<ov::opset8::Constant>(ov::element::boolean, ov::Shape{1}, true);
+        auto Xi = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
+        auto Yi = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
+        auto M_body = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
+        auto body_condition = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{1}, true);
 
-        auto trip_count = std::make_shared<ov::opset8::Constant>(ngraph::element::i64, ov::Shape{1}, 3);
-        auto exec_condition = std::make_shared<ov::opset8::Constant>(ngraph::element::boolean, ov::Shape{1}, true);
+        auto trip_count = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, ov::Shape{1}, 3);
+        auto exec_condition = std::make_shared<ov::op::v0::Constant>(ngraph::element::boolean, ov::Shape{1}, true);
         // Body
-        auto sum = std::make_shared<ov::opset8::Add>(Xi, Yi);
-        auto Zo = std::make_shared<ov::opset8::Multiply>(sum, M_body);
+        auto sum = std::make_shared<ov::op::v1::Add>(Xi, Yi);
+        auto Zo = std::make_shared<ov::op::v1::Multiply>(sum, M_body);
         auto body = std::make_shared<ov::Model>(ov::OutputVector{body_condition, Zo},
                                                 ov::ParameterVector{Xi, Yi, M_body});
 
-        auto loop = std::make_shared<ov::opset8::Loop>(trip_count, exec_condition);
+        auto loop = std::make_shared<ov::op::v5::Loop>(trip_count, exec_condition);
         loop->set_function(body);
 
         loop->set_invariant_input(Xi, X);
         loop->set_invariant_input(Yi, Y);
         loop->set_merged_input(M_body, M, Zo);
 
-        loop->set_special_body_ports(ov::opset8::Loop::SpecialBodyPorts{-1, 0});
+        loop->set_special_body_ports(ov::op::v5::Loop::SpecialBodyPorts{-1, 0});
 
         // Output is last Zo
-        auto result = std::make_shared<ov::opset8::Result>(loop->get_iter_value(Zo, -1));
+        auto result = std::make_shared<ov::op::v0::Result>(loop->get_iter_value(Zo, -1));
         function_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{X, Y, M});
         function = function_ref->clone();
     }
@@ -455,21 +462,21 @@ TEST(GraphComparatorTests, CheckSinksPositive) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto arg = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 1});
-        auto init_const = ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 1}, {0});
+        auto arg = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 1});
+        auto init_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1}, {0});
         const std::string variable_name("variable0");
         auto variable = std::make_shared<ngraph::Variable>(ngraph::VariableInfo{ov::PartialShape::dynamic(),
                                                                                 ov::element::dynamic, variable_name});
 
-        auto read = std::make_shared<ov::opset8::ReadValue>(init_const, variable);
-        auto read2 = std::make_shared<ov::opset8::ReadValue>(init_const, variable);
-        auto add = std::make_shared<ov::opset8::Add>(arg, read);
-        auto add2 = std::make_shared<ov::opset8::Add>(arg, read2);
-        auto assign = std::make_shared<ov::opset8::Assign>(add, variable);
-        auto assign2 = std::make_shared<ov::opset8::Assign>(add, variable);
+        auto read = std::make_shared<ov::op::v6::ReadValue>(init_const, variable);
+        auto read2 = std::make_shared<ov::op::v6::ReadValue>(init_const, variable);
+        auto add = std::make_shared<ov::op::v1::Add>(arg, read);
+        auto add2 = std::make_shared<ov::op::v1::Add>(arg, read2);
+        auto assign = std::make_shared<ov::op::v6::Assign>(add, variable);
+        auto assign2 = std::make_shared<ov::op::v6::Assign>(add, variable);
 
-        auto res = std::make_shared<ov::opset8::Result>(add);
-        auto res2 = std::make_shared<ov::opset8::Result>(add2);
+        auto res = std::make_shared<ov::op::v0::Result>(add);
+        auto res2 = std::make_shared<ov::op::v0::Result>(add2);
 
         function_ref = std::make_shared<ov::Model>(ov::ResultVector({res, res2}), ov::SinkVector({assign, assign2}),
                                                    ov::ParameterVector({arg}));
@@ -484,42 +491,42 @@ TEST(GraphComparatorTests, CheckSinksNegative) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto arg = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 1});
-        auto init_const = ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 1}, {0});
+        auto arg = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 1});
+        auto init_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1}, {0});
         const std::string variable_name("variable0");
         auto variable = std::make_shared<ngraph::Variable>(ngraph::VariableInfo{ov::PartialShape::dynamic(),
                                                                                 ov::element::dynamic, variable_name});
 
-        auto read = std::make_shared<ov::opset8::ReadValue>(init_const, variable);
-        auto read2 = std::make_shared<ov::opset8::ReadValue>(init_const, variable);
-        auto add = std::make_shared<ov::opset8::Add>(arg, read);
-        auto add2 = std::make_shared<ov::opset8::Add>(arg, read2);
-        auto assign = std::make_shared<ov::opset8::Assign>(add, variable);
-        auto assign2 = std::make_shared<ov::opset8::Assign>(add, variable);
+        auto read = std::make_shared<ov::op::v6::ReadValue>(init_const, variable);
+        auto read2 = std::make_shared<ov::op::v6::ReadValue>(init_const, variable);
+        auto add = std::make_shared<ov::op::v1::Add>(arg, read);
+        auto add2 = std::make_shared<ov::op::v1::Add>(arg, read2);
+        auto assign = std::make_shared<ov::op::v6::Assign>(add, variable);
+        auto assign2 = std::make_shared<ov::op::v6::Assign>(add, variable);
 
-        auto res = std::make_shared<ov::opset8::Result>(add);
-        auto res2 = std::make_shared<ov::opset8::Result>(add2);
+        auto res = std::make_shared<ov::op::v0::Result>(add);
+        auto res2 = std::make_shared<ov::op::v0::Result>(add2);
 
         function_ref = std::make_shared<ov::Model>(ov::ResultVector({res, res2}), ov::SinkVector({assign, assign2}),
                                                    ov::ParameterVector({arg}));
     }
 
     {
-        auto arg = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 1});
-        auto init_const = ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 1}, {0});
+        auto arg = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 1});
+        auto init_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1}, {0});
         const std::string variable_name("variable_different");
         auto variable = std::make_shared<ngraph::Variable>(ngraph::VariableInfo{ov::PartialShape::dynamic(),
                                                                                 ov::element::dynamic, variable_name});
 
-        auto read = std::make_shared<ov::opset8::ReadValue>(init_const, variable);
-        auto read2 = std::make_shared<ov::opset8::ReadValue>(init_const, variable);
-        auto add = std::make_shared<ov::opset8::Add>(arg, read);
-        auto add2 = std::make_shared<ov::opset8::Add>(arg, read2);
-        auto assign = std::make_shared<ov::opset8::Assign>(add, variable);
-        auto assign2 = std::make_shared<ov::opset8::Assign>(add, variable);
+        auto read = std::make_shared<ov::op::v6::ReadValue>(init_const, variable);
+        auto read2 = std::make_shared<ov::op::v6::ReadValue>(init_const, variable);
+        auto add = std::make_shared<ov::op::v1::Add>(arg, read);
+        auto add2 = std::make_shared<ov::op::v1::Add>(arg, read2);
+        auto assign = std::make_shared<ov::op::v6::Assign>(add, variable);
+        auto assign2 = std::make_shared<ov::op::v6::Assign>(add, variable);
 
-        auto res = std::make_shared<ov::opset8::Result>(add);
-        auto res2 = std::make_shared<ov::opset8::Result>(add2);
+        auto res = std::make_shared<ov::op::v0::Result>(add);
+        auto res2 = std::make_shared<ov::op::v0::Result>(add2);
 
         function = std::make_shared<ov::Model>(ov::ResultVector({res, res2}), ov::SinkVector({assign, assign2}),
                                                ov::ParameterVector({arg}));
@@ -533,9 +540,9 @@ TEST(GraphComparatorTests, DisableCheck) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input });
         function = function_ref->clone();
     }
@@ -549,15 +556,15 @@ TEST(GraphComparatorTests, CheckAccuracyPositive) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add}, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add}, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::ACCURACY);
@@ -569,15 +576,15 @@ TEST(GraphComparatorTests, CheckAccuracyNegative) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {12});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {12});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add}, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {200});
-        auto add = std::make_shared<ov::opset8::Add>(input, constant);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {200});
+        auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add}, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::ACCURACY);
@@ -589,12 +596,12 @@ TEST(GraphComparatorTests, CheckAccuracyNotEnabled) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 12, 12 });
-        auto const_weights = ov::opset8::Constant::create(ov::element::f16,
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 12, 12 });
+        auto const_weights = ov::op::v0::Constant::create(ov::element::f16,
                                                           ov::Shape{ 1, 3, 3, 3 },
                                                           { 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
-        auto convert_ins1 = std::make_shared<ov::opset8::Convert>(const_weights, ov::element::f32);
-        auto conv = std::make_shared<ov::opset8::Convolution>(input,
+        auto convert_ins1 = std::make_shared<ov::op::v0::Convert>(const_weights, ov::element::f32);
+        auto conv = std::make_shared<ov::op::v1::Convolution>(input,
                                                               convert_ins1,
                                                               ov::Strides{ 1, 1 },
                                                               ov::CoordinateDiff{ 1, 1 },
@@ -603,12 +610,12 @@ TEST(GraphComparatorTests, CheckAccuracyNotEnabled) {
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ conv }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 12, 12 });
-        auto const_weights = ov::opset8::Constant::create(ov::element::f16,
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 12, 12 });
+        auto const_weights = ov::op::v0::Constant::create(ov::element::f16,
                                                           ov::Shape{ 1, 3, 3, 3 },
                                                           { 1, 9, 3, 4, 5, 6, 7, 8, 9, 1, 12, 3, 9, 5, 0, 7, 8, 9, 1, 2, 12, 4, 9, 6, 7, 8, 9 });
-        auto convert_ins1 = std::make_shared<ov::opset8::Convert>(const_weights, ov::element::f32);
-        auto conv = std::make_shared<ov::opset8::Convolution>(input,
+        auto convert_ins1 = std::make_shared<ov::op::v0::Convert>(const_weights, ov::element::f32);
+        auto conv = std::make_shared<ov::op::v1::Convolution>(input,
                                                               convert_ins1,
                                                               ov::Strides{ 1, 1 },
                                                               ov::CoordinateDiff{ 1, 1 },
@@ -625,19 +632,19 @@ TEST(GraphComparatorTests, CheckConsumersCountPositive) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add_1 = std::make_shared<ov::opset8::Add>(input, constant);
-        auto add_2 = std::make_shared<ov::opset8::Add>(input, constant);
-        auto mul = std::make_shared<ov::opset8::Multiply>(add_1, add_2);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add_1 = std::make_shared<ov::op::v1::Add>(input, constant);
+        auto add_2 = std::make_shared<ov::op::v1::Add>(input, constant);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(add_1, add_2);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ mul }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add_1 = std::make_shared<ov::opset8::Add>(input, constant);
-        auto add_2 = std::make_shared<ov::opset8::Add>(input, constant);
-        auto mul = std::make_shared<ov::opset8::Multiply>(add_1, add_2);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add_1 = std::make_shared<ov::op::v1::Add>(input, constant);
+        auto add_2 = std::make_shared<ov::op::v1::Add>(input, constant);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(add_1, add_2);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ mul }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::NODES).enable(FunctionsComparator::CONSUMERS_COUNT);
@@ -649,20 +656,20 @@ TEST(GraphComparatorTests, CheckConsumersCountNegative) {
     FunctionsComparator comparator(FunctionsComparator::no_default());
     std::shared_ptr<ov::Model> function, function_ref;
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add_1 = std::make_shared<ov::opset8::Add>(input, constant);
-        auto add_2 = std::make_shared<ov::opset8::Add>(input, constant);
-        auto mul = std::make_shared<ov::opset8::Multiply>(add_1, add_2);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add_1 = std::make_shared<ov::op::v1::Add>(input, constant);
+        auto add_2 = std::make_shared<ov::op::v1::Add>(input, constant);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(add_1, add_2);
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ mul }, ngraph::ParameterVector{ input });
     }
     {
-        auto input = std::make_shared<ov::opset8::Parameter>(ngraph::element::i64, ov::Shape{1});
-        auto constant_1 = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto constant_2 = ov::opset8::Constant::create(ngraph::element::i64, {1}, {0});
-        auto add_1 = std::make_shared<ov::opset8::Add>(input, constant_1);
-        auto add_2 = std::make_shared<ov::opset8::Add>(input, constant_2);
-        auto mul = std::make_shared<ov::opset8::Multiply>(add_1, add_2);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ngraph::element::i64, ov::Shape{1});
+        auto constant_1 = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto constant_2 = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {0});
+        auto add_1 = std::make_shared<ov::op::v1::Add>(input, constant_1);
+        auto add_2 = std::make_shared<ov::op::v1::Add>(input, constant_2);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(add_1, add_2);
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ mul }, ngraph::ParameterVector{ input });
     }
     comparator.enable(FunctionsComparator::NODES).enable(FunctionsComparator::CONSUMERS_COUNT);

--- a/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/fake_quantize_on_weights_and_unsupported_child_function.hpp
+++ b/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/fake_quantize_on_weights_and_unsupported_child_function.hpp
@@ -19,7 +19,7 @@ public:
 static std::shared_ptr<ngraph::Function> get(
     const ngraph::Shape& inputShape,
     const ngraph::element::Type inputPrecision,
-    const std::shared_ptr<ngraph::opset1::Constant> weights,
+    const std::shared_ptr<ov::op::v0::Constant> weights,
     const ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights);
 };
 

--- a/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/reduce_function.hpp
+++ b/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/reduce_function.hpp
@@ -25,10 +25,10 @@ public:
         const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const std::vector<int64_t>& constantValues,
         const bool keepDims) {
-        const auto input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
+        const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
         const auto dequantization = makeDequantization(input, dequantizationBefore);
 
-        const auto constant = std::make_shared<ngraph::opset1::Constant>(
+        const auto constant = std::make_shared<ov::op::v0::Constant>(
             ngraph::element::i32,
             ngraph::Shape{ constantValues.size() },
             constantValues);
@@ -42,7 +42,7 @@ public:
             keepDims);
 
         reduce->set_friendly_name("Output");
-        const auto result = std::make_shared<ngraph::opset1::Result>(reduce);
+        const auto result = std::make_shared<ov::op::v0::Result>(reduce);
         const auto function = std::make_shared<ngraph::Function>(
             ngraph::ResultVector{ result },
             ngraph::ParameterVector{ input },
@@ -61,7 +61,7 @@ public:
         const std::vector<int64_t>& constantValues,
         const bool keepDims,
         ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
-        const auto input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
+        const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
         std::shared_ptr<ngraph::Node> parent = input;
 
         if (!fqOnData.empty()) {
@@ -69,14 +69,14 @@ public:
         }
 
         if (!convert.empty()) {
-            parent = std::make_shared<opset1::Convert>(parent, convert.outPrecision);
+            parent = std::make_shared<ov::op::v0::Convert>(parent, convert.outPrecision);
         }
 
         if (!dequantizationBefore.empty()) {
             parent = makeDequantization(parent, dequantizationBefore);
         }
 
-        const auto constant = std::make_shared<ngraph::opset1::Constant>(
+        const auto constant = std::make_shared<ov::op::v0::Constant>(
             ngraph::element::i32,
             ngraph::Shape{ constantValues.size() },
             constantValues);
@@ -88,7 +88,7 @@ public:
             parent = makeDequantization(parent, dequantizationAfter);
         }
 
-        const auto result = std::make_shared<ngraph::opset1::Result>(parent);
+        const auto result = std::make_shared<ov::op::v0::Result>(parent);
         const auto function = std::make_shared<ngraph::Function>(
             ngraph::ResultVector{ result },
             ngraph::ParameterVector{ input },
@@ -106,10 +106,10 @@ public:
         const bool keepDims,
         const ngraph::element::Type precisionAfterOperation,
         const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
-        const auto input = std::make_shared<ngraph::opset1::Parameter>(precision, inputShape);
+        const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
         const auto dequantization = makeDequantization(input, dequantizationBefore);
 
-        const auto constant = std::make_shared<ngraph::opset1::Constant>(
+        const auto constant = std::make_shared<ov::op::v0::Constant>(
             ngraph::element::i32,
             ngraph::Shape{ constantValues.size() },
             constantValues);
@@ -123,7 +123,7 @@ public:
         std::shared_ptr<Node> lastOperation = makeDequantization(reduce, dequantizationAfter);
 
         lastOperation->set_friendly_name("Output");
-        const auto result = std::make_shared<ngraph::opset1::Result>(lastOperation);
+        const auto result = std::make_shared<ov::op::v0::Result>(lastOperation);
         const auto function = std::make_shared<ngraph::Function>(
             ngraph::ResultVector{ result },
             ngraph::ParameterVector{ input },

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/src/subgraph_simple.cpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/src/subgraph_simple.cpp
@@ -328,20 +328,20 @@ std::shared_ptr<ov::Model> EdgeReplaceFunction::initOriginal() const {
     auto mul_rhs = split->output(1);
 
     // first parent subgraph in tokenization stage
-    const auto data0 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({1, 1, 1, 3, 2}),
+    const auto data0 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({1, 1, 1, 3, 2}),
         std::vector<float>{0.0, 0.2, 0.4, 0.6, 0.8, 1.0});
-    const auto const_a4 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.2, 0.1});
+    const auto const_a4 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.2, 0.1});
     auto mul_a4 = std::make_shared<op::v1::Multiply>(mul_rhs, const_a4);
     auto add_a1 = std::make_shared<op::v1::Add>(mul_a4, data0);
     auto mul_a5 = std::make_shared<op::v1::Multiply>(add_a1, mul_lhs);
 
     // second parent subgraph in tokenization stage
-    const auto data1 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({1, 1, 1, 3, 2}),
+    const auto data1 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({1, 1, 1, 3, 2}),
         std::vector<float>{0.1, 0.3, 0.5, 0.7, 0.9, 1.0});
     auto mul_a1 = std::make_shared<op::v1::Multiply>(data1, mul_lhs);
-    const auto const_a2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.2, 0.4});
+    const auto const_a2 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.2, 0.4});
     auto mul_a2 = std::make_shared<op::v1::Multiply>(mul_a1, const_a2);
-    const auto const_a3 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.3, 0.1});
+    const auto const_a3 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.3, 0.1});
     auto mul_a3 = std::make_shared<op::v1::Multiply>(mul_a2, const_a3);
 
     auto add_a3 = std::make_shared<op::v1::Add>(mul_a5, mul_a3);


### PR DESCRIPTION
### Details:
 - Rename ngraph and ie names to ov
 - Rewrite tests to use api 2.0
 - Fix dependent code

### Tickets:
 - CVS-111358