### PR TITLE
Allow new shape infer of ShapeOf

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/shape_of.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/shape_of.hpp
@@ -22,11 +22,11 @@ struct shape_of : public primitive_base<shape_of> {
     /// @param output_data_type type of output values. can be i32 and i64.
     shape_of(const primitive_id& id,
              const input_info& input,
-             size_t output_rank,
+             size_t input_rank,
              const data_types output_data_type,
              const padding& output_padding = padding())
         : primitive_base(id, {input}, {output_padding}, {optional_data_type{output_data_type}})
-        , output_rank(output_rank) {}
+        , input_rank(input_rank) {}
 
     /// @brief Constructs shape_of primitive.
     /// @param id This primitive id.
@@ -37,9 +37,9 @@ struct shape_of : public primitive_base<shape_of> {
              const data_types output_data_type,
              const padding& output_padding = padding())
         : primitive_base(id, {input}, {output_padding}, {optional_data_type{output_data_type}})
-        , output_rank(0) {}
+        , input_rank(0) {}
 
-    size_t output_rank;
+    size_t input_rank;
 
     bool operator==(const primitive& rhs) const override {
         if (!compare_common_params(rhs))
@@ -47,17 +47,17 @@ struct shape_of : public primitive_base<shape_of> {
 
         auto rhs_casted = downcast<const shape_of>(rhs);
 
-        return output_rank == rhs_casted.output_rank;
+        return input_rank == rhs_casted.input_rank;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
         primitive_base<shape_of>::save(ob);
-        ob << output_rank;
+        ob << input_rank;
     }
 
     void load(BinaryInputBuffer& ib) override {
         primitive_base<shape_of>::load(ib);
-        ib >> output_rank;
+        ib >> input_rank;
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/shape_of.cpp
@@ -24,7 +24,8 @@ layout shape_of_inst::calc_output_layout(shape_of_node const& node, kernel_impl_
         dt = impl_param.get_fused_output_layout().data_type;
     }
 
-    cldnn::tensor out_size{static_cast<tensor::value_type>(prim->output_rank), 1, 1, 1};
+    auto in_shape = impl_param.get_input_layout();
+    cldnn::tensor out_size{static_cast<tensor::value_type>(in_shape.get_rank()), 1, 1, 1};
 
     return layout{dt, format::bfyx, out_size};
 }

--- a/src/plugins/intel_gpu/src/graph/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/shape_of.cpp
@@ -24,8 +24,7 @@ layout shape_of_inst::calc_output_layout(shape_of_node const& node, kernel_impl_
         dt = impl_param.get_fused_output_layout().data_type;
     }
 
-    auto in_shape = impl_param.get_input_layout();
-    cldnn::tensor out_size{static_cast<tensor::value_type>(in_shape.get_rank()), 1, 1, 1};
+    cldnn::tensor out_size{static_cast<tensor::value_type>(prim->input_rank), 1, 1, 1};
 
     return layout{dt, format::bfyx, out_size};
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/shape_of.cpp
@@ -19,7 +19,7 @@ static void CreateShapeOfOpCommon(Program& p, const std::shared_ptr<ngraph::Node
 
     auto primitive = cldnn::shape_of(layerName,
                                      inputs[0],
-                                     op->get_output_partial_shape(0).rank().get_length(),
+                                     op->get_input_partial_shape(0).rank().get_length(),
                                      cldnn::element_type_to_data_type(op->get_output_element_type(0)));
 
     p.add_primitive(*op, primitive);

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/shapeof.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/shapeof.cpp
@@ -112,6 +112,21 @@ INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf_3d_compareWithRefs_dynamic,
         ::testing::ValuesIn(netPrecisions)),
     ShapeOfLayerGPUTest::getTestCaseName);
 
+std::vector<Shape> inShapesStatic3d = {
+    { 8, 5, 4 },
+    { 8, 5, 3 },
+    { 8, 5, 2 },
+    { 1, 2, 4 },
+    { 1, 2, 3 },
+    { 1, 2, 2 }
+};
+INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf_3d_compareWithRefs_static,
+    ShapeOfLayerGPUTest,
+    ::testing::Combine(
+            ::testing::ValuesIn(static_shapes_to_test_representation(inShapesStatic3d)),
+            ::testing::ValuesIn(netPrecisions)),
+    ShapeOfLayerGPUTest::getTestCaseName);
+
 // ==============================================================================
 // 4D
 std::vector<ov::test::InputShape> inShapesDynamic4d = {
@@ -139,6 +154,21 @@ INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf_4d_compareWithRefs_dynamic,
         ::testing::ValuesIn(netPrecisions)),
     ShapeOfLayerGPUTest::getTestCaseName);
 
+std::vector<Shape> inShapesStatic4d = {
+    { 8, 5, 3, 4 },
+    { 8, 5, 3, 3 },
+    { 8, 5, 3, 2 },
+    { 1, 2, 3, 4 },
+    { 1, 2, 3, 3 },
+    { 1, 2, 3, 2 }
+};
+INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf_4d_compareWithRefs_static,
+    ShapeOfLayerGPUTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(static_shapes_to_test_representation(inShapesStatic4d)),
+        ::testing::ValuesIn(netPrecisions)),
+    ShapeOfLayerGPUTest::getTestCaseName);
+
 // ==============================================================================
 // 5D
 std::vector<ov::test::InputShape> inShapesDynamic5d = {
@@ -163,6 +193,21 @@ INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf_5d_compareWithRefs_dynamic,
     ShapeOfLayerGPUTest,
     ::testing::Combine(
         ::testing::ValuesIn(inShapesDynamic5d),
+        ::testing::ValuesIn(netPrecisions)),
+    ShapeOfLayerGPUTest::getTestCaseName);
+
+std::vector<Shape> inShapesStatic5d = {
+    { 8, 5, 3, 2, 4 },
+    { 8, 5, 3, 2, 3 },
+    { 8, 5, 3, 2, 2 },
+    { 1, 2, 3, 4, 4 },
+    { 1, 2, 3, 4, 3 },
+    { 1, 2, 3, 4, 2 }
+};
+INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf_5d_compareWithRefs_static,
+    ShapeOfLayerGPUTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(static_shapes_to_test_representation(inShapesStatic5d)),
         ::testing::ValuesIn(netPrecisions)),
     ShapeOfLayerGPUTest::getTestCaseName);
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/shape_of_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/shape_of_gpu_test.cpp
@@ -197,6 +197,23 @@ TEST(shape_of_gpu, dynamic) {
     }
 }
 
+TEST(shape_of_gpu, static) {
+    auto& engine = get_test_engine();
+
+    layout in_layout = {ov::PartialShape::dynamic(4), data_types::f32, format::bfyx};
+
+    cldnn::topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(shape_of("shape_of", input_info("input"), 1, data_types::i32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(false));
+    network network(engine, topology, config);
+
+    auto inst = network.get_primitive("shape_of");
+    ASSERT_EQ(inst->get_output_layout(0).get_shape()[0], 4);
+}
+
 TEST(shape_of_gpu, shape_infer_optimization_dynamic) {
     auto& engine = get_test_engine();
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/shape_of_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/shape_of_gpu_test.cpp
@@ -197,23 +197,6 @@ TEST(shape_of_gpu, dynamic) {
     }
 }
 
-TEST(shape_of_gpu, static) {
-    auto& engine = get_test_engine();
-
-    layout in_layout = {ov::PartialShape::dynamic(4), data_types::f32, format::bfyx};
-
-    cldnn::topology topology;
-    topology.add(input_layout("input", in_layout));
-    topology.add(shape_of("shape_of", input_info("input"), 1, data_types::i32));
-
-    ExecutionConfig config = get_test_default_config(engine);
-    config.set_property(ov::intel_gpu::allow_new_shape_infer(false));
-    network network(engine, topology, config);
-
-    auto inst = network.get_primitive("shape_of");
-    ASSERT_EQ(inst->get_output_layout(0).get_shape()[0], 4);
-}
-
 TEST(shape_of_gpu, shape_infer_optimization_dynamic) {
     auto& engine = get_test_engine();
 


### PR DESCRIPTION
### Details:
 - *Fixed to use input shape rank when calculating output layout*
 - *In the case of ShapeOfOp, enable allow_new_shape_infer (deprecated)*
 
### Tickets:
 - *110900*
