### PR TITLE
[EISW-83125] C++ benchmark_app 2.0 does not recognise VPU/VPUX

### DIFF
--- a/samples/cpp/benchmark_app/utils.cpp
+++ b/samples/cpp/benchmark_app/utils.cpp
@@ -61,6 +61,7 @@ size_t InputInfo::depth() const {
 uint32_t device_default_device_duration_in_seconds(const std::string& device) {
     static const std::map<std::string, uint32_t> deviceDefaultDurationInSeconds{{"CPU", 60},
                                                                                 {"GPU", 60},
+                                                                                {"VPU", 60},
                                                                                 {"UNKNOWN", 120}};
     uint32_t duration = 0;
     for (const auto& deviceDurationInSeconds : deviceDefaultDurationInSeconds) {


### PR DESCRIPTION
### Details:
 - *Added `{"VPU", 60}` to `deviceDefaultDurationInSeconds` map*

### Tickets:
 - *[EISW-83125](https://jira.devtools.intel.com/browse/EISW-83125)*
