### PR TITLE
[DOCS] BuildingForLinux fix for 23.0

### DIFF
--- a/docs/dev/build_linux.md
+++ b/docs/dev/build_linux.md
@@ -12,7 +12,7 @@ The software was validated on:
 - [CMake](https://cmake.org/download/) 3.13 or higher
 - GCC 7.5 or higher to build OpenVINO Runtime
 - Python 3.7 - 3.11 for OpenVINO Runtime Python API
-- (Optional) [Install Intel® Graphics Compute Runtime for OpenCL™ Driver package 19.41.14441](https://github.com/intel/compute-runtime/releases/tag/19.41.14441) to enable inference on Intel integrated GPUs.
+- (Optional) [Install Intel® Graphics Compute Runtime for OpenCL™ Driver package 23.13.26032.30](https://github.com/intel/compute-runtime/releases/tag/23.13.26032.30) to enable inference on Intel integrated GPUs.
 
 ## How to build
 


### PR DESCRIPTION
Ticket: 101774

Link update for driver package in "Build OpenVINO™ Runtime for Linux systems" from 19.41.14441 to 23.13.26032.30

Port from https://github.com/openvinotoolkit/openvino/pull/17966
