### PR TITLE
[Snippets] Refactored LoopManager

### DIFF
--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -78,15 +78,15 @@ public:
                    const std::vector<ExpressionPort>& exits);
 
     void fuse_loops(const LinearIR& linear_ir, size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper = true);
-    void fuse_loops(size_t loop_id_upper, size_t loop_id_lower,
-                    LinearIR::constExprIt loop_begin_target, LinearIR::constExprIt loop_end_target, bool fuse_into_upper = true);
+    void fuse_loops(LinearIR::constExprIt loop_begin_target, LinearIR::constExprIt loop_end_target,
+                    size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper = true);
 
     // The following methods update ports of LoopInfo. They save the order of ports!
     // Remainder: the order is important to find Loop bounds (the most first and the most last expressions)
     //   - Update LoopPort - insert new loop target ports instead of existing.
-    void update_loop_port(size_t loop_id, const LoopPort& actual_port, const std::vector<LoopPort>& target_ports, bool is_entry = true);
     //   - Update ExpressionPort in the LoopPort - with saving of port parameters. It's softer method since ExpressionPort may not be port of Loop
-    void update_loop_port(size_t loop_id, const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports, bool is_entry = true);
+    template<typename T>
+    void update_loop_port(size_t loop_id, const T& actual_port, const std::vector<T>& target_ports, bool is_entry = true);
     template<typename T>
     void update_loops_port(const std::vector<size_t>& loop_ids, const T& actual_port,
                            const std::vector<T>& target_ports, bool is_entry = true) {
@@ -98,11 +98,11 @@ public:
     void sort_loop_ports(LinearIR::constExprIt& loop_begin_pos, LinearIR::constExprIt& loop_end_pos, size_t loop_id);
 
     // When the previous expression was replaced with new expressions (decomposition), the method updates the corresponding Loop.
-    // `Entries` and `exits` are known new loop ports if there are
+    // If ports of decomposed expression were the Loop ports, these Loop ports may be updated by parameters `entries` and `exits`
     // Note: This method should be removed when Softmax decomposition will be moved on data flow pipeline since
-    //       all decomposition should be call on this pipeline
+    //       all decompositions should be call on this pipeline
     void expression_replacement(constExprIt new_expr_begin, constExprIt new_expr_end, const ExpressionPtr& decomposed_expr,
-                                size_t loop_id, const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits);
+                                size_t loop_id, const std::vector<ExpressionPort>& new_entries, const std::vector<ExpressionPort>& exits);
 
     void get_loop_bounds(const LinearIR& linear_ir,
                          size_t loop_id,

--- a/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
@@ -53,8 +53,8 @@ private:
                                         const std::shared_ptr<ExpressionPort>& current_entry_point,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
-    static void fuse_points(std::vector<LinearIR::LoopManager::LoopPort>& exit_points, std::vector<LinearIR::LoopManager::LoopPort>& entry_points,
-                            LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos);
+    static void move(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id,
+                     LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos, LinearIR::constExprIt pos);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/insert_load_store.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_load_store.hpp
@@ -27,13 +27,9 @@ public:
     bool run(LinearIR& linear_ir) override;
 
 private:
+    size_t get_count(const PortDescriptorPtr& port_desc) const;
     bool insert_load(LinearIR& linear_ir, const LinearIR::constExprIt& data_expr_it);
     bool insert_store(LinearIR& linear_ir, const LinearIR::constExprIt& data_expr_it);
-    void update_loops(const LinearIR::LoopManagerPtr& loop_manager, const std::vector<size_t>& loop_ids,
-                      const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports, bool is_entry = true);
-    void update_loop(const LinearIR::LoopManager::LoopInfoPtr& loop_info,
-                     const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports, bool is_entry = true);
-    size_t get_count(const PortDescriptorPtr& port_desc) const;
 
     size_t m_vector_size;
 };

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -62,6 +62,13 @@ LoopInfoPtr LinearIR::LoopManager::get_loop_info(size_t index) const {
     return it->second;
 }
 
+std::vector<size_t> LinearIR::LoopManager::get_outer_expr_loops(const ExpressionPtr& expr, size_t loop_id) {
+    const auto loop_ids = expr->get_loop_ids();
+    const auto it = std::find(loop_ids.cbegin(), loop_ids.cend(), loop_id);
+    OPENVINO_ASSERT(it != loop_ids.cend(), "Loop ID hasn't been found");
+    return std::vector<size_t>(loop_ids.cbegin(), it);
+}
+
 void LinearIR::LoopManager::get_loop_bounds(const LinearIR &linear_ir,
                                             size_t loop_id,
                                             LinearIR::constExprIt &loop_begin_pos,
@@ -207,7 +214,169 @@ void LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
         insert_loop_id(*expr_it, loop_id);
     }
 }
+void LinearIR::LoopManager::fuse_loops(const LinearIR& linear_ir, size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper) {
+    LinearIR::constExprIt loop_begin_target, loop_end_target;
+    get_loop_bounds(linear_ir, fuse_into_upper ? loop_id_lower : loop_id_upper, loop_begin_target, loop_end_target);
+    fuse_loops(loop_id_upper, loop_id_lower, loop_begin_target, loop_end_target, fuse_into_upper);
+}
 
+void LinearIR::LoopManager::fuse_loops(size_t loop_id_upper, size_t loop_id_lower,
+                                       LinearIR::constExprIt loop_begin_target, LinearIR::constExprIt loop_end_target,
+                                       bool fuse_into_upper) {
+    OPENVINO_ASSERT(m_map.count(loop_id_upper) == 1 && m_map.count(loop_id_lower) == 1,
+                    "Failed Loop Fusion: the Loop with the Loop ID isn't existed");
+
+    const auto& loop_info_upper = m_map[loop_id_upper];
+    const auto& loop_info_lower = m_map[loop_id_lower];
+
+    auto entry_points_upper = loop_info_upper->entry_points;
+    auto exit_points_upper = loop_info_upper->exit_points;
+    auto entry_points_lower = loop_info_lower->entry_points;
+    auto exit_points_lower = loop_info_lower->exit_points;
+    fuse_loop_ports(exit_points_upper, entry_points_lower, loop_id_upper);
+
+    std::vector<LoopManager::LoopPort> new_entries = entry_points_upper;
+    new_entries.insert(new_entries.end(), entry_points_lower.begin(), entry_points_lower.end());
+    std::vector<LoopManager::LoopPort> new_exits = exit_points_upper;
+    new_exits.insert(new_exits.end(), exit_points_lower.begin(), exit_points_lower.end());
+
+    auto& loop_info = fuse_into_upper ? loop_info_upper : loop_info_lower;
+    loop_info->entry_points = new_entries;
+    loop_info->exit_points = new_exits;
+
+    const auto& from = fuse_into_upper ? loop_id_lower : loop_id_upper;
+    const auto& to = fuse_into_upper ? loop_id_upper : loop_id_lower;
+    for (auto it = loop_begin_target; it != loop_end_target; ++it) {
+        const auto& expr = *it;
+        replace_loop_id(expr, from, to);
+    }
+
+    remove_loop_info(from);
+}
+
+void LinearIR::LoopManager::fuse_loop_ports(std::vector<LinearIR::LoopManager::LoopPort>& exit_points,
+                                            std::vector<LinearIR::LoopManager::LoopPort>& entry_points,
+                                            size_t loop_id) {
+    auto is_loop_id_found = [](const std::vector<size_t>& ids, size_t id) {
+        return std::find(ids.cbegin(), ids.cend(), id) != ids.cend();
+    };
+
+    std::vector<LinearIR::LoopManager::LoopPort> new_exit_points;
+    for (const auto& exit_point : exit_points) {
+        const auto consumers_inputs = exit_point.expr_port->get_connected_ports();
+
+        std::set<LinearIR::LoopManager::LoopPort> mapped_entry_points;
+        std::set<ExpressionPtr> outside_consumers;
+        for (const auto& consumer_input : consumers_inputs) {
+            const auto entry_point_it = std::find_if(entry_points.begin(), entry_points.end(),
+                                                     [&consumer_input](const LoopManager::LoopPort& point) {
+                                                             return *point.expr_port.get() == consumer_input;
+                                                         });
+            if (entry_point_it != entry_points.end()) {
+                mapped_entry_points.insert(*entry_point_it);
+                continue;
+            }
+
+            const auto& consumer = consumer_input.get_expr();
+            const auto loop_ids = consumer->get_loop_ids();
+            if (!is_loop_id_found(loop_ids, loop_id)) {
+                outside_consumers.insert(consumer);
+            }
+        }
+
+        // Remove entry points which are mapped
+        auto last_point = entry_points.end();
+        for (const auto& mapped_entry_point : mapped_entry_points) {
+            last_point = std::remove(entry_points.begin(), last_point, mapped_entry_point);
+        }
+        entry_points.resize(entry_points.size() - mapped_entry_points.size());
+
+        // Leave exit point if there are consumers outside after fusion
+        if (!outside_consumers.empty()) {
+            new_exit_points.push_back(exit_point);
+        }
+    }
+
+    exit_points = new_exit_points;
+}
+
+void LinearIR::LoopManager::update_loop_port(size_t loop_id, const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports,
+                                             bool is_entry) {
+    const auto& loop_info = get_loop_info(loop_id);
+    auto& ports = is_entry ? loop_info->entry_points : loop_info->exit_points;
+    auto port_it = std::find_if(ports.begin(), ports.end(),
+                                [&actual_port](const LoopPort& point) { return *point.expr_port.get() == actual_port; });
+    // In some cases actual ExpressionPort may not be LoopPort. We shouldn't throw exception here since ExpressionPort is not strong condition as LoopPort
+    // For example, not all inner loop ports are ports of outer loops
+    if (port_it == ports.end())
+        return;
+
+    // to save other parameters except expression port
+    std::vector<LoopPort> target_loop_ports(target_ports.size(), *port_it);
+    std::transform(target_loop_ports.begin(), target_loop_ports.end(), target_ports.begin(), target_loop_ports.begin(),
+                   [](const LoopPort& loop_port, const ExpressionPort& expr_port) {
+                       LoopPort copy = loop_port;  // to save loop port parameters
+                       copy.expr_port = std::make_shared<ExpressionPort>(expr_port);
+                       return copy;
+                   });
+    port_it = ports.erase(port_it);
+    ports.insert(port_it, target_ports.cbegin(), target_ports.cend());
+}
+
+void LinearIR::LoopManager::update_loop_port(size_t loop_id, const LoopPort& actual_port, const std::vector<LoopPort>& target_ports,
+                                             bool is_entry) {
+    const auto& loop_info = get_loop_info(loop_id);
+    auto& ports = is_entry ? loop_info->entry_points : loop_info->exit_points;
+    auto port_it = std::find_if(ports.begin(), ports.end(),
+                                [&actual_port](const LoopPort& point) { return point == actual_port; });
+    OPENVINO_ASSERT(port_it != ports.end(), "Failed update_loop_port: existing loop ports has not been found");
+    port_it = ports.erase(port_it);
+    ports.insert(port_it, target_ports.cbegin(), target_ports.cend());
+}
+
+void LinearIR::LoopManager::expression_replacement(constExprIt new_expr_begin, constExprIt new_expr_end, const ExpressionPtr& decomposed_expr,
+                                                   size_t loop_id, const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits) {
+    for (auto it = new_expr_begin; it!= new_expr_end; ++it) {
+        insert_loop_id(*it, loop_id, true);
+    }
+    remove_loop_id(decomposed_expr, loop_id);
+
+    auto new_entries = entries;
+    auto new_exits = exits;
+    if (new_entries.empty() || new_exits.empty()) {
+        const auto loop_info = get_loop_info(loop_id);
+        get_io_loop_ports(new_expr_begin, new_expr_end, new_entries, new_exits);
+    }
+    for (size_t i = 0; i < decomposed_expr->get_input_count(); ++i) {
+        update_loop_port(loop_id, decomposed_expr->get_input_port(i), new_entries);
+    }
+    for (size_t i = 0; i < decomposed_expr->get_output_count(); ++i) {
+        update_loop_port(loop_id, decomposed_expr->get_output_port(i), new_exits, false);
+    }
+}
+
+void LinearIR::LoopManager::sort_loop_ports(LinearIR::constExprIt& loop_begin_pos, LinearIR::constExprIt& loop_end_pos, size_t loop_id) {
+    auto push = [](const std::vector<LoopPort>& ports, std::vector<LoopPort>& sorted_ports, const ExpressionPtr& expr) {
+        for (const auto& port : ports) {
+            if (port.expr_port->get_expr() == expr) {
+                sorted_ports.push_back(port);
+            }
+        }
+    };
+    auto loop_info = get_loop_info(loop_id);
+    const auto& loop_entries = loop_info->entry_points;
+    const auto& loop_exits = loop_info->exit_points;
+    std::vector<LoopPort> entries, exits;
+    entries.reserve(loop_entries.size());
+    exits.reserve(loop_exits.size());
+    for (auto it = loop_begin_pos; it != loop_end_pos; ++it) {
+        const auto& expr = *it;
+        push(loop_entries, entries, expr);
+        push(loop_exits, exits, expr);
+    }
+    loop_info->entry_points = entries;
+    loop_info->exit_points = exits;
+}
 
 void LinearIR::LoopManager::insert_loop_id(const ExpressionPtr& expr, size_t new_id, bool before, size_t target_id) {
     OPENVINO_ASSERT(m_map.count(new_id) == 1, "Failed marking expression by Loop ID: the Loop with this ID hasn't registered");

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -105,7 +105,7 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::Loo
 
     LinearIR::constExprIt target_loop_begin_pos, target_loop_end_pos;
     loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
-    loop_manager->fuse_loops(target_loop_id, current_loop_id, target_loop_begin_pos, target_loop_end_pos, false);
+    loop_manager->fuse_loops(target_loop_begin_pos, target_loop_end_pos, target_loop_id, current_loop_id, false);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
     loop_current->work_amount = std::max(loop_current->work_amount, loop_target->work_amount);
 
@@ -147,7 +147,7 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::Loo
 
     LinearIR::constExprIt target_loop_begin_pos, target_loop_end_pos;
     loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
-    loop_manager->fuse_loops(current_loop_id, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
+    loop_manager->fuse_loops(target_loop_begin_pos, target_loop_end_pos, current_loop_id, target_loop_id);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
     loop_current->work_amount = std::max(loop_current->work_amount, loop_target->work_amount);
 

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -42,46 +42,35 @@ bool FuseLoops::can_be_fused(const LoopInfoPtr& loop_current, const LoopInfoPtr&
     return supported_work_amount && supported_increment && supported_dim_idxs;
 }
 
-void FuseLoops::fuse_points(std::vector<LinearIR::LoopManager::LoopPort>& exit_points,
-                            std::vector<LinearIR::LoopManager::LoopPort>& entry_points,
-                            LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos) {
-    std::vector<LinearIR::LoopManager::LoopPort> new_exit_points;
-    for (const auto& exit_point : exit_points) {
-        const auto consumers_inputs = exit_point.expr_port->get_connected_ports();
-
-        std::set<LinearIR::LoopManager::LoopPort> mapped_entry_points;
-        std::set<ExpressionPtr> outside_consumers;
-        for (const auto& consumer_input : consumers_inputs) {
-            const auto entry_point_it = std::find_if(entry_points.begin(), entry_points.end(),
-                                                     [&consumer_input](const LoopManager::LoopPort& point) {
-                                                        return *point.expr_port.get() == consumer_input;
-                                                     });
-            if (entry_point_it != entry_points.end()) {
-                mapped_entry_points.insert(*entry_point_it);
-                continue;
-            }
-
-            const auto& consumer = consumer_input.get_expr();
-            const auto inside_it = std::find(loop_begin_pos, loop_end_pos, consumer);
-            if (inside_it == loop_end_pos) {
-                outside_consumers.insert(consumer);
-            }
-        }
-
-        // Remove entry points which are mapped
-        auto last_point = entry_points.end();
-        for (const auto& mapped_entry_point : mapped_entry_points) {
-            last_point = std::remove(entry_points.begin(), last_point, mapped_entry_point);
-        }
-        entry_points.resize(entry_points.size() - mapped_entry_points.size());
-
-        // Leave exit point if there are consumers outside after fusion
-        if (!outside_consumers.empty()) {
-            new_exit_points.push_back(exit_point);
-        }
+void FuseLoops::move(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id,
+                     LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos, LinearIR::constExprIt pos) {
+    // Inner Loops can contain ports which are ports of outer Loops as well.
+    // When we move these inner loops, we can corrupt the sort of LoopPorts of outer Loops.
+    // Firstly, we should find correct target loop bounds before their movings.
+    std::map<size_t, std::pair<LinearIR::constExprIt, LinearIR::constExprIt>> outer_loops;  // The map: LoopID -> [ LoopBegin, LoopEnd ]
+    const auto outer_loop_ids = LinearIR::LoopManager::get_outer_expr_loops(*loop_begin_pos, loop_id);
+    for (const auto& loop_id : outer_loop_ids) {
+        LinearIR::constExprIt begin, end;
+        loop_manager->get_loop_bounds(linear_ir, loop_id, begin, end);
+        // save previos iterator since the current iterator can be moved
+        outer_loops[loop_id] = {std::prev(begin), end};
     }
-
-    exit_points = new_exit_points;
+     // Secondly, move expressions
+    for (auto it = loop_begin_pos; it != loop_end_pos;) {
+        auto expr_it = it;
+        // After moving we will have `it` in new place in the current Loop,
+        // but for markup we need have the expression from the target Loop.
+        // Because of that we manually increment iterator before moving
+        it = std::next(it);
+        linear_ir.move(expr_it, pos);
+    }
+    // Thirdly, sort Loop Ports of outer Loops.
+    for (auto& loop : outer_loops) {
+        const auto loop_id = loop.first;
+        auto begin = std::next(loop.second.first);
+        auto end = loop.second.second;
+        loop_manager->sort_loop_ports(begin, end, loop_id);
+    }
 }
 
 bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager,
@@ -92,9 +81,6 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::Loo
     const auto& loop_target = loop_manager->get_loop_info(target_loop_id);
     if (!can_be_fused(loop_current, loop_target))
         return false;
-
-    LinearIR::constExprIt target_loop_begin_pos, target_loop_end_pos;
-    loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
 
     // We can fuse Loop_up to Loop_down only in cases when other consumers of Loop_up are after Loop_down
     // Because Loop_up should be explicitly moved before Loop_down in linear IR, and we must save control dependency
@@ -117,40 +103,19 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::Loo
     if (!is_fusion_allowed)
         return false;
 
-    // Update entry and exit points in current Loop information before moving till Loop iterators are valid
-    auto current_entry_points = loop_current->entry_points;
-    auto current_exit_points = loop_current->exit_points;
-    auto target_entry_points = loop_target->entry_points;
-    auto target_exit_points = loop_target->exit_points;
-    fuse_points(target_exit_points, current_entry_points, target_loop_begin_pos, target_loop_end_pos);
-
-    const auto insertion_place = current_loop_begin_pos;
-    const auto is_move_needed = target_loop_end_pos != current_loop_begin_pos;
-    for (auto it = target_loop_begin_pos; it != target_loop_end_pos;) {
-        auto expr_it = it;
-        const auto& expr = *expr_it;
-        // After moving we will have `it` in new place in the current Loop,
-        // but for markup we need have the expression from the target Loop.
-        // Because of that we manually increment iterator before moving
-        it = std::next(it);
-        loop_manager->replace_loop_id(expr, target_loop_id, current_loop_id);
-        if (is_move_needed)
-            linear_ir.move(expr_it, insertion_place);
-    }
-
-    // Update current Loop bounds:
-    current_loop_begin_pos = target_loop_begin_pos;
-
+    LinearIR::constExprIt target_loop_begin_pos, target_loop_end_pos;
+    loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
+    loop_manager->fuse_loops(target_loop_id, current_loop_id, target_loop_begin_pos, target_loop_end_pos, false);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
     loop_current->work_amount = std::max(loop_current->work_amount, loop_target->work_amount);
 
-    std::vector<LoopManager::LoopPort> new_entries = target_entry_points;
-    new_entries.insert(new_entries.end(), current_entry_points.begin(), current_entry_points.end());
-    std::vector<LoopManager::LoopPort> new_exits = target_exit_points;
-    new_exits.insert(new_exits.end(), current_exit_points.begin(), current_exit_points.end());
+    const auto insertion_place = current_loop_begin_pos;
+    const auto is_move_needed = target_loop_end_pos != current_loop_begin_pos;
+    if (is_move_needed)
+        move(linear_ir, loop_manager, current_loop_id, target_loop_begin_pos, target_loop_end_pos, insertion_place);
 
-    loop_current->entry_points = new_entries;
-    loop_current->exit_points = new_exits;
+    // Update current Loop bounds:
+    current_loop_begin_pos = target_loop_begin_pos;
 
     return true;
 }
@@ -182,43 +147,17 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::Loo
 
     LinearIR::constExprIt target_loop_begin_pos, target_loop_end_pos;
     loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
-
-    // Update entry and exit points in current Loop information before moving till Loop iterators are valid
-    auto current_entry_points = loop_current->entry_points;
-    auto current_exit_points = loop_current->exit_points;
-    auto target_entry_points = loop_target->entry_points;
-    auto target_exit_points = loop_target->exit_points;
-    fuse_points(current_exit_points, target_entry_points, current_loop_begin_pos, current_loop_end_pos);
-
-    const auto insertion_place = current_loop_end_pos;
-    const auto is_move_needed = insertion_place != target_loop_begin_pos;
-    for (auto it = target_loop_begin_pos; it != target_loop_end_pos;) {
-        auto expr_it = it;
-        const auto& expr = *expr_it;
-        // After moving we will have `it` in new place in the current Loop,
-        // but for markup we need have the expression from the target Loop.
-        // Because of that we manually increment iterator before moving
-        it = std::next(it);
-        loop_manager->replace_loop_id(expr, target_loop_id, current_loop_id);
-        if (is_move_needed)
-            linear_ir.move(expr_it, insertion_place);
-    }
-
-    // Update current Loop bounds:
-    if (!is_move_needed)
-        current_loop_end_pos = target_loop_end_pos;
-
+    loop_manager->fuse_loops(current_loop_id, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
     loop_current->work_amount = std::max(loop_current->work_amount, loop_target->work_amount);
 
-    std::vector<LoopManager::LoopPort>& new_entries = current_entry_points;
-    new_entries.insert(new_entries.end(), target_entry_points.begin(), target_entry_points.end());
-    std::vector<LoopManager::LoopPort>& new_exits = current_exit_points;
-    new_exits.insert(new_exits.end(), target_exit_points.begin(), target_exit_points.end());
-
-    loop_current->entry_points = new_entries;
-    loop_current->exit_points = new_exits;
-
+    const auto insertion_place = current_loop_end_pos;
+    const auto is_move_needed = insertion_place != target_loop_begin_pos;
+    if (is_move_needed) {
+        move(linear_ir, loop_manager, current_loop_id, target_loop_begin_pos, target_loop_end_pos, insertion_place);
+    } else {
+        current_loop_end_pos = target_loop_end_pos;
+    }
     return true;
 }
 
@@ -292,7 +231,6 @@ bool FuseLoops::run(LinearIR& linear_ir) {
                     if (fuse_upper_into_current(linear_ir, loop_manager, entry_point.expr_port, current_loop_id, upper_loop_id,
                                                 current_loop_begin_pos, current_loop_end_pos)) {
                         was_fusion_up = true;
-                        loop_manager->remove_loop_info(upper_loop_id);
                         prev_fused_loops.insert(current_loop_id);
                     }
                 }
@@ -339,7 +277,6 @@ bool FuseLoops::run(LinearIR& linear_ir) {
                         if (fuse_lower_into_current(linear_ir, loop_manager, exit_point.expr_port, current_loop_id, lower_loop_id,
                                                     current_loop_begin_pos, current_loop_end_pos)) {
                             was_fusion_down = true;
-                            loop_manager->remove_loop_info(lower_loop_id);
                             prev_fused_loops.insert(current_loop_id);
                             // Need to check for possible fusion again because of new input expressions for Loop
                             break;

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -19,24 +19,6 @@ using LoopInfoPtr = LoopManager::LoopInfoPtr;
 
 InsertLoadStore::InsertLoadStore(size_t vector_size) : m_vector_size(vector_size) {}
 
-void InsertLoadStore::update_loops(const LinearIR::LoopManagerPtr& loop_manager, const std::vector<size_t>& loop_ids,
-                                   const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports, bool is_entry) {
-    for (auto loop_id : loop_ids) {
-        update_loop(loop_manager->get_loop_info(loop_id), actual_port, target_ports, is_entry);
-    }
-}
-
-void InsertLoadStore::update_loop(const LinearIR::LoopManager::LoopInfoPtr& loop_info,
-                                  const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports, bool is_entry) {
-    auto& ports = is_entry ? loop_info->entry_points : loop_info->exit_points;
-    auto port_it = std::find_if(ports.begin(), ports.end(),
-                                [&actual_port](const LoopManager::LoopPort& point) { return *point.expr_port.get() == actual_port; });
-    if (port_it == ports.end())
-        return;
-    port_it = ports.erase(port_it);
-    ports.insert(port_it, target_ports.cbegin(), target_ports.cend());
-}
-
 size_t InsertLoadStore::get_count(const PortDescriptorPtr& port_desc) const {
     const auto layout = port_desc->get_layout();
     const auto shape = port_desc->get_shape();
@@ -75,7 +57,7 @@ bool InsertLoadStore::insert_load(LinearIR& linear_ir, const LinearIR::constExpr
         // Need to update all the corresponding Loops with the same Entry Point
         const auto prev_entry_point = consumer_input;
         const auto new_entry_point = load_expr->get_input_port(0);
-        update_loops(loop_manager, loop_ids, prev_entry_point, {new_entry_point}, true);
+        loop_manager->update_loops_port(loop_ids, prev_entry_point, {new_entry_point}, true);
         was_inserted = true;
     }
 
@@ -122,7 +104,7 @@ bool InsertLoadStore::insert_store(LinearIR& linear_ir, const LinearIR::constExp
     const auto new_exit_point = store_expr->get_output_port(0);
     const auto new_exit_points = should_be_saved ? std::vector<ExpressionPort>{prev_exit_point, new_exit_point}
                                                  : std::vector<ExpressionPort>{new_exit_point};
-    update_loops(loop_manager, loop_ids, prev_exit_point, new_exit_points, false);
+    loop_manager->update_loops_port(loop_ids, prev_exit_point, new_exit_points, false);
     return true;
 }
 


### PR DESCRIPTION
### Details:
 - *Hided all methods with explicit `Loop ID` work inside private section of `LoopManager`*
 - *Added methods `update_loop_ports`*
 - *Added methods `fuse_loops` that unite two `LoopInfo` into one and mark expression by new `Loop ID`*
 - *Added method `expression_replacement`. The method should be removed after `Softmax Decomposition` refactoring (moving to data flow)*
 - *Fixed `FuseLoops` pass. Inner Loops can contain ports which are ports of outer Loops as well. When we fuse and move these inner loops, we can corrupt the sort of LoopPorts of outer Loops. Because of that we have to sort outer Loop ports if we moved loops*

### Tickets:
 - *112195*
