### PR TITLE
[GPU] Fix in-order queue synchronization issue related to OCL/OneDNN impls interaction with CPU impls

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/common/wait_for_events.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/wait_for_events.cpp
@@ -40,7 +40,9 @@ public:
 
     event::ptr execute(const std::vector<event::ptr>& events, primitive_inst& instance) override {
         auto& stream = instance.get_network().get_stream();
-        return stream.enqueue_marker(events);
+
+        return events.empty() ? stream.create_user_event(true)
+                              : stream.enqueue_marker(events);
     }
 
     static std::unique_ptr<primitive_impl> create_data(const data_node& data, const kernel_impl_params&) {

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -230,7 +230,7 @@ public:
     bool is_dynamic() const { return _is_dynamic; }
     bool can_share_buffer() const { return _can_share_buffer; }
     bool is_constant() const { return _is_constant; }
-    bool is_output_event() const { return _is_output_event; }
+    bool needs_completion_event() const { return _needs_completion_event; }
     bool has_unfused_subgraph() const { return (_unfused_subgraph != nullptr); }
 
     void allocate_internal_buffers();
@@ -330,7 +330,7 @@ protected:
     bool _can_be_optimized = false;
     bool _can_share_buffer = true;
     bool _is_constant = false;
-    bool _is_output_event = false;
+    bool _needs_completion_event = false;
 
     size_t max_output_layout_size = 0;
     std::vector<size_t> max_intermediates_memory_sizes;

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -1396,8 +1396,11 @@ void network::execute_primitive(const std::shared_ptr<primitive_inst>& primitive
                                 const std::vector<event::ptr>& events) {
     event::ptr ev = primitive->execute(events);
 
-    // Collect events only for OOO queue and Profiling mode
-    if (get_stream().get_queue_type() == QueueTypes::out_of_order || _enable_profiling) {
+    // Collect events under any of the following conditions:
+    // 1) OOO queue execution
+    // 2) Profiling mode is enabled
+    // 3) Primitive has CPU user or primitive is output
+    if (get_stream().get_queue_type() == QueueTypes::out_of_order || _enable_profiling || primitive->needs_completion_event()) {
         auto id = primitive->id();
         _events.insert({id, ev});
     }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -322,8 +322,13 @@ void ocl_stream::enqueue_barrier() {
 }
 
 event::ptr ocl_stream::enqueue_marker(std::vector<event::ptr> const& deps, bool is_output) {
-    if (deps.empty())
-        return std::make_shared<ocl_user_event>(_engine.get_cl_context(), true);
+    // Wait for all previously enqueued tasks if deps list is empty
+    if (deps.empty()) {
+        cl::Event ret_ev;
+        _command_queue.enqueueMarkerWithWaitList(nullptr, &ret_ev);
+
+        return std::make_shared<ocl_event>(ret_ev);
+    }
 
     if (sync_method == sync_methods::events) {
         cl::Event ret_ev;

--- a/src/plugins/intel_gpu/tests/unit/module_tests/network_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/network_test.cpp
@@ -7,8 +7,13 @@
 #include "intel_gpu/graph/network.hpp"
 #include "intel_gpu/primitives/input_layout.hpp"
 #include "intel_gpu/primitives/data.hpp"
+#include "intel_gpu/primitives/activation.hpp"
 #include "intel_gpu/primitives/broadcast.hpp"
 #include "intel_gpu/primitives/concatenation.hpp"
+#include "intel_gpu/primitives/reorder.hpp"
+#include "intel_gpu/primitives/reshape.hpp"
+
+#include "runtime/ocl/ocl_event.hpp"
 
 #include <memory>
 
@@ -60,3 +65,147 @@ TEST(network_test, model_with_dynamic_input_is_dynamic) {
 
     ASSERT_TRUE(net.is_dynamic());
 }
+
+TEST(network_test, has_proper_event_for_in_order_queue) {
+    auto& engine = get_test_engine();
+    layout in_layout{{1, 2, 2, 4}, data_types::f32, format::bfyx};
+    auto input_mem = engine.allocate_memory(in_layout);
+    auto const_mem = engine.allocate_memory({{1, 2, 2, 4}, data_types::f32, format::bfyx});
+
+    topology topology;
+    topology.add(input_layout("input1", in_layout));
+    topology.add(data("input2", const_mem));
+    topology.add(activation("activation1", input_info("input1"), activation_func::clamp, {-10.f, 10.f}));
+    topology.add(concatenation("concat", { input_info("activation1"), input_info("input2") }, 1));
+    topology.add(reorder("reorder", input_info("concat"), in_layout));
+    topology.add(activation("activation2", input_info("concat"), activation_func::relu));
+
+    auto impl_desc = ov::intel_gpu::ImplementationDesc{format::bfyx, "", impl_types::cpu};
+    auto impl_forcing_map = ov::intel_gpu::ImplForcingMap{{"activation2", impl_desc}};
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::force_implementations(impl_forcing_map));
+
+    network net(engine, topology, config);
+
+    net.set_input_data("input1", input_mem);
+    net.execute();
+
+    ASSERT_FALSE(net.has_event("activation1"));
+    ASSERT_TRUE(net.has_event("concat"));
+    ASSERT_TRUE(net.has_event("reorder"));
+    ASSERT_TRUE(net.has_event("activation2"));
+
+    auto concat_ev = net.get_primitive_event("concat");
+    auto reorder_ev = net.get_primitive_event("reorder");
+    auto activation_ev = net.get_primitive_event("activation2");
+
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(concat_ev.get()));
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(reorder_ev.get()));
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(activation_ev.get()));
+
+    // Check if we have real underlying OpenCL events
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(concat_ev.get())->get().get() != nullptr);
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(reorder_ev.get())->get().get() != nullptr);
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(activation_ev.get())->get().get() != nullptr);
+}
+
+TEST(network_test, has_proper_event_for_in_order_queue_optimized_out) {
+    auto& engine = get_test_engine();
+    layout in_layout{{1, 2, 2, 4}, data_types::f32, format::bfyx};
+    auto input_mem = engine.allocate_memory(in_layout);
+    auto const_mem = engine.allocate_memory({{1, 2, 2, 4}, data_types::f32, format::bfyx});
+
+    topology topology;
+    topology.add(input_layout("input1", in_layout));
+    topology.add(data("input2", const_mem));
+    topology.add(concatenation("concat", { input_info("input1"), input_info("input2") }, 1));
+    topology.add(reshape("reshape", input_info("concat"), false, {1, 2, 4, 4}, {1, 2, 4, 4}));
+    topology.add(reorder("reorder", input_info("reshape"), in_layout));
+    topology.add(activation("activation", input_info("reshape"), activation_func::relu));
+
+    auto impl_desc = ov::intel_gpu::ImplementationDesc{format::bfyx, "", impl_types::cpu};
+    auto impl_forcing_map = ov::intel_gpu::ImplForcingMap{{"activation", impl_desc}};
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::force_implementations(impl_forcing_map));
+
+    network net(engine, topology, config);
+
+    net.set_input_data("input1", input_mem);
+    net.execute();
+
+    ASSERT_TRUE(net.has_event("concat"));
+    ASSERT_TRUE(net.has_event("reshape"));
+    ASSERT_TRUE(net.has_event("reorder"));
+    ASSERT_TRUE(net.has_event("activation"));
+
+    auto concat_ev = net.get_primitive_event("concat");
+    auto reshape_ev = net.get_primitive_event("reshape");
+    auto reorder_ev = net.get_primitive_event("reorder");
+    auto activation_ev = net.get_primitive_event("activation");
+
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(concat_ev.get()));
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(reshape_ev.get()));
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(reorder_ev.get()));
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(activation_ev.get()));
+
+    // Check if we have real underlying OpenCL events
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(concat_ev.get())->get().get() != nullptr);
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(reshape_ev.get())->get().get() != nullptr);
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(reorder_ev.get())->get().get() != nullptr);
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(activation_ev.get())->get().get() != nullptr);
+}
+
+#ifdef ENABLE_ONEDNN_FOR_GPU
+TEST(network_test, has_proper_event_for_in_order_queue_onednn) {
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    layout in_layout{{1, 16, 2, 4}, data_types::f32, format::bfyx};
+    auto input_mem = engine.allocate_memory(in_layout);
+    auto weights = engine.allocate_memory({{16, 16, 1, 1}, data_types::f32, format::bfyx});
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights));
+    topology.add(convolution("conv", input_info("input"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(activation("activation", input_info("conv"), activation_func::relu));
+    topology.add(reorder("reorder", input_info("conv"), in_layout));
+
+    auto impl_desc_cpu = ov::intel_gpu::ImplementationDesc{format::bfyx, "", impl_types::cpu};
+    auto impl_desc_onednn = ov::intel_gpu::ImplementationDesc{format::bfyx, "", impl_types::onednn};
+    auto impl_forcing_map = ov::intel_gpu::ImplForcingMap{{"conv", impl_desc_onednn}, {"activation", impl_desc_cpu}};
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::force_implementations(impl_forcing_map));
+
+    network net(engine, topology, config);
+    net.set_input_data("input", input_mem);
+    net.execute();
+
+    ASSERT_TRUE(net.has_event("conv"));
+    ASSERT_TRUE(net.has_event("reorder"));
+    ASSERT_TRUE(net.has_event("activation"));
+
+    auto conv_ev = net.get_primitive_event("conv");
+    auto reorder_ev = net.get_primitive_event("reorder");
+    auto activation_ev = net.get_primitive_event("activation");
+
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(conv_ev.get()));
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(reorder_ev.get()));
+    ASSERT_NO_THROW(downcast<ocl::ocl_base_event>(activation_ev.get()));
+
+    // Check if we have real underlying OpenCL events
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(conv_ev.get())->get().get() != nullptr);
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(reorder_ev.get())->get().get() != nullptr);
+    ASSERT_TRUE(downcast<ocl::ocl_base_event>(activation_ev.get())->get().get() != nullptr);
+}
+#endif


### PR DESCRIPTION
### Details:
 - Aligned behavior of `ocl_stream::enqueue_marker()` method with OpenCL specification (marker with empty dependencies vector waits for all previous tasks in the queue)
 - Fixed events collection in `network::execute_primitive()` method. Previously we stored events only for OOO queue and profiling mode, despite the fact that we need events for synchronization between GPU and CPU impls in in-order queue
 - Added dependency events preparation in `primitive_inst::execute()` method for CPU implementations and optimized out implementation if it has CPU users (previously it was done only for OOO queue)
 - Return marker from `onednn_primitive::execute()` method if the next operation require synchronization
 - Related tests added
 
### Tickets:
 - *ticket-id*
