### PR TITLE
[Snippets] Precision propagation: INT32 enabling

### DIFF
--- a/src/common/snippets/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/src/pass/collapse_subgraph.cpp
@@ -227,7 +227,7 @@ auto get_num_result_children(const std::shared_ptr<const Node> &node) -> size_t 
 } // namespace
 
 const std::set<ov::element::Type> ov::snippets::pass::TokenizeSnippets::supported_element_types =
-        { ov::element::f32, ov::element::bf16, ov::element::i8, ov::element::u8 };
+        { ov::element::f32, ov::element::bf16, ov::element::i8, ov::element::u8, ov::element::i32, ov::element::u32 };
 
 bool TokenizeSnippets::AppropriateForSubgraph(const std::shared_ptr<const Node> &node) {
     return

--- a/src/common/snippets/tests/src/pass/precision_propagation.cpp
+++ b/src/common/snippets/tests/src/pass/precision_propagation.cpp
@@ -97,9 +97,12 @@ TEST_P(PrecisionPropagationTest, CompareFunctions) {
         test_values.actual.op1_supported_precisions,
         test_values.actual.op2_supported_precisions);
 
+    manager.register_pass<ngraph::pass::VisualizeTree>("svg/test.original.svg");
     manager.register_pass<ov::snippets::pass::PropagatePrecision>(target_machine);
+    manager.register_pass<ngraph::pass::VisualizeTree>("svg/test.transformed.svg");
 
     function_ref = function_stub.getReference();
+    ngraph::pass::VisualizeTree("svg/test.reference.svg").run_on_model(function_ref);
 }
 
 namespace PrecisionPropagationTestInstantiation {
@@ -169,6 +172,22 @@ std::vector<PrecisionPropagationParamsValues> test_cases {
             {element::i8},
             {element::i32, element::i32},
             {element::i8}
+        }
+    },
+    {
+        {element::i32, element::i32, element::i32},
+        {
+            {},
+            {},
+            {},
+            {{element::i32, element::i32}},
+            {{element::i32, element::i32}}
+        },
+        {
+            {},
+            {element::i32},
+            {element::i32, element::i32},
+            {element::i32}
         }
     },
     {


### PR DESCRIPTION
### Details:
 - *INT32 precision enabling for snippets*

### Tickets:
 - *CVS-105804*
