### PR TITLE
Allow weight sharing across NUMA nodes inside one socket

### DIFF
--- a/src/plugins/intel_cpu/src/exec_network.cpp
+++ b/src/plugins/intel_cpu/src/exec_network.cpp
@@ -161,11 +161,11 @@ ExecNetwork::ExecNetwork(const InferenceEngine::CNNNetwork &network,
 
 ExecNetwork::GraphGuard::Lock ExecNetwork::GetGraph() const {
     int streamId = 0;
-    int numaNodeId = 0;
+    int socketId = 0;
     auto streamsExecutor = dynamic_cast<InferenceEngine::IStreamsExecutor*>(_taskExecutor.get());
     if (nullptr != streamsExecutor) {
         streamId = streamsExecutor->GetStreamId();
-        numaNodeId = streamsExecutor->GetNumaNodeId();
+        socketId = streamsExecutor->GetSocketId();
     }
     auto graphLock = GraphGuard::Lock(_graphs[streamId % _graphs.size()]);
     if (!graphLock._graph.IsReady()) {
@@ -177,7 +177,7 @@ ExecNetwork::GraphGuard::Lock ExecNetwork::GetGraph() const {
                     std::lock_guard<std::mutex> lock{*_mutex.get()};
                     // disable weights caching if graph was created only once
                     auto weightsCache =
-                        _cfg.streamExecutorConfig._streams != 1 ? _numaNodesWeights[numaNodeId] : nullptr;
+                        _cfg.streamExecutorConfig._streams != 1 ? _socketWeights[socketId] : nullptr;
 
                     auto isQuantizedFlag =
                         (_cfg.lpTransformsMode == Config::On) &&

--- a/src/plugins/intel_cpu/src/exec_network.cpp
+++ b/src/plugins/intel_cpu/src/exec_network.cpp
@@ -176,8 +176,9 @@ ExecNetwork::GraphGuard::Lock ExecNetwork::GetGraph() const {
                 {
                     std::lock_guard<std::mutex> lock{*_mutex.get()};
                     // disable weights caching if graph was created only once
+                    // "socketId != -1" is the WA for MacOS, will remove later
                     auto weightsCache =
-                        _cfg.streamExecutorConfig._streams != 1 ? _socketWeights[socketId] : nullptr;
+                        (_cfg.streamExecutorConfig._streams != 1 && socketId != -1) ? _socketWeights[socketId] : nullptr;
 
                     auto isQuantizedFlag =
                         (_cfg.lpTransformsMode == Config::On) &&

--- a/src/plugins/intel_cpu/src/exec_network.h
+++ b/src/plugins/intel_cpu/src/exec_network.h
@@ -68,7 +68,7 @@ protected:
 
     // WARNING: Do not use _graphs directly.
     mutable std::deque<GraphGuard>              _graphs;
-    mutable NumaNodesWeights                    _numaNodesWeights;
+    mutable SocketsWeights                      _socketWeights;
 
     /* WARNING: Use GetGraph() function to get access to graph in current stream.
      * NOTE: Main thread is interpreted as master thread of external stream so use this function to get access to graphs

--- a/src/plugins/intel_cpu/src/weights_cache.cpp
+++ b/src/plugins/intel_cpu/src/weights_cache.cpp
@@ -71,22 +71,23 @@ WeightsSharing::SharedMemory::Ptr WeightsSharing::get(const std::string& key) co
                                                 : std::unique_lock<std::mutex>(ptr->guard), ptr, newPtr);
 }
 
-NumaNodesWeights::NumaNodesWeights() {
-    for (auto numa_id : InferenceEngine::getAvailableNUMANodes())
-        _cache_map[numa_id] = std::make_shared<WeightsSharing>();
+SocketsWeights::SocketsWeights() {
+    int num_sockets = get_num_numa_nodes();
+    for (int socket_id = 0; socket_id < num_sockets; socket_id++)
+         _cache_map[socket_id] = std::make_shared<WeightsSharing>();
 }
 
-WeightsSharing::Ptr& NumaNodesWeights::operator[](int numa_id) {
-    auto found = _cache_map.find(numa_id);
+WeightsSharing::Ptr& SocketsWeights::operator[](int socket_id) {
+    auto found = _cache_map.find(socket_id);
     if (found == _cache_map.end())
-        IE_THROW() << "Unknown numa node id " << numa_id;
+        IE_THROW() << "Unknown socket id " << socket_id;
     return found->second;
 }
 
-const WeightsSharing::Ptr& NumaNodesWeights::operator[](int numa_id) const {
-    auto found = _cache_map.find(numa_id);
+const WeightsSharing::Ptr& SocketsWeights::operator[](int socket_id) const {
+    auto found = _cache_map.find(socket_id);
     if (found == _cache_map.end())
-        IE_THROW() << "Unknown numa node id " << numa_id;
+        IE_THROW() << "Unknown socket id " << socket_id;
     return found->second;
 }
 

--- a/src/plugins/intel_cpu/src/weights_cache.cpp
+++ b/src/plugins/intel_cpu/src/weights_cache.cpp
@@ -72,7 +72,7 @@ WeightsSharing::SharedMemory::Ptr WeightsSharing::get(const std::string& key) co
 }
 
 SocketsWeights::SocketsWeights() {
-    int num_sockets = get_num_numa_nodes();
+    int num_sockets = get_num_sockets();
     for (int socket_id = 0; socket_id < num_sockets; socket_id++)
          _cache_map[socket_id] = std::make_shared<WeightsSharing>();
 }

--- a/src/plugins/intel_cpu/src/weights_cache.hpp
+++ b/src/plugins/intel_cpu/src/weights_cache.hpp
@@ -103,13 +103,13 @@ protected:
 };
 
 /**
- * Collection of memory caching store per NUMA node(former socket)
+ * Collection of memory caching store per socket
  *
  * Is a thread safe
  */
-class NumaNodesWeights {
+class SocketsWeights {
 public:
-    NumaNodesWeights();
+    SocketsWeights();
 
     WeightsSharing::Ptr& operator[](int i);
     const WeightsSharing::Ptr& operator[](int i) const;


### PR DESCRIPTION
### Details:
 - *Current OpenVINO weight sharing mechanism only shares weight inside NUMA Node, each NUMA Node has one copy of weight. It's not always efficient in a system with SNC enabled. This PR put only one copy of weight in one Socket, the NUMA nodes inside the Socket can share weight*
 - *...*

### Tickets:
 - CVS-113069
 - Closes https://github.com/openvinotoolkit/openvino/issues/17942
