### PR TITLE
[GPU] Support FC 6d output by compressing as 4d in kernel

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -158,9 +158,9 @@ std::vector<layout> fully_connected_inst::calc_output_layouts(fully_connected_no
     ov::op::v0::shape_infer(&op, input_shapes, output_shapes);
 
     bool is_static = input_layout.is_static() && weights_layout.is_static();
-
-    format::type output_format = is_static ? get_preferred_format(node, impl_param) :
-                                             input_layout.format.value;
+    bool allow_new_shape_infer = impl_param.get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+    format::type output_format = is_static && !allow_new_shape_infer ? get_preferred_format(node, impl_param) :
+                                              input_layout.format.value;
 
     return { layout{output_shapes[0], output_type, output_format} };
 }

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1727,6 +1727,15 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         if (use_onednn_impls) {
             expected = node.get_preferred_output_fmt();
         }
+
+        if (!allow_new_shape_infer && node.is_type<fully_connected>()) {
+            auto& fc_node = node.as<fully_connected>();
+            auto input_layout = fc_node.input().get_output_layout();
+            if (input_layout.format.dimension() > 4) {
+                expected = format::bfyx;
+                node.set_preferred_input_fmt(0, format::bfyx);
+            }
+        }
     }
 
     if (allow_new_shape_infer && node.get_preferred_input_fmt() != format::any) {


### PR DESCRIPTION
### Details:
 - *FC kernel supports only 4d input/output for dynamic case, so compress the shape 6d/5d to 4d for fc kernel execution*

### Tickets:
 - *105930*
