### PR TITLE
[GNA] Fix for concat requantization problem

### DIFF
--- a/src/plugins/intel_gna/src/common/graph_utils.hpp
+++ b/src/plugins/intel_gna/src/common/graph_utils.hpp
@@ -202,6 +202,18 @@ inline bool is_pooling(const std::shared_ptr<ngraph::Node>& node) {
             std::dynamic_pointer_cast<ov::intel_gna::op::GNAMaxPool>(node) != nullptr);
 }
 
+inline bool is_concat(const std::shared_ptr<ngraph::Node>& node) {
+    return (std::dynamic_pointer_cast<ov::opset12::Concat>(node) != nullptr);
+}
+
+inline bool is_fake_quantize(const std::shared_ptr<ngraph::Node>& node) {
+    return (std::dynamic_pointer_cast<ov::opset12::FakeQuantize>(node) != nullptr);
+}
+
+inline bool is_read_value(const std::shared_ptr<ngraph::Node>& node) {
+    return (std::dynamic_pointer_cast<ov::opset12::ReadValue>(node) != nullptr);
+}
+
 template <typename T>
 inline bool is_Tbit_fq(const std::shared_ptr<ngraph::Node>& node) {
     auto fq_node = std::dynamic_pointer_cast<ngraph::opset9::FakeQuantize>(node);
@@ -275,8 +287,7 @@ inline bool is_interleaved(const std::shared_ptr<ov::Node>& node) {
 inline bool is_gna_precision_agnostic(std::shared_ptr<ngraph::Node> node) {
     return ((std::dynamic_pointer_cast<ngraph::opset9::VariadicSplit>(node) != nullptr) ||
             (std::dynamic_pointer_cast<ngraph::opset9::Split>(node) != nullptr) ||
-            (std::dynamic_pointer_cast<ngraph::opset9::Slice>(node) != nullptr) ||
-            (std::dynamic_pointer_cast<ngraph::opset9::Concat>(node) != nullptr) ||
+            (std::dynamic_pointer_cast<ngraph::opset9::Slice>(node) != nullptr) || is_concat(node) ||
             (std::dynamic_pointer_cast<ngraph::opset9::Reshape>(node) != nullptr) ||
             (std::dynamic_pointer_cast<ngraph::opset9::Squeeze>(node) != nullptr) ||
             (std::dynamic_pointer_cast<ngraph::opset9::Unsqueeze>(node) != nullptr) ||

--- a/src/plugins/intel_gna/src/gna_transformations_pipeline.cpp
+++ b/src/plugins/intel_gna/src/gna_transformations_pipeline.cpp
@@ -176,6 +176,7 @@ void TransformationsPipeline::apply(const std::shared_ptr<ov::Model>& model,
     manager.register_pass<ov::intel_gna::pass::MarkIdentityCandidates>(config.gnaFlags.input_low_precision);
     manager.register_pass<ov::intel_gna::pass::InsertIdentity>();
     manager.register_pass<ov::intel_gna::pass::IdentityCandidatesCleanup>();
+    manager.register_pass<ov::intel_gna::pass::InsertIdentityForPrecAgnosticConcatInput>();
     // Breaks fusing of layers before result
     manager.register_pass<ov::intel_gna::pass::BreakFusingOfOutputLayers>();
     if (!config.gnaFlags.sw_fp32 && !config.gnaFlags.uniformPwlDesign) {

--- a/src/plugins/intel_gna/src/transformations/insert_copy_layer.cpp
+++ b/src/plugins/intel_gna/src/transformations/insert_copy_layer.cpp
@@ -157,8 +157,7 @@ InsertCopyBeforeAssignLayer::InsertCopyBeforeAssignLayer() {
 
             // Crop -> Memory, Input -> Split -> Memory, Concat -> Memory
             if ((std::dynamic_pointer_cast<ngraph::op::CropIE>(current_node) && !is_crop_affined(current_node)) ||
-                std::dynamic_pointer_cast<ngraph::opset8::Concat>(current_node) ||
-                std::dynamic_pointer_cast<ngraph::opset8::Split>(current_node) ||
+                is_concat(current_node) || std::dynamic_pointer_cast<ngraph::opset8::Split>(current_node) ||
                 std::dynamic_pointer_cast<ngraph::opset8::VariadicSplit>(current_node)) {
                 insert_copy_layer_between(matched_node_input, node, i);
             }
@@ -281,7 +280,7 @@ bool HandleMultiConnectedLayerToConcatAndMemory::run_on_model(const std::shared_
                 for (const auto& child_info : children_info) {
                     auto child = std::get<1>(child_info);
 
-                    if (std::dynamic_pointer_cast<ngraph::opset8::Concat>(child)) {
+                    if (is_concat(child)) {
                         concat_nodes.push_back(child_info);
                     } else if (std::dynamic_pointer_cast<ngraph::op::ReadValueBase>(child) ||
                                std::dynamic_pointer_cast<ngraph::op::AssignBase>(child)) {

--- a/src/plugins/intel_gna/src/transformations/insert_identity_layer.hpp
+++ b/src/plugins/intel_gna/src/transformations/insert_identity_layer.hpp
@@ -70,6 +70,14 @@ public:
 
 /**
  * @brief Inserts identity for precision agnostic (or FQ) concat inputs
+ * Scale factor propagation requires unified scale factors for each Concat input.
+ * If some input does not contain any layer, which is capable of storing scale factors,
+ * additional layer must be introduced.
+ * InsertIdentityForPrecAgnosticConcatInput pass adds Identity layer, which
+ * is capable of storing scale factors, so the scale factors propagation can proceed.
+ * Note: Identity will be added to all affected inputs.
+ * Note: Algorighm does not depend on inputs order.
+ *
  * Example model:
  *
  *                         Parameter
@@ -80,11 +88,7 @@ public:
  *                  |
  *               Result
  *
- * For the above model, during scale factors propagation, when one Concat input
- * will be selected as a scale factors source, then algorithm will not be able to
- * apply the scale factors to the second Concat input and will throw exception.
- * InsertIdentityForPrecAgnosticConcatInput pass adds Identity layer, which
- * is capable of storing scale factors, so the scale factors propagation can proceed:
+ * After execution:
  *
  *                    Parameter
  *                        |
@@ -96,8 +100,6 @@ public:
  *                  |
  *               Result
  *
- * Note: Identity will be added to all affected inputs.
- * Note: Algorighm does not depend on inputs order.
  */
 class InsertIdentityForPrecAgnosticConcatInput : public ov::pass::ModelPass {
 public:

--- a/src/plugins/intel_gna/src/transformations/insert_identity_layer.hpp
+++ b/src/plugins/intel_gna/src/transformations/insert_identity_layer.hpp
@@ -68,6 +68,73 @@ public:
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 };
 
+/**
+ * @brief Inserts identity for precision agnostic (or FQ) concat inputs
+ * Example model:
+ *
+ *                      Parameter
+ *                          |
+ *   Functional      Prec-Agnostic or FQ
+ *              \       /
+ *               Concat
+ *                  |
+ *               Result
+ *
+ * For the above model, during scale factors propagation, when left Concat input
+ * will be selected as a scale factors source, then algorithm will not be able to
+ * apply the scale factors to the right Concat input and will throw exception.
+ * InsertIdentityForPrecAgnosticConcatInput pass adds Identity layer, which
+ * is capable of storing scale factors, so the scale factors propagation can proceed:
+ *
+ *                    Parameter
+ *                        |
+ *                  Prec-Agnostic or FQ
+ *                        |
+ *      Functional     Identity
+ *              \       /
+ *               Concat
+ *                  |
+ *               Result
+ */
+class InsertIdentityForPrecAgnosticConcatInput : public ov::pass::ModelPass {
+    /**
+     * @brief Check if FakeQuantize exists on any input
+     */
+    bool has_fq_on_any_input(const std::shared_ptr<ov::Node> concat_node);
+
+    /**
+     * @brief Check if at least two inputs are not identical
+     */
+    bool all_inputs_point_the_same_node(const std::shared_ptr<Node>& node);
+
+    /**
+     * @brief Return vector of nodes for Identity insertion
+     */
+    std::vector<std::shared_ptr<ov::Node>> get_nodes_for_identity_insertion(
+        const std::shared_ptr<ov::Node>& concat_node);
+
+    /**
+     * @brief Invokes Identity layer insertion after each node in vector
+     */
+    bool insert_identity_after_nodes(const std::vector<std::shared_ptr<ov::Node>>& nodes,
+                                     const std::shared_ptr<ov::Node>& next);
+
+    /**
+     * @brief Invoke Identity layer insertion in case the Concat input is unable
+     * to store scale factors
+     */
+    bool insert_identity_for_prec_agnostic_concat_inputs(const std::shared_ptr<ov::Node>& node);
+
+    /**
+     * @brief Find the output index of 'prev' layer, on which it is connected to 'next' layer
+     */
+    size_t find_prev_layer_output_index(std::shared_ptr<ov::Node> prev, std::shared_ptr<ov::Node> next);
+
+public:
+    OPENVINO_RTTI("InsertIdentityForPrecAgnosticConcatInput", "0");
+    bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
+};
+
 }  // namespace pass
 }  // namespace intel_gna
 }  // namespace ov

--- a/src/plugins/intel_gna/src/transformations/insert_identity_layer.hpp
+++ b/src/plugins/intel_gna/src/transformations/insert_identity_layer.hpp
@@ -123,6 +123,7 @@ private:
 
     /**
      * @brief Invokes Identity layer insertion after each node in vector
+     * returns true if any Identity layer was inserted
      */
     bool insert_identity_after_nodes(const std::vector<std::shared_ptr<ov::Node>>& nodes,
                                      const std::shared_ptr<ov::Node>& next);
@@ -130,13 +131,14 @@ private:
     /**
      * @brief Invoke Identity layer insertion in case the Concat input is unable
      * to store scale factors
+     * returns true if any Identity layer was inserted
      */
     bool insert_identity_for_prec_agnostic_concat_inputs(const std::shared_ptr<ov::Node>& node);
 
     /**
      * @brief Find the output index of 'prev' layer, on which it is connected to 'next' layer
      */
-    size_t find_prev_layer_output_index(std::shared_ptr<ov::Node> prev, std::shared_ptr<ov::Node> next);
+    size_t find_prev_layer_output_index(const std::shared_ptr<ov::Node>& prev, const std::shared_ptr<ov::Node>& next);
 };
 
 }  // namespace pass

--- a/src/plugins/intel_gna/tests/unit/transformations/gna_insert_identity_layer.cpp
+++ b/src/plugins/intel_gna/tests/unit/transformations/gna_insert_identity_layer.cpp
@@ -7,18 +7,29 @@
 #include <common_test_utils/ngraph_test_utils.hpp>
 #include <legacy/ngraph_ops/eltwise.hpp>
 #include <ngraph/function.hpp>
-#include <ngraph/opsets/opset7.hpp>
-#include <ngraph/opsets/opset9.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <ngraph_functions/builders.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
 
+#include "openvino/opsets/opset12.hpp"
+#include "openvino/opsets/opset7.hpp"
 #include "ops/identity.hpp"
 #include "transformations/insert_identity_layer.hpp"
 #include "transformations/rt_info/gna_precision_change_flag.hpp"
 
 namespace testing {
+
+using namespace ngraph::builder;
+using namespace ngraph::op;
+using namespace ov;
+using namespace ov::opset12;
+using namespace ov::pass;
+using namespace ov::intel_gna;
+using namespace ov::intel_gna::pass;
+using namespace ov::intel_gna::op;
+using namespace ov::element;
+using namespace std;
 
 class InsertIdentityLayerTest : public CommonTestUtils::TestsCommon {
 public:
@@ -26,17 +37,17 @@ public:
     virtual void Run();
 
 public:
-    std::shared_ptr<ngraph::Function> m_func, m_ref_func;
-    ngraph::Shape m_input_shape{10};
+    shared_ptr<Model> m_func, m_ref_func;
+    Shape m_input_shape{10};
     bool m_low_precision = false;
 };
 
 void InsertIdentityLayerTest::Validate() {
-    ngraph::pass::Manager m;
-    m.register_pass<ov::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_gna::pass::MarkIdentityCandidates>(m_low_precision);
-    m.register_pass<ov::intel_gna::pass::InsertIdentity>();
-    m.register_pass<ov::intel_gna::pass::BreakFusingOfOutputLayers>();
+    Manager m;
+    m.register_pass<InitNodeInfo>();
+    m.register_pass<MarkIdentityCandidates>(m_low_precision);
+    m.register_pass<InsertIdentity>();
+    m.register_pass<BreakFusingOfOutputLayers>();
     m.run_passes(m_func);
     ASSERT_NO_THROW(check_rt_info(m_func));
 
@@ -44,12 +55,12 @@ void InsertIdentityLayerTest::Validate() {
     ASSERT_TRUE(result.first);
 
     // Cleanup rt info and check
-    m.register_pass<ov::intel_gna::pass::IdentityCandidatesCleanup>();
+    m.register_pass<IdentityCandidatesCleanup>();
     m.run_passes(m_func);
     for (auto& node : m_func->get_ordered_ops()) {
         for (auto& input : node->inputs()) {
-            const ov::RTMap& rt_info = input.get_rt_info();
-            ASSERT_EQ(rt_info.count(ov::intel_gna::rt_info::GNAPrecisionChangeFlag::get_type_info_static()), 0);
+            const RTMap& rt_info = input.get_rt_info();
+            ASSERT_EQ(rt_info.count(rt_info::GNAPrecisionChangeFlag::get_type_info_static()), 0);
         }
     }
 }
@@ -62,19 +73,19 @@ void InsertIdentityLayerTest::Run() {
 /******************************************************* Concat layer tests
  * *******************************************************/
 
-typedef std::tuple<size_t,  // Concat axis
-                   size_t   // input number
-                   >
+typedef tuple<size_t,  // Concat axis
+              size_t   // input number
+              >
     InsertIdentityConcatTestParams;
 
 class InsertIdentityLayerConcatTest : public InsertIdentityLayerTest,
                                       public ::testing::WithParamInterface<InsertIdentityConcatTestParams> {
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<InsertIdentityConcatTestParams>& obj) {
+    static string getTestCaseName(const testing::TestParamInfo<InsertIdentityConcatTestParams>& obj) {
         size_t axis, inputs_num;
-        std::tie(axis, inputs_num) = obj.param;
+        tie(axis, inputs_num) = obj.param;
 
-        std::ostringstream result;
+        ostringstream result;
         result << "inputsNum=" << inputs_num << "_";
         result << "axis=" << axis;
 
@@ -82,46 +93,45 @@ public:
     }
     void SetUp() override {
         size_t axis, inputs_num;
-        std::tie(axis, inputs_num) = this->GetParam();
+        tie(axis, inputs_num) = this->GetParam();
 
         InsertIdentityLayerTest::SetUp();
         {
-            auto params = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
-            auto const_add = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto add = std::make_shared<ngraph::opset9::Add>(params, const_add);
-            ngraph::OutputVector concat_inputs = {add};
+            auto params = make_shared<Parameter>(f32, m_input_shape);
+            auto const_add = Constant::create(f32, m_input_shape, {1});
+            auto add = make_shared<Add>(params, const_add);
+            OutputVector concat_inputs = {add};
             for (size_t i = 1; i < inputs_num; ++i) {
-                auto const_mul = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {i});
-                auto mul = std::make_shared<ngraph::opset9::Multiply>(add, const_mul);
+                auto const_mul = Constant::create(f32, m_input_shape, {i});
+                auto mul = make_shared<Multiply>(add, const_mul);
                 concat_inputs.push_back(mul);
             }
-            auto concat = std::make_shared<ngraph::opset9::Concat>(concat_inputs, axis);
-            auto result = std::make_shared<ngraph::opset9::Result>(concat);
-            m_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{params});
+            auto concat = make_shared<Concat>(concat_inputs, axis);
+            auto result = make_shared<Result>(concat);
+            m_func = make_shared<Model>(ResultVector{result}, ParameterVector{params});
         }
 
         {
-            auto params = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
-            auto const_add = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto add = std::make_shared<ngraph::opset9::Add>(params, const_add);
-            auto identity = std::make_shared<ov::intel_gna::op::Identity>(add);
-            ngraph::OutputVector concat_inputs = {identity};
+            auto params = make_shared<Parameter>(f32, m_input_shape);
+            auto const_add = Constant::create(f32, m_input_shape, {1});
+            auto add = make_shared<Add>(params, const_add);
+            auto identity = make_shared<Identity>(add);
+            OutputVector concat_inputs = {identity};
             for (size_t i = 1; i < inputs_num; ++i) {
-                auto const_mul = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {i});
-                auto mul = std::make_shared<ngraph::opset9::Multiply>(identity, const_mul);
-                auto identity_mul = std::make_shared<ov::intel_gna::op::Identity>(mul);
+                auto const_mul = Constant::create(f32, m_input_shape, {i});
+                auto mul = make_shared<Multiply>(identity, const_mul);
+                auto identity_mul = make_shared<Identity>(mul);
                 concat_inputs.push_back(identity_mul);
             }
-            auto concat = std::make_shared<ngraph::opset9::Concat>(concat_inputs, axis);
-            auto result = std::make_shared<ngraph::opset9::Result>(concat);
-            m_ref_func =
-                std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{params});
+            auto concat = make_shared<Concat>(concat_inputs, axis);
+            auto result = make_shared<Result>(concat);
+            m_ref_func = make_shared<Model>(ResultVector{result}, ParameterVector{params});
         }
     }
 };
 
 const size_t axis = 0;
-const std::vector<size_t> inputCounts = {1, 8};
+const vector<size_t> inputCounts = {1, 8};
 
 TEST_P(InsertIdentityLayerConcatTest, CompareWithRefs) {
     Run();
@@ -140,36 +150,34 @@ public:
     void SetUp() override {
         InsertIdentityLayerTest::SetUp();
         {
-            auto params = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
-            auto const_add = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto add = std::make_shared<ngraph::opset9::Add>(params, const_add);
-            auto axis_const = ngraph::opset9::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0});
-            auto split = std::make_shared<ngraph::opset9::Split>(add, axis_const, 2);
-            auto result1 = std::make_shared<ngraph::opset9::Result>(split->output(0));
-            auto const_reshape = ngraph::opset9::Constant::create(ngraph::element::i64, {2}, {1, 5});
-            auto reshape = std::make_shared<ngraph::opset9::Reshape>(split->output(1), const_reshape, false);
-            auto const_mul = ngraph::opset9::Constant::create(ngraph::element::f32, {1, 5}, {1});
-            auto mul = std::make_shared<ngraph::opset9::Multiply>(reshape, const_mul);
-            auto result2 = std::make_shared<ngraph::opset9::Result>(mul);
-            m_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
-                                                        ngraph::ParameterVector{params});
+            auto params = make_shared<Parameter>(f32, m_input_shape);
+            auto const_add = Constant::create(f32, m_input_shape, {1});
+            auto add = make_shared<Add>(params, const_add);
+            auto axis_const = Constant::create(i64, Shape{}, {0});
+            auto split = make_shared<Split>(add, axis_const, 2);
+            auto result1 = make_shared<Result>(split->output(0));
+            auto const_reshape = Constant::create(i64, {2}, {1, 5});
+            auto reshape = make_shared<Reshape>(split->output(1), const_reshape, false);
+            auto const_mul = Constant::create(f32, {1, 5}, {1});
+            auto mul = make_shared<Multiply>(reshape, const_mul);
+            auto result2 = make_shared<Result>(mul);
+            m_func = make_shared<Model>(ResultVector{result1, result2}, ParameterVector{params});
         }
 
         {
-            auto params = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
-            auto const_add = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto add = std::make_shared<ngraph::opset9::Add>(params, const_add);
-            auto identity = std::make_shared<ov::intel_gna::op::Identity>(add);
-            auto axis_const = ngraph::opset9::Constant::create(ngraph::element::i64, ngraph::Shape{}, {0});
-            auto split = std::make_shared<ngraph::opset9::Split>(identity, axis_const, 2);
-            auto result1 = std::make_shared<ngraph::opset9::Result>(split->output(0));
-            auto const_reshape = ngraph::opset9::Constant::create(ngraph::element::i64, {2}, {1, 5});
-            auto reshape = std::make_shared<ngraph::opset9::Reshape>(split->output(1), const_reshape, false);
-            auto const_mul = ngraph::opset9::Constant::create(ngraph::element::f32, {1, 5}, {1});
-            auto mul = std::make_shared<ngraph::opset9::Multiply>(reshape, const_mul);
-            auto result2 = std::make_shared<ngraph::opset9::Result>(mul);
-            m_ref_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
-                                                            ngraph::ParameterVector{params});
+            auto params = make_shared<Parameter>(f32, m_input_shape);
+            auto const_add = Constant::create(f32, m_input_shape, {1});
+            auto add = make_shared<Add>(params, const_add);
+            auto identity = make_shared<Identity>(add);
+            auto axis_const = Constant::create(i64, Shape{}, {0});
+            auto split = make_shared<Split>(identity, axis_const, 2);
+            auto result1 = make_shared<Result>(split->output(0));
+            auto const_reshape = Constant::create(i64, {2}, {1, 5});
+            auto reshape = make_shared<Reshape>(split->output(1), const_reshape, false);
+            auto const_mul = Constant::create(f32, {1, 5}, {1});
+            auto mul = make_shared<Multiply>(reshape, const_mul);
+            auto result2 = make_shared<Result>(mul);
+            m_ref_func = make_shared<Model>(ResultVector{result1, result2}, ParameterVector{params});
         }
     }
 };
@@ -181,21 +189,21 @@ TEST_F(InsertIdentityLayerSplitTest, CompareWithRefs) {
 /******************************************************* Eltwise layer tests
  * *******************************************************/
 
-typedef std::tuple<ELTWISE_TYPE,  // eltwise type
-                   bool,          // use low precision input
-                   bool           // both 32bit inputs
-                   >
+typedef tuple<ELTWISE_TYPE,  // eltwise type
+              bool,          // use low precision input
+              bool           // both 32bit inputs
+              >
     InsertIdentityEltwiseTestParams;
 
 class InsertIdentityLayerEltwiseTest : public InsertIdentityLayerTest,
                                        public ::testing::WithParamInterface<InsertIdentityEltwiseTestParams> {
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<InsertIdentityEltwiseTestParams>& obj) {
+    static string getTestCaseName(const testing::TestParamInfo<InsertIdentityEltwiseTestParams>& obj) {
         ELTWISE_TYPE type;
         bool low_precision, both_inputs_32bits;
-        std::tie(type, low_precision, both_inputs_32bits) = obj.param;
+        tie(type, low_precision, both_inputs_32bits) = obj.param;
 
-        std::ostringstream result;
+        ostringstream result;
         result << "type=";
         switch (type) {
         case ELTWISE_TYPE::Sum:
@@ -215,71 +223,70 @@ public:
     void SetUp() override {
         ELTWISE_TYPE type;
         bool both_inputs_32bits;
-        std::tie(type, m_low_precision, both_inputs_32bits) = this->GetParam();
+        tie(type, m_low_precision, both_inputs_32bits) = this->GetParam();
 
         InsertIdentityLayerTest::SetUp();
         {
-            ngraph::ParameterVector params;
-            auto input1 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+            ParameterVector params;
+            auto input1 = make_shared<Parameter>(f32, m_input_shape);
             params.push_back(input1);
-            auto const_input1 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto eltwise1 = std::make_shared<ngraph::op::Eltwise>(input1, const_input1, type);
-            std::shared_ptr<ov::Node> second_input;
+            auto const_input1 = Constant::create(f32, m_input_shape, {1});
+            auto eltwise1 = make_shared<Eltwise>(input1, const_input1, type);
+            shared_ptr<Node> second_input;
 
             if (both_inputs_32bits) {
-                auto input2 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+                auto input2 = make_shared<Parameter>(f32, m_input_shape);
                 params.push_back(input2);
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-                auto eltwise2 = std::make_shared<ngraph::op::Eltwise>(input2, const_input2, type);
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
+                auto eltwise2 = make_shared<Eltwise>(input2, const_input2, type);
                 second_input = eltwise2;
             } else {
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
                 second_input = const_input2;
             }
 
-            auto eltwise3 = std::make_shared<ngraph::op::Eltwise>(eltwise1, second_input, type);
+            auto eltwise3 = make_shared<Eltwise>(eltwise1, second_input, type);
 
-            auto result = std::make_shared<ngraph::opset9::Result>(eltwise3);
-            m_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{params});
+            auto result = make_shared<Result>(eltwise3);
+            m_func = make_shared<Model>(ResultVector{result}, ParameterVector{params});
         }
 
         {
-            ngraph::ParameterVector params;
-            auto input1 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+            ParameterVector params;
+            auto input1 = make_shared<Parameter>(f32, m_input_shape);
             params.push_back(input1);
-            auto const_input1 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto eltwise1 = std::make_shared<ngraph::op::Eltwise>(input1, const_input1, type);
-            std::shared_ptr<ov::Node> first_input, second_input;
+            auto const_input1 = Constant::create(f32, m_input_shape, {1});
+            auto eltwise1 = make_shared<Eltwise>(input1, const_input1, type);
+            shared_ptr<Node> first_input, second_input;
             first_input = eltwise1;
 
             if (both_inputs_32bits) {
-                auto input2 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+                auto input2 = make_shared<Parameter>(f32, m_input_shape);
                 params.push_back(input2);
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-                auto eltwise2 = std::make_shared<ngraph::op::Eltwise>(input2, const_input2, type);
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
+                auto eltwise2 = make_shared<Eltwise>(input2, const_input2, type);
                 second_input = eltwise2;
             } else {
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
                 second_input = const_input2;
             }
 
             if (type == ELTWISE_TYPE::Sum && !m_low_precision && both_inputs_32bits) {
-                auto identity = std::make_shared<ov::intel_gna::op::Identity>(eltwise1);
+                auto identity = make_shared<Identity>(eltwise1);
                 first_input = identity;
             } else if (type == ELTWISE_TYPE::Prod || m_low_precision) {
-                auto identity = std::make_shared<ov::intel_gna::op::Identity>(eltwise1);
+                auto identity = make_shared<Identity>(eltwise1);
                 first_input = identity;
                 if (both_inputs_32bits) {
-                    auto identity = std::make_shared<ov::intel_gna::op::Identity>(eltwise1);
+                    auto identity = make_shared<Identity>(eltwise1);
                     second_input = identity;
                 }
             }
 
-            auto eltwise3 = std::make_shared<ngraph::op::Eltwise>(first_input, second_input, type);
+            auto eltwise3 = make_shared<Eltwise>(first_input, second_input, type);
 
-            auto result = std::make_shared<ngraph::opset9::Result>(eltwise3);
-            m_ref_func =
-                std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{params});
+            auto result = make_shared<Result>(eltwise3);
+            m_ref_func = make_shared<Model>(ResultVector{result}, ParameterVector{params});
         }
     }
 };
@@ -303,74 +310,72 @@ public:
     void SetUp() override {
         ELTWISE_TYPE type;
         bool both_inputs_32bits;
-        std::tie(type, m_low_precision, both_inputs_32bits) = this->GetParam();
+        tie(type, m_low_precision, both_inputs_32bits) = this->GetParam();
 
         InsertIdentityLayerTest::SetUp();
         {
-            ngraph::ParameterVector params;
-            auto input1 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+            ParameterVector params;
+            auto input1 = make_shared<Parameter>(f32, m_input_shape);
             params.push_back(input1);
-            auto const_input1 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto eltwise1 = std::make_shared<ngraph::op::Eltwise>(input1, const_input1, type);
-            std::shared_ptr<ov::Node> second_input;
+            auto const_input1 = Constant::create(f32, m_input_shape, {1});
+            auto eltwise1 = make_shared<Eltwise>(input1, const_input1, type);
+            shared_ptr<Node> second_input;
 
             if (both_inputs_32bits) {
-                auto input2 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+                auto input2 = make_shared<Parameter>(f32, m_input_shape);
                 params.push_back(input2);
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-                auto eltwise2 = std::make_shared<ngraph::op::Eltwise>(input2, const_input2, type);
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
+                auto eltwise2 = make_shared<Eltwise>(input2, const_input2, type);
                 second_input = eltwise2;
             } else {
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
                 second_input = const_input2;
             }
-            auto relu = std::make_shared<ngraph::opset9::Relu>(eltwise1);
-            auto eltwise3 = std::make_shared<ngraph::op::Eltwise>(eltwise1, second_input, type);
+            auto relu = make_shared<Relu>(eltwise1);
+            auto eltwise3 = make_shared<Eltwise>(eltwise1, second_input, type);
 
-            auto result1 = std::make_shared<ngraph::opset9::Result>(relu);
-            auto result2 = std::make_shared<ngraph::opset9::Result>(eltwise3);
-            m_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
-                                                        ngraph::ParameterVector{params});
+            auto result1 = make_shared<Result>(relu);
+            auto result2 = make_shared<Result>(eltwise3);
+            m_func = make_shared<Model>(ResultVector{result1, result2}, ParameterVector{params});
         }
 
         {
-            ngraph::ParameterVector params;
-            auto input1 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+            ParameterVector params;
+            auto input1 = make_shared<Parameter>(f32, m_input_shape);
             params.push_back(input1);
-            auto const_input1 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto eltwise1 = std::make_shared<ngraph::op::Eltwise>(input1, const_input1, type);
-            std::shared_ptr<ov::Node> first_input, second_input;
+            auto const_input1 = Constant::create(f32, m_input_shape, {1});
+            auto eltwise1 = make_shared<Eltwise>(input1, const_input1, type);
+            shared_ptr<Node> first_input, second_input;
             first_input = eltwise1;
 
             if (both_inputs_32bits) {
-                auto input2 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+                auto input2 = make_shared<Parameter>(f32, m_input_shape);
                 params.push_back(input2);
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-                auto eltwise2 = std::make_shared<ngraph::op::Eltwise>(input2, const_input2, type);
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
+                auto eltwise2 = make_shared<Eltwise>(input2, const_input2, type);
                 second_input = eltwise2;
             } else {
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
                 second_input = const_input2;
             }
 
             if (type == ELTWISE_TYPE::Sum && !m_low_precision && both_inputs_32bits) {
-                auto identity = std::make_shared<ov::intel_gna::op::Identity>(eltwise1);
+                auto identity = make_shared<Identity>(eltwise1);
                 first_input = identity;
             } else if (type == ELTWISE_TYPE::Prod || m_low_precision) {
-                auto identity = std::make_shared<ov::intel_gna::op::Identity>(eltwise1);
+                auto identity = make_shared<Identity>(eltwise1);
                 first_input = identity;
                 if (both_inputs_32bits) {
-                    auto identity = std::make_shared<ov::intel_gna::op::Identity>(eltwise1);
+                    auto identity = make_shared<Identity>(eltwise1);
                     second_input = identity;
                 }
             }
-            auto relu = std::make_shared<ngraph::opset9::Relu>(first_input);
-            auto eltwise3 = std::make_shared<ngraph::op::Eltwise>(first_input, second_input, type);
+            auto relu = make_shared<Relu>(first_input);
+            auto eltwise3 = make_shared<Eltwise>(first_input, second_input, type);
 
-            auto result1 = std::make_shared<ngraph::opset9::Result>(relu);
-            auto result2 = std::make_shared<ngraph::opset9::Result>(eltwise3);
-            m_ref_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
-                                                            ngraph::ParameterVector{params});
+            auto result1 = make_shared<Result>(relu);
+            auto result2 = make_shared<Result>(eltwise3);
+            m_ref_func = make_shared<Model>(ResultVector{result1, result2}, ParameterVector{params});
         }
     }
 };
@@ -394,55 +399,50 @@ public:
     void SetUp() override {
         ELTWISE_TYPE type;
         bool both_inputs_32bits;
-        std::tie(type, m_low_precision, both_inputs_32bits) = this->GetParam();
+        tie(type, m_low_precision, both_inputs_32bits) = this->GetParam();
 
         InsertIdentityLayerTest::SetUp();
 
-        auto add_fake_quantize = [&](const std::shared_ptr<ngraph::Node>& node) {
-            auto levels = (m_low_precision) ? std::numeric_limits<int8_t>::max() : std::numeric_limits<int16_t>::max();
-            auto input_low = ngraph::opset9::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {1});
-            auto input_high = ngraph::opset9::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {5});
-            auto output_low = ngraph::opset9::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0});
-            auto output_high = ngraph::opset9::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {10});
-            return std::make_shared<ngraph::opset9::FakeQuantize>(node,
-                                                                  input_low,
-                                                                  input_high,
-                                                                  output_low,
-                                                                  output_high,
-                                                                  levels);
+        auto add_fake_quantize = [&](const shared_ptr<Node>& node) {
+            auto levels = (m_low_precision) ? numeric_limits<int8_t>::max() : numeric_limits<int16_t>::max();
+            auto input_low = Constant::create(i64, Shape{1}, {1});
+            auto input_high = Constant::create(i64, Shape{1}, {5});
+            auto output_low = Constant::create(i64, Shape{1}, {0});
+            auto output_high = Constant::create(i64, Shape{1}, {10});
+            return make_shared<FakeQuantize>(node, input_low, input_high, output_low, output_high, levels);
         };
 
         {
-            ngraph::ParameterVector params;
-            auto input1 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+            ParameterVector params;
+            auto input1 = make_shared<Parameter>(f32, m_input_shape);
             params.push_back(input1);
             auto input1_fq = add_fake_quantize(input1);
-            auto const_input1 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
+            auto const_input1 = Constant::create(f32, m_input_shape, {1});
             auto const_input1_fq = add_fake_quantize(const_input1);
-            auto eltwise1 = std::make_shared<ngraph::op::Eltwise>(input1_fq, const_input1_fq, type);
+            auto eltwise1 = make_shared<Eltwise>(input1_fq, const_input1_fq, type);
             auto eltwise1_fq = add_fake_quantize(eltwise1);
-            std::shared_ptr<ov::Node> second_input;
+            shared_ptr<Node> second_input;
 
             if (both_inputs_32bits) {
-                auto input2 = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
+                auto input2 = make_shared<Parameter>(f32, m_input_shape);
                 params.push_back(input2);
                 auto input2_fq = add_fake_quantize(input2);
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
                 auto const_input2_fq = add_fake_quantize(const_input2);
-                auto eltwise2 = std::make_shared<ngraph::op::Eltwise>(input2_fq, const_input2_fq, type);
+                auto eltwise2 = make_shared<Eltwise>(input2_fq, const_input2_fq, type);
                 auto eltwise2_fq = add_fake_quantize(eltwise2);
                 second_input = eltwise2_fq;
             } else {
-                auto const_input2 = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
+                auto const_input2 = Constant::create(f32, m_input_shape, {1});
                 auto const_input2_fq = add_fake_quantize(const_input2);
                 second_input = const_input2_fq;
             }
 
-            auto eltwise3 = std::make_shared<ngraph::op::Eltwise>(eltwise1_fq, second_input, type);
+            auto eltwise3 = make_shared<Eltwise>(eltwise1_fq, second_input, type);
             auto eltwise3_fq = add_fake_quantize(eltwise3);
 
-            auto result = std::make_shared<ngraph::opset9::Result>(eltwise3_fq);
-            m_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{params});
+            auto result = make_shared<Result>(eltwise3_fq);
+            m_func = make_shared<Model>(ResultVector{result}, ParameterVector{params});
         }
 
         { m_ref_func = m_func->clone(); }
@@ -463,20 +463,20 @@ INSTANTIATE_TEST_SUITE_P(TransformationTests,
 /***************************************************** Convolution layer tests
  * *****************************************************/
 
-typedef std::tuple<bool,  // with pooling
-                   bool,  // with activation
-                   bool   // swap matmul input
-                   >
+typedef tuple<bool,  // with pooling
+              bool,  // with activation
+              bool   // swap matmul input
+              >
     InsertIdentityConvTestParams;
 
 class InsertIdentityLayerConvMatMulTest : public InsertIdentityLayerTest,
                                           public ::testing::WithParamInterface<InsertIdentityConvTestParams> {
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<InsertIdentityConvTestParams>& obj) {
+    static string getTestCaseName(const testing::TestParamInfo<InsertIdentityConvTestParams>& obj) {
         bool with_pool, with_act, swap_matmul;
-        std::tie(with_pool, with_act, swap_matmul) = obj.param;
+        tie(with_pool, with_act, swap_matmul) = obj.param;
 
-        std::ostringstream result;
+        ostringstream result;
         result << "with_pool=" << with_pool;
         result << "_with_act=" << with_act;
         result << "_swap_matmul=" << swap_matmul;
@@ -485,85 +485,74 @@ public:
     }
     void SetUp() override {
         bool with_pool, with_act, swap_matmul;
-        std::tie(with_pool, with_act, swap_matmul) = this->GetParam();
+        tie(with_pool, with_act, swap_matmul) = this->GetParam();
 
         InsertIdentityLayerTest::SetUp();
 
         m_input_shape = {1, 3, 1, 64};
-        auto reshape_shape = ngraph::Shape{3, 64};
+        auto reshape_shape = Shape{3, 64};
 
         {
-            std::shared_ptr<ov::Node> last_node;
-            auto input = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
-            auto weights = ngraph::opset9::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 2}, {1});
-            auto conv = std::make_shared<ngraph::opset9::Convolution>(input,
-                                                                      weights,
-                                                                      ngraph::Strides{1, 1},
-                                                                      ngraph::CoordinateDiff{0, 0},
-                                                                      ngraph::CoordinateDiff{0, 1},
-                                                                      ngraph::Strides{1, 1});
+            shared_ptr<Node> last_node;
+            auto input = make_shared<Parameter>(f32, m_input_shape);
+            auto weights = Constant::create(f32, Shape{3, 3, 1, 2}, {1});
+            auto conv = make_shared<Convolution>(input,
+                                                 weights,
+                                                 Strides{1, 1},
+                                                 CoordinateDiff{0, 0},
+                                                 CoordinateDiff{0, 1},
+                                                 Strides{1, 1});
             last_node = conv;
             if (with_pool) {
-                auto max_pool = std::make_shared<ngraph::opset7::MaxPool>(last_node,
-                                                                          ngraph::Strides{1, 1},
-                                                                          ngraph::Shape{0, 0},
-                                                                          ngraph::Shape{0, 1},
-                                                                          ngraph::Shape{1, 2});
+                auto max_pool =
+                    make_shared<opset7::MaxPool>(last_node, Strides{1, 1}, Shape{0, 0}, Shape{0, 1}, Shape{1, 2});
                 last_node = max_pool;
             }
             if (with_act) {
-                auto relu = std::make_shared<ngraph::opset9::Relu>(last_node);
+                auto relu = make_shared<Relu>(last_node);
                 last_node = relu;
             }
-            auto reshape_const = ngraph::opset9::Constant::create(ngraph::element::i64,
-                                                                  ngraph::Shape{reshape_shape.size()},
-                                                                  reshape_shape);
-            auto reshape = std::make_shared<ngraph::opset9::Reshape>(last_node, reshape_const, false);
-            auto matmul_const = ngraph::opset9::Constant::create(ngraph::element::f32, {64, 3}, {1.2});
-            auto matmul = swap_matmul ? std::make_shared<ngraph::opset9::MatMul>(matmul_const, reshape)
-                                      : std::make_shared<ngraph::opset9::MatMul>(reshape, matmul_const);
+            auto reshape_const = Constant::create(i64, Shape{reshape_shape.size()}, reshape_shape);
+            auto reshape = make_shared<Reshape>(last_node, reshape_const, false);
+            auto matmul_const = Constant::create(f32, {64, 3}, {1.2});
+            auto matmul =
+                swap_matmul ? make_shared<MatMul>(matmul_const, reshape) : make_shared<MatMul>(reshape, matmul_const);
 
-            auto result = std::make_shared<ngraph::opset9::Result>(matmul);
-            m_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{input});
+            auto result = make_shared<Result>(matmul);
+            m_func = make_shared<Model>(ResultVector{result}, ParameterVector{input});
         }
 
         {
-            std::shared_ptr<ov::Node> last_node;
-            auto input = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
-            auto weights = ngraph::opset9::Constant::create(ngraph::element::f32, ngraph::Shape{3, 3, 1, 2}, {1});
-            auto conv = std::make_shared<ngraph::opset9::Convolution>(input,
-                                                                      weights,
-                                                                      ngraph::Strides{1, 1},
-                                                                      ngraph::CoordinateDiff{0, 0},
-                                                                      ngraph::CoordinateDiff{0, 1},
-                                                                      ngraph::Strides{1, 1});
+            shared_ptr<Node> last_node;
+            auto input = make_shared<Parameter>(f32, m_input_shape);
+            auto weights = Constant::create(f32, Shape{3, 3, 1, 2}, {1});
+            auto conv = make_shared<Convolution>(input,
+                                                 weights,
+                                                 Strides{1, 1},
+                                                 CoordinateDiff{0, 0},
+                                                 CoordinateDiff{0, 1},
+                                                 Strides{1, 1});
             last_node = conv;
             if (with_pool) {
-                auto max_pool = std::make_shared<ngraph::opset7::MaxPool>(last_node,
-                                                                          ngraph::Strides{1, 1},
-                                                                          ngraph::Shape{0, 0},
-                                                                          ngraph::Shape{0, 1},
-                                                                          ngraph::Shape{1, 2});
+                auto max_pool =
+                    make_shared<opset7::MaxPool>(last_node, Strides{1, 1}, Shape{0, 0}, Shape{0, 1}, Shape{1, 2});
                 last_node = max_pool;
             }
             if (with_act) {
-                auto relu = std::make_shared<ngraph::opset9::Relu>(last_node);
+                auto relu = make_shared<Relu>(last_node);
                 last_node = relu;
             } else {
-                auto identity = std::make_shared<ov::intel_gna::op::Identity>(last_node);
+                auto identity = make_shared<Identity>(last_node);
                 last_node = identity;
             }
-            auto reshape_const = ngraph::opset9::Constant::create(ngraph::element::i64,
-                                                                  ngraph::Shape{reshape_shape.size()},
-                                                                  reshape_shape);
-            auto reshape = std::make_shared<ngraph::opset9::Reshape>(last_node, reshape_const, false);
-            auto matmul_const = ngraph::opset9::Constant::create(ngraph::element::f32, {64, 3}, {1.2});
-            auto matmul = swap_matmul ? std::make_shared<ngraph::opset9::MatMul>(matmul_const, reshape)
-                                      : std::make_shared<ngraph::opset9::MatMul>(reshape, matmul_const);
+            auto reshape_const = Constant::create(i64, Shape{reshape_shape.size()}, reshape_shape);
+            auto reshape = make_shared<Reshape>(last_node, reshape_const, false);
+            auto matmul_const = Constant::create(f32, {64, 3}, {1.2});
+            auto matmul =
+                swap_matmul ? make_shared<MatMul>(matmul_const, reshape) : make_shared<MatMul>(reshape, matmul_const);
 
-            auto result = std::make_shared<ngraph::opset9::Result>(matmul);
-            m_ref_func =
-                std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{input});
+            auto result = make_shared<Result>(matmul);
+            m_ref_func = make_shared<Model>(ResultVector{result}, ParameterVector{input});
         }
     }
 };
@@ -587,32 +576,30 @@ public:
     void SetUp() override {
         InsertIdentityLayerTest::SetUp();
         {
-            auto params = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
-            auto const_add = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto add = std::make_shared<ngraph::opset9::Add>(params, const_add);
-            auto relu = std::make_shared<ngraph::opset9::Relu>(add);
-            auto result1 = std::make_shared<ngraph::opset9::Result>(add);
-            auto result2 = std::make_shared<ngraph::opset9::Result>(relu);
-            m_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
-                                                        ngraph::ParameterVector{params});
+            auto params = make_shared<Parameter>(f32, m_input_shape);
+            auto const_add = Constant::create(f32, m_input_shape, {1});
+            auto add = make_shared<Add>(params, const_add);
+            auto relu = make_shared<Relu>(add);
+            auto result1 = make_shared<Result>(add);
+            auto result2 = make_shared<Result>(relu);
+            m_func = make_shared<Model>(ResultVector{result1, result2}, ParameterVector{params});
         }
 
         {
-            auto params = std::make_shared<ngraph::opset9::Parameter>(ngraph::element::f32, m_input_shape);
-            auto const_add = ngraph::opset9::Constant::create(ngraph::element::f32, m_input_shape, {1});
-            auto add = std::make_shared<ngraph::opset9::Add>(params, const_add);
-            auto identity = std::make_shared<ov::intel_gna::op::Identity>(add);
-            auto relu = std::make_shared<ngraph::opset9::Relu>(add);
-            auto result1 = std::make_shared<ngraph::opset9::Result>(identity);
-            auto result2 = std::make_shared<ngraph::opset9::Result>(relu);
-            m_ref_func = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
-                                                            ngraph::ParameterVector{params});
+            auto params = make_shared<Parameter>(f32, m_input_shape);
+            auto const_add = Constant::create(f32, m_input_shape, {1});
+            auto add = make_shared<Add>(params, const_add);
+            auto identity = make_shared<Identity>(add);
+            auto relu = make_shared<Relu>(add);
+            auto result1 = make_shared<Result>(identity);
+            auto result2 = make_shared<Result>(relu);
+            m_ref_func = make_shared<Model>(ResultVector{result1, result2}, ParameterVector{params});
         }
     }
     void Validate() override {
-        ngraph::pass::Manager m;
-        m.register_pass<ov::pass::InitNodeInfo>();
-        m.register_pass<ov::intel_gna::pass::BreakFusingOfOutputLayers>();
+        Manager m;
+        m.register_pass<InitNodeInfo>();
+        m.register_pass<BreakFusingOfOutputLayers>();
         m.run_passes(m_func);
         ASSERT_NO_THROW(check_rt_info(m_func));
 
@@ -622,6 +609,68 @@ public:
 };
 
 TEST_F(InsertIdentityLayerResultTest, CompareWithRefs) {
+    Run();
+}
+
+class InsertIdentityForNonQuantizableConcatInputTest : public InsertIdentityLayerTest {
+    string getName() {
+        return "InsertIdentityForPrecAgnosticConcatInput";
+    }
+
+    shared_ptr<FakeQuantize> create_fq(const Type& type,
+                                       const shared_ptr<ov::Node>& node,
+                                       float fq_min,
+                                       float fq_max,
+                                       std::size_t levels) {
+        //
+        auto fq_inp_min = makeConstant<float>(type, {1}, {fq_min});
+        auto fq_inp_max = makeConstant<float>(type, {1}, {fq_max});
+        auto fq_out_min = makeConstant<float>(type, {1}, {fq_min});
+        auto fq_out_max = makeConstant<float>(type, {1}, {fq_max});
+        return make_shared<FakeQuantize>(node, fq_inp_min, fq_inp_max, fq_out_min, fq_out_max, levels);
+    }
+
+public:
+    void SetUp() override {
+        InsertIdentityLayerTest::SetUp();
+        {
+            auto inputs = makeParams(f32, {{m_input_shape}, {m_input_shape}});
+            auto fq = create_fq(f32, inputs[0], -1, 1, 256);
+            auto relu = make_shared<Relu>(fq);
+            auto reshape_const = make_shared<Constant>(i64, Shape{1}, m_input_shape);
+            auto reshape = make_shared<Reshape>(inputs[1], reshape_const, false);
+            auto concat = makeConcat({relu, reshape}, 0);
+            auto result = make_shared<Result>(concat);
+            m_func = make_shared<Model>(result, inputs, getName());
+        }
+
+        {
+            auto inputs = makeParams(f32, {{m_input_shape}, {m_input_shape}});
+            auto fq = create_fq(f32, inputs[0], -1, 1, 256);
+            auto relu = make_shared<Relu>(fq);
+            auto reshape_const = make_shared<Constant>(i64, Shape{1}, m_input_shape);
+            auto reshape = make_shared<Reshape>(inputs[1], reshape_const, false);
+            // We expect the following Identity layer to be inserted
+            auto identity = make_shared<Identity>(reshape);
+            auto concat = makeConcat({relu, identity}, 0);
+            auto result = make_shared<Result>(concat);
+            m_ref_func = make_shared<Model>(result, inputs, getName());
+        }
+    }
+
+    void Validate() override {
+        Manager m;
+        m.register_pass<InitNodeInfo>();
+        m.register_pass<InsertIdentityForPrecAgnosticConcatInput>();
+        m.run_passes(m_func);
+        ASSERT_NO_THROW(check_rt_info(m_func));
+
+        auto result = compare_functions(m_func, m_ref_func);
+        ASSERT_TRUE(result.first);
+    }
+};
+
+TEST_F(InsertIdentityForNonQuantizableConcatInputTest, CompareWithRefs) {
     Run();
 }
 }  // namespace testing


### PR DESCRIPTION
### Details:
 Problem: if between one of Concat inputs and the Parameter layer there is no layer, which could get requantized according to scale factors from the second Concat input, plugin cannot properly propagate scale factors

Solution: in such a case additional layer has been added - Identity, which is used as a holder for scale factors data

### Tickets:
 - 111356
