### PR TITLE
Reduce binary size by optimize exceptions

### DIFF
--- a/src/core/include/ngraph/util.hpp
+++ b/src/core/include/ngraph/util.hpp
@@ -150,7 +150,7 @@ NGRAPH_API_DEPRECATED T parse_string(const std::string& s) {
 
     // Check that (1) parsing succeeded and (2) the entire string was used.
     if (ss.fail() || ss.rdbuf()->in_avail() != 0) {
-        throw std::runtime_error("Could not parse literal '" + s + "'");
+        OPENVINO_THROW("Could not parse literal '" + s + "'");
     }
 
     return result;
@@ -238,7 +238,7 @@ void parse_version_string(std::string version, size_t& major, size_t& minor, siz
 template <typename T>
 NGRAPH_API_DEPRECATED T double_to_int(double x, double float_to_int_converter(double)) {
     if (!std::is_integral<T>()) {
-        throw std::runtime_error("Function double_to_int template parameter must be an integral type.");
+        OPENVINO_THROW("Function double_to_int template parameter must be an integral type.");
     }
 
     x = float_to_int_converter(x);
@@ -260,7 +260,7 @@ NGRAPH_API_DEPRECATED T double_to_int(double x, double float_to_int_converter(do
 template <typename T>
 NGRAPH_API_DEPRECATED std::vector<T> read_vector(std::shared_ptr<ngraph::runtime::Tensor> tv) {
     if (ngraph::element::from<T>() != tv->get_element_type()) {
-        throw std::invalid_argument("read_vector type must match Tensor type");
+        OPENVINO_THROW("read_vector type must match Tensor type");
     }
     size_t element_count = ngraph::shape_size(tv->get_shape());
     size_t size = element_count * sizeof(T);

--- a/src/core/include/openvino/core/except.hpp
+++ b/src/core/include/openvino/core/except.hpp
@@ -22,14 +22,15 @@ struct CheckLocInfo {
 /// Base error for ov runtime errors.
 class OPENVINO_API Exception : public std::runtime_error {
 public:
+    OPENVINO_DEPRECATED("This constructor is deprecated and will be removed, please use OPENVINO_THROW instead")
+    explicit Exception(const std::string& what_arg);
+
     [[noreturn]] static void create(const CheckLocInfo& check_loc_info, const std::string& explanation);
     virtual ~Exception();
 
     static const std::string default_msg;
 
 protected:
-    explicit Exception(const std::string& what_arg);
-
     static std::string make_what(const CheckLocInfo& check_loc_info,
                                  const std::string& context_info,
                                  const std::string& explanation);

--- a/src/core/include/openvino/core/except.hpp
+++ b/src/core/include/openvino/core/except.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <sstream>
 #include <stdexcept>
 
@@ -21,16 +22,14 @@ struct CheckLocInfo {
 /// Base error for ov runtime errors.
 class OPENVINO_API Exception : public std::runtime_error {
 public:
-    OPENVINO_DEPRECATED("This constructor is deprecated and will be removed, please use OPENVINO_THROW instead")
-    explicit Exception(const std::string& what_arg);
-    OPENVINO_DEPRECATED("This constructor is deprecated and will be removed, please use OPENVINO_THROW instead")
-    explicit Exception(const std::stringstream& what_arg);
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const std::string& context_info,
-                                    const std::string& explanation);
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info, const std::string& explanation);
     virtual ~Exception();
 
+    static const std::string default_msg;
+
 protected:
+    explicit Exception(const std::string& what_arg);
+
     static std::string make_what(const CheckLocInfo& check_loc_info,
                                  const std::string& context_info,
                                  const std::string& explanation);
@@ -42,6 +41,13 @@ static inline std::ostream& write_all_to_stream(std::ostream& str) {
 template <typename T, typename... TS>
 static inline std::ostream& write_all_to_stream(std::ostream& str, const T& arg, TS&&... args) {
     return write_all_to_stream(str << arg, args...);
+}
+
+template <class T>
+static inline std::string stringify(T&& arg) {
+    std::stringstream stream;
+    stream << arg;
+    return stream.str();
 }
 
 /// Base class for check failure exceptions.
@@ -65,6 +71,8 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
     ~NotImplemented() override;
+
+    static const std::string default_msg;
 
 protected:
     explicit NotImplemented(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
@@ -142,29 +150,46 @@ protected:
         }                                                                                            \
     } while (0)
 
-#define OPENVINO_ASSERT_HELPER1(exc_class, ctx, check)                                      \
-    do {                                                                                    \
-        if (!(check)) {                                                                     \
-            exc_class::create((::ov::CheckLocInfo{__FILE__, __LINE__, #check}), (ctx), ""); \
-        }                                                                                   \
+#define OPENVINO_ASSERT_HELPER1(exc_class, ctx, check)                                                          \
+    do {                                                                                                        \
+        if (!(check)) {                                                                                         \
+            exc_class::create((::ov::CheckLocInfo{__FILE__, __LINE__, #check}), (ctx), exc_class::default_msg); \
+        }                                                                                                       \
     } while (0)
+
+#define OPENVINO_ASSERT_HELPER(exc_class, ctx, ...) CALL_OVERLOAD(OPENVINO_ASSERT_HELPER, exc_class, ctx, __VA_ARGS__)
+
+// Helper macros for OPENVINO_THROW which is special case of OPENVINO_ASSERT_HELPER without some not required
+// parameters for ov::Exception, as result reduce binary size.
+#define OPENVINO_THROW_HELPER2(exc_class, ctx, ...)                                        \
+    do {                                                                                   \
+        ::std::stringstream ss___;                                                         \
+        ::ov::write_all_to_stream(ss___, __VA_ARGS__);                                     \
+        exc_class::create((::ov::CheckLocInfo{__FILE__, __LINE__, nullptr}), ss___.str()); \
+    } while (0)
+
+#define OPENVINO_THROW_HELPER1(exc_class, ctx, explanation)                                                 \
+    do {                                                                                                    \
+        exc_class::create((::ov::CheckLocInfo{__FILE__, __LINE__, nullptr}), ::ov::stringify(explanation)); \
+    } while (0)
+
+#define OPENVINO_THROW_HELPER(exc_class, ctx, ...) CALL_OVERLOAD(OPENVINO_THROW_HELPER, exc_class, ctx, __VA_ARGS__)
 
 /// \brief Macro to check whether a boolean condition holds.
 /// \param cond Condition to check
 /// \param ... Additional error message info to be added to the error message via the `<<`
 ///            stream-insertion operator. Note that the expressions here will be evaluated lazily,
-///            i.e., only if the `cond` evalutes to `false`.
+///            i.e., only if the `cond` evaluates to `false`.
 /// \throws ::ov::AssertFailure if `cond` is false.
-#define OPENVINO_ASSERT(...) OPENVINO_ASSERT_HELPER(::ov::AssertFailure, "", __VA_ARGS__)
+#define OPENVINO_ASSERT(...) OPENVINO_ASSERT_HELPER(::ov::AssertFailure, ::ov::AssertFailure::default_msg, __VA_ARGS__)
 
 /// \brief Macro to signal a code path that is unreachable in a successful execution. It's
 /// implemented with OPENVINO_ASSERT macro.
 /// \param ... Additional error message that should describe why that execution path is unreachable.
-/// \throws ::ov::AssertFailure if the macro is executed.
-// TODO: OPENVINO_THROW after migration to functions
-#define OPENVINO_THROW(...)                         OPENVINO_ASSERT_HELPER(::ov::Exception, "", false, __VA_ARGS__)
-#define OPENVINO_ASSERT_HELPER(exc_class, ctx, ...) CALL_OVERLOAD(OPENVINO_ASSERT_HELPER, exc_class, ctx, __VA_ARGS__)
-#define OPENVINO_NOT_IMPLEMENTED                    OPENVINO_ASSERT_HELPER(::ov::NotImplemented, "", false, "Not Implemented", "")
+/// \throws ::ov::Exception if the macro is executed.
+#define OPENVINO_THROW(...) OPENVINO_THROW_HELPER(::ov::Exception, ov::Exception::default_msg, __VA_ARGS__)
+
+#define OPENVINO_NOT_IMPLEMENTED OPENVINO_ASSERT_HELPER(::ov::NotImplemented, ::ov::Exception::default_msg, false)
 
 #define GLUE(x, y) x y
 

--- a/src/core/include/openvino/core/type/element_type.hpp
+++ b/src/core/include/openvino/core/type/element_type.hpp
@@ -178,7 +178,7 @@ constexpr Type u64(Type_t::u64);
 
 template <typename T>
 Type from() {
-    throw std::invalid_argument("Unknown type");
+    OPENVINO_THROW("Unknown type");
 }
 template <>
 OPENVINO_API Type from<char>();

--- a/src/core/include/openvino/op/constant.hpp
+++ b/src/core/include/openvino/op/constant.hpp
@@ -143,7 +143,7 @@ public:
             break;
         case Type_t::undefined:
         case Type_t::dynamic:
-            throw std::runtime_error("unsupported type");
+            OPENVINO_THROW("unsupported type");
         }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)
 #    pragma GCC diagnostic pop
@@ -281,8 +281,9 @@ public:
     template <typename T>
     std::vector<T> get_vector() const {
         const T* p = get_data_ptr<T>();
-        if (p == nullptr)
-            throw std::runtime_error("Cannot create vector! Buffer is not allocated.");
+        if (p == nullptr) {
+            OPENVINO_THROW("Cannot create vector! Buffer is not allocated.");
+        }
         return std::vector<T>(p, p + shape_size(m_shape));
     }
 
@@ -349,7 +350,7 @@ public:
             cast_vector<Type_t::u64>(rc);
             break;
         default:
-            throw std::runtime_error("unsupported type");
+            OPENVINO_THROW("unsupported type");
         }
 #if defined(_MSC_VER)
 #    pragma warning(pop)
@@ -644,7 +645,7 @@ private:
         const auto& target_type = m_element_type;
         size_t target_element_count = shape_size(m_shape);
         if (source.size() != target_element_count) {
-            throw std::runtime_error("Constant initializer does not match shape");
+            OPENVINO_THROW("Constant initializer does not match shape");
         }
         using Type_t = element::Type_t;
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)
@@ -703,7 +704,7 @@ private:
             break;
         case element::Type_t::undefined:
         case element::Type_t::dynamic:
-            throw std::runtime_error("unsupported type");
+            OPENVINO_THROW("unsupported type");
         }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)
 #    pragma GCC diagnostic pop

--- a/src/core/src/except.cpp
+++ b/src/core/src/except.cpp
@@ -6,18 +6,8 @@
 
 ov::Exception::Exception(const std::string& what_arg) : std::runtime_error(what_arg) {}
 
-ov::Exception::Exception(const std::stringstream& what_arg) : std::runtime_error(what_arg.str()) {}
-
-void ov::Exception::create(const CheckLocInfo& check_loc_info,
-                           const std::string& context_info,
-                           const std::string& explanation) {
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    CheckLocInfo loc_info;
-    loc_info.file = check_loc_info.file;
-    loc_info.line = check_loc_info.line;
-    loc_info.check_string = nullptr;
-    throw ov::Exception(make_what(loc_info, context_info, explanation));
-    OPENVINO_SUPPRESS_DEPRECATED_END
+void ov::Exception::create(const CheckLocInfo& check_loc_info, const std::string& explanation) {
+    throw ov::Exception(make_what(check_loc_info, default_msg, explanation));
 }
 
 std::string ov::Exception::make_what(const CheckLocInfo& check_loc_info,
@@ -52,6 +42,8 @@ std::string ov::Exception::make_what(const CheckLocInfo& check_loc_info,
 
 ov::Exception::~Exception() = default;
 
+const std::string ov::Exception::default_msg{};
+
 void ov::AssertFailure::create(const CheckLocInfo& check_loc_info,
                                const std::string& context_info,
                                const std::string& explanation) {
@@ -65,3 +57,5 @@ void ov::NotImplemented::create(const CheckLocInfo& check_loc_info,
     throw ov::NotImplemented(make_what(check_loc_info, context_info, explanation));
 }
 ov::NotImplemented::~NotImplemented() = default;
+
+const std::string ov::NotImplemented::default_msg{"Not Implemented"};

--- a/src/core/src/except.cpp
+++ b/src/core/src/except.cpp
@@ -7,7 +7,9 @@
 ov::Exception::Exception(const std::string& what_arg) : std::runtime_error(what_arg) {}
 
 void ov::Exception::create(const CheckLocInfo& check_loc_info, const std::string& explanation) {
+    OPENVINO_SUPPRESS_DEPRECATED_START
     throw ov::Exception(make_what(check_loc_info, default_msg, explanation));
+    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 std::string ov::Exception::make_what(const CheckLocInfo& check_loc_info,

--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -26,7 +26,11 @@
 
 using namespace std;
 
-NGRAPH_SUPPRESS_DEPRECATED_START
+namespace {
+static const char node_idx_out_of_range_txt[] = "node index is out of range";
+static const char idx_txt[] = "index '";
+static const char out_of_range_txt[] = "' out of range";
+}  // namespace
 
 void ov::NodeValidationFailure::create(const CheckLocInfo& check_loc_info,
                                        const Node* node,
@@ -231,7 +235,7 @@ void ov::Node::constructor_validate_and_infer_types() {
 }
 
 void ov::Node::set_output_size(size_t n) {
-    NGRAPH_CHECK(n >= m_outputs.size(), "shrinking ", m_outputs.size(), " to ", n);
+    OPENVINO_ASSERT(n >= m_outputs.size(), "shrinking ", m_outputs.size(), " to ", n);
     for (size_t i = m_outputs.size(); i < n; ++i) {
         // create the descriptors
         get_output_descriptor(i);
@@ -246,18 +250,12 @@ void ov::Node::invalidate_values() {
 void ov::Node::validate_and_infer_types() {}
 
 void ov::Node::set_input_is_relevant_to_shape(size_t i, bool relevant) {
-    NGRAPH_CHECK(i < m_inputs.size(),
-                 "index '",
-                 i,
-                 "' out of range in set_input_is_relevant_to_shape(size_t index, bool relevant)");
+    OPENVINO_ASSERT(i < m_inputs.size(), idx_txt, i, out_of_range_txt);
     m_inputs[i].m_is_relevant_to_shape = relevant;
 }
 
 void ov::Node::set_input_is_relevant_to_value(size_t i, bool relevant) {
-    NGRAPH_CHECK(i < m_inputs.size(),
-                 "index '",
-                 i,
-                 "' out of range in set_input_is_relevant_to_value(size_t index, bool relevant)");
+    OPENVINO_ASSERT(i < m_inputs.size(), idx_txt, i, out_of_range_txt);
     m_inputs[i].m_is_relevant_to_value = relevant;
 }
 
@@ -290,12 +288,12 @@ void ov::Node::set_friendly_name(const string& name) {
 }
 
 ov::Node* ov::Node::get_input_node_ptr(size_t index) const {
-    NGRAPH_CHECK(index < m_inputs.size(), "index '", index, "' out of range in get_argument(size_t index)");
+    OPENVINO_ASSERT(index < m_inputs.size(), idx_txt, index, out_of_range_txt);
     return m_inputs[index].get_output().get_node().get();
 }
 
 std::shared_ptr<ov::Node> ov::Node::get_input_node_shared_ptr(size_t index) const {
-    NGRAPH_CHECK(index < m_inputs.size(), "index '", index, "' out of range in get_argument(size_t index)");
+    OPENVINO_ASSERT(index < m_inputs.size(), idx_txt, index, out_of_range_txt);
     return m_inputs[index].get_output().get_node();
 }
 
@@ -419,7 +417,7 @@ size_t ov::Node::get_output_size() const {
 }
 
 const ov::element::Type& ov::Node::get_output_element_type(size_t i) const {
-    NGRAPH_CHECK(i < m_outputs.size(), "index '", i, "' out of range in get_output_element_type(size_t i)");
+    OPENVINO_ASSERT(i < m_outputs.size(), idx_txt, i, out_of_range_txt);
     return m_outputs[i].get_element_type();
 }
 
@@ -431,12 +429,12 @@ const ov::element::Type& ov::Node::get_element_type() const {
 }
 
 const ov::Shape& ov::Node::get_output_shape(size_t i) const {
-    NGRAPH_CHECK(i < m_outputs.size(), "index '", i, "' out of range in get_output_shape(size_t i)");
+    OPENVINO_ASSERT(i < m_outputs.size(), idx_txt, i, out_of_range_txt);
     return m_outputs[i].get_shape();
 }
 
 const ov::PartialShape& ov::Node::get_output_partial_shape(size_t i) const {
-    NGRAPH_CHECK(i < m_outputs.size(), "index '", i, "' out of range in get_output_partial_shape(size_t i)");
+    OPENVINO_ASSERT(i < m_outputs.size(), idx_txt, i, out_of_range_txt);
     return m_outputs[i].get_partial_shape();
 }
 
@@ -456,12 +454,12 @@ std::set<ov::Input<ov::Node>> ov::Node::get_output_target_inputs(size_t i) const
 }
 
 ov::descriptor::Tensor& ov::Node::get_output_tensor(size_t i) const {
-    NGRAPH_CHECK(i < m_outputs.size(), "index '", i, "' out of range in get_output_tensor(size_t i) for node ", *this);
+    OPENVINO_ASSERT(i < m_outputs.size(), idx_txt, i, out_of_range_txt);
     return m_outputs[i].get_tensor();
 }
 
 ov::descriptor::Tensor& ov::Node::get_input_tensor(size_t i) const {
-    NGRAPH_CHECK(i < m_inputs.size(), "index '", i, "' out of range in get_input_tensor(size_t i)");
+    OPENVINO_ASSERT(i < m_inputs.size(), idx_txt, i, out_of_range_txt);
     descriptor::Input input = m_inputs[i];
     return input.get_tensor();
 }
@@ -471,17 +469,17 @@ size_t ov::Node::get_input_size() const {
 }
 
 const ov::element::Type& ov::Node::get_input_element_type(size_t i) const {
-    NGRAPH_CHECK(i < m_inputs.size(), "index '", i, "' out of range in get_input_element_type(size_t i)");
+    OPENVINO_ASSERT(i < m_inputs.size(), idx_txt, i, out_of_range_txt);
     return m_inputs[i].get_element_type();
 }
 
 const ov::Shape& ov::Node::get_input_shape(size_t i) const {
-    NGRAPH_CHECK(i < m_inputs.size(), "index '", i, "' out of range in get_input_shape(size_t i)");
+    OPENVINO_ASSERT(i < m_inputs.size(), idx_txt, i, out_of_range_txt);
     return m_inputs[i].get_shape();
 }
 
 const ov::PartialShape& ov::Node::get_input_partial_shape(size_t i) const {
-    NGRAPH_CHECK(i < m_inputs.size(), "index '", i, "' out of range in get_input_partial_shape(size_t i)");
+    OPENVINO_ASSERT(i < m_inputs.size(), idx_txt, i, out_of_range_txt);
     return m_inputs[i].get_partial_shape();
 }
 
@@ -520,7 +518,7 @@ std::string ov::node_validation_failure_loc_string(const Node* node) {
 }
 
 const std::shared_ptr<ov::Node>& ngraph::check_single_output_arg(const std::shared_ptr<Node>& node, size_t i) {
-    NGRAPH_CHECK(node->get_output_size() == 1, "Argument ", i, node, " must produce exactly one value.");
+    OPENVINO_ASSERT(node->get_output_size() == 1, "Argument ", i, node, " must produce exactly one value.");
     return node;
 }
 
@@ -575,7 +573,7 @@ bool ov::Node::is_dynamic() const {
 
 ov::Input<ov::Node> ov::Node::input(size_t input_index) {
     if (input_index >= m_inputs.size()) {
-        throw out_of_range("node input index is out of range");
+        OPENVINO_THROW(node_idx_out_of_range_txt);
     }
 
     return {this, input_index};
@@ -587,7 +585,7 @@ ov::Output<ov::Node> ov::Node::input_value(size_t input_index) const {
 
 ov::Input<const ov::Node> ov::Node::input(size_t input_index) const {
     if (input_index >= m_inputs.size()) {
-        throw out_of_range("node input index is out of range");
+        OPENVINO_THROW(node_idx_out_of_range_txt);
     }
 
     return {this, input_index};
@@ -596,7 +594,7 @@ ov::Input<const ov::Node> ov::Node::input(size_t input_index) const {
 ov::Output<ov::Node> ov::Node::output(size_t output_index) {
     // All nodes will have at least 1 output
     if (output_index > 0 && output_index >= m_outputs.size()) {
-        throw out_of_range("node output index is out of range");
+        OPENVINO_THROW(node_idx_out_of_range_txt);
     }
 
     return Output<Node>(this, output_index);
@@ -605,7 +603,7 @@ ov::Output<ov::Node> ov::Node::output(size_t output_index) {
 ov::Output<const ov::Node> ov::Node::output(size_t output_index) const {
     // All nodes will have at least 1 output
     if (output_index > 0 && output_index >= m_outputs.size()) {
-        throw out_of_range("node output index is out of range");
+        OPENVINO_THROW(node_idx_out_of_range_txt);
     }
 
     return Output<const Node>(this, output_index);

--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -26,6 +26,8 @@
 
 using namespace std;
 
+NGRAPH_SUPPRESS_DEPRECATED_START
+
 namespace {
 static const char node_idx_out_of_range_txt[] = "node index is out of range";
 static const char idx_txt[] = "index '";

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -130,9 +130,9 @@ ov::op::v0::Constant::Constant(const element::Type& type,
             fill_data<Type_t::u64>(ngraph::parse_string<uint64_t>(values[0]));
             break;
         case Type_t::undefined:
-            throw std::runtime_error("deserialize unsupported type undefined");
+            OPENVINO_THROW("deserialize unsupported type undefined");
         case Type_t::dynamic:
-            throw std::runtime_error("deserialize unsupported type dynamic");
+            OPENVINO_THROW("deserialize unsupported type dynamic");
         }
         update_identical_flags(true, true);
     } else {
@@ -186,9 +186,9 @@ ov::op::v0::Constant::Constant(const element::Type& type,
             write_buffer<Type_t::u64>(ngraph::parse_string<uint64_t>(values));
             break;
         case Type_t::undefined:
-            throw std::runtime_error("deserialize unsupported type undefined");
+            OPENVINO_THROW("deserialize unsupported type undefined");
         case Type_t::dynamic:
-            throw std::runtime_error("deserialize unsupported type dynamic");
+            OPENVINO_THROW("deserialize unsupported type dynamic");
         }
         update_identical_flags(false, false);
     }
@@ -296,9 +296,8 @@ string ov::op::v0::Constant::convert_value_to_string(size_t index) const {
         rc = to_string(get_element_value<Type_t::u64>(index));
         break;
     case Type_t::undefined:
-        throw runtime_error("unsupported type");
     case Type_t::dynamic:
-        throw runtime_error("unsupported type");
+        OPENVINO_THROW("unsupported type");
     }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)
 #    pragma GCC diagnostic pop
@@ -393,7 +392,7 @@ vector<string> ov::op::v0::Constant::get_value_strings() const {
         break;
     case element::Type_t::undefined:
     case element::Type_t::dynamic:
-        throw runtime_error("unsupported type");
+        OPENVINO_THROW("unsupported type");
     }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)
 #    pragma GCC diagnostic pop

--- a/src/core/src/partial_shape.cpp
+++ b/src/core/src/partial_shape.cpp
@@ -12,6 +12,10 @@
 #include "ngraph/check.hpp"
 #include "ngraph/util.hpp"
 
+namespace {
+static constexpr char dim_out_range_access_txt[] = "Accessing out-of-range dimension in Dimension[]";
+}
+
 ov::PartialShape::PartialShape() : PartialShape(std::initializer_list<Dimension>{}) {}
 
 ov::PartialShape::PartialShape(std::initializer_list<Dimension> init) : PartialShape(true, init) {}
@@ -139,7 +143,7 @@ ov::PartialShape ov::operator+(const PartialShape& s1, const PartialShape& s2) {
     }
 
     if (!s1.rank().compatible(s2.rank())) {
-        throw std::invalid_argument("rank mismatch");
+        OPENVINO_THROW("rank mismatch");
     }
 
     PartialShape result;
@@ -268,7 +272,7 @@ bool ov::PartialShape::merge_rank(const Rank& r) {
 
 ov::Shape ov::PartialShape::to_shape() const {
     if (is_dynamic()) {
-        throw std::invalid_argument("to_shape was called on a dynamic shape.");
+        OPENVINO_THROW("to_shape was called on a dynamic shape.");
     }
 
     std::vector<size_t> shape_dimensions(m_dimensions.size());
@@ -375,14 +379,14 @@ bool ov::PartialShape::all_non_negative() const {
 
 const ov::Dimension& ov::PartialShape::operator[](size_t i) const {
     if (i >= m_dimensions.size()) {
-        throw std::out_of_range("Accessing out-of-range dimension in Dimension[]");
+        OPENVINO_THROW(dim_out_range_access_txt);
     }
     return m_dimensions[i];
 }
 
 ov::Dimension& ov::PartialShape::operator[](size_t i) {
     if (i >= m_dimensions.size()) {
-        throw std::out_of_range("Accessing out-of-range dimension in Dimension[]");
+        OPENVINO_THROW(dim_out_range_access_txt);
     }
     m_shape_type = ShapeType::SHAPE_IS_UPDATED;  // We can't guarantee that the shape remains static or dynamic.
     return m_dimensions[i];

--- a/src/core/src/util.cpp
+++ b/src/core/src/util.cpp
@@ -277,7 +277,7 @@ void ngraph::parse_version_string(std::string version, size_t& major, size_t& mi
         error = true;
     }
     if (error) {
-        throw runtime_error("Error parsing version string '" + version + "'");
+        OPENVINO_THROW("Error parsing version string '", version, "'");
     }
 }
 

--- a/src/core/tests/node_input_output.cpp
+++ b/src/core/tests/node_input_output.cpp
@@ -37,7 +37,7 @@ TEST(node_input_output, input_create) {
     EXPECT_TRUE(add_in_1.get_partial_shape().same_scheme(PartialShape{1, 2, 3, 4}));
     EXPECT_EQ(add_in_1.get_source_output(), Output<Node>(y, 0));
 
-    EXPECT_THROW(add->input(2), std::out_of_range);
+    EXPECT_THROW(add->input(2), ov::Exception);
 }
 
 TEST(node_input_output, input_create_const) {
@@ -62,7 +62,7 @@ TEST(node_input_output, input_create_const) {
     EXPECT_TRUE(add_in_1.get_partial_shape().same_scheme(PartialShape{1, 2, 3, 4}));
     EXPECT_EQ(add_in_1.get_source_output(), Output<Node>(y, 0));
 
-    EXPECT_THROW(add->input(2), std::out_of_range);
+    EXPECT_THROW(add->input(2), ov::Exception);
 }
 
 TEST(node_input_output, output_create) {
@@ -84,7 +84,7 @@ TEST(node_input_output, output_create) {
     EXPECT_EQ(add_out_0.get_shape(), (Shape{1, 2, 3, 4}));
     EXPECT_TRUE(add_out_0.get_partial_shape().same_scheme(PartialShape{1, 2, 3, 4}));
 
-    EXPECT_THROW(add->output(1), std::out_of_range);
+    EXPECT_THROW(add->output(1), ov::Exception);
 }
 
 TEST(node_input_output, output_create_const) {
@@ -101,7 +101,7 @@ TEST(node_input_output, output_create_const) {
     EXPECT_EQ(add_out_0.get_shape(), (Shape{1, 2, 3, 4}));
     EXPECT_TRUE(add_out_0.get_partial_shape().same_scheme(PartialShape{1, 2, 3, 4}));
 
-    EXPECT_THROW(add->output(1), std::out_of_range);
+    EXPECT_THROW(add->output(1), ov::Exception);
 }
 
 TEST(node_input_output, output_rt_info) {

--- a/src/core/tests/partial_shape.cpp
+++ b/src/core/tests/partial_shape.cpp
@@ -208,12 +208,12 @@ TEST(partial_shape, to_shape_static) {
 
 TEST(partial_shape, to_shape_dims_dynamic) {
     PartialShape ps{2, 4, Dimension::dynamic(), 8};
-    ASSERT_THROW({ ps.to_shape(); }, std::invalid_argument);
+    ASSERT_THROW({ ps.to_shape(); }, ov::Exception);
 }
 
 TEST(partial_shape, to_shape_rank_dynamic) {
     PartialShape ps{PartialShape::dynamic()};
-    ASSERT_THROW({ ps.to_shape(); }, std::invalid_argument);
+    ASSERT_THROW({ ps.to_shape(); }, ov::Exception);
 }
 
 TEST(partial_shape, tensor_descriptor_from_shape) {


### PR DESCRIPTION
### Details:
 - Introduce new helper macros for OPENVINO_THROW and NOT_IMPLEMENTED to reduce insert not used code.
 - Add Exception default message as class static member which reduce insert literal string by macro
 - Use OPENVINO macros instead `throw` and optimize some throw messages.
 - On test machine with Ubuntu 20.04 and gcc 9.3 get at least `200 KiB` in size reduction for `libopenvino.so` (LTO enabled)

### Tickets:
 -  103685
