### PR TITLE
[GPU] graceful exit

### DIFF
--- a/samples/cpp/benchmark_app/infer_request_wrap.hpp
+++ b/samples/cpp/benchmark_app/infer_request_wrap.hpp
@@ -168,7 +168,12 @@ public:
         std::unique_lock<std::mutex> lock(_mutex);
         _cv.wait(lock, [this] {
             if (inferenceException) {
-                std::rethrow_exception(inferenceException);
+                try {
+                    std::rethrow_exception(inferenceException);
+                } catch (const std::exception& ex) {
+                    /// copy an exception to avoid the thread race issue.
+                    throw std::runtime_error(ex.what());
+                }
             }
             return _idleIds.size() > 0;
         });
@@ -182,7 +187,12 @@ public:
         std::unique_lock<std::mutex> lock(_mutex);
         _cv.wait(lock, [this] {
             if (inferenceException) {
-                std::rethrow_exception(inferenceException);
+                try {
+                    std::rethrow_exception(inferenceException);
+                } catch (const std::exception& ex) {
+                    /// copy an exception to avoid the thread race issue.
+                    throw std::runtime_error(ex.what());
+                }
             }
             return _idleIds.size() == requests.size();
         });

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
@@ -156,16 +156,5 @@ inline InferenceEngine::Layout InferenceEngineLayoutFromOVLayout(ov::Layout l) {
     IE_THROW() << "The plugin does not support " << l.to_string() << " layout";
 }
 
-/// WA: Force exit. Any opencl api call can be hang after CL_OUT_OF_RESOURCES.
-inline void ForceExit() {
-    std::cerr << "[GPU] force exit.\n"
-              << "\tDue to the driver bug any subsequent OpenCL API call will cause application hang, "
-              << "so GPU plugin can't finish correctly.\n"
-              << "\tPlease try to update the driver or reduce memory consumption "
-              << "(use smaller batch size, less streams, lower precision, etc)"
-              << "to avoid CL_OUT_OF_RESOURCES exception" << std::endl;
-    std::_Exit(-1);
-}
-
 }  // namespace intel_gpu
 }  // namespace ov

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -8,7 +8,6 @@
 
 #include "primitive_inst.h"
 #include "intel_gpu/graph/serialization/binary_buffer.hpp"
-#include "intel_gpu/plugin/common_utils.hpp"
 #include "intel_gpu/runtime/memory.hpp"
 #include "to_string_utils.h"
 #include "register.hpp"
@@ -483,10 +482,6 @@ protected:
             try {
                 _prim.execute(stream.get_onednn_stream(), _args[net_id]);
             } catch (dnnl::error& err) {
-                /// WA: Force exit. Any opencl api call can be hang after CL_OUT_OF_RESOURCES.
-                if (err.status == dnnl_status_t::dnnl_out_of_memory) {
-                    ov::intel_gpu::ForceExit();
-                }
                 throw;    // rethrowing dnnl::error if not out_of_memory
             }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -6,7 +6,6 @@
 #include "ocl_event.hpp"
 #include "ocl_user_event.hpp"
 #include "ocl_command_queues_builder.hpp"
-#include "intel_gpu/plugin/common_utils.hpp"
 #include "intel_gpu/runtime/debug_configuration.hpp"
 #include "ocl_kernel.hpp"
 #include "ocl_common.hpp"
@@ -307,10 +306,6 @@ event::ptr ocl_stream::enqueue_kernel(kernel& kernel,
     try {
         _command_queue.enqueueNDRangeKernel(kern, cl::NullRange, global, local, dep_events_ptr, set_output_event ? &ret_ev : nullptr);
     } catch (cl::Error const& err) {
-        /// WA: Force exit. Any opencl api call can be hang after CL_OUT_OF_RESOURCES.
-        if (err.err() == CL_OUT_OF_RESOURCES) {
-            ov::intel_gpu::ForceExit();
-        }
         throw ocl_error(err);
     }
 


### PR DESCRIPTION
### Issue.
- preparation: revert commit (fef04e468a / WA code to avoid hang issue)
- 'Segmentation fault' when the error occurs from OpenCL api. Benchmark_app could not catch the exception because the exception ptr is released before the app catches it.

### Reproduce.
- Model link: https://jira.devtools.intel.com/secure/attachment/3407787/east_resnet_v1_50.fp16.tf.zip
- cmd
```shell
/// need to try increasing the batch number to occur 'CL_OUT_OF_RESOURCES' erorr from the OpenCL api.
benchmark_app -d GPU -m $MODEL -nireq 4 -nstreams 2 --hint none -t 10 -ip u8 --infer_precision f32 -b 32
``` 

### Avoid this issue.
- It needs to move the compiled_model variable out of try-catch block at main.cpp.
- or it copies the exception and throws it at infer_request_wrap.hpp.

### Tickets:
 - 112952
