### PR TITLE
Improved samples build stability

### DIFF
--- a/samples/cpp/build_samples.sh
+++ b/samples/cpp/build_samples.sh
@@ -3,19 +3,22 @@
 # Copyright (C) 2018-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+# exit when any command fails
+set -e
+
 usage() {
     echo "Build OpenVINO Runtime samples"
     echo
     echo "Options:"
     echo "  -h                       Print the help message"
-    echo "  -b SAMPLE_BUILD_DIR      Specify the sample build directory"
-    echo "  -i SAMPLE_INSTALL_DIR    Specify the sample install directory"
+    echo "  -b SAMPLES_BUILD_DIR     Specify the samples build directory"
+    echo "  -i SAMPLES_INSTALL_DIR   Specify the samples install directory"
     echo
     exit 1
 }
 
 samples_type="$(basename "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
-build_dir="$HOME/openvino_${samples_type}_samples_build"
+samples_build_dir="$HOME/openvino_${samples_type}_samples_build"
 sample_install_dir=""
 
 # parse command line options
@@ -23,7 +26,7 @@ while [[ $# -gt 0 ]]
 do
 case "$1" in
     -b | --build_dir)
-    build_dir="$2"
+    samples_build_dir="$2"
     shift
     ;;
     -i | --install_dir)
@@ -52,16 +55,16 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
-SAMPLES_PATH="$( cd "$( dirname "$(realpath "${BASH_SOURCE[0]}")" )" && pwd )"
+SAMPLES_SOURCE_DIR="$( cd "$( dirname "$(realpath "${BASH_SOURCE[0]}")" )" && pwd )"
 printf "\nSetting environment variables for building samples...\n"
 
 if [ -z "$INTEL_OPENVINO_DIR" ]; then
-    if [[ "$SAMPLES_PATH" = "/usr/share/openvino"* ]]; then
+    if [[ "$SAMPLES_SOURCE_DIR" = "/usr/share/openvino"* ]]; then
         true
-    elif [ -e "$SAMPLES_PATH/../../setupvars.sh" ]; then
-        setvars_path="$SAMPLES_PATH/../../setupvars.sh"
+    elif [ -e "$SAMPLES_SOURCE_DIR/../../setupvars.sh" ]; then
+        setupvars_path="$SAMPLES_SOURCE_DIR/../../setupvars.sh"
         # shellcheck source=/dev/null
-        source "$setvars_path" || true
+        source "$setupvars_path" || true
     else
         printf "Failed to set the environment variables automatically. To fix, run the following command:"
         printf "source <INTEL_OPENVINO_DIR>/setupvars.sh"
@@ -88,22 +91,22 @@ OS_PATH=$(uname -m)
 NUM_THREADS="-j2"
 
 if [ "$OS_PATH" == "x86_64" ]; then
-  OS_PATH="intel64"
-  NUM_THREADS="-j8"
+    OS_PATH="intel64"
+    NUM_THREADS="-j8"
 fi
 
-if [ -e "$build_dir/CMakeCache.txt" ]; then
-  rm -rf "$build_dir/CMakeCache.txt"
+if [ -e "$samples_build_dir/CMakeCache.txt" ]; then
+    rm -rf "$samples_build_dir/CMakeCache.txt"
 fi
 
-mkdir -p "$build_dir"
-cd "$build_dir" || exit
-$CMAKE_EXEC -DCMAKE_BUILD_TYPE=Release "$SAMPLES_PATH"
-make $NUM_THREADS
+mkdir -p "$samples_build_dir"
+cd "$samples_build_dir"
+$CMAKE_EXEC -DCMAKE_BUILD_TYPE=Release "$SAMPLES_SOURCE_DIR"
+$CMAKE_EXEC --build "$samples_build_dir" --config Release -- -j $NUM_THREADS
 
 if [ "$sample_install_dir" != "" ]; then
     $CMAKE_EXEC -DCMAKE_INSTALL_PREFIX="$sample_install_dir" -DCOMPONENT=samples_bin -P cmake_install.cmake
     printf "\nBuild completed, you can find binaries for all samples in the %s/samples_bin subfolder.\n\n" "$sample_install_dir"
 else
-    printf "\nBuild completed, you can find binaries for all samples in the $build_dir/%s/Release subfolder.\n\n" "$OS_PATH"
+    printf "\nBuild completed, you can find binaries for all samples in the $samples_build_dir/%s/Release subfolder.\n\n" "$OS_PATH"
 fi

--- a/samples/cpp/build_samples_msvc.bat
+++ b/samples/cpp/build_samples_msvc.bat
@@ -5,20 +5,20 @@
 
 @setlocal
 SETLOCAL EnableDelayedExpansion
-set "ROOT_DIR=%~dp0"
-FOR %%i IN ("%ROOT_DIR%\.") DO set SAMPLES_TYPE=%%~nxi
+set "SAMPLES_SOURCE_DIR=%~dp0"
+FOR %%i IN ("%SAMPLES_SOURCE_DIR%\.") DO set SAMPLES_TYPE=%%~nxi
 
-set "SAMPLE_BUILD_DIR=%USERPROFILE%\Documents\Intel\OpenVINO\openvino_%SAMPLES_TYPE%_samples_build"
-set SAMPLE_INSTALL_DIR=
+set "SAMPLES_BUILD_DIR=%USERPROFILE%\Documents\Intel\OpenVINO\openvino_%SAMPLES_TYPE%_samples_build"
+set SAMPLES_INSTALL_DIR=
 
 :: command line arguments parsing
 :input_arguments_loop
 if not "%1"=="" (
     if "%1"=="-b" (
-        set SAMPLE_BUILD_DIR=%2
+        set SAMPLES_BUILD_DIR=%2
         shift
     ) else if "%1"=="-i" (
-        set SAMPLE_INSTALL_DIR=%2
+        set SAMPLES_INSTALL_DIR=%2
         shift
     ) else if "%1"=="-h" (
         goto usage
@@ -31,8 +31,8 @@ if not "%1"=="" (
 )
 
 if "%INTEL_OPENVINO_DIR%"=="" (
-    if exist "%ROOT_DIR%\..\..\setupvars.bat" (
-        call "%ROOT_DIR%\..\..\setupvars.bat"
+    if exist "%SAMPLES_SOURCE_DIR%\..\..\setupvars.bat" (
+        call "%SAMPLES_SOURCE_DIR%\..\..\setupvars.bat"
     ) else (
         echo Failed to set the environment variables automatically. To fix, run the following command:
         echo ^<INTEL_OPENVINO_DIR^>\setupvars.bat
@@ -41,26 +41,22 @@ if "%INTEL_OPENVINO_DIR%"=="" (
     )
 )
 
-if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
-   set "PLATFORM=x64"
-) else (
-   set "PLATFORM=Win32"
-)
+if exist "%SAMPLES_BUILD_DIR%\CMakeCache.txt" del "%SAMPLES_BUILD_DIR%\CMakeCache.txt"
 
-if exist "%SAMPLE_BUILD_DIR%\CMakeCache.txt" del "%SAMPLE_BUILD_DIR%\CMakeCache.txt"
-
-cd /d "%ROOT_DIR%" && cmake -E make_directory "%SAMPLE_BUILD_DIR%" && cd /d "%SAMPLE_BUILD_DIR%" && cmake -A %PLATFORM% "%ROOT_DIR%"
+cd /d "%SAMPLES_SOURCE_DIR%" && cmake -E make_directory "%SAMPLES_BUILD_DIR%" && cd /d "%SAMPLES_BUILD_DIR%" && cmake -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON "%SAMPLES_SOURCE_DIR%"
 if ERRORLEVEL 1 GOTO errorHandling
 
 echo.
 echo ###############^|^| Build OpenVINO Runtime samples using MS Visual Studio (MSBuild.exe) ^|^|###############
 echo.
 
-echo cmake --build . --config Release --parallel
-cmake --build . --config Release --parallel
+echo cmake --build "%SAMPLES_BUILD_DIR%" --config Release --parallel
+cmake --build "%SAMPLES_BUILD_DIR%" --config Release --parallel
 if ERRORLEVEL 1 GOTO errorHandling
 
-if NOT "%SAMPLE_INSTALL_DIR%"=="" cmake -DCMAKE_INSTALL_PREFIX="%SAMPLE_INSTALL_DIR%" -DCOMPONENT=samples_bin -P cmake_install.cmake
+if NOT "%SAMPLES_INSTALL_DIR%"=="" (
+    cmake -DCMAKE_INSTALL_PREFIX="%SAMPLES_INSTALL_DIR%" -DCOMPONENT=samples_bin -P "%SAMPLES_BUILD_DIR%\cmake_install.cmake"
+)
 
 echo Done.
 exit /b
@@ -69,9 +65,9 @@ exit /b
 echo Build OpenVINO Runtime samples
 echo.
 echo Options:
-echo   -h                       Print the help message
-echo   -b SAMPLE_BUILD_DIR      Specify the sample build directory
-echo   -i SAMPLE_INSTALL_DIR    Specify the sample install directory
+echo   -h                        Print the help message
+echo   -b SAMPLES_BUILD_DIR      Specify the samples build directory
+echo   -i SAMPLES_INSTALL_DIR    Specify the samples install directory
 exit /b
 
 :errorHandling


### PR DESCRIPTION
### Details:
 - Don't user direct `make` => use `cmake --build`
 - Don't use `-A` to specify platform on Windows, because it works only for MSVC generator