### PR TITLE
Support VPU as a name in AUTO plugin

### DIFF
--- a/src/plugins/auto/src/auto_executable_network.cpp
+++ b/src/plugins/auto/src/auto_executable_network.cpp
@@ -215,7 +215,7 @@ IE::Parameter AutoExecutableNetwork::GetMetric(const std::string& name) const {
                             iie.what());
                     }
                     real = (std::max)(requests, optimalBatchSize);
-                } else if (deviceInfo.deviceName.find("VPUX") != std::string::npos) {
+                } else if (deviceInfo.deviceName.find("VPU") != std::string::npos) {
                     real = 8u;
                 } else {
                     real = upperBoundStreamsNum ? 2 * upperBoundStreamsNum : defaultNumForTPUT;

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -544,7 +544,7 @@ std::list<DeviceInformation> MultiDeviceInferencePlugin::GetValidDevice(
             MYRIAD.push_back(item);
             continue;
         }
-        if (item.deviceName.find("VPUX") == 0) {
+        if (item.deviceName.find("VPU") == 0) {
             VPUX.push_back(item);
             continue;
         }

--- a/src/plugins/auto/src/plugin_config.cpp
+++ b/src/plugins/auto/src/plugin_config.cpp
@@ -7,7 +7,7 @@ namespace MultiDevicePlugin {
 // AUTO will enable the blocklist if
 // 1.No device priority passed to AUTO/MULTI.(eg. core.compile_model(model, "AUTO", configs);)
 // 2.No valid device parsed out from device priority (eg. core.compile_model(model, "AUTO:-CPU,-GPU", configs);).
-const std::set<std::string> PluginConfig::_deviceBlocklist = {"VPUX", "GNA", "notIntelGPU"};
+const std::set<std::string> PluginConfig::_deviceBlocklist = {"VPUX", "VPU", "GNA", "notIntelGPU"};
 
 PluginConfig::PluginConfig() {
     set_default();


### PR DESCRIPTION
### Details:
 - Rename VPU device name from VPUX to VPU.

### Tickets:
 - 113017
