### PR TITLE
Validate only one If body if condiction is const

### DIFF
--- a/src/core/src/op/if.cpp
+++ b/src/core/src/op/if.cpp
@@ -107,8 +107,12 @@ void ov::op::v8::If::validate_and_infer_types() {
                               val.size() == 1,
                               "The number of values in the If condition constant is greater than 1");
 
-        validate_and_infer_type_body(get_then_body(), m_input_descriptions[THEN_BODY_INDEX]);
-        validate_and_infer_type_body(get_else_body(), m_input_descriptions[ELSE_BODY_INDEX]);
+        // Condition is constant we only need to validate one body
+        if (val[0]) {
+            validate_and_infer_type_body(get_then_body(), m_input_descriptions[THEN_BODY_INDEX]);
+        } else {
+            validate_and_infer_type_body(get_else_body(), m_input_descriptions[ELSE_BODY_INDEX]);
+        }
         auto output_nodes = outputs();
 
         auto cond_index = val[0] ? THEN_BODY_INDEX : ELSE_BODY_INDEX;

--- a/src/core/tests/type_prop/if.cpp
+++ b/src/core/tests/type_prop/if.cpp
@@ -44,12 +44,12 @@ TEST(type_prop, if_simple_test) {
     Shape out0_shape{32, 40, 10};
     auto sh = result0->get_output_shape(0);
     EXPECT_EQ(sh, out0_shape);
-    // Check that If validation validates both bodies
+    // Check that If validation when condition is constant validates single body
     convert_then_op->set_convert_element_type(ov::element::f16);
     convert_else_op->set_convert_element_type(ov::element::f16);
     if_op->validate_and_infer_types();
-    EXPECT_EQ(else_op_res->get_element_type(), ov::element::f16);
     EXPECT_EQ(then_op_res->get_element_type(), ov::element::f16);
+    EXPECT_EQ(else_op_res->get_element_type(), ov::element::f32);
 }
 
 TEST(type_prop, if_non_const_condition_test) {
@@ -340,7 +340,7 @@ TEST(type_prop, if_element_type_dynamic) {
     // That which we iterate over
     auto X = make_shared<op::Parameter>(element::f16, Shape{32, 40, 10});
     auto Y = make_shared<op::Parameter>(element::f16, Shape{32, 40, 10});
-    auto cond = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
+    auto cond = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, false);
 
     // Set up the cell body, a function from (Xi, Yi) -> (Zo)
     // Body parameters
@@ -367,8 +367,8 @@ TEST(type_prop, if_element_type_dynamic) {
     Shape out0_shape{32, 40, 10};
     auto sh = result0->get_output_shape(0);
     EXPECT_EQ(sh, out0_shape);
-    // Check that If validation validates both bodies
+    // Check that If validation when condition is constant validates single body
     if_op->validate_and_infer_types();
+    EXPECT_EQ(then_op_res->get_element_type(), ov::element::dynamic);
     EXPECT_EQ(else_op_res->get_element_type(), ov::element::f16);
-    EXPECT_EQ(then_op_res->get_element_type(), ov::element::f16);
 }


### PR DESCRIPTION
### Details:
 - *If body can be invalid for specific inputs, but that shouldn't be a problem if we know the condition, we can validate only the body that corresponds to the condition*

### Tickets:
 - *None*
