### PR TITLE
[DOCS] CMake options description in build guide for 23.0

### DIFF
--- a/docs/dev/build_linux.md
+++ b/docs/dev/build_linux.md
@@ -65,7 +65,7 @@ You can use the following additional build options:
    cmake -DCMAKE_TOOLCHAIN_FILE=<openvino_repo>/cmake/toolchains/ia32.linux.toolchain.cmake ..
    ```
 
-- If you don't want to use the GPU plugin, use the `-DENABLE_INTEL_GPU=OFF` CMake build option and skip the installation of the Intel® Graphics Compute Runtime for OpenCL™ Driver.
+- OpenVINO offers several CMake options that can be used to build a custom OpenVINO runtime, which can speed up compilation. These options allow you to skip compilation of other plugins and frontends by disabling/enabling them. You can find a list of available options [here](https://github.com/openvinotoolkit/openvino/blob/master/docs/dev/cmake_options_for_custom_compilation.md)
 
 - To build the OpenVINO Runtime Python API:
   1. Install all additional packages (e.g., cython and opencv) listed in the `/src/bindings/python/src/compatibility/openvino/requirements-dev.txt` file:


### PR DESCRIPTION
Port from https://github.com/openvinotoolkit/openvino/pull/18101

Ticket: 113196

Updated the Build OpenVINO™ Runtime for Linux systems article to include information on CMake options for Custom Compilation with a link to list of all available options.
