### PR TITLE
Fix benchmark_app random inputs filling for boolean data type

### DIFF
--- a/samples/cpp/benchmark_app/inputs_filling.cpp
+++ b/samples/cpp/benchmark_app/inputs_filling.cpp
@@ -250,7 +250,7 @@ ov::Tensor create_tensor_random(const benchmark_app::InputInfo& inputInfo,
     size_t tensor_size =
         std::accumulate(inputInfo.dataShape.begin(), inputInfo.dataShape.end(), 1, std::multiplies<size_t>());
     auto tensor = ov::Tensor(inputInfo.type, inputInfo.dataShape);
-    auto data = tensor.data<T>();
+    auto data = inputInfo.type == ov::element::boolean ? static_cast<T*>(tensor.data()) : tensor.data<T>();
 
     std::mt19937 gen(0);
     uniformDistribution<T2> distribution(rand_min, rand_max);


### PR DESCRIPTION
### Details:
 - This PR fixes data type mismatch error for random tensors filling with boolean data types
Currently we have `tensor.data<T>()` which is supposed to check data types compatibility, thus we get an error when trying to call `tensor.data<uint8_t>()` of tensor with boolean data type:
```
[ ERROR ] Exception from src/core/src/runtime/ov_tensor.cpp:222:
Check 'element_type == get_element_type()' failed at src/inference/src/dev/make_tensor.cpp:37:
Tensor data with element type boolean, is not representable as pointer to u8
```
This fix obtains raw pointer and removes data types compatibility check for boolean

### Tickets:
 - *ticket-id*
