### PR TITLE
Add missing header for std::tolower

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/gru_cell_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/gru_cell_fusion.cpp
@@ -4,6 +4,7 @@
 
 #include "transformations/common_optimizations/gru_cell_fusion.hpp"
 
+#include <cctype>
 #include <memory>
 
 #include "itt.hpp"


### PR DESCRIPTION
Missing header causes syntax error when compiling for Windows using Visual studio 2017. Similar to [this PR](https://github.com/openvinotoolkit/openvino/pull/4156).