### PR TITLE
Fixed Snappy dependent option default value

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -126,7 +126,7 @@ ie_option(ENABLE_OV_IR_FRONTEND "Enable IR FrontEnd" ON)
 ie_option(ENABLE_OV_TF_FRONTEND "Enable TensorFlow FrontEnd" ON)
 ie_option(ENABLE_OV_TF_LITE_FRONTEND "Enable TensorFlow Lite FrontEnd" ON)
 ie_dependent_option(ENABLE_SNAPPY_COMPRESSION "Enables compression support for TF FE" ON
-    "ENABLE_OV_TF_FRONTEND" ON)
+    "ENABLE_OV_TF_FRONTEND" OFF)
 
 if(CMAKE_HOST_LINUX AND LINUX)
     # Debian packages are enabled on Ubuntu systems


### PR DESCRIPTION
### Details:
 - When TF is disabled, we don't have to build Snappy dependency
