### PR TITLE
[CompileTool] Throw when provided plugin config is incorrect

### DIFF
--- a/tools/compile_tool/main.cpp
+++ b/tools/compile_tool/main.cpp
@@ -598,12 +598,14 @@ static std::map<std::string, std::string> parseConfigFile(char comment = '#') {
                 continue;
             }
             size_t spacePos = option.find(' ');
-            std::string key, value;
-            if (spacePos != std::string::npos) {
-                key = option.substr(0, spacePos);
-                value = option.substr(spacePos + 1);
-                config[key] = value;
+            if (spacePos == std::string::npos) {
+              throw std::invalid_argument("Failed to find a space separator in "
+                                          "provided plugin config option: " +
+                                          option);
             }
+            std::string key = option.substr(0, spacePos);
+            std::string value = option.substr(spacePos + 1);
+            config[key] = value;
         }
     }
     return config;

--- a/tools/compile_tool/main.cpp
+++ b/tools/compile_tool/main.cpp
@@ -598,11 +598,12 @@ static std::map<std::string, std::string> parseConfigFile(char comment = '#') {
                 continue;
             }
             size_t spacePos = option.find(' ');
-            if (spacePos == std::string::npos) {
-              throw std::invalid_argument("Failed to find a space separator in "
-                                          "provided plugin config option: " +
-                                          option);
-            }
+
+            OPENVINO_ASSERT(spacePos != std::string::npos,
+                            "Failed to find a space separator in "
+                            "provided plugin config option: " +
+                                option);
+
             std::string key = option.substr(0, spacePos);
             std::string value = option.substr(spacePos + 1);
             config[key] = value;


### PR DESCRIPTION
### Details:
A common mistake is to provide `compile_tool` with  `-c plugin.conf` file that contains `KEY=VALUE`. The parameter will be silently ignored. Fix that behavior by throwing an exception.

### Tickets:
#-113187
