### PR TITLE
[GPU] fix issues of MobileFaceNet for dynamic shape

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -1063,6 +1063,11 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 auto eltw_in_size = peer_node->get_output_layout();
                 if (eltw_in_size.is_dynamic())
                     return;
+                // When input rank > 4, fused eltwise to gemm should be converted to 4 dim in init_onednn_primitive_attribute()
+                // But current init_onednn_primitive_attribute() cannot handle dynamic shape case.
+                auto eltw_in_rank = fused_node->get_output_layout().get_rank();
+                if ((fused_node->is_type<gemm>()) && (eltw_in_rank > 4))
+                    return;
             }
             if (parent1.first->is_type<convolution>() && !conv_supports_fusings(parent1.first->as<convolution>()))
                 return;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1294,7 +1294,9 @@ bool primitive_inst::is_valid_fusion() const {
 
         auto outer_dep_pshape = outer_dep.first->_impl_params->get_output_layout().get_partial_shape();
         auto merged_shape = out_pshape;
-        auto can_broadcast = ov::PartialShape::broadcast_merge_into(merged_shape, outer_dep_pshape, fd.typed_desc<eltwise>()->broadcast_spec);
+        bool can_broadcast = true;
+        if (fd.is_type<eltwise>())
+            can_broadcast = ov::PartialShape::broadcast_merge_into(merged_shape, outer_dep_pshape, fd.typed_desc<eltwise>()->broadcast_spec);
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
         // WA for OneDNN binary add fusions: we need to broadcast batch dimension to avoid situation with

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -965,7 +965,7 @@ void program_node::init_onednn_primitive_attributes() {
             if (fused_desc->activation_function == cldnn::activation_func::relu_negative_slope
                 && !fused_desc->additional_params_input.empty()) {
                 auto dep_idx = cldnn_post_ops[idx].outer_dep_start_idx;
-                int oc_dim = static_cast<int>(desc.output_layout.get_tensor().feature.size());
+                auto oc_dim = static_cast<int>(desc.output_layout.get_partial_shape()[1].get_max_length());
                 post_ops.append_prelu(1 << oc_dim);
                 update_onednn_post_op_list(onednn_post_op_type::binary_relu, dep_idx);
             } else if (fused_desc->activation_function == cldnn::activation_func::hard_sigmoid) {

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/is_valid_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/is_valid_fusion_test.cpp
@@ -1,0 +1,92 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include <intel_gpu/primitives/input_layout.hpp>
+#include <intel_gpu/primitives/softmax.hpp>
+#include <intel_gpu/primitives/reorder.hpp>
+#include <intel_gpu/primitives/reshape.hpp>
+#include <intel_gpu/primitives/data.hpp>
+
+#include "softmax_inst.h"
+
+#include "program_wrapper.h"
+
+#include <cmath>
+#include <algorithm>
+
+using namespace cldnn;
+using namespace ::tests;
+
+namespace is_valid_fusion_tests {
+TEST(eltwise_activation_fusing_test, basic) {
+    auto& engine = get_test_engine();
+
+    layout weight_layout = layout{ov::PartialShape{1, 3, 3, 3}, data_types::f32, format::bfyx};
+
+    auto weights = engine.allocate_memory(weight_layout);
+    set_values<FLOAT16>(weights, {
+            1.0f, 1.0f, 1.0f,
+            1.0f, 1.0f, 1.0f,
+            1.0f, 1.0f, 1.0f,
+            //
+            2.0f, 2.0f, 2.0f,
+            2.0f, 2.0f, 2.0f,
+            2.0f, 2.0f, 2.0f,
+            //
+            3.0f, 3.0f, 3.0f,
+            3.0f, 3.0f, 3.0f,
+            3.0f, 3.0f, 3.0f,
+    });
+
+    layout input_layout_1 = layout{ov::PartialShape{1, 3, 2, 2}, data_types::f32, format::bfyx};
+    auto input_mem_1 = engine.allocate_memory(input_layout_1);
+    set_values(input_mem_1, {11.0f,  11.0f, 11.0f, 11.0f,
+                             11.0f,  11.0f, 11.0f, 11.0f,
+                             11.0f,  11.0f, 11.0f, 11.0f});
+    std::vector<float> ref_output_1 = { 66, 132, 132, 66, 132, 264, 264, 132, 132, 264, 264, 132, 66, 132, 132, 66};
+    
+    auto const1 = engine.allocate_memory(layout{ov::PartialShape({1, 1, 1, 1}), data_types::f32, format::bfyx});
+    set_values(const1, {11.0f});
+    auto const2 = engine.allocate_memory(layout{ov::PartialShape({1, 1, 1, 1}), data_types::f32, format::bfyx});
+    set_values(const2, {0.05f});
+    std::vector<float> values_to_subtract = {};
+
+    auto in_layout = layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx};
+    topology topology(input_layout("input", in_layout),
+                      data("weights", weights),
+                      data("const1", const1),
+                      reorder("reorder", input_info("input"), format::bfyx, data_types::f16,
+                      values_to_subtract, reorder_mean_mode::subtract, padding{{0, 0, 2, 2}, 0}),
+                      convolution("conv",
+                                  input_info("input"),
+                                  "weights",
+                                  "",     /*bias*/
+                                  1,
+                                  {1, 1}, /*stride*/
+                                  {1, 1}, /*dilation*/
+                                  {2, 2},  /*pad_above*/
+                                  {2, 2},  /*pad_below*/
+                                  false,
+                                  ov::op::PadType::EXPLICIT,
+                                  padding{{0, 0, 0, 0}, 0}),
+                      eltwise("eltwise", input_info("conv"), input_info("const1"), eltwise_mode::sum),
+                      activation("relu", input_info("eltwise"), activation_func::relu),
+                      reorder("output", input_info("relu"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    //config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
+    network.set_input_data("input", input_mem_1);
+    auto outputs_1 = network.execute();
+    auto output_mem_1 = outputs_1.begin()->second.get_memory();
+    cldnn::mem_lock<float> output_mem_1_ptr(output_mem_1, get_test_stream());
+    for (size_t i = 0; i < output_mem_1->get_layout().get_buffer_size().count(); ++i) {
+        ASSERT_EQ(output_mem_1_ptr[i], ref_output_1[i]);
+    }
+}
+}  // memory_realloc_tests

--- a/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include "intel_gpu/runtime/engine.hpp"
+
+#include "intel_gpu/graph/network.hpp"
+#include "intel_gpu/graph/program.hpp"
+#include "data_inst.h"
+#include "eltwise_inst.h"
+#include "activation_inst.h"
+#include "reorder_inst.h"
+#include "convolution_inst.h"
+#include "pass_manager.h"
+#include "to_string_utils.h"
+
+#include "program_wrapper.h"
+
+#include <memory>
+
+using namespace cldnn;
+using namespace ::tests;
+
+TEST(add_onednn_optimization_attributes, init_attribute_for_fused_onednn_primitive) {
+    auto& engine = get_test_engine();
+
+    auto in_layout = layout{ov::PartialShape({-1, 3, 112, 112}), data_types::f16, format::bfyx};
+    auto input = engine.allocate_memory(layout{ov::PartialShape({1, 3, 112, 112}), data_types::f16, format::bfyx});
+    auto weight = engine.allocate_memory(layout{ov::PartialShape({128, 3, 3, 3}), data_types::f16, format::bfyx});
+    auto const1 = engine.allocate_memory(layout{ov::PartialShape({1, 128, 1, 1}), data_types::f16, format::bfyx});
+    auto const2 = engine.allocate_memory(layout{ov::PartialShape({1, 128, 1, 1}), data_types::f16, format::bfyx});
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weight", weight));
+    topology.add(data("const1", const1));
+    topology.add(data("const2", const2));
+    topology.add(convolution("convolution", input_info("input"), "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(eltwise("eltwise", input_info("convolution"), input_info("const1"), eltwise_mode::sum));
+    topology.add(activation("prelu", input_info("eltwise"), "const2", activation_func::relu_negative_slope));
+    topology.add(reorder("reorder", input_info("prelu"), format::bfyx, data_types::f32));
+
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    auto prog = program::build_program(engine, topology, config, false, false);
+
+    layout_optimizer lo(true);
+    lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);
+
+    program_wrapper::apply_opt_pass<prepare_primitive_fusing>(*prog, lo);
+    program_wrapper::apply_opt_pass<add_onednn_optimization_attributes>(*prog);
+
+    ASSERT_NE(prog, nullptr);
+    ASSERT_FALSE(has_node(*prog, "eltwise"));
+    ASSERT_FALSE(has_node(*prog, "prelu"));
+}


### PR DESCRIPTION
### Details:
 - Avoiding wrong enum type check in activation fusing
 - Getting feature value by get_partial_shapes() instead of get_tensor() for dynamic shape unbounded case
 - Avoiding eltwise fusing to onednn gemm when rank > 4.

### Tickets:
 - 110936
