### PR TITLE
[TF FE] Handle control dependencies to have correct outputs

### DIFF
--- a/src/frontends/tensorflow/src/input_model.cpp
+++ b/src/frontends/tensorflow/src/input_model.cpp
@@ -214,6 +214,14 @@ void InputModel::InputModelTFImpl::load_places() {
                                              producer_op_name,
                                              producer_output_port_name,
                                              producer_output_port_idx);
+                if (is_conditional_edge(producer_op_name)) {
+                    // exclude "^" mark indicating (execution) conditional dependency
+                    // for example, "^sub_op" means dependency on a producer node with a name "sub_op"
+                    // if a node has dependent operation nodes and has no data consumers,
+                    // this node is not terminating and will not output to the Result node
+                    producer_op_name = producer_op_name.substr(1);
+                }
+
                 op_names_with_consumers.insert(producer_op_name);
             } catch (const std::exception&) {
                 FRONT_END_THROW("[ ERROR ] Exception happened when preparing input " + std::to_string(input_port_idx) +

--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -700,3 +700,19 @@ TEST_F(FrontEndConversionWithReferenceTestsF, PartitionedCallsWithConvInBodyGrap
         model_ref = make_shared<Model>(OutputVector{conv}, ParameterVector{input1, filter});
     }
 }
+
+TEST_F(FrontEndConversionWithReferenceTestsF, ControlDependencyNumberOutputs) {
+    // The test aims to check a number of outputs of the resulted model
+    // If the node has dependent nodes by conditional edge, it is not terminating
+    // and it should not go to the Result node
+    { model = convert_model("control_dependency/control_dependency.pb"); }
+    {
+        auto input1 = make_shared<Parameter>(f32, Shape{2, 3});
+        auto input2 = make_shared<Parameter>(f32, Shape{2, 3});
+
+        // AddV2 node is excluded since it is not terminating
+        auto sub = make_shared<Subtract>(input1, input2);
+
+        model_ref = make_shared<Model>(OutputVector{sub}, ParameterVector{input1, input2});
+    }
+}

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_control_dependency.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_control_dependency.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import numpy as np
+import tensorflow as tf
+
+tf.compat.v1.reset_default_graph()
+
+# Create the graph and model
+with tf.compat.v1.Session() as sess:
+    input1 = tf.compat.v1.placeholder(tf.float32, [2, 3], 'input1')
+    input2 = tf.compat.v1.placeholder(tf.float32, [2, 3], 'input2')
+
+    add = tf.add(input1, input2, name="add")
+    with tf.control_dependencies([add]):
+        sub = tf.subtract(input1, input2, name="sub")
+
+    tf.compat.v1.global_variables_initializer()
+    tf_net = sess.graph_def
+
+tf.io.write_graph(tf_net, os.path.join(sys.argv[1], "control_dependency"), 'control_dependency.pb', False)


### PR DESCRIPTION
**Details:** Handle control dependencies to have correct a number of outputs. Nodes having control flow dependents can be terminating.

**Ticket:** 111548
