### PR TITLE
Fix flake8 warnings and ignore VNE001 for Python samples

### DIFF
--- a/samples/python/setup.cfg
+++ b/samples/python/setup.cfg
@@ -3,6 +3,7 @@
 # D100 - Missing docstring in public module
 # D101 - Missing docstring in public class
 # D103 - Missing docstring in public function
+# VNE001 - Single letter variable names are not allowed
 filename = *.py
 max-line-length = 160
 ignore = E203,D100,D101,D103,VNE001

--- a/samples/python/setup.cfg
+++ b/samples/python/setup.cfg
@@ -5,7 +5,7 @@
 # D103 - Missing docstring in public function
 filename = *.py
 max-line-length = 160
-ignore = E203,D100,D101,D103
+ignore = E203,D100,D101,D103,VNE001
 max-parameters-amount = 8
 show_source = True
 docstring-convention = google

--- a/src/bindings/python/tests/test_onnx/test_ops_reshape.py
+++ b/src/bindings/python/tests/test_onnx/test_ops_reshape.py
@@ -412,7 +412,7 @@ def test_split_1d():
 
 
 def test_depth_to_space():
-    b, c, h, w = shape = (2, 8, 3, 3)
+    b, c, h, w = shape = (2, 8, 3, 3)  # noqa: VNE001
     blocksize = 2
     data = np.random.random_sample(shape).astype(np.float32)
     tmp = np.reshape(data, [b, blocksize, blocksize, c // (blocksize ** 2), h, w])

--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -220,7 +220,7 @@ class CustomBuild(build):
         ("cmake-args=", None, "Additional options to be passed to CMake."),
         ("python-extensions-only", None, "Install Python extensions without C++ libraries."),
     ]
-    boolean_options = build.boolean_options + ['python-extensions-only']
+    boolean_options = build.boolean_options + ["python-extensions-only"]
 
     def initialize_options(self):
         """Set default values for all the options that this command supports."""
@@ -436,7 +436,7 @@ class CopyExt(build_ext):
     user_options = [
         ("skip-rpath", None, "Skips RPATH for Python extensions."),
     ]
-    boolean_options = ['skip_rpath']
+    boolean_options = ["skip_rpath"]
 
     def initialize_options(self):
         """Set default values for all the options that this command supports."""


### PR DESCRIPTION
### Details:
 - Ignore the rule of flake8-variables-names "single letter variable names" which is not applicable in samples.
 - Fix other minor issues in other files.

### Tickets:
 - N/A