### PR TITLE
Removed benchmark_tool from openvino

### DIFF
--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -175,30 +175,30 @@ PY_INSTALL_CFG = {
         "install_dir": PY_PACKAGES_DIR,
         "binary_dir": OPENVINO_PYTHON_BINARY_DIR,
     },
-    "benchmark_app": {
-        "entry_point": {
-            "console_scripts": [
-                "benchmark_app = openvino.tools.benchmark.main:main",
-            ],
-        },
-        "name": f"pyopenvino_{PYTHON_VERSION}",
-        "prefix": f"{BUILD_BASE}/site-packages",
-        "source_dir": f"{OPENVINO_SOURCE_DIR}/tools/benchmark_tool",
-        "install_dir": PY_PACKAGES_DIR,
-        "binary_dir": "benchmark_app",
-    },
-    # "model_optimizer": {                                  # noqa: E731
-    #     "entry_point": {                                  # noqa: E731
-    #         "console_scripts": [                          # noqa: E731
-    #             "mo = openvino.tools.mo.main:main",       # noqa: E731
-    #         ],                                            # noqa: E731
-    #     },                                                # noqa: E731
-    #     "name": f"pyopenvino_{PYTHON_VERSION}",           # noqa: E731
-    #     "prefix": f"{BUILD_BASE}/site-packages",          # noqa: E731
-    #     "source_dir": f"{OPENVINO_SOURCE_DIR}/tools/mo",  # noqa: E731
-    #     "install_dir": PY_PACKAGES_DIR,                   # noqa: E731
-    #     "binary_dir": "model_optimizer",                  # noqa: E731
-    # },                                                    # noqa: E731
+    # "benchmark_app": {                                                 # noqa: E731
+    #     "entry_point": {                                               # noqa: E731
+    #         "console_scripts": [                                       # noqa: E731
+    #             "benchmark_app = openvino.tools.benchmark.main:main",  # noqa: E731
+    #         ],                                                         # noqa: E731
+    #     },                                                             # noqa: E731
+    #     "name": f"pyopenvino_{PYTHON_VERSION}",                        # noqa: E731
+    #     "prefix": f"{BUILD_BASE}/site-packages",                       # noqa: E731
+    #     "source_dir": f"{OPENVINO_SOURCE_DIR}/tools/benchmark_tool",   # noqa: E731
+    #     "install_dir": PY_PACKAGES_DIR,                                # noqa: E731
+    #     "binary_dir": "benchmark_app",                                 # noqa: E731
+    # },                                                                 # noqa: E731
+    # "model_optimizer": {                                               # noqa: E731
+    #     "entry_point": {                                               # noqa: E731
+    #         "console_scripts": [                                       # noqa: E731
+    #             "mo = openvino.tools.mo.main:main",                    # noqa: E731
+    #         ],                                                         # noqa: E731
+    #     },                                                             # noqa: E731
+    #     "name": f"pyopenvino_{PYTHON_VERSION}",                        # noqa: E731
+    #     "prefix": f"{BUILD_BASE}/site-packages",                       # noqa: E731
+    #     "source_dir": f"{OPENVINO_SOURCE_DIR}/tools/mo",               # noqa: E731
+    #     "install_dir": PY_PACKAGES_DIR,                                # noqa: E731
+    #     "binary_dir": "model_optimizer",                               # noqa: E731
+    # },                                                                 # noqa: E731
 }
 
 
@@ -266,6 +266,7 @@ class CustomBuild(build):
                     binary_dir = os.path.join(self.build_temp, binary_dir)
                     self.announce(f"Configuring {comp} cmake project", level=3)
                     self.spawn(["cmake", f"-DOpenVINODeveloperPackage_DIR={OPENVINO_BINARY_DIR}",
+                                         f"-DPYTHON_EXECUTABLE={sys.executable}",
                                          "-DCMAKE_BUILD_TYPE=Release",
                                          "-DENABLE_WHEEL=OFF",
                                          self.cmake_args,

--- a/tools/benchmark_tool/CMakeLists.txt
+++ b/tools/benchmark_tool/CMakeLists.txt
@@ -16,9 +16,9 @@ endif()
 
 if(NOT IEDevScripts_FOUND)
     find_package(IEDevScripts REQUIRED
-                PATHS "${OpenVINO_SOURCE_DIR}/cmake/developer_package"
-                NO_CMAKE_FIND_ROOT_PATH
-                NO_DEFAULT_PATH)
+                 PATHS "${OpenVINO_SOURCE_DIR}/cmake/developer_package"
+                 NO_CMAKE_FIND_ROOT_PATH
+                 NO_DEFAULT_PATH)
 endif()
 
 #


### PR DESCRIPTION
### Details:
 - Removed benchmark_tool from `openvino` since the `opencv` dependency is still not solved