### PR TITLE
[GPU] Fix output layout calculation for crop and fc

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
@@ -615,15 +615,17 @@ public:
         return offset;
     }
 
-    /// @brief Returns tensor as Partial shape of requested rank
-    ov::PartialShape get_partial_shape(size_t rank) const {
+    /// @brief Returns partial shape of the requested rank
+    /// @param rank The requested rank of partial shape
+    /// @param dims Number of actual dimensions for layout's format
+    ov::PartialShape get_partial_shape(size_t rank, size_t dims) const {
         ov::Shape shape;
         size_t i = 0;
         for (; i < std::min(static_cast<size_t>(2), rank); ++i) {
             shape.push_back(_sizes[i]);
         }
         for (; i < rank; ++i) {
-            shape.push_back(_sizes[rank - (i - 2) - 1]);
+            shape.push_back(_sizes[dims - (i - 2) - 1]);
         }
         return ov::PartialShape(shape);
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
@@ -617,15 +617,15 @@ public:
 
     /// @brief Returns partial shape of the requested rank
     /// @param rank The requested rank of partial shape
-    /// @param dims Number of actual dimensions for layout's format
-    ov::PartialShape get_partial_shape(size_t rank, size_t dims) const {
+    /// @param format_dims Number of actual dimensions for layout's format
+    ov::PartialShape get_partial_shape(size_t rank, size_t format_dims) const {
         ov::Shape shape;
         size_t i = 0;
         for (; i < std::min(static_cast<size_t>(2), rank); ++i) {
             shape.push_back(_sizes[i]);
         }
         for (; i < rank; ++i) {
-            shape.push_back(_sizes[dims - (i - 2) - 1]);
+            shape.push_back(_sizes[format_dims - (i - 2) - 1]);
         }
         return ov::PartialShape(shape);
     }

--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -102,9 +102,9 @@ std::vector<layout> crop_inst::calc_output_layouts(const crop_node& /*node*/, co
             const auto lt_sizes = offsets.sub({0, 0, 0, 0, 0});
             const auto out_sizes = in_sizes - (rb_sizes + lt_sizes);
 
-            return {layout{out_sizes.get_partial_shape(in_layout.get_partial_shape().size()), in_layout.data_type, in_layout.format}};
+            return {layout{out_sizes.get_partial_shape(in_layout.get_partial_shape().size(), in_layout.get_rank()), in_layout.data_type, in_layout.format}};
         }
-        return {layout{ref_in_sizes.get_partial_shape(in_layout.get_partial_shape().size()), in_layout.data_type, in_layout.format}};
+        return {layout{ref_in_sizes.get_partial_shape(in_layout.get_partial_shape().size(), in_layout.get_rank()), in_layout.data_type, in_layout.format}};
     }
 
     bool is_output_static = false;

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -139,8 +139,9 @@ std::vector<layout> fully_connected_inst::calc_output_layouts(fully_connected_no
     auto input_layout = impl_param.get_input_layout();
     auto weights_layout = *impl_param.weights_layout;
 
-    auto default_out_dt = data_type_traits::is_floating_point(input_layout.data_type) ? input_layout.data_type : data_types::f32;
-    auto output_type = desc->output_data_types[0].value_or(default_out_dt);
+    auto output_type = input_layout.data_type;
+    if (data_type_traits::is_i8_u8(output_type) && desc->output_data_types[0])
+        output_type = *desc->output_data_types[0];
 
     if (impl_param.has_fused_primitives()) {
         output_type = impl_param.get_fused_output_layout().data_type;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/crop.cpp
@@ -53,7 +53,7 @@ struct crop_impl : public typed_primitive_impl<crop> {
         auto output_layout = params->output_layouts[0];
 
         auto input_shape = input_layout.get_partial_shape().to_shape();
-        auto offsets_shape = input_offset.get_partial_shape(input_shape.size()).to_shape();
+        auto offsets_shape = input_offset.get_partial_shape(input_shape.size(), input_layout.get_rank()).to_shape();
         auto output_shape = output_layout.get_partial_shape().to_shape();
 
         OPENVINO_ASSERT(offsets_shape.size() == output_shape.size(), "[GPU] Offset shape is supposed to have the same rank as output shape");

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1259,7 +1259,7 @@ bool layout_optimizer::are_data_types_suitable_for_onednn(program_node& node) {
         return onednn_check_data_types_for_deconvolution(in_dt, wei_dt, out_dt);
     } else if (node.is_type<fully_connected>() || node.is_type<gemm>()) {
         bool is_fc = node.is_type<fully_connected>();
-        auto wei_dt = is_fc ? node.as<fully_connected>().weights().get_output_layout().data_type :
+        auto wei_dt = is_fc ? node.as<fully_connected>().weights().get_output_layout(false).data_type :
                               node.as<gemm>().get_input_layout(1).data_type;
         return onednn_check_data_types_for_fc_gemm(in_dt, wei_dt, out_dt);
     } else if (node.is_type<reorder>()) {

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/crop_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/crop_si_test.cpp
@@ -184,6 +184,13 @@ INSTANTIATE_TEST_SUITE_P(smoke, crop_si_test,
             {{{7,1,1},data_types::f32,format::bfyx}, {{},data_types::i64,format::bfyx}, {{1},data_types::i64,format::bfyx}},
             {{{7,1,1},data_types::f32,format::bfyx}}, 0
         },
+        {
+            tensor({128,100,1,3,1,1,1}),
+            {tensor({0,0,0,0,1,1,1})},
+            {},
+            {{{128,100,4},data_types::f32,format::bfyx}},
+            {{{128,100,3},data_types::f32,format::bfyx}}, 0
+        }
     }));
 
 };  // shape_infer_tests

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/matmul_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/matmul_si_test.cpp
@@ -107,6 +107,12 @@ INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_test,
             layout{ov::PartialShape{10, 1000}, data_types::f16, format::bfyx}
         },
         {
+            layout{ov::PartialShape{10, 1024}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{1000, 1024}, data_types::f32, format::bfyx},
+            data_types::i32, false, false,
+            layout{ov::PartialShape{10, 1000}, data_types::f32, format::bfyx}
+        },
+        {
             layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx},
             layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx},
             data_types::f32, false, false,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -2214,9 +2214,9 @@ struct dynamic_fully_connected_gpu : ::testing::TestWithParam<fully_connected_dy
         };
 
         if (fc_3d)
-            topology.add(fully_connected("fc", input_info("input"), "weights", "bias", padding(), 3));
+            topology.add(fully_connected("fc", input_info("input"), "weights", "bias", output_dt, padding(), 3));
         else
-            topology.add(fully_connected("fc", input_info("input"), "weights", "bias"));
+            topology.add(fully_connected("fc", input_info("input"), "weights", "bias", output_dt));
 
         ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));


### PR DESCRIPTION
### Details:
 - Fix `get_partial_shape` tensor API to access the correct index of dimensions
 - Update the rule specifying output data type to the legacy one by referring to `calc_output_layout` to prevent propagating to output data type not supported by fc kernels
 - Fix `are_data_types_sutable_for_onednn` not to invalidate output layout

### Tickets:
 - 99450
