### PR TITLE
[GPU] Fix bug in weight reorder.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1014,7 +1014,7 @@ event::ptr primitive_inst::update_weights() {
             memory::ptr weights_memory = nullptr;
             if (_reordered_weights_cache.is_full()) {
                 weights_memory = _reordered_weights_cache.get_lru_element().second;
-                can_reuse = weights_memory->size() <= expected_layout.bytes_count() && weights_memory != original_weights_memory;
+                can_reuse = weights_memory->size() <= expected_layout.bytes_count() && (weights_memory->buffer_ptr() != original_weights_memory->buffer_ptr());
             }
 
             if (can_reuse) {


### PR DESCRIPTION
### Details:
 - The original memory was overwritten unexpectedly because it was chekcing shared_ptr instead of actual buffer address
 - This case happened in the following sequence 
 - 1) At first run, a layer uses a kernel, which requires reorder weight reorder and the format is compatible with original layout(e.g., jit::gemm::any with oiyx) => So the memory object is original as is and it is registered to reordered_weights_cache
 - 2) Then in the next iteration with different shape, it selects a new kernel which requires weight reorder(e.g., fc_bf_tiled_opt kernel with os_iyx_osv16 format). At this time, it attempts to check whether the memory in the reordered_weights_cache is reusable. Here, it was reordering the "original memory" object because it was registered in the reordered_weights_cahce. 
 - 3) In the next iteration, it uses again the kernel in the first iteration. Here, it uses the reinterpreted original memory object. However the weight data in the original memory is reordered.... So it goes with wrong weight. 

It is hard to reproduce this sequence in the unittest because this happens when the network is quite large so the first execution of the layer can use kernel in the in_memory_cache but the second execution of the layer cannot use in_memory_cache. 
 
### Tickets:
 - 113166
