### PR TITLE
[CPU] Reduce node supports fp16 precision

### DIFF
--- a/src/inference/dev_api/ie_system_conf.h
+++ b/src/inference/dev_api/ie_system_conf.h
@@ -122,13 +122,6 @@ using ov::with_cpu_x86_avx512_core_vnni;
 using ov::with_cpu_x86_bfloat16;
 
 /**
- * @brief      Checks whether CPU supports fp16 capability
- * @ingroup    ie_dev_api_system_conf
- * @return     `True` is tAVX512_FP16 instructions are available, `false` otherwise
- */
-using ov::with_cpu_x86_fp16;
-
-/**
  * @brief      Checks whether CPU supports AMX int8 capability
  * @ingroup    ie_dev_api_system_conf
  * @return     `True` is tAMX_INT8 instructions are available, `false` otherwise

--- a/src/inference/dev_api/ie_system_conf.h
+++ b/src/inference/dev_api/ie_system_conf.h
@@ -122,6 +122,13 @@ using ov::with_cpu_x86_avx512_core_vnni;
 using ov::with_cpu_x86_bfloat16;
 
 /**
+ * @brief      Checks whether CPU supports fp16 capability
+ * @ingroup    ie_dev_api_system_conf
+ * @return     `True` is tAVX512_FP16 instructions are available, `false` otherwise
+ */
+using ov::with_cpu_x86_fp16;
+
+/**
  * @brief      Checks whether CPU supports AMX int8 capability
  * @ingroup    ie_dev_api_system_conf
  * @return     `True` is tAMX_INT8 instructions are available, `false` otherwise

--- a/src/inference/dev_api/ie_system_conf.h
+++ b/src/inference/dev_api/ie_system_conf.h
@@ -122,6 +122,13 @@ using ov::with_cpu_x86_avx512_core_vnni;
 using ov::with_cpu_x86_bfloat16;
 
 /**
+ * @brief      Checks whether CPU supports fp16 capability
+ * @ingroup    ie_dev_api_system_conf
+ * @return     `True` is tAVX512_FP16 instructions are available, `false` otherwise
+ */
+using ov::with_cpu_x86_avx512_core_fp16;
+
+/**
  * @brief      Checks whether CPU supports AMX int8 capability
  * @ingroup    ie_dev_api_system_conf
  * @return     `True` is tAMX_INT8 instructions are available, `false` otherwise

--- a/src/inference/dev_api/openvino/runtime/system_conf.hpp
+++ b/src/inference/dev_api/openvino/runtime/system_conf.hpp
@@ -111,13 +111,6 @@ OPENVINO_RUNTIME_API bool with_cpu_x86_avx512_core_vnni();
 OPENVINO_RUNTIME_API bool with_cpu_x86_bfloat16();
 
 /**
- * @brief      Checks whether CPU supports fp16 capability
- * @ingroup    ov_dev_api_system_conf
- * @return     `True` is tAVX512_FP16 instructions are available, `false` otherwise
- */
-OPENVINO_RUNTIME_API bool with_cpu_x86_fp16();
-
-/**
  * @brief      Checks whether CPU supports AMX int8 capability
  * @ingroup    ov_dev_api_system_conf
  * @return     `True` is tAMX_INT8 instructions are available, `false` otherwise

--- a/src/inference/dev_api/openvino/runtime/system_conf.hpp
+++ b/src/inference/dev_api/openvino/runtime/system_conf.hpp
@@ -111,6 +111,13 @@ OPENVINO_RUNTIME_API bool with_cpu_x86_avx512_core_vnni();
 OPENVINO_RUNTIME_API bool with_cpu_x86_bfloat16();
 
 /**
+ * @brief      Checks whether CPU supports fp16 capability
+ * @ingroup    ov_dev_api_system_conf
+ * @return     `True` is tAVX512_FP16 instructions are available, `false` otherwise
+ */
+OPENVINO_RUNTIME_API bool with_cpu_x86_fp16();
+
+/**
  * @brief      Checks whether CPU supports AMX int8 capability
  * @ingroup    ov_dev_api_system_conf
  * @return     `True` is tAMX_INT8 instructions are available, `false` otherwise

--- a/src/inference/dev_api/openvino/runtime/system_conf.hpp
+++ b/src/inference/dev_api/openvino/runtime/system_conf.hpp
@@ -111,6 +111,13 @@ OPENVINO_RUNTIME_API bool with_cpu_x86_avx512_core_vnni();
 OPENVINO_RUNTIME_API bool with_cpu_x86_bfloat16();
 
 /**
+ * @brief      Checks whether CPU supports fp16 capability
+ * @ingroup    ov_dev_api_system_conf
+ * @return     `True` is tAVX512_FP16 instructions are available, `false` otherwise
+ */
+OPENVINO_RUNTIME_API bool with_cpu_x86_avx512_core_fp16();
+
+/**
  * @brief      Checks whether CPU supports AMX int8 capability
  * @ingroup    ov_dev_api_system_conf
  * @return     `True` is tAMX_INT8 instructions are available, `false` otherwise

--- a/src/inference/src/system_conf.cpp
+++ b/src/inference/src/system_conf.cpp
@@ -72,6 +72,10 @@ bool with_cpu_x86_bfloat16() {
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_BF16);
 }
 
+bool with_cpu_x86_fp16() {
+    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_FP16);
+}
+
 bool with_cpu_x86_avx512_core_amx_int8() {
     return get_cpu_info().has(Xbyak::util::Cpu::tAMX_INT8);
 }
@@ -105,6 +109,9 @@ bool with_cpu_x86_avx512_core_vnni() {
     return false;
 }
 bool with_cpu_x86_bfloat16() {
+    return false;
+}
+bool with_cpu_x86_fp16() {
     return false;
 }
 bool with_cpu_x86_avx512_core_amx_int8() {

--- a/src/inference/src/system_conf.cpp
+++ b/src/inference/src/system_conf.cpp
@@ -72,10 +72,6 @@ bool with_cpu_x86_bfloat16() {
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_BF16);
 }
 
-bool with_cpu_x86_fp16() {
-    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_FP16);
-}
-
 bool with_cpu_x86_avx512_core_amx_int8() {
     return get_cpu_info().has(Xbyak::util::Cpu::tAMX_INT8);
 }
@@ -109,9 +105,6 @@ bool with_cpu_x86_avx512_core_vnni() {
     return false;
 }
 bool with_cpu_x86_bfloat16() {
-    return false;
-}
-bool with_cpu_x86_fp16() {
     return false;
 }
 bool with_cpu_x86_avx512_core_amx_int8() {

--- a/src/inference/src/system_conf.cpp
+++ b/src/inference/src/system_conf.cpp
@@ -72,6 +72,10 @@ bool with_cpu_x86_bfloat16() {
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_BF16);
 }
 
+bool with_cpu_x86_avx512_core_fp16() {
+    return get_cpu_info().has(Xbyak::util::Cpu::tAVX512_FP16);
+}
+
 bool with_cpu_x86_avx512_core_amx_int8() {
     return get_cpu_info().has(Xbyak::util::Cpu::tAMX_INT8);
 }
@@ -105,6 +109,9 @@ bool with_cpu_x86_avx512_core_vnni() {
     return false;
 }
 bool with_cpu_x86_bfloat16() {
+    return false;
+}
+bool with_cpu_x86_avx512_core_fp16() {
     return false;
 }
 bool with_cpu_x86_avx512_core_amx_int8() {

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -179,7 +179,7 @@ void Config::readProperties(const std::map<std::string, std::string> &prop) {
                     inferencePrecisionSetExplicitly = true;
                 }
             } else if (val == "f16") {
-                if (mayiuse(avx512_core_fp16) || mayiuse(avx512_core_amx_fp16)) {
+                if (mayiuse(avx2)) {
                     inferencePrecision = ov::element::f16;
                     inferencePrecisionSetExplicitly = true;
                 }

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -179,7 +179,7 @@ void Config::readProperties(const std::map<std::string, std::string> &prop) {
                     inferencePrecisionSetExplicitly = true;
                 }
             } else if (val == "f16") {
-                if (mayiuse(avx2)) {
+                if (mayiuse(avx512_core_fp16) || mayiuse(avx512_core_amx_fp16)) {
                     inferencePrecision = ov::element::f16;
                     inferencePrecisionSetExplicitly = true;
                 }

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -312,6 +312,7 @@ void Graph::Replicate(const CNNNetwork &network) {
         for (size_t i = 0; i < childEdges.size(); i++) {
             const auto child = childEdges[i]->getChild();
             if (child->getOriginalInputPrecisionAtPort(childEdges[i]->getOutputNum()) != Precision::BF16 &&
+                child->getOriginalInputPrecisionAtPort(childEdges[i]->getOutputNum()) != Precision::FP16 &&
                 // remove this WA when #78939 is resolved
                 !hasSubgraphConsumers(child))
                 child->setOriginalInputPrecisionAtPort(childEdges[i]->getOutputNum(), precToSet);

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -311,8 +311,8 @@ void Graph::Replicate(const CNNNetwork &network) {
         const auto childEdges = input.second->getChildEdgesAtPort(0);
         for (size_t i = 0; i < childEdges.size(); i++) {
             const auto child = childEdges[i]->getChild();
-            if (child->getOriginalInputPrecisionAtPort(childEdges[i]->getOutputNum()) != Precision::BF16 &&
-                child->getOriginalInputPrecisionAtPort(childEdges[i]->getOutputNum()) != Precision::FP16 &&
+            if (!one_of(child->getOriginalInputPrecisionAtPort(childEdges[i]->getOutputNum()),
+                Precision::BF16, Precision::FP16) &&
                 // remove this WA when #78939 is resolved
                 !hasSubgraphConsumers(child))
                 child->setOriginalInputPrecisionAtPort(childEdges[i]->getOutputNum(), precToSet);

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -246,10 +246,6 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(.*Snippets.*MHA.*)");
         retVector.emplace_back(R"(.*Snippets.*(MatMul|Matmul).*)");
     }
-    if (!InferenceEngine::with_cpu_x86_fp16()) {
-        // Skip fp16 tests for paltforms that don't support fp16 precision
-        retVector.emplace_back(R"(.*INFERENCE_PRECISION_HINT=(F|f)16.*)");
-    }
     if (!InferenceEngine::with_cpu_x86_avx512_core_vnni() && !InferenceEngine::with_cpu_x86_avx512_core_amx_int8()) {
         // MatMul in Snippets uses BRGEMM that supports i8 only on platforms with VNNI or AMX instructions
         retVector.emplace_back(R"(.*Snippets.*MatMulFQ.*)");

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -74,7 +74,7 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*OVCompiledModelBaseTest.*(CanGetInputsInfoAndCheck|canSetConfigToCompiledModel).*)",
         R"(.*Behavior.*CorrectConfigCheck.*(canSetConfigAndCheckGetConfig|canSetConfigTwiceAndCheckGetConfig).*CPU_BIND_THREAD=YES.*)",
         // Issue: 72021 Unreasonable abs_threshold for comparing bf16 results
-        R"(.*smoke_Reduce.*type=(Prod|Min).*netPRC=(BF|bf)16.*)",
+        R"(.*smoke_Reduce.*type=(Prod|Min).*INFERENCE_PRECISION_HINT=(BF|bf)16.*)",
         // TODO: 56520 Accuracy mismatch
         R"(.*ReduceOpsLayerTest.*type=Mean_.*netPRC=(I64|I32).*)",
         R"(.*ReduceOpsLayerTest.*type=Mean_.*netPRC=U64.*)",
@@ -245,6 +245,10 @@ std::vector<std::string> disabledTestPatterns() {
         // Disabled Snippets MHA tests as well because MHA pattern contains MatMul
         retVector.emplace_back(R"(.*Snippets.*MHA.*)");
         retVector.emplace_back(R"(.*Snippets.*(MatMul|Matmul).*)");
+    }
+    if (!InferenceEngine::with_cpu_x86_fp16()) {
+        // Skip fp16 tests for paltforms that don't support fp16 precision
+        retVector.emplace_back(R"(.*INFERENCE_PRECISION_HINT=(F|f)16.*)");
     }
     if (!InferenceEngine::with_cpu_x86_avx512_core_vnni() && !InferenceEngine::with_cpu_x86_avx512_core_amx_int8()) {
         // MatMul in Snippets uses BRGEMM that supports i8 only on platforms with VNNI or AMX instructions

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -246,6 +246,10 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(.*Snippets.*MHA.*)");
         retVector.emplace_back(R"(.*Snippets.*(MatMul|Matmul).*)");
     }
+    if (!InferenceEngine::with_cpu_x86_avx512_core_fp16()) {
+        // Skip fp16 tests for paltforms that don't support fp16 precision
+        retVector.emplace_back(R"(.*INFERENCE_PRECISION_HINT=(F|f)16.*)");
+    }
     if (!InferenceEngine::with_cpu_x86_avx512_core_vnni() && !InferenceEngine::with_cpu_x86_avx512_core_amx_int8()) {
         // MatMul in Snippets uses BRGEMM that supports i8 only on platforms with VNNI or AMX instructions
         retVector.emplace_back(R"(.*Snippets.*MatMulFQ.*)");

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -246,10 +246,12 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(.*Snippets.*MHA.*)");
         retVector.emplace_back(R"(.*Snippets.*(MatMul|Matmul).*)");
     }
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
     if (!InferenceEngine::with_cpu_x86_avx512_core_fp16()) {
         // Skip fp16 tests for paltforms that don't support fp16 precision
         retVector.emplace_back(R"(.*INFERENCE_PRECISION_HINT=(F|f)16.*)");
     }
+#endif
     if (!InferenceEngine::with_cpu_x86_avx512_core_vnni() && !InferenceEngine::with_cpu_x86_avx512_core_amx_int8()) {
         // MatMul in Snippets uses BRGEMM that supports i8 only on platforms with VNNI or AMX instructions
         retVector.emplace_back(R"(.*Snippets.*MatMulFQ.*)");

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.cpp
@@ -53,7 +53,7 @@ std::string ReduceCPULayerTest::getTestCaseName(testing::TestParamInfo<ReduceLay
     result << "outPRC=" << outPrc << "_";
 
     if (!additionalConfig.empty()) {
-        result << "_PluginConf";
+        result << "PluginConf";
         for (auto& item : additionalConfig) {
             result << "_" << item.first << "=" << item.second.get_type_name();
         }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.cpp
@@ -260,6 +260,13 @@ const std::vector<std::map<std::string, ov::element::Type>> additionalConfig() {
     return additionalConfig;
 }
 
+const std::vector<std::map<std::string, ov::element::Type>> additionalConfigFP32() {
+    static const std::vector<std::map<std::string, ov::element::Type>> additionalConfig = {
+        {{ov::hint::inference_precision.name(), ov::element::f32}}
+    };
+    return additionalConfig;
+}
+
 const std::vector<ngraph::helpers::ReductionType>& reductionTypesInt32() {
     static const std::vector<ngraph::helpers::ReductionType> reductionTypesInt32 = {
             ngraph::helpers::ReductionType::Sum,

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.cpp
@@ -255,7 +255,10 @@ const std::vector<std::map<std::string, ov::element::Type>> additionalConfig() {
     static const std::vector<std::map<std::string, ov::element::Type>> additionalConfig = {
         {{ov::hint::inference_precision.name(), ov::element::f32}},
         {{ov::hint::inference_precision.name(), ov::element::bf16}},
+// ARM doesn't support FP16 for now
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
         {{ov::hint::inference_precision.name(), ov::element::f16}},
+#endif
     };
     return additionalConfig;
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.hpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.hpp
@@ -29,7 +29,8 @@ typedef std::tuple<
 typedef std::tuple<
         basicReduceParams,
         CPUSpecificParams,
-        fusingSpecificParams> ReduceLayerCPUTestParamSet;
+        fusingSpecificParams,
+        std::map<std::string, ov::element::Type>> ReduceLayerCPUTestParamSet;
 
 class ReduceCPULayerTest : public testing::WithParamInterface<ReduceLayerCPUTestParamSet>,
                            virtual public SubgraphBaseTest, public CpuTestWithFusing {
@@ -52,6 +53,7 @@ const std::vector<std::vector<int>>& axesND();
 const std::vector<CommonTestUtils::OpType>& opTypes();
 const std::vector<ngraph::helpers::ReductionType>& reductionTypes();
 const std::vector<ElementType>& inpOutPrc();
+const std::vector<std::map<std::string, ov::element::Type>> additionalConfig();
 const std::vector<ngraph::helpers::ReductionType>& reductionTypesInt32();
 
 } // namespace Reduce

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.hpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/reduce.hpp
@@ -54,6 +54,7 @@ const std::vector<CommonTestUtils::OpType>& opTypes();
 const std::vector<ngraph::helpers::ReductionType>& reductionTypes();
 const std::vector<ElementType>& inpOutPrc();
 const std::vector<std::map<std::string, ov::element::Type>> additionalConfig();
+const std::vector<std::map<std::string, ov::element::Type>> additionalConfigFP32();
 const std::vector<ngraph::helpers::ReductionType>& reductionTypesInt32();
 
 } // namespace Reduce

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/common/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/common/reduce.cpp
@@ -67,7 +67,8 @@ const auto params_OneAxis = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes)),
         testing::Values(emptyCPUSpec),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_OneAxis_dynamic = testing::Combine(
         testing::Combine(
@@ -80,7 +81,8 @@ const auto params_OneAxis_dynamic = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_dynamic_3dims)),
         testing::Values(emptyCPUSpec),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_4D = testing::Combine(
         testing::Combine(
@@ -93,7 +95,8 @@ const auto params_MultiAxis_4D = testing::Combine(
                 testing::Values(ElementType::undefined),
                 testing::ValuesIn(inputShapes)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_4D_dynamic = testing::Combine(
         testing::Combine(
@@ -106,7 +109,8 @@ const auto params_MultiAxis_4D_dynamic = testing::Combine(
                 testing::Values(ElementType::undefined),
                 testing::ValuesIn(inputShapes_dynamic_2dims)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_Int32 = testing::Combine(
         testing::Combine(
@@ -119,7 +123,8 @@ const auto params_Int32 = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_Int32)),
         testing::Values(emptyCPUSpec),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_OneAxis_CPU,

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/reduce.cpp
@@ -187,7 +187,7 @@ const auto params_MultiAxis_4D_Hybrid = testing::Combine(
             testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_4D)),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_5D_Hybrid = testing::Combine(
         testing::Combine(
@@ -201,7 +201,7 @@ const auto params_MultiAxis_5D_Hybrid = testing::Combine(
             testing::ValuesIn(inputShapes_5D_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_5D)),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_6D = testing::Combine(
         testing::Combine(
@@ -215,7 +215,7 @@ const auto params_MultiAxis_6D = testing::Combine(
                 testing::ValuesIn(inputShapes_6D_dyn)),
         testing::Values(emptyCPUSpec),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_Int32 = testing::Combine(
         testing::Combine(
@@ -229,7 +229,7 @@ const auto params_Int32 = testing::Combine(
             testing::ValuesIn(inputShapes_Int32_dyn)),
         testing::Values(emptyCPUSpec),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_NHWC_SmallChannel = testing::Combine(
         testing::Combine(
@@ -335,7 +335,7 @@ const auto params_OneAxis_Logical = testing::Combine(
             testing::ValuesIn(inputShapes_dyn)),
         testing::Values(emptyCPUSpec),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_4D_Logical = testing::Combine(
         testing::Combine(
@@ -349,7 +349,7 @@ const auto params_MultiAxis_4D_Logical = testing::Combine(
                 testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_5D_Logical = testing::Combine(
         testing::Combine(
@@ -363,7 +363,7 @@ const auto params_MultiAxis_5D_Logical = testing::Combine(
                 testing::ValuesIn(inputShapes_5D_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_4D_Hybrid_Logical = testing::Combine(
         testing::Combine(
@@ -377,7 +377,7 @@ const auto params_MultiAxis_4D_Hybrid_Logical = testing::Combine(
             testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_4D)),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_5D_Hybrid_Logical = testing::Combine(
         testing::Combine(
@@ -391,7 +391,7 @@ const auto params_MultiAxis_5D_Hybrid_Logical = testing::Combine(
             testing::ValuesIn(inputShapes_5D_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_5D)),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_6D_Logical = testing::Combine(
         testing::Combine(
@@ -405,7 +405,7 @@ const auto params_MultiAxis_6D_Logical = testing::Combine(
                 testing::ValuesIn(inputShapes_6D_dyn)),
         testing::Values(emptyCPUSpec),
         testing::Values(emptyFusingSpec),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_OneAxis_Logical_CPU,
@@ -526,7 +526,7 @@ const auto params_OneAxis_fusing_KeepNoDims = testing::Combine(
             testing::ValuesIn(inputShapes_dyn)),
         testing::Values(emptyCPUSpec),
         testing::ValuesIn(fusingParamsSet_KeepNoDims),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_4D_Hybrid_fusing_KeepNoDims = testing::Combine(
         testing::Combine(
@@ -540,7 +540,7 @@ const auto params_MultiAxis_4D_Hybrid_fusing_KeepNoDims = testing::Combine(
             testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_4D)),
         testing::ValuesIn(fusingParamsSet_KeepNoDims),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 const auto params_MultiAxis_5D_Hybrid_fusing_KeepNoDims = testing::Combine(
         testing::Combine(
@@ -554,7 +554,7 @@ const auto params_MultiAxis_5D_Hybrid_fusing_KeepNoDims = testing::Combine(
             testing::ValuesIn(inputShapes_5D_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_5D)),
         testing::ValuesIn(fusingParamsSet_KeepNoDims),
-        testing::ValuesIn(additionalConfig()));
+        testing::ValuesIn(additionalConfigFP32()));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_OneAxis_fusing_KeepNoDims_CPU,

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/reduce.cpp
@@ -132,6 +132,7 @@ const std::vector<fusingSpecificParams> fusingParamsSet_KeepNoDims {
         fusingScaleShift
 };
 
+/* ================================ 1.1 No fusion - Arithmetic ================================ */
 const auto params_OneAxis = testing::Combine(
         testing::Combine(
             testing::ValuesIn(axes()),
@@ -143,7 +144,8 @@ const auto params_OneAxis = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_dyn)),
         testing::Values(emptyCPUSpec),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_4D = testing::Combine(
         testing::Combine(
@@ -156,7 +158,64 @@ const auto params_MultiAxis_4D = testing::Combine(
                 testing::Values(ElementType::undefined),
                 testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
+
+const auto params_MultiAxis_5D = testing::Combine(
+        testing::Combine(
+                testing::ValuesIn(axes5D),
+                testing::Values(CommonTestUtils::OpType::VECTOR),
+                testing::Values(true),
+                testing::ValuesIn(reductionTypes()),
+                testing::ValuesIn(inpOutPrc()),
+                testing::Values(ElementType::undefined),
+                testing::Values(ElementType::undefined),
+                testing::ValuesIn(inputShapes_5D_dyn)),
+        testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
+
+const auto params_MultiAxis_4D_Hybrid = testing::Combine(
+        testing::Combine(
+            testing::ValuesIn(axesND()),
+            testing::Values(CommonTestUtils::OpType::VECTOR),
+            testing::Values(false),
+            testing::ValuesIn(reductionTypes()),
+            testing::ValuesIn(inpOutPrc()),
+            testing::Values(ElementType::undefined),
+            testing::Values(ElementType::undefined),
+            testing::ValuesIn(inputShapes_dyn)),
+        testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_4D)),
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
+
+const auto params_MultiAxis_5D_Hybrid = testing::Combine(
+        testing::Combine(
+            testing::ValuesIn(axes5D),
+            testing::Values(CommonTestUtils::OpType::VECTOR),
+            testing::Values(false),
+            testing::ValuesIn(reductionTypes()),
+            testing::ValuesIn(inpOutPrc()),
+            testing::Values(ElementType::undefined),
+            testing::Values(ElementType::undefined),
+            testing::ValuesIn(inputShapes_5D_dyn)),
+        testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_5D)),
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
+
+const auto params_MultiAxis_6D = testing::Combine(
+        testing::Combine(
+                testing::ValuesIn(axes6D),
+                testing::Values(CommonTestUtils::OpType::VECTOR),
+                testing::ValuesIn(keepDims()),
+                testing::ValuesIn(reductionTypes()),
+                testing::ValuesIn(inpOutPrc()),
+                testing::Values(ElementType::undefined),
+                testing::Values(ElementType::undefined),
+                testing::ValuesIn(inputShapes_6D_dyn)),
+        testing::Values(emptyCPUSpec),
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_Int32 = testing::Combine(
         testing::Combine(
@@ -169,7 +228,36 @@ const auto params_Int32 = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_Int32_dyn)),
         testing::Values(emptyCPUSpec),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
+
+const auto params_NHWC_SmallChannel = testing::Combine(
+        testing::Combine(
+                testing::ValuesIn(axesHW),
+                testing::Values(CommonTestUtils::OpType::VECTOR),
+                testing::Values(true),
+                testing::ValuesIn(reductionTypes()),
+                testing::ValuesIn(inpOutPrc()),
+                testing::Values(ElementType::undefined),
+                testing::Values(ElementType::undefined),
+                testing::ValuesIn(inputShapes_SmallChannel_dyn)),
+        testing::ValuesIn(filterCPUSpecificParams(cpuParams_NHWC_4D)),
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
+
+const auto params_SingleBatch = testing::Combine(
+        testing::Combine(
+                testing::ValuesIn(axes()),
+                testing::Values(CommonTestUtils::OpType::VECTOR),
+                testing::Values(true),
+                testing::ValuesIn(reductionTypes()),
+                testing::ValuesIn(inpOutPrc()),
+                testing::Values(ElementType::undefined),
+                testing::Values(ElementType::undefined),
+                testing::ValuesIn(inputShapes_SingleBatch_dyn)),
+        testing::ValuesIn(filterCPUSpecificParams(cpuParams_NHWC_4D)),
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_OneAxis_CPU,
@@ -184,91 +272,6 @@ INSTANTIATE_TEST_SUITE_P(
         params_MultiAxis_4D,
         ReduceCPULayerTest::getTestCaseName
 );
-
-INSTANTIATE_TEST_SUITE_P(
-        smoke_Reduce_Int32_CPU,
-        ReduceCPULayerTest,
-        params_Int32,
-        ReduceCPULayerTest::getTestCaseName
-);
-
-const auto params_MultiAxis_5D = testing::Combine(
-        testing::Combine(
-                testing::ValuesIn(axes5D),
-                testing::Values(CommonTestUtils::OpType::VECTOR),
-                testing::Values(true),
-                testing::ValuesIn(reductionTypes()),
-                testing::ValuesIn(inpOutPrc()),
-                testing::Values(ElementType::undefined),
-                testing::Values(ElementType::undefined),
-                testing::ValuesIn(inputShapes_5D_dyn)),
-        testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
-        testing::Values(emptyFusingSpec));
-
-const auto params_MultiAxis_4D_Hybrid = testing::Combine(
-        testing::Combine(
-            testing::ValuesIn(axesND()),
-            testing::Values(CommonTestUtils::OpType::VECTOR),
-            testing::Values(false),
-            testing::ValuesIn(reductionTypes()),
-            testing::ValuesIn(inpOutPrc()),
-            testing::Values(ElementType::undefined),
-            testing::Values(ElementType::undefined),
-            testing::ValuesIn(inputShapes_dyn)),
-        testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_4D)),
-        testing::Values(emptyFusingSpec));
-
-const auto params_MultiAxis_5D_Hybrid = testing::Combine(
-        testing::Combine(
-            testing::ValuesIn(axes5D),
-            testing::Values(CommonTestUtils::OpType::VECTOR),
-            testing::Values(false),
-            testing::ValuesIn(reductionTypes()),
-            testing::ValuesIn(inpOutPrc()),
-            testing::Values(ElementType::undefined),
-            testing::Values(ElementType::undefined),
-            testing::ValuesIn(inputShapes_5D_dyn)),
-        testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_5D)),
-        testing::Values(emptyFusingSpec));
-
-const auto params_MultiAxis_6D = testing::Combine(
-        testing::Combine(
-                testing::ValuesIn(axes6D),
-                testing::Values(CommonTestUtils::OpType::VECTOR),
-                testing::ValuesIn(keepDims()),
-                testing::ValuesIn(reductionTypes()),
-                testing::ValuesIn(inpOutPrc()),
-                testing::Values(ElementType::undefined),
-                testing::Values(ElementType::undefined),
-                testing::ValuesIn(inputShapes_6D_dyn)),
-        testing::Values(emptyCPUSpec),
-        testing::Values(emptyFusingSpec));
-
-const auto params_NHWC_SmallChannel = testing::Combine(
-        testing::Combine(
-                testing::ValuesIn(axesHW),
-                testing::Values(CommonTestUtils::OpType::VECTOR),
-                testing::Values(true),
-                testing::ValuesIn(reductionTypes()),
-                testing::ValuesIn(inpOutPrc()),
-                testing::Values(ElementType::undefined),
-                testing::Values(ElementType::undefined),
-                testing::ValuesIn(inputShapes_SmallChannel_dyn)),
-        testing::ValuesIn(filterCPUSpecificParams(cpuParams_NHWC_4D)),
-        testing::Values(emptyFusingSpec));
-
-const auto params_SingleBatch = testing::Combine(
-        testing::Combine(
-                testing::ValuesIn(axes()),
-                testing::Values(CommonTestUtils::OpType::VECTOR),
-                testing::Values(true),
-                testing::ValuesIn(reductionTypes()),
-                testing::ValuesIn(inpOutPrc()),
-                testing::Values(ElementType::undefined),
-                testing::Values(ElementType::undefined),
-                testing::ValuesIn(inputShapes_SingleBatch_dyn)),
-        testing::ValuesIn(filterCPUSpecificParams(cpuParams_NHWC_4D)),
-        testing::Values(emptyFusingSpec));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_MultiAxis_5D_CPU,
@@ -299,6 +302,13 @@ INSTANTIATE_TEST_SUITE_P(
 );
 
 INSTANTIATE_TEST_SUITE_P(
+        smoke_Reduce_Int32_CPU,
+        ReduceCPULayerTest,
+        params_Int32,
+        ReduceCPULayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_NHWC_SmallChannel_CPU,
         ReduceCPULayerTest,
         params_NHWC_SmallChannel,
@@ -324,7 +334,8 @@ const auto params_OneAxis_Logical = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_dyn)),
         testing::Values(emptyCPUSpec),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_4D_Logical = testing::Combine(
         testing::Combine(
@@ -337,7 +348,8 @@ const auto params_MultiAxis_4D_Logical = testing::Combine(
                 testing::Values(ElementType::undefined),
                 testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_5D_Logical = testing::Combine(
         testing::Combine(
@@ -350,7 +362,8 @@ const auto params_MultiAxis_5D_Logical = testing::Combine(
                 testing::Values(ElementType::undefined),
                 testing::ValuesIn(inputShapes_5D_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_4D_Hybrid_Logical = testing::Combine(
         testing::Combine(
@@ -363,7 +376,8 @@ const auto params_MultiAxis_4D_Hybrid_Logical = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_4D)),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_5D_Hybrid_Logical = testing::Combine(
         testing::Combine(
@@ -376,7 +390,8 @@ const auto params_MultiAxis_5D_Hybrid_Logical = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_5D_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_5D)),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_6D_Logical = testing::Combine(
         testing::Combine(
@@ -389,7 +404,8 @@ const auto params_MultiAxis_6D_Logical = testing::Combine(
                 testing::Values(ElementType::undefined),
                 testing::ValuesIn(inputShapes_6D_dyn)),
         testing::Values(emptyCPUSpec),
-        testing::Values(emptyFusingSpec));
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_OneAxis_Logical_CPU,
@@ -445,7 +461,8 @@ const auto params_OneAxis_fusing = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_dyn)),
         testing::Values(emptyCPUSpec),
-        testing::ValuesIn(fusingParamsSet));
+        testing::ValuesIn(fusingParamsSet),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_4D_fusing = testing::Combine(
         testing::Combine(
@@ -458,7 +475,8 @@ const auto params_MultiAxis_4D_fusing = testing::Combine(
                 testing::Values(ElementType::undefined),
                 testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
-        testing::ValuesIn(fusingParamsSet));
+        testing::ValuesIn(fusingParamsSet),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_5D_fusing = testing::Combine(
         testing::Combine(
@@ -471,7 +489,8 @@ const auto params_MultiAxis_5D_fusing = testing::Combine(
                 testing::Values(ElementType::undefined),
                 testing::ValuesIn(inputShapes_5D_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
-        testing::ValuesIn(fusingParamsSet));
+        testing::ValuesIn(fusingParamsSet),
+        testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_OneAxis_fusing_CPU,
@@ -506,7 +525,8 @@ const auto params_OneAxis_fusing_KeepNoDims = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_dyn)),
         testing::Values(emptyCPUSpec),
-        testing::ValuesIn(fusingParamsSet_KeepNoDims));
+        testing::ValuesIn(fusingParamsSet_KeepNoDims),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_4D_Hybrid_fusing_KeepNoDims = testing::Combine(
         testing::Combine(
@@ -519,7 +539,8 @@ const auto params_MultiAxis_4D_Hybrid_fusing_KeepNoDims = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_4D)),
-        testing::ValuesIn(fusingParamsSet_KeepNoDims));
+        testing::ValuesIn(fusingParamsSet_KeepNoDims),
+        testing::ValuesIn(additionalConfig()));
 
 const auto params_MultiAxis_5D_Hybrid_fusing_KeepNoDims = testing::Combine(
         testing::Combine(
@@ -532,7 +553,8 @@ const auto params_MultiAxis_5D_Hybrid_fusing_KeepNoDims = testing::Combine(
             testing::Values(ElementType::undefined),
             testing::ValuesIn(inputShapes_5D_dyn)),
         testing::ValuesIn(filterCPUSpecificParams(cpuParams_HybridLayout_5D)),
-        testing::ValuesIn(fusingParamsSet_KeepNoDims));
+        testing::ValuesIn(fusingParamsSet_KeepNoDims),
+        testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_OneAxis_fusing_KeepNoDims_CPU,


### PR DESCRIPTION
### Details:
 - *Reduce node supports fp16 precision.*

### Tickets:
 - *https://jira.devtools.intel.com/browse/CVS-108837*
