### PR TITLE
[GPU] memory reuse for dynamic models

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -69,6 +69,7 @@ struct memory {
 
         return true;
     }
+    void set_reused(bool reused = true) { _reused = reused; }
 
     virtual event::ptr copy_from(stream& /* stream */, const memory& /* other */, bool blocking = true) = 0;
     virtual event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */, bool blocking = true) = 0;

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -234,9 +234,8 @@ public:
     bool has_unfused_subgraph() const { return (_unfused_subgraph != nullptr); }
     bool has_inner_networks() const;
     void allocate_internal_buffers();
-    static memory::ptr allocate_output(engine& engine, memory_pool& pool, const program_node& _node, const primitive_inst* prim,
-            const kernel_impl_params& impl_params, uint32_t net_id, bool is_internal, size_t idx = 0,
-            bool reset_mem = true, bool is_output_buffer = false, bool runtime_alloc = false, memory* curr_memory = nullptr);
+    static memory::ptr allocate_output(engine& engine, memory_pool& pool, const program_node& _node, const kernel_impl_params& impl_params, uint32_t net_id,
+            bool is_internal, size_t idx = 0, bool reset_mem = true, bool is_output_buffer = false, memory* curr_memory = nullptr);
 
     std::vector<memory::cptr> get_intermediates_memories() const { return _intermediates_memory; }
 

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -234,8 +234,9 @@ public:
     bool has_unfused_subgraph() const { return (_unfused_subgraph != nullptr); }
     bool has_inner_networks() const;
     void allocate_internal_buffers();
-    static memory::ptr allocate_output(engine& engine, memory_pool& pool, const program_node& _node,
-            const kernel_impl_params& impl_params, uint32_t net_id, bool is_internal, size_t idx = 0, bool reset_mem = true, bool is_output_buffer = false);
+    static memory::ptr allocate_output(engine& engine, memory_pool& pool, const program_node& _node, const primitive_inst* prim,
+            const kernel_impl_params& impl_params, uint32_t net_id, bool is_internal, size_t idx = 0,
+            bool reset_mem = true, bool is_output_buffer = false, bool runtime_alloc = false, memory* curr_memory = nullptr);
 
     std::vector<memory::cptr> get_intermediates_memories() const { return _intermediates_memory; }
 

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -235,7 +235,7 @@ public:
     bool has_inner_networks() const;
     void allocate_internal_buffers();
     static memory::ptr allocate_output(engine& engine, memory_pool& pool, const program_node& _node, const kernel_impl_params& impl_params, uint32_t net_id,
-            bool is_internal, size_t idx = 0, bool reset_mem = true, bool is_output_buffer = false, memory* curr_memory = nullptr);
+            bool is_internal, size_t idx = 0, bool reset_mem = true, bool is_output_buffer = false, memory* curr_memory = nullptr, bool runtime_alloc = false);
 
     std::vector<memory::cptr> get_intermediates_memories() const { return _intermediates_memory; }
 

--- a/src/plugins/intel_gpu/src/graph/include/reduce_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reduce_inst.h
@@ -33,6 +33,14 @@ public:
     static layout calc_output_layout(reduce_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(reduce_node const& node);
 
+    bool need_reset_input_memory() const override {
+        auto input_layout = _deps[0].first->_impl_params->get_output_layout(_deps[0].second);
+        if (!format::format::is_simple_data_format(input_layout.format) && input_layout.feature() % 16 != 0) {
+            return true;
+        }
+        return false;
+    }
+
     typed_primitive_inst(network& network, reduce_node const& desc);
 };
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1086,7 +1086,7 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
                         const kernel_impl_params& impl_params, uint32_t net_id, bool is_internal, size_t idx, bool reset, bool is_output_buffer,
                         bool runtime_alloc, memory* curr_memory) {
     auto get_memory_from_pool = [&](engine& _engine, const layout& layout, const primitive_id id, std::set<primitive_id> dependencies,
-            allocation_type type, bool reusable, bool reset = true, memory* curr_memory) {
+            allocation_type type, bool reusable, bool reset = true, memory* curr_memory = nullptr) {
         OPENVINO_ASSERT(!layout.is_dynamic() || layout.has_upper_bound(), "[GPU] Can't allocate output for dynamic layout without upper bound");
         // Use layout with max tensor for dynamic shape with upper bound
         auto static_layout = cldnn::layout(layout.get_partial_shape().get_max_shape(), layout.data_type, layout.format, layout.data_padding);

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1082,8 +1082,9 @@ static bool user_requesting_mem_reuse_false(const program_node& node, const prim
     return false;
 }
 
-memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, const program_node& _node, const primitive_inst* prim, const kernel_impl_params& impl_params,
-                        uint32_t net_id, bool is_internal, size_t idx, bool reset, bool is_output_buffer, bool runtime_alloc, memory* curr_memory) {
+memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, const program_node& _node, const primitive_inst* prim,
+                        const kernel_impl_params& impl_params, uint32_t net_id, bool is_internal, size_t idx, bool reset, bool is_output_buffer,
+                        bool runtime_alloc, memory* curr_memory) {
     auto get_memory_from_pool = [&](engine& _engine, const layout& layout, const primitive_id id, std::set<primitive_id> dependencies,
             allocation_type type, bool reusable, bool reset = true, memory* curr_memory) {
         OPENVINO_ASSERT(!layout.is_dynamic() || layout.has_upper_bound(), "[GPU] Can't allocate output for dynamic layout without upper bound");

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -364,8 +364,10 @@ event::ptr primitive_inst::realloc_if_needed() {
 
     if (can_reuse_buffer) {
         GPU_DEBUG_TRACE_DETAIL << id() << ": reuse previously allocated output buffer" << std::endl;
-        if (_outputs[0]->get_layout() != actual_layout)
+        if (_outputs[0]->get_layout() != actual_layout) {
+            _outputs[0]->set_reused(true);
             _outputs[0] = _network.get_engine().reinterpret_buffer(*_outputs[0], actual_layout);
+        }
         if (need_reset_output_memory()) {
             ev = _outputs[0]->fill(_network.get_stream());
         }
@@ -1054,28 +1056,44 @@ event::ptr primitive_inst::update_weights() {
     return nullptr;
 }
 
-static bool user_requesting_mem_reuse_false(const program_node& node) {
-    for (auto& user : node.get_users()) {
-        if ((user->get_selected_impl() != nullptr) && (user->get_selected_impl()->can_reuse_memory == false)) {
-            return true;
-        } else if (user->get_selected_impl() == nullptr) {
-            if (user_requesting_mem_reuse_false(*user)) {
+static bool user_requesting_mem_reuse_false(const program_node& node, const primitive_inst* prim, bool runtime_alloc) {
+    if (prim == nullptr || runtime_alloc == false) {
+        for (auto& user : node.get_users()) {
+            if ((user->get_selected_impl() != nullptr) && (user->get_selected_impl()->can_reuse_memory == false)) {
                 return true;
+            } else if (user->get_selected_impl() == nullptr) {
+                if (user_requesting_mem_reuse_false(*user, nullptr, runtime_alloc)) {
+                    return true;
+                }
+            }
+        }
+    } else {
+        for (auto& user : prim->get_user_insts()) {
+            if ((user->get_impl() != nullptr) && (user->get_impl()->can_reuse_memory == false)) {
+                return true;
+            } else if (user->get_impl() == nullptr) {
+                if (user_requesting_mem_reuse_false(user->get_node(), user.get(), runtime_alloc)) {
+                    return true;
+                }
             }
         }
     }
+
     return false;
 }
 
-memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, const program_node& _node, const kernel_impl_params& impl_params,
-                                            uint32_t net_id, bool is_internal, size_t idx, bool reset, bool is_output_buffer) {
+memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, const program_node& _node, const primitive_inst* prim, const kernel_impl_params& impl_params,
+                        uint32_t net_id, bool is_internal, size_t idx, bool reset, bool is_output_buffer, bool runtime_alloc, memory* curr_memory) {
     auto get_memory_from_pool = [&](engine& _engine, const layout& layout, const primitive_id id, std::set<primitive_id> dependencies,
-            allocation_type type, bool reusable, bool reset = true) {
+            allocation_type type, bool reusable, bool reset = true, memory* curr_memory) {
         OPENVINO_ASSERT(!layout.is_dynamic() || layout.has_upper_bound(), "[GPU] Can't allocate output for dynamic layout without upper bound");
         // Use layout with max tensor for dynamic shape with upper bound
         auto static_layout = cldnn::layout(layout.get_partial_shape().get_max_shape(), layout.data_type, layout.format, layout.data_padding);
-        if (_node.get_program().get_config().get_property(ov::intel_gpu::enable_memory_pool))
+        if (_node.get_program().get_config().get_property(ov::intel_gpu::enable_memory_pool)) {
+            if (curr_memory != nullptr)
+                pool.release_memory(curr_memory, id, net_id);
             return pool.get_memory(static_layout, id, net_id, dependencies, type, reusable, reset);
+        }
         return pool.get_memory(static_layout, type, reset);
     };
 
@@ -1095,7 +1113,7 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
     if (total_device_input_mem_size > _engine.get_device_info().max_global_mem_size)
         usm_device_allocatable = false;
 
-    bool memory_reuse_by_user = !user_requesting_mem_reuse_false(_node);
+    bool memory_reuse_by_user = !user_requesting_mem_reuse_false(_node, prim, runtime_alloc);
 
     // For outputs, cpu prim we want to have lockable alloc type
     // Also if the successor of a node is an cpu, then memory needs to be lockable.
@@ -1121,7 +1139,8 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
                                         _node.get_memory_dependencies(),
                                         alloc_type,
                                         false,
-                                        reset);
+                                        reset,
+                                        curr_memory);
         } else {
             if ((_node.is_output() && _node.is_type<generic_layer>()) || (!_node.is_output() && _node.is_type<input_layout>()))
                 reset = false;
@@ -1138,7 +1157,8 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
                                     _node.get_memory_dependencies(),
                                     alloc_type,
                                     memory_reuse_by_user,
-                                    reset);
+                                    reset,
+                                    curr_memory);
     }
 }
 
@@ -1146,8 +1166,9 @@ std::vector<memory::ptr> primitive_inst::allocate_outputs(kernel_impl_params* up
     std::vector<memory::ptr> outputs;
     for (size_t i = 0; i < get_node().get_outputs_count() ; ++i) {
         outputs.push_back(allocate_output(get_network().get_engine(), _network.get_memory_pool(),
-                         *_node, (updated_params != nullptr) ? *updated_params : *_impl_params,
-                         get_network_id(), _network.is_internal(), i, reset_mem, is_output_buffer(this, runtime_alloc)));
+                         *_node, this, (updated_params != nullptr) ? *updated_params : *_impl_params,
+                         get_network_id(), _network.is_internal(), i, reset_mem, is_output_buffer(this, runtime_alloc),
+                         runtime_alloc, output_memory_ptr(i).get()));
     }
     return outputs;
 }
@@ -1432,7 +1453,7 @@ void primitive_inst::save(cldnn::BinaryOutputBuffer& ob) const {
     }
 
     bool can_reuse_memory = true;
-    if (user_requesting_mem_reuse_false(*_node)) {
+    if (user_requesting_mem_reuse_false(*_node, this, false)) {
         can_reuse_memory = false;
     }
     ob << can_reuse_memory;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1056,8 +1056,6 @@ event::ptr primitive_inst::update_weights() {
 
 static bool user_requesting_mem_reuse_false(const program_node& node) {
     for (auto& user : node.get_users()) {
-        if (user->is_dynamic())
-            return true;
         if ((user->get_selected_impl() != nullptr) && (user->get_selected_impl()->can_reuse_memory == false)) {
             return true;
         } else if (user->get_selected_impl() == nullptr) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1100,7 +1100,7 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
     if (total_device_input_mem_size > _engine.get_device_info().max_global_mem_size)
         usm_device_allocatable = false;
 
-    bool memory_reuse_by_user = _node.is_dynamic() ? !reset : !user_requesting_mem_reuse_false(_node);
+    bool memory_reuse_by_user = _node.is_dynamic_output_layout() ? !reset : !user_requesting_mem_reuse_false(_node);
 
     // For outputs, cpu prim we want to have lockable alloc type
     // Also if the successor of a node is an cpu, then memory needs to be lockable.

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1641,6 +1641,7 @@ std::pair<int64_t, int64_t> program::get_estimated_device_mem_usage() {
             allocated_mem_ptrs.insert(primitive_inst::allocate_output(engine,
                                                                       pool,
                                                                       *node,
+                                                                      nullptr,
                                                                       *node->get_kernel_impl_params(),
                                                                       0,
                                                                       false,

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1641,7 +1641,6 @@ std::pair<int64_t, int64_t> program::get_estimated_device_mem_usage() {
             allocated_mem_ptrs.insert(primitive_inst::allocate_output(engine,
                                                                       pool,
                                                                       *node,
-                                                                      nullptr,
                                                                       *node->get_kernel_impl_params(),
                                                                       0,
                                                                       false,

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -55,13 +55,12 @@ void memory_pool::release_memory(memory* mem, const primitive_id& id, uint32_t n
     auto type = mem->get_allocation_type();
 
     {
-        auto range = _non_padded_pool.equal_range(_layout.bytes_count());
-        auto it = range.first;
+        auto it = _non_padded_pool.lower_bound(_layout.bytes_count());
 
-        while (it != range.second && it != _non_padded_pool.end()) {
+        while (it != _non_padded_pool.end()) {
             if (it->second._network_id == network_id &&
                 it->second._type == type &&
-                it->second._memory.get() == mem) {
+                it->second._memory->buffer_ptr() == mem->buffer_ptr()) {
                 auto user_it = it->second._users.find({ id, network_id });
 
                 // normally there should be only one entry

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -60,7 +60,7 @@ void memory_pool::release_memory(memory* mem, const primitive_id& id, uint32_t n
         while (it != _non_padded_pool.end()) {
             if (it->second._network_id == network_id &&
                 it->second._type == type &&
-                it->second._memory->buffer_ptr() == mem->buffer_ptr()) {
+                it->second._memory->get_internal_params().mem == mem->get_internal_params().mem) {
                 auto user_it = it->second._users.find({ id, network_id });
 
                 // normally there should be only one entry

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -2573,7 +2573,7 @@ public:
         std::tie(b, in_f, in_x, in_y, out_f, in_fmt) = GetParam();
 
         quantization_t quant_data;
-        quant_data.output_low  = std::numeric_limits<WeightsT>::min();
+        quant_data.output_low  = std::numeric_limits<WeightsT>::lowest();
         quant_data.output_high = std::numeric_limits<WeightsT>::max();
 
         VVVVF<InputT> input_data = generate_random_4d<InputT>(b, in_f, in_y, in_x, 0, 127);


### PR DESCRIPTION
### Details:
 - This PR enables memory reuse for dynamic models.
   * updated `user_requesting_mem_reuse_false` not to return true when dynamic models
   * updated `user_requesting_mem_reuse_false` to use `primitive_inst` instead of `program_node` in runtime
   * updated memory_pool.release_memory() to compare buffer_ptrs 

### Tickets:
 - 91383
