### PR TITLE
Fix model names resolving in the ONNX OMZ update script

### DIFF
--- a/src/bindings/python/tests/test_onnx/model_zoo_preprocess.sh
+++ b/src/bindings/python/tests/test_onnx/model_zoo_preprocess.sh
@@ -72,8 +72,8 @@ function pull_and_postprocess_onnx_model_zoo() {
 
     printf "Extracting tar.gz archives into %s\n" "$ONNX_MODELS_DIR"
     find "$ONNX_MODELS_DIR" -name '*.tar.gz' \
-        -execdir sh -c 'BASEDIR=$(basename "{$1}" .tar.gz) && rm -rf $BASEDIR && mkdir -p $BASEDIR' shell {} \; \
-        -execdir sh -c 'BASEDIR=$(basename "{$1}" .tar.gz) && tar --warning=no-unknown-keyword -xvzf "{$1}" -C $BASEDIR' shell {} \;
+        -execdir sh -c 'BASEDIR=$(basename "{}" .tar.gz) && rm -rf $BASEDIR && mkdir -p $BASEDIR' \; \
+        -execdir sh -c 'BASEDIR=$(basename "{}" .tar.gz) && tar --warning=no-unknown-keyword -xvzf "{}" -C $BASEDIR' \;
 
     echo "Postprocessing of ONNX Model Zoo models:"
 


### PR DESCRIPTION
### Details:
The script fails when unpacking onnx models tar archives due to wrong name resolution.


### Tickets:
 - *ticket-id*
