### PR TITLE
[GPU] Fix crash for shape of subgraph due to missing mem_dep

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -272,8 +272,6 @@ void primitive_inst::update_shape() {
             continue;
         }
         auto& dep = _node->get_dependency(i);
-        if (dep.is_in_shape_of_subgraph())
-            continue;
         auto dep_id = dep.id();
         // exclude fused node from memory_deps
         if (_node->is_fused_dep(i)) {
@@ -286,7 +284,8 @@ void primitive_inst::update_shape() {
         }
         auto dep_mem = _network.get_output_memory(dep_id);
         memory_deps.insert({i, dep_mem});
-        has_runtime_deps = true;
+        if (!dep.is_in_shape_of_subgraph())
+            has_runtime_deps = true;
     }
 
     if (has_runtime_deps) {
@@ -692,7 +691,6 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
         set_arguments();
     }
     on_execute();
-
     GPU_DEBUG_TRACE << id() << ": execute " << _impl->get_kernel_name() << std::endl;
 
     if (_exec_deps.empty() && dependencies.empty()) {

--- a/src/plugins/intel_gpu/tests/unit/passes/mark_shape_of_subgraphs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/mark_shape_of_subgraphs_test.cpp
@@ -52,13 +52,15 @@ static bool check_subgraph(const program_node& node, const program_node& last_no
 TEST(mark_shape_of_subgraphs, simple_chain) {
     auto& engine = get_test_engine();
     auto input_layout_dynamic = layout{ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension::dynamic()},
-                                       data_types::f16, format::bfyx};
+                                       data_types::f32, format::bfyx};
     auto data_0 = engine.allocate_memory({ ov::PartialShape{1}, data_types::i64, format::bfyx });
-
+    auto data_1 = engine.allocate_memory({ ov::PartialShape{1}, data_types::i64, format::bfyx });
+    set_values(data_0, {0});
+    set_values(data_1, {2});
     topology topology;
     topology.add(input_layout("input", input_layout_dynamic));
     topology.add(data("data_0", data_0));
-    topology.add(data("data_1", data_0));
+    topology.add(data("data_1", data_1));
     topology.add(shape_of("shape_of", input_info("input"), data_types::i64));
     topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {}));
     topology.add(eltwise("eltwise", input_info("gather"), input_info("data_1"), eltwise_mode::sum));
@@ -74,6 +76,18 @@ TEST(mark_shape_of_subgraphs, simple_chain) {
     ASSERT_NE(prog, nullptr);
 
     ASSERT_TRUE(check_subgraph(prog->get_node("shape_of"), prog->get_node("concat")));
+
+    auto input_mem = engine.allocate_memory({ov::PartialShape{1, 1}, data_types::f32, format::bfyx});
+    set_values(input_mem, {10.f});
+    network.set_input_data("input", input_mem);
+    auto outputs = network.execute();
+    auto output_prim = outputs.begin()->second.get_memory();
+
+    cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
+    ASSERT_EQ(6, output_prim->get_layout().count());
+    for (size_t i = 0; i < output_prim->get_layout().count(); ++i) {
+        ASSERT_EQ(10.0f, output_ptr[i]);
+    }
 }
 
 TEST(mark_shape_of_subgraphs, simple_chain_w_reshape_inside_subgraph) {


### PR DESCRIPTION
### Details:
 - From the PR https://github.com/openvinotoolkit/openvino/pull/18158, shape of subgraphs' mem dep was missing so that many dynamic shape execution crashed
 - Fixed not to skip memdep set  


