### PR TITLE
Optimize IE_THROW and IE_ASSERT for size reduction

### DIFF
--- a/src/bindings/python/src/compatibility/openvino/inference_engine/ie_api_impl.cpp
+++ b/src/bindings/python/src/compatibility/openvino/inference_engine/ie_api_impl.cpp
@@ -511,10 +511,8 @@ void InferenceEnginePython::IEExecNetwork::createInferRequests(int num_requests)
                     if (code != InferenceEngine::StatusCode::OK) {
                         IE_EXCEPTION_SWITCH(code,
                                             ExceptionType,
-                                            InferenceEngine::details::ThrowNow<ExceptionType>{} <<=
-                                            std::stringstream{}
-                                            << IE_LOCATION
-                                            << InferenceEngine::details::ExceptionTraits<ExceptionType>::string());
+                                            InferenceEngine::details::ThrowNow<ExceptionType>{IE_LOCATION_PARAM} <<=
+                                            std::stringstream{});
                     }
 
                     auto end_time = Time::now();

--- a/src/inference/include/ie/details/ie_so_pointer.hpp
+++ b/src/inference/include/ie/details/ie_so_pointer.hpp
@@ -164,8 +164,8 @@ protected:
                 if (sts != OK) {
                     IE_EXCEPTION_SWITCH(sts,
                                         ExceptionType,
-                                        InferenceEngine::details::ThrowNow<ExceptionType>{} <<=
-                                        std::stringstream{} << IE_LOCATION << desc.msg)
+                                        InferenceEngine::details::ThrowNow<ExceptionType>{IE_LOCATION_PARAM} <<=
+                                        std::stringstream{} << desc.msg)
                 }
                 IE_SUPPRESS_DEPRECATED_START
                 _ptr = std::shared_ptr<T>(object, [](T* ptr) {

--- a/src/inference/include/ie/ie_common.h
+++ b/src/inference/include/ie/ie_common.h
@@ -402,18 +402,32 @@ namespace details {
  */
 template <typename ExceptionType>
 struct INFERENCE_ENGINE_1_0_DEPRECATED ThrowNow final {
-    [[noreturn]] void operator<<=(const std::ostream& ostream) {
-        std::ostringstream stream;
-        stream << ostream.rdbuf();
+#ifndef NDEBUG
+    const char* const file;
+    const int line;
+#endif
+
+    [[noreturn]] void create(const std::ostream& ostream) const {
+        std::stringstream stream;
+#ifndef NDEBUG
+        stream << '\n' << file << ':' << line << ' ';
+#endif
+        stream << InferenceEngine::details::ExceptionTraits<ExceptionType>::string() << ' ' << ostream.rdbuf();
         throw ExceptionType{stream.str()};
+    }
+
+    [[noreturn]] void operator<<=(const std::ostream& ostream) {
+        create(ostream);
     }
 };
 
 /// @cond
 #ifndef NDEBUG
-#    define IE_LOCATION '\n' << __FILE__ << ':' << __LINE__ << ' '
+#    define IE_LOCATION       '\n' << __FILE__ << ':' << __LINE__ << ' '
+#    define IE_LOCATION_PARAM __FILE__, __LINE__
 #else
 #    define IE_LOCATION ""
+#    define IE_LOCATION_PARAM
 #endif  // NDEBUG
 
 // WARNING: DO NOT USE THIS MACRO! Use openvino/util/pp.hpp macro library
@@ -430,13 +444,10 @@ struct INFERENCE_ENGINE_1_0_DEPRECATED ThrowNow final {
 // ENDWARNING
 
 #define IE_THROW_0() \
-    InferenceEngine::details::ThrowNow<InferenceEngine::GeneralError>{} <<= std::stringstream{} << IE_LOCATION
+    (InferenceEngine::details::ThrowNow<InferenceEngine::GeneralError>{IE_LOCATION_PARAM}) <<= std::stringstream {}
 
-#define IE_THROW_1(ExceptionType)                                                                                  \
-    InferenceEngine::details::ThrowNow<InferenceEngine::ExceptionType>{} <<=                                       \
-        std::stringstream{} << IE_LOCATION                                                                         \
-                            << InferenceEngine::details::ExceptionTraits<InferenceEngine::ExceptionType>::string() \
-                            << ' '
+#define IE_THROW_1(ExceptionType) \
+    (InferenceEngine::details::ThrowNow<InferenceEngine::ExceptionType>{IE_LOCATION_PARAM}) <<= std::stringstream {}
 /// @endcond
 
 /**
@@ -452,7 +463,7 @@ struct INFERENCE_ENGINE_1_0_DEPRECATED ThrowNow final {
 #ifdef NDEBUG
 #    define IE_ASSERT(EXPRESSION) \
         if (!(EXPRESSION))        \
-        IE_THROW(GeneralError) << " AssertionFailed: " << #EXPRESSION
+        IE_THROW(GeneralError) << " AssertionError " #EXPRESSION
 #else
 /**
  * @private
@@ -470,9 +481,9 @@ struct NullStream {
 #endif  // NDEBUG
 
 /// @cond
-#define THROW_IE_EXCEPTION                                                                                           \
-    InferenceEngine::details::ThrowNow<InferenceEngine::details::InferenceEngineException>{} <<= std::stringstream{} \
-                                                                                                 << IE_LOCATION
+#define THROW_IE_EXCEPTION                                                                                          \
+    (InferenceEngine::details::ThrowNow<InferenceEngine::details::InferenceEngineException>{IE_LOCATION_PARAM}) <<= \
+        std::stringstream {}
 
 #define IE_EXCEPTION_CASE(TYPE_ALIAS, STATUS_CODE, EXCEPTION_TYPE, ...) \
     case InferenceEngine::STATUS_CODE: {                                \

--- a/src/inference/src/cpp/exception2status.hpp
+++ b/src/inference/src/cpp/exception2status.hpp
@@ -59,15 +59,16 @@ namespace InferenceEngine {
     }
 
 #define CALL_STATUS_FNC(function, ...)                     \
-    if (!actual)                                           \
+    if (!actual) {                                         \
         IE_THROW() << "Wrapper used was not initialized."; \
+    }                                                      \
     ResponseDesc resp;                                     \
     auto res = actual->function(__VA_ARGS__, &resp);       \
     if (res != OK)                                         \
     IE_EXCEPTION_SWITCH(                                   \
         res,                                               \
         ExceptionType,                                     \
-        InferenceEngine::details::ThrowNow<ExceptionType>{} <<= std::stringstream{} << IE_LOCATION << resp.msg)
+        (InferenceEngine::details::ThrowNow<ExceptionType>{IE_LOCATION_PARAM}) <<= std::stringstream{} << resp.msg)
 
 #define CALL_STATUS_FNC_NO_ARGS(function)                                                 \
     if (!actual)                                                                          \
@@ -75,8 +76,9 @@ namespace InferenceEngine {
     ResponseDesc resp;                                                                    \
     auto res = actual->function(&resp);                                                   \
     if (res != OK)                                                                        \
-    IE_EXCEPTION_SWITCH(res,                                                              \
-                        ExceptionType,                                                    \
-                        InferenceEngine::details::ThrowNow<ExceptionType>{} <<= std::stringstream{} << IE_LOCATION)
+    IE_EXCEPTION_SWITCH(                                                                  \
+        res,                                                                              \
+        ExceptionType,                                                                    \
+        (InferenceEngine::details::ThrowNow<ExceptionType>{IE_LOCATION_PARAM}) <<= std::stringstream{})
 
 }  // namespace InferenceEngine

--- a/src/inference/src/cpp/ie_extension.cpp
+++ b/src/inference/src/cpp/ie_extension.cpp
@@ -31,10 +31,9 @@ std::shared_ptr<T> CreateExtensionFromLibrary(std::shared_ptr<void> _so) {
             ResponseDesc desc;
             StatusCode sts = reinterpret_cast<CreateF*>(create)(object, &desc);
             if (sts != OK) {
-                IE_EXCEPTION_SWITCH(
-                    sts,
-                    ExceptionType,
-                    details::ThrowNow<ExceptionType>{} <<= std::stringstream{} << IE_LOCATION << desc.msg)
+                IE_EXCEPTION_SWITCH(sts,
+                                    ExceptionType,
+                                    details::ThrowNow<ExceptionType>{} <<= std::stringstream{} << desc.msg)
             }
             IE_SUPPRESS_DEPRECATED_START
             _ptr = std::shared_ptr<T>(object, [](T* ptr) {

--- a/src/inference/tests/unit/cpp_interfaces/exception_test.cpp
+++ b/src/inference/tests/unit/cpp_interfaces/exception_test.cpp
@@ -18,14 +18,14 @@ public:
         TO_STATUS(IE_EXCEPTION_SWITCH(
             statusCode,
             ExceptionType,
-            InferenceEngine::details::ThrowNow<ExceptionType>{} <<= std::stringstream{} << IE_LOCATION))
+            InferenceEngine::details::ThrowNow<ExceptionType>{IE_LOCATION_PARAM} <<= std::stringstream{}))
     }
 
     static InferenceEngine::StatusCode toStatusWrapperMsg(std::string& msg, InferenceEngine::ResponseDesc* resp) {
         TO_STATUS(IE_EXCEPTION_SWITCH(
             statusCode,
             ExceptionType,
-            InferenceEngine::details::ThrowNow<ExceptionType>{} <<= std::stringstream{} << IE_LOCATION << msg))
+            InferenceEngine::details::ThrowNow<ExceptionType>{IE_LOCATION_PARAM} <<= std::stringstream{} << msg))
     }
 };
 
@@ -72,7 +72,7 @@ TEST_F(ExceptionTests, throwAfterConvertStatusToClassContainMessage) {
     std::string refMessage = "Exception message!";
     auto actual = std::make_shared<WrapperClass<StatusCode::NOT_ALLOCATED>>();
     try {
-        CALL_STATUS_FNC(toStatusWrapperMsg, refMessage)
+        CALL_STATUS_FNC(toStatusWrapperMsg, refMessage);
     } catch (const NotAllocated& iex) {
         std::string actualMessage = iex.what();
         ASSERT_TRUE(actualMessage.find(refMessage) != std::string::npos);

--- a/src/inference/tests/unit/ie_exception_test.cpp
+++ b/src/inference/tests/unit/ie_exception_test.cpp
@@ -36,7 +36,8 @@ TEST(ExceptionTests, ExceptionShowsCorrectMessageDebugVersion) {
         lineNum = __LINE__ + 1;
         IE_THROW() << message;
     } catch (InferenceEngine::Exception& iex) {
-        std::string ref_message = std::string{"\n"} + __FILE__ + ":" + std::to_string(lineNum) + " " + message;
+        std::string ref_message =
+            std::string{"\n"} + __FILE__ + ":" + std::to_string(lineNum) + " [ GENERAL_ERROR ] " + message;
         ASSERT_STREQ(iex.what(), ref_message.c_str());
     }
 }
@@ -46,7 +47,7 @@ TEST(ExceptionTests, ExceptionShowsCorrectMessageReleaseVersion) {
     try {
         IE_THROW() << message;
     } catch (InferenceEngine::Exception& iex) {
-        std::string ref_message = message;
+        std::string ref_message = "[ GENERAL_ERROR ] " + message;
         ASSERT_STREQ(iex.what(), ref_message.c_str());
     }
 }

--- a/src/plugins/intel_gna/src/gna_infer_request.cpp
+++ b/src/plugins/intel_gna/src/gna_infer_request.cpp
@@ -62,12 +62,10 @@ void GNAInferRequest::StartAsyncImpl() {
         std::exception_ptr exceptionPtr;
         if (res != InferenceEngine::StatusCode::OK) {
             try {
-                IE_EXCEPTION_SWITCH(res,
-                                    ExceptionType,
-                                    InferenceEngine::details::ThrowNow<ExceptionType>{} <<=
-                                    std::stringstream{}
-                                    << IE_LOCATION
-                                    << InferenceEngine::details::ExceptionTraits<ExceptionType>::string());
+                IE_EXCEPTION_SWITCH(
+                    res,
+                    ExceptionType,
+                    InferenceEngine::details::ThrowNow<ExceptionType>{IE_LOCATION_PARAM} <<= std::stringstream{});
             } catch (...) {
                 exceptionPtr = std::current_exception();
             }


### PR DESCRIPTION
### Details:
 -  Reduce binary size of IE_THROW and IE_ASSERT macros.

- The size reduction difference in libraries (on Ubuntu 20.04, gcc 9.3 no LTO)

|   **Library**                                  | **Size reduction [KiB]** |
|-------------------------------------|---------------------------|
| libopenvino.so                             | 29.97                              |
| libopenvino_intel_cpu_plugin.so | 40.38                              |
| libopenvino_intel_gpu_plugin.so | 12.73                              |
| libopenvino_intel_gna_plugin.so | 45.23                              |
| libopenvino_ir_frontend.so          | 0.69                                |
| libopenvino_onnx_frontend.so    | 0                                     |
| libopenvino_hetero_plugin.so     | 2.45                                |

**Total reduction: 131.26 KiB**

### Tickets:
 - 113180
