### PR TITLE
[MO] fix np.copy error for older numpy versions

### DIFF
--- a/tools/mo/openvino/tools/mo/back/preprocessing.py
+++ b/tools/mo/openvino/tools/mo/back/preprocessing.py
@@ -3,7 +3,6 @@
 
 import argparse
 import logging as log
-from copy import copy
 
 from openvino.tools.mo.utils.error import Error
 from openvino.tools.mo.utils.utils import refer_to_faq_msg
@@ -23,7 +22,7 @@ def update_mean_scale_to_dict(input_nodes: list, mean_scale_val, scale):
         if len(mean_scale_val) != len(input_nodes):
             raise Error('Numbers of inputs and mean/scale values do not match. ' + refer_to_faq_msg(61))
 
-        data = copy(mean_scale_val)
+        data = mean_scale_val
         mean_scale_val = {}
         for idx, node in enumerate(input_nodes):
             names_list = list(node.get_tensor().get_names())

--- a/tools/mo/openvino/tools/mo/back/preprocessing.py
+++ b/tools/mo/openvino/tools/mo/back/preprocessing.py
@@ -3,12 +3,10 @@
 
 import argparse
 import logging as log
+from copy import copy
 
 from openvino.tools.mo.utils.error import Error
 from openvino.tools.mo.utils.utils import refer_to_faq_msg
-
-import numpy as np
-
 from openvino.preprocess import PrePostProcessor        # pylint: disable=no-name-in-module,import-error
 # pylint: disable=no-name-in-module,import-error
 from openvino.runtime import Model, Layout, PartialShape, layout_helpers
@@ -25,7 +23,7 @@ def update_mean_scale_to_dict(input_nodes: list, mean_scale_val, scale):
         if len(mean_scale_val) != len(input_nodes):
             raise Error('Numbers of inputs and mean/scale values do not match. ' + refer_to_faq_msg(61))
 
-        data = np.copy(mean_scale_val)
+        data = copy(mean_scale_val)
         mean_scale_val = {}
         for idx, node in enumerate(input_nodes):
             names_list = list(node.get_tensor().get_names())


### PR DESCRIPTION
#### Details:
 There was an error in 2022.3.1 LTS with resnet-50-tf and some other models. The error message `"setting an array element with a sequence. The requested array has an inhomogeneous shape after 2 dimensions. The detected shape was (1, 2) + inhomogeneous part."` is in numpy. And happens for newer numpy>=1.24.4 when np.copy is called:

https://github.com/openvinotoolkit/openvino/blob/358efd2d0645aa4eeac37fb243269b4af48af6da/tools/mo/openvino/tools/mo/back/preprocessing.py#L28
np.copy function does not want to copy mean_scale_val (which is a list with a an array and with a None). 
![image](https://github.com/openvinotoolkit/openvino/assets/5703039/00fab372-7fcb-469b-91bb-c7932d944afe)

To fix this need to replace `np.copy` -> `copy`, indeed this is already done in PR #17070. Here i port that changes into 2022.3 (changes in unit-tests were not ported since they are not compatible with 2022.3)

#### Tickets:
 - xxx-114094
