### PR TITLE
[core] Update setShape TensorMemoryBlob

### DIFF
--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -541,7 +541,12 @@ public:
 
     void setShape(const ie::SizeVector& dims) override {
         tensor->set_shape(dims);
-        ie::TBlob<T>::setShape(dims);
+        ie::TBlob<T>::getTensorDesc().setDims(dims);
+        if (ie::TBlob<T>::buffer() != tensor->data()) {
+            ie::TBlob<T>::_allocator =
+                ie::details::make_pre_allocator(static_cast<T*>(tensor->data()), tensor->get_byte_size());
+            ie::TBlob<T>::allocate();
+        }
     }
 
     std::shared_ptr<ITensor> tensor;

--- a/src/inference/tests/unit/ie_blob_test.cpp
+++ b/src/inference/tests/unit/ie_blob_test.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <ie_blob.h>
 
+#include "dev/make_tensor.hpp"
 #include "unit_test_utils/mocks/mock_allocator.hpp"
 
 IE_SUPPRESS_DEPRECATED_START
@@ -595,4 +596,28 @@ TEST_F(BlobTests, readRangeRoiBlob) {
             ASSERT_EQ(roiPtr[i], i + roiOffset);
         }
     }
+}
+
+TEST_F(BlobTests, setBiggerShapeOnPreAllocatedMemory) {
+    const auto t = ov::make_tensor(ov::element::i64, ov::Shape{2, 6});
+    const auto b = ov::tensor_to_blob(t);
+
+    const auto origin_ptr = t->data();
+    b->setShape({2, 8});
+
+    ASSERT_EQ(b->buffer(), t->data());
+    // New allocation, pointer different than origin.
+    ASSERT_NE(b->buffer().as<void*>(), origin_ptr);
+}
+
+TEST_F(BlobTests, setSmallerShapeOnPreAllocatedMemory) {
+    const auto t = ov::make_tensor(ov::element::i64, ov::Shape{2, 6});
+    const auto b = ov::tensor_to_blob(t);
+
+    const auto origin_ptr = t->data();
+    b->setShape({2, 4});
+
+    ASSERT_EQ(b->buffer(), t->data());
+    // No new allocation same as origin pointer
+    ASSERT_EQ(b->buffer(), origin_ptr);
 }


### PR DESCRIPTION
### Details:
 - Update the `setShape` member function of `TensorMemoryBlob` class to synchronize the Blob pointer with `ITensor` instance data pointer.

### Tickets:
 - 114388