### PR TITLE
PropagateDownDisableSensitivityForQuantized Pad12 support

### DIFF
--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -17,6 +17,7 @@
 #include "transformations/convert_precision.hpp"
 #include "transformations/rt_info/disable_fp16_compression.hpp"
 #include "transformations/utils/utils.hpp"
+#include <openvino/op/util/pad_base.hpp>
 
 using namespace std;
 using namespace ov::opset10;
@@ -343,7 +344,7 @@ public:
                                                                                   opset11::Interpolate,
                                                                                   opset2::MaxPool,
                                                                                   MaxPool,
-                                                                                  Pad,
+                                                                                  op::util::PadBase,
                                                                                   ReduceMax,
                                                                                   ReduceMin,
                                                                                   Relu,

--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -4,6 +4,8 @@
 
 #include "transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.hpp"
 
+#include <openvino/op/util/pad_base.hpp>
+
 #include "itt.hpp"
 #include "openvino/op/util/broadcast_base.hpp"
 #include "openvino/op/util/gather_base.hpp"
@@ -17,7 +19,6 @@
 #include "transformations/convert_precision.hpp"
 #include "transformations/rt_info/disable_fp16_compression.hpp"
 #include "transformations/utils/utils.hpp"
-#include <openvino/op/util/pad_base.hpp>
 
 using namespace std;
 using namespace ov::opset10;


### PR DESCRIPTION
### Details:
 - fix PropagateDownDisableSensitivityForQuantized to support both v1::Pad and v12::Pad
 
### Tickets:
 - 112279
