### PR TITLE
[GPU] updates to use a graph local net_id for model caching

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -92,8 +92,8 @@ public:
 
     network(program::ptr program, stream::ptr stream, uint16_t stream_id);
 
-    network(cldnn::BinaryInputBuffer& ifs, stream::ptr stream, engine& engine, bool is_primary_stream = true);
-    network(cldnn::BinaryInputBuffer& ifs, const ExecutionConfig& config, stream::ptr stream, engine& engine, bool is_primary_stream = true);
+    network(cldnn::BinaryInputBuffer& ifs, stream::ptr stream, engine& engine, bool is_primary_stream, uint32_t local_net_id);
+    network(cldnn::BinaryInputBuffer& ifs, const ExecutionConfig& config, stream::ptr stream, engine& engine, bool is_primary_stream, uint32_t local_net_id);
 
     ~network();
 
@@ -215,6 +215,7 @@ public:
     void configure_primitives_second_output();
     void build_insts_deps();
     uint32_t get_id() const { return net_id; }
+    uint32_t get_local_id() const { return _local_net_id; }
     stream& get_stream() const { return *_stream; }
     stream::ptr get_stream_ptr() const { return _stream; }
     bool is_internal() const { return _internal; }
@@ -254,6 +255,7 @@ private:
     bool _is_dynamic = false;
     bool _enable_profiling = false;
     bool _reset_arguments;
+    uint32_t _local_net_id = 0;
 
     std::unordered_map<primitive_id, std::shared_ptr<primitive_inst>> _primitives;
     std::vector<shared_mem_type> _in_out_shared_mem_types;

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -255,7 +255,8 @@ private:
     bool _is_dynamic = false;
     bool _enable_profiling = false;
     bool _reset_arguments;
-    uint32_t _local_net_id = 0;
+    uint32_t _local_net_id = 0;     // This is for thread-safe deserialization. 'net_id' is globally unique,
+                                    // but '_local_net_id' is unique only in each intel_gpu::Graph.
 
     std::unordered_map<primitive_id, std::shared_ptr<primitive_inst>> _primitives;
     std::vector<shared_mem_type> _in_out_shared_mem_types;

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -37,7 +37,7 @@ private:
 class BinaryInputBuffer : public InputBuffer<BinaryInputBuffer> {
 public:
     BinaryInputBuffer(std::istream& stream, engine& engine)
-    : InputBuffer(this, engine), _stream(stream), _impl_params(nullptr), _num_networks(0), _stream_id(0) {}
+    : InputBuffer(this, engine), _stream(stream), _impl_params(nullptr) {}
 
     void read(void* const data, std::streamsize size) {
         auto const read_size = _stream.rdbuf()->sgetn(reinterpret_cast<char*>(data), size);
@@ -62,18 +62,10 @@ public:
     std::streampos tellg() { return _stream.tellg(); }
     void seekg(std::streampos pos) { _stream.seekg(pos); }
 
-    void new_network_added() { _num_networks += 1; }
-    int get_num_networks() const { return _num_networks; }
-
-    void set_stream_id(uint16_t stream_id) { _stream_id = stream_id; }
-    uint16_t get_stream_id() const { return _stream_id; }
-
 private:
     std::istream& _stream;
     void* _impl_params;
     std::vector<std::unordered_map<std::string, std::shared_ptr<memory>>> _const_data_map;
-    int _num_networks;
-    uint16_t _stream_id;
 };
 
 template <typename T>

--- a/src/plugins/intel_gpu/src/graph/data.cpp
+++ b/src/plugins/intel_gpu/src/graph/data.cpp
@@ -87,7 +87,7 @@ void data_inst::load(BinaryInputBuffer& ib) {
     ib >> make_data(&data_size, sizeof(size_t));
 
     if (!get_network().is_primary_stream()) {
-        _outputs[0] = ib.getConstData(get_network_id() - (ib.get_num_networks() * ib.get_stream_id()), id());
+        _outputs[0] = ib.getConstData(_network.get_local_id(), id());
         auto pos = ib.tellg();
         pos += data_size;
         ib.seekg(pos);
@@ -103,7 +103,7 @@ void data_inst::load(BinaryInputBuffer& ib) {
             _outputs[0]->copy_from(get_network().get_stream(), _buf.data());
         }
 
-        ib.addConstData(get_network_id(), id(), _outputs[0]);
+        ib.addConstData(_network.get_local_id(), id(), _outputs[0]);
     }
 }
 

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -529,7 +529,7 @@ void loop_inst::load(BinaryInputBuffer& ib) {
     ib >> _condition_id;
     ib >> _num_iteration_id;
     ib >> _max_iteration;
-    body_network = std::make_shared<cldnn::network>(ib, get_network().get_stream_ptr(), get_network().get_engine(), get_network().is_primary_stream());
+    body_network = std::make_shared<cldnn::network>(ib, get_network().get_stream_ptr(), get_network().get_engine(), get_network().is_primary_stream(), 0);
 }
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -359,10 +359,10 @@ network::network(program::ptr program, uint16_t stream_id)
 network::network(program::ptr program, stream::ptr stream, uint16_t stream_id)
     : network(program, program->get_config(), stream, false, stream_id == 0) {}
 
-network::network(cldnn::BinaryInputBuffer& ib, stream::ptr stream, engine& engine, bool is_primary_stream)
-    : network(ib, ExecutionConfig{}, stream, engine, is_primary_stream) {}
+network::network(cldnn::BinaryInputBuffer& ib, stream::ptr stream, engine& engine, bool is_primary_stream, uint32_t local_net_id)
+    : network(ib, ExecutionConfig{}, stream, engine, is_primary_stream, local_net_id) {}
 
-network::network(cldnn::BinaryInputBuffer& ib, const ExecutionConfig& config, stream::ptr stream, engine& engine, bool is_primary_stream)
+network::network(cldnn::BinaryInputBuffer& ib, const ExecutionConfig& config, stream::ptr stream, engine& engine, bool is_primary_stream, uint32_t local_net_id)
     : _program(nullptr)
     , _config(config)
     , _engine(engine)
@@ -370,10 +370,9 @@ network::network(cldnn::BinaryInputBuffer& ib, const ExecutionConfig& config, st
     , _memory_pool(new memory_pool(engine))
     , _internal(false)
     , _is_primary_stream(is_primary_stream)
-    , _reset_arguments(true) {
+    , _reset_arguments(true)
+    , _local_net_id(local_net_id) {
     net_id = get_unique_net_id();
-    if (is_primary_stream)
-        ib.new_network_added();
 
     kernels_cache kernels_cache(get_engine(), config, 0, nullptr, {""});
     ib >> kernels_cache;

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -107,8 +107,7 @@ Graph::Graph(cldnn::BinaryInputBuffer &ib, RemoteContextImpl::Ptr context, const
     size_t num_networks;
     ib >> num_networks;
     for (size_t i = 0; i < num_networks; ++i) {
-        ib.set_stream_id(m_stream_id);
-        m_networks.emplace_back(std::make_shared<cldnn::network>(ib, get_engine().create_stream(config), get_engine(), m_stream_id == 0));
+        m_networks.emplace_back(std::make_shared<cldnn::network>(ib, get_engine().create_stream(config), get_engine(), m_stream_id == 0, i));
     }
 }
 

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -106,7 +106,7 @@ Graph::Graph(cldnn::BinaryInputBuffer &ib, RemoteContextImpl::Ptr context, const
 
     size_t num_networks;
     ib >> num_networks;
-    for (size_t i = 0; i < num_networks; ++i) {
+    for (uint32_t i = 0; i < num_networks; ++i) {
         m_networks.emplace_back(std::make_shared<cldnn::network>(ib, get_engine().create_stream(config), get_engine(), m_stream_id == 0, i));
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -138,7 +138,7 @@ public:
             {
                 std::istream in_mem(&mem_buf);
                 BinaryInputBuffer ib = BinaryInputBuffer(in_mem, engine);
-                network = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine);
+                network = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine, true, 0);
             }
         } else {
             network = std::make_shared<cldnn::network>(engine, tp, get_test_default_config(engine));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/proposal_cpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/proposal_cpu_test.cpp
@@ -101,7 +101,7 @@ TestRunnerProposal<Dtype, ImInfoType>::TestRunnerProposal(cldnn::tensor image_in
         {
             std::istream in_mem(&mem_buf);
             BinaryInputBuffer ib = BinaryInputBuffer(in_mem, get_test_engine());
-            _network.reset(new network(ib, get_test_stream_ptr(), get_test_engine()));
+            _network.reset(new network(ib, get_test_stream_ptr(), get_test_engine(), true, 0));
         }
     } else {
         _network.reset(new network(get_test_engine(), _topology));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/streams_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/streams_test.cpp
@@ -93,9 +93,9 @@ public:
                     std::istream in_mem(&mem_buf);
                     BinaryInputBuffer ib = BinaryInputBuffer(in_mem, engine);
                     auto pos = ib.tellg();
-                    network0 = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine, true);
+                    network0 = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine, true, 0);
                     ib.seekg(pos);
-                    network1 = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine, false);
+                    network1 = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine, false, 0);
                 }
             }
         } else {
@@ -192,12 +192,12 @@ public:
                 {
                     std::istream in_mem0(&mem_buf0);
                     BinaryInputBuffer ib0 = BinaryInputBuffer(in_mem0, engine);
-                    network0 = std::make_shared<cldnn::network>(ib0, get_test_stream_ptr(), engine, false);
+                    network0 = std::make_shared<cldnn::network>(ib0, get_test_stream_ptr(), engine, false, 0);
                 }
                 {
                     std::istream in_mem1(&mem_buf1);
                     BinaryInputBuffer ib1 = BinaryInputBuffer(in_mem1, engine);
-                    network1 = std::make_shared<cldnn::network>(ib1, get_test_stream_ptr(), engine, true);
+                    network1 = std::make_shared<cldnn::network>(ib1, get_test_stream_ptr(), engine, true, 0);
                 }
             }
         } else {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/streams_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/streams_test.cpp
@@ -95,7 +95,6 @@ public:
                     auto pos = ib.tellg();
                     network0 = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine, true);
                     ib.seekg(pos);
-                    ib.set_stream_id(1);
                     network1 = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine, false);
                 }
             }
@@ -198,7 +197,6 @@ public:
                 {
                     std::istream in_mem1(&mem_buf1);
                     BinaryInputBuffer ib1 = BinaryInputBuffer(in_mem1, engine);
-                    ib1.set_stream_id(1);
                     network1 = std::make_shared<cldnn::network>(ib1, get_test_stream_ptr(), engine, true);
                 }
             }

--- a/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.h
+++ b/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.h
@@ -771,7 +771,7 @@ inline cldnn::network::ptr get_network(cldnn::engine& engine,
         {
             std::istream in_mem(&mem_buf);
             cldnn::BinaryInputBuffer ib = cldnn::BinaryInputBuffer(in_mem, engine);
-            network = std::make_shared<cldnn::network>(ib, config, stream, engine);
+            network = std::make_shared<cldnn::network>(ib, config, stream, engine, true, 0);
         }
     } else {
         network = std::make_shared<cldnn::network>(engine, topology, config);


### PR DESCRIPTION
### Details:
 - This PR updates the model caching to use a new graph local net_id for the multiple streams execution.
 - It resolves a thread safety issue of GPU model caching.

### Tickets:
 - 112483
