### PR TITLE
[DOCS] Fix references in installation guide

### DIFF
--- a/docs/OV_Runtime_UG/supported_plugins/GNA.md
+++ b/docs/OV_Runtime_UG/supported_plugins/GNA.md
@@ -47,7 +47,7 @@ exported for GNA 2.0 runs on GNA 3.0 or vice versa.
 
    In most cases, a network compiled for GNA 2.0 runs as expected on GNA 3.0. However, performance may be worse 
    compared to when a network is compiled specifically for the latter. The exception is a network with convolutions 
-   with the number of filters greater than 8192 (see the :ref:`Model and Operation Limitations <#model-and-operation-limitations>` section).
+   with the number of filters greater than 8192 (see the `Model and Operation Limitations <#model-and-operation-limitations>`__ section).
 
 
 For optimal work with POT quantized models, which include 2D convolutions on GNA 3.0 hardware, the following requirements should be satisfied:
@@ -136,7 +136,7 @@ quantization hints based on statistics for the provided dataset.
 * Performance (i8 weights)
 
 For POT quantized models, the ``ov::hint::inference_precision`` property has no effect except in cases described in the
-:ref:`Model and Operation Limitations section <#model-and-operation-limitations>`.
+`Model and Operation Limitations section <#model-and-operation-limitations>`__.
 
 
 Supported Features

--- a/docs/install_guides/installing-openvino-overview.md
+++ b/docs/install_guides/installing-openvino-overview.md
@@ -44,11 +44,11 @@ The best way to get started with OpenVINO is to install OpenVINO Development Too
 
 **Python**
 
-For developers working in Python, OpenVINO Development Tools can easily be installed using PyPI. See the :ref:`For Python Developers <openvino_docs_install_guides_install_dev_tools.html#python_developers>` section of the Install OpenVINO Development Tools page for instructions.
+For developers working in Python, OpenVINO Development Tools can easily be installed using PyPI. See the :ref:`For Python Developers <python_developers>` section of the Install OpenVINO Development Tools page for instructions.
 
 **C++**
 
-For developers working in C++, the core OpenVINO Runtime libraries must be installed separately. Then, OpenVINO Development Tools can be installed using requirements files or PyPI. See the :ref:`For C++ Developers <openvino_docs_install_guides_install_dev_tools.html#cpp_developers>` section of the Install OpenVINO Development Tools page for instructions.
+For developers working in C++, the core OpenVINO Runtime libraries must be installed separately. Then, OpenVINO Development Tools can be installed using requirements files or PyPI. See the :ref:`For C++ Developers <cpp_developers>` section of the Install OpenVINO Development Tools page for instructions.
 
 Install OpenVINO Runtime only
 +++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Fixing references in the `Install Intel® Distribution of OpenVINO™ Toolkit` article.