### PR TITLE
[Snippets][CPU] Enabled MHA tokenization for quant and bf16 cases

### DIFF
--- a/src/common/snippets/include/snippets/op/vector_buffer.hpp
+++ b/src/common/snippets/include/snippets/op/vector_buffer.hpp
@@ -21,7 +21,7 @@ public:
 
     VectorBuffer(const ov::element::Type element_type = ov::element::f32);
 
-    bool visit_attributes(AttributeVisitor& visitor) override { return true;}
+    bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
     void validate_and_infer_types() override;
 

--- a/src/common/snippets/include/snippets/pass/tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/tokenization.hpp
@@ -61,16 +61,17 @@ public:
      * @ingroup snippets
      */
     struct Config {
-        Config(size_t minimal_concurrency = 1, bool split_m_dimension = true, bool enable_transpose = true)
-            : minimal_concurrency(minimal_concurrency), split_m_dimension(split_m_dimension), mha_token_enable_transpose(enable_transpose) {}
+        Config(size_t minimal_concurrency = 1, bool split_m_dimension = true, bool enable_transpose_on_output = true)
+            : minimal_concurrency(minimal_concurrency), split_m_dimension(split_m_dimension),
+              mha_token_enable_transpose_on_output(enable_transpose_on_output) {}
 
         size_t minimal_concurrency = 1;
         // True if "SplitDimensionM" optimization is enabled. Otherwise, it's disabled.
         bool split_m_dimension = true;
-        // False if all Transposes aren't tokenized in MHA Tokenization.
-        // Otherwise, they may be fused into Subgraph if possible
-        // TODO [106921]: Remove please when the ticket 106921 is implemented
-        bool mha_token_enable_transpose = true;
+        // False if Transpose on output isn't tokenized in MHA Tokenization.
+        // Otherwise, it may be fused into Subgraph if possible
+        // TODO [111813]: Remove please when the ticket 111813 is implemented
+        bool mha_token_enable_transpose_on_output = true;
     };
 
     OPENVINO_RTTI("SnippetsTokenization", "0");

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -81,7 +81,8 @@ Generator::opRegType Generator::get_op_reg_type(const std::shared_ptr<Node>& op)
              std::dynamic_pointer_cast<op::BroadcastMove>(op) ||
              std::dynamic_pointer_cast<op::Scalar>(op) ||
              std::dynamic_pointer_cast<op::HorizonMax>(op) ||
-             std::dynamic_pointer_cast<op::HorizonSum>(op))
+             std::dynamic_pointer_cast<op::HorizonSum>(op) ||
+             std::dynamic_pointer_cast<op::Fill>(op))
         return vec2vec;
     else
         return get_specific_op_reg_type(op);

--- a/src/common/snippets/src/lowered/pass/allocate_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/allocate_buffers.cpp
@@ -17,6 +17,7 @@ void AllocateBuffers::propagate_offset(const LinearIR& linear_ir, const Expressi
     // to correctly read and write data because all Buffers has the common data pointer on buffer scratchpad
 
     const auto buffer = ov::as_type_ptr<op::Buffer>(buffer_expr->get_node());
+    buffer->set_offset(static_cast<int64_t>(offset));
 
     // Propagate to up: in Store. Buffer can have only one Store
     {
@@ -57,26 +58,34 @@ void AllocateBuffers::propagate_offset(const LinearIR& linear_ir, const Expressi
 
 bool AllocateBuffers::run(LinearIR& linear_ir) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::AllocateBuffers");
+    // [113664] The pass contains two main logics: it defines which of buffers can be inplace (use the same memory) and
+    // allocate memory of needed size. It should be splitted into several passes and updated in bounds of the ticket 113664.
 
-    size_t offset = 0;
+    // [113664] At the moment New Memory Buffer is used only in BrgemmCPU for AMX case. This memory can be reused for each Brgemm.
+    // This plugin-specific condition will be removed in the near future after the task 113664 will be implemented
+    size_t offset = 0, new_memory_buffer_offset = 0;
+    size_t prev_data_size = 0, current_data_size = 0;
     std::set<ExpressionPtr> allocated_buffers;
+    bool new_memory_buffer_allocated = false;
 
     auto allocate = [&](const std::shared_ptr<op::Buffer>& buffer, const ExpressionPtr& expr, size_t buffer_size) {
         offset = m_buffer_scratchpad_size;
-        buffer->set_offset(static_cast<int64_t>(offset));
         propagate_offset(linear_ir, expr, offset);
         m_buffer_scratchpad_size += buffer_size;
         allocated_buffers.insert(expr);
+        prev_data_size = current_data_size;
     };
 
     for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end(); expr_it++) {
         const auto& expr = *expr_it;
         if (auto buffer = as_type_ptr<op::Buffer>(expr->get_node())) {
             const auto buffer_size = buffer->get_byte_size();
+            current_data_size = buffer->get_element_type().size();
             // If it's the first buffer, offsets are zero => nothing to propagate, can continue
             if (m_buffer_scratchpad_size == 0) {
                 m_buffer_scratchpad_size += buffer_size;
                 allocated_buffers.insert(expr);
+                prev_data_size = current_data_size;
                 continue;
             }
 
@@ -84,7 +93,7 @@ bool AllocateBuffers::run(LinearIR& linear_ir) {
                 const auto& parent_expr = expr->get_input_port_connector(0)->get_source().get_expr();
                 const auto& parent_node = parent_expr->get_node();
                 // Full MemoryAccess ops need new memory. Previous logic is to check for parent isn't Loop
-                // TODO: It should be unified in MemoryManager with memory reuse in the near future
+                // [113664] It should be unified in MemoryManager with memory reuse in the near future
                 const auto ma = ov::as_type_ptr<op::MemoryAccess>(parent_node);
                 if (ma && ma->is_full_memory_access_op()) {
                     allocate(buffer, *expr_it, buffer_size);
@@ -99,7 +108,7 @@ bool AllocateBuffers::run(LinearIR& linear_ir) {
                 // At the moment the pass support only sequentially implicit InPlace.
                 // If Buffer_0 is allocated firstly as Buffer after full memory access op,
                 // we cannot reuse this allocated memory for Buffer_1 - we must allocate new memory for it.
-                // TODO: It should be unified in MemoryManager with memory reuse in the near future
+                // [113664] It should be unified in MemoryManager with memory reuse in the near future
                 bool need_allocate = false;
                 const auto consumers = expr->get_output_port_connector(0)->get_consumers();
                 for (const auto& consumer : consumers) {
@@ -122,16 +131,26 @@ bool AllocateBuffers::run(LinearIR& linear_ir) {
                     continue;
                 }
 
+                // [113664] For more details and reason of the current solution, please, go to the ticket description
                 const auto current_allocated_memory_size = m_buffer_scratchpad_size - offset;
-                if (buffer_size > current_allocated_memory_size) {
+                if (((current_data_size == prev_data_size) && buffer_size > current_allocated_memory_size) ||
+                    ((current_data_size != prev_data_size) && buffer_size != current_allocated_memory_size)) {
                     allocate(buffer, expr, buffer_size);
                     continue;
                 }
                 propagate_offset(linear_ir, *expr_it, offset);
                 allocated_buffers.insert(expr);
+                prev_data_size = current_data_size;
             } else {
-                // Single Buffer without input should allocate new memory
-                allocate(buffer, *expr_it, buffer_size);
+                if (!new_memory_buffer_allocated) {
+                    allocate(buffer, *expr_it, buffer_size);
+                    new_memory_buffer_allocated = true;
+                    new_memory_buffer_offset = offset;
+                } else {
+                    propagate_offset(linear_ir, *expr_it, new_memory_buffer_offset);
+                    allocated_buffers.insert(expr);
+                    prev_data_size = current_data_size;
+                }
             }
         }
     }

--- a/src/common/snippets/src/lowered/pass/assign_registers.cpp
+++ b/src/common/snippets/src/lowered/pass/assign_registers.cpp
@@ -69,8 +69,12 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
             const auto& input_expr = input_tensor->get_source().get_expr();
             const auto& input_expr_input_tensors = input_expr->get_input_port_connectors();
             for (const auto& tensor : input_expr_input_tensors) {
-                if (ov::is_type<op::VectorBuffer>(tensor->get_source().get_expr()->get_node())) {
+                const auto parent_expr = tensor->get_source().get_expr();
+                if (ov::is_type<op::Fill>(parent_expr->get_node())) {
                     manually_assigned_vecs[tensor] = static_cast<Reg>(accumulator_reg);
+                    if (ov::is_type<op::VectorBuffer>(parent_expr->get_input_port_connector(0)->get_source().get_expr()->get_node())) {
+                        manually_assigned_vecs[parent_expr->get_input_port_connector(0)] = static_cast<Reg>(accumulator_reg);
+                }
                 }
             }
             const auto& output_tensor = expr->get_output_port_connector(0);

--- a/src/common/snippets/src/op/vector_buffer.cpp
+++ b/src/common/snippets/src/op/vector_buffer.cpp
@@ -10,7 +10,8 @@ namespace ov {
 namespace snippets {
 namespace op {
 
-VectorBuffer::VectorBuffer(const ov::element::Type element_type) : Op(), m_element_type(std::move(element_type)) {
+VectorBuffer::VectorBuffer(const ov::element::Type element_type)
+    : Op(), m_element_type(std::move(element_type)) {
     constructor_validate_and_infer_types();
 }
 
@@ -23,6 +24,12 @@ std::shared_ptr<Node> VectorBuffer::clone_with_new_inputs(const OutputVector& ne
 void VectorBuffer::validate_and_infer_types() {
     INTERNAL_OP_SCOPE(VectorBuffer_validate_and_infer_types);
     set_output_type(0, m_element_type, Shape{1lu});
+}
+
+bool VectorBuffer::visit_attributes(AttributeVisitor& visitor) {
+    INTERNAL_OP_SCOPE(VectorBuffer_visit_attributes);
+    visitor.on_attribute("element_type", m_element_type);
+    return true;
 }
 
 } // namespace op

--- a/src/plugins/intel_cpu/src/emitters/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/cpu_generator.cpp
@@ -55,7 +55,7 @@ ov::intel_cpu::CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_
     jitters[ov::op::v0::Parameter::get_type_info_static()] = CREATE_EMITTER(NopEmitter);
     jitters[ov::op::v0::Result::get_type_info_static()] = CREATE_EMITTER(NopEmitter);
     jitters[snippets::op::Buffer::get_type_info_static()] = CREATE_EMITTER(NopEmitter);
-    jitters[snippets::op::VectorBuffer::get_type_info_static()] = CREATE_EMITTER(VectorBufferEmitter);
+    jitters[snippets::op::VectorBuffer::get_type_info_static()] = CREATE_EMITTER(NopEmitter);
     // jitters[ov::op::v1::Constant::get_type_info_static()] = CREATE_EMITTER(); // Not supported
 
     jitters[snippets::op::Load::get_type_info_static()] = CREATE_EMITTER(LoadEmitter);

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
@@ -455,21 +455,6 @@ private:
     enum class OpType { max, sum };
     OpType m_op_type = OpType::max;
 };
-
-class VectorBufferEmitter : public jit_emitter {
-public:
-    VectorBufferEmitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa, const std::shared_ptr<ov::Node>& n);
-
-    size_t get_inputs_num() const override {return 0;}
-
-private:
-    void emit_impl(const std::vector<size_t>& in,
-                   const std::vector<size_t>& out) const override;
-
-    template <dnnl::impl::cpu::x64::cpu_isa_t isa>
-    void emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
-};
-
 class FillEmitter : public jit_emitter {
 public:
     FillEmitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa, const std::shared_ptr<ov::Node>& n);
@@ -485,8 +470,13 @@ private:
 
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>
     void emit_isa(const std::vector<size_t> &in, const std::vector<size_t> &out) const;
+    template <typename Vmm>
+    void fill_full(const Vmm& vmm_dst) const;
+    template <typename Vmm>
+    void fill_tail(const Vmm& vmm_src, const Vmm& vmm_dst) const;
 
-    void register_table_entries() override;
+    bool is_full_reg() const { return offset == 0; }
+    bool is_optimized() const { return is_full_reg() && fill_value == uint32_t(0x0); }
 
     size_t offset = 0;
     uint32_t fill_value = 0x0;

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -96,7 +96,6 @@
 // CPU specific transformations
 #include "transformations/cpu_opset/convert_to_cpu_specific_opset.hpp"
 #include "transformations/snippets/x64/pass/snippets_mark_skipped.hpp"
-#include "transformations/cpu_opset/x64/pass/mha_fusion.hpp"
 #include "transformations/cpu_opset/x64/pass/convert_to_interaction.hpp"
 #include "transformations/cpu_opset/arm/pass/convert_group_conv.hpp"
 #include "transformations/cpu_opset/arm/pass/convert_group_conv1d.hpp"
@@ -560,35 +559,7 @@ void Transformations::PostLpt() {
 
     CPU_REGISTER_PASS_COMMON(postLPTPassManager, ov::pass::ConstantFolding);
 
-    // Snippets may brake MHA patterns so the fusion has to performed before
-    CPU_REGISTER_PASS_X64(postLPTPassManager, MHAFusion);
     CPU_REGISTER_PASS_X64(postLPTPassManager, FuseFQtoInteraction);
-
-    CPU_SET_CALLBACK_X64(postLPTPassManager,
-        ([this](const std::shared_ptr<const ov::Node>& n) -> bool {
-            std::string errorMessage;
-
-            if (!node::MHA::isSupportedOperation(n, errorMessage))
-                return true;
-
-            // Implementation calls AMX BF16 brgemm only for tensors with K and N aligned on 2, otherwise fallbacks on vector impl
-            // Vector madd BF16 instruction on SPR has reduced performance on HW level, which results in overall perf degradation
-            size_t bf16Factor = 2;
-            if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx) &&
-                (n->get_input_element_type(0) == element::bf16 || (n->get_input_element_type(0) == element::f32 && inferencePrecision == ov::element::bf16)) &&
-                (n->get_input_shape(0)[3] % bf16Factor != 0 || n->get_input_shape(1)[1] % bf16Factor != 0 || n->get_input_shape(3)[3] % bf16Factor != 0)) {
-                return true;
-            }
-
-            return false;
-        }),
-        MHAFloatFusion, MHAFloatFusion2, MHAQuantFusion, MHAQuantFusion2);
-
-    // Float MHA is supported by snippets now
-    if (inferencePrecision == ov::element::f32) {
-        CPU_DISABLE_PASS_X64(postLPTPassManager, MHAFloatFusion);
-        CPU_DISABLE_PASS_X64(postLPTPassManager, MHAFloatFusion2);
-    }
 
     // Execute before snippets. Otherwise FQ will be converted to Subgraph
     CPU_REGISTER_PASS_X64(postLPTPassManager, ConvertFqRnnToQuantizedRnn);
@@ -618,11 +589,7 @@ void Transformations::MainSnippets(void) {
         CPU_REGISTER_PASS_X64(snippetsManager, SnippetsMarkSkipped, inferencePrecision != ov::element::f32);
     CPU_REGISTER_PASS_X64(snippetsManager, snippets::pass::SnippetsTokenization, tokenization_config);
 
-    // Tokenize MHA in quantized model or with BF16 only in tests.
-    // TODO [106921]: Please enable the tokenization when the ticket 106921 with blocking support for BRGEMM will be implemented
-    const bool onlyFloatSupported = snippetsMode != Config::SnippetsMode::IgnoreCallback;
     const bool isMHASupported =
-            IMPLICATION(inferencePrecision != ov::element::f32, !onlyFloatSupported) &&
             dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core);  // MHA has BRGEMM that is supported only on AVX512 platforms
     if (!isMHASupported) {
         CPU_DISABLE_PASS_X64(snippetsManager, snippets::pass::TokenizeMHASnippets);
@@ -631,15 +598,38 @@ void Transformations::MainSnippets(void) {
 
     if (snippetsMode != Config::SnippetsMode::IgnoreCallback) {
 #if defined(OPENVINO_ARCH_X86_64)
-        auto is_supported_matmul = [onlyFloatSupported](const std::shared_ptr<const ov::Node>& n) {
+        auto is_supported_matmul = [this](const std::shared_ptr<const ov::Node>& n) {
             const auto matmul = ov::as_type_ptr<const ov::op::v0::MatMul>(n);
             if (!matmul)
                 return false;
-            if (matmul->get_input_element_type(1) == ov::element::i8)
-                return !onlyFloatSupported && dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_vnni);
-            if (matmul->get_input_element_type(0) == ov::element::bf16 &&
-                matmul->get_input_element_type(1) == ov::element::bf16)
-                return !onlyFloatSupported && dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16);
+            const auto in_type0 = matmul->get_input_element_type(0);
+            const auto in_type1 = matmul->get_input_element_type(1);
+            if (in_type0 == ov::element::f32 && in_type1 == ov::element::f32 && inferencePrecision == ov::element::f32)
+                return true;
+            // [114487] brgemm kernel in oneDNN requires brgemm_copy_b kernel if MatMul node has transposed_b=True
+            // The current solution with ExtractExplicitMatMulTranspose pass is slower for non-f32 cases than using of brgemm_copy_b kernel
+            if (matmul->get_transpose_a() || matmul->get_transpose_b())
+                return false;
+            // [115165] At the moment Quantized and BF16 Brgemm doesn't support blocking by K and N.
+            // Big shapes may lead to perf degradation
+            const auto K = *(matmul->get_input_partial_shape(0).rbegin());
+            const auto N = *(matmul->get_input_partial_shape(1).rbegin());
+            if ((K.is_static() && K.get_length() > 512) || // heuristic values
+                (N.is_static() && N.get_length() > 256))
+                return false;
+            if (in_type0 == ov::element::i8)
+                return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_vnni);
+            if ((in_type0 == ov::element::bf16 && in_type1 == ov::element::bf16) ||
+                ((in_type0 == element::f32 && in_type1 == ov::element::f32 && inferencePrecision == ov::element::bf16))) {
+                // Implementation calls AMX BF16 brgemm only for tensors with K and N aligned on 2, otherwise fallbacks on vector impl
+                // Vector madd BF16 instruction on SPR has reduced performance on HW level, which results in overall perf degradation
+                size_t bf16Factor = 2;
+                if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
+                    return K.is_static() && (K.get_length() % bf16Factor == 0) &&
+                           N.is_static() && (N.get_length() % bf16Factor == 0);
+                }
+                return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16);
+            }
             return true;
         };
         auto is_unsupported_parallel_work_amount = [&](const std::shared_ptr<const ov::Node>& n, const ov::Shape& shape) {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -264,6 +264,7 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(.*Snippets.*MatMul.*Quantized.*)");
         retVector.emplace_back(R"(.*Snippets.*MHAFQ.*)");
         retVector.emplace_back(R"(.*Snippets.*MHAINT8.*)");
+        retVector.emplace_back(R"(.*Snippets.*MHAQuant.*)");
     }
     if (!InferenceEngine::with_cpu_x86_avx512_core_amx_int8())
         //TODO: Issue 92895

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -203,6 +203,18 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAINT8MatMul, MHAINT8MatMul,
                                  ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig)),
                          MHA::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAQuantMatMul0, MHAQuantMatMul0,
+                         ::testing::Combine(
+                                 ::testing::Values(std::vector<ov::PartialShape>{{1, 128, 768}, {1, 128, 768}, {1, 1, 1, 128}, {1, 128, 768}}),
+                                 ::testing::Values(std::vector<element::Type>{}),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::Values(false), // The graph doesn't contain Multiply
+                                 ::testing::Values(8),     // FQ on input + MHA + Transpose on output + 4 Reshapes + Deq Mul
+                                 ::testing::Values(3),     // FQ on input + MHA + Deq Mul
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                 ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig)),
+                         MHA::getTestCaseName);
+
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAFQAfterMatMul, MHAFQAfterMatMul,
                          ::testing::Combine(
                                  ::testing::ValuesIn(inputShapes),

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
@@ -290,15 +290,14 @@ INSTANTIATE_TEST_SUITE_P(smoke_MHA, MHATest,
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         MHATest::getTestCaseName);
 
-// Snippets doesn't support Transpose tokenization when inference_precision = bf16
 INSTANTIATE_TEST_SUITE_P(smoke_MHA_BF16, MHATest,
                          ::testing::Combine(
                                  ::testing::ValuesIn(static_shapes_to_test_representation(inputShapes)),
                                  ::testing::Values(std::vector<ElementType>{ ElementType::bf16, ElementType::bf16, ElementType::bf16, ElementType::bf16 }),
                                  ::testing::ValuesIn(matMulIn0Precisions),
                                  ::testing::ValuesIn(patternTypes),
-                                 ::testing::Values(ExpectedNodes{{"Subgraph", 2},    // MHA + Decomposed Transpose
-                                                                 {"Transpose", 3}}),
+                                 ::testing::Values(ExpectedNodes{{"Subgraph", 1},
+                                                                 {"Transpose", 1}}),  // Plugin disables tokenization of Transpose on output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          MHATest::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
@@ -21,12 +21,14 @@ using namespace ngraph::helpers;
 
 namespace CPUSubgraphTestsDefinitions {
 
+using ExpectedNodes = std::vector<std::pair<std::string, size_t>>;
+
 typedef std::tuple<
         std::vector<InputShape>,   // Input shapes
         std::vector<ElementType>,  // Input precisions
         std::vector<ElementType>,  // MatMul input #0 precisions
         size_t,                    // pattern type #
-        std::string,               // Expected node
+        ExpectedNodes,             // Expected node -> count
         std::string                // Device name
 > MHATuple;
 
@@ -157,9 +159,9 @@ public:
         std::vector<ElementType> inputPrecisions;
         std::vector<ElementType> matMulIn0Precisions;
         size_t patternType;
-        std::string expectedNode;
+        ExpectedNodes expectedNodes;
         std::string targetName;
-        std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNode, targetName) = obj.param;
+        std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNodes, targetName) = obj.param;
         std::ostringstream results;
 
         results << "IS=(";
@@ -176,7 +178,10 @@ public:
             results << "InPRC" << std::to_string(i) << "=" << inputPrecisions[i] << "_";
         }
         results << "patternType=" << patternType;
-        results << "expect=" << expectedNode;
+        results << "expect=";
+        for (const auto& node : expectedNodes) {
+            results << node.first << "[" << node.second << "]" << "_";
+        }
         results << "targetDevice=" << targetName;
 
         return results.str();
@@ -188,24 +193,23 @@ public:
         for (size_t i = 0; i < funcInputs.size(); ++i) {
             const auto& funcInput = funcInputs[i];
             ov::Tensor tensor;
-            // TODO: after snippets fixed should remove 2nd condition, ticket: 105339
-            if (patternType == 0 || expectedNode == "Subgraph")
-                tensor = ov::test::utils::create_and_fill_tensor_normal_distribution(funcInput.get_element_type(), targetInputStaticShapes[i], 1.0f, 0.5f);
+            if (funcInput.get_element_type() == ov::element::bf16)
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 2, -1, 256);
             else
-                // generate all negative inputs
-                tensor = ov::test::utils::create_and_fill_tensor_unique_sequence(funcInput.get_element_type(), targetInputStaticShapes[i], -1, -5);
+                tensor = ov::test::utils::create_and_fill_tensor_unique_sequence(funcInput.get_element_type(), targetInputStaticShapes[i], -1, 5);
+            inputs.insert({funcInput.get_node_shared_ptr(), tensor});
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
         }
     }
 
 protected:
     size_t patternType;
-    std::string expectedNode;
+    ExpectedNodes expectedNodes;
     void SetUp() override {
         std::vector<InputShape> inputShapes;
         std::vector<ElementType> inputPrecisions;
         std::vector<ElementType> matMulIn0Precisions;
-        std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNode, targetDevice) = this->GetParam();
+        std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNodes, targetDevice) = this->GetParam();
 
         init_input_shapes(inputShapes);
 
@@ -240,8 +244,8 @@ TEST_P(MHATest, CompareWithRefs) {
     std::vector<ElementType> inputPrecisions;
     std::vector<ElementType> matMulIn0Precisions;
     size_t patternType;
-    std::string expectedNode;
-    std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNode, targetDevice) = this->GetParam();
+    ExpectedNodes expectedNodes;
+    std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNodes, targetDevice) = this->GetParam();
 
     if (inputPrecisions[0] == ElementType::bf16 && !InferenceEngine::with_cpu_x86_bfloat16())
         GTEST_SKIP();
@@ -250,7 +254,10 @@ TEST_P(MHATest, CompareWithRefs) {
         GTEST_SKIP();
 
     run();
-    CheckNumberOfNodesWithType(compiledModel, expectedNode, 1);
+
+    for (const auto& node : expectedNodes) {
+        CheckNumberOfNodesWithType(compiledModel, node.first, node.second);
+    }
 }
 
 namespace {
@@ -273,23 +280,25 @@ std::vector<size_t> patternTypes = {
     0, 1
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA, MHATest,
+INSTANTIATE_TEST_SUITE_P(smoke_MHA, MHATest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapes)),
                                 ::testing::Values(std::vector<ElementType>{ ElementType::f32, ElementType::f32, ElementType::f32, ElementType::f32 }),
                                 ::testing::ValuesIn(matMulIn0Precisions),
                                 ::testing::ValuesIn(patternTypes),
-                                ::testing::Values("Subgraph"),
+                                ::testing::Values(ExpectedNodes{{"Subgraph", 1}}),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         MHATest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_MHA, MHATest,
+// Snippets doesn't support Transpose tokenization when inference_precision = bf16
+INSTANTIATE_TEST_SUITE_P(smoke_MHA_BF16, MHATest,
                          ::testing::Combine(
                                  ::testing::ValuesIn(static_shapes_to_test_representation(inputShapes)),
                                  ::testing::Values(std::vector<ElementType>{ ElementType::bf16, ElementType::bf16, ElementType::bf16, ElementType::bf16 }),
                                  ::testing::ValuesIn(matMulIn0Precisions),
                                  ::testing::ValuesIn(patternTypes),
-                                 ::testing::Values("MHA"),  // Snippets don't support BF16 MHA pattern yet
+                                 ::testing::Values(ExpectedNodes{{"Subgraph", 2},    // MHA + Decomposed Transpose
+                                                                 {"Transpose", 3}}),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          MHATest::getTestCaseName);
 
@@ -454,8 +463,8 @@ public:
         std::vector<ElementType> matMulIn0Precisions;
         size_t patternType;
         std::string targetName;
-        std::string expectedNode;
-        std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNode, targetName) = obj.param;
+        ExpectedNodes expectedNodes;
+        std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNodes, targetName) = obj.param;
         std::ostringstream results;
 
         results << "IS=(";
@@ -475,7 +484,10 @@ public:
             results << "MatMulIn0PRC" << std::to_string(i) << "=" << matMulIn0Precisions[i] << "_";
         }
         results << "patternType=" << patternType;
-        results << "expect=" << expectedNode;
+        results << "expect=";
+        for (const auto& node : expectedNodes) {
+            results << node.first << "[" << node.second << "]" << "_";
+        }
         results << "targetDevice=" << targetName;
 
         return results.str();
@@ -505,8 +517,8 @@ protected:
         std::vector<ElementType> inputPrecisions;
         std::vector<ElementType> matMulIn0Precisions;
         size_t patternType;
-        std::string expectedNode;
-        std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNode, targetDevice) = this->GetParam();
+        ExpectedNodes expectedNodes;
+        std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNodes, targetDevice) = this->GetParam();
 
         init_input_shapes(inputShapes);
 
@@ -534,8 +546,8 @@ TEST_P(MHAQuantTest, CompareWithRefs) {
     std::vector<ElementType> inputPrecisions;
     std::vector<ElementType> matMulIn0Precisions;
     size_t patternType;
-    std::string expectedNode;
-    std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNode, targetDevice) = this->GetParam();
+    ExpectedNodes expectedNodes;
+    std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNodes, targetDevice) = this->GetParam();
 
     if (inputPrecisions[0] == ElementType::bf16 && !InferenceEngine::with_cpu_x86_bfloat16())
         GTEST_SKIP();
@@ -544,7 +556,10 @@ TEST_P(MHAQuantTest, CompareWithRefs) {
         GTEST_SKIP();
 
     run();
-    CheckNumberOfNodesWithType(compiledModel, expectedNode, 1);
+
+    for (const auto& node : expectedNodes) {
+        CheckNumberOfNodesWithType(compiledModel, node.first, node.second);
+    }
 }
 
 namespace {
@@ -570,17 +585,37 @@ std::vector<std::vector<ElementType>> matMulIn0PrecisionsQuant = {
     { ElementType::i8, ElementType::u8 },
 };
 
-std::vector<size_t> patternTypesQuant = {
-    0, 1, 2
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant, MHAQuantTest,
+INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant_Pattern0, MHAQuantTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesQuant)),
                                 ::testing::ValuesIn(inputPrecisionsQuant),
                                 ::testing::ValuesIn(matMulIn0PrecisionsQuant),
-                                ::testing::ValuesIn(patternTypesQuant),
-                                ::testing::Values("MHA"),
+                                ::testing::Values(0),
+                                ::testing::Values(ExpectedNodes{{"Subgraph", 5},  // FQs on inputs x 3 + MHA + Deq Mul
+                                                                {"Transpose", 1}}),  // Transpose between MHA and Deq Mul
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                        MHAQuantTest::getTestCaseName);
+
+
+INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant_Pattern1, MHAQuantTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesQuant)),
+                                ::testing::ValuesIn(inputPrecisionsQuant),
+                                ::testing::ValuesIn(matMulIn0PrecisionsQuant),
+                                ::testing::Values(1),
+                                ::testing::Values(ExpectedNodes{{"Subgraph", 3},  // FQ on input + MHA + Deq Mul
+                                                                {"Transpose", 1}}),  // Transpose between MHA and Deq Mul
+                                ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                        MHAQuantTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant_Pattern2, MHAQuantTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesQuant)),
+                                ::testing::ValuesIn(inputPrecisionsQuant),
+                                ::testing::ValuesIn(matMulIn0PrecisionsQuant),
+                                ::testing::Values(2),
+                                ::testing::Values(ExpectedNodes{{"Subgraph", 2},  // MHA + Deq Mul
+                                                                {"Transpose", 0}}), // Transpose is fused
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         MHAQuantTest::getTestCaseName);
 

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -66,6 +66,11 @@ protected:
     std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
 };
 
+class MHAQuantMatMul0 : public MHA {
+protected:
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+};
+
 class MHAFQAfterMatMul : public MHA {
 protected:
     std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -115,6 +115,10 @@ std::shared_ptr<SnippetsFunctionBase> MHAINT8MatMul::get_subgraph() {
     return std::make_shared<ov::test::snippets::MHAINT8MatMulFunction>(inputDynamicShapes);
 }
 
+std::shared_ptr<SnippetsFunctionBase> MHAQuantMatMul0::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHAQuantMatMul0Function>(inputDynamicShapes);
+}
+
 std::shared_ptr<SnippetsFunctionBase> MHAFQAfterMatMul::get_subgraph() {
     return std::make_shared<ov::test::snippets::MHAFQAfterMatMulFunction>(inputDynamicShapes);
 }
@@ -172,6 +176,12 @@ TEST_P(MHATransposedB, CompareWithRefImpl) {
 }
 
 TEST_P(MHAINT8MatMul, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    run();
+    validateNumSubgraphs();
+}
+
+TEST_P(MHAQuantMatMul0, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     validateNumSubgraphs();


### PR DESCRIPTION
### Details:
 - *Enable Snippets tokenization on quantized models and float models with `inference_precision=bf16`*
 - *Disabled custom MHA Fusion pass*
 - *Added `Fill` op after `VectorBuffer` to fill the correct default value for accumulator pattern. Before `ReduceMax` had zeros in buffers but should have `-float_max`*
 - *Fixed buffer allocation size*
 - *Updated subgraph CPU tests for MHA*

### Tickets:
 - *112973, 105339*
 
 ### TODO:
- [x] *Add check for matmul shapes since blocking by k, n dimensions is supported only for f32*
- [x] *Performance validation results are attached to the ticket 112973*
- [x] *Accuracy validation results are attached to the ticket 112973*