### PR TITLE
fix get_profiling_info tests not run in ci

### DIFF
--- a/src/plugins/auto/src/infer_request.cpp
+++ b/src/plugins/auto/src/infer_request.cpp
@@ -105,7 +105,7 @@ std::vector<ov::ProfilingInfo> ov::auto_plugin::InferRequest::get_profiling_info
     if (m_shared_request)
         return m_shared_request->get_profiling_info();
     if (m_scheduled_request)
-        return m_shared_request->get_profiling_info();
+        return m_scheduled_request->get_profiling_info();
     OPENVINO_NOT_IMPLEMENTED;
 }
 

--- a/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/perf_counters.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/perf_counters.hpp
@@ -12,6 +12,7 @@ namespace test {
 namespace behavior {
 struct OVInferRequestPerfCountersTest : public virtual OVInferRequestTests {
     void SetUp() override;
+    static std::string getTestCaseName(testing::TestParamInfo<InferRequestParams> obj);
     ov::InferRequest req;
 };
 using OVInferRequestPerfCountersExceptionTest = OVInferRequestPerfCountersTest;

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/perf_counters.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/perf_counters.cpp
@@ -19,6 +19,23 @@ void OVInferRequestPerfCountersTest::SetUp() {
     req = execNet.create_infer_request();
 }
 
+std::string OVInferRequestPerfCountersTest::getTestCaseName(testing::TestParamInfo<InferRequestParams> obj) {
+    std::string targetDevice;
+    ov::AnyMap configuration;
+    std::tie(targetDevice, configuration) = obj.param;
+    std::replace(targetDevice.begin(), targetDevice.end(), ':', '.');
+    std::ostringstream result;
+    result << "targetDevice=" << targetDevice << "_";
+    if (!configuration.empty()) {
+        using namespace CommonTestUtils;
+        for (auto &configItem : configuration) {
+            result << "configItem=" << configItem.first << "_";
+            configItem.second.print(result);
+        }
+    }
+    return result.str();
+}
+
 TEST_P(OVInferRequestPerfCountersTest, NotEmptyAfterAsyncInfer) {
     OV_ASSERT_NO_THROW(req.start_async());
     OV_ASSERT_NO_THROW(req.wait());


### PR DESCRIPTION
### Details:
 - profiling tests not tested in CI

### Tickets:
 - *ticket-id*
