### PR TITLE
[PyOV] Limit `numpy` version to 1.23 for MO mxnet

### DIFF
--- a/tools/mo/requirements_mxnet.txt
+++ b/tools/mo/requirements_mxnet.txt
@@ -1,5 +1,5 @@
 -c ../constraints.txt
-numpy>=1.16.6,<1.26
+numpy>=1.16.6,<1.24
 mxnet
 networkx
 defusedxml


### PR DESCRIPTION
### Details:
 - the newest version of mxnet is 1.9.1: https://pypi.org/project/mxnet/1.9.1/#history
 - numpy==1.24.0 deprecated `np.bool` symbol: https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations
 - mxnet==1.9.1 uses it, causing errors in CI pipelines: https://github.com/apache/mxnet/blob/v1.9.1/python/mxnet/numpy/utils.py#L37
 - we can't upgrade mxnet, so we have to limit numpy version for MO mxnet

### Tickets:
 - N/A
