### PR TITLE
partial backport of PR#14754 disabling MULTI configuration functional…

### DIFF
--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/executable_network/get_metric.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/executable_network/get_metric.cpp
@@ -25,7 +25,7 @@ INSTANTIATE_TEST_SUITE_P(
 // TODO: this metric is not supported by the plugin
 INSTANTIATE_TEST_SUITE_P(
         DISABLED_smoke_IEClassExecutableNetworkGetMetricTest, IEClassExecutableNetworkGetMetricTest_NETWORK_NAME,
-        ::testing::Values("GNA", "MULTI:GNA", "HETERO:GNA"));
+        ::testing::Values("GNA", /* "MULTI:GNA", */ "HETERO:GNA"));
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_SUITE_P(

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/ov_executable_network/get_metric.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/ov_executable_network/get_metric.cpp
@@ -72,7 +72,7 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_OVClassExecutableNetworkGetMetricTest,
 // TODO: this metric is not supported by the plugin
 INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_OVClassExecutableNetworkGetMetricTest,
         OVClassExecutableNetworkGetMetricTest_NETWORK_NAME,
-        ::testing::Values("GNA", "MULTI:GNA", "HETERO:GNA"));
+        ::testing::Values("GNA", /* "MULTI:GNA", */ "HETERO:GNA"));
 
 // TODO: Convolution with 3D input is not supported on GNA
 INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_OVClassExecutableNetworkGetMetricTest,

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/plugin/core_threading_tests.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/plugin/core_threading_tests.cpp
@@ -11,7 +11,7 @@ Params params[] = {
     std::tuple<Device, Config>{ CommonTestUtils::DEVICE_MULTI, {{ MULTI_CONFIG_KEY(DEVICE_PRIORITIES), CommonTestUtils::DEVICE_GNA }}},
 };
 // TODO: Consider to append params[1] after issue *-45658 resolved
-std::vector< std::tuple<Device, Config> > paramsWithIterations{ params[0], params[2] };
+std::vector< std::tuple<Device, Config> > paramsWithIterations{ params[0] };
 }  // namespace
 
 INSTANTIATE_TEST_SUITE_P(GNA, CoreThreadingTests, testing::ValuesIn(params), CoreThreadingTests::getTestCaseName);

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -100,5 +100,6 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: Issue: 95234
         R"(.*CachingSupportCase_GNA.*)",
         R"(.*IEClassLoadNetworkTest.*LoadNetwork(HETERO|MULTI|WithDeviceIDNoThrow|WithInvalidDeviceIDThrows).*)",
+        R"(.*smoke_Multi_BehaviorTests.*)",
     };
 }


### PR DESCRIPTION
### Details:
 - Disable functional tests for MULTI configuration 
 - Disable Multi Behavior tests
 - This is partial backport of #14754 

### Tickets:
 - 112854
