### PR TITLE
[GPU] fix compilation context to use kernel_impl_params as key

### DIFF
--- a/src/plugins/intel_gpu/src/graph/compilation_context.cpp
+++ b/src/plugins/intel_gpu/src/graph/compilation_context.cpp
@@ -17,7 +17,7 @@ public:
         _task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(_task_executor_config);
     }
 
-    void push_task(size_t key, Task&& task) override {
+    void push_task(kernel_impl_params key, Task&& task) override {
         if (_stop_compilation)
             return;
 
@@ -29,7 +29,7 @@ public:
         }
     }
 
-    void remove_keys(std::vector<size_t>&& keys) override {
+    void remove_keys(std::vector<kernel_impl_params>&& keys) override {
         std::lock_guard<std::mutex> lock(_mutex);
         if (!_task_keys.empty()) {
             for (auto key : keys) {
@@ -65,7 +65,7 @@ private:
     ov::threading::IStreamsExecutor::Config _task_executor_config;
     std::shared_ptr<ov::threading::IStreamsExecutor> _task_executor;
     std::mutex _mutex;
-    std::unordered_set<size_t> _task_keys;
+    std::unordered_set<kernel_impl_params, kernel_impl_params::Hasher> _task_keys;
     std::atomic_bool _stop_compilation{false};
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/compilation_context.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/compilation_context.hpp
@@ -7,14 +7,15 @@
 #include "openvino/runtime/threading/cpu_streams_executor.hpp"
 #include <functional>
 #include <memory>
+#include "intel_gpu/graph/kernel_impl_params.hpp"
 
 namespace cldnn {
 
 class ICompilationContext {
 public:
     using Task = std::function<void()>;
-    virtual void push_task(size_t key, Task&& task) = 0;
-    virtual void remove_keys(std::vector<size_t>&& keys) = 0;
+    virtual void push_task(kernel_impl_params key, Task&& task) = 0;
+    virtual void remove_keys(std::vector<kernel_impl_params>&& keys) = 0;
     virtual ~ICompilationContext() = default;
     virtual bool is_stopped() = 0;
     virtual void cancel() = 0;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -550,7 +550,7 @@ bool primitive_inst::update_impl() {
                 };
                 if (use_async_compilation()) {
                     auto& compilation_context = get_network().get_program()->get_compilation_context();
-                    compilation_context.push_task(updated_params_no_dyn_pad.hash(), [this, &compilation_context, updated_params_no_dyn_pad]() {
+                    compilation_context.push_task(updated_params_no_dyn_pad, [this, &compilation_context, updated_params_no_dyn_pad]() {
                         if (compilation_context.is_stopped())
                             return;
                         auto _program = get_network().get_program();

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -218,7 +218,7 @@ void program::init_program() {
     // Remove items of compilation context's internal queue when some impl is popped in kernels_cache
     // compilation context's queue check duplication of inserted task
     _impls_cache->set_remove_item_callback([this](ImplementationsCache::ItemType& item) {
-        get_compilation_context().remove_keys({item.first.hash()});
+        get_compilation_context().remove_keys({item.first});
     });
 }
 


### PR DESCRIPTION
### Details:
 - This PR fixes the async compilation context to use the kernel_impl_params as the keys to overcome hash collisions.

### Tickets:
 - 114982
