### PR TITLE
Fix test executable name for Azure CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -383,8 +383,8 @@ jobs:
       - name: Common test utils tests
         run: |
           source ${{ env.INSTALL_DIR }}/setupvars.sh
-          ${{ env.INSTALL_TEST_DIR }}/commonUtilsTests --gtest_print_time=1 \
-                --gtest_output=xml:${{ env.INSTALL_TEST_DIR }}/TEST-commonUtilsTests.xml
+          ${{ env.INSTALL_TEST_DIR }}/ov_util_tests --gtest_print_time=1 \
+                --gtest_output=xml:${{ env.INSTALL_TEST_DIR }}/TEST-ov_util_tests.xml
 
       - name: CPU plugin unit tests
         run: |


### PR DESCRIPTION
### Details:
 - Rename commonUtilsTests test executable to ov_util_tests for Azure CI

### Tickets:
 - *ticket-id*
