### PR TITLE
[GPU] Set default format only for the dynamic model with static input…

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1645,7 +1645,8 @@ format layout_optimizer::get_preferred_format(program_node& node) {
 
         // Return default format for output layout rank when user node is reshape
         // to add reorder in front of reshape in reorder_input stage instead of handle_reshpae stage.
-        if (has_reshape_user(node))
+        // It is only applied for the dynamic shape with static input shape
+        if (!node.is_dynamic() &&  has_reshape_user(node))
             return format::get_default_format(out_lay_rank);
 
         if (node.is_type<shape_of>())


### PR DESCRIPTION
### Details:
 - *Set default format only for the dynamic model with static input shape*
 - This is to resolve accuracy regression in twins transformer  
 

### Tickets:
 - *100495*
