### PR TITLE
Do not freeze models with compressed constants

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
@@ -176,8 +176,17 @@ class TorchScriptPythonDecoder (Decoder):
             for n in scripted.inlined_graph.nodes():
                 # TODO: switch off freezing for all traced models
                 if "quantize" in n.kind():
+                    # do not freeze quantized models
                     skip_freeze = True
                     break
+                elif "aten::to" in n.kind():
+                    first_input = next(n.inputs())
+                    if first_input.node().kind() == "prim::Constant":
+                        ivalue = first_input.toIValue()
+                        if ivalue is not None and ivalue.dtype in [torch.uint8, torch.int8]:
+                            # do not freeze models with compressed constants
+                            skip_freeze = True
+                            break
             if not skip_freeze:
                 f_model = torch.jit.freeze(scripted)
             else:

--- a/src/frontends/pytorch/src/op/to.cpp
+++ b/src/frontends/pytorch/src/op/to.cpp
@@ -50,8 +50,7 @@ OutputVector translate_to(const NodeContext& context) {
         }
     } else if (context.get_input_size() == 8) {
         // aten::to(Tensor(a) self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool?
-        // pin_memory=None,
-        // bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None)
+        // pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None)
         dtype_idx = 1;
         memory_format_idx = 7;
         if (context.input_is_none(dtype_idx)) {


### PR DESCRIPTION
### Details:
 - *Pytorch models produced by nncf can be compressed: have int8/uint8 Constant followed by conversion to floating type*

### Tickets:
 - *113593*
