### PR TITLE
[GNA]Optimization for scratch buffer allocations

### DIFF
--- a/src/plugins/intel_gna/src/backend/gna_limitations.hpp
+++ b/src/plugins/intel_gna/src/backend/gna_limitations.hpp
@@ -263,11 +263,11 @@ public:
     void check_all_ops_supported(const std::shared_ptr<ov::Model>& model,
                                  const InferenceEngine::Precision gna_precision);
 
-    bool use_only_16bit_convolution_weights() const;
     bool is_crop_affined_offset(size_t numberOfElements) const;
     bool is_aligned(size_t addr) const;
-    bool has_internal_memory_buffers() const;
+    bool use_scratch_for_fusable_layers() const;
     size_t get_memory_alignment() const;
+    bool use_only_16bit_convolution_weights() const;
     std::shared_ptr<cnn2d::AbstractValidator> get_cnn_validator() const;
 
     constexpr static uint32_t kBufferMaxSize = 65528;
@@ -301,15 +301,17 @@ public:
     constexpr static uint32_t kMemoryPageSize = 4096;
 
 private:
-    struct LimitationsWrapper {
-        LimitationsWrapper() = default;
+    struct TargetLimitations {
+        TargetLimitations() = default;
 
-        LimitationsWrapper(bool buffers_memory, bool use_only_16bit_conv_weights, size_t mem_alignment)
-            : internal_memory_buffers(buffers_memory),
+        TargetLimitations(bool use_scratch_for_fusable_layers, bool use_only_16bit_conv_weights, size_t mem_alignment)
+            : use_scratch_for_fusable_layers(use_scratch_for_fusable_layers),
               use_only_16bit_conv_weights(use_only_16bit_conv_weights),
               mem_alignment(mem_alignment) {}
-
-        bool internal_memory_buffers;
+        // Starting from MTL intermediate convolution results are stored in internal buffers, eliminating the need to
+        // allocate scratch memory by the plugin. For fully connected or element-wise operations, scratch
+        // memory is allocated by the GNA library.
+        bool use_scratch_for_fusable_layers;
         bool use_only_16bit_conv_weights;
         size_t mem_alignment;
     };
@@ -318,9 +320,9 @@ private:
     Limitations(const Limitations&) = delete;
     Limitations& operator=(const Limitations&) = delete;
 
-    LimitationsWrapper get_limitations_for_target(const target::DeviceVersion& target) const;
+    TargetLimitations get_limitations_for_target(const target::DeviceVersion& target) const;
 
-    LimitationsWrapper m_limitations;
+    TargetLimitations m_target_limitations;
     std::shared_ptr<cnn2d::AbstractValidator> m_cnn_validator;
     static thread_local std::shared_ptr<Limitations> k_instance;
 };
@@ -341,12 +343,16 @@ inline bool Limitations::is_aligned(size_t addr) const {
     return (addr == ALIGN(addr, get_memory_alignment()));
 }
 
-inline bool Limitations::has_internal_memory_buffers() const {
-    return m_limitations.internal_memory_buffers;
+inline bool Limitations::use_scratch_for_fusable_layers() const {
+    return m_target_limitations.use_scratch_for_fusable_layers;
 }
 
 inline size_t Limitations::get_memory_alignment() const {
-    return m_limitations.mem_alignment;
+    return m_target_limitations.mem_alignment;
+}
+
+inline bool Limitations::use_only_16bit_convolution_weights() const {
+    return m_target_limitations.use_only_16bit_conv_weights;
 }
 
 inline std::shared_ptr<cnn2d::AbstractValidator> Limitations::get_cnn_validator() const {

--- a/src/plugins/intel_gna/src/gna_graph_compiler.cpp
+++ b/src/plugins/intel_gna/src/gna_graph_compiler.cpp
@@ -2407,8 +2407,17 @@ bool GNAGraphCompiler::should_use_scratch_allocation(const InferenceEngine::CNNL
             if (LayerInfo(next_layer).isFusableWithConv()) {
                 return false;
             }
-        } else if (LayerInfo(layer).isFusableWithConv() && prev_layer && next_layer) {
+        }
+
+        if (LayerInfo(layer).isFusableWithConv() && prev_layer && next_layer) {
             if (LayerInfo(prev_layer).isConvolution() && LayerInfo(next_layer).isFusableWithConv()) {
+                return false;
+            }
+        }
+
+        if ((LayerInfo(layer).isFullyConnected() || LayerInfo(layer).isEltwise() || LayerInfo(layer).isScaleShift()) &&
+            next_layer) {
+            if (LayerInfo(next_layer).isActivation()) {
                 return false;
             }
         }

--- a/src/plugins/intel_gna/src/gna_graph_compiler.hpp
+++ b/src/plugins/intel_gna/src/gna_graph_compiler.hpp
@@ -35,6 +35,7 @@ private:
     std::shared_ptr<backend::AMIntelDNN> dnn;
     std::shared_ptr<gna_memory_type> gnamem;
     std::shared_ptr<GnaInputs> inputs_ptr_;
+    std::shared_ptr<limitations::cnn2d::AbstractValidator> m_cnn2d_validator;
 
     // layers with extra storage for connections and additional
     // non trivial processing
@@ -59,8 +60,7 @@ private:
                                             uint32_t num_cols);
 
     bool ShouldUseOnlyConv2DGnaIface() const;
-
-    std::shared_ptr<limitations::cnn2d::AbstractValidator> m_cnn2d_validator;
+    bool should_use_scratch_allocation(const InferenceEngine::CNNLayerPtr& layer, bool fp32_mode) const;
 
 public:
     backend::DnnComponents dnnComponents;

--- a/src/plugins/intel_gna/src/gna_graph_tools.hpp
+++ b/src/plugins/intel_gna/src/gna_graph_tools.hpp
@@ -135,19 +135,24 @@ inline typename ExtractRawPtr<T>::raw_ptr_type raw_ptr(T obj) {
 template <class Layer>
 inline InferenceEngine::CNNLayerPtr CNNNetPrevLayerSkipCertain(Layer layer,
                                                                int idx,
-                                                               const std::function<bool(CNNLayerPtr)>& shouldSkip) {
+                                                               const std::function<bool(CNNLayerPtr)>& shouldSkip,
+                                                               bool bOnlyCheck = false) {
     IE_ASSERT(layer != nullptr);
     if (!CNNNetHasPrevLayer(raw_ptr(layer), idx)) {
+        if (bOnlyCheck) {
+            return nullptr;
+        };
         THROW_GNA_EXCEPTION << "Can't find PrevLayer. All layers are skipped.";
-        return nullptr;
     }
     auto prev = CNNNetPrevLayer(layer, idx);
 
     /// using upper search simplified version
     while (shouldSkip(prev)) {
         if (!CNNNetHasPrevLayer(prev.get(), 0)) {
+            if (bOnlyCheck) {
+                return nullptr;
+            };
             THROW_GNA_EXCEPTION << "Can't find PrevLayer. All layers are skipped.";
-            return nullptr;
         }
         prev = CNNNetPrevLayer(prev, 0);
     }

--- a/src/plugins/intel_gna/src/gna_graph_tools.hpp
+++ b/src/plugins/intel_gna/src/gna_graph_tools.hpp
@@ -130,16 +130,17 @@ inline typename ExtractRawPtr<T>::raw_ptr_type raw_ptr(T obj) {
  * @brief gets pointer to previous layer
  * @param idx - index in previous layer connection - in other layers only zero idx will be used
  * @param layer - source layer
- * @param shouldSkip - skip kriteria
+ * @param shouldSkip - skip criteria
+ * @param no_throw - doesn't throw exception if previous layer missed
  */
 template <class Layer>
 inline InferenceEngine::CNNLayerPtr CNNNetPrevLayerSkipCertain(Layer layer,
                                                                int idx,
                                                                const std::function<bool(CNNLayerPtr)>& shouldSkip,
-                                                               bool bOnlyCheck = false) {
+                                                               bool no_throw = false) {
     IE_ASSERT(layer != nullptr);
     if (!CNNNetHasPrevLayer(raw_ptr(layer), idx)) {
-        if (bOnlyCheck) {
+        if (no_throw) {
             return nullptr;
         };
         THROW_GNA_EXCEPTION << "Can't find PrevLayer. All layers are skipped.";
@@ -149,7 +150,7 @@ inline InferenceEngine::CNNLayerPtr CNNNetPrevLayerSkipCertain(Layer layer,
     /// using upper search simplified version
     while (shouldSkip(prev)) {
         if (!CNNNetHasPrevLayer(prev.get(), 0)) {
-            if (bOnlyCheck) {
+            if (no_throw) {
                 return nullptr;
             };
             THROW_GNA_EXCEPTION << "Can't find PrevLayer. All layers are skipped.";

--- a/src/plugins/intel_gna/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_gna/tests/unit/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # TODO: fix CVS-71010 and remove BUILD_SHARED_LIBS
 if(NOT BUILD_SHARED_LIBS)
-    set(exclude_path EXCLUDED_SOURCE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/(gna_api_stub|gna_wait_test|gna_export_import_test|gna_infer_request_test|gna_plugin_load_network_test|gna_mock_api_initializer|gna_extra_pwl_segments_tests).cpp")
+    set(exclude_path EXCLUDED_SOURCE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/(gna_api_stub|gna_wait_test|gna_export_import_test|gna_infer_request_test|gna_plugin_load_network_test|gna_mock_api_initializer|gna_extra_pwl_segments_tests|gna_scratch_area_size_test).cpp")
 endif()
 
 addIeTargetTest(

--- a/src/plugins/intel_gna/tests/unit/gna_scratch_area_size_test.cpp
+++ b/src/plugins/intel_gna/tests/unit/gna_scratch_area_size_test.cpp
@@ -1,0 +1,154 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common/gna_target.hpp"
+#include "gna_mock_api_initializer.hpp"
+#include "gna_plugin.hpp"
+#include "ngraph_functions/builders.hpp"
+
+using namespace ngraph::helpers;
+using namespace ov::intel_gna::target;
+
+namespace {
+
+typedef struct ConvParams {
+    ConvParams() = default;
+    ConvParams(ngraph::Shape inputs_shape,
+               ngraph::Shape kernels_shape,
+               size_t channels,
+               ngraph::Shape maxpool_kernels_shape,
+               ActivationTypes activation = ActivationTypes::None)
+        : inputs_shape(inputs_shape),
+          kernels_shape(kernels_shape),
+          channels(channels),
+          maxpool_kernels_shape(maxpool_kernels_shape),
+          activation(activation) {}
+
+    ngraph::Shape inputs_shape;
+    ngraph::Shape kernels_shape;
+    size_t channels;
+    ngraph::Shape maxpool_kernels_shape;
+    ActivationTypes activation;
+} ConvParams;
+
+typedef struct {
+    DeviceVersion mock_target;
+    ConvParams conv;
+    const size_t scratch_region_size;
+} ConvModelTestParams;
+
+class GNAPluginTest : public GNAPlugin {
+public:
+    GNAPluginTest() : GNAPlugin(std::map<std::string, std::string>{{GNA_CONFIG_KEY(COMPACT_MODE), CONFIG_VALUE(NO)}}) {}
+
+    size_t get_scratch_region_size() const {
+        return this->gnamem->getQueue(rRegion::REGION_SCRATCH)->getSize();
+    }
+};
+
+class ConvolutionScratchAreaSizeTest : public ::testing::Test,
+                                       public ::testing::WithParamInterface<ConvModelTestParams> {
+protected:
+    void Run() {
+        GNAPluginTest gna_plugin{};
+        InferenceEngine::CNNNetwork cnn_network{m_function};
+
+        gna_plugin.LoadNetwork(cnn_network);
+        gna_plugin.get_scratch_region_size();
+
+        EXPECT_EQ(m_test_param.scratch_region_size, gna_plugin.get_scratch_region_size());
+    }
+
+    void SetUp() override {
+        m_mock.set_gna_device_version(DeviceToGna(m_test_param.mock_target));
+        m_mock.init();
+        create_model();
+    }
+
+private:
+    void create_model() {
+        auto inputs = std::make_shared<ngraph::opset9::Parameter>(m_prec, m_test_param.conv.inputs_shape);
+        std::shared_ptr<ngraph::Node> conv;
+        std::shared_ptr<ngraph::Node> maxpool;
+        std::shared_ptr<ngraph::Node> activation;
+        std::shared_ptr<ngraph::Node> result_operation;
+
+        conv = ngraph::builder::makeConvolution(
+            inputs,
+            m_prec,
+            m_test_param.conv.kernels_shape,
+            // Set the stride and kernel shape to the same value in order to force padding equal to 0
+            m_test_param.conv.kernels_shape,
+            {0, 0},
+            {0, 0},
+            {1, 1},
+            ngraph::op::PadType::VALID,
+            m_test_param.conv.channels);
+        result_operation = conv;
+
+        if (m_test_param.conv.maxpool_kernels_shape.size()) {
+            maxpool = ngraph::builder::makePooling(
+                result_operation,
+                // Set the stride and kernel shape to the same value in order to force padding equal to 0
+                m_test_param.conv.maxpool_kernels_shape,
+                {0, 0},
+                {0, 0},
+                m_test_param.conv.maxpool_kernels_shape,
+                ngraph::op::RoundingType::FLOOR,
+                ngraph::op::PadType::VALID,
+                false,
+                PoolingTypes::MAX);
+            result_operation = maxpool;
+        }
+
+        if (m_test_param.conv.activation != ActivationTypes::None) {
+            activation = ngraph::builder::makeActivation(result_operation, m_prec, m_test_param.conv.activation);
+            result_operation = activation;
+        }
+
+        auto result = std::make_shared<ngraph::opset9::Result>(result_operation);
+        m_function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
+                                                        ov::ParameterVector{inputs},
+                                                        "Convolution");
+    }
+
+    std::shared_ptr<ngraph::Function> m_function;
+    const ov::element::Type m_prec = ngraph::element::f32;
+    ConvModelTestParams m_test_param = GetParam();
+    GnaMockApiInitializer m_mock;
+};
+
+// Memory regions assignment for tested model:
+//           |   inp/out   | precision | GNA3.0  |  GNA3.5+   |
+//  input    |------------------------------------------------|
+//    |      | conv inp    |    I16    | Input   | Input      |
+//  conv     |             |           |         |            |
+//    |      | conv out    |    I32    | Scratch | Int buffer |
+//  maxPool  |             |           |         |            |
+//    |      | maxPool out |    I16    | Scratch | Int buffer |
+//  relu     |             |           |         |            |
+//    |      | relu out    |    I16    | Output  | Output     |
+//  output   |             |           |         |            |
+//
+
+std::vector<ConvModelTestParams> tests_vectors{
+    // target | inp shape | conv kernel shape | conv out count | maxPool kernel shape | activation func | scratch size
+    // conv
+    {DeviceVersion::GNA3_0, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {}), 0},
+    {DeviceVersion::GNA3_5, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {}), 0},
+    // conv + maxpool
+    {DeviceVersion::GNA3_0, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {2, 2}), 4096},
+    {DeviceVersion::GNA3_5, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {2, 2}), 0},
+    // conv + maxpool + relu
+    {DeviceVersion::GNA3_0, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {2, 2}, ActivationTypes::Relu), 4096 + 512},
+    {DeviceVersion::GNA3_5, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {2, 2}, ActivationTypes::Relu), 0}};
+
+TEST_P(ConvolutionScratchAreaSizeTest, CheckScratchAreaSizeForConvolution) {
+    Run();
+}
+
+INSTANTIATE_TEST_SUITE_P(ScratchMemoryTest, ConvolutionScratchAreaSizeTest, ::testing::ValuesIn(tests_vectors));
+}  // namespace

--- a/src/plugins/intel_gna/tests/unit/gna_scratch_area_size_test.cpp
+++ b/src/plugins/intel_gna/tests/unit/gna_scratch_area_size_test.cpp
@@ -14,89 +14,100 @@ using namespace ov::intel_gna::target;
 
 namespace {
 
-typedef struct ConvParams {
-    ConvParams() = default;
-    ConvParams(ngraph::Shape inputs_shape,
-               ngraph::Shape kernels_shape,
-               size_t channels,
-               ngraph::Shape maxpool_kernels_shape,
-               ActivationTypes activation = ActivationTypes::None)
-        : inputs_shape(inputs_shape),
-          kernels_shape(kernels_shape),
-          channels(channels),
-          maxpool_kernels_shape(maxpool_kernels_shape),
-          activation(activation) {}
-
-    ngraph::Shape inputs_shape;
-    ngraph::Shape kernels_shape;
-    size_t channels;
-    ngraph::Shape maxpool_kernels_shape;
-    ActivationTypes activation;
-} ConvParams;
-
-typedef struct {
-    DeviceVersion mock_target;
-    ConvParams conv;
-    const size_t scratch_region_size;
-} ConvModelTestParams;
-
 class GNAPluginTest : public GNAPlugin {
 public:
     GNAPluginTest() : GNAPlugin(std::map<std::string, std::string>{{GNA_CONFIG_KEY(COMPACT_MODE), CONFIG_VALUE(NO)}}) {}
+
+    size_t get_scratch_region_requests_cnt() const {
+        return this->gnamem->getQueue(rRegion::REGION_SCRATCH)->futureHeap().size();
+    }
 
     size_t get_scratch_region_size() const {
         return this->gnamem->getQueue(rRegion::REGION_SCRATCH)->getSize();
     }
 };
 
-class ConvolutionScratchAreaSizeTest : public ::testing::Test,
-                                       public ::testing::WithParamInterface<ConvModelTestParams> {
+template <typename T>
+class ScratchAreaSizeTestBase : public ::testing::Test, public ::testing::WithParamInterface<T> {
 protected:
+    ScratchAreaSizeTestBase(DeviceVersion target, size_t scratch_region_requests_cnt, size_t scratch_region_size)
+        : m_target(target),
+          m_scratch_region_requests_cnt(scratch_region_requests_cnt),
+          m_scratch_region_size(scratch_region_size) {}
+
+    virtual std::shared_ptr<ngraph::Function> create_model() = 0;
+
     void Run() {
         GNAPluginTest gna_plugin{};
         InferenceEngine::CNNNetwork cnn_network{m_function};
 
         gna_plugin.LoadNetwork(cnn_network);
-        gna_plugin.get_scratch_region_size();
 
-        EXPECT_EQ(m_test_param.scratch_region_size, gna_plugin.get_scratch_region_size());
+        EXPECT_EQ(m_scratch_region_requests_cnt, gna_plugin.get_scratch_region_requests_cnt());
+        EXPECT_EQ(m_scratch_region_size, gna_plugin.get_scratch_region_size());
     }
 
     void SetUp() override {
-        m_mock.set_gna_device_version(DeviceToGna(m_test_param.mock_target));
+        m_mock.set_gna_device_version(DeviceToGna(m_target));
         m_mock.init();
-        create_model();
+        m_function = create_model();
     }
 
 private:
-    void create_model() {
-        auto inputs = std::make_shared<ngraph::opset9::Parameter>(m_prec, m_test_param.conv.inputs_shape);
-        std::shared_ptr<ngraph::Node> conv;
+    std::shared_ptr<ngraph::Function> m_function;
+    GnaMockApiInitializer m_mock;
+    DeviceVersion m_target;
+    size_t m_scratch_region_requests_cnt;
+    size_t m_scratch_region_size;
+};
+
+struct ConvParams {
+    DeviceVersion target;
+    size_t scratch_region_requests_cnt;
+    size_t scratch_region_size;
+    ngraph::Shape input_shape;
+    ngraph::Shape kernels_shape;
+    size_t channels;
+    ngraph::Shape maxpool_kernels_shape;
+    ActivationTypes activation;
+};
+
+class ConvolutionScratchAreaSizeTest : public ScratchAreaSizeTestBase<ConvParams> {
+public:
+    ConvolutionScratchAreaSizeTest()
+        : ScratchAreaSizeTestBase(GetParam().target,
+                                  GetParam().scratch_region_requests_cnt,
+                                  GetParam().scratch_region_size) {}
+
+private:
+    std::shared_ptr<ngraph::Function> create_model() override {
+        ConvParams param = GetParam();
+        const ov::element::Type ng_prec = ngraph::element::f32;
+        const auto input_shape = std::make_shared<ngraph::opset9::Parameter>(ng_prec, param.input_shape);
         std::shared_ptr<ngraph::Node> maxpool;
         std::shared_ptr<ngraph::Node> activation;
         std::shared_ptr<ngraph::Node> result_operation;
 
-        conv = ngraph::builder::makeConvolution(
-            inputs,
-            m_prec,
-            m_test_param.conv.kernels_shape,
+        result_operation = ngraph::builder::makeConvolution(
+            input_shape,
+            ng_prec,
+            param.kernels_shape,
             // Set the stride and kernel shape to the same value in order to force padding equal to 0
-            m_test_param.conv.kernels_shape,
+            param.kernels_shape,
             {0, 0},
             {0, 0},
             {1, 1},
             ngraph::op::PadType::VALID,
-            m_test_param.conv.channels);
-        result_operation = conv;
+            param.channels);
 
-        if (m_test_param.conv.maxpool_kernels_shape.size()) {
+        if (param.maxpool_kernels_shape.size()) {
             maxpool = ngraph::builder::makePooling(
                 result_operation,
                 // Set the stride and kernel shape to the same value in order to force padding equal to 0
-                m_test_param.conv.maxpool_kernels_shape,
+                param.maxpool_kernels_shape,
                 {0, 0},
                 {0, 0},
-                m_test_param.conv.maxpool_kernels_shape,
+                param.maxpool_kernels_shape,
                 ngraph::op::RoundingType::FLOOR,
                 ngraph::op::PadType::VALID,
                 false,
@@ -104,24 +115,98 @@ private:
             result_operation = maxpool;
         }
 
-        if (m_test_param.conv.activation != ActivationTypes::None) {
-            activation = ngraph::builder::makeActivation(result_operation, m_prec, m_test_param.conv.activation);
+        if (param.activation != ActivationTypes::None) {
+            activation = ngraph::builder::makeActivation(result_operation, ng_prec, param.activation);
             result_operation = activation;
         }
 
         auto result = std::make_shared<ngraph::opset9::Result>(result_operation);
-        m_function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
-                                                        ov::ParameterVector{inputs},
-                                                        "Convolution");
-    }
 
-    std::shared_ptr<ngraph::Function> m_function;
-    const ov::element::Type m_prec = ngraph::element::f32;
-    ConvModelTestParams m_test_param = GetParam();
-    GnaMockApiInitializer m_mock;
+        return std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
+                                                  ov::ParameterVector{input_shape},
+                                                  "Convolution");
+    }
 };
 
-// Memory regions assignment for tested model:
+struct FullyConnectedParams {
+    DeviceVersion target;
+    size_t scratch_region_requests_cnt;
+    size_t scratch_region_size;
+    ngraph::Shape input_shape;
+    size_t out_size;
+    ActivationTypes activation;
+};
+
+class FullyConnectedScratchAreaSizeTest : public ScratchAreaSizeTestBase<FullyConnectedParams> {
+public:
+    FullyConnectedScratchAreaSizeTest()
+        : ScratchAreaSizeTestBase(GetParam().target,
+                                  GetParam().scratch_region_requests_cnt,
+                                  GetParam().scratch_region_size) {}
+
+private:
+    std::shared_ptr<ngraph::Function> create_model() override {
+        FullyConnectedParams param = GetParam();
+        const ov::element::Type ng_prec = ngraph::element::f32;
+        const auto input_shape = std::make_shared<ngraph::opset9::Parameter>(ng_prec, param.input_shape);
+        std::shared_ptr<ngraph::Node> activation;
+        std::shared_ptr<ngraph::Node> result_operation;
+
+        result_operation = ngraph::builder::makeFullyConnected(input_shape, ng_prec, param.out_size, false);
+
+        if (param.activation != ActivationTypes::None) {
+            activation = ngraph::builder::makeActivation(result_operation, ng_prec, param.activation);
+            result_operation = activation;
+        }
+
+        auto result = std::make_shared<ngraph::opset9::Result>(result_operation);
+
+        return std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
+                                                  ov::ParameterVector{input_shape},
+                                                  "FullyConnected");
+    }
+};
+
+struct EltwiseParams {
+    DeviceVersion target;
+    size_t scratch_region_requests_cnt;
+    size_t scratch_region_size;
+    ngraph::Shape input_shape;
+    ActivationTypes activation;
+};
+
+class EltwiseScratchAreaSizeTest : public ScratchAreaSizeTestBase<EltwiseParams> {
+public:
+    EltwiseScratchAreaSizeTest()
+        : ScratchAreaSizeTestBase(GetParam().target,
+                                  GetParam().scratch_region_requests_cnt,
+                                  GetParam().scratch_region_size) {}
+
+private:
+    std::shared_ptr<ngraph::Function> create_model() override {
+        EltwiseParams param = GetParam();
+        const ov::element::Type ng_prec = ngraph::element::f32;
+        const auto input_shape = std::make_shared<ngraph::opset9::Parameter>(ng_prec, param.input_shape);
+        std::shared_ptr<ngraph::Node> activation;
+        std::shared_ptr<ngraph::Node> result_operation;
+
+        result_operation =
+            ngraph::builder::makeEltwise(input_shape, input_shape, ngraph::helpers::EltwiseTypes::MULTIPLY);
+
+        if (param.activation != ActivationTypes::None) {
+            activation = ngraph::builder::makeActivation(result_operation, ng_prec, param.activation);
+            result_operation = activation;
+        }
+
+        auto result = std::make_shared<ngraph::opset9::Result>(result_operation);
+
+        return std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
+                                                  ov::ParameterVector{input_shape},
+                                                  "Eltwise");
+    }
+};
+
+// Memory regions assignment for model with convolution:
 //           |   inp/out   | precision | GNA3.0  |  GNA3.5+   |
 //  input    |------------------------------------------------|
 //    |      | conv inp    |    I16    | Input   | Input      |
@@ -133,22 +218,77 @@ private:
 //    |      | relu out    |    I16    | Output  | Output     |
 //  output   |             |           |         |            |
 //
-
-std::vector<ConvModelTestParams> tests_vectors{
-    // target | inp shape | conv kernel shape | conv out count | maxPool kernel shape | activation func | scratch size
-    // conv
-    {DeviceVersion::GNA3_0, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {}), 0},
-    {DeviceVersion::GNA3_5, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {}), 0},
-    // conv + maxpool
-    {DeviceVersion::GNA3_0, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {2, 2}), 4096},
-    {DeviceVersion::GNA3_5, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {2, 2}), 0},
-    // conv + maxpool + relu
-    {DeviceVersion::GNA3_0, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {2, 2}, ActivationTypes::Relu), 4096 + 512},
-    {DeviceVersion::GNA3_5, ConvParams({1, 8, 16, 32}, {2, 2}, 8, {2, 2}, ActivationTypes::Relu), 0}};
+// conv scrach size = H/2 * W/2 * outC * prec (4) maxpool scratch size = H/2 * W/2 * C * prec (2)
+// params: target | scratch reuquest cnt | scratch size | inp shape | conv kernel shape | conv out count |
+// maxPool kernel shape | activation
+std::vector<ConvParams> vectors_for_conv_test{
+    // only convolution
+    {DeviceVersion::GNA3_0, 0, 0, {1, 8, 16, 32}, {2, 2}, 8, {}},
+    {DeviceVersion::GNA3_5, 0, 0, {1, 8, 16, 32}, {2, 2}, 8, {}},
+    // convolution + maxpool
+    {DeviceVersion::GNA3_0, 1, 4096, {1, 8, 16, 32}, {2, 2}, 8, {2, 2}},
+    {DeviceVersion::GNA3_5, 0, 0, {1, 8, 16, 32}, {2, 2}, 8, {2, 2}},
+    // convolution + maxpool + relu
+    {DeviceVersion::GNA3_0, 2, 4096 + 512, {1, 8, 16, 32}, {2, 2}, 8, {2, 2}, ActivationTypes::Relu},
+    {DeviceVersion::GNA3_5, 0, 0, {1, 8, 16, 32}, {2, 2}, 8, {2, 2}, ActivationTypes::Relu}};
 
 TEST_P(ConvolutionScratchAreaSizeTest, CheckScratchAreaSizeForConvolution) {
     Run();
 }
 
-INSTANTIATE_TEST_SUITE_P(ScratchMemoryTest, ConvolutionScratchAreaSizeTest, ::testing::ValuesIn(tests_vectors));
+INSTANTIATE_TEST_SUITE_P(ScratchMemoryTest, ConvolutionScratchAreaSizeTest, ::testing::ValuesIn(vectors_for_conv_test));
+
+// Memory regions assignment for model with fullyConnected layer:
+//                  |   inp/out   | precision | GNA3.0  |  GNA3.5+   |
+//     input        |------------------------------------------------|
+//       |          | conv inp    |    I16    | Input   | Input      |
+// fullyConnected   |             |           |         |            |
+//       |          | conv out    |    I32    | Scratch | Int buffer |
+//     relu         |             |           |         |            |
+//       |          | relu out    |    I16    | Output  | Output     |
+//     output       |             |           |         |            |
+//
+// fullyConnected scratch size = H * out * prec (4)
+// params: target | scratch reuquest cnt |scratch size | inp shape | out size | activation
+std::vector<FullyConnectedParams> vectors_for_fullyconnected_test{
+    // only fullyConnected
+    {DeviceVersion::GNA3_0, 0, 0, {6, 7}, 8, {}},
+    {DeviceVersion::GNA3_5, 0, 0, {6, 7}, 8, {}},
+    // fullyConnected + relu
+    {DeviceVersion::GNA3_0, 1, 6 * 8 * 4, {6, 7}, 8, ActivationTypes::Relu},
+    {DeviceVersion::GNA3_5, 0, 0, {6, 7}, 8, ActivationTypes::Relu}};
+
+TEST_P(FullyConnectedScratchAreaSizeTest, CheckScratchAreaSizeForFullyConnected) {
+    Run();
+}
+
+INSTANTIATE_TEST_SUITE_P(ScratchMemoryTest,
+                         FullyConnectedScratchAreaSizeTest,
+                         ::testing::ValuesIn(vectors_for_fullyconnected_test));
+
+// Memory regions assignment for model with eltwise layer:
+//                  |   inp/out   | precision | GNA3.0  |  GNA3.5+   |
+//     input        |------------------------------------------------|
+//       |          | conv inp    |    I16    | Input   | Input      |
+//    eltwise       |             |           |         |            |
+//       |          | conv out    |    I32    | Scratch | Int buffer |
+//     relu         |             |           |         |            |
+//       |          | relu out    |    I16    | Output  | Output     |
+//     output       |             |           |         |            |
+//
+// eltwise scratch size = H * (W + padding) * prec (4)
+// params: target | scratch reuquest cnt | scratch size | inp shape | activation
+std::vector<EltwiseParams> vectors_for_eltwise_test{
+    // only eltwise
+    {DeviceVersion::GNA3_0, 0, 0, {8, 8}, {}},
+    {DeviceVersion::GNA3_5, 0, 0, {8, 8}, {}},
+    // eltwise + relu
+    {DeviceVersion::GNA3_0, 1, 8 * 8 * 4, {8, 8}, ActivationTypes::Relu},
+    {DeviceVersion::GNA3_5, 0, 0, {8, 8}, ActivationTypes::Relu}};
+
+TEST_P(EltwiseScratchAreaSizeTest, CheckScratchAreaSizeForEltwise) {
+    Run();
+}
+
+INSTANTIATE_TEST_SUITE_P(ScratchMemoryTest, EltwiseScratchAreaSizeTest, ::testing::ValuesIn(vectors_for_eltwise_test));
 }  // namespace


### PR DESCRIPTION
### Details:
Optimize the allocation of scratch buffers for layer outputs by avoiding allocation when the layer can be fused with convolution, fully connected, or element-wise operations.
 - affected primitives: convolution, fullyconnected, eltwise
 - tested PR with default target set to GNA3.5 - done
 - functional test covered by smoke_FcBetweenConvsTest - no update needed

### Tickets:
 - *ticket-id*
