### PR TITLE
[GPU] Fix data races in RegisterFactory() and log functions

### DIFF
--- a/src/common/util/src/log.cpp
+++ b/src/common/util/src/log.cpp
@@ -8,6 +8,7 @@
 #include <ctime>
 #include <functional>
 #include <iostream>
+#include <mutex>
 
 void ov::util::default_logger_handler_func(const std::string& s) {
     std::cout << s << std::endl;
@@ -33,12 +34,16 @@ ov::util::LogHelper::LogHelper(LOG_TYPE type,
         break;
     }
 
-    time_t tt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    auto tm = gmtime(&tt);
-    if (tm) {
-        char buffer[256];
-        strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%Sz", tm);
-        m_stream << buffer << " ";
+    {
+        static std::mutex m;
+        time_t tt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+        std::lock_guard<std::mutex> lock(m);
+        auto tm = gmtime(&tt);
+        if (tm) {
+            char buffer[256];
+            strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%Sz", tm);
+            m_stream << buffer << " ";
+        }
     }
 
     m_stream << file;

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/program.hpp
@@ -135,10 +135,10 @@ public:
 
     template<typename OpType>
     static void RegisterFactory(factory_t func) {
-        static std::mutex m;
-        std::lock_guard<std::mutex> lock(m);
-        if (Program::factories_map.find(OpType::get_type_info_static()) == Program::factories_map.end())
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (Program::factories_map.find(OpType::get_type_info_static()) == Program::factories_map.end()) {
             Program::factories_map.insert({OpType::get_type_info_static(), func});
+        }
     }
 
     template<typename PType, typename = typename std::enable_if<!is_smart_pointer<PType>::value>::type>
@@ -166,6 +166,7 @@ private:
     std::vector<std::shared_ptr<cldnn::program>> m_programs;
     ExecutionConfig m_config;
     cldnn::engine& m_engine;
+    static std::mutex m_mutex;
 
     std::shared_ptr<cldnn::topology> m_topology;
     InferenceEngine::InputsDataMap m_networkInputs;

--- a/src/plugins/intel_gpu/src/plugin/program.cpp
+++ b/src/plugins/intel_gpu/src/plugin/program.cpp
@@ -33,6 +33,7 @@ const cldnn::primitive_id Program::m_meanValuesTag("_cldnn_mean_values");
 const cldnn::primitive_id Program::m_preCustomLayerTag("_cldnn_custom_preprocess");
 const cldnn::primitive_id Program::m_postCustomLayerTag("_cldnn_custom_postprocess");
 Program::factories_map_t Program::factories_map = {};
+std::mutex Program::m_mutex = {};
 
 std::string layer_type_lower(const ngraph::Node* op) {
     std::string layerType = op->get_type_name();


### PR DESCRIPTION
### Details:
 - Fixed data race in RegisterFactory() function (previously we had unique instance of static mutex for each specific template's type)
 - Fixed access to not a thread safe result of gmtime() function which uses single static buffer under the hood

### Tickets:
 - *ticket-id*
