### PR TITLE
[CI] [GHA] Do not run GHA pipelines (Linux & Windows) on documentation-related PRs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,21 @@ name: Tests on Linux (Ubuntu 22.04, Python 3.11)
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
   push:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
     branches:
       - master
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,21 @@ name: Tests on Windows (VS 2022, Python 3.11)
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
   push:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
     branches:
       - master
 


### PR DESCRIPTION
### Details:
This PR introduces the skip mechanism for GHA pipelines that prevents the Linux & Windows pipelines from running on documentation-related PRs.

### Tickets:
 - *115385*
