### PR TITLE
[CI] [GHA] Cancel in-progress Linux & Win pipelines in favour of that of on the latest commit in PRs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   Build:
     defaults:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref || github.run_id }}-linux
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.head_ref || github.run_id }}-windows
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CMAKE_BUILD_TYPE: 'Release'
   CMAKE_GENERATOR: 'Ninja'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ## Contents:
 
+
  - [What is OpenVINO?](#what-is-openvino-toolkit)
     - [Components](#components)
  - [Supported Hardware matrix](#supported-hardware-matrix)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 
 ## Contents:
 
-
  - [What is OpenVINO?](#what-is-openvino-toolkit)
     - [Components](#components)
  - [Supported Hardware matrix](#supported-hardware-matrix)


### PR DESCRIPTION
### Details:
This PR introduces the cancel mechanism for the in-progress pipelines of PRs in favour of that of the latest commit. It affects only the pipelines on PRs, it **_does not change_** the behaviour on the master branch as `github.head_ref` is only defined for the PRs and `github.run_id` is guaranteed to be unique.

### Tickets:
 - *115463*
