### PR TITLE
Suppress `signal-unsafe call` tsan issue

### DIFF
--- a/src/tests/ie_tsan.supp
+++ b/src/tests/ie_tsan.supp
@@ -14,3 +14,7 @@ race:^GNAPluginNS::supported_values[abi:cxx11]$
 
 # Issue 91368
 race:libopenvino_gapi_preproc.so
+
+# Issue 114114 ThreadSanitizer: signal-unsafe call inside of a signal
+# Suppress it since it's caused by signal handler from tests utilities that not uses threads
+signal:src/tests/ie_test_utils/functional_test_utils/src/crash_handler.cpp


### PR DESCRIPTION
### Details:
 - Issue is caused by signal that terminates full run. After signal is handled by tests utilities, run generates tests report, and TSAN claims issue (`handler calls malloc()` - from https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions) on it

### Tickets:
 - CVS-114114
