### PR TITLE
Don't require opencv-python for benchmark_app

### DIFF
--- a/tools/benchmark_tool/requirements.txt
+++ b/tools/benchmark_tool/requirements.txt
@@ -1,3 +1,2 @@
 -c ../constraints.txt
 numpy>=1.16.6
-opencv-python

--- a/tools/constraints.txt
+++ b/tools/constraints.txt
@@ -19,4 +19,3 @@ test-generator==0.1.1
 py>=1.9.0
 urllib3>=1.26.4
 openvino-telemetry>=2022.1.0
-opencv-python>=4.5


### PR DESCRIPTION
cv2 availability is already optional: https://github.com/openvinotoolkit/openvino/blob/238c7fa47e02e9cc44aa0ede9e934a45d0a6cd45/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py#L148