### PR TITLE
Improve __FILE__ trim on windows builds

### DIFF
--- a/cmake/developer_package/compile_flags/os_flags.cmake
+++ b/cmake/developer_package/compile_flags/os_flags.cmake
@@ -378,8 +378,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # C4275 non dll-interface class used as base for dll-interface class
     ie_add_compiler_flags(/wd4275)
 
-    # Enable __FILE__ trim
-    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/d1trimfile:${OV_NATIVE_PROJECT_ROOT_DIR}\\>")
+    # Enable __FILE__ trim, use path with forward and backward slash as directory separator
+    add_compile_options(
+        "$<$<COMPILE_LANGUAGE:CXX>:/d1trimfile:${OV_NATIVE_PROJECT_ROOT_DIR}\\>"
+        "$<$<COMPILE_LANGUAGE:CXX>:/d1trimfile:${OpenVINO_SOURCE_DIR}/>")
 
     #
     # Debug information flags, by default CMake adds /Zi option

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -636,8 +636,20 @@ void ov::util::save_binary(const std::string& path, std::vector<uint8_t> binary)
 }
 
 const char* ov::util::trim_file_name(const char* const fname) {
-    static const auto pattern = std::string(OV_NATIVE_PARENT_PROJECT_ROOT_DIR) + FileTraits<char>::file_separator;
+    static const auto pattern_native_sep =
+        std::string(OV_NATIVE_PARENT_PROJECT_ROOT_DIR) + FileTraits<char>::file_separator;
 
-    const auto has_pattern_ptr = std::strstr(fname, pattern.c_str());
-    return has_pattern_ptr ? has_pattern_ptr + pattern.size() : fname;
+    const auto has_native_sep_pattern_ptr = std::strstr(fname, pattern_native_sep.c_str());
+    auto fname_trim_ptr = has_native_sep_pattern_ptr ? has_native_sep_pattern_ptr + pattern_native_sep.size() : fname;
+
+#if defined(_WIN32)
+    // On windows check also forward slash as in some case the __FILE__ can have it instead native backward slash.
+    if (fname_trim_ptr == fname) {
+        static const auto pattern_fwd_sep = std::string(OV_NATIVE_PARENT_PROJECT_ROOT_DIR) + '/';
+        if (const auto has_fwd_sep_pattern_ptr = std::strstr(fname, pattern_fwd_sep.c_str())) {
+            fname_trim_ptr = has_fwd_sep_pattern_ptr + pattern_fwd_sep.size();
+        }
+    }
+#endif
+    return fname_trim_ptr;
 }

--- a/src/core/tests/file_util.cpp
+++ b/src/core/tests/file_util.cpp
@@ -156,3 +156,19 @@ TEST_F(TrimFileTest, absolute_path_to_source_but_no_project_dir) {
     auto str_ptr = ov::util::trim_file_name(file_path.c_str());
     EXPECT_EQ(file_path, str_ptr);
 }
+
+TEST_F(TrimFileTest, absolute_path_to_source_forward_slash_always_supported) {
+    const auto exp_path = std::string("src/test_src.cpp");
+
+    const auto file_path = std::string("home/user/") + project_dir_name + "/src/test_src.cpp";
+    auto str_ptr = ov::util::trim_file_name(file_path.c_str());
+    EXPECT_EQ(exp_path, str_ptr);
+}
+
+TEST_F(TrimFileTest, relatice_path_to_source_forward_slash_always_supported) {
+    const auto exp_path = std::string("src/test_src.cpp");
+
+    const auto file_path = std::string("../../") + project_dir_name + "/src/test_src.cpp";
+    auto str_ptr = ov::util::trim_file_name(file_path.c_str());
+    EXPECT_EQ(exp_path, str_ptr);
+}


### PR DESCRIPTION
### Details:
 - __FILE__ macro on windows build can have also forward slash as path separator add it to trim by compiler.
 - If not trimmed by compiler, function `ov::util::trim_file_name` will also try trim forward slash if file not already trimmed (on windows only).

### Tickets:
 - 115443
