### PR TITLE
[CPU][ARM] Fix perf issues of oneDNN 3.2 migration

### DIFF
--- a/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
+++ b/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
@@ -360,6 +360,8 @@ elseif(NOT TARGET arm_compute::arm_compute)
         set(arm_compute_full_path "${arm_compute}")
     endif()
 
+    list(APPEND ARM_COMPUTE_OPTIONS experimental_fixed_format_kernels=True)
+
     add_custom_command(
         OUTPUT
             ${arm_compute_full_path}


### PR DESCRIPTION
### Details:
 - gemm primitive is selected instead of acl one
 - revert v3.2 changes for acl_matmul for now
 - enable fixed size kernels to use "any" format (has_opt_impl() acl feature)
 - bring back winograd convolution
 
oneDNN PR:
- https://github.com/openvinotoolkit/oneDNN/pull/200

Ticket:
- 115969

TBD:
- [x] perf regression check