### PR TITLE
[GPU]  Reduce clfinish io and allow input reorder to use device mem

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -33,13 +33,15 @@ struct network_output {
     event::ptr get_event() const { return _event; }
 
     /// @brief Returns @ref memory object of the output. Blocked until associated @ref event is not complete.
-    memory::ptr get_memory() const {
+    memory::ptr get_memory(bool do_sync = true) const {
         // TODO: in_order queue doesn't create proper output event in some cases which leads to syncronization issues with user app
         // So call finish for associated stream to enusre that the output data is ready.
-        if (_stream->get_queue_type() == QueueTypes::in_order) {
-            _stream->finish();
-        } else {
-            _event->wait();
+        if (do_sync) {
+            if (_stream->get_queue_type() == QueueTypes::in_order) {
+                _stream->finish();
+            } else {
+                _event->wait();
+            }
         }
         return _result;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -128,8 +128,8 @@ public:
     engine& get_engine() const { return _engine; }
 
     void reset_execution(bool wait = true);
-    void set_input_data(const primitive_id& id, memory::ptr data);
-    void set_output_memory(const primitive_id& id, memory::ptr mem);
+    event::ptr set_input_data(const primitive_id& id, memory::ptr data);
+    std::vector<event::ptr> set_output_memory(const primitive_id& id, memory::ptr mem);
 
     std::vector<std::shared_ptr<primitive_inst>> const& get_outputs() { return _outputs; }
 
@@ -246,6 +246,9 @@ public:
     const ExecutionConfig& get_config() const { return _config; }
 
     ShapePredictor& get_shape_predictor() { return *_shape_predictor; }
+
+    int64_t last_barrier = 0;
+    int64_t dynamic_shape_proc_count = 0;
 
 private:
     using output_chains_map = std::map<primitive_id, std::vector<std::shared_ptr<primitive_inst>>>;

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -247,9 +247,6 @@ public:
 
     ShapePredictor& get_shape_predictor() { return *_shape_predictor; }
 
-    int64_t last_barrier = 0;
-    int64_t dynamic_shape_proc_count = 0;
-
 private:
     using output_chains_map = std::map<primitive_id, std::vector<std::shared_ptr<primitive_inst>>>;
     uint32_t net_id = 0;

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/infer_request.hpp
@@ -76,7 +76,8 @@ private:
 
     void prepare_input(const cldnn::primitive_id &inputName, InferenceEngine::Blob::Ptr &inputBlob,
                        std::vector<cldnn::event::ptr>& dependencies);
-    void prepare_output(const cldnn::primitive_id& outputName, InferenceEngine::Blob::Ptr& outputBlob);
+    void prepare_output(const cldnn::primitive_id& outputName, InferenceEngine::Blob::Ptr& outputBlob,
+                       std::vector<cldnn::event::ptr>& dependencies);
     void allocate_dev_mem_if_needed(InferenceEngine::BlobMap& device_mems, InferenceEngine::Blob::Ptr& user_blob,
                                     const cldnn::primitive_id& blob_name, const cldnn::layout& layout,
                                     const bool need_lockable_mem = false);
@@ -85,8 +86,6 @@ private:
     InferenceEngine::Blob::Ptr create_device_blob(const InferenceEngine::TensorDesc& desc);
 
     void copy_output_data(cldnn::memory::ptr outputMemory, InferenceEngine::Blob::Ptr bptr);
-    void copy_input_data(std::shared_ptr<cldnn::network> network, const cldnn::primitive_id& inputName,
-                         const cldnn::layout& inputLayout, const InferenceEngine::Blob &inputBlob);
 
     template<typename RemoteBlobType, typename = typename std::enable_if<std::is_same<RemoteBlobType, RemoteCLbuffer>::value ||
                                                                          std::is_same<RemoteBlobType, RemoteUSMbuffer>::value>::type>

--- a/src/plugins/intel_gpu/src/graph/include/input_layout_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/input_layout_inst.h
@@ -35,7 +35,7 @@ public:
     void update_shape() override;
     typed_primitive_inst(network& network, input_layout_node const& node);
 
-    void set_data(memory::ptr mem);
+    event::ptr set_data(memory::ptr mem);
 };
 
 using input_layout_inst = typed_primitive_inst<input_layout>;

--- a/src/plugins/intel_gpu/src/graph/include/loop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/loop_inst.h
@@ -528,7 +528,7 @@ public:
     void preprocess_output_memory();
     void preprocess_backedge_memory();
     void update_mapped_memory();
-    void set_output_memory(memory::ptr mem, bool check = true, size_t idx = 0) override;
+    event::ptr set_output_memory(memory::ptr mem, bool check = true, size_t idx = 0) override;
     const backedge_memory_mapping& get_current_iteration_backedge_mapping() const {
         OPENVINO_ASSERT(node->is_current_iteration_used(), "[GPU] No backedge mapping for current_iteration for primitive ", node->id());
         return backedge_memory_mappings.at(current_iteratoin_backedge_mapping_idx);

--- a/src/plugins/intel_gpu/src/graph/include/mutable_data_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/mutable_data_inst.h
@@ -42,7 +42,7 @@ public:
     static std::string to_string(mutable_data_node const& node);
 
     typed_primitive_inst(network& network, mutable_data_node const& node);
-    void set_output_memory(memory::ptr mem, bool check = true, size_t idx = 0) override;
+    event::ptr set_output_memory(memory::ptr mem, bool check = true, size_t idx = 0) override;
     const std::list<primitive_id>& get_user_ids() const { return _user_ids; }
     void save(BinaryOutputBuffer& ob) const override;
     void load(BinaryInputBuffer& ib) override;

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -33,7 +33,6 @@ namespace cldnn {
 
 // checks if any user in a list is a cpu primitive
 bool is_any_user_cpu(const std::list<const program_node*>& users);
-bool has_any_cpu_user_not_shape_of(const std::list<const program_node*>& users);
 
 class primitive_inst;
 

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -33,6 +33,7 @@ namespace cldnn {
 
 // checks if any user in a list is a cpu primitive
 bool is_any_user_cpu(const std::list<const program_node*>& users);
+bool has_any_cpu_user_not_shape_of(const std::list<const program_node*>& users);
 
 class primitive_inst;
 
@@ -157,7 +158,7 @@ public:
     program_node const& get_node() const { return *_node; }
     network& get_network() const { return _network; }
     uint32_t get_network_id() const;
-    virtual void set_output_memory(memory::ptr mem, bool check = true, size_t idx = 0);
+    virtual event::ptr set_output_memory(memory::ptr mem, bool check = true, size_t idx = 0);
     void check_memory_to_set(const memory& mem, const layout& layout) const;
     const std::list<const cldnn::program_node *>& get_users() const { return _node->get_users(); }
     std::vector<std::shared_ptr<primitive_inst>> get_user_insts() const {
@@ -266,6 +267,7 @@ public:
     std::shared_ptr<const PType> get_typed_desc() const { return _impl_params->typed_desc<PType>(); }
 
     virtual void update_output_memory() {}
+    int64_t dynamic_shape_proc_count;
 
 protected:
     primitive_inst(network& network, program_node const& node, bool allocate_memory);

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -267,7 +267,6 @@ public:
     std::shared_ptr<const PType> get_typed_desc() const { return _impl_params->typed_desc<PType>(); }
 
     virtual void update_output_memory() {}
-    int64_t dynamic_shape_proc_count;
 
 protected:
     primitive_inst(network& network, program_node const& node, bool allocate_memory);

--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -35,22 +35,21 @@ input_layout_inst::typed_primitive_inst(network& network, input_layout_node cons
     _has_valid_input = false;  // by default input for 'input_layout' is invalid as long as user doesn't call set_data
 }
 
-void input_layout_inst::set_data(memory::ptr mem) {
+event::ptr input_layout_inst::set_data(memory::ptr mem) {
     auto ol = get_node_output_layout();
 
     check_memory_to_set(*mem, ol);
-
+    event::ptr ev = nullptr;
     if (mem->is_allocated_by(get_network().get_engine())) {
         OPENVINO_ASSERT(!_outputs.empty(), "[GPU] Can't set data for empty input memory");
         _outputs[0] = mem;
+        ev = get_network().get_stream().create_user_event(true);
     } else {
-        mem_lock<char, mem_lock_type::read> src(mem, get_network().get_stream());
-        mem_lock<char, mem_lock_type::write> dst(_outputs[0], get_network().get_stream());
-        std::copy(src.begin(), src.end(), dst.begin());
+        ev = _outputs[0]->copy_from(get_network().get_stream(), *mem, false);
     }
-
     _has_valid_input = true;
     _output_changed = true;
+    return ev;
 }
 
 void input_layout_inst::update_shape() {

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -316,9 +316,10 @@ void loop_inst::update_mapped_memory() {
     }
 }
 
-void loop_inst::set_output_memory(memory::ptr mem, bool check, size_t idx) {
-    primitive_inst::set_output_memory(mem, check, idx);
+event::ptr loop_inst::set_output_memory(memory::ptr mem, bool check, size_t idx) {
+    auto ev = primitive_inst::set_output_memory(mem, check, idx);
     update_mapped_memory();
+    return ev;
 }
 
 void loop_inst::preprocess_output_memory() {

--- a/src/plugins/intel_gpu/src/graph/mutable_data.cpp
+++ b/src/plugins/intel_gpu/src/graph/mutable_data.cpp
@@ -50,16 +50,15 @@ std::string mutable_data_inst::to_string(mutable_data_node const& node) {
     return primitive_description.str();
 }
 
-void mutable_data_inst::set_output_memory(memory::ptr mem_new, bool check, size_t idx) {
+event::ptr mutable_data_inst::set_output_memory(memory::ptr mem_new, bool check, size_t idx) {
     if (_node != nullptr) {
         auto& eng = _network.get_engine();
         auto& mem_node = const_cast<program_node*>(_node)->as<mutable_data>();
         auto& mem_attached = mem_node.get_attached_memory();
         const auto& mem_orig = *_outputs[idx];
-
         if (!eng.is_the_same_buffer(*mem_new, mem_attached)) {
             if (_node->is_input()) {
-                mem_new->copy_from(_network.get_stream(), *_outputs[idx]);
+                get_network().get_stream().wait_for_events({mem_new->copy_from(_network.get_stream(), *_outputs[idx])});
             }
 
             // re-attach mutable_data internal memory if necessary
@@ -68,7 +67,7 @@ void mutable_data_inst::set_output_memory(memory::ptr mem_new, bool check, size_
             }
         }
     }
-    primitive_inst::set_output_memory(mem_new, check);
+    return primitive_inst::set_output_memory(mem_new, check);
 }
 
 mutable_data_inst::typed_primitive_inst(network& network, mutable_data_node const& node)

--- a/src/plugins/intel_gpu/src/graph/mutable_data.cpp
+++ b/src/plugins/intel_gpu/src/graph/mutable_data.cpp
@@ -51,6 +51,7 @@ std::string mutable_data_inst::to_string(mutable_data_node const& node) {
 }
 
 event::ptr mutable_data_inst::set_output_memory(memory::ptr mem_new, bool check, size_t idx) {
+    event::ptr input_ev = nullptr;
     if (_node != nullptr) {
         auto& eng = _network.get_engine();
         auto& mem_node = const_cast<program_node*>(_node)->as<mutable_data>();
@@ -58,7 +59,7 @@ event::ptr mutable_data_inst::set_output_memory(memory::ptr mem_new, bool check,
         const auto& mem_orig = *_outputs[idx];
         if (!eng.is_the_same_buffer(*mem_new, mem_attached)) {
             if (_node->is_input()) {
-                get_network().get_stream().wait_for_events({mem_new->copy_from(_network.get_stream(), *_outputs[idx])});
+                input_ev = mem_new->copy_from(_network.get_stream(), *_outputs[idx], false);
             }
 
             // re-attach mutable_data internal memory if necessary
@@ -67,7 +68,11 @@ event::ptr mutable_data_inst::set_output_memory(memory::ptr mem_new, bool check,
             }
         }
     }
-    return primitive_inst::set_output_memory(mem_new, check);
+    auto ev = primitive_inst::set_output_memory(mem_new, check);
+    if (input_ev == nullptr)
+        return ev;
+    else
+        return _network.get_stream().group_events({ev, input_ev});
 }
 
 mutable_data_inst::typed_primitive_inst(network& network, mutable_data_node const& node)

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -740,7 +740,7 @@ void network::reset_execution(bool wait) {
     _events.clear();
 }
 
-void network::set_input_data(const primitive_id& id, memory::ptr data) {
+event::ptr network::set_input_data(const primitive_id& id, memory::ptr data) {
     std::shared_ptr<primitive_inst> primitive_inst;
 
     primitive_inst = find_primitive(id);
@@ -754,10 +754,7 @@ void network::set_input_data(const primitive_id& id, memory::ptr data) {
 
     auto input = std::static_pointer_cast<input_layout_inst>(primitive_inst);
 
-    // Wait for previous execution completion
-    reset_execution(true);
-
-    input->set_data(data);
+    return input->set_data(data);
 }
 
 void network::add_default_output_chains() {
@@ -885,9 +882,9 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
     return _output_chains.insert({ p_inst->id(), chain }).first;
 }
 
-void network::set_output_memory(const primitive_id& id, memory::ptr mem_new) {
+std::vector<event::ptr> network::set_output_memory(const primitive_id& id, memory::ptr mem_new) {
     std::shared_ptr<primitive_inst> p_inst;
-
+    std::vector<event::ptr> ret_ev;
     p_inst = find_primitive(id);
 
     if (!p_inst)
@@ -896,9 +893,6 @@ void network::set_output_memory(const primitive_id& id, memory::ptr mem_new) {
     auto iter = std::find(_outputs.begin(), _outputs.end(), p_inst);
     if (iter == _outputs.end())
         throw std::runtime_error("primitive: " + id + " is not a network output");
-
-    // Wait for previous execution completion
-    reset_execution(true);
 
     auto& eng = get_engine();
     // locate primitive chain for this output
@@ -909,12 +903,13 @@ void network::set_output_memory(const primitive_id& id, memory::ptr mem_new) {
     }
 
     for (auto& prim : o_iter->second) {
-        prim->set_output_memory(eng.reinterpret_buffer(*mem_new, prim->output_memory().get_layout()), false);
+        ret_ev.push_back(prim->set_output_memory(eng.reinterpret_buffer(*mem_new, prim->output_memory().get_layout()), false));
         if (!_reset_arguments &&
             (prim->type() != cldnn::data::type_id() && !(prim->type() == cldnn::mutable_data::type_id() && prim->dependencies().empty()))) {
             prim->set_arguments();
         }
     }
+    return ret_ev;
 }
 
 void cldnn::network::check_names() {
@@ -1160,6 +1155,8 @@ void network::execute_impl(const std::vector<event::ptr>& events) {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, "NetworkImpl::Execute");
     // Wait for previous execution completion
     reset_execution(false);
+    dynamic_shape_proc_count = 0;
+    last_barrier = 0;
     GPU_DEBUG_TRACE << "----------------------------------------------" << std::endl;
     GPU_DEBUG_TRACE << "Start network execution" << std::endl;
 

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -1155,8 +1155,6 @@ void network::execute_impl(const std::vector<event::ptr>& events) {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, "NetworkImpl::Execute");
     // Wait for previous execution completion
     reset_execution(false);
-    dynamic_shape_proc_count = 0;
-    last_barrier = 0;
     GPU_DEBUG_TRACE << "----------------------------------------------" << std::endl;
     GPU_DEBUG_TRACE << "Start network execution" << std::endl;
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -115,19 +115,19 @@ bool has_cpu_user_not_shape_of(const program_node* user) {
         return impl->is_cpu() && !user->is_type<shape_of>();
     return false;
 }
+
+bool has_any_cpu_user_not_shape_of(const std::list<const program_node*>& users) {
+    for (const auto& user : users) {
+        if (has_cpu_user_not_shape_of(user))
+            return true;
+    }
+    return false;
+}
 }  // namespace
 
 bool is_any_user_cpu(const std::list<const program_node*>& users) {
     for (const auto& user : users) {
         if (is_user_cpu(user))
-            return true;
-    }
-    return false;
-}
-
-bool has_any_cpu_user_not_shape_of(const std::list<const program_node*>& users) {
-    for (const auto& user : users) {
-        if (has_cpu_user_not_shape_of(user))
             return true;
     }
     return false;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -101,11 +101,33 @@ bool is_user_cpu(const program_node* user) {
         return impl->is_cpu();
     return false;
 }
+bool has_cpu_user_not_shape_of(const program_node* user) {
+    if (user->can_be_optimized()) {
+        auto users = user->get_users();
+        for (const auto& u : users) {
+            if (has_cpu_user_not_shape_of(u)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if (auto impl = user->get_selected_impl())
+        return impl->is_cpu() && !user->is_type<shape_of>();
+    return false;
+}
 }  // namespace
 
 bool is_any_user_cpu(const std::list<const program_node*>& users) {
     for (const auto& user : users) {
         if (is_user_cpu(user))
+            return true;
+    }
+    return false;
+}
+
+bool has_any_cpu_user_not_shape_of(const std::list<const program_node*>& users) {
+    for (const auto& user : users) {
+        if (has_cpu_user_not_shape_of(user))
             return true;
     }
     return false;
@@ -174,11 +196,12 @@ void primitive_inst::check_memory_to_set(const memory& mem, const layout& layout
     }
 }
 
-void primitive_inst::set_output_memory(memory::ptr mem_new, bool check, size_t idx) {
+event::ptr primitive_inst::set_output_memory(memory::ptr mem_new, bool check, size_t idx) {
     auto& eng = _network.get_engine();
     // skip all the buzz if no action actually required
+    event::ptr ev = nullptr;
     if (_outputs[idx] && eng.is_the_same_buffer(*mem_new, *_outputs[idx])) {
-        return;
+        return get_network().get_stream().create_user_event(true);
     }
 
     auto ol = _impl_params->get_output_layout(idx);
@@ -187,10 +210,12 @@ void primitive_inst::set_output_memory(memory::ptr mem_new, bool check, size_t i
         check_memory_to_set(*mem_new, ol);
 
     if (is_constant()) {
-        mem_new->copy_from(_network.get_stream(), *_outputs[idx]);
+        ev = mem_new->copy_from(_network.get_stream(), *_outputs[idx]);
     } else {
+        ev = get_network().get_stream().create_user_event(true);
         _outputs[idx] = mem_new;
     }
+    return ev;
 }
 
 void primitive_inst::update_shape() {
@@ -267,6 +292,7 @@ void primitive_inst::update_shape() {
     std::vector<event::ptr> dependencies_events;
     auto queue_type = get_network().get_stream().get_queue_type();
     bool has_runtime_deps = false;
+    int64_t max_dyn_proc_count = 0;
     for (auto& i : _node->get_shape_infer_dependencies()) {
         // Some primitives may have flexible count of deps (e.g. reshape), thus allow skipping some deps
         if (memory_deps.count(i) > 0 || i >= _node->get_dependencies().size()) {
@@ -285,7 +311,9 @@ void primitive_inst::update_shape() {
         }
         auto dep_mem = _network.get_output_memory(dep_id);
         memory_deps.insert({i, dep_mem});
-        if (!dep.is_in_shape_of_subgraph())
+        max_dyn_proc_count =
+            std::max(max_dyn_proc_count, (get_network().get_primitive(dep_id)->dynamic_shape_proc_count));
+        if (!get_node().is_in_shape_of_subgraph() && !dep.is_in_shape_of_subgraph())
             has_runtime_deps = true;
     }
 
@@ -293,7 +321,13 @@ void primitive_inst::update_shape() {
         if (!dependencies_events.empty() && queue_type == QueueTypes::out_of_order) {
             _network.get_stream().wait_for_events(dependencies_events);
         } else if (queue_type == QueueTypes::in_order) {
-            _network.get_stream().finish();
+            if (max_dyn_proc_count > get_network().last_barrier) {
+            //if (1) {
+                _network.get_stream().finish();
+               // get_network().last_barrier = get_network().dynamic_shape_proc_count++;
+            } else {
+               // std::cout << "skipped clfinish" << std::endl;
+            }
         }
     }
 
@@ -662,7 +696,7 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
     const auto primitive_id = id();
     OPENVINO_ASSERT(_has_valid_input, primitive_id, " has invalid/unset input");
     GPU_DEBUG_GET_INSTANCE(debug_config);
-
+    // init
     bool need_args_update = false;
     std::vector<event::ptr> dependencies;
     if (is_dynamic() && !has_inner_networks()) {
@@ -723,6 +757,7 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
                         "[GPU] Can't execute ", primitive_id, " primitive as output layout is dynamic in runtime");
     }
     update_shape_done_by_other = false; // reset
+    this->dynamic_shape_proc_count = get_network().dynamic_shape_proc_count++;
     OPENVINO_ASSERT(_impl != nullptr, "[GPU] Implementation is nullptr for ", primitive_id,  " primitive");
 
     // Output buffer may be changed under the following conditions, so we need to set args to kernel on each iteration
@@ -1146,9 +1181,11 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
     // For outputs, cpu prim we want to have lockable alloc type
     // Also if the successor of a node is an cpu, then memory needs to be lockable.
     bool is_cpu = _node.get_selected_impl() ? _node.get_selected_impl()->is_cpu() : false;
-    auto use_lockable_memory = is_output_buffer|| is_cpu || is_any_user_cpu(_node.get_users()) ||
-                               !_engine.supports_allocation(allocation_type::usm_device) ||
-                               (_node.is_shape_infer_dep() && _engine.get_device_info().dev_type == device_type::integrated_gpu);
+    auto use_lockable_memory =
+        is_output_buffer || is_cpu ||
+        has_any_cpu_user_not_shape_of(_node.get_users()) ||
+        !_engine.supports_allocation(allocation_type::usm_device) ||
+        (_node.is_shape_infer_dep() && _engine.get_device_info().dev_type == device_type::integrated_gpu);
     const auto& lockable_mem_type = _engine.get_lockable_preferred_memory_allocation_type(layout.format.is_image_2d());
 
     auto alloc_type = use_lockable_memory ? lockable_mem_type

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -210,7 +210,7 @@ event::ptr primitive_inst::set_output_memory(memory::ptr mem_new, bool check, si
         check_memory_to_set(*mem_new, ol);
 
     if (is_constant()) {
-        ev = mem_new->copy_from(_network.get_stream(), *_outputs[idx]);
+        ev = mem_new->copy_from(_network.get_stream(), *_outputs[idx], false);
     } else {
         ev = get_network().get_stream().create_user_event(true);
         _outputs[idx] = mem_new;


### PR DESCRIPTION
### Details:
 - Not need to do reset_execution for each prepare_input/output
 - Instead, fixed the sync of I/O to be done by event
 - Also there was a problem of allocation of output memory, i.e., even though the node has only  shape_of user as cpu user, it was allocating host memory. 
 - Also fixed not to do clFinish before shape_of
### Tickets:
 - 115589
