### PR TITLE
Revert "Remove extra model from CompiledModelDesc" 

### DIFF
--- a/src/inference/tests/functional/caching_test.cpp
+++ b/src/inference/tests/functional/caching_test.cpp
@@ -1893,7 +1893,6 @@ TEST_P(CachingTest, TestCacheFileOldVersion) {
     }
 }
 
-#if defined(ENABLE_HETERO)
 TEST_P(CachingTest, LoadHetero_NoCacheMetric) {
     EXPECT_CALL(*mockPlugin, GetMetric(METRIC_KEY(SUPPORTED_CONFIG_KEYS), _))
         .Times(AnyNumber())
@@ -1918,9 +1917,10 @@ TEST_P(CachingTest, LoadHetero_NoCacheMetric) {
         EXPECT_CALL(*mockPlugin, LoadExeNetworkImpl(_, _)).Times(1);
         EXPECT_CALL(*mockPlugin, ImportNetwork(_, _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, ImportNetwork(_, _)).Times(0);
-        for (auto& net : networks) {
-            EXPECT_CALL(*net, Export(_)).Times(0);
-        }
+        m_post_mock_net_callbacks.emplace_back([&](MockExecutableNetwork& net) {
+            EXPECT_CALL(net, Export(_)).Times(0);
+            EXPECT_CALL(net, GetExecGraphInfo()).Times(0);
+        });
         testLoad([&](Core& ie) {
             ie.SetConfig({{CONFIG_KEY(CACHE_DIR), m_cacheDir}});
             m_testFunction(ie);
@@ -2156,7 +2156,6 @@ TEST_P(CachingTest, LoadHetero_MultiArchs_TargetFallback_FromCore) {
         });
     }
 }
-#endif  // define(ENABLE_HETERO)
 
 #if defined(ENABLE_AUTO)
 // AUTO-DEVICE test

--- a/src/plugins/hetero/src/compiled_model.cpp
+++ b/src/plugins/hetero/src/compiled_model.cpp
@@ -401,6 +401,7 @@ ov::hetero::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model
                                                        subgraph._sinks,
                                                        subgraph._parameters,
                                                        m_name + '_' + std::to_string(id));
+        m_compiled_submodels[id].model = subFunctions[id];
 
         auto metaDevices = get_hetero_plugin()->get_properties_per_device(m_compiled_submodels[id].device,
                                                                           m_cfg.get_device_properties());
@@ -409,8 +410,9 @@ ov::hetero::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model
         auto device_config = metaDevices[m_compiled_submodels[id].device];
         device_config[ov::cache_dir.name()] = "";
 
-        m_compiled_submodels[id].compiled_model =
-            plugin->get_core()->compile_model(subFunctions[id], m_compiled_submodels[id].device, device_config);
+        m_compiled_submodels[id].compiled_model = plugin->get_core()->compile_model(m_compiled_submodels[id].model,
+                                                                                    m_compiled_submodels[id].device,
+                                                                                    device_config);
         ++id;
     }
 
@@ -455,6 +457,7 @@ ov::hetero::CompiledModel::CompiledModel(std::istream& model,
         auto& loadConfig = metaDevices[device];
 
         ov::SoPtr<ov::ICompiledModel> compiled_model;
+        std::shared_ptr<ov::Model> ov_model;
 
         if (get_plugin()->get_core()->device_supports_model_caching(device)) {
             compiled_model = plugin->get_core()->import_model(model, device, loadConfig);
@@ -474,12 +477,13 @@ ov::hetero::CompiledModel::CompiledModel(std::istream& model,
                 model.read(weights.data<char>(), dataSize);
             }
 
-            auto ov_model = plugin->get_core()->read_model(xmlString, weights);
+            ov_model = plugin->get_core()->read_model(xmlString, weights);
             compiled_model = plugin->get_core()->compile_model(ov_model, device, loadConfig);
         }
 
         m_compiled_submodels.emplace_back(ov::hetero::CompiledModel::CompiledModelDesc{
             device,
+            ov_model,
             compiled_model,
         });
     }
@@ -686,7 +690,7 @@ void ov::hetero::CompiledModel::export_model(std::ostream& model_stream) const {
         if (get_plugin()->get_core()->device_supports_model_caching(comp_model_desc.device)) {
             comp_model_desc.compiled_model->export_model(model_stream);
         } else {
-            auto model = std::const_pointer_cast<ov::Model>(comp_model_desc.compiled_model->get_runtime_model());
+            auto model = comp_model_desc.model;
             if (!model)
                 OPENVINO_THROW("OpenVINO Model is empty");
 

--- a/src/plugins/hetero/src/compiled_model.hpp
+++ b/src/plugins/hetero/src/compiled_model.hpp
@@ -58,6 +58,7 @@ private:
 
     struct CompiledModelDesc {
         std::string device;
+        std::shared_ptr<ov::Model> model;
         ov::SoPtr<ov::ICompiledModel> compiled_model;
     };
     std::vector<CompiledModelDesc> m_compiled_submodels;


### PR DESCRIPTION
### Details:
 - Model returned by `get_runtime_model()` not useful for import/export
