### PR TITLE
[PT FE]: support upsample2d bilinear and bicubic with antialias

### DIFF
--- a/src/frontends/pytorch/src/op/upsample.cpp
+++ b/src/frontends/pytorch/src/op/upsample.cpp
@@ -19,7 +19,8 @@ using namespace ov::op;
 namespace {
 OutputVector base_translate_upsample(const NodeContext& context,
                                      v11::Interpolate::InterpolateMode interpolate_mode,
-                                     size_t dims) {
+                                     size_t dims,
+                                     bool antialias = false) {
     num_inputs_check(context, 1, 4);
     auto data = context.get_input(0);
     std::vector<size_t> pad(dims, 0);
@@ -74,6 +75,7 @@ OutputVector base_translate_upsample(const NodeContext& context,
             attrs.coordinate_transformation_mode = v11::Interpolate::CoordinateTransformMode::ALIGN_CORNERS;
         }
     }
+    attrs.antialias = antialias;
     return {context.mark_node(std::make_shared<v11::Interpolate>(data, scales_sizes, target_axes, attrs))};
 };
 }  // namespace
@@ -84,6 +86,12 @@ OutputVector translate_upsample_linear1d(const NodeContext& context) {
 
 OutputVector translate_upsample_bilinear2d(const NodeContext& context) {
     return base_translate_upsample(context, v11::Interpolate::InterpolateMode::LINEAR_ONNX, 2);
+};
+
+// antialiasing supported only for bicubic and bilinear interpolations
+// realization is the same like in Pillow
+OutputVector translate_upsample_bilinear2d_aa(const NodeContext& context) {
+    return base_translate_upsample(context, v11::Interpolate::InterpolateMode::BILINEAR_PILLOW, 2);
 };
 
 OutputVector translate_upsample_trilinear3d(const NodeContext& context) {
@@ -105,6 +113,12 @@ OutputVector translate_upsample_nearest3d(const NodeContext& context) {
 // bicubic is only supported for 2d in pytorch
 OutputVector translate_upsample_bicubic2d(const NodeContext& context) {
     return base_translate_upsample(context, v11::Interpolate::InterpolateMode::CUBIC, 2);
+};
+
+// antialiasing supported only for bicubic and bilinear interpolations
+// realization is the same like in Pillow
+OutputVector translate_upsample_bicubic2d_aa(const NodeContext& context) {
+    return base_translate_upsample(context, v11::Interpolate::InterpolateMode::BICUBIC_PILLOW, 2);
 };
 
 }  // namespace op

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -146,6 +146,8 @@ OP_CONVERTER(translate_unflatten);
 OP_CONVERTER(translate_unfold);
 OP_CONVERTER(translate_upsample_bicubic2d);
 OP_CONVERTER(translate_upsample_bilinear2d);
+OP_CONVERTER(translate_upsample_bicubic2d_aa);
+OP_CONVERTER(translate_upsample_bilinear2d_aa);
 OP_CONVERTER(translate_upsample_linear1d);
 OP_CONVERTER(translate_upsample_nearest1d);
 OP_CONVERTER(translate_upsample_nearest2d);
@@ -391,6 +393,8 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"aten::unsqueeze_", op::inplace_op<op::translate_1to1_match_2_inputs<opset10::Unsqueeze>>},
         {"aten::upsample_bicubic2d", op::translate_upsample_bicubic2d},
         {"aten::upsample_bilinear2d", op::translate_upsample_bilinear2d},
+        {"aten::_upsample_bicubic2d_aa", op::translate_upsample_bicubic2d_aa},
+        {"aten::_upsample_bilinear2d_aa", op::translate_upsample_bilinear2d_aa},
         {"aten::upsample_linear1d", op::translate_upsample_linear1d},
         {"aten::upsample_nearest1d", op::translate_upsample_nearest1d},
         {"aten::upsample_nearest2d", op::translate_upsample_nearest2d},

--- a/tests/layer_tests/pytorch_tests/test_upsample.py
+++ b/tests/layer_tests/pytorch_tests/test_upsample.py
@@ -96,6 +96,51 @@ class TestUpsample2D(PytorchLayerTest):
                    precision, ir_version, trace_model=True, **{"custom_eps": 1e-3})
 
 
+
+class TestUpsample2DAntialias(PytorchLayerTest):
+    def _prepare_input(self):
+        import numpy as np
+        return (np.random.randn(1, 3, 200, 200).astype(np.float32),)
+
+    def create_model(self, size, scale, mode):
+        import torch
+        import torch.nn.functional as F
+
+        class aten_upsample(torch.nn.Module):
+            def __init__(self, size, scale, mode):
+                super().__init__()
+                self.size = size
+                self.scale = scale
+                self.mode = mode
+
+            def forward(self, x):
+                return F.interpolate(x, self.size, scale_factor=self.scale, mode=self.mode, antialias=True)
+
+        ref_net = None
+
+        return aten_upsample(size, scale, mode), ref_net, F"aten::_upsample_{mode}2d_aa"
+
+    @pytest.mark.parametrize("mode,size,scale", [
+        ('bilinear', 300, None),
+        ('bilinear', 150, None),
+        ('bilinear', (400, 480), None),
+        ('bilinear', None, 2.5,),
+        ('bilinear', None, 0.75),
+        ('bilinear', None, (1.2, 1.3)),
+        ('bicubic', 300, None),
+        ('bicubic', 150, None),
+        ('bicubic', (400, 480), None),
+        ('bicubic', None, 2.5,),
+        ('bicubic', None, 0.75),
+        ('bicubic', None, (1.2, 1.3))
+    ])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_upsample2d(self, mode, size, scale, ie_device, precision, ir_version):
+        self._test(*self.create_model(size, scale, mode), ie_device,
+                   precision, ir_version, trace_model=True, **{"custom_eps": 1e-3})
+
+
 class TestUpsample3D(PytorchLayerTest):
     def _prepare_input(self):
         import numpy as np


### PR DESCRIPTION
### Details:
 - *support aten::_upsample_bilinear2d_aa, aten::_upsample_bicubic2d_aa*
tested on fastcomposer model

### Tickets:
 - *ticket-id*
