### PR TITLE
Add Python requirements to wheel requirements

### DIFF
--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r ../src/compatibility/openvino/requirements-dev.txt
 setuptools>=65.6.1
 wheel>=0.38.1
 patchelf<=0.17.2.1; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
When building a wheel by definition you need Python. This small change allows you to install requirements with one pip install command instead of two. If you have already installed the Python requirements separately, it is harmless. 

cc @jiwaszki 