### PR TITLE
[GPU] Disable permute_f_y_axis because of accuracy issue

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_selector.cpp
@@ -16,7 +16,7 @@ permute_kernel_selector::permute_kernel_selector() {
     Attach<PermuteKernel_tile_8x8_4x4>();
     Attach<PermuteKernel_tile_8x8_4x4_fsv>();
     Attach<PermuteKernel_bfzyx_to_bfyxz>();
-    Attach<PermuteKernel_f_y_axes>();
+    // Attach<PermuteKernel_f_y_axes>();
 }
 
 KernelsData permute_kernel_selector::GetBestKernels(const Params& params, const optional_params& options) const {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -2247,17 +2247,18 @@ TEST_P(permute_tile_fsv_5d, i64_cached) {
 
 class permute_f_y_axes_tile: public TiledPermuteTest {};
 
-INSTANTIATE_TEST_SUITE_P(smoke_permute_f_y_axes_tile,
-                         permute_f_y_axes_tile,
-                         ::testing::ValuesIn(std::vector<TiledPermuteParam>{
-                             {{1, 4, 8, 1}, format::bfyx},                // permute_f_y_axes
-                             {{1, 64, 32, 1}, format::bfyx},              // permute_f_y_axes
-                             {{1, 32, 256, 512}, format::b_fs_yx_fsv32},  // THREE_DIM_TRANSPOSE
-                             {{1, 32, 256, 512}, format::bfyx},           // PERMUTE_SIMPLE_MEM_COPY
-                             {{1, 256, 256, 1}, format::b_fs_yx_fsv32},   // permute_f_y_axes
-                             {{1, 32, 16, 4}, format::b_fs_yx_fsv16},     // THREE_DIM_TRANSPOSE
-                         }),
-                         TiledPermuteTest::PrintToStringParamName);
+// Test cases are disabled because permute_f_y_axes_tile kernel itself is disabled for accuracy issue
+// INSTANTIATE_TEST_SUITE_P(smoke_permute_f_y_axes_tile,
+//                          permute_f_y_axes_tile,
+//                          ::testing::ValuesIn(std::vector<TiledPermuteParam>{
+//                              {{1, 4, 8, 1}, format::bfyx},                // permute_f_y_axes
+//                              {{1, 64, 32, 1}, format::bfyx},              // permute_f_y_axes
+//                              {{1, 32, 256, 512}, format::b_fs_yx_fsv32},  // THREE_DIM_TRANSPOSE
+//                              {{1, 32, 256, 512}, format::bfyx},           // PERMUTE_SIMPLE_MEM_COPY
+//                              {{1, 256, 256, 1}, format::b_fs_yx_fsv32},   // permute_f_y_axes
+//                              {{1, 32, 16, 4}, format::b_fs_yx_fsv16},     // THREE_DIM_TRANSPOSE
+//                          }),
+//                          TiledPermuteTest::PrintToStringParamName);
 
 TEST_P(permute_f_y_axes_tile, combined) {
     auto p = GetParam();


### PR DESCRIPTION
### Details:
 - The PR https://github.com/openvinotoolkit/openvino/pull/13561 caused many accuracy issues. Disable it and enable it once the issues are resolved.

### Tickets:
 - *ticket-id*
