### PR TITLE
Removed -Wl,--allow-shlib-undefined from OpenVINOConfig.cmake

### DIFF
--- a/cmake/templates/OpenVINOConfig.cmake.in
+++ b/cmake/templates/OpenVINOConfig.cmake.in
@@ -425,10 +425,6 @@ function(_ov_target_no_deprecation_error)
         else()
             set(flags "-Wno-error=deprecated-declarations")
         endif()
-        if(CMAKE_CROSSCOMPILING)
-            set_target_properties(${ARGV} PROPERTIES
-                                  INTERFACE_LINK_OPTIONS "-Wl,--allow-shlib-undefined")
-        endif()
 
         set_target_properties(${ARGV} PROPERTIES INTERFACE_COMPILE_OPTIONS ${flags})
     endif()


### PR DESCRIPTION
### Details:
 - on older macOS targets this option is not available, so we cannot cross-compile for arm64 from x86_64 hosts. 
 - Were introduced here https://github.com/openvinotoolkit/openvino/pull/2397
 - Let's see what CI will say us