### PR TITLE
[GPU] Force ov::enable_profiling if OV_GPU_DumpProfilingData debug option is used

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -53,10 +53,6 @@ struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
         _attrs(attrs),
         _pd(pd) {
             _enable_profiling = config.get_property(ov::enable_profiling);
-            GPU_DEBUG_GET_INSTANCE(debug_config);
-            GPU_DEBUG_IF(!debug_config->dump_profiling_data.empty()) {
-                _enable_profiling = true;
-            }
             build_primitive(config);
         }
 

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -175,6 +175,11 @@ void ExecutionConfig::apply_debug_options(const cldnn::device_info& info) {
         set_property(ov::compilation_num_threads(1));
     }
 
+    GPU_DEBUG_IF(!debug_config->dump_profiling_data.empty()) {
+        GPU_DEBUG_COUT << "[WARNING] ov::enable_profiling property was forced because of enabled OV_GPU_DumpProfilingData debug option\n";
+        set_property(ov::enable_profiling(true));
+    }
+
     GPU_DEBUG_IF(debug_config->disable_dynamic_impl == 1) {
         set_property(ov::intel_gpu::use_only_static_kernels_for_dynamic_shape(true));
     }


### PR DESCRIPTION
### Details:
 - This change enables ov::enable_profiling property if OV_GPU_DumpProfilingData debug option applied. ov::enable_profiling property configures OpenCL queue with CL_QUEUE_PROFILING_ENABLE option which is needed for proper OneDNN's primitives profiling

### Tickets:
 - *ticket-id*
