### PR TITLE
Ensure const blob 16 byte alignment on SSE.

### DIFF
--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -112,21 +112,6 @@ bool Edge::enforceReorder() {
         }
     }
 
-    // In case the parent node is an input constant, the memory is unaligned and the child primitive isa is SSE,
-    // we have to insert reorder since the vast majority of arithmetic and data processing instructions in legacy SSE isa requires
-    // the memory address in the operands must be aligned on 16-byte boundary.
-    if ((childSPD->getImplementationType() & impl_desc_type::sse42) &&
-        Type::Input == parentNode->getType() &&
-        parentNode->isConstant()) {
-        if (auto pInputNode = std::dynamic_pointer_cast<node::Input>(parentNode)) {
-            auto rawMemPtr = pInputNode->getMemoryPtr()->getData();
-            bool isAligned = (reinterpret_cast<uintptr_t>(rawMemPtr) & 15) == 0;
-            if (!isAligned) {
-                return true;
-            }
-        }
-    }
-
     return false;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -292,7 +292,7 @@ void Input::cloneBlobIfRequired() {
         // Majority of arithmetic and data processing instructions in legacy SSE isa requires
         // the memory address in the operands must be aligned on 16-byte boundary. To ensure
         // safely reusing ngraph const blob memory, need to check address alignment.
-        blobAlignedOnSSE = !mayiuse(cpu_isa_t::avx2) && ((reinterpret_cast<uintptr_t>(ptr) & 15) == 0);
+        blobAlignedOnSSE = mayiuse(cpu_isa_t::avx2) || ((reinterpret_cast<uintptr_t>(ptr) & 15) == 0);
 #endif
         const bool blobAlignedWithPrec = prec.size() > 1 ? (reinterpret_cast<size_t>(ptr) % prec.size()) == 0 : true;
         return blobAlignedWithPrec && blobAlignedOnSSE;

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -292,7 +292,7 @@ void Input::cloneBlobIfRequired() {
         // Majority of arithmetic and data processing instructions in legacy SSE isa requires
         // the memory address in the operands must be aligned on 16-byte boundary. To ensure
         // safely reusing ngraph const blob memory, need to check address alignment.
-        blobAlignedOnSSE = !mayiuse(cpu_isa_t::avx) && ((reinterpret_cast<uintptr_t>(ptr) & 15) == 0);
+        blobAlignedOnSSE = !mayiuse(cpu_isa_t::avx2) && ((reinterpret_cast<uintptr_t>(ptr) & 15) == 0);
 #endif
         const bool blobAlignedWithPrec = prec.size() > 1 ? (reinterpret_cast<size_t>(ptr) % prec.size()) == 0 : true;
         return blobAlignedWithPrec && blobAlignedOnSSE;


### PR DESCRIPTION
## Details:

When nstreams is 1,  CPU plugin would directly reuse the ngraph const blob memory. Current ngrpah would use mmap() to 

map the whole blob into user space memory. So there is no memory alignment from Ngrpah side. SSE41 has 16-byte memory 

alignment with some  instructions. Fix by cloning input blob if input blob is not 16 byte aligned on SSE.

### Tickets:
 - *114257*
