### PR TITLE
[apiConformance] Fix run_confoormance fails after exclusion opset tests

### DIFF
--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/run_parallel.py
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/run_parallel.py
@@ -681,11 +681,13 @@ class TestParallelRunner:
                                 copyfile(xml_file, failed_ir_xml)
                                 copyfile(bin_file, failed_ir_bin)
                                 copyfile(meta_file, failed_ir_meta)
-                output_file_name = failed_ir_dir + '.tar'
-                with tar_open(output_file_name, "w:gz") as tar:
-                    tar.add(failed_ir_dir, arcname=os.path.basename(failed_ir_dir))
-                    logger.info(f"All Conformance IRs for failed tests are saved to: {output_file_name}")
-                rmtree(failed_ir_dir)
+                # api conformance has no failed irs
+                if os.path.exists(failed_ir_dir):
+                    output_file_name = failed_ir_dir + '.tar'
+                    with tar_open(output_file_name, "w:gz") as tar:
+                        tar.add(failed_ir_dir, arcname=os.path.basename(failed_ir_dir))
+                        logger.info(f"All Conformance IRs for failed tests are saved to: {output_file_name}")
+                    rmtree(failed_ir_dir)
 
         disabled_tests_path = os.path.join(logs_dir, "disabled_tests.log")
         with open(disabled_tests_path, "w") as disabled_tests_file:


### PR DESCRIPTION
### Details:
 - *run_conformance.py and run_parallel.py fails for apiConformanceTests, because opset tests was excluded from apiConformance. So also report_op.xml and failed_ir no longer exists for apiConformance.*

### Tickets:
 - *CVS-116217*
