### PR TITLE
Increased telemetry version in requirements, corrected telemetry imports.

### DIFF
--- a/src/bindings/python/requirements.txt
+++ b/src/bindings/python/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.16.6
 singledispatchmethod; python_version<'3.8'
-openvino-telemetry>=2023.0.0
+openvino-telemetry>=2023.1.0

--- a/tools/constraints.txt
+++ b/tools/constraints.txt
@@ -18,4 +18,4 @@ pyenchant>=3.0.0
 test-generator==0.1.1
 py>=1.9.0
 urllib3>=1.26.4
-openvino-telemetry>=2022.1.0
+openvino-telemetry>=2023.1.0

--- a/tools/mo/openvino/tools/mo/convert_impl.py
+++ b/tools/mo/openvino/tools/mo/convert_impl.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 
@@ -48,7 +49,7 @@ from openvino.tools.mo.utils.guess_framework import deduce_legacy_frontend_by_na
 from openvino.tools.mo.utils.logger import init_logger, progress_printer  # pylint: disable=no-name-in-module,import-error
 from openvino.tools.mo.utils.utils import refer_to_faq_msg, check_values_equal
 from openvino.tools.mo.utils.telemetry_utils import send_params_info, send_framework_info, send_conversion_result, \
-    get_tid
+    init_mo_telemetry
 from openvino.tools.mo.moc_frontend.check_config import legacy_extensions_used  # pylint: disable=no-name-in-module,import-error
 from openvino.tools.mo.moc_frontend.pytorch_frontend_utils import get_pytorch_decoder, extract_input_info_from_example  # pylint: disable=no-name-in-module,import-error
 from openvino.tools.mo.moc_frontend.paddle_frontend_utils import paddle_frontend_converter  # pylint: disable=no-name-in-module,import-error
@@ -824,7 +825,7 @@ def _convert(cli_parser: argparse.ArgumentParser, framework, args, python_api_us
         show_mo_convert_help()
         return None, None
     simplified_mo_version = VersionChecker().get_mo_simplified_version()
-    telemetry = tm.Telemetry(tid=get_tid(), app_name='Model Optimizer', app_version=simplified_mo_version, backend='ga4')
+    telemetry = init_mo_telemetry()
     telemetry.start_session('mo')
     telemetry.send_event('mo', 'version', simplified_mo_version)
     # Initialize logger with 'ERROR' as default level to be able to form nice messages

--- a/tools/mo/openvino/tools/mo/main.py
+++ b/tools/mo/openvino/tools/mo/main.py
@@ -7,6 +7,7 @@ import sys
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 from openvino.tools.mo.convert_impl import _convert

--- a/tools/mo/openvino/tools/mo/utils/check_ie_bindings.py
+++ b/tools/mo/openvino/tools/mo/utils/check_ie_bindings.py
@@ -19,14 +19,15 @@ except ModuleNotFoundError:
 import openvino.tools.mo.utils.version as v
 try:
     import openvino_telemetry as tm  # pylint: disable=import-error,no-name-in-module
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 from openvino.tools.mo.utils.error import classify_error_type
-from openvino.tools.mo.utils.telemetry_utils import get_tid
+from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
 
 
 def send_telemetry(mo_version: str, message: str, event_type: str):
-    t = tm.Telemetry(tid=get_tid(), app_name='Version Checker', app_version=mo_version, backend='ga4')
+    t = init_mo_telemetry('Version Checker')
     # do not trigger new session if we are executing from the check from within the MO because it is actually not model
     # conversion run which we want to send
     if execution_type != 'mo':

--- a/tools/mo/openvino/tools/mo/utils/telemetry_utils.py
+++ b/tools/mo/openvino/tools/mo/utils/telemetry_utils.py
@@ -16,12 +16,13 @@ from openvino.tools.mo.utils.utils import check_values_equal
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 
 
-def init_mo_telemetry():
-    _ = tm.Telemetry(tid=get_tid(), app_name='Model Conversion API', app_version=get_rt_version(), backend='ga4')
+def init_mo_telemetry(app_name='Model Optimizer'):
+    return tm.Telemetry(tid=get_tid(), app_name=app_name, app_version=get_rt_version(), backend='ga4')
 
 
 def send_framework_info(framework: str):

--- a/tools/mo/openvino/tools/mo/utils/utils.py
+++ b/tools/mo/openvino/tools/mo/utils/utils.py
@@ -13,6 +13,7 @@ from openvino.tools.mo.front.common.partial_infer.utils import dynamic_dimension
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 

--- a/tools/mo/unit_tests/mo/extensions_test_actual.py
+++ b/tools/mo/unit_tests/mo/extensions_test_actual.py
@@ -19,6 +19,7 @@ from openvino.frontend import (
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 

--- a/tools/mo/unit_tests/mo/unit_test_with_mocked_telemetry.py
+++ b/tools/mo/unit_tests/mo/unit_test_with_mocked_telemetry.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 

--- a/tools/mo/unit_tests/mo/utils/freeze_placeholder_test.py
+++ b/tools/mo/unit_tests/mo/utils/freeze_placeholder_test.py
@@ -52,6 +52,7 @@ def base_args_config(use_legacy_fe: bool = None, use_new_fe: bool = None):
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 

--- a/tools/mo/unit_tests/mo/utils/mo_fallback_test_actual.py
+++ b/tools/mo/unit_tests/mo/utils/mo_fallback_test_actual.py
@@ -20,8 +20,10 @@ from generator import generator, generate
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
+
 
 def base_args_config(use_legacy_fe:bool=None, use_new_fe:bool=None):
     args = argparse.Namespace()

--- a/tools/mo/unit_tests/mo/utils/mo_fallback_test_tf_fe.py
+++ b/tools/mo/unit_tests/mo/utils/mo_fallback_test_tf_fe.py
@@ -14,6 +14,7 @@ from openvino.tools.mo.convert_impl import prepare_ir
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 

--- a/tools/mo/unit_tests/mo/utils/telemetry_utils_test.py
+++ b/tools/mo/unit_tests/mo/utils/telemetry_utils_test.py
@@ -12,6 +12,7 @@ from unit_tests.utils.graph import build_graph, regular_op
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
 

--- a/tools/mo/unit_tests/mo/utils/test_mo_model_analysis_actual.py
+++ b/tools/mo/unit_tests/mo/utils/test_mo_model_analysis_actual.py
@@ -15,8 +15,10 @@ from openvino.frontend import FrontEndManager # pylint: disable=no-name-in-modul
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
+
 
 def base_args_config():
     args = argparse.Namespace()

--- a/tools/ovc/openvino/tools/ovc/convert_impl.py
+++ b/tools/ovc/openvino/tools/ovc/convert_impl.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.ovc.telemetry_stub as tm
 
@@ -29,7 +30,7 @@ from openvino.tools.ovc.version import VersionChecker
 from openvino.tools.ovc.utils import check_values_equal
 from openvino.tools.ovc.logger import init_logger
 from openvino.tools.ovc.telemetry_utils import send_params_info, send_conversion_result, \
-    get_tid
+    init_mo_telemetry
 from openvino.tools.ovc.moc_frontend.pytorch_frontend_utils import get_pytorch_decoder, extract_input_info_from_example
 from openvino.tools.ovc.moc_frontend.paddle_frontend_utils import paddle_frontend_converter
 
@@ -424,9 +425,8 @@ def _convert(cli_parser: argparse.ArgumentParser, args, python_api_used):
     if 'help' in args and args['help']:
         show_mo_convert_help()
         return None, None
-    framework = None
     simplified_ie_version = VersionChecker().get_ie_simplified_version()
-    telemetry = tm.Telemetry(tid=get_tid(), app_name='Model Conversion API', app_version=simplified_ie_version, backend='ga4')
+    telemetry = init_mo_telemetry()
     telemetry.start_session('mo')
     telemetry.send_event('mo', 'version', simplified_ie_version)
     # Initialize logger with 'ERROR' as default level to be able to form nice messages

--- a/tools/ovc/openvino/tools/ovc/main.py
+++ b/tools/ovc/openvino/tools/ovc/main.py
@@ -6,6 +6,7 @@ import sys
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.ovc.telemetry_stub as tm
 from openvino.tools.ovc.convert_impl import _convert

--- a/tools/ovc/openvino/tools/ovc/telemetry_utils.py
+++ b/tools/ovc/openvino/tools/ovc/telemetry_utils.py
@@ -11,13 +11,13 @@ from openvino.tools.ovc.utils import check_values_equal
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.ovc.telemetry_stub as tm
 
 
-def init_mo_telemetry():
-    _ = tm.Telemetry(tid=get_tid(), app_name='Model Conversion API', app_version=get_rt_version(), backend='ga4')
-
+def init_mo_telemetry(app_name='Model Conversion API'):
+    return tm.Telemetry(tid=get_tid(), app_name=app_name, app_version=get_rt_version(), backend='ga4')
 
 def send_framework_info(framework: str):
     """

--- a/tools/ovc/openvino/tools/ovc/utils.py
+++ b/tools/ovc/openvino/tools/ovc/utils.py
@@ -10,6 +10,7 @@ from openvino.tools.ovc.error import Error
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.ovc.telemetry_stub as tm
 

--- a/tools/ovc/unit_tests/ovc/unit_test_with_mocked_telemetry.py
+++ b/tools/ovc/unit_tests/ovc/unit_test_with_mocked_telemetry.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 try:
     import openvino_telemetry as tm
+    from openvino_telemetry.backend import backend_ga4
 except ImportError:
     import openvino.tools.ovc.telemetry_stub as tm
 


### PR DESCRIPTION
Root cause analysis: 

Telemetry package with version less than 2023.1.0 causes error during Telemetry initialization with GA4 backend.

Solution: 
Increase openvino_telemetry version in requirements to 2023.1.0
In case if GA4 backend is not available use telemetry_stab class.

Ticket: 116174


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update