### PR TITLE
[CPU] MatMul: move i8 compressed constants constant folding to the plugin

### DIFF
--- a/src/common/low_precision_transformations/src/convert_subtract_constant.cpp
+++ b/src/common/low_precision_transformations/src/convert_subtract_constant.cpp
@@ -50,6 +50,10 @@ ngraph::pass::low_precision::ConvertSubtractConstant::ConvertSubtractConstant(co
         const auto quantizePrecision = weightsConvert->get_input_element_type(0);
         const auto dequantizationPrecision = weightsConvert->get_output_element_type(0);
 
+        if (transformation_callback(m.get_match_root())) {
+            return false;
+        }
+
         // validation by Convert operation input precisions
         if (!constantPrecisions.empty()) {
             const ngraph::element::Type inputPrecision = quantizePrecision;

--- a/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
@@ -469,3 +469,53 @@ TEST_F(TransformationTestsF, MarkDequantizationSubgraphTransformationNotConstant
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
 }
+
+TEST_F(TransformationTestsF, MarkDequantizationSubgraphTransformationFoldSubConst) {
+    // Input graph:           After transformation:
+    //
+    // Constant    Constant               Constant
+    //    |U8         |U8                    |U8
+    //    |           |                      |
+    // Convert     Convert                Convert(DCF)  Constant
+    //    |FP32   /F32                       |FP32      /FP32
+    //    |      /                            \        /
+    //   Subtract  Constant                    Subtract   Constant
+    //    |FP32    /FP32                          |FP32     /FP32
+    //    |       /                                \        /
+    //   Multiply                                   Multiply
+    //
+    // After MarkDequantizationSubgraph all Subtract and Multiply nodes from above graph
+    // are marked with 'DequantizationNode' attribute.
+    // Also all 'Convert(DCF)' node before weights is marked with 'DisableConstantFolding' attribute
+    // but Convert before Dequantization Sub const isn't because fold_subtract_const is set to true
+
+    {
+        auto weights = opset10::Constant::create(element::u8, Shape{4, 16, 1, 1}, {3});
+        auto convert = std::make_shared<opset10::Convert>(weights, element::f32);
+        auto zero_point = opset10::Constant::create(element::u8, Shape{}, {127});
+        auto convert_on_zero_point = std::make_shared<opset10::Convert>(zero_point, element::f32);
+        auto subtract = std::make_shared<opset10::Subtract>(convert, convert_on_zero_point);
+        auto scale = opset10::Constant::create(element::f32, Shape{}, {0.2});
+        auto multiply = std::make_shared<opset10::Multiply>(subtract, scale);
+        function = std::make_shared<ov::Model>(ov::OutputVector{multiply});
+    }
+
+    manager.register_pass<pass::MarkDequantizationSubgraph>(element::TypeVector{element::u8}, true);
+    manager.register_pass<pass::ConstantFolding>();
+
+    {
+        auto weights = opset10::Constant::create(element::u8, Shape{4, 16, 1, 1}, {3});
+        auto convert = std::make_shared<opset10::Convert>(weights, element::f32);
+        pass::disable_constant_folding(convert);
+        auto zero_point = opset10::Constant::create(element::f32, Shape{}, {127});
+        auto subtract = std::make_shared<opset10::Subtract>(convert, zero_point);
+        mark_as_dequantization_node(subtract);
+        auto scale = opset10::Constant::create(element::f32, Shape{}, {0.2});
+        auto multiply = std::make_shared<opset10::Multiply>(subtract, scale);
+        mark_as_dequantization_node(multiply);
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{multiply});
+    }
+
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
+}

--- a/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
+++ b/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
@@ -22,7 +22,7 @@ namespace pass {
 class TRANSFORMATIONS_API MarkDequantizationSubgraph : public MatcherPass {
 public:
     OPENVINO_RTTI("MarkDequantizationSubgraph", "0");
-    MarkDequantizationSubgraph(const element::TypeVector& precisions);
+    MarkDequantizationSubgraph(const element::TypeVector& precisions, const bool fold_subtract_const = false);
 };
 }  // namespace pass
 }  // namespace ov

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -11,7 +11,8 @@
 #include <transformations/rt_info/disable_constant_folding.hpp>
 #include <transformations/utils/utils.hpp>
 
-ov::pass::MarkDequantizationSubgraph::MarkDequantizationSubgraph(const element::TypeVector& precisions) {
+ov::pass::MarkDequantizationSubgraph::MarkDequantizationSubgraph(const element::TypeVector& precisions,
+                                                                 const bool fold_subtract_const) {
     // Dequantization subgraph may have two forms: with and without Subtract
     //
     //    Input                                 Input
@@ -67,7 +68,8 @@ ov::pass::MarkDequantizationSubgraph::MarkDequantizationSubgraph(const element::
             // mark Subtract as dequantization node
             ov::mark_as_dequantization_node(subtract_it->second.get_node_shared_ptr());
             auto zero_point = pattern_map.at(zero_point_pattern).get_node_shared_ptr();
-            if (ov::is_type<opset10::Convert>(zero_point) && input_precision == zero_point->get_input_element_type(0) &&
+            if (!fold_subtract_const && ov::is_type<opset10::Convert>(zero_point) &&
+                input_precision == zero_point->get_input_element_type(0) &&
                 ov::is_type<opset10::Constant>(zero_point->get_input_node_ptr(0))) {
                 // disable ConstantFolding also for Convert on zero_point
                 // so we don't have to constantfold it and then convert it back to

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -36,6 +36,10 @@ ov::pass::MarkDequantizationSubgraph::MarkDequantizationSubgraph(const element::
         auto input = pattern_map.at(input_pattern).get_node_shared_ptr();
         const auto multiply = m.get_match_root();
 
+        if (transformation_callback(multiply)) {
+            return false;
+        }
+
         auto subtract_it = pattern_map.find(subtract_pattern);
         if (subtract_it == pattern_map.end()) {
             for (size_t i = 0; i < multiply->get_input_size(); i++) {

--- a/src/plugins/intel_cpu/src/graph_optimizer.h
+++ b/src/plugins/intel_cpu/src/graph_optimizer.h
@@ -21,6 +21,7 @@ public:
 
 private:
     void FuseConvMatmulFCDeconvAndDQScales(Graph &graph);
+    void FuseFCAndWeightsDecompression(Graph &graph);
     void FuseConvolutionMatMulDeconvAndBias(Graph &graph);
     void FuseDeconvolutionAndSimpleOperation(Graph &graph);
     void FuseMultiplyAndAdd(Graph &graph);

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -57,6 +57,12 @@ public:
     void executeDynamicImpl(dnnl::stream strm) override;
     bool canBeExecutedInInt8() const override;
 
+    void fuseDecompressionMultiply(const NodePtr& constData);
+    const std::vector<float>& fuseDecompressionMultiply() const { return decompressionMultiply; }
+
+    void fuseDecompressionSubtract(const NodePtr& constData);
+    const std::vector<float>& fuseDecompressionSubtract() const { return decompressionSubtract; }
+
 private:
     void createDescriptorInternal(const dnnl::memory::desc &inputDesc,
                                   const dnnl::memory::desc &outputDesc);
@@ -107,6 +113,9 @@ private:
     void executeMLAS();
     void prepackMLASWeight();
 #endif
+
+    std::vector<float> decompressionSubtract;
+    std::vector<float> decompressionMultiply;
 };
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -58,10 +58,10 @@ public:
     bool canBeExecutedInInt8() const override;
 
     void fuseDecompressionMultiply(const NodePtr& constData);
-    const std::vector<float>& fuseDecompressionMultiply() const { return decompressionMultiply; }
+    const std::vector<float>& getDecompressionMultiply() const { return decompressionMultiply; }
 
     void fuseDecompressionSubtract(const NodePtr& constData);
-    const std::vector<float>& fuseDecompressionSubtract() const { return decompressionSubtract; }
+    const std::vector<float>& getDecompressionSubtract() const { return decompressionSubtract; }
 
 private:
     void createDescriptorInternal(const dnnl::memory::desc &inputDesc,
@@ -99,6 +99,7 @@ private:
                                     const dnnl::engine& engine);
 
     bool canBeExecutedInConv1x1() const;
+    void fuseDecompressionConstant(const NodePtr& constData, std::vector<float>& decompressionValues);
 
     // sparse weights
     bool useSparseWeights = false;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_matmul_to_fc.cpp
@@ -14,7 +14,10 @@
 ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
     MATCHER_SCOPE(ConvertMatMulToFC);
     auto activations_m = ngraph::pattern::any_input(ngraph::pattern::has_static_rank());
-    auto weights_m = ngraph::pattern::wrap_type<ngraph::opset1::Constant, ngraph::opset1::Convert>(ngraph::pattern::has_static_rank());
+    auto weights_path = [](const ov::Output<ov::Node>& output) {
+        return ov::op::util::is_on_constant_path(output.get_node_shared_ptr());
+    };
+    auto weights_m = ngraph::pattern::any_input(weights_path);
     auto matmul_m = ngraph::pattern::wrap_type<ngraph::opset1::MatMul>({ activations_m, weights_m }, ngraph::pattern::has_static_rank());
 
     ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.cpp
@@ -94,14 +94,6 @@ ov::intel_cpu::MoveFCReshapeToWeights::MoveFCReshapeToWeights() {
         squeeze_constant(weights);
         if (with_subtract)
             squeeze_constant(mul_parent->get_input_node_shared_ptr(1));
-
-        // We have to call validate manually because validation pass doesn't change these shapes
-        // TODO: investigate
-        convert->validate_and_infer_types();
-        if (with_subtract)
-            mul_parent->validate_and_infer_types();
-        mul->validate_and_infer_types();
-
         return true;
     };
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/cpu_opset/common/op/fully_connected.hpp"
+#include "move_fc_reshape_to_weights.hpp"
+#include <transformations/utils/utils.hpp>
+#include <openvino/pass/pattern/op/wrap_type.hpp>
+#include <openvino/pass/pattern/op/or.hpp>
+#include <openvino/opsets/opset1.hpp>
+
+#include "itt.hpp"
+
+ov::intel_cpu::MoveFCReshapeToWeights::MoveFCReshapeToWeights() {
+    MATCHER_SCOPE(MoveFCReshapeToWeights);
+    using namespace ov::pass::pattern;
+    auto weights_m = wrap_type<ov::opset1::Constant>(consumers_count(1));
+    auto convert_m = wrap_type<ov::opset1::Convert>({weights_m});
+
+    auto sub_const_m = wrap_type<ov::opset1::Constant>(consumers_count(1));
+    auto subtract_m = wrap_type<ov::opset1::Subtract>({convert_m, sub_const_m});
+
+    auto mul_const_m = wrap_type<ov::opset1::Constant>(consumers_count(1));
+    auto mul_with_sub_m = wrap_type<ov::opset1::Multiply>({subtract_m, mul_const_m}, rank_equals(3));
+    auto mul_no_sub_m = wrap_type<ov::opset1::Multiply>({convert_m, mul_const_m}, rank_equals(3));
+    auto mul_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{mul_with_sub_m, mul_no_sub_m});
+
+    auto one_consumer_rank_2 = [](const ov::Output<ov::Node>& out) {
+        return consumers_count(1)(out) && rank_equals(2)(out);
+    };
+    auto reshape_const_m = wrap_type<ov::opset1::Constant>();
+    auto reshape_m = wrap_type<ov::opset1::Reshape>({mul_m, reshape_const_m}, one_consumer_rank_2);
+
+    auto transpose_const_m = wrap_type<ov::opset1::Constant>();
+    auto transpose_m = wrap_type<ov::opset1::Transpose>({reshape_m, transpose_const_m});
+    auto weights_input_m = std::make_shared<ov::pass::pattern::op::Or>(ov::OutputVector{reshape_m, transpose_m});
+
+    auto data_m = any_input();
+    auto fully_connected_m = wrap_type<ov::intel_cpu::FullyConnectedNode>({data_m, weights_input_m});
+
+    ov::matcher_pass_callback callback = [&](ov::pass::pattern::Matcher& m) {
+        const auto fully_connected = m.get_match_root();
+        const auto weights_path = fully_connected->get_input_node_shared_ptr(1);
+        const bool with_transpose = ov::is_type<ov::opset1::Transpose>(weights_path);
+        if (with_transpose) {
+            const auto transpose_const = ov::as_type_ptr<ov::opset1::Constant>(weights_path->get_input_node_shared_ptr(1));
+            if (transpose_const->cast_vector<int>() != std::vector<int>{1, 0}) {
+                return false;
+            }
+        }
+
+        const auto reshape = with_transpose ? weights_path->get_input_node_shared_ptr(0) : weights_path;
+        std::cout << "All is OK\n\n" << std::endl;
+        // // Create FullyConnected
+        // auto output_rank = matmul->get_output_partial_shape(0).rank();
+        // auto fc = std::make_shared<ov::intel_cpu::FullyConnectedNode>(fc_input_a, fc_input_b, output_rank,
+        //         matmul->get_output_element_type(0));
+        // fc->set_friendly_name(matmul->get_friendly_name());
+        // new_ops.push_back(fc);
+        // ov::copy_runtime_info(matmul, new_ops);
+        // ov::replace_node(matmul, fc);
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(fully_connected_m, matcher_name);
+    this->register_matcher(m, callback);
+}

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <openvino/pass/graph_rewrite.hpp>
+
+namespace ov {
+namespace intel_cpu {
+
+/**
+ * This transformation is applied to the FC with compressed 3D u8 weights. It moves Reshape at the weights path to the constants
+ * in order to constant fold the Reshape node.
+ * Example:
+ *                    Weights(3D)                                            Weights(2D)
+ *                       |                                                      |
+ *                    Convert    Subtract_const(3D)                          Convert    Subtract_const(2D)
+ *                       |      /                                               |      /
+ *                   Subtract(opt)                                          Subtract(opt)
+ *                       |      Multiply_const(3D)        ====>                 |      Multiply_const(2D)
+ *                       |     /                                                |     /
+ *                    Multiply                                               Multiply
+ *                       |                                                      |
+ *                    Reshape(2D)                                               |
+ *                       |                                                      |
+ *         Data      Transpose(opt)                               Data      Transpose(opt)
+ *             \     /                                                \     /
+ *         FullyConnected                                         FullyConnected
+ */
+class MoveFCReshapeToWeights: public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("MoveFCReshapeToWeights", "0");
+    MoveFCReshapeToWeights();
+};
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
@@ -33,7 +33,8 @@ inline void ConvertToCPUSpecificOpset(std::shared_ptr<ngraph::Function> &nGraphF
     ngraph::pass::Manager manager;
     manager.set_per_pass_validation(false);
     CPU_REGISTER_PASS_COMMON(manager, ConvertMatMulToFC);
-    CPU_REGISTER_PASS_COMMON(manager, MoveFCReshapeToWeights);
+    CPU_REGISTER_PASS_X64(manager, MoveFCReshapeToWeights);
+    CPU_REGISTER_PASS_X64(manager, ov::pass::Validate);
     CPU_REGISTER_PASS_COMMON(manager, AlignMatMulInputRanks);
     CPU_REGISTER_PASS_COMMON(manager, ConvertTileToSeqTiles);
     CPU_REGISTER_PASS_X64(manager, ConvertToPowerStatic);

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
@@ -14,6 +14,7 @@
 #include "common/pass/convert_to_power_static.hpp"
 #include "common/pass/convert_to_leaky_relu.hpp"
 #include "common/pass/convert_to_swish_cpu.hpp"
+#include "common/pass/move_fc_reshape_to_weights.hpp"
 #include "transformations/convert_precision.hpp"
 #include "transformations/utils/utils.hpp"
 #include "common/pass/rnn_sequences_optimization.hpp"
@@ -32,6 +33,7 @@ inline void ConvertToCPUSpecificOpset(std::shared_ptr<ngraph::Function> &nGraphF
     ngraph::pass::Manager manager;
     manager.set_per_pass_validation(false);
     CPU_REGISTER_PASS_COMMON(manager, ConvertMatMulToFC);
+    CPU_REGISTER_PASS_COMMON(manager, MoveFCReshapeToWeights);
     CPU_REGISTER_PASS_COMMON(manager, AlignMatMulInputRanks);
     CPU_REGISTER_PASS_COMMON(manager, ConvertTileToSeqTiles);
     CPU_REGISTER_PASS_X64(manager, ConvertToPowerStatic);

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
@@ -400,7 +400,7 @@ bool isSuitableReduceChild(const std::shared_ptr<const Node> &node, const int ch
 bool isSuitableMatMulWithConstantPath(const std::shared_ptr<Node>& node) {
     return ov::is_type<ov::opset1::MatMul>(node) &&
            !ov::is_type<ov::opset1::Constant>(node->get_input_node_shared_ptr(1)) &&
-           ov::op::util::is_on_constant_path(node->get_input_node_shared_ptr(1));
+           ov::op::util::is_on_constant_path(node->input_value(1));
 }
 // Continue fusing chain of the passed type if the node has one child
 // Otherwise mark node as FusedTerminator (Fused, but fusing chain is interrupted)

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
@@ -416,7 +416,7 @@ bool isSuitableMatMulCompressedWeights(const std::shared_ptr<Node>& node) {
     if (consumers.size() != 1)
         return false;
     const auto consumer = consumers.begin()->get_node()->shared_from_this();
-    return ov::is_type<ov::opset1::MatMul>(consumer) && ov::op::util::is_constfoldable(multiply);
+    return ov::is_type<ov::opset1::MatMul>(consumer) && ov::op::util::is_on_constant_path(multiply);
 }
 // Continue fusing chain of the passed type if the node has one child
 // Otherwise mark node as FusedTerminator (Fused, but fusing chain is interrupted)

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -211,7 +211,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     } else {
         // MarkDequantizationSubgraph is used even in non-LPT pipeline on X64 platforms
         // in order to keep compressed u8 MatMul weights with decompression operations as is
-        CPU_REGISTER_PASS_X64(manager, ov::pass::MarkDequantizationSubgraph, ov::element::TypeVector{ov::element::u8});
+        CPU_REGISTER_PASS_X64(manager, ov::pass::MarkDequantizationSubgraph, ov::element::TypeVector{ov::element::u8}, true);
         CPU_SET_CALLBACK_X64(manager, [](const_node_ptr &node) -> bool {
             auto get_single_consumer = [](const_node_ptr &node) -> std::shared_ptr<ov::Node> {
                 const auto consumers = node->get_output_target_inputs(0);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -206,8 +206,33 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::KeepConstAndDecompressionForMatMul);
 
     const bool useLpt = !defaultPrecisions.empty();
-    if (useLpt) {
-        CPU_REGISTER_PASS_COMMON(manager, ov::pass::MarkDequantizationSubgraph, defaultPrecisions);
+    // MarkDequantizationSubgraph is used even in non-LPT pipeline to keep compressed MatMul weights as is
+    const auto mark_dequantization_precisions = useLpt ? defaultPrecisions : ngraph::pass::low_precision::precision_set::int8_support;
+    CPU_REGISTER_PASS_COMMON(manager, ov::pass::MarkDequantizationSubgraph, mark_dequantization_precisions);
+
+    if (!useLpt) {
+        CPU_SET_CALLBACK_COMMON(manager, [](const_node_ptr &node) -> bool {
+            auto get_single_consumer = [](const_node_ptr &node) -> std::shared_ptr<ov::Node> {
+                const auto consumers = node->get_output_target_inputs(0);
+                if (consumers.size() != 1)
+                    return nullptr;
+                return consumers.begin()->get_node()->shared_from_this();
+            };
+
+            auto consumer = get_single_consumer(node);
+            if (!consumer)
+                return true;
+
+            if (ov::is_type<ov::opset1::MatMul>(consumer)) {
+                return false;
+            } else if (ov::is_type<ov::opset1::Transpose>(consumer)) {
+                consumer = get_single_consumer(consumer);
+                if (consumer != nullptr && ov::is_type<ov::opset1::MatMul>(consumer)) {
+                    return false;
+                }
+            }
+            return true;
+        }, ov::pass::MarkDequantizationSubgraph);
     }
 
     auto get_convert_precisions = []() {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -188,6 +188,8 @@ std::vector<std::string> disabledTestPatterns() {
         // New plugin API doesn't support changes of pre-processing
         R"(.*(Auto|Multi|Hetero).*InferRequestPreprocessTest.*SetPreProcessToInputInfo.*)",
         R"(.*(Auto|Multi|Hetero).*InferRequestPreprocessTest.*SetPreProcessToInferRequest.*)",
+        // Issue: 113727
+        R"(.*MatMulCompressedU8Weights.*)",
     };
 
 #if defined(OPENVINO_ARCH_X86)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -189,7 +189,7 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*(Auto|Multi|Hetero).*InferRequestPreprocessTest.*SetPreProcessToInputInfo.*)",
         R"(.*(Auto|Multi|Hetero).*InferRequestPreprocessTest.*SetPreProcessToInferRequest.*)",
         // Issue: 113727
-        R"(.*MatMulCompressedU8Weights.*)",
+        R"(.*MatMulCompressedWeights.*)",
     };
 
 #if defined(OPENVINO_ARCH_X86)

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_reshape_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_reshape_concat.cpp
@@ -110,15 +110,11 @@ public:
             results.push_back(std::make_shared<ngraph::opset1::Result>(soft_max->output(i)));
 
         function = std::make_shared<ngraph::Function>(results, input_params, "ConcatReshapeConcatPattern");
-        ov::pass::Serialize serializer("ngraph.xml", "ngraph.bin");
-        serializer.run_on_model(function);
     }
 };
 
 TEST_P(ConcatReshapeConcatSubgraphTest, CompareWithRefs) {
     run();
-    ov::pass::Serialize serializer("exec_graph_dyn.xml", "exec_graph_dyn.bin");
-    serializer.run_on_model(std::const_pointer_cast<ov::Model>(compiledModel.get_runtime_model()));
 }
 
 namespace {

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_compressed_i8_weights.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_compressed_i8_weights.cpp
@@ -1,0 +1,203 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils/fusing_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "transformations/rt_info/decompression.hpp"
+
+using namespace ngraph;
+using namespace InferenceEngine;
+using namespace CPUTestUtils;
+using namespace ov::test;
+
+namespace SubgraphTestsDefinitions {
+
+/* Graph before:
+   ------------             ------------
+   |Input(f32)|             |Input(f16)|
+   ------------             ------------
+        |                        |
+        |                   --------------
+        |                   |Convert(f32)|
+        |                   --------------
+        |                        |
+    -----------------------------------------------
+    |                   MatMul                    |
+    -----------------------------------------------
+                          |
+                       --------
+                       |Output|
+                       --------
+
+ * Exec graph:
+   ------------    ------------
+   |Input(f32)|    |Input(f16)|
+   ------------    ------------
+        |               |
+   ----------------------------
+   |      FullyConnected      |
+   ----------------------------
+                 |
+              --------
+              |Output|
+              --------
+*/
+static std::shared_ptr<ov::Model> initSubgraph(std::vector<ov::PartialShape>& inputShapes,
+                                               const ov::element::Type data_precision,
+                                               const ov::element::Type weights_precision,
+                                               const bool transpose_weights,
+                                               const bool add_subtract) {
+    auto params = builder::makeDynamicParams(data_precision, {inputShapes[0]});
+
+        auto transpose_if_necessary = [&](const ov::Shape& shape) {
+            if (!transpose_weights)
+                return shape;
+            auto transposed_shape = shape;
+            std::swap(*transposed_shape.rbegin(), *(transposed_shape.rbegin() + 1));
+            return transposed_shape;
+        };
+
+        auto weights_shape = transpose_if_necessary(inputShapes[1].to_shape());
+        auto weights = ngraph::builder::makeConstant<uint8_t>(weights_precision, weights_shape, {}, true);
+        auto weights_convert = std::make_shared<ngraph::opset1::Convert>(weights, data_precision);
+
+        std::shared_ptr<ov::Node> mul_parent = weights_convert;
+        auto output_channels = transpose_weights ? *(weights_shape.rbegin() + 1) : *weights_shape.rbegin();
+        auto scaleshift_target_shape = transpose_if_necessary(ov::Shape{1, output_channels});
+        if (add_subtract) {
+            auto shift_const = ngraph::builder::makeConstant<uint8_t>(weights_precision, ov::Shape{output_channels}, {}, true);
+            auto shift_convert = std::make_shared<ngraph::opset1::Convert>(shift_const, data_precision);
+            auto shift_reshape_const = ov::opset10::Constant::create(ov::element::i32, {scaleshift_target_shape.size()}, scaleshift_target_shape);
+            auto shift_reshape = std::make_shared<ov::opset10::Reshape>(shift_convert, shift_reshape_const, false);
+            mul_parent = std::make_shared<ov::opset10::Subtract>(weights_convert, shift_reshape);
+        }
+
+        auto scale_const = ngraph::builder::makeConstant<float>(data_precision, ov::Shape{output_channels}, {}, true);
+        auto scale_reshape_const = ov::opset10::Constant::create(ov::element::i32, {scaleshift_target_shape.size()}, scaleshift_target_shape);
+        auto scale_reshape = std::make_shared<ov::opset10::Reshape>(scale_const, scale_reshape_const, false);
+        auto multiply = std::make_shared<ov::opset10::Multiply>(mul_parent, scale_reshape);
+
+        std::shared_ptr<ov::Node> matmul_weights = multiply;
+        if (transpose_weights) {
+            const size_t rank = matmul_weights->get_output_partial_shape(0).size();
+            std::vector<int> order(rank);
+            std::iota(order.begin(), order.end(), 0);
+            std::swap(*order.rbegin(), *(order.rbegin() + 1));
+            const auto transpose_constant = ov::opset10::Constant::create(ov::element::i32, {rank}, order);
+            const auto transpose = std::make_shared<ov::opset10::Transpose>(matmul_weights, transpose_constant);
+            matmul_weights = transpose;
+        }
+        auto matMul = builder::makeMatMul(params[0], matmul_weights);
+        ov::Shape bias_const_shape{static_cast<size_t>(matMul->get_output_partial_shape(0).rbegin()->get_length())};
+        // TODO: remove bias?
+        auto bias_const = ngraph::builder::makeConstant<float>(data_precision, bias_const_shape, {}, true);
+        auto bias = std::make_shared<ov::opset10::Add>(matMul, bias_const);
+
+        return std::make_shared<ov::Model>(matMul, params, "MatmulWeightsDecompression");
+}
+
+using MatMulDecompressConvertParams = std::tuple<std::vector<InputShape>,            // input shapes
+                                                 bool,                               // transpose on weights
+                                                 bool,                               // decompression subtract
+                                                 std::map<std::string, std::string>  // additional config
+                                                 >;
+
+class MatMulCompressedI8Weights : public testing::WithParamInterface<MatMulDecompressConvertParams>,
+                                  virtual public SubgraphBaseTest,
+                                  public CPUTestsBase {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<MatMulDecompressConvertParams> obj) {
+        std::vector<InputShape> inputShapes;
+        bool transpose;
+        bool decompression_sub;
+        std::map<std::string, std::string> additionalConfig;
+
+        std::tie(inputShapes, transpose, decompression_sub, additionalConfig) = obj.param;
+
+        std::ostringstream result;
+        for (const auto& shape : inputShapes) {
+            result << CommonTestUtils::partialShape2str({shape.first}) << "_";
+        }
+        result << "TS=";
+        for (const auto& shape : inputShapes) {
+            result << "(";
+            if (!shape.second.empty()) {
+                auto itr = shape.second.begin();
+                do {
+                    result << CommonTestUtils::vec2str(*itr);
+                } while (++itr != shape.second.end() && result << "_");
+            }
+            result << ")_";
+        }
+        result << "transpose_weights=" << transpose << "_";
+        result << "decompression_subtract=" << decompression_sub << "_";
+
+        result << "config=(";
+        for (const auto& configEntry : additionalConfig) {
+            result << configEntry.first << ", " << configEntry.second << ":";
+        }
+        result << ")";
+
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+
+        std::vector<InputShape> inputShapes;
+        bool transpose_weights;
+        bool decompression_sub;
+        std::map<std::string, std::string> additionalConfig;
+
+        std::tie(inputShapes, transpose_weights, decompression_sub, additionalConfig) = this->GetParam();
+
+        configuration.insert(additionalConfig.begin(), additionalConfig.end());
+        init_input_shapes(inputShapes);
+
+        ElementType netType = element::f32;
+        if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES)
+            netType = ElementType::bf16;
+        inType = outType = netType;
+
+        function = initSubgraph(inputDynamicShapes, netType, ov::element::u8, transpose_weights, decompression_sub);
+    }
+};
+
+TEST_P(MatMulCompressedI8Weights, CompareWithRefs) {
+    run();
+    CheckNumberOfNodesWithType(compiledModel, "Convert", 0);
+    CheckNumberOfNodesWithType(compiledModel, "Eltwise", 0);
+}
+
+namespace {
+
+std::vector<std::map<std::string, std::string>> filterAdditionalConfig() {
+    std::vector<std::map<std::string, std::string>> additionalConfig{CPUTestUtils::cpuEmptyPluginConfig};
+    // if (with_cpu_x86_avx512_core()) {
+    //     additionalConfig.push_back({{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}});
+    // }
+
+    return additionalConfig;
+}
+
+const std::vector<std::vector<InputShape>> input_shapes = {
+    {{{}, {{1, 4, 16}}}, {{}, {{16, 32}}}},
+    {{{}, {{1, 4, 16}}}, {{}, {{1, 16, 32}}}},
+    {{{}, {{1, 2, 3}}}, {{}, {{1, 3, 4}}}}
+};
+const std::vector<bool> transpose_weights = {true, false};
+const std::vector<bool> add_decompression_sub = {true, false};
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedI8Weights,
+                         MatMulCompressedI8Weights,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes),
+                                            ::testing::ValuesIn(transpose_weights),
+                                            ::testing::ValuesIn(add_decompression_sub),
+                                            ::testing::ValuesIn(filterAdditionalConfig())),
+                         MatMulCompressedI8Weights::getTestCaseName);
+} // namespace
+
+} // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
@@ -192,6 +192,7 @@ protected:
         const size_t expected_count = additional_config[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES ? 1 : 0;
         CheckNumberOfNodesWithType(compiledModel, "Convert", expected_count);
         CheckNumberOfNodesWithType(compiledModel, "Eltwise", expected_count);
+        CheckNumberOfNodesWithType(compiledModel, "Subgraph", 0);
     }
 };
 

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/convert_matmul_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/convert_matmul_test.cpp
@@ -35,7 +35,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest1) {
     }
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 3, 2, 2 });
-        auto transpose_constant = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 3 }, { 0, 2, 1 });
+        auto transpose_constant = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 3 }, { 0, 2, 1 });
         auto transpose = std::make_shared<ngraph::opset1::Transpose>(input1, transpose_constant);
         auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2, 2 }, { 1 });
         auto matmul = std::make_shared<FullyConnectedNode>(transpose, input2, ngraph::Rank(3));
@@ -280,29 +280,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_2) {
     }
 }
 
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_3_with_bias) {
-    {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 5, 2, 3 });
-        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 2, 3 }, { 1 });
-        auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, weights, false, true);
-        auto biases = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 1, 2 }, { 1 });
-        auto add = std::make_shared<ngraph::opset1::Add>(matmul, biases);
-
-        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input1 });
-        manager.register_pass<ConvertMatMulToFC>();
-    }
-    {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 5, 2, 3 });
-
-        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2, 3 }, { 1 });
-        auto matmul = std::make_shared<FullyConnectedNode>(input1, weights,  ngraph::Rank(2));
-        auto biases = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{  1, 1, 2 }, { 1 });
-        auto add = std::make_shared<ngraph::opset1::Add>(matmul, biases);
-        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input1 });
-    }
-}
-
-TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_3_without_bias) {
+TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_3) {
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 5, 2, 3 });
         auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 2, 3 }, { 1 });
@@ -315,7 +293,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_3_witho
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 5, 2, 3 });
 
         auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2, 3 }, { 1 });
-        auto matmul = std::make_shared<FullyConnectedNode>(input1, weights,  ngraph::Rank(2));
+        auto matmul = std::make_shared<FullyConnectedNode>(input1, weights,  ngraph::Rank(3));
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
     }
 }
@@ -354,12 +332,45 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_1) {
     }
     {
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 3, 2, 2 });
-        auto transpose_constant = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 3 }, { 0, 2, 1 });
+        auto transpose_constant = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 3 }, { 0, 2, 1 });
         auto transpose = std::make_shared<ngraph::opset1::Transpose>(input1, transpose_constant);
         auto input2 = ngraph::opset1::Constant::create(ngraph::element::f16, ngraph::Shape{2, 2 }, { 1 });
         auto convert = std::make_shared<ngraph::opset1::Convert>(input2, ngraph::element::f32);
         auto matmul = std::make_shared<FullyConnectedNode>(transpose, convert, ngraph::Rank(3));
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+    }
+}
+
+TEST_F(TransformationTestsF, ConvertMatMulToFCTest_compressed_u8_weights) {
+    {
+        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 2, 2});
+        auto weights = ngraph::opset1::Constant::create(ngraph::element::u8, ngraph::Shape{1, 2, 2}, {1});
+        auto convert = std::make_shared<ngraph::opset1::Convert>(weights, ngraph::element::f32);
+        auto sub_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 2}, {1});
+        auto sub = std::make_shared<ngraph::opset1::Subtract>(convert, sub_const);
+        auto mul_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 2}, {1});
+        auto mul = std::make_shared<ngraph::opset1::Multiply>(sub, mul_const);
+        auto matmul = std::make_shared<ngraph::opset1::MatMul>(data, mul);
+
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{data});
+        manager.register_pass<ConvertMatMulToFC>();
+    }
+    {
+        auto data = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 2, 2});
+        auto weights = ngraph::opset1::Constant::create(ngraph::element::u8, ngraph::Shape{1, 2, 2}, {1});
+        auto convert = std::make_shared<ngraph::opset1::Convert>(weights, ngraph::element::f32);
+        auto sub_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 2}, {1});
+        auto sub = std::make_shared<ngraph::opset1::Subtract>(convert, sub_const);
+        auto mul_const = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 2}, {1});
+        auto mul = std::make_shared<ngraph::opset1::Multiply>(sub, mul_const);
+
+        auto reshape_const = ngraph::opset1::Constant::create(ov::element::i32, {2}, {2, -1});
+        auto reshape = std::make_shared<ngraph::opset1::Reshape>(mul, reshape_const, false);
+        auto transpose_const = ngraph::opset1::Constant::create(ov::element::i32, {2}, {1, 0});
+        auto transpose = std::make_shared<ngraph::opset1::Transpose>(reshape, transpose_const);
+        auto matmul = std::make_shared<FullyConnectedNode>(data, transpose, ngraph::Rank(3));
+
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ data });
     }
 }

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_fc_reshape_to_weights.cpp
@@ -86,7 +86,6 @@ protected:
         ref_weights_shape.erase(ref_weights_shape.begin());
         model = initModel(input_shapes.first, input_shapes.second, add_transpose, add_subtract, true);
         model_ref = initModel(input_shapes.first, ref_weights_shape, add_transpose, add_subtract, false);
-        manager.register_pass<ov::pass::Serialize>("/home/vgolubev/models/test.xml", "");
         manager.register_pass<MoveFCReshapeToWeights>();
     }
 };

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_fc_reshape_to_weights.cpp
@@ -1,0 +1,132 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include <openvino/core/model.hpp>
+#include <openvino/opsets/opset1.hpp>
+#include <transformations/cpu_opset/common/op/fully_connected.hpp>
+#include <transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.hpp>
+#include <transformations/init_node_info.hpp>
+#include <transformations/utils/utils.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+using namespace testing;
+using namespace ov::intel_cpu;
+
+using MoveFCReshapeToWeightsParams = std::tuple<std::pair<ov::PartialShape, ov::Shape>,  // data_shape - weights_shape
+                                                bool,                                    // add transpose
+                                                bool>;                                   // add subtract
+
+class MoveFCReshapeToWeightsTests : public TransformationTestsF, public WithParamInterface<MoveFCReshapeToWeightsParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<MoveFCReshapeToWeightsParams> obj) {
+        std::pair<ov::PartialShape, ov::Shape> input_shapes;
+        bool add_transpose;
+        bool add_subtract;
+        std::tie(input_shapes, add_transpose, add_subtract) = obj.param;
+
+        std::ostringstream result;
+        result << "Input_shape=(" << input_shapes.first << ")_Weights_shape=(" << input_shapes.second
+               << ")_add_transpose=" << add_transpose << "_add_subtract=" << add_subtract;
+        return result.str();
+    }
+
+    static std::shared_ptr<ov::Model> initModel(const ov::PartialShape& data_shape,
+                                                const ov::Shape& weigths_shape,
+                                                const bool add_transpose,
+                                                const bool add_subtract,
+                                                const bool add_reshape) {
+        auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f32, data_shape);
+        std::shared_ptr<ov::Node> weights_path = ov::opset1::Constant::create(ov::element::u8, weigths_shape, {1});
+        weights_path = std::make_shared<ov::opset1::Convert>(weights_path, ov::element::f32);
+
+        ov::Shape decompression_shape(weigths_shape.size(), 1);
+        const size_t n_idx = add_transpose ? weigths_shape.size() - 1 : weigths_shape.size() - 2;
+        decompression_shape[n_idx] = weigths_shape[n_idx];
+
+        if (add_subtract) {
+            auto sub_const = ov::opset1::Constant::create(ov::element::f32, decompression_shape, {1});
+            weights_path = std::make_shared<ov::opset1::Subtract>(weights_path, sub_const);
+        }
+        auto mul_const = ov::opset1::Constant::create(ov::element::f32, decompression_shape, {1});
+        weights_path = std::make_shared<ov::opset1::Multiply>(weights_path, mul_const);
+
+        if (add_reshape) {
+            auto reshape_const = ov::opset1::Constant::create(ov::element::i32, {2}, {2, -1});
+            weights_path = std::make_shared<ov::opset1::Reshape>(weights_path, reshape_const, false);
+        }
+        if (add_transpose) {
+            auto transpose_const = ov::opset1::Constant::create(ov::element::i32, {2}, {1, 0});
+            weights_path = std::make_shared<ov::opset1::Transpose>(weights_path, transpose_const);
+        }
+        auto fully_connected = std::make_shared<FullyConnectedNode>(data, weights_path, ov::Rank(3));
+        return std::make_shared<ov::Model>(ov::NodeVector{fully_connected}, ov::ParameterVector{data});
+    }
+
+protected:
+    void SetUp() override {
+        // TransformationTestsF::SetUp();
+        std::pair<ov::PartialShape, ov::Shape> input_shapes;
+        bool add_transpose;
+        bool add_subtract;
+        std::tie(input_shapes, add_transpose, add_subtract) = this->GetParam();
+
+        ov::Shape ref_weights_shape = input_shapes.second;
+        ref_weights_shape.erase(ref_weights_shape.begin());
+        model = initModel(input_shapes.first, input_shapes.second, add_transpose, add_subtract, true);
+        model_ref = initModel(input_shapes.first, ref_weights_shape, add_transpose, add_subtract, false);
+        manager.register_pass<ov::pass::Serialize>("/home/vgolubev/models/test.xml", "");
+        manager.register_pass<MoveFCReshapeToWeights>();
+    }
+};
+
+TEST_P(MoveFCReshapeToWeightsTests, CompareFunctions) {}
+
+const std::vector<std::pair<ov::PartialShape, ov::Shape>> input_shapes = {
+    {{1, 2, 4}, {1, 4, 3}}
+};
+const std::vector<bool> add_transpose = {false, true};
+const std::vector<bool> add_subtract = {false, true};
+
+INSTANTIATE_TEST_SUITE_P(TransformationTests, MoveFCReshapeToWeightsTests,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(input_shapes),
+                                ::testing::ValuesIn(add_transpose),
+                                ::testing::ValuesIn(add_subtract)),
+                            MoveFCReshapeToWeightsTests::getTestCaseName);
+
+// TEST_F(TransformationTestsF, MoveFCReshapeToWeights) {
+//     {
+//         auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
+//         auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{1, 2, 2}, {1});
+//         auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f32);
+//         auto sub_const = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 2}, {1});
+//         auto sub = std::make_shared<ov::opset1::Subtract>(convert, sub_const);
+//         auto mul_const = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 2}, {1});
+//         auto mul = std::make_shared<ov::opset1::Multiply>(sub, mul_const);
+
+//         auto reshape_const = ov::opset1::Constant::create(ov::element::i32, {2}, {2, -1});
+//         auto reshape = std::make_shared<ov::opset1::Reshape>(mul, reshape_const, false);
+//         auto transpose_const = ov::opset1::Constant::create(ov::element::i32, {2}, {1, 0});
+//         auto transpose = std::make_shared<ov::opset1::Transpose>(reshape, transpose_const);
+//         auto matmul = std::make_shared<FullyConnectedNode>(data, transpose, ov::Rank(3));
+
+//         model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data});
+//         manager.register_pass<MoveFCReshapeToWeights>();
+//     }
+//     {
+//         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
+//         auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
+//         auto transpose = std::make_shared<ov::opset1::Transpose>(input1, transpose_constant);
+//         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
+//         auto matmul = std::make_shared<FullyConnectedNode>(transpose, input2, ov::Rank(3));
+
+//         model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+//     }
+// }

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_fc_reshape_to_weights.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.hpp>
+
 #include <gtest/gtest.h>
 
 #include <string>
@@ -10,7 +12,6 @@
 #include <openvino/core/model.hpp>
 #include <openvino/opsets/opset1.hpp>
 #include <transformations/cpu_opset/common/op/fully_connected.hpp>
-#include <transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
 
@@ -93,7 +94,7 @@ protected:
 TEST_P(MoveFCReshapeToWeightsTests, CompareFunctions) {}
 
 const std::vector<std::pair<ov::PartialShape, ov::Shape>> input_shapes_wo_transpose = {
-    {{1, 2, 3}, {1, 4, 3}}
+    {{-1, -1, -1}, {1, 4, 3}}
 };
 const std::vector<bool> add_transpose = {false, true};
 const std::vector<bool> add_subtract = {false, true};
@@ -104,33 +105,3 @@ INSTANTIATE_TEST_SUITE_P(TransformationTests_wo_transpose, MoveFCReshapeToWeight
                                 ::testing::ValuesIn(add_transpose),
                                 ::testing::ValuesIn(add_subtract)),
                             MoveFCReshapeToWeightsTests::getTestCaseName);
-
-// TEST_F(TransformationTestsF, MoveFCReshapeToWeights) {
-//     {
-//         auto data = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-//         auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{1, 2, 2}, {1});
-//         auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f32);
-//         auto sub_const = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 2}, {1});
-//         auto sub = std::make_shared<ov::opset1::Subtract>(convert, sub_const);
-//         auto mul_const = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 2}, {1});
-//         auto mul = std::make_shared<ov::opset1::Multiply>(sub, mul_const);
-
-//         auto reshape_const = ov::opset1::Constant::create(ov::element::i32, {2}, {2, -1});
-//         auto reshape = std::make_shared<ov::opset1::Reshape>(mul, reshape_const, false);
-//         auto transpose_const = ov::opset1::Constant::create(ov::element::i32, {2}, {1, 0});
-//         auto transpose = std::make_shared<ov::opset1::Transpose>(reshape, transpose_const);
-//         auto matmul = std::make_shared<FullyConnectedNode>(data, transpose, ov::Rank(3));
-
-//         model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data});
-//         manager.register_pass<MoveFCReshapeToWeights>();
-//     }
-//     {
-//         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
-//         auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
-//         auto transpose = std::make_shared<ov::opset1::Transpose>(input1, transpose_constant);
-//         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
-//         auto matmul = std::make_shared<FullyConnectedNode>(transpose, input2, ov::Rank(3));
-
-//         model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
-//     }
-// }

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_fc_reshape_to_weights.cpp
@@ -92,12 +92,11 @@ protected:
 
 TEST_P(MoveFCReshapeToWeightsTests, CompareFunctions) {}
 
-const std::vector<bool> add_transpose = {false, true};
-const std::vector<bool> add_subtract = {false, true};
-
 const std::vector<std::pair<ov::PartialShape, ov::Shape>> input_shapes_wo_transpose = {
     {{1, 2, 3}, {1, 4, 3}}
 };
+const std::vector<bool> add_transpose = {false, true};
+const std::vector<bool> add_subtract = {false, true};
 
 INSTANTIATE_TEST_SUITE_P(TransformationTests_wo_transpose, MoveFCReshapeToWeightsTests,
                         ::testing::Combine(


### PR DESCRIPTION
### Details:
 - *Reused LPT pass for ConstantFold pass disabling for decompression subgraph*
 - *GraphOptimizer: added FuseFCAndWeightsDecompression transformation*
 - *Transformation pipeline adapted to the MatMuls with compressed weights*
 - *Added MoveFCReshapeToWeights CPU transformation*

### Tickets:
 - *CVS-113732*
