### PR TITLE
[GPU] fix accuracy issue in Dolly 

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -310,8 +310,9 @@ void primitive_inst::update_shape() {
         }
         auto dep_mem = _network.get_output_memory(dep_id);
         memory_deps.insert({i, dep_mem});
-        if (!get_node().is_in_shape_of_subgraph() && !dep.is_in_shape_of_subgraph())
+        if (!dep.is_in_shape_of_subgraph()) {
             has_runtime_deps = true;
+        }
     }
 
     if (has_runtime_deps) {


### PR DESCRIPTION
### Details:
 - Revert partial change in PR18596 to fix acc issue in dolly for dGPU
 - The issue happens by removing sync before shapeof 
 - The sync issue only happens in a complicated network execution, cannot reproduce with unittest


