### PR TITLE
Disabled multi_isa in ARM CPU plugin

### DIFF
--- a/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
+++ b/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
@@ -177,7 +177,8 @@ elseif(NOT TARGET arm_compute::arm_compute)
         list(APPEND ARM_COMPUTE_OPTIONS estate=64)
         if(NOT APPLE AND CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.2)
             # arm_sve.h header is not available on gcc older 10.2
-            list(APPEND ARM_COMPUTE_OPTIONS multi_isa=1)
+            # TODO: validate it on machines with FP16 / SVE support and enabled back
+            # list(APPEND ARM_COMPUTE_OPTIONS multi_isa=1)
         endif()
     endif()
 


### PR DESCRIPTION
### Details:
 - It currently does not affect any production code, because we use gcc older than 10 in production builds.
 - But in conda-forge or Ubuntu 22.04 newer compiler versions are used and this branch is triggered. But it leads to internal issues inside the scons build.