### PR TITLE
[Snippets] Optimized second attempt of SplitDimensionM optimization

### DIFF
--- a/src/common/snippets/include/snippets/pass/common_optimizations.hpp
+++ b/src/common/snippets/include/snippets/pass/common_optimizations.hpp
@@ -18,7 +18,7 @@ public:
     CommonOptimizations(const SnippetsTokenization::Config& config = {});
 
     // Returns True if parallelism work amount can be increased using SplitDimensionM optimization
-    static bool CanOptimizeParallelWA(const std::shared_ptr<const ov::Node>& node, size_t minimal_concurrency);
+    static bool CanOptimizeParallelWA(const std::shared_ptr<const ov::Node>& node, size_t concurrency);
 
 private:
     // Move up Constants which aren't scalars from body to Subgraph and replace them with Parameters inside body
@@ -28,7 +28,7 @@ private:
     // Insert Reshape nodes after and before Parameters and Results in Subgraphs with MatMul inside
     // to split dimension M for MatMuls to increase work amount for parallelism
     // Note: works only with 3D MHA patterns
-    void SplitDimensionM(const std::shared_ptr<op::Subgraph>& subgraph, size_t minimal_concurrency);
+    void SplitDimensionM(const std::shared_ptr<op::Subgraph>& subgraph, size_t concurrency);
 };
 
 }  // namespace pass

--- a/src/common/snippets/include/snippets/pass/tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/tokenization.hpp
@@ -61,11 +61,11 @@ public:
      * @ingroup snippets
      */
     struct Config {
-        Config(size_t minimal_concurrency = 1, bool split_m_dimension = true, bool enable_transpose_on_output = true)
-            : minimal_concurrency(minimal_concurrency), split_m_dimension(split_m_dimension),
+        Config(size_t concurrency = 1, bool split_m_dimension = true, bool enable_transpose_on_output = true)
+            : concurrency(concurrency), split_m_dimension(split_m_dimension),
               mha_token_enable_transpose_on_output(enable_transpose_on_output) {}
 
-        size_t minimal_concurrency = 1;
+        size_t concurrency = 1;
         // True if "SplitDimensionM" optimization is enabled. Otherwise, it's disabled.
         bool split_m_dimension = true;
         // False if Transpose on output isn't tokenized in MHA Tokenization.

--- a/src/common/snippets/src/pass/common_optimizations.cpp
+++ b/src/common/snippets/src/pass/common_optimizations.cpp
@@ -277,7 +277,7 @@ void CommonOptimizations::SplitDimensionM(const std::shared_ptr<ov::snippets::op
                 const auto shape_const = ov::as_type_ptr<ov::op::v0::Constant>(broadcast->input_value(1).get_node_shared_ptr());
                 OPENVINO_ASSERT(shape_const, "SplitDimensionM expects Broadcast with Constant output shape");
                 const auto new_shape = get_updated_shape(shape_const->cast_vector<size_t>(), true);
-                broadcast->set_argument(1, std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{new_shape.size()}, new_shape));
+                broadcast->set_argument(1, std::make_shared<ov::op::v0::Constant>(shape_const->get_element_type(), ov::Shape{new_shape.size()}, new_shape));
             }
         }
         subgraph->validate_and_infer_types();

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -90,23 +90,13 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM) {
     run();
 }
 
-TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM_NotFullConcurrency) {
-    const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{4, 256, 128}, {4, 128, 256}, {4, 256, 128}},
-                                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32}),
-                                                 std::vector<Shape>{{4, 4, 64, 128}, {4, 1, 128, 256}, {4, 1, 256, 128}, {4, 256, 128}});
-    function = f.getOriginal();
-    function_ref = f.getReference();
-    config.concurrency = 18;
-    run();
-}
-
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM_AlmostAllThreads) {
-    const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{5, 384, 32}, {5, 32, 384}, {5, 384, 32}},
+    const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{5, 30, 32}, {5, 32, 30}, {5, 30, 32}},
                                                  std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32}),
-                                                 std::vector<Shape>{{5, 3, 128, 32}, {5, 1, 32, 384}, {5, 1, 384, 32}, {5, 384, 32}});
+                                                 std::vector<Shape>{{5, 6, 5, 32}, {5, 1, 32, 30}, {5, 1, 30, 32}, {5, 30, 32}});
     function = f.getOriginal();
     function_ref = f.getReference();
-    config.concurrency = 8;
+    config.concurrency = 32;
     run();
 }
 

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -86,7 +86,27 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM) {
                                                  std::vector<Shape>{{10, 9, 1024, 128}, {10, 1, 128, 9216}, {10, 1, 9216, 128}, {10, 9216, 128}});
     function = f.getOriginal();
     function_ref = f.getReference();
-    config.minimal_concurrency = 18;
+    config.concurrency = 18;
+    run();
+}
+
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM_NotFullConcurrency) {
+    const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{4, 256, 128}, {4, 128, 256}, {4, 256, 128}},
+                                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32}),
+                                                 std::vector<Shape>{{4, 4, 64, 128}, {4, 1, 128, 256}, {4, 1, 256, 128}, {4, 256, 128}});
+    function = f.getOriginal();
+    function_ref = f.getReference();
+    config.concurrency = 18;
+    run();
+}
+
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM_AlmostAllThreads) {
+    const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{5, 384, 32}, {5, 32, 384}, {5, 384, 32}},
+                                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32}),
+                                                 std::vector<Shape>{{5, 3, 128, 32}, {5, 1, 32, 384}, {5, 1, 384, 32}, {5, 384, 32}});
+    function = f.getOriginal();
+    function_ref = f.getReference();
+    config.concurrency = 8;
     run();
 }
 
@@ -96,7 +116,7 @@ TEST_F(SKIP_TokenizeMHASnippetsTests /* CVS-114607 */, smoke_Snippets_MHASelect_
                                                                {8, 1, 64, 512}, {8, 512, 512}});
     function = f.getOriginal();
     function_ref = f.getReference();
-    config.minimal_concurrency = 16;
+    config.concurrency = 16;
     run();
 }
 

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -110,7 +110,7 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM_AlmostAllThreads) {
     run();
 }
 
-TEST_F(SKIP_TokenizeMHASnippetsTests /* CVS-114607 */, smoke_Snippets_MHASelect_SplitM) {
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHASelect_SplitM) {
     const auto& f = MHASelectSplitMFunction(std::vector<PartialShape>{{8, 512, 18}, {8, 18, 64}, {1, 512, 64}, {1, 1, 64}, {8, 64, 512}},
                                             std::vector<Shape>{{8, 2, 256, 18}, {8, 1, 18, 64}, {1, 2, 256, 64}, {1, 1, 1, 64},
                                                                {8, 1, 64, 512}, {8, 512, 512}});

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -579,7 +579,7 @@ void Transformations::MainSnippets(void) {
     // To avoid sitations when Transpose is not alone node between MatMul and Result,
     // Plugin disables Transpose tokenization on output
     tokenization_config.mha_token_enable_transpose_on_output = (inferencePrecision == ov::element::f32);
-    tokenization_config.minimal_concurrency = parallel_get_num_threads();
+    tokenization_config.concurrency = parallel_get_num_threads();
     // The optimization "SplitDimensionM" depends on target machine (thread count).
     // To avoid uncontrolled behavior in tests, we disabled the optimization when there is Config::SnippetsMode::IgnoreCallback
     tokenization_config.split_m_dimension = snippetsMode != Config::SnippetsMode::IgnoreCallback;
@@ -642,7 +642,7 @@ void Transformations::MainSnippets(void) {
             const auto is_unsupported_parallel_work_amount =
                 parallel_get_num_threads() / 2 > parallel_work_amount &&
                 static_cast<size_t>(parallel_work_amount) < needed_num_of_threads &&
-                !ov::snippets::pass::CommonOptimizations::CanOptimizeParallelWA(n, tokenization_config.minimal_concurrency);
+                !ov::snippets::pass::CommonOptimizations::CanOptimizeParallelWA(n, tokenization_config.concurrency);
             return is_unsupported_parallel_work_amount;
         };
 #endif // OPENVINO_ARCH_X86_64


### PR DESCRIPTION
### Details:
 - *SplitDimensionM optimization has 2 tries to reshape body. First step splits dimension `M` of MHA pattern into two `batch_dim` and `new_dim_m` to have `batch * batch_dim % threads == 0` - all threads have the same work amount. If it's not possible, we have Second step (second attempt). On the master branch this stage tries to make `new_dim_m` as the most value that `new_dim_m < optimal_m_dim`. It's not optimal way since not all threads have work anyway. The PR updates this step. Now the algorithm tries to select such values so that as many threads as possible have work (see the comment for `[ Second Step ]`)*
 - *Removed `optimal_m_dim` to increase work thread amount*

### Tickets:
 - *115284*
