### PR TITLE
Use of share_memory parameter in tf.Graph decoder.

### DIFF
--- a/src/bindings/python/src/openvino/frontend/tensorflow/graph_iterator.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/graph_iterator.py
@@ -10,12 +10,13 @@ from openvino.frontend.tensorflow.py_tensorflow_frontend import _FrontEndPyGraph
 
 
 class GraphIteratorTFGraph(GraphIterator):
-    def __init__(self, tf_graph: tf.Graph, inner_graph: bool = False):
+    def __init__(self, tf_graph: tf.Graph, share_weights: bool, inner_graph: bool = False):
         GraphIterator.__init__(self)
         self.m_graph = tf_graph
         self.m_node_index = 0
         self.m_decoders = []
         self.m_inner_graph = inner_graph
+        self.m_share_weights = share_weights
 
         self.m_vars = None
         if hasattr(tf_graph, "variables"):
@@ -24,7 +25,7 @@ class GraphIteratorTFGraph(GraphIterator):
             self.m_vars = tf_graph.variables
 
         for op in tf_graph.get_operations():
-            self.m_decoders.append(TFGraphNodeDecoder(op, inner_graph))
+            self.m_decoders.append(TFGraphNodeDecoder(op, share_weights, inner_graph))
 
         self.m_iterators = {}
         for func_name, _ in self.m_graph._functions.items():
@@ -85,5 +86,7 @@ class GraphIteratorTFGraph(GraphIterator):
         if func_name not in self.m_iterators:
             return None
         if self.m_iterators[func_name] is None:
-            self.m_iterators[func_name] = GraphIteratorTFGraph(self.m_graph._functions[func_name].graph, True)
+            self.m_iterators[func_name] = GraphIteratorTFGraph(self.m_graph._functions[func_name].graph,
+                                                               self.m_share_weights,
+                                                               True)
         return self.m_iterators[func_name]

--- a/src/bindings/python/src/openvino/frontend/tensorflow/node_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/node_decoder.py
@@ -47,7 +47,7 @@ def tf_attr_to_ov(attr):
 
 
 class TFGraphNodeDecoder(DecoderBase):
-    def __init__(self, operation: tf.Operation, inner_graph: bool):
+    def __init__(self, operation: tf.Operation, share_weights: bool, inner_graph: bool):
         DecoderBase.__init__(self)
         assert isinstance(operation, tf.Operation), "Unknown operation type. " \
                                                     "Expected tf.Operation, got {}".format(type(operation))
@@ -57,9 +57,7 @@ class TFGraphNodeDecoder(DecoderBase):
 
         # Copies value from inner buffer of TF_Operation to NodeDef class.
         self.m_node_def = self.m_operation.node_def
-
-        # TODO: Create parameter in convert_model() for turning on/off shared memory, ticket: 114971
-        self.m_shared_memory = True
+        self.m_shared_memory = share_weights
 
         if self.m_operation.type == "Const":
             self.m_data_type = tf.dtypes.DType(self.m_node_def.attr["dtype"].type).name

--- a/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
@@ -143,7 +143,7 @@ def type_supported_by_tf_fe(input_model):
     return False
 
 
-def create_tf_graph_iterator(input_model, placeholder_shapes, placeholder_data_types, example_input):
+def create_tf_graph_iterator(input_model, placeholder_shapes, placeholder_data_types, example_input, share_weights):
     input_model = trace_tf_model_if_needed(input_model, placeholder_shapes, placeholder_data_types, example_input)
 
     import tensorflow as tf
@@ -151,9 +151,9 @@ def create_tf_graph_iterator(input_model, placeholder_shapes, placeholder_data_t
     if model_is_graph_iterator(input_model):
         return input_model
     if isinstance(input_model, tf.Graph):
-        return GraphIteratorTFGraph(input_model)
+        return GraphIteratorTFGraph(input_model, share_weights)
     elif isinstance(input_model, tf.types.experimental.ConcreteFunction):
-        return GraphIteratorTFGraph(input_model.graph)
+        return GraphIteratorTFGraph(input_model.graph, share_weights)
     raise Exception("Could not wrap model of type {} to GraphIteratorTFGraph.".format(type(input_model)))
 
 

--- a/tools/mo/openvino/tools/mo/convert_impl.py
+++ b/tools/mo/openvino/tools/mo/convert_impl.py
@@ -395,7 +395,8 @@ def prepare_ir(argv: argparse.Namespace):
                 argv.input_model = create_tf_graph_iterator(argv.input_model,
                                                             argv.placeholder_shapes,
                                                             argv.placeholder_data_types,
-                                                            getattr(argv, "example_input", None))
+                                                            getattr(argv, "example_input", None),
+                                                            argv.share_weights)
             try:
                 t.send_event("mo", "conversion_method", moc_front_end.get_name() + "_frontend")
                 moc_front_end.add_extension(TelemetryExtension("mo", t.send_event, t.send_error, t.send_stack_trace))

--- a/tools/ovc/openvino/tools/ovc/convert_impl.py
+++ b/tools/ovc/openvino/tools/ovc/convert_impl.py
@@ -135,7 +135,8 @@ def prepare_ir(argv: argparse.Namespace):
             argv.input_model = create_tf_graph_iterator(argv.input_model,
                                                         argv.placeholder_shapes,
                                                         argv.placeholder_data_types,
-                                                        getattr(argv, "example_input", None))
+                                                        getattr(argv, "example_input", None),
+                                                        argv.share_weights)
         t.send_event("mo", "conversion_method", moc_front_end.get_name() + "_frontend")
         moc_front_end.add_extension(TelemetryExtension("mo", t.send_event, t.send_error, t.send_stack_trace))
         if new_extensions_used(argv):


### PR DESCRIPTION
Description: 
Used "share_memory" parameter to turn on/off shared memory in tf.Graph decoder.

Ticket: 114971


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update