### PR TITLE
[GPU] Add onednn reorder selection available at bfzyx, b_fs_zyx_fsv32.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -195,10 +195,12 @@ public:
         }
 
         auto format = impl_param.get_output_layout().format;
-        if (format == format::b_fs_zyx_fsv16 ||
-            format == format::bs_fs_zyx_bsv16_fsv16 ||
-            format == format::bs_fs_yx_bsv16_fsv16 ||
-            format == format::b_fs_zyx_fsv32)
+        if ((format == format::b_fs_zyx_fsv16 ||
+             format == format::bs_fs_zyx_bsv16_fsv16 ||
+             format == format::bs_fs_yx_bsv16_fsv16 ||
+             format == format::b_fs_zyx_fsv32) &&
+            (input_layout.data_type == data_types::f16 ||
+             input_layout.data_type == data_types::f32))
             conv_optional_params.allowInputReordering = true;
 
         conv_params.set_dynamic_shape_offsets();

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1463,8 +1463,10 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
 
         std::vector<format> onednn_optimized_fmt = {
             format::bfyx,
+            format::bfzyx,
             format::b_fs_zyx_fsv16,
             format::b_fs_yx_fsv16,
+            format::b_fs_zyx_fsv32,
             format::b_fs_yx_fsv32,
             format::bs_fs_zyx_bsv8_fsv4,
             format::bs_fs_yx_bsv8_fsv4,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/resample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/resample_gpu_test.cpp
@@ -1834,6 +1834,7 @@ TYPED_TEST_SUITE(onnx_5d_format,  cldnn_5d_formats);
 TYPED_TEST(onnx_5d_format, interpolate_linear_onnx5d)
 {
     auto& engine = get_test_engine();
+    auto config = get_test_default_config(engine);
 
     std::size_t i = 0;
     for (const auto& s : this->shapes_and_attrs) {
@@ -1858,7 +1859,7 @@ TYPED_TEST(onnx_5d_format, interpolate_linear_onnx5d)
 
         set_values(input, this->input_data_list[i]);
 
-        cldnn::network net {engine, topology };
+        cldnn::network net {engine, topology, config};
         net.set_input_data("input", input);
         auto outputs = net.execute();
 


### PR DESCRIPTION
Add to use onednn Reorder at bfzyx, b_fs_zyx_fsv32(5dims)

allowInputReordring is available in case float data_type.
It's the failure of unit-test unt-test. allowInputReordring white-list format is for gen9_common_conv_fwd_data_f16/f32. But convolution_kernel_b_fs_zyx_fsv16_imad also support zyx_fsv16 format and it cause an accuracy issue without padding. So we need to add the condition for only gen9_common_conv_kernel (float input only).
    
    

### Tickets:
 - *116368*
