### PR TITLE
Fixed -Wabi warnings in headers

### DIFF
--- a/src/core/include/openvino/pass/pass_config.hpp
+++ b/src/core/include/openvino/pass/pass_config.hpp
@@ -56,6 +56,9 @@ using param_callback_map = std::map<ov::DiscreteTypeInfo, param_callback>;
 /// \ingroup ov_pass_cpp_api
 class OPENVINO_API PassConfig {
 public:
+    /// \brief Default constructor
+    PassConfig();
+
     /// \brief Disable transformation by its type_info
     /// \param type_info Transformation type_info
     void disable(const DiscreteTypeInfo& type_info);
@@ -157,9 +160,7 @@ public:
     void add_disabled_passes(const PassConfig& rhs);
 
 private:
-    param_callback m_callback = [](const std::shared_ptr<const ::ov::Node>&) {
-        return false;
-    };
+    param_callback m_callback;
     param_callback_map m_callback_map;
     std::unordered_set<DiscreteTypeInfo> m_disabled;
     std::unordered_set<DiscreteTypeInfo> m_enabled;

--- a/src/core/src/pass/pass_config.cpp
+++ b/src/core/src/pass/pass_config.cpp
@@ -4,6 +4,12 @@
 
 #include "openvino/pass/pass_config.hpp"
 
+ov::pass::PassConfig::PassConfig() {
+    m_callback = [](const std::shared_ptr<const ::ov::Node>&) {
+        return false;
+    };
+}
+
 ov::pass::param_callback ov::pass::PassConfig::get_callback(const DiscreteTypeInfo& type_info) const {
     const auto& it = m_callback_map.find(type_info);
     if (it != m_callback_map.end()) {

--- a/src/frontends/onnx/frontend/include/openvino/frontend/onnx/extension/conversion.hpp
+++ b/src/frontends/onnx/frontend/include/openvino/frontend/onnx/extension/conversion.hpp
@@ -26,6 +26,8 @@ public:
           m_domain{domain},
           m_converter(converter) {}
 
+    ~ConversionExtension() override;
+
     const std::string& get_domain() const {
         return m_domain;
     }

--- a/src/frontends/onnx/frontend/src/extensions.cpp
+++ b/src/frontends/onnx/frontend/src/extensions.cpp
@@ -1,0 +1,7 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/onnx/extension/conversion.hpp"
+
+ov::frontend::onnx::ConversionExtension::~ConversionExtension() = default;

--- a/src/frontends/paddle/include/openvino/frontend/paddle/extension/conversion.hpp
+++ b/src/frontends/paddle/include/openvino/frontend/paddle/extension/conversion.hpp
@@ -23,6 +23,8 @@ public:
         : ConversionExtensionBase(op_type),
           m_converter(converter) {}
 
+    ~ConversionExtension() override;
+
     const ov::frontend::CreatorFunctionNamed& get_converter() const {
         return m_converter;
     }

--- a/src/frontends/paddle/src/extensions.cpp
+++ b/src/frontends/paddle/src/extensions.cpp
@@ -1,0 +1,7 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/paddle/extension/conversion.hpp"
+
+ov::frontend::paddle::ConversionExtension::~ConversionExtension() = default;

--- a/src/frontends/pytorch/include/openvino/frontend/pytorch/extension/conversion.hpp
+++ b/src/frontends/pytorch/include/openvino/frontend/pytorch/extension/conversion.hpp
@@ -27,7 +27,7 @@ public:
         return m_converter;
     }
 
-    ~ConversionExtension() override = default;
+    ~ConversionExtension() override;
 
 private:
     ov::frontend::CreatorFunction m_converter;

--- a/src/frontends/pytorch/src/extensions.cpp
+++ b/src/frontends/pytorch/src/extensions.cpp
@@ -1,0 +1,7 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/extension/conversion.hpp"
+
+ov::frontend::pytorch::ConversionExtension::~ConversionExtension() = default;


### PR DESCRIPTION
### Details:
 - Fixed warnings like:
 ```
In file included from $SRC_DIR/src/core/include/openvino/pass/pass.hpp:16,
                 from $SRC_DIR/src/core/include/openvino/pass/graph_rewrite.hpp:11,
                 from $SRC_DIR/src/frontends/common/include/openvino/frontend/node_context.hpp:10,
                 from $SRC_DIR/src/frontends/paddle/include/openvino/frontend/paddle/decoder.hpp:7,
                 from $SRC_DIR/src/frontends/paddle/include/openvino/frontend/paddle/node_context.hpp:7,
                 from $SRC_DIR/src/frontends/paddle/src/op/hard_sigmoid.cpp:5:
$SRC_DIR/src/core/include/openvino/pass/pass_config.hpp:160:33: warning: the mangled name of 'ov::pass::PassConfig::<lambda(const std::shared_ptr<const ov::Node>&)>::operator bool (*)(const std::shared_ptr<const ov::Node>&)() const' changed between '-fabi-version=11' ('_ZNK2ov4pass10PassConfig10m_callbackMUlRKSt10shared_ptrIKNS_4NodeEEE_cvPFbS7_EEv') and '-fabi-version=18' ('_ZNK2ov4pass10PassConfig10m_callbackMUlRKSt10shared_ptrIKNS_4NodeEEE_cvPFbS8_EEv') [-Wabi]
  160 |     param_callback m_callback = [](const std::shared_ptr<const ::ov::Node>&) {
      |                                 ^
$SRC_DIR/src/core/include/openvino/pass/pass_config.hpp:160:33: warning: the mangled name of 'static bool ov::pass::PassConfig::<lambda(const std::shared_ptr<const ov::Node>&)>::_FUN(const std::shared_ptr<const ov::Node>&)' changed between '-fabi-version=11' ('_ZN2ov4pass10PassConfig10m_callbackMUlRKSt10shared_ptrIKNS_4NodeEEE_4_FUNES7_') and '-fabi-version=18' ('_ZN2ov4pass10PassConfig10m_callbackMUlRKSt10shared_ptrIKNS_4NodeEEE_4_FUNES8_') [-Wabi]
```
 - Added destructors for frontend conversion extensions classes to ensure that extensions will depend on frontend library.
