### PR TITLE
Fix `get_directory()` to return `/` on Linux

### DIFF
--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -87,7 +87,7 @@ std::string ov::util::get_directory(const std::string& s) {
     // Linux-style separator
     auto pos = s.find_last_of('/');
     if (pos != std::string::npos) {
-        rc = s.substr(0, pos);
+        rc = s.substr(0, pos ? pos : 1);
         return rc;
     }
     // Windows-style separator

--- a/src/tests/test_utils/common_test_utils/tests/utils_tests.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/utils_tests.cpp
@@ -1,0 +1,14 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "openvino/util/file_util.hpp"
+
+using namespace testing;
+using namespace ov::util;
+
+TEST(UtilsTests, get_directory_returns_root) {
+    ASSERT_EQ(get_directory("/test"), "/");
+}


### PR DESCRIPTION
### Details:
 - Fixes https://github.com/openvinotoolkit/openvino/issues/18243
