### PR TITLE
[apiConformanceReport] Fix double 'passed' in 'all test amount' and fist mandatory view

### DIFF
--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/summarize.py
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/summarize.py
@@ -364,8 +364,8 @@ def create_api_summary(xml_paths: list, output_folder: str, expected_devices:lis
                             api_info[test_type.tag].setdefault(sw_plugin_name, {device.tag: {}})
                             api_info[test_type.tag][sw_plugin_name][device.tag] = {'passrate': float(sw_plugin.get('passrate', 0)),
                                                                                    'relative_passrate': float(sw_plugin.get('relative_passrate', 0)),
-                                                                                   'relative_all': float(sw_plugin.get('relative_all', 0)),
-                                                                                   'relative_passed': float(sw_plugin.get('relative_passed', 0)),
+                                                                                   'relative_all': int(float(sw_plugin.get('relative_all', 0))),
+                                                                                   'relative_passed': int(float(sw_plugin.get('relative_passed', 0))),
                                                                                    'passed': int(sw_plugin.get('passed', 0)), 
                                                                                    'failed': int(sw_plugin.get('failed', 0)),
                                                                                    'crashed': int(sw_plugin.get('crashed', 0)),
@@ -373,8 +373,8 @@ def create_api_summary(xml_paths: list, output_folder: str, expected_devices:lis
                                                                                    'hanged': int(sw_plugin.get('hanged', 0)),
                                                                                    'test_amout': int(sw_plugin.get('passed', 0)) +\
                                                                                                     int(sw_plugin.get('failed', 0)) +\
-                                                                                                    int(sw_plugin.get('passed', 0)) +\
                                                                                                     int(sw_plugin.get('crashed', 0)) +\
+                                                                                                    int(sw_plugin.get('skipped', 0)) +\
                                                                                                     int(sw_plugin.get('hanged', 0))}
 
             except ET.ParseError:

--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/template/report_api_template.html
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/template/report_api_template.html
@@ -133,13 +133,13 @@
                                         data-hanged="{{api_info[test_type][sw_plugin][device]['hanged']}}"
 
                                         >
-                                        <span>{{api_info[test_type][sw_plugin][device]['passrate']}} %</span>
+                                        <span>{{api_info[test_type][sw_plugin][device]['relative_passrate']}} %</span>
                                         <div style="width: 150px; margin: auto;">
-                                            <span class="green" title="Passed">P:{{api_info[test_type][sw_plugin][device]['passed']}}</span>
-                                            <span class="red" title="Failed">F:{{api_info[test_type][sw_plugin][device]['failed']}}</span>
-                                            <span class="grey" title="Skipped">S:{{api_info[test_type][sw_plugin][device]['skipped']}}</span>
-                                            <span class="dark" title="Crashed">C:{{api_info[test_type][sw_plugin][device]['crashed']}}</span>
-                                            <span class="grey-red" title="Hanged">H:{{api_info[test_type][sw_plugin][device]['hanged']}}</span>
+                                            <span class="green" title="Passed">P:{{ api_info[test_type][sw_plugin][device]['relative_passed'] }}</span>
+                                            <span class="red" title="Failed">F:{{ api_info[test_type][sw_plugin][device]['relative_all'] - api_info[test_type][sw_plugin][device]['relative_passed'] }}</span>
+                                            <span class="grey" title="Skipped" style="display: none;">---</span>
+                                            <span class="dark" title="Crashed" style="display: none;">---</span>
+                                            <span class="grey-red" title="Hanged" style="display: none;">---</span>
                                         </div>
                                     </td>
                                 {% else %}


### PR DESCRIPTION
### Details:
 - *'passed' counted twice for 'all test amount' for optional scope, so passrate was wrong*
 - *first view option was 'mandatory', but it was shown statistic for 'optional' scope*

### Tickets:
 - *CVS-116515*
