### PR TITLE
[CPU] Extensions shape inference issue fix

### DIFF
--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.hpp
@@ -33,7 +33,7 @@ public:
         return m_shape_infer->get_pads_end();
     }
     port_mask_t get_port_mask() const override {
-        return m_port_mask & m_shape_infer->get_port_mask();
+        return m_port_mask;
     }
 private:
     std::shared_ptr<IStaticShapeInfer> m_shape_infer;

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/custom_op_internal_dyn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/custom_op_internal_dyn.cpp
@@ -89,9 +89,10 @@ protected:
         auto inputParams = ngraph::builder::makeDynamicParams(ngPrc, inputDynamicShapes);
         auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
         auto customOp = std::make_shared<CustomOp>(paramOuts);
+        auto shapeOf = std::make_shared<ov::opset10::ShapeOf>(customOp->output(1));
 
         ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(customOp->output(0)),
-                                    std::make_shared<ngraph::opset3::Result>(customOp->output(1))};
+                                    std::make_shared<ngraph::opset3::Result>(shapeOf)};
         function = std::make_shared<ngraph::Function>(results, inputParams, "customOpTest");
     }
 


### PR DESCRIPTION
### Details:
 - *Fixed `get_port_mask()` behavior of `NgraphShapeInfer`: only port mask which was set by plugin node is returned, mask from `m_shape_infer` is ignored*

### Tickets:
 - *CVS-116464*
