### PR TITLE
[GPU] Fuse MVN before ConvertPrecision

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -70,6 +70,7 @@
 #include <transformations/op_conversions/lstm_cell_decomposition.hpp>
 #include <transformations/op_conversions/rnn_cell_decomposition.hpp>
 #include <transformations/op_conversions/mvn6_decomposition.hpp>
+#include <transformations/common_optimizations/mvn_fusion.hpp>
 #include <transformations/op_conversions/normalize_l2_decomposition.hpp>
 #include <transformations/op_conversions/bidirectional_sequences_decomposition.hpp>
 #include <transformations/op_conversions/convert_previous_nms_to_nms_9.hpp>
@@ -193,9 +194,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         type_to_fuse_map empty_fuse_map = {};
         manager.register_pass<ov::pass::Validate>();
 
-        // fuse softmax patterns so that they will not be marked as precision sensitive in ConvertPrecision
+        // fuse softmax, MVN patterns, so that they will not be marked as precision sensitive in ConvertPrecision
         manager.register_pass<ov::pass::SoftmaxFusion>();
-        // decompose MVNs that sre not supported in GPU, so the they will be marked as precision sensitive in ConvertPrecision
+        manager.register_pass<ov::pass::MVNFusion>();
+        // decompose MVNs that sre not supported in GPU, so that they will be marked as precision sensitive in ConvertPrecision
         manager.register_pass<ov::pass::MVN6Decomposition>();
         manager.register_pass<ov::pass::BroadcastTransition>();
 


### PR DESCRIPTION
### Details:
 - A monolith MVN on GPU side can handle overflows inside itself without being marked as precision sensitive.
 - Need to fuse subgraphs into a singe MVN before the `ConveertPrecision` pass where marking of precision sensitive nodes takes place. If we don't do that because of `Division`s with `Eps` these subgraphs will be marked as precision sensitive and additional converts to `f32` and back to `f16` will be inserted, slowing down execution. 

### Tickets:
 - [CVS-115851](https://jira.devtools.intel.com/browse/CVS-115851)
