### PR TITLE
Review preprocessing ops convert color i420 nv12 color classes for shape inference aspects

### DIFF
--- a/src/core/shape_inference/include/i420_shape_inference.hpp
+++ b/src/core/shape_inference/include/i420_shape_inference.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "dimension_util.hpp"
+#include "openvino/op/util/convert_color_i420_base.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace op {
+template <class TShape, class TRShape = result_shape_t<TShape>>
+std::vector<TRShape> shape_infer(const util::ConvertColorI420Base* op, const std::vector<TShape>& input_shapes) {
+    const auto has_single_plane = input_shapes.size() == 1;
+    NODE_VALIDATION_CHECK(op, has_single_plane || input_shapes.size() == 3);
+    using TDim = typename std::iterator_traits<typename TShape::iterator>::value_type;
+    using namespace ov::util;
+
+    const auto& shape_y = input_shapes[0];
+    const auto rank_y = shape_y.rank();
+
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, rank_y.compatible(4), "Y input shall have 4 dimensions (N, H, W, C)");
+
+    auto output_shapes = std::vector<TRShape>(1);
+    auto& out_shape = output_shapes.front();
+
+    if (rank_y.is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               shape_y[3].compatible(1),
+                               "Y input number of channels should be equal to 1");
+        out_shape = shape_y;
+    } else {
+        out_shape.resize(4);
+    }
+
+    if (has_single_plane) {
+        out_shape[1] *= 2;
+        out_shape[1] /= 3;
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               !dim::is_empty(out_shape[1]),
+                               "I420 image height shall be divisible by 3");
+
+    } else {
+        TRShape shape_uv = input_shapes[1];
+        const auto is_uv_consistent = TRShape::merge_into(shape_uv, input_shapes[2]);
+
+        if (shape_uv.rank().is_static()) {
+            NODE_SHAPE_INFER_CHECK(op,
+                                   input_shapes,
+                                   (shape_uv.size() == 4) && shape_uv[3].compatible(1),
+                                   "U, V inputs number of channels should be equal to 1");
+
+            std::for_each(shape_uv.begin() + 1, shape_uv.begin() + 3, [](TDim& d) {
+                d *= 2;
+            });
+        }
+
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               is_uv_consistent && TRShape::merge_into(out_shape, shape_uv),
+                               "Y shape is inconsistent with U and V");
+    }
+    out_shape[3] = 3;
+
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, dim::is_divisible(out_shape[1], 2), "Image height must be even");
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, dim::is_divisible(out_shape[2], 2), "Image width must be even");
+
+    return output_shapes;
+}
+}  // namespace op
+}  // namespace ov

--- a/src/core/shape_inference/include/nv12_shape_inference.hpp
+++ b/src/core/shape_inference/include/nv12_shape_inference.hpp
@@ -5,22 +5,22 @@
 #pragma once
 
 #include "dimension_util.hpp"
-#include "openvino/op/util/convert_color_i420_base.hpp"
+#include "openvino/op/util/convert_color_nv12_base.hpp"
 #include "utils.hpp"
 
 namespace ov {
 namespace op {
 template <class TShape, class TRShape = result_shape_t<TShape>>
-std::vector<TRShape> shape_infer(const util::ConvertColorI420Base* op, const std::vector<TShape>& input_shapes) {
+std::vector<TRShape> shape_infer(const util::ConvertColorNV12Base* op, const std::vector<TShape>& input_shapes) {
     const auto has_single_plane = input_shapes.size() == 1;
-    NODE_VALIDATION_CHECK(op, has_single_plane || input_shapes.size() == 3);
+    NODE_VALIDATION_CHECK(op, has_single_plane || input_shapes.size() == 2);
     using TDim = typename std::iterator_traits<typename TShape::iterator>::value_type;
     using namespace ov::util;
 
     const auto& shape_y = input_shapes[0];
     const auto rank_y = shape_y.rank();
 
-    NODE_SHAPE_INFER_CHECK(op, input_shapes, rank_y.compatible(4), "Y(UV) input shall have 4 dimensions (N, H, W, C)");
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, rank_y.compatible(4), "Y(UV) input shall have 4 dimensions (N, H, W,C)");
 
     auto output_shapes = std::vector<TRShape>{shape_y};
     auto& out_shape = output_shapes.front();
@@ -29,7 +29,7 @@ std::vector<TRShape> shape_infer(const util::ConvertColorI420Base* op, const std
         NODE_SHAPE_INFER_CHECK(op,
                                input_shapes,
                                shape_y[3].compatible(1),
-                               "Y input number of channels should be equal to 1");
+                               "YUV input number of channels should be equal to 1");
     } else {
         out_shape.resize(4);
     }
@@ -40,22 +40,21 @@ std::vector<TRShape> shape_infer(const util::ConvertColorI420Base* op, const std
         NODE_SHAPE_INFER_CHECK(op, input_shapes, !dim::is_empty(out_shape[1]), "Image height shall be divisible by 3");
     } else {
         TRShape shape_uv = input_shapes[1];
-        const auto is_uv_consistent = TRShape::merge_into(shape_uv, input_shapes[2]);
-
         if (shape_uv.rank().is_static()) {
             NODE_SHAPE_INFER_CHECK(op,
                                    input_shapes,
-                                   (shape_uv.size() == 4) && shape_uv[3].compatible(1),
-                                   "U, V inputs number of channels should be equal to 1");
+                                   (shape_uv.size() == 4) && shape_uv[3].compatible(2),
+                                   "UV input number of channels should be equal to 2");
             std::for_each(shape_uv.begin() + 1, shape_uv.end() - 1, [](TDim& d) {
                 d *= 2;
             });
         }
 
+        out_shape[3] = 2;
         NODE_SHAPE_INFER_CHECK(op,
                                input_shapes,
-                               is_uv_consistent && TRShape::merge_into(out_shape, shape_uv),
-                               "Y shape is inconsistent with U and V");
+                               TRShape::merge_into(out_shape, shape_uv),
+                               "Y shape is inconsistent with UV");
     }
     out_shape[3] = 3;
 

--- a/src/core/src/op/util/convert_color_i420_base.cpp
+++ b/src/core/src/op/util/convert_color_i420_base.cpp
@@ -4,16 +4,8 @@
 
 #include "openvino/op/util/convert_color_i420_base.hpp"
 
-#include <ngraph/validation_util.hpp>
-
+#include "i420_shape_inference.hpp"
 #include "itt.hpp"
-#include "openvino/core/layout.hpp"
-
-namespace i420_op {
-static const size_t H_DIM = 1;
-static const size_t W_DIM = 2;
-static const size_t C_DIM = 3;
-}  // namespace i420_op
 
 ov::op::util::ConvertColorI420Base::ConvertColorI420Base(const Output<Node>& arg, ColorConversion format)
     : Op({arg}),
@@ -24,98 +16,42 @@ ov::op::util::ConvertColorI420Base::ConvertColorI420Base(const Output<Node>& arg
                                                          const Output<Node>& arg_v,
                                                          ColorConversion format)
     : Op({arg_y, arg_u, arg_v}),
-      m_format(format) {
-    constructor_validate_and_infer_types();
-}
+      m_format(format) {}
 
 void ov::op::util::ConvertColorI420Base::validate_and_infer_types() {
     OV_OP_SCOPE(v8_Convert_I420_Base_validate_and_infer_types);
 
-    NODE_VALIDATION_CHECK(this,
-                          get_input_size() == 1 || get_input_size() == 3,
-                          "I420 conversion shall have one or 3 inputs, but it is ",
-                          get_input_size());
-    auto single_plane = get_input_size() == 1;
-    auto y_type = get_input_element_type(0);
-    const auto& shape_y = get_input_partial_shape(0);
-    const auto one_channel_nhwc_shape =
-        PartialShape({Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 1});
-    NODE_VALIDATION_CHECK(this,
-                          shape_y.compatible(one_channel_nhwc_shape),
-                          "Y input shall have 4 dimensions (N, H, W, C) with channels dimension equal to 1");
-    auto out_shape = shape_y;
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    const auto input_shapes = get_node_input_partial_shapes(*this);
+    const auto output_shapes = shape_infer(this, input_shapes);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+
+    const auto& y_type = get_input_element_type(0);
     auto out_type = y_type;
-    if (out_shape.rank().is_dynamic()) {
-        out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 3};
-    }
-    out_shape[i420_op::C_DIM] = 3;  // 3 is number of channels (R, G, B)
-    if (single_plane) {
-        if (shape_y.rank().is_static() && shape_y[i420_op::H_DIM].is_static()) {
-            NODE_VALIDATION_CHECK(this,
-                                  shape_y[i420_op::H_DIM].get_length() % 3 == 0,
-                                  "I420 image height shall be divisible by 3, but it is ",
-                                  shape_y[i420_op::H_DIM].get_length());
-            // E.g. if input shape height is 720 for I420, then real image height is 720 * 2 / 3 = 480
-            out_shape[i420_op::H_DIM] = shape_y[i420_op::H_DIM].get_length() * 2 / 3;
-        }
-    } else {
-        auto u_type = get_input_element_type(1);
-        auto v_type = get_input_element_type(2);
+
+    if (get_input_size() == 3) {
+        const auto& u_type = get_input_element_type(1);
+        const auto& v_type = get_input_element_type(2);
+
         NODE_VALIDATION_CHECK(this,
-                              ov::element::Type::merge(out_type, out_type, u_type),
+                              element::Type::merge(out_type, out_type, u_type),
                               "Y, U, V inputs shall have compatible types, got ",
                               y_type,
                               u_type,
                               v_type);
         NODE_VALIDATION_CHECK(this,
-                              ov::element::Type::merge(out_type, out_type, v_type),
+                              element::Type::merge(out_type, out_type, v_type),
                               "Y, U, V inputs shall have compatible types, got ",
                               y_type,
                               u_type,
                               v_type);
-        // Validate Y/U/V shapes compatibility
-        const auto& shape_u = get_input_partial_shape(1);
-        NODE_VALIDATION_CHECK(this,
-                              shape_u.compatible(one_channel_nhwc_shape),
-                              "U input shall have 4 dimensions (N, H, W, C) with channels dimension equal to 1, got ",
-                              shape_u);
-        const auto& shape_v = get_input_partial_shape(2);
-        NODE_VALIDATION_CHECK(this,
-                              shape_v.compatible(one_channel_nhwc_shape),
-                              "V input shall have 4 dimensions (N, H, W, C) with channels dimension equal to 1, got ",
-                              shape_v);
-        NODE_VALIDATION_CHECK(this,
-                              shape_u.compatible(shape_v),
-                              "U shape shall be compatible with V shape: ",
-                              shape_u,
-                              shape_v);
-        auto shape_uv = shape_u;
-        PartialShape::merge_into(shape_uv, shape_v);
-        if (shape_uv.rank().is_static()) {
-            shape_uv[i420_op::H_DIM] *= 2;
-            shape_uv[i420_op::W_DIM] *= 2;
-        }
-        NODE_VALIDATION_CHECK(this,
-                              shape_y.compatible(shape_uv),
-                              "Y shape is inconsistent with U and V shapes: ",
-                              shape_y,
-                              shape_u,
-                              shape_v);
-        PartialShape::merge_into(out_shape, shape_uv);
     }
-    NODE_VALIDATION_CHECK(this,
-                          out_shape[i420_op::H_DIM].is_dynamic() || out_shape[i420_op::H_DIM].get_length() % 2 == 0,
-                          "Image height must be even, but it is ",
-                          out_shape[i420_op::H_DIM].get_length());
-    NODE_VALIDATION_CHECK(this,
-                          out_shape[i420_op::W_DIM].is_dynamic() || out_shape[i420_op::W_DIM].get_length() % 2 == 0,
-                          "Image width must be even, but it is ",
-                          out_shape[i420_op::W_DIM].get_length());
     NODE_VALIDATION_CHECK(this,
                           is_type_supported(out_type),
                           "Input type shall have u8 or floating-point precision, got ",
                           out_type);
-    set_output_type(0, out_type, out_shape);
+
+    set_output_type(0, out_type, output_shapes.front());
 }
 
 bool ov::op::util::ConvertColorI420Base::visit_attributes(AttributeVisitor& visitor) {

--- a/src/core/src/op/util/convert_color_nv12_base.cpp
+++ b/src/core/src/op/util/convert_color_nv12_base.cpp
@@ -4,15 +4,8 @@
 
 #include "openvino/op/util/convert_color_nv12_base.hpp"
 
-#include <ngraph/validation_util.hpp>
-
 #include "itt.hpp"
-#include "openvino/core/layout.hpp"
-
-static const size_t N_DIM = 0;
-static const size_t H_DIM = 1;
-static const size_t W_DIM = 2;
-static const size_t C_DIM = 3;
+#include "nv12_shape_inference.hpp"
 
 ov::op::util::ConvertColorNV12Base::ConvertColorNV12Base(const Output<Node>& arg, ColorConversion format)
     : Op({arg}),
@@ -22,121 +15,32 @@ ov::op::util::ConvertColorNV12Base::ConvertColorNV12Base(const Output<Node>& arg
                                                          const Output<Node>& arg_uv,
                                                          ColorConversion format)
     : Op({arg_y, arg_uv}),
-      m_format(format) {
-    constructor_validate_and_infer_types();
-}
+      m_format(format) {}
 
 void ov::op::util::ConvertColorNV12Base::validate_and_infer_types() {
     OV_OP_SCOPE(v8_Convert_NV12_Base_validate_and_infer_types);
 
-    NODE_VALIDATION_CHECK(this,
-                          get_input_size() == 1 || get_input_size() == 2,
-                          "NV12 conversion shall have one or 2 inputs, but it is ",
-                          get_input_size());
-    auto single_plane = get_input_size() == 1;
-    auto y_type = get_input_element_type(0);
-    NODE_VALIDATION_CHECK(this,
-                          is_type_supported(y_type),
-                          "Y input shall have u8 or floating-point precision, got ",
-                          y_type);
-    const auto& shape_y = get_input_partial_shape(0);
-    if (shape_y.rank().is_static()) {
-        NODE_VALIDATION_CHECK(this,
-                              shape_y.rank().get_length() == 4,
-                              "Y input with static shape shall have 4 dimensions (N, H, W, C)");
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    const auto input_shapes = get_node_input_partial_shapes(*this);
+    const auto output_shapes = shape_infer(this, input_shapes);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+
+    auto out_type = get_input_element_type(0);
+    if (get_input_size() == 2) {
+        const auto& uv_type = get_input_element_type(1);
 
         NODE_VALIDATION_CHECK(this,
-                              shape_y[C_DIM].is_dynamic() || shape_y[C_DIM].get_length() == 1,
-                              "Y channels dimension shall be either dynamic or equal to 1. Current value is ",
-                              shape_y[C_DIM].get_length());
+                              element::Type::merge(out_type, out_type, uv_type),
+                              "Y, UV inputs shall have compatible types, got ",
+                              out_type,
+                              uv_type);
     }
-    auto out_shape = shape_y;
-    auto out_type = y_type;
-    if (out_shape.rank().is_dynamic()) {
-        out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 3};
-    }
-    out_shape[C_DIM] = 3;  // 3 is number of channels (R, G, B)
-    if (single_plane) {
-        if (shape_y.rank().is_static() && shape_y[H_DIM].is_static()) {
-            NODE_VALIDATION_CHECK(this,
-                                  shape_y[H_DIM].get_length() % 3 == 0,
-                                  "NV12 image height shall be divisible by 3, but it is ",
-                                  shape_y[H_DIM].get_length());
-            // E.g. if input shape height is 720 for NV12, then real image height is 720 * 2 / 3 = 480
-            out_shape[H_DIM] = shape_y[H_DIM].get_length() * 2 / 3;
-        }
-    } else {
-        auto uv_type = get_input_element_type(1);
-        if (y_type.is_dynamic()) {
-            NODE_VALIDATION_CHECK(this,
-                                  is_type_supported(uv_type),
-                                  "UV input shall have u8 or floating-point precision, got ",
-                                  uv_type);
-            out_type = uv_type;
-        } else {
-            NODE_VALIDATION_CHECK(this,
-                                  uv_type.is_dynamic() || uv_type == y_type,
-                                  "UV input ",
-                                  uv_type,
-                                  " shall have same precision as Y input ",
-                                  y_type);
-        }
-        const auto& shape_uv = get_input_partial_shape(1);
-        NODE_VALIDATION_CHECK(this,
-                              shape_uv.rank().is_dynamic() || shape_uv.rank().get_length() == 4,
-                              "UV input with static shape shall have 4 dimensions (N, H, W, C)");
-        if (shape_y.rank().is_static() && shape_uv.rank().is_static()) {
-            // Verify that height for Y input is 2 times bigger than input height for UV
-            NODE_VALIDATION_CHECK(this,
-                                  shape_y[H_DIM].is_dynamic() || shape_uv[H_DIM].is_dynamic() ||
-                                      shape_y[H_DIM].get_length() == shape_uv[H_DIM].get_length() * 2,
-                                  "Y input height shall be 2 times bigger that UV input height: Y height = ",
-                                  shape_y[H_DIM].get_length(),
-                                  " UV height = ",
-                                  shape_uv[H_DIM].get_length());
-            // Verify that width for Y input is 2 times bigger than input width for UV
-            NODE_VALIDATION_CHECK(this,
-                                  shape_y[W_DIM].is_dynamic() || shape_uv[W_DIM].is_dynamic() ||
-                                      shape_y[W_DIM].get_length() == shape_uv[W_DIM].get_length() * 2,
-                                  "Y input width shall be 2 times bigger that UV input width: Y width = ",
-                                  shape_y[W_DIM].get_length(),
-                                  " UV width = ",
-                                  shape_uv[W_DIM].get_length());
-            NODE_VALIDATION_CHECK(this,
-                                  shape_uv[C_DIM].is_dynamic() || shape_uv[C_DIM].get_length() == 2,
-                                  "UV channels dimension shall be either dynamic or equal to 2. Current value is ",
-                                  shape_uv[C_DIM].get_length());
+    NODE_VALIDATION_CHECK(this,
+                          is_type_supported(out_type),
+                          "Input type shall have u8 or floating-point precision, got ",
+                          out_type);
 
-            NODE_VALIDATION_CHECK(this,
-                                  shape_y[N_DIM].is_dynamic() || shape_uv[N_DIM].is_dynamic() ||
-                                      shape_y[N_DIM].get_length() == shape_uv[N_DIM].get_length(),
-                                  "Y input batch shall be same as UV input batch: Y batch = ",
-                                  shape_y[N_DIM].get_length(),
-                                  " UV batch = ",
-                                  shape_uv[N_DIM].get_length());
-        }
-        // Set shape based on UV shape, if Y are dynamic
-        if (shape_uv.rank().is_static()) {
-            if (out_shape[N_DIM].is_dynamic()) {
-                out_shape[N_DIM] = shape_uv[N_DIM];
-            }
-            if (out_shape[H_DIM].is_dynamic()) {
-                out_shape[H_DIM] = shape_uv[H_DIM] * 2;
-            }
-            if (out_shape[W_DIM].is_dynamic()) {
-                out_shape[W_DIM] = shape_uv[W_DIM] * 2;
-            }
-        }
-    }
-    NODE_VALIDATION_CHECK(this,
-                          out_shape[H_DIM].is_dynamic() || out_shape[H_DIM].get_length() % 2 == 0,
-                          "Image height must be even, but it is ",
-                          out_shape[H_DIM].get_length());
-    NODE_VALIDATION_CHECK(this,
-                          out_shape[W_DIM].is_dynamic() || out_shape[W_DIM].get_length() % 2 == 0,
-                          "Image width must be even, but it is ",
-                          out_shape[W_DIM].get_length());
-    set_output_type(0, out_type, out_shape);
+    set_output_type(0, out_type, output_shapes.front());
 }
 
 bool ov::op::util::ConvertColorNV12Base::visit_attributes(AttributeVisitor& visitor) {

--- a/src/core/tests/type_prop/convert_color_i420_base.hpp
+++ b/src/core/tests/type_prop/convert_color_i420_base.hpp
@@ -355,6 +355,22 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_error_2_planes) {
     EXPECT_THROW(empty->constructor_validate_and_infer_types(), ov::AssertFailure);
 }
 
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_2_plane_interval_dims_and_labels) {
+    auto param_shape_y = PartialShape{{2, 5}, {2, 20}, -1, 1};
+    auto param_shape_uv = PartialShape{{2, 3}, {2, 12}, 2, -1};
+    set_shape_labels(param_shape_y, 10);
+    set_shape_labels(param_shape_uv, 20);
+
+    auto param_y = std::make_shared<op::v0::Parameter>(element::f32, param_shape_y);
+    auto param_u = std::make_shared<op::v0::Parameter>(element::f32, param_shape_uv);
+    auto param_v = std::make_shared<op::v0::Parameter>(element::f32, param_shape_uv);
+    auto op = std::make_shared<TypeParam>(param_y, param_u, param_v);
+
+    EXPECT_EQ(op->output(0).get_partial_shape(), PartialShape({{2, 3}, {4, 20}, 4, 3}));
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(20, 11, 12, no_label));
+}
+
 REGISTER_TYPED_TEST_SUITE_P(ConvertI420BaseTest,
                             shape_inference_default_ctor_single_plane,
                             shape_inference_single_tensor,
@@ -389,4 +405,5 @@ REGISTER_TYPED_TEST_SUITE_P(ConvertI420BaseTest,
                             shape_inference_3_plane_error_width,
                             shape_inference_3_plane_error_width_odd,
                             shape_inference_3_plane_error_channels,
-                            shape_inference_error_2_planes);
+                            shape_inference_error_2_planes,
+                            shape_inference_2_plane_interval_dims_and_labels);

--- a/src/core/tests/type_prop/convert_color_i420_base.hpp
+++ b/src/core/tests/type_prop/convert_color_i420_base.hpp
@@ -4,24 +4,44 @@
 
 #include <vector>
 
+#include "common_test_utils/test_assertions.hpp"
+#include "common_test_utils/type_prop.hpp"
 #include "gtest/gtest.h"
 #include "openvino/op/op.hpp"
 #include "openvino/opsets/opset8.hpp"
 
 using namespace ov;
+using namespace testing;
 
 template <class T>
 class ConvertI420BaseTest : public testing::Test {};
 
 TYPED_TEST_SUITE_P(ConvertI420BaseTest);
 
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_default_ctor_single_plane) {
+    auto param_shape = PartialShape{5, 3, 2, 1};
+    set_shape_labels(param_shape, 10);
+    auto out_shape = PartialShape{5, 2, 2, 3};
+    auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
+
+    auto op = std::make_shared<TypeParam>();
+    op->set_argument(0, param);
+    op->validate_and_infer_types();
+
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(10, ov::no_label, 12, ov::no_label));
+}
+
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor) {
     auto param_shape = PartialShape{5, 3, 2, 1};
+    set_shape_labels(param_shape, 10);
     auto out_shape = PartialShape{5, 2, 2, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_element_type(), element::f32);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(10, ov::no_label, 12, ov::no_label));
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic) {
@@ -29,8 +49,8 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic) {
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 3};
     auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_dims) {
@@ -38,8 +58,8 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_dims) {
     auto out_shape = PartialShape{Dimension::dynamic(), 2, Dimension::dynamic(), 3};
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::u8);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_height) {
@@ -47,8 +67,19 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_height) 
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), 8, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::u8);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
+}
+
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_interval_dims_and_labels) {
+    auto param_shape = PartialShape{{2, 20}, {5, 10}, 8, 1};
+    set_shape_labels(param_shape, 10);
+    auto out_shape = PartialShape{{2, 20}, {4, 6}, 8, 3};
+    auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
+    auto op = std::make_shared<TypeParam>(param);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(10, ov::no_label, 12, ov::no_label));
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_type) {
@@ -56,44 +87,59 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_type) {
     auto out_shape = PartialShape{1, 4, 8, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::dynamic, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::dynamic);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::dynamic);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_channels) {
     auto param_shape = PartialShape{1, 3, 4, 2};  // shall be 1 channel, not 2
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_dims_5) {
     auto param_shape = PartialShape{1, 3, 3, 1, 1};  // must be 4 dimensions
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_dims_3) {
     auto param_shape = PartialShape{640, 480, 1};  // must be 4 dimensions
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure, HasSubstr(""));
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_height) {
     auto param_shape = PartialShape{1, 4, 6, 1};  // height = 4, can't split to Y and UV
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_width_odd) {
     auto param_shape = PartialShape{1, 6, 5, 1};  // width is odd, can't split to U and V
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure, HasSubstr(""));
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_i8) {
     auto param_shape = PartialShape{1, 640, 480, 1};
     auto param = std::make_shared<op::v0::Parameter>(element::i8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
+}
+
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_default_ctor_3_planes) {
+    auto param_shape_y = PartialShape{10, 480, 640, 1};
+    auto param_shape_uv = PartialShape{10, 240, 320, 1};
+    auto out_shape = PartialShape{10, 480, 640, 3};
+    auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
+    auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
+    auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
+
+    auto op = std::make_shared<TypeParam>();
+    op->set_arguments(OutputVector{param_y, param_u, param_v});
+    op->validate_and_infer_types();
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_simple) {
@@ -104,8 +150,8 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_simple) {
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_u, param_v);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::u8);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic) {
@@ -117,8 +163,8 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic) {
     auto param_u = std::make_shared<op::v0::Parameter>(element::f32, param_shape_u);
     auto param_v = std::make_shared<op::v0::Parameter>(element::f32, param_shape_v);
     auto op = std::make_shared<TypeParam>(param_y, param_u, param_v);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_y_dynamic) {
@@ -129,8 +175,8 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_y_dynamic) {
     auto param_u = std::make_shared<op::v0::Parameter>(element::bf16, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::bf16, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_u, param_v);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::bf16);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::bf16);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_dynamic) {
@@ -141,13 +187,16 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_dynamic) {
     auto param_u = std::make_shared<op::v0::Parameter>(element::f16, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::f16, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_u, param_v);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::f16);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::f16);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic_types) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape{1, 2, 2, 1};
+    set_shape_labels(param_shape_y, 10);
+    set_shape_labels(param_shape_uv, 20);
+
     auto out_shape = PartialShape{1, 4, 4, 3};
     auto y_type = element::dynamic;
     auto uv_type = element::dynamic;
@@ -156,13 +205,15 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic_types) {
     auto param_u = std::make_shared<op::v0::Parameter>(uv_type, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(uv_type, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_u, param_v);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), out_type);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), out_type);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(20, 11, 12, ov::no_label));
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_type) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape{1, 2, 2, 1};
+    set_shape_labels(param_shape_uv, 20);
     auto out_shape = PartialShape{1, 4, 4, 3};
     auto y_type = element::dynamic;
     auto uv_type = element::f64;
@@ -171,43 +222,45 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_type) {
     auto param_u = std::make_shared<op::v0::Parameter>(uv_type, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(uv_type, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_u, param_v);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), out_type);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), out_type);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)),
+                ElementsAre(20, ov::no_label, ov::no_label, ov::no_label));
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_y) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_u) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_v) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, PartialShape::dynamic());
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_u_type) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::i8, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_v_type) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::i8, PartialShape::dynamic());
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_5dims) {
@@ -217,12 +270,12 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_5dims) {
     auto param_1 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_2 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_u);
     auto param_3 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_v);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_1, param_2, param_3), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_1, param_3, param_2), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_2, param_1, param_3), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_2, param_3, param_1), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_3, param_1, param_2), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_3, param_2, param_1), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_1, param_2, param_3), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_1, param_3, param_2), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_2, param_1, param_3), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_2, param_3, param_1), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_3, param_1, param_2), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_3, param_2, param_1), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_3dims) {
@@ -231,12 +284,12 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_3dims) {
     auto param_1 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_good);
     auto param_2 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_bad);
     auto param_3 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_good);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_1, param_2, param_3), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_1, param_3, param_2), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_2, param_1, param_3), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_2, param_3, param_1), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_3, param_1, param_2), ov::AssertFailure);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_3, param_2, param_1), ov::AssertFailure);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_1, param_2, param_3), ov::AssertFailure, _);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_1, param_3, param_2), ov::AssertFailure, _);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_2, param_1, param_3), ov::AssertFailure, _);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_2, param_3, param_1), ov::AssertFailure, _);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_3, param_1, param_2), ov::AssertFailure, _);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_3, param_2, param_1), ov::AssertFailure, _);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_batch) {
@@ -245,7 +298,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_batch) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_height) {
@@ -254,7 +307,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_height) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_height_odd) {
@@ -263,7 +316,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_height_odd) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_width) {
@@ -272,7 +325,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_width) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_width_odd) {
@@ -281,7 +334,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_width_odd) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_channels) {
@@ -290,7 +343,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_channels) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertI420BaseTest, shape_inference_error_2_planes) {
@@ -303,17 +356,20 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_error_2_planes) {
 }
 
 REGISTER_TYPED_TEST_SUITE_P(ConvertI420BaseTest,
+                            shape_inference_default_ctor_single_plane,
                             shape_inference_single_tensor,
                             shape_inference_single_tensor_dynamic,
                             shape_inference_single_tensor_dynamic_dims,
                             shape_inference_single_tensor_dynamic_height,
                             shape_inference_single_tensor_dynamic_type,
+                            shape_inference_interval_dims_and_labels,
                             shape_inference_single_tensor_error_channels,
                             shape_inference_single_tensor_error_dims_5,
                             shape_inference_single_tensor_error_dims_3,
                             shape_inference_single_tensor_error_height,
                             shape_inference_single_tensor_error_width_odd,
                             shape_inference_single_tensor_error_i8,
+                            shape_inference_default_ctor_3_planes,
                             shape_inference_3_plane_simple,
                             shape_inference_3_plane_dynamic,
                             shape_inference_3_plane_y_dynamic,

--- a/src/core/tests/type_prop/convert_color_nv12_base.hpp
+++ b/src/core/tests/type_prop/convert_color_nv12_base.hpp
@@ -4,24 +4,43 @@
 
 #include <vector>
 
+#include "common_test_utils/type_prop.hpp"
 #include "gtest/gtest.h"
 #include "openvino/op/op.hpp"
 #include "openvino/opsets/opset8.hpp"
 
 using namespace ov;
+using namespace testing;
 
 template <class T>
 class ConvertNV12BaseTest : public testing::Test {};
 
 TYPED_TEST_SUITE_P(ConvertNV12BaseTest);
 
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_default_ctor_single_plane) {
+    auto param_shape = PartialShape{5, 3, 2, 1};
+    set_shape_labels(param_shape, 10);
+    auto out_shape = PartialShape{5, 2, 2, 3};
+    auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
+
+    auto op = std::make_shared<TypeParam>();
+    op->set_argument(0, param);
+    op->validate_and_infer_types();
+
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(10, ov::no_label, 12, ov::no_label));
+}
+
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor) {
     auto param_shape = PartialShape{5, 3, 2, 1};
+    set_shape_labels(param_shape, 10);
     auto out_shape = PartialShape{5, 2, 2, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_element_type(), element::f32);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(10, ov::no_label, 12, ov::no_label));
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic) {
@@ -29,8 +48,8 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic) {
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 3};
     auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_dims) {
@@ -38,8 +57,8 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_dims) {
     auto out_shape = PartialShape{Dimension::dynamic(), 2, Dimension::dynamic(), 3};
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::u8);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_height) {
@@ -47,8 +66,8 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_height) 
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), 8, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::u8);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_type) {
@@ -56,44 +75,69 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_type) {
     auto out_shape = PartialShape{1, 4, 8, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::dynamic, param_shape);
     auto op = std::make_shared<TypeParam>(param);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::dynamic);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::dynamic);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_channels) {
     auto param_shape = PartialShape{1, 3, 4, 2};  // shall be 1 channel, not 2
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_dims_5) {
     auto param_shape = PartialShape{1, 3, 3, 1, 1};  // must be 4 dimensions
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_dims_3) {
     auto param_shape = PartialShape{640, 480, 1};  // must be 4 dimensions
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_height) {
     auto param_shape = PartialShape{1, 4, 6, 1};  // height = 4, can't split to Y and UV
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_width_odd) {
     auto param_shape = PartialShape{1, 6, 5, 1};  // width is odd, can't split to U and V
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_i8) {
     auto param_shape = PartialShape{1, 640, 480, 1};
     auto param = std::make_shared<op::v0::Parameter>(element::i8, param_shape);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param), ov::AssertFailure);
+}
+
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_interval_dims_and_labels) {
+    auto param_shape = PartialShape{{2, 20}, {5, 10}, 8, 1};
+    set_shape_labels(param_shape, 10);
+    auto out_shape = PartialShape{{2, 20}, {4, 6}, 8, 3};
+    auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
+    auto op = std::make_shared<TypeParam>(param);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(10, no_label, 12, no_label));
+}
+
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_default_ctor_2_planes) {
+    auto param_shape_y = PartialShape{10, 480, 640, 1};
+    auto param_shape_uv = PartialShape{10, 240, 320, 2};
+    auto out_shape = PartialShape{10, 480, 640, 3};
+    auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
+    auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
+
+    auto op = std::make_shared<TypeParam>();
+    op->set_arguments(OutputVector{param_y, param_uv});
+    op->validate_and_infer_types();
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_simple) {
@@ -103,8 +147,8 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_simple) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_uv);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::u8);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic) {
@@ -114,8 +158,8 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::f32, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::f32, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_uv);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_y_dynamic) {
@@ -125,8 +169,8 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_y_dynamic) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::bf16, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::bf16, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_uv);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::bf16);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::bf16);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_dynamic) {
@@ -136,13 +180,16 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_dynamic) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::f16, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::f16, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_uv);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), element::f16);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), element::f16);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic_types) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape{1, 2, 2, 2};
+    set_shape_labels(param_shape_y, 10);
+    set_shape_labels(param_shape_uv, 20);
+
     auto out_shape = PartialShape{1, 4, 4, 3};
     auto y_type = element::dynamic;
     auto uv_type = element::dynamic;
@@ -150,13 +197,16 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic_types) {
     auto param_y = std::make_shared<op::v0::Parameter>(y_type, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(uv_type, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_uv);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), out_type);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), out_type);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(20, 11, 12, no_label));
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_type) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape{1, 2, 2, 2};
+    set_shape_labels(param_shape_uv, 20);
+
     auto out_shape = PartialShape{1, 4, 4, 3};
     auto y_type = element::dynamic;
     auto uv_type = element::f64;
@@ -164,20 +214,22 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_type) {
     auto param_y = std::make_shared<op::v0::Parameter>(y_type, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(uv_type, param_shape_uv);
     auto op = std::make_shared<TypeParam>(param_y, param_uv);
-    ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
-    ASSERT_EQ(op->output(0).get_element_type(), out_type);
+    EXPECT_EQ(op->output(0).get_partial_shape(), out_shape);
+    EXPECT_EQ(op->output(0).get_element_type(), out_type);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)),
+                ElementsAre(20, ov::no_label, ov::no_label, ov::no_label));
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_type_mismatch) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, PartialShape::dynamic());
     auto param_uv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_uv_type) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_uv = std::make_shared<op::v0::Parameter>(element::i8, PartialShape::dynamic());
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_5dims) {
@@ -185,7 +237,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_5dims) {
     auto param_shape_uv = PartialShape{2, 2, 2, 2, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_3dims) {
@@ -193,7 +245,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_3dims) {
     auto param_shape_uv = PartialShape{2, 2, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_batch) {
@@ -201,7 +253,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_batch) {
     auto param_shape_uv = PartialShape{1, 240, 320, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_height) {
@@ -209,7 +261,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_height) {
     auto param_shape_uv = PartialShape{2, 480, 320, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_height_odd) {
@@ -217,7 +269,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_height_odd) {
     auto param_shape_uv = PartialShape::dynamic();
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_width) {
@@ -225,7 +277,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_width) {
     auto param_shape_uv = PartialShape{2, 240, 640, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_width_odd) {
@@ -233,7 +285,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_width_odd) {
     auto param_shape_uv = PartialShape::dynamic();
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_channels) {
@@ -241,7 +293,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_channels) {
     auto param_shape_uv = PartialShape{2, 240, 320, 1};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(std::ignore = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
 TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_error_many_types) {
@@ -254,7 +306,23 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_error_many_types) {
     EXPECT_THROW(empty->constructor_validate_and_infer_types(), ov::AssertFailure);
 }
 
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_interval_dims_and_labels) {
+    auto param_shape_y = PartialShape{{2, 5}, {2, 20}, -1, 1};
+    auto param_shape_uv = PartialShape{{2, 3}, {2, 12}, 2, -1};
+    set_shape_labels(param_shape_y, 10);
+    set_shape_labels(param_shape_uv, 20);
+
+    auto param_y = std::make_shared<op::v0::Parameter>(element::f32, param_shape_y);
+    auto param_uv = std::make_shared<op::v0::Parameter>(element::f32, param_shape_uv);
+    auto op = std::make_shared<TypeParam>(param_y, param_uv);
+
+    EXPECT_EQ(op->output(0).get_partial_shape(), PartialShape({{2, 3}, {4, 20}, 4, 3}));
+    EXPECT_EQ(op->output(0).get_element_type(), element::f32);
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), ElementsAre(20, 11, 12, no_label));
+}
+
 REGISTER_TYPED_TEST_SUITE_P(ConvertNV12BaseTest,
+                            shape_inference_default_ctor_single_plane,
                             shape_inference_single_tensor,
                             shape_inference_single_tensor_dynamic,
                             shape_inference_single_tensor_dynamic_dims,
@@ -266,6 +334,8 @@ REGISTER_TYPED_TEST_SUITE_P(ConvertNV12BaseTest,
                             shape_inference_single_tensor_error_height,
                             shape_inference_single_tensor_error_width_odd,
                             shape_inference_single_tensor_error_i8,
+                            shape_inference_single_interval_dims_and_labels,
+                            shape_inference_default_ctor_2_planes,
                             shape_inference_2_plane_simple,
                             shape_inference_2_plane_dynamic,
                             shape_inference_2_plane_y_dynamic,
@@ -282,4 +352,5 @@ REGISTER_TYPED_TEST_SUITE_P(ConvertNV12BaseTest,
                             shape_inference_2_plane_error_width,
                             shape_inference_2_plane_error_width_odd,
                             shape_inference_2_plane_error_channels,
-                            shape_inference_error_many_types);
+                            shape_inference_error_many_types,
+                            shape_inference_2_plane_interval_dims_and_labels);

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
@@ -67,6 +67,7 @@
 #include "lstm_sequence_shape_inference.hpp"
 #include "matmul_shape_inference.hpp"
 #include "max_pool_shape_inference.hpp"
+#include "nv12_shape_inference.hpp"
 #include "one_hot_shape_inference.hpp"
 #include "pad_shape_inference.hpp"
 #include "prior_box_clustered_shape_inference.hpp"
@@ -207,7 +208,6 @@ public:
             }
         }
         local_op = op->clone_with_new_inputs(new_inputs);
-
         local_op->validate_and_infer_types();
 
         output_shapes.resize(local_op->get_output_size());
@@ -405,13 +405,15 @@ const IStaticShapeInferFactory::TRegistry IStaticShapeInferFactory::registry{
     // opset8
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::AdaptiveAvgPool, ShapeInferTA, util::bit::mask(1)),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::AdaptiveMaxPool, ShapeInferTA, util::bit::mask(1)),
-    _OV_OP_SHAPE_INFER_MASK_REG(opset8::I420toBGR, ShapeInferTA, util::bit::mask()),
-    _OV_OP_SHAPE_INFER_MASK_REG(opset8::I420toRGB, ShapeInferTA, util::bit::mask()),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::DeformableConvolution, ShapeInferPaddingTA, util::bit::mask()),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::DetectionOutput, ShapeInferTA, util::bit::mask()),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::Gather, ShapeInferTA, util::bit::mask(2)),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::GatherND, ShapeInferTA, util::bit::mask()),
+    _OV_OP_SHAPE_INFER_MASK_REG(opset8::I420toBGR, ShapeInferTA, util::bit::mask()),
+    _OV_OP_SHAPE_INFER_MASK_REG(opset8::I420toRGB, ShapeInferTA, util::bit::mask()),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::MaxPool, ShapeInferPaddingTA, util::bit::mask()),
+    _OV_OP_SHAPE_INFER_MASK_REG(opset8::NV12toBGR, ShapeInferTA, util::bit::mask()),
+    _OV_OP_SHAPE_INFER_MASK_REG(opset8::NV12toRGB, ShapeInferTA, util::bit::mask()),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::PriorBox, ShapeInferTA, util::bit::mask(0)),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::RandomUniform, ShapeInferTA, util::bit::mask(0, 1, 2)),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::Slice, ShapeInferTA, util::bit::mask(1, 2, 3, 4)),

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
@@ -60,6 +60,7 @@
 #include "group_convolution_shape_inference.hpp"
 #include "gru_cell_shape_inference.hpp"
 #include "gru_sequence_shape_inference.hpp"
+#include "i420_shape_inference.hpp"
 #include "interpolate_shape_inference.hpp"
 #include "irdft_shape_inference.hpp"
 #include "lstm_cell_shape_inference.hpp"
@@ -404,6 +405,8 @@ const IStaticShapeInferFactory::TRegistry IStaticShapeInferFactory::registry{
     // opset8
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::AdaptiveAvgPool, ShapeInferTA, util::bit::mask(1)),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::AdaptiveMaxPool, ShapeInferTA, util::bit::mask(1)),
+    _OV_OP_SHAPE_INFER_MASK_REG(opset8::I420toBGR, ShapeInferTA, util::bit::mask()),
+    _OV_OP_SHAPE_INFER_MASK_REG(opset8::I420toRGB, ShapeInferTA, util::bit::mask()),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::DeformableConvolution, ShapeInferPaddingTA, util::bit::mask()),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::DetectionOutput, ShapeInferTA, util::bit::mask()),
     _OV_OP_SHAPE_INFER_MASK_REG(opset8::Gather, ShapeInferTA, util::bit::mask(2)),

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/i420_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/i420_shape_inference_test.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gmock/gmock.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/op/i420_to_bgr.hpp"
+#include "openvino/op/i420_to_rgb.hpp"
+#include "utils.hpp"
+
+using namespace ov;
+using namespace ov::intel_cpu;
+using namespace testing;
+
+template <class TOp>
+class ConvertColorI420Test : public OpStaticShapeInferenceTest<TOp> {
+protected:
+};
+
+TYPED_TEST_SUITE_P(ConvertColorI420Test);
+
+TYPED_TEST_P(ConvertColorI420Test, default_ctor_single_plane_no_args) {
+    this->op = this->make_op();
+
+    this->input_shapes = ShapeVector{{3, 10, 10, 1}, {3, 5, 5, 1}, {3, 5, 5, 1}};
+    auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({3, 10, 10, 3}));
+}
+
+TYPED_TEST_P(ConvertColorI420Test, default_ctor_three_plane_no_args) {
+    this->op = this->make_op();
+
+    this->input_shapes = ShapeVector{{3, 20, 20, 1}, {3, 10, 10, 1}, {3, 10, 10, 1}};
+    auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({3, 20, 20, 3}));
+}
+
+TYPED_TEST_P(ConvertColorI420Test, single_plane_dynamic_rank) {
+    const auto yuv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
+    this->op = this->make_op(yuv);
+
+    this->input_shapes = ShapeVector{{3, 12, 10, 1}};
+    auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({3, 8, 10, 3}));
+}
+
+TYPED_TEST_P(ConvertColorI420Test, single_plane_static_rank) {
+    const auto yuv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    this->op = this->make_op(yuv);
+
+    this->input_shapes = ShapeVector{{5, 3, 2, 1}};
+    auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({5, 2, 2, 3}));
+}
+
+TYPED_TEST_P(ConvertColorI420Test, three_plane_dynamic_rank) {
+    const auto y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
+    const auto u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
+    const auto v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
+    this->op = this->make_op(y, u, v);
+
+    this->input_shapes = ShapeVector{{3, 10, 10, 1}, {3, 5, 5, 1}, {3, 5, 5, 1}};
+    auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({3, 10, 10, 3}));
+}
+
+TYPED_TEST_P(ConvertColorI420Test, three_plane_static_rank) {
+    const auto y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    const auto u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    const auto v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    this->op = this->make_op(y, u, v);
+
+    this->input_shapes = ShapeVector{{5, 20, 20, 1}, {5, 10, 10, 1}, {5, 10, 10, 1}};
+    auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({5, 20, 20, 3}));
+}
+
+TYPED_TEST_P(ConvertColorI420Test, three_plane_u_shape_not_compatible) {
+    const auto y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    const auto u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    const auto v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    this->op = this->make_op(y, u, v);
+
+    this->input_shapes = ShapeVector{{5, 20, 20, 1}, {4, 10, 10, 1}, {5, 10, 10, 1}};
+    OV_EXPECT_THROW(shape_inference(this->op.get(), this->input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("Y shape is inconsistent with U and V"));
+}
+
+TYPED_TEST_P(ConvertColorI420Test, single_plane_height_not_div_by_three) {
+    const auto yuv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    this->op = this->make_op(yuv);
+
+    this->input_shapes = ShapeVector{{5, 19, 20, 1}};
+    OV_EXPECT_THROW(shape_inference(this->op.get(), this->input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("I420 image height shall be divisible by 3"));
+}
+
+REGISTER_TYPED_TEST_SUITE_P(ConvertColorI420Test,
+                            default_ctor_single_plane_no_args,
+                            default_ctor_three_plane_no_args,
+                            single_plane_dynamic_rank,
+                            single_plane_static_rank,
+                            three_plane_dynamic_rank,
+                            three_plane_static_rank,
+                            three_plane_u_shape_not_compatible,
+                            single_plane_height_not_div_by_three);
+
+using I420Types = testing::Types<op::v8::I420toRGB, op::v8::I420toBGR>;
+INSTANTIATE_TYPED_TEST_SUITE_P(StaticShapeInference, ConvertColorI420Test, I420Types);

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/nv12_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/nv12_shape_inference_test.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/op/i420_to_bgr.hpp"
-#include "openvino/op/i420_to_rgb.hpp"
+#include "openvino/op/nv12_to_bgr.hpp"
+#include "openvino/op/nv12_to_rgb.hpp"
 #include "utils.hpp"
 
 using namespace ov;
@@ -14,33 +14,31 @@ using namespace ov::intel_cpu;
 using namespace testing;
 
 template <class TOp>
-class ConvertColorI420Test : public OpStaticShapeInferenceTest<TOp> {
-protected:
-};
+class ConvertColorNV12Test : public OpStaticShapeInferenceTest<TOp> {};
 
-TYPED_TEST_SUITE_P(ConvertColorI420Test);
+TYPED_TEST_SUITE_P(ConvertColorNV12Test);
 
-TYPED_TEST_P(ConvertColorI420Test, default_ctor_single_plane_no_args) {
+TYPED_TEST_P(ConvertColorNV12Test, default_ctor_single_plane_no_args) {
     this->op = this->make_op();
 
-    this->input_shapes = ShapeVector{{3, 15, 10, 1}};
+    this->input_shapes = ShapeVector{{3, 30, 10, 1}};
     auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
 
     EXPECT_EQ(output_shapes.size(), 1);
-    EXPECT_EQ(output_shapes.front(), StaticShape({3, 10, 10, 3}));
+    EXPECT_EQ(output_shapes.front(), StaticShape({3, 20, 10, 3}));
 }
 
-TYPED_TEST_P(ConvertColorI420Test, default_ctor_three_plane_no_args) {
+TYPED_TEST_P(ConvertColorNV12Test, default_ctor_two_plane_no_args) {
     this->op = this->make_op();
 
-    this->input_shapes = ShapeVector{{3, 20, 20, 1}, {3, 10, 10, 1}, {3, 10, 10, 1}};
+    this->input_shapes = ShapeVector{{3, 20, 20, 1}, {3, 10, 10, 2}};
     auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
 
     EXPECT_EQ(output_shapes.size(), 1);
     EXPECT_EQ(output_shapes.front(), StaticShape({3, 20, 20, 3}));
 }
 
-TYPED_TEST_P(ConvertColorI420Test, single_plane_dynamic_rank) {
+TYPED_TEST_P(ConvertColorNV12Test, single_plane_dynamic_rank) {
     const auto yuv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     this->op = this->make_op(yuv);
 
@@ -51,7 +49,7 @@ TYPED_TEST_P(ConvertColorI420Test, single_plane_dynamic_rank) {
     EXPECT_EQ(output_shapes.front(), StaticShape({3, 8, 10, 3}));
 }
 
-TYPED_TEST_P(ConvertColorI420Test, single_plane_static_rank) {
+TYPED_TEST_P(ConvertColorNV12Test, single_plane_static_rank) {
     const auto yuv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
     this->op = this->make_op(yuv);
 
@@ -62,45 +60,53 @@ TYPED_TEST_P(ConvertColorI420Test, single_plane_static_rank) {
     EXPECT_EQ(output_shapes.front(), StaticShape({5, 2, 2, 3}));
 }
 
-TYPED_TEST_P(ConvertColorI420Test, three_plane_dynamic_rank) {
+TYPED_TEST_P(ConvertColorNV12Test, two_plane_dynamic_rank) {
     const auto y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    const auto u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    const auto v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    this->op = this->make_op(y, u, v);
+    const auto uv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
+    this->op = this->make_op(y, uv);
 
-    this->input_shapes = ShapeVector{{3, 10, 10, 1}, {3, 5, 5, 1}, {3, 5, 5, 1}};
+    this->input_shapes = ShapeVector{{3, 10, 10, 1}, {3, 5, 5, 2}};
     auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
 
     EXPECT_EQ(output_shapes.size(), 1);
     EXPECT_EQ(output_shapes.front(), StaticShape({3, 10, 10, 3}));
 }
 
-TYPED_TEST_P(ConvertColorI420Test, three_plane_static_rank) {
+TYPED_TEST_P(ConvertColorNV12Test, two_plane_static_rank) {
     const auto y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
-    const auto u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
-    const auto v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
-    this->op = this->make_op(y, u, v);
+    const auto uv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    this->op = this->make_op(y, uv);
 
-    this->input_shapes = ShapeVector{{5, 20, 20, 1}, {5, 10, 10, 1}, {5, 10, 10, 1}};
+    this->input_shapes = ShapeVector{{5, 20, 20, 1}, {5, 10, 10, 2}};
     auto output_shapes = shape_inference(this->op.get(), this->input_shapes);
 
     EXPECT_EQ(output_shapes.size(), 1);
     EXPECT_EQ(output_shapes.front(), StaticShape({5, 20, 20, 3}));
 }
 
-TYPED_TEST_P(ConvertColorI420Test, three_plane_u_shape_not_compatible) {
+TYPED_TEST_P(ConvertColorNV12Test, two_plane_uv_shape_not_compatible) {
     const auto y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
-    const auto u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
-    const auto v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
-    this->op = this->make_op(y, u, v);
+    const auto uv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    this->op = this->make_op(y, uv);
 
-    this->input_shapes = ShapeVector{{5, 20, 20, 1}, {4, 10, 10, 1}, {5, 10, 10, 1}};
+    this->input_shapes = ShapeVector{{5, 20, 20, 1}, {4, 10, 10, 2}};
     OV_EXPECT_THROW(shape_inference(this->op.get(), this->input_shapes),
                     NodeValidationFailure,
-                    HasSubstr("Y shape is inconsistent with U and V"));
+                    HasSubstr("Y shape is inconsistent with UV"));
 }
 
-TYPED_TEST_P(ConvertColorI420Test, single_plane_height_not_div_by_three) {
+TYPED_TEST_P(ConvertColorNV12Test, two_plane_y_dims_not_div_by_2) {
+    const auto y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    const auto uv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    this->op = this->make_op(y, uv);
+
+    this->input_shapes = ShapeVector{{5, 19, 19, 1}, {4, 10, 10, 2}};
+    OV_EXPECT_THROW(shape_inference(this->op.get(), this->input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("Y shape is inconsistent with UV"));
+}
+
+TYPED_TEST_P(ConvertColorNV12Test, single_plane_height_not_div_by_three) {
     const auto yuv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
     this->op = this->make_op(yuv);
 
@@ -110,15 +116,16 @@ TYPED_TEST_P(ConvertColorI420Test, single_plane_height_not_div_by_three) {
                     HasSubstr("Image height shall be divisible by 3"));
 }
 
-REGISTER_TYPED_TEST_SUITE_P(ConvertColorI420Test,
+REGISTER_TYPED_TEST_SUITE_P(ConvertColorNV12Test,
                             default_ctor_single_plane_no_args,
-                            default_ctor_three_plane_no_args,
+                            default_ctor_two_plane_no_args,
                             single_plane_dynamic_rank,
                             single_plane_static_rank,
-                            three_plane_dynamic_rank,
-                            three_plane_static_rank,
-                            three_plane_u_shape_not_compatible,
+                            two_plane_dynamic_rank,
+                            two_plane_static_rank,
+                            two_plane_uv_shape_not_compatible,
+                            two_plane_y_dims_not_div_by_2,
                             single_plane_height_not_div_by_three);
 
-using I420Types = testing::Types<op::v8::I420toRGB, op::v8::I420toBGR>;
-INSTANTIATE_TYPED_TEST_SUITE_P(StaticShapeInference, ConvertColorI420Test, I420Types);
+using NV12Types = testing::Types<op::v8::NV12toRGB, op::v8::NV12toBGR>;
+INSTANTIATE_TYPED_TEST_SUITE_P(StaticShapeInference, ConvertColorNV12Test, NV12Types);


### PR DESCRIPTION
### Details:
 - Review static and dynamic shapes with label propagation
 - Add template implementation of `shape_infer` for `I420` and `NV12`
 - Check interval shape propagation

### Tickets:
 - 97241
