### PR TITLE
[GNA] Fixed absent node_id crash

### DIFF
--- a/src/plugins/intel_gna/src/ops/gna_convolution.hpp
+++ b/src/plugins/intel_gna/src/ops/gna_convolution.hpp
@@ -133,9 +133,6 @@ public:
     void set_auto_pad(const ov::op::PadType& auto_pad) {
         m_auto_pad = auto_pad;
     }
-    bool has_add_node() const {
-        return m_has_add_node;
-    }
     bool has_bias() const {
         return m_has_add_node;
     }


### PR DESCRIPTION
### Details:
 - Markup function uses ngraph function get_ordered_ops which doesn't return layers inside the tensor operator. This fix takes care about that.

### Tickets:
 - *N/A*
