### PR TITLE
[MO] Raise exception for older nncf models

### DIFF
--- a/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
@@ -19,6 +19,17 @@ def get_pytorch_decoder(model, input_shape, example_inputs, args):
     except Exception as e:
         log.error("PyTorch frontend loading failed")
         raise e
+    try:
+        import nncf
+        from nncf.torch.nncf_network import NNCFNetwork
+        from packaging import version
+
+        if isinstance(model, NNCFNetwork):
+            if version.parse(nncf.__version__) < version.parse("2.6"):
+                raise RuntimeError(
+                    "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
+    except:
+        pass
     inputs = prepare_torch_inputs(example_inputs, input_shape, args.get("input"), allow_none=True)
     decoder = TorchScriptPythonDecoder(model, example_input=inputs)
     args['input_model'] = decoder

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
@@ -19,7 +19,8 @@ def get_pytorch_decoder(model, example_inputs, args):
     except Exception as e:
         log.error("PyTorch frontend loading failed")
         raise e
-    inputs = prepare_torch_inputs(example_inputs, args.get("input"), allow_none=True)
+    inputs = prepare_torch_inputs(
+        example_inputs, args.get("input"), allow_none=True)
     try:
         import nncf
         from nncf.torch.nncf_network import NNCFNetwork
@@ -27,7 +28,8 @@ def get_pytorch_decoder(model, example_inputs, args):
 
         if isinstance(model, NNCFNetwork):
             if version.parse(nncf.__version__) < version.parse("2.6"):
-                model = model.strip()
+                raise RuntimeError(
+                    "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
     except:
         pass
     decoder = TorchScriptPythonDecoder(model, example_input=inputs)

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
@@ -19,19 +19,18 @@ def get_pytorch_decoder(model, example_inputs, args):
     except Exception as e:
         log.error("PyTorch frontend loading failed")
         raise e
-    inputs = prepare_torch_inputs(
-        example_inputs, args.get("input"), allow_none=True)
     try:
         import nncf
         from nncf.torch.nncf_network import NNCFNetwork
         from packaging import version
 
         if isinstance(model, NNCFNetwork):
-            if version.parse(nncf.__version__) < version.parse("2.6"):
+            if version.parse(nncf.__version__) <= version.parse("2.6"):
                 raise RuntimeError(
                     "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
     except:
         pass
+    inputs = prepare_torch_inputs(example_inputs, args.get("input"), allow_none=True)
     decoder = TorchScriptPythonDecoder(model, example_input=inputs)
     args['input_model'] = decoder
     args["example_input"] = inputs

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
@@ -20,6 +20,16 @@ def get_pytorch_decoder(model, example_inputs, args):
         log.error("PyTorch frontend loading failed")
         raise e
     inputs = prepare_torch_inputs(example_inputs, args.get("input"), allow_none=True)
+    try:
+        import nncf
+        from nncf.torch.nncf_network import NNCFNetwork
+        from packaging import version
+
+        if isinstance(model, NNCFNetwork):
+            if version.parse(nncf.__version__) < version.parse("2.6"):
+                model = model.strip()
+    except:
+        pass
     decoder = TorchScriptPythonDecoder(model, example_input=inputs)
     args['input_model'] = decoder
     args["example_input"] = inputs


### PR DESCRIPTION
### Details:
 - *Models from `nncf<2.6` require strip() to be called before conversion otherwise converted model will lose quantization.*

### Tickets:
 - *115147*
