### PR TITLE
[GPU] updated to enqueue only fully_connected layers for async build

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -283,6 +283,7 @@ private:
     bool is_body_program;
     std::unique_ptr<ImplementationsCache> _impls_cache;
     const size_t _impls_cache_capacity = 10000;
+    const int _num_async_build_threads = 1;
     std::unique_ptr<ICompilationContext> _compilation_context;
 
     std::map<primitive_id, std::shared_ptr<program_node>> nodes_map;

--- a/src/plugins/intel_gpu/src/graph/compilation_context.cpp
+++ b/src/plugins/intel_gpu/src/graph/compilation_context.cpp
@@ -13,7 +13,7 @@ namespace cldnn {
 class CompilationContext : public ICompilationContext {
 public:
     CompilationContext(ov::threading::IStreamsExecutor::Config task_executor_config) : _task_executor_config(task_executor_config) {
-        _task_executor_config._streams = 4;
+        _task_executor_config._streams = 1;
         _task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(_task_executor_config);
     }
 

--- a/src/plugins/intel_gpu/src/graph/compilation_context.cpp
+++ b/src/plugins/intel_gpu/src/graph/compilation_context.cpp
@@ -13,7 +13,6 @@ namespace cldnn {
 class CompilationContext : public ICompilationContext {
 public:
     CompilationContext(ov::threading::IStreamsExecutor::Config task_executor_config) : _task_executor_config(task_executor_config) {
-        _task_executor_config._streams = 1;
         _task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(_task_executor_config);
     }
 

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -351,6 +351,7 @@ protected:
 
     virtual void update_shape();
     virtual event::ptr update_weights();
+    bool use_async_compilation();
     // if primitive_inst doesn't replace impl to new impl(static impl with opt kerenl or dynamic impl), return false
     bool update_impl();
     event::ptr realloc_if_needed();

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -486,6 +486,7 @@ bool primitive_inst::use_async_compilation() {
     }
     return (_node->is_type<convolution>() ||
             _node->is_type<fully_connected>() ||
+            _node->is_type<gemm>() ||
             _node->is_type<softmax>());
 }
 

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -124,9 +124,9 @@ static void adjust_num_cores(ov::threading::IStreamsExecutor::Config& config) {
     config._streams = std::min(config._streams, num_cores);
 }
 
-static ov::threading::IStreamsExecutor::Config make_task_executor_config(const ExecutionConfig& config, std::string tags) {
+static ov::threading::IStreamsExecutor::Config make_task_executor_config(const ExecutionConfig& config, std::string tags, int num_streams = 0) {
     ov::threading::IStreamsExecutor::Config task_executor_config(tags, 1);
-    task_executor_config._streams = config.get_property(ov::compilation_num_threads);
+    task_executor_config._streams = (num_streams > 0) ? num_streams : config.get_property(ov::compilation_num_threads);
     auto priority = config.get_property(ov::intel_gpu::hint::host_task_priority);
     switch (priority) {
         case ov::hint::Priority::LOW: task_executor_config._threadPreferredCoreType = ov::threading::IStreamsExecutor::Config::LITTLE; break;
@@ -214,7 +214,7 @@ void program::init_program() {
                                                                       kernel_selector::KernelBase::get_db().get_batch_header_str()));
 
     _compilation_context = ICompilationContext::create(make_task_executor_config(_config,
-                                                            "Task executor config for CompilationContext in GPU plugin"));
+                                                            "Task executor config for CompilationContext in GPU plugin", 1));
 
     _impls_cache = cldnn::make_unique<ImplementationsCache>(_impls_cache_capacity);
     // Remove items of compilation context's internal queue when some impl is popped in kernels_cache

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -214,7 +214,7 @@ void program::init_program() {
                                                                       kernel_selector::KernelBase::get_db().get_batch_header_str()));
 
     _compilation_context = ICompilationContext::create(make_task_executor_config(_config,
-                                                            "Task executor config for CompilationContext in GPU plugin", 1));
+                                                       "Task executor config for CompilationContext in GPU plugin", _num_async_build_threads));
 
     _impls_cache = cldnn::make_unique<ImplementationsCache>(_impls_cache_capacity);
     // Remove items of compilation context's internal queue when some impl is popped in kernels_cache

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -1499,7 +1499,7 @@ INSTANTIATE_TEST_SUITE_P(gemm_gpu, gemm_onednn_ndims, ::testing::ValuesIn(std::v
     gemm_onednn_test_params{ CASE_GEMM_ONEDNN_I8_6D },
 }));
 
-TEST(gemm_onednn, impl_replacement_with_cldnn) {
+TEST(gemm_onednn, DISABLED_impl_replacement_with_cldnn) {
     auto& engine = get_test_engine();
 
     if (!engine.get_device_info().supports_immad)

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -1499,7 +1499,7 @@ INSTANTIATE_TEST_SUITE_P(gemm_gpu, gemm_onednn_ndims, ::testing::ValuesIn(std::v
     gemm_onednn_test_params{ CASE_GEMM_ONEDNN_I8_6D },
 }));
 
-TEST(gemm_onednn, DISABLED_impl_replacement_with_cldnn) {
+TEST(gemm_onednn, impl_replacement_with_cldnn) {
     auto& engine = get_test_engine();
 
     if (!engine.get_device_info().supports_immad)


### PR DESCRIPTION
### Details:
 - This PR updates the async build for dynamic models to build convolution, fully_connected, and softmax layers.
 - Current kernel build process has negative impact on inference tasks. So we need to select effective kernels and to build them.

### Tickets:
 - 103753
