### PR TITLE
[CPU] Fix jit compilation exception on sse for mvn

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -89,7 +89,21 @@ static inline bool isFloatCompatible(Precision prc) {
     return one_of(prc, Precision::FP32, Precision::BF16, Precision::FP16);
 }
 
-static const int kTileNum = 3;
+// 8/4/2/1 tile
+static const int kTileNum = 4;
+
+// 4-7 for src, 8-11 for sum, 12-15 for mean. 4 vector for 8/4/2/1 tiles
+static inline int get_tile_vr_id(const int& step) {
+    int vec_reg_id = 3;
+    if (step == 8) {
+        vec_reg_id = 0;
+    } else if (step == 4) {
+        vec_reg_id = 1;
+    } else if (step == 2) {
+        vec_reg_id = 2;
+    }
+    return vec_reg_id;
+}
 
 // normalize_variance = false : src->mean
 // normalize_variance = true : src+mean->variance:sqr(x-mean)
@@ -113,6 +127,7 @@ struct jit_uni_mvn_mean_variance_kernel_f32 : public jit_uni_mvn_mean_variance_k
         load_emitter[TAIL1] = std::unique_ptr<jit_load_emitter>(new jit_load_emitter(this, isa, jcp_.src_prc, dst_prc, 1));
         load_emitter[TAIL8_FILL] = std::unique_ptr<jit_load_emitter>(new jit_load_emitter(this, isa, jcp_.src_prc, dst_prc, 8, Precision::FP32, true, "zero"));
         load_emitter[TAIL4_FILL] = std::unique_ptr<jit_load_emitter>(new jit_load_emitter(this, isa, jcp_.src_prc, dst_prc, 4, Precision::FP32, true, "zero"));
+        load_emitter[TAIL2_FILL] = std::unique_ptr<jit_load_emitter>(new jit_load_emitter(this, isa, jcp_.src_prc, dst_prc, 2, Precision::FP32, true, "zero"));
         load_emitter[TAIL1_FILL] = std::unique_ptr<jit_load_emitter>(new jit_load_emitter(this, isa, jcp_.src_prc, dst_prc, 1, Precision::FP32, true, "zero"));
 
         this->preamble();
@@ -207,14 +222,11 @@ private:
 
     size_t src_stride = 0;
 
-    enum { VECTOR, TAIL8, TAIL4, TAIL2, TAIL1, TAIL8_FILL, TAIL4_FILL, TAIL1_FILL, LOAD_EMITTERS_NUM };
+    enum { VECTOR, TAIL8, TAIL4, TAIL2, TAIL1, TAIL8_FILL, TAIL4_FILL, TAIL2_FILL, TAIL1_FILL, LOAD_EMITTERS_NUM };
     std::unique_ptr<jit_load_emitter> load_emitter[LOAD_EMITTERS_NUM];
     std::vector<size_t> load_pool_gpr_idxs;
 
-    // used for tails process(except nspc&&per_channel)
-    Label tail_start[kTileNum];
-    Label tail_exit[kTileNum];
-    const int tile_size[kTileNum] = {8, 4, 1};
+    const int tile_size[kTileNum] = {8, 4, 2, 1};
 
     // nspc across channel
     inline void nspc_ac_ker() {
@@ -431,15 +443,16 @@ private:
         mov(reg_src_aux, reg_src);
         mov(reg_work_amount, reg_work_amount_bk);
 
-        // 4-7 for src, 8-11 for sum, 12-15 for mean. 4 vector for 8/4/2/1 tiles
-        auto init_tails = [&](int vmm_id, int step) {
+        auto init_tails = [&](int step) {
+            int vmm_id = get_tile_vr_id(step);
             uni_vpxor(Vmm(ur_base + 4 + vmm_id), Vmm(ur_base + 4 + vmm_id), Vmm(ur_base + 4 + vmm_id));
             if (jcp_.normalize_variance) {
                 uni_vmovups(Vmm(ur_base + 8 + vmm_id), ptr[reg_mean]);
                 add(reg_mean, step * sizeof(float));
             }
         };
-        auto load_src_tails = [&](int vmm_id, int step) {
+        auto load_src_tails = [&](int step) {
+            int vmm_id = get_tile_vr_id(step);
             int emitter_id = 4;
             if (step == 8) {
                 emitter_id = 1;
@@ -452,7 +465,8 @@ private:
                                                 {}, {load_pool_gpr_idxs});
             add(reg_src_aux, step * jcp_.src_data_size);
         };
-        auto mv_tails = [&](int vmm_id, int step) {
+        auto mv_tails = [&](int step) {
+            int vmm_id = get_tile_vr_id(step);
             if (jcp_.normalize_variance) {
                 if (!isFloatCompatible(jcp_.src_prc)) {
                     uni_vcvtdq2ps(Vmm(ur_base + vmm_id), Vmm(ur_base + vmm_id));
@@ -466,7 +480,8 @@ private:
                     uni_vaddps(Vmm(ur_base + 4 + vmm_id), Vmm(ur_base + 4 + vmm_id), Vmm(ur_base + vmm_id));
             }
         };
-        auto store_tails = [&](int vmm_id, size_t step) {
+        auto store_tails = [&](size_t step) {
+            int vmm_id = get_tile_vr_id(step);
             if (jcp_.normalize_variance) {
                 uni_vmovups(ptr[reg_variance], Vmm(ur_base + 4 + vmm_id));
                 add(reg_variance, step * sizeof(float));
@@ -478,36 +493,9 @@ private:
             }
         };
 
-        auto tails_worker = [&](std::function<void(int, int)> func) {
-            Label tail_blk8_exit_label;
-            Label tail_blk4_exit_label;
-            Label tail_blk2_exit_label;
-            Label tail_blk1_exit_label;
-            cmp(reg_tails_num_active, 8);
-            jl(tail_blk8_exit_label, T_NEAR);
-            func(0, 8);
-            sub(reg_tails_num_active, 8);
-            L(tail_blk8_exit_label);
-            cmp(reg_tails_num_active, 4);
-            jl(tail_blk4_exit_label, T_NEAR);
-            func(1, 4);
-            sub(reg_tails_num_active, 4);
-            L(tail_blk4_exit_label);
-            cmp(reg_tails_num_active, 2);
-            jl(tail_blk2_exit_label, T_NEAR);
-            func(2, 2);
-            sub(reg_tails_num_active, 2);
-            L(tail_blk2_exit_label);
-            cmp(reg_tails_num_active, 1);
-            jl(tail_blk1_exit_label, T_NEAR);
-            func(3, 1);
-            sub(reg_tails_num_active, 1);
-            L(tail_blk1_exit_label);
-        };
-
         // init
         mov(reg_tails_num_active, reg_tail_num);
-        tails_worker(init_tails);
+        worker_tails(reg_tails_num_active, init_tails);
 
         Xbyak::Label loop_tail_label;
         Xbyak::Label label_tails_end;
@@ -519,11 +507,11 @@ private:
 
             // load src
             mov(reg_tails_num_active, reg_tail_num);
-            tails_worker(load_src_tails);
+            worker_tails(reg_tails_num_active, load_src_tails);
 
             // m/v compute
             mov(reg_tails_num_active, reg_tail_num);
-            tails_worker(mv_tails);
+            worker_tails(reg_tails_num_active, mv_tails);
 
             mov(rdi, reg_vector_num);
             imul(rdi, rdi, vector_step * jcp_.src_data_size);
@@ -535,7 +523,7 @@ private:
 
         // store tails
         mov(reg_tails_num_active, reg_tail_num);
-        tails_worker(store_tails);
+        worker_tails(reg_tails_num_active, store_tails);
 
         L(label_exit);
     }
@@ -747,22 +735,19 @@ private:
     }
 
     inline void worker_tails(Xbyak::Reg64& reg_tail_num, std::function<void(int)> func) {
-        for (int i = 0; i < kTileNum; i++) {
-            L(tail_start[i]);
-            {
-                cmp(reg_tail_num, tile_size[i]);
-                jl(tail_exit[i], T_NEAR);
+        int tile_start_idx = (isa == cpu::x64::avx512_core) ? 0 : ((isa == cpu::x64::avx2) ? 1 : 2);
+        Label tile_exit[kTileNum];
+        for (int i = tile_start_idx; i < kTileNum; i++) {
+            cmp(reg_tail_num, tile_size[i]);
+            jl(tile_exit[i], T_NEAR);
 
-                func(tile_size[i]);
+            func(tile_size[i]);
+            sub(reg_tail_num, tile_size[i]);
 
-                sub(reg_tail_num, tile_size[i]);
-                jmp(tail_start[i], T_NEAR);
-            }
-            L(tail_exit[i]);
+            L(tile_exit[i]);
         }
     }
 
-    // needed and supported case: 1. scalar with zero pad. 2. tails w/ or w/o zero pad
     inline void worker_block(int block_num, bool is_zero_pad) {
         if (is_zero_pad) {
             switch (block_num) {
@@ -774,12 +759,16 @@ private:
                 load_emitter[TAIL4_FILL]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
                                            {}, {load_pool_gpr_idxs});
                 break;
+            case 2:
+                load_emitter[TAIL2_FILL]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
+                                           {}, {load_pool_gpr_idxs});
+                break;
             case 1:
                 load_emitter[TAIL1_FILL]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
                                            {}, {load_pool_gpr_idxs});
                 break;
             default:
-                assert(!"MVN layer tails is processed only with 8/4/1 blocks.");
+                assert(!"MVN layer tails is processed only with 8/4/2/1 blocks.");
                 break;
             }
         } else {
@@ -792,12 +781,16 @@ private:
                 load_emitter[TAIL4]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
                                            {}, {load_pool_gpr_idxs});
                 break;
+            case 2:
+                load_emitter[TAIL2]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
+                                           {}, {load_pool_gpr_idxs});
+                break;
             case 1:
                 load_emitter[TAIL1]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
                                            {}, {load_pool_gpr_idxs});
                 break;
             default:
-                assert(!"MVN layer tails is processed only with 8/4/1 blocks.");
+                assert(!"MVN layer tails is processed only with 8/4/2/1 blocks.");
                 break;
             }
         }
@@ -1045,10 +1038,7 @@ private:
     std::vector<size_t> store_pool_vec_idxs;
     std::vector<size_t> load_pool_gpr_idxs;
 
-    // used for tails process(except nspc&&per_channel)
-    Label tail_start[kTileNum];
-    Label tail_exit[kTileNum];
-    const int tile_size[kTileNum] = {8, 4, 1};
+    const int tile_size[kTileNum] = {8, 4, 2, 1};
 
     std::vector<std::shared_ptr<jit_uni_eltwise_injector_f32<isa>>> eltwise_injectors;
     std::vector<std::shared_ptr<jit_uni_depthwise_injector_f32<isa>>> depthwise_injectors;
@@ -1415,47 +1405,38 @@ private:
             }
             return emitter_id;
         };
-        auto load_src_tails = [&](int vmm_id, int step) {
+        auto load_mv_tails = [&](int step) {
+            load_mv(get_tile_vr_id(step), step);
+        };
+        auto load_weight_bias_tails = [&](int step) {
+            load_weight_bias(get_tile_vr_id(step), step);
+        };
+        auto norm_tails = [&](int step) {
+            norm(get_tile_vr_id(step), step);
+        };
+        auto optimized_ss_tails = [&](int step) {
+            optimized_ss(get_tile_vr_id(step), step);
+        };
+        auto post_ops_tails = [&](int step) {
+            post_ops(get_tile_vr_id(step), step);
+        };
+        auto load_src_tails = [&](int step) {
+            int vmm_id = get_tile_vr_id(step);
             int emitter_id = get_tile_emitter_id(step);
             load_emitter[emitter_id]->emit_code({static_cast<size_t>(reg_src_aux.getIdx())},
                                                 {static_cast<size_t>(ur_base + vmm_id)}, {}, {load_pool_gpr_idxs});
             add(reg_src_aux, step * jcp_.src_data_size);
         };
-        auto store_tails = [&](int vmm_id, int step) {
+        auto store_tails = [&](int step) {
+            int vmm_id = get_tile_vr_id(step);
             int emitter_id = get_tile_emitter_id(step);
             store_emitter[emitter_id]->emit_code({static_cast<size_t>(ur_base + vmm_id)}, {static_cast<size_t>(reg_dst_aux.getIdx())},
                                        {store_pool_vec_idxs}, {store_pool_gpr_idxs});
             add(reg_dst_aux, step * jcp_.dst_data_size);
         };
-        auto tails_worker = [&](std::function<void(int, int)> func) {
-            Label tail_blk8_exit_label;
-            Label tail_blk4_exit_label;
-            Label tail_blk2_exit_label;
-            Label tail_blk1_exit_label;
-            cmp(reg_tails_num_active, 8);
-            jl(tail_blk8_exit_label, T_NEAR);
-            func(0, 8);
-            sub(reg_tails_num_active, 8);
-            L(tail_blk8_exit_label);
-            cmp(reg_tails_num_active, 4);
-            jl(tail_blk4_exit_label, T_NEAR);
-            func(1, 4);
-            sub(reg_tails_num_active, 4);
-            L(tail_blk4_exit_label);
-            cmp(reg_tails_num_active, 2);
-            jl(tail_blk2_exit_label, T_NEAR);
-            func(2, 2);
-            sub(reg_tails_num_active, 2);
-            L(tail_blk2_exit_label);
-            cmp(reg_tails_num_active, 1);
-            jl(tail_blk1_exit_label, T_NEAR);
-            func(3, 1);
-            sub(reg_tails_num_active, 1);
-            L(tail_blk1_exit_label);
-        };
 
         // load m/v m:8-11, v:12-15
-        tails_worker(load_mv);
+        worker_mvn_tails(reg_tails_num_active, load_mv_tails);
 
         // optimized scaleshift. 16-23 for weight, 24-31 for bias.
         // reg_post_ops_data[0]:----w0---- ----b0---- reg_post_ops_data[1]:----w1---- ----b1----
@@ -1472,7 +1453,7 @@ private:
             imul(rax, rax, sizeof(float));
             add(reg_d_bias, rax);
 
-            tails_worker(load_weight_bias);
+            worker_mvn_tails(reg_tails_num_active, load_weight_bias_tails);
 
             post_ops_data_offset += sizeof(float*);
             ss_repeat_id++;
@@ -1486,7 +1467,7 @@ private:
             jle(loop_tails_end_label, T_NEAR);
             mov(reg_tails_num_active, addr_tail_num);
 
-            tails_worker(load_src_tails);
+            worker_mvn_tails(reg_tails_num_active, load_src_tails);
 
             // to next iteration(next work_amount)
             mov(rax, addr_vector_num);
@@ -1495,25 +1476,25 @@ private:
 
             // norm
             mov(reg_tails_num_active, addr_tail_num);
-            tails_worker(norm);
+            worker_mvn_tails(reg_tails_num_active, norm_tails);
 
             // optimized scaleShift
             ss_repeat_id = 0;
             for (int i = 0; i < optimized_scaleshift_num; i++) {
                 mov(reg_tails_num_active, addr_tail_num);
-                tails_worker(optimized_ss);
+                worker_mvn_tails(reg_tails_num_active, optimized_ss_tails);
                 ss_repeat_id++;
             }
 
             // post-ops
             if (attr_.post_ops_.len() != 0) {
                 mov(reg_tails_num_active, addr_tail_num);
-                tails_worker(post_ops);
+                worker_mvn_tails(reg_tails_num_active, post_ops_tails);
             }
 
             // store
             mov(reg_tails_num_active, addr_tail_num);
-            tails_worker(store_tails);
+            worker_mvn_tails(reg_tails_num_active, store_tails);
 
             // dst advance
             mov(rax, reg_rt_shape);
@@ -1575,7 +1556,7 @@ private:
         Xbyak::Label mvn_loop_end_label;
 
         int step_sub = jcp_.layout == MVNLayoutType::mvn_by_channel ? vector_step : 1;
-        int step_left = jcp_.layout == MVNLayoutType::mvn_by_channel ? vector_step : 0;
+        int step_left = jcp_.layout == MVNLayoutType::mvn_by_channel ? vector_step - 1 : 0;
 
         L(mvn_loop_label);
         {
@@ -1611,18 +1592,16 @@ private:
     }
 
     inline void worker_mvn_tails(Xbyak::Reg64& reg_tail_num, std::function<void(int)> func) {
-        for (int i = 0; i < kTileNum; i++) {
-            L(tail_start[i]);
-            {
-                cmp(reg_tail_num, tile_size[i]);
-                jl(tail_exit[i], T_NEAR);
+        int tile_start_idx = (isa == cpu::x64::avx512_core) ? 0 : ((isa == cpu::x64::avx2) ? 1 : 2);
+        Label tile_exit[kTileNum];
+        for (int i = tile_start_idx; i < kTileNum; i++) {
+            cmp(reg_tail_num, tile_size[i]);
+            jl(tile_exit[i], T_NEAR);
 
-                func(tile_size[i]);
+            func(tile_size[i]);
+            sub(reg_tail_num, tile_size[i]);
 
-                sub(reg_tail_num, tile_size[i]);
-                jmp(tail_start[i], T_NEAR);
-            }
-            L(tail_exit[i]);
+            L(tile_exit[i]);
         }
     }
 
@@ -1636,12 +1615,16 @@ private:
             load_emitter[TAIL4]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
                 {}, {load_pool_gpr_idxs});
             break;
+        case 2:
+            load_emitter[TAIL2]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
+                {}, {load_pool_gpr_idxs});
+            break;
         case 1:
             load_emitter[TAIL1]->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_val.getIdx())},
                 {}, {load_pool_gpr_idxs});
             break;
         default:
-            assert(!"MVN layer tails is processed only with 8/4/1 blocks.");
+            assert(!"MVN layer tails is processed only with 8/4/2/1 blocks.");
             break;
         }
 
@@ -1660,12 +1643,16 @@ private:
             store_emitter[TAIL4]->emit_code({static_cast<size_t>(vmm_val.getIdx())}, {static_cast<size_t>(reg_dst.getIdx())},
                 {store_pool_vec_idxs}, {store_pool_gpr_idxs});
             break;
+        case 2:
+            store_emitter[TAIL2]->emit_code({static_cast<size_t>(vmm_val.getIdx())}, {static_cast<size_t>(reg_dst.getIdx())},
+                {store_pool_vec_idxs}, {store_pool_gpr_idxs});
+            break;
         case 1:
             store_emitter[TAIL1]->emit_code({static_cast<size_t>(vmm_val.getIdx())}, {static_cast<size_t>(reg_dst.getIdx())},
                 {store_pool_vec_idxs}, {store_pool_gpr_idxs});
             break;
         default:
-            assert(!"MVN layer tails is processed only with 8/4/1 blocks.");
+            assert(!"MVN layer tails is processed only with 8/4/2/1 blocks.");
             break;
         }
     }


### PR DESCRIPTION
### Details:
 - *Valid tails number is [0, 15] on avx512, [0, 7] on avx2 and [0, 3] on sse41. Generic 8/4/2/1 tiles processing for tails should have conditional start. On AVX2, should be 4/2/1. On SSE, should be 2/1. Otherwise, for example, load 8 tails on sse is not allowed*

### Tickets:
 - *CVS-116378*
