### PR TITLE
[PyOV] Restore ONNX requirement for Python tests

### DIFF
--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -1,4 +1,6 @@
 -c ./constraints.txt
+protobuf
+onnx
 numpy
 bandit
 black


### PR DESCRIPTION
### Details:
 - Revert the packages to requirements file, which were deleted in https://github.com/openvinotoolkit/openvino/pull/18259
 - They need to stay there until Python API 1.0 is removed.
 - This fixes openvino-lin-debian postcommit check

### Tickets:
 - N/A
