### PR TITLE
[CI] [GHA] Unskip `test_keras_upsampling2d_bilinear` and `test_lrn_basic` in GHA

### DIFF
--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -54,7 +54,6 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_bilinear)
     @pytest.mark.nightly
-    @pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == 'true', reason="Ticket - 113362")
     def test_keras_upsampling2d_bilinear(self, params, ie_device, precision, ir_version, temp_dir,
                                          use_old_api, use_new_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),

--- a/tests/layer_tests/tensorflow_tests/test_tf_LRN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LRN.py
@@ -28,7 +28,6 @@ class TestLRN(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     #@pytest.mark.precommit_tf_fe - ticket 116032
     @pytest.mark.nightly
-    @pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == 'true', reason="Ticket - 113362")
     def test_lrn_basic(self, params, ie_device, precision, ir_version, temp_dir,
                        use_new_frontend, use_old_api):
         self._test(*self.create_lrn_net(**params),


### PR DESCRIPTION
### Details:
 - This PR unskips several tests that were failing in the GitHub Actions environment.

### Tickets:
 - *113362*
