### PR TITLE
[CPU] FullyConnected acceleration with 8bit weights decompression

### DIFF
--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.h
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.h
@@ -42,6 +42,9 @@ public:
     bool appendLinear(const std::vector<float>& scale, const std::vector<float>& shift, bool isLastPostOp, bool allowBinary = true);
     void appendClip(const std::vector<float>& low, const std::vector<float>& high);
 
+    void appendDecompressionScales(const std::vector<float>& scales);
+    void appendDecompressionZeroPoints(const std::vector<float>& zero_points);
+
     const VectorDims& getOutputDims() {
         return outputDims;
     }

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -287,13 +287,13 @@ void GraphOptimizer::FuseFCAndWeightsDecompression(Graph &graph) {
         return node->getType() == expectedType && node->getChildEdges().size() == 1;
     };
 
+    if (!impl::cpu::x64::mayiuse(impl::cpu::x64::avx2))
+        return;
+
     auto& graphNodes = graph.GetNodes();
     for (size_t i = 0; i < graphNodes.size(); i++) {
         const auto fcNode = dynamic_cast<node::FullyConnected*>(graphNodes[i].get());
         if (fcNode == nullptr)
-            continue;
-
-        if (!impl::cpu::x64::mayiuse(impl::cpu::x64::avx2))
             continue;
 
         const auto parent = fcNode->getParentEdgesAtPort(1)[0]->getParent();

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -192,10 +192,6 @@ void FullyConnected::getSupportedDescriptors() {
     if (getChildEdges().empty())
         IE_THROW()<< errorPrefix << " has incorrect number of output edges";
 
-    withBiases = getOriginalInputsNumber() == 3;
-
-    useSparseWeights = useSparseWeightsDecompression();
-
     auto inputDataType = DnnlExtensionUtils::IEPrecisionToDataType(getOriginalInputPrecisionAtPort(DATA_ID));
     outputDataType = DnnlExtensionUtils::IEPrecisionToDataType(getOriginalOutputPrecisionAtPort(DATA_ID));
 
@@ -203,6 +199,13 @@ void FullyConnected::getSupportedDescriptors() {
         outputDataType = DnnlExtensionUtils::IEPrecisionToDataType(fusedWith[fusedWith.size() - 1]->getOriginalOutputPrecisionAtPort(0));
     }
     auto weightsDataType = DnnlExtensionUtils::IEPrecisionToDataType(getOriginalInputPrecisionAtPort(WEIGHTS_ID));
+
+    withBiases = getOriginalInputsNumber() == 3;
+
+    useSparseWeights = useSparseWeightsDecompression();
+    useWeightsDecompressionImpl = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2) &&
+                                  inputDataType == memory::data_type::f32 && weightsDataType == memory::data_type::u8;
+
     // revert back outputDataType on special cases
     if (inputDataType == memory::data_type::f32) {
         // oneDNN only support f32 output when input is f32, even if FQ is fused
@@ -240,7 +243,7 @@ void FullyConnected::getSupportedDescriptors() {
 #if defined(OV_CPU_WITH_MLAS) && (defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64))
     // MLAS doesn't support post-ops fusing and only supports FP32. INT8 is not enabled yet
     // Disable MLAS when FC could fuse post-ops
-    useMlas = !useSparseWeights &&
+    useMlas = !useSparseWeights && !useWeightsDecompressionImpl &&
               (inputDataType == memory::data_type::f32 && weightsDataType == memory::data_type::f32) &&
               fusedWith.empty();
     auto wgtDims = getInputShapeAtPort(WEIGHTS_ID).getStaticDims();
@@ -587,6 +590,10 @@ void FullyConnected::setPostOps(dnnl::primitive_attr& attr, const VectorDims& di
     DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, canBeExecutedInInt8(),
                                     1 << 0,  getDQScales(), withBiases);
 
+    dnnlpoc.appendDecompressionScales(decompressionMultiply);
+    if (!decompressionSubtract.empty())
+        dnnlpoc.appendDecompressionZeroPoints(decompressionSubtract);
+
     for (size_t i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];
         bool isLastPostOp = (i == (fusedWith.size() - 1));
@@ -673,11 +680,15 @@ void FullyConnected::createDescriptorInternal(const dnnl::memory::desc &inputDes
     dnnl::memory::data_type wdt = indt;
     dnnl::memory::data_type bdt = outdt;
 
-    if (one_of(indt, dnnl::memory::data_type::bf16, dnnl::memory::data_type::f16)) {
-    //oneDNN ARM InnerProduct primitive supports only identical in/out data types
+    dnnl::memory::data_type original_wdt = DnnlExtensionUtils::IEPrecisionToDataType(getOriginalInputPrecisionAtPort(WEIGHTS_ID));
+    if (indt == dnnl::memory::data_type::f32 && original_wdt == dnnl::memory::data_type::u8) {
+        // Weights decompression case
+        wdt = original_wdt;
+    } else if (one_of(indt, dnnl::memory::data_type::bf16, dnnl::memory::data_type::f16)) {
 #if defined(OPENVINO_ARCH_X86_64)
         bdt = dnnl::memory::data_type::f32;
 #else
+        // oneDNN ARM InnerProduct primitive supports only identical in/out data types
         bdt = dnnl::memory::data_type::f16;
 #endif
     } else if (indt == dnnl::memory::data_type::u8 || indt == dnnl::memory::data_type::s8) {
@@ -939,6 +950,9 @@ bool FullyConnected::canBeExecutedInConv1x1() const {
     bool retVal = false;
     const auto inRank = getInputShapeAtPort(DATA_ID).getRank();
     const auto weightRank = getInputShapeAtPort(WEIGHTS_ID).getRank();
+    if (useWeightsDecompressionImpl) {
+        return false;
+    }
     // disable rank=4:
     // if layout is nhwc:
     //   A matrix: N * IC * H * W --> N * (IC*H*W), the M, N', K of matrix multiply will be:

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -115,6 +115,7 @@ private:
     void prepackMLASWeight();
 #endif
 
+    bool useWeightsDecompressionImpl = false;
     std::vector<float> decompressionSubtract;
     std::vector<float> decompressionMultiply;
 };

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -188,8 +188,6 @@ std::vector<std::string> disabledTestPatterns() {
         // New plugin API doesn't support changes of pre-processing
         R"(.*(Auto|Multi|Hetero).*InferRequestPreprocessTest.*SetPreProcessToInputInfo.*)",
         R"(.*(Auto|Multi|Hetero).*InferRequestPreprocessTest.*SetPreProcessToInferRequest.*)",
-        // Issue: 113727
-        R"(.*MatMulCompressedWeights.*)",
         // TODO: for 22.2 (CVS-68949)
         R"(.*smoke_AutoBatching_CPU/AutoBatching_Test_DetectionOutput.*)",
     };

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
@@ -220,6 +220,9 @@ const std::vector<std::vector<InputShape>> input_shapes_basic = {
     {{{}, {{1, 4, 48}}}, {{}, {{48, 256}}}},
     {{{}, {{1, 4, 512}}}, {{}, {{512, 256}}}},
     {{{}, {{1, 16, 32}}}, {{}, {{32, 64}}}},
+    {{{}, {{2, 4, 32}}}, {{}, {{32, 65}}}},
+    {{{}, {{11, 339, 377}}}, {{}, {{377, 335}}}},
+    {{{}, {{3, 12, 768}}}, {{}, {{768, 1024}}}},
 };
 const std::vector<fusingSpecificParams> fusingParamsSet {
     emptyFusingSpec,

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
@@ -189,7 +189,9 @@ protected:
         }
 
         std::map<std::string, std::string> additional_config = std::get<5>(test_param);
-        const size_t expected_count = additional_config[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES ? 1 : 0;
+        const size_t expected_count =
+            InferenceEngine::with_cpu_x86_avx2() &&
+            additional_config[PluginConfigParams::KEY_ENFORCE_BF16] != PluginConfigParams::YES ? 0 : 1;
         CheckNumberOfNodesWithType(compiledModel, "Convert", expected_count);
         CheckNumberOfNodesWithType(compiledModel, "Eltwise", expected_count);
         CheckNumberOfNodesWithType(compiledModel, "Subgraph", 0);

--- a/src/plugins/intel_cpu/tests/functional/target_per_test.cmake
+++ b/src/plugins/intel_cpu/tests/functional/target_per_test.cmake
@@ -87,7 +87,7 @@ function(create_target_per_test_for_directory TEST_DIR TARGET_PREFIX)
 endfunction()
 
 if(ENABLE_CPU_SPECIFIC_TARGET_PER_TEST)
-  create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/subgraph_tests/src/arm ov_cpu_func_subgraph)
+  create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/subgraph_tests/src ov_cpu_func_subgraph)
   create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/single_layer_tests ov_cpu_func_slt)
 endif()
 


### PR DESCRIPTION
### Details:
 - This PR adds runtime acceleration for LLMs with quantized weights on x86 CPUs
 - Supported cases:
 -- nodes: FullyConnected
 -- weights compression: unsigned 8bit
 -- isa: avx2, avx512
 - OneDNN PR: https://github.com/openvinotoolkit/oneDNN/pull/206/

### Tickets:
 - *[CVS-113727](https://jira.devtools.intel.com/browse/CVS-113727)*
