### PR TITLE
Change linker flags to fix ngraph_obj build in Debug mode

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -58,6 +58,14 @@ openvino_developer_export_targets(COMPONENT core TARGETS openvino::core::dev)
 # Install interface libraries for case BUILD_SHARED_LIBS=OFF
 ov_install_static_lib(ov_core_dev ${OV_CPACK_COMP_CORE})
 
+# Fix error LNK1248: image size (...) exceeds maximum allowable size (FFFFFFFF)
+# the symbolic debugging information will be stored in a separate .pdb file.
+if(WIN32)
+    string(REPLACE "/Z7" "/Zi" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REPLACE "/Z7" "/Zi" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/Z7" "/Zi" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+    string(REPLACE "/Z7" "/Zi" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+endif()
 #
 # Create static or shared library depending on BUILD_SHARED_LIBS
 #


### PR DESCRIPTION
### Details:
 - Fixed: `Error    LNK1248    image size (1010DF49D) exceeds maximum allowable size (FFFFFFFF)    ngraph_obj `

### Tickets:
 - CVS-116682
