### PR TITLE
Fixed OVC "input_model" parameter to work with pathlib.Path.

### DIFF
--- a/tools/mo/unit_tests/mo/convert/import_from_mo_test.py
+++ b/tools/mo/unit_tests/mo/convert/import_from_mo_test.py
@@ -103,9 +103,9 @@ class ConvertImportMOTest(UnitTestWithMockedTelemetry):
         with tempfile.TemporaryDirectory(dir=self.test_directory) as tmpdir:
             model = self.create_onnx_model()
             model_path = save_to_onnx(model, tmpdir)
-            out_xml = os.path.join(tmpdir, Path("model.xml"))
+            out_xml = os.path.join(tmpdir, "model.xml")
 
-            ov_model = convert_model(input_model=model_path)
+            ov_model = convert_model(Path(model_path))
             serialize(ov_model, out_xml.encode('utf-8'), out_xml.replace('.xml', '.bin').encode('utf-8'))
 
             ir = IREngine(out_xml, out_xml.replace('.xml', '.bin'))

--- a/tools/ovc/openvino/tools/ovc/cli_parser.py
+++ b/tools/ovc/openvino/tools/ovc/cli_parser.py
@@ -318,7 +318,7 @@ def readable_dirs_or_files_or_empty(paths: [str, list, tuple]):
     if isinstance(paths, (list, tuple)):
         paths_list = [readable_file_or_dir_or_object(path) for path in paths]
     if isinstance(paths, (str, pathlib.Path)):
-        paths_list = [readable_file_or_dir_or_object(path) for path in paths.split(',')]
+        paths_list = [readable_file_or_dir_or_object(path) for path in str(paths).split(',')]
 
     return paths_list[0] if isinstance(paths, (list, tuple)) and len(paths_list) == 1 else paths_list
 
@@ -331,7 +331,7 @@ def readable_files_or_empty(paths: [str, list, tuple]):
     if isinstance(paths, (list, tuple)):
         return [readable_file_or_object(path) for path in paths]
     if isinstance(paths, (str, pathlib.Path)):
-        paths_list = [readable_file_or_object(path) for path in paths.split(',')]
+        paths_list = [readable_file_or_object(path) for path in str(paths).split(',')]
         return paths_list
     return paths
 

--- a/tools/ovc/unit_tests/ovc/convert/import_from_mo_test.py
+++ b/tools/ovc/unit_tests/ovc/convert/import_from_mo_test.py
@@ -78,9 +78,9 @@ class ConvertImportMOTest(UnitTestWithMockedTelemetry):
         with tempfile.TemporaryDirectory(dir=self.test_directory) as tmpdir:
             model = self.create_onnx_model()
             model_path = save_to_onnx(model, tmpdir)
-            out_xml = os.path.join(tmpdir, Path("model.xml"))
+            out_xml = os.path.join(tmpdir, "model.xml")
 
-            ov_model = convert_model(input_model=model_path)
+            ov_model = convert_model(Path(model_path))
             serialize(ov_model, out_xml.encode('utf-8'), out_xml.replace('.xml', '.bin').encode('utf-8'))
 
             #TODO: check that model is correct


### PR DESCRIPTION
Root cause analysis: 
OVC tries to split pathlib.Path by "," which leads to error.

Solution: 
convert pathlib.Path to str before splitting.

Ticket: _CVS-117018_


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
