### PR TITLE
[PT FE]: support aten::view_as and aten::std

### DIFF
--- a/src/frontends/pytorch/src/op/var_mean.cpp
+++ b/src/frontends/pytorch/src/op/var_mean.cpp
@@ -10,6 +10,7 @@
 #include "openvino/op/reduce_mean.hpp"
 #include "openvino/op/reduce_prod.hpp"
 #include "openvino/op/shape_of.hpp"
+#include "openvino/op/sqrt.hpp"
 #include "openvino/op/subtract.hpp"
 #include "utils.hpp"
 
@@ -78,6 +79,18 @@ OutputVector translate_var_mean(const NodeContext& context) {
 OutputVector translate_var(const NodeContext& context) {
     auto res = translate_var_mean(context);
     return {res[0]};
+}
+
+OutputVector translate_std(const NodeContext& context) {
+    auto res = translate_var_mean(context);
+    auto var = res[0];
+    return {context.mark_node(std::make_shared<v0::Sqrt>(var))};
+}
+
+OutputVector translate_std_mean(const NodeContext& context) {
+    auto res = translate_var_mean(context);
+    auto var = res[0];
+    return {context.mark_node(std::make_shared<v0::Sqrt>(var)), res[1]};
 }
 
 }  // namespace op

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -149,6 +149,8 @@ OP_CONVERTER(translate_softmax);
 OP_CONVERTER(translate_sort);
 OP_CONVERTER(translate_square);
 OP_CONVERTER(translate_squeeze);
+OP_CONVERTER(translate_std);
+OP_CONVERTER(translate_std_mean);
 OP_CONVERTER(translate_sub);
 OP_CONVERTER(translate_sum);
 OP_CONVERTER(translate_t);
@@ -407,6 +409,8 @@ const std::map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::sqrt", op::translate_1to1_match_1_inputs_with_fp32_type_alignment<opset10::Sqrt>},
         {"aten::square", op::translate_square},
         {"aten::squeeze", op::quantizable_op<op::translate_squeeze>},
+        {"aten::std", op::translate_std},
+        {"aten::std_mean", op::translate_std_mean},
         {"aten::sub", op::translate_sub},
         {"aten::sub_", op::inplace_op<op::translate_sub>},
         {"aten::sum", op::translate_sum},
@@ -442,6 +446,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::var", op::translate_var},
         {"aten::var_mean", op::translate_var_mean},
         {"aten::view", op::quantizable_op<op::translate_reshape>},
+        {"aten::view_as", op::translate_reshape_as},
         {"aten::where", op::translate_where},
         {"aten::zero_", op::inplace_op<op::translate_zeros_like>},
         {"aten::zeros", op::translate_zeros},

--- a/tests/layer_tests/pytorch_tests/test_reshape_as.py
+++ b/tests/layer_tests/pytorch_tests/test_reshape_as.py
@@ -8,15 +8,12 @@ import torch
 from pytorch_layer_test_class import PytorchLayerTest
 
 
-@pytest.mark.parametrize('input_tesnors', ((np.ones((3, 6)), np.ones((2, 9))),
-                                           (np.ones((2, 2, 3)), np.ones((6, 2))),
-                                           (np.ones((6, 2)), np.ones((2, 2, 3)))))
 class TestReshapeAs(PytorchLayerTest):
 
-    def _prepare_input(self):
-        return self.input_tesnors
+    def _prepare_input(self, shape1, shape2):
+        return (np.ones(shape1, dtype=np.float32), np.ones(shape2, dtype=np.float32))
 
-    def create_model(self):
+    def create_model(self, op):
         class aten_reshape_as(torch.nn.Module):
 
             def forward(self, input_tensor, shape_tensor):
@@ -24,10 +21,12 @@ class TestReshapeAs(PytorchLayerTest):
 
         ref_net = None
 
-        return aten_reshape_as(), ref_net, "aten::reshape_as"
+        return aten_reshape_as(), ref_net, "aten::{op}"
 
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_reshape_as(self, ie_device, precision, ir_version, input_tesnors):
-        self.input_tesnors = input_tesnors
-        self._test(*self.create_model(), ie_device, precision, ir_version)
+    @pytest.mark.parametrize("op", ["reshape_as", "view_as"])
+    @pytest.mark.parametrize('input_tesnor_shapes',( ((3, 6), (2, 9)), ((2, 2, 3), (6, 2)), ((6, 2), (2, 2, 3))))
+    def test_reshape_as(self, op, input_tensor_shapes, ie_device, precision, ir_version):
+        self._test(*self.create_model(op), ie_device, precision, ir_version, 
+                   kwargs_to_prepare_input={"shape1": input_tensor_shapes[0], "shape2": input_tensor_shapes[1]})

--- a/tests/layer_tests/pytorch_tests/test_reshape_as.py
+++ b/tests/layer_tests/pytorch_tests/test_reshape_as.py
@@ -15,18 +15,25 @@ class TestReshapeAs(PytorchLayerTest):
 
     def create_model(self, op):
         class aten_reshape_as(torch.nn.Module):
+            def __init__(self, op) -> None:
+                super().__init__()
+                if op == "view_as":
+                    self.forward = self.forward_view
 
             def forward(self, input_tensor, shape_tensor):
                 return input_tensor.reshape_as(shape_tensor)
 
+            def forward_view(self, input_tensor, shape_tensor):
+                return input_tensor.view_as(shape_tensor)
+
         ref_net = None
 
-        return aten_reshape_as(), ref_net, "aten::{op}"
+        return aten_reshape_as(op), ref_net, f"aten::{op}"
 
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.parametrize("op", ["reshape_as", "view_as"])
-    @pytest.mark.parametrize('input_tesnor_shapes',( ((3, 6), (2, 9)), ((2, 2, 3), (6, 2)), ((6, 2), (2, 2, 3))))
+    @pytest.mark.parametrize('input_tensor_shapes',( ((3, 6), (2, 9)), ((2, 2, 3), (6, 2)), ((6, 2), (2, 2, 3))))
     def test_reshape_as(self, op, input_tensor_shapes, ie_device, precision, ir_version):
         self._test(*self.create_model(op), ie_device, precision, ir_version, 
                    kwargs_to_prepare_input={"shape1": input_tensor_shapes[0], "shape2": input_tensor_shapes[1]})

--- a/tests/layer_tests/pytorch_tests/test_var_mean.py
+++ b/tests/layer_tests/pytorch_tests/test_var_mean.py
@@ -11,47 +11,55 @@ class TestVar(PytorchLayerTest):
         import numpy as np
         return (np.random.randn(1, 3, 224, 224).astype(np.float32),)
 
-    def create_model(self, unbiased, dim=None, keepdim=True, two_args_case=True, return_mean=False):
+    def create_model(self, unbiased, dim=None, keepdim=True, two_args_case=True, op_type="var"):
         import torch
 
+        ops = {
+            "var": torch.var,
+            "var_mean": torch.var_mean,
+            "std": torch.std,
+            "std_mean": torch.std_mean
+        }
+
+        op = ops[op_type]
+
         class aten_var(torch.nn.Module):
-            def __init__(self, dim, unbiased, keepdim, return_mean):
+            def __init__(self, dim, unbiased, keepdim, op):
                 super(aten_var, self).__init__()
                 self.unbiased = unbiased
                 self.dim = dim
                 self.keepdim = keepdim
-                self.op = torch.var if not return_mean else torch.var_mean
+                self.op = op
 
             def forward(self, x):
                 return self.op(x, self.dim, unbiased=self.unbiased, keepdim=self.keepdim)
 
         class aten_var2args(torch.nn.Module):
-            def __init__(self, unbiased, return_mean):
+            def __init__(self, unbiased, op):
                 super(aten_var2args, self).__init__()
                 self.unbiased = unbiased
-                self.op =  torch.var if not return_mean else torch.var_mean
-
+                self.op =  op
             def forward(self, x):
-                return torch.var(x, self.unbiased)
+                return self.op(x, self.unbiased)
 
         ref_net = None
-        op_name = "aten::var" if not return_mean else "aten::var_mean"
+        op_name = f"aten::{op_type}"
         if two_args_case:
-            return aten_var2args(unbiased, return_mean), ref_net, op_name
-        return aten_var(dim, unbiased, keepdim, return_mean), ref_net, op_name
+            return aten_var2args(unbiased, op), ref_net, op_name
+        return aten_var(dim, unbiased, keepdim, op), ref_net, op_name
 
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.parametrize("unbiased", [True, False])
-    @pytest.mark.parametrize("return_mean", [True, False])
-    def test_var2args(self, unbiased, return_mean, ie_device, precision, ir_version):
-        self._test(*self.create_model(unbiased, return_mean), ie_device, precision, ir_version)
+    @pytest.mark.parametrize("op_type", ["var", "var_mean", "std", "std_mean"])
+    def test_var2args(self, unbiased, op_type, ie_device, precision, ir_version):
+        self._test(*self.create_model(unbiased, op_type=op_type), ie_device, precision, ir_version)
 
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.parametrize("unbiased", [False, True])
     @pytest.mark.parametrize("dim", [None, 0, 1, 2, 3, -1, -2, (0, 1), (-1, -2), (0, 1, -1), (0, 1, 2, 3)])
     @pytest.mark.parametrize("keepdim", [True, False])
-    @pytest.mark.parametrize("return_mean", [True, False])
-    def test_var(self, unbiased, dim, keepdim, return_mean, ie_device, precision, ir_version):
-        self._test(*self.create_model(unbiased, dim, keepdim, two_args_case=False, return_mean=return_mean), ie_device, precision, ir_version)
+    @pytest.mark.parametrize("op_type", ["var", "var_mean", "std", "std_mean"])
+    def test_var(self, unbiased, dim, keepdim, op_type, ie_device, precision, ir_version):
+        self._test(*self.create_model(unbiased, dim, keepdim, two_args_case=False, op_type=op_type), ie_device, precision, ir_version)


### PR DESCRIPTION
### Details:
 - *support aten::std. aten::std_mean and aten::view_as ops*
tested on wavelm and vaw2vec-conformer models


### Tickets:
 - *CVS-117016*
 - *CVS-117015*
