### PR TITLE
[PT FE] Remove converts to target type before Range for aten::arange op

### DIFF
--- a/src/frontends/pytorch/src/op/arange.cpp
+++ b/src/frontends/pytorch/src/op/arange.cpp
@@ -75,10 +75,7 @@ OutputVector translate_arange(const NodeContext& context) {
             FRONT_END_OP_CONVERSION_CHECK(false, "Couldn't get dtype input");
         }
     }
-    auto r_end = context.mark_node(std::make_shared<v0::Convert>(end, dtype));
-    auto r_start = context.mark_node(std::make_shared<v0::Convert>(start, dtype));
-    auto r_step = context.mark_node(std::make_shared<v0::Convert>(step, dtype));
-    auto range = context.mark_node(std::make_shared<v4::Range>(r_start, r_end, r_step, dtype));
+    auto range = context.mark_node(std::make_shared<v4::Range>(start, end, step, dtype));
     if (!dtype_applied) {
         range = context.mark_node(std::make_shared<v1::ConvertLike>(range, out_tensor));
     }


### PR DESCRIPTION
### Details:
 - *Remove converts to target type before `Range` for `aten::arange` op. `Range` operation specification allow mixed type input, so conversion to destination type before calling Range is not required. Layer tests pass after removing conversion.*

### Tickets:
 - *116366*
