### PR TITLE
[GPU] Minor fix for dynamic model regression

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
+++ b/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
@@ -189,6 +189,7 @@ debug_configuration::debug_configuration()
         , disable_async_compilation(0)
         , disable_dynamic_impl(0)
         , disable_runtime_buffer_fusing(0)
+        , disable_memory_reuse(0)
         , disable_build_time_weight_reorder_for_dynamic_nodes(0)
         , disable_runtime_skip_reorder(0) {
 #ifdef GPU_DEBUG_CONFIG


### PR DESCRIPTION
### Details:
 - Restore `disable_memory_reuse` debug config initialization (removed from https://github.com/openvinotoolkit/openvino/pull/18859)
 - This issue forces new allocation rather than reuse from memory pool at runtime

### Tickets:
 - 117089