### PR TITLE
[PyOV] Add temporary workaround for wheel building issue

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -11,7 +11,7 @@ pytest-timeout==2.1.0
 py>=1.9.0
 pygments>=2.8.1
 setuptools>=53.0.0
-wheel>=0.38.1
+wheel>=0.38.1,<=0.41.0
 
 # Frontends
 docopt~=0.6.2

--- a/src/bindings/python/src/openvino/preprocess/__init__.py
+++ b/src/bindings/python/src/openvino/preprocess/__init__.py
@@ -28,3 +28,5 @@ from openvino._pyopenvino.preprocess import PreProcessSteps
 from openvino._pyopenvino.preprocess import PostProcessSteps
 from openvino._pyopenvino.preprocess import ColorFormat
 from openvino._pyopenvino.preprocess import ResizeAlgorithm
+
+from .torchvision import PreprocessConverter

--- a/src/bindings/python/src/openvino/preprocess/__init__.py
+++ b/src/bindings/python/src/openvino/preprocess/__init__.py
@@ -28,5 +28,3 @@ from openvino._pyopenvino.preprocess import PreProcessSteps
 from openvino._pyopenvino.preprocess import PostProcessSteps
 from openvino._pyopenvino.preprocess import ColorFormat
 from openvino._pyopenvino.preprocess import ResizeAlgorithm
-
-from .torchvision import PreprocessConverter

--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,3 @@
 setuptools>=65.6.1
-wheel>=0.38.1
+wheel>=0.38.1,<=0.41.0
 patchelf<=0.17.2.1; sys_platform == 'linux' and platform_machine == 'x86_64'

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -7,7 +7,7 @@ pandas>=1.3.5
 pymongo>=3.12.0
 PyYAML>=5.4.1
 scipy>=1.7
-wheel>=0.38.1
+wheel>=0.38.1,<=0.41.0
 defusedxml>=0.7.1
 fastjsonschema~=2.17.1
 test-generator==0.1.2


### PR DESCRIPTION
### Details:
 - Attempt to unblock CI pipelines
 - This is not a fix for the issue, but rather a workaround to give us time to resolve it
 - The issue with pipelines is most likely to come from new wheel release on August 5 (https://pypi.org/project/wheel/0.41.1/#history)
 - Wheel package has caused problems in the past with being non backwards-compatible

### Tickets:
 - 117193
