### PR TITLE
Fix of tensor names loosing for cf=True flag in MOC transformations.

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -254,7 +254,7 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ngraph::Fu
         // Restore original shapes to the nGraph Function
         for (auto&& param : f->get_parameters()) {
             param->set_partial_shape(input_shapes.at(param.get()));
-        }   
+        }
     }
     f->validate_nodes_and_infer_types();
 

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -254,13 +254,9 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ngraph::Fu
         // Restore original shapes to the nGraph Function
         for (auto&& param : f->get_parameters()) {
             param->set_partial_shape(input_shapes.at(param.get()));
-        }
-        f->validate_nodes_and_infer_types();
-    } else {
-        for (auto&& result : f->get_results()) {
-            result->validate_and_infer_types();
-        }
+        }   
     }
+    f->validate_nodes_and_infer_types();
 
     return false;
 }

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -257,6 +257,11 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ngraph::Fu
         }
         f->validate_nodes_and_infer_types();
     }
+    else {
+        for (auto&&  result: f->get_results()) {
+            result->validate_and_infer_types();
+        }
+    }
 
     return false;
 }

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -256,9 +256,8 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ngraph::Fu
             param->set_partial_shape(input_shapes.at(param.get()));
         }
         f->validate_nodes_and_infer_types();
-    }
-    else {
-        for (auto&&  result: f->get_results()) {
+    } else {
+        for (auto&& result : f->get_results()) {
             result->validate_and_infer_types();
         }
     }

--- a/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+#include <string>
+#include "openvino/core/model.hpp"
+#include "openvino/opsets/opset12.hpp"
+#include "openvino/pass/manager.hpp"
+#include <transformations/common_optimizations/moc_transformations.hpp>
+
+using namespace testing;
+using namespace ov;
+using namespace ov::opset12;
+
+
+
+TEST(TransformationTests, TestModelTensorsConsistencyUseShapesTrue) {
+     auto input = std::make_shared<opset12::Parameter>(element::f32, Shape{1});
+     auto const1 = opset12::Constant::create(element::f32, Shape{1}, {1});
+     auto const2 = opset12::Constant::create(element::f32, Shape{1}, {2});
+     auto const3 = opset12::Constant::create(element::f32, Shape{1}, {3});
+     auto add1 = std::make_shared<opset12::Add>(input, const1);
+     auto add2 = std::make_shared<opset12::Add>(add1, const2);
+     auto add3 = std::make_shared<opset12::Add>(add2, const3);
+
+     auto model = std::make_shared<Model>(NodeVector{add3}, ParameterVector{input});
+     ov::pass::Manager m;
+     m.register_pass<ov::pass::MOCTransformations>(true);
+     m.run_passes(model);
+
+    std::unordered_set<std::string> new_tensors = {"new_name"};
+    model->outputs()[0].set_names(new_tensors);
+    EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
+    
+    model->validate_nodes_and_infer_types();  
+    EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
+}
+
+TEST(TransformationTests, TestModelTensorsConsistencyUseShapesFalse) {
+     auto input = std::make_shared<opset12::Parameter>(element::f32, Shape{1});
+     auto const1 = opset12::Constant::create(element::f32, Shape{1}, {1});
+     auto const2 = opset12::Constant::create(element::f32, Shape{1}, {2});
+     auto const3 = opset12::Constant::create(element::f32, Shape{1}, {3});
+     auto add1 = std::make_shared<opset12::Add>(input, const1);
+     auto add2 = std::make_shared<opset12::Add>(add1, const2);
+     auto add3 = std::make_shared<opset12::Add>(add2, const3);
+
+     auto model = std::make_shared<Model>(NodeVector{add3}, ParameterVector{input});
+     ov::pass::Manager m;
+     m.register_pass<ov::pass::MOCTransformations>(false);
+     m.run_passes(model);
+
+    std::unordered_set<std::string> new_tensors = {"new_name"};
+    model->outputs()[0].set_names(new_tensors);
+    EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
+    
+    model->validate_nodes_and_infer_types();  
+    EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
+}

--- a/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
@@ -3,58 +3,58 @@
 //
 
 #include <gtest/gtest.h>
+
 #include <string>
+#include <transformations/common_optimizations/moc_transformations.hpp>
+
 #include "openvino/core/model.hpp"
 #include "openvino/opsets/opset12.hpp"
 #include "openvino/pass/manager.hpp"
-#include <transformations/common_optimizations/moc_transformations.hpp>
 
 using namespace testing;
 using namespace ov;
 using namespace ov::opset12;
 
-
-
 TEST(TransformationTests, TestModelTensorsConsistencyUseShapesTrue) {
-     auto input = std::make_shared<opset12::Parameter>(element::f32, Shape{1});
-     auto const1 = opset12::Constant::create(element::f32, Shape{1}, {1});
-     auto const2 = opset12::Constant::create(element::f32, Shape{1}, {2});
-     auto const3 = opset12::Constant::create(element::f32, Shape{1}, {3});
-     auto add1 = std::make_shared<opset12::Add>(input, const1);
-     auto add2 = std::make_shared<opset12::Add>(add1, const2);
-     auto add3 = std::make_shared<opset12::Add>(add2, const3);
+    auto input = std::make_shared<opset12::Parameter>(element::f32, Shape{1});
+    auto const1 = opset12::Constant::create(element::f32, Shape{1}, {1});
+    auto const2 = opset12::Constant::create(element::f32, Shape{1}, {2});
+    auto const3 = opset12::Constant::create(element::f32, Shape{1}, {3});
+    auto add1 = std::make_shared<opset12::Add>(input, const1);
+    auto add2 = std::make_shared<opset12::Add>(add1, const2);
+    auto add3 = std::make_shared<opset12::Add>(add2, const3);
 
-     auto model = std::make_shared<Model>(NodeVector{add3}, ParameterVector{input});
-     ov::pass::Manager m;
-     m.register_pass<ov::pass::MOCTransformations>(true);
-     m.run_passes(model);
+    auto model = std::make_shared<Model>(NodeVector{add3}, ParameterVector{input});
+    ov::pass::Manager m;
+    m.register_pass<ov::pass::MOCTransformations>(true);
+    m.run_passes(model);
 
     std::unordered_set<std::string> new_tensors = {"new_name"};
     model->outputs()[0].set_names(new_tensors);
     EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
-    
-    model->validate_nodes_and_infer_types();  
+
+    model->validate_nodes_and_infer_types();
     EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
 }
 
 TEST(TransformationTests, TestModelTensorsConsistencyUseShapesFalse) {
-     auto input = std::make_shared<opset12::Parameter>(element::f32, Shape{1});
-     auto const1 = opset12::Constant::create(element::f32, Shape{1}, {1});
-     auto const2 = opset12::Constant::create(element::f32, Shape{1}, {2});
-     auto const3 = opset12::Constant::create(element::f32, Shape{1}, {3});
-     auto add1 = std::make_shared<opset12::Add>(input, const1);
-     auto add2 = std::make_shared<opset12::Add>(add1, const2);
-     auto add3 = std::make_shared<opset12::Add>(add2, const3);
+    auto input = std::make_shared<opset12::Parameter>(element::f32, Shape{1});
+    auto const1 = opset12::Constant::create(element::f32, Shape{1}, {1});
+    auto const2 = opset12::Constant::create(element::f32, Shape{1}, {2});
+    auto const3 = opset12::Constant::create(element::f32, Shape{1}, {3});
+    auto add1 = std::make_shared<opset12::Add>(input, const1);
+    auto add2 = std::make_shared<opset12::Add>(add1, const2);
+    auto add3 = std::make_shared<opset12::Add>(add2, const3);
 
-     auto model = std::make_shared<Model>(NodeVector{add3}, ParameterVector{input});
-     ov::pass::Manager m;
-     m.register_pass<ov::pass::MOCTransformations>(false);
-     m.run_passes(model);
+    auto model = std::make_shared<Model>(NodeVector{add3}, ParameterVector{input});
+    ov::pass::Manager m;
+    m.register_pass<ov::pass::MOCTransformations>(false);
+    m.run_passes(model);
 
     std::unordered_set<std::string> new_tensors = {"new_name"};
     model->outputs()[0].set_names(new_tensors);
     EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
-    
-    model->validate_nodes_and_infer_types();  
+
+    model->validate_nodes_and_infer_types();
     EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
 }


### PR DESCRIPTION
Root cause analysis: 
Names are lost after `validate_nodes_and_infer_types()`. 
In Result `validate_and_infer_types()` output tensor pointer is replaced with input tensor pointer : https://github.com/openvinotoolkit/openvino/blob/648351ba391ce55e17bcc6e758d824a9220f4711/src/core/src/op/result.cpp#L34
So if some tensor name was set in Result output tensor, it becomes lost. 
If we try to set tensor name again after `validate_nodes_and_infer_types()`, it works, as pointers are the same at this point.

The issue appeared when `cf=True` was turned on in MOC transformations.
`cf=True` turns on shape-off constant folding and removes `validate_nodes_and_infer_types()` in the end of MOC transformations pipeline: https://github.com/openvinotoolkit/openvino/blob/648351ba391ce55e17bcc6e758d824a9220f4711/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp#L258

Solution: 
Add `validate_and_infer_types()` in the end of MOC pipeline if `cf=True`.

Ticket: CVS-117068


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
