### PR TITLE
[CPU] Replace memory_order_relaxed with release/acquire in UpdateNodesBase class

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1163,15 +1163,15 @@ public:
             m_completion.store(true, std::memory_order::memory_order_relaxed);
             throw;
         }
-        m_prepareCounter.store(stop_indx, std::memory_order::memory_order_release);
-        m_completion.store(true, std::memory_order::memory_order_relaxed);
+        m_prepareCounter.store(stop_indx, std::memory_order::memory_order_relaxed);
+        m_completion.store(true, std::memory_order::memory_order_release);
     }
 
     void updateDynParams(size_t node_indx, size_t /*unused*/) {
         size_t local_counter = node_indx;
         while (true) {
-            bool completion = m_completion.load(std::memory_order::memory_order_acquire);
-            size_t prepareCounter = m_prepareCounter.load(std::memory_order::memory_order_acquire);
+            const bool completion = m_completion.load(std::memory_order::memory_order_acquire);
+            const size_t prepareCounter = m_prepareCounter.load(std::memory_order::memory_order_relaxed);
             if (completion && local_counter == prepareCounter) {
                 break;
             }

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1170,8 +1170,8 @@ public:
     void updateDynParams(size_t node_indx, size_t /*unused*/) {
         size_t local_counter = node_indx;
         while (true) {
-            const size_t prepareCounter = m_prepareCounter.load(std::memory_order::memory_order_acquire);
-            const bool completion = m_completion.load(std::memory_order::memory_order_relaxed);
+            bool completion = m_completion.load(std::memory_order::memory_order_acquire);
+            size_t prepareCounter = m_prepareCounter.load(std::memory_order::memory_order_acquire);
             if (completion && local_counter == prepareCounter) {
                 break;
             }

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1160,18 +1160,18 @@ public:
             }
         }
         catch(...) {
-            m_completion.store(true, std::memory_order::memory_order_release);
+            m_completion.store(true, std::memory_order::memory_order_relaxed);
             throw;
         }
+        m_completion.store(true, std::memory_order::memory_order_relaxed);
         m_prepareCounter.store(stop_indx, std::memory_order::memory_order_release);
-        m_completion.store(true, std::memory_order::memory_order_release);
     }
 
     void updateDynParams(size_t node_indx, size_t /*unused*/) {
         size_t local_counter = node_indx;
         while (true) {
-            bool completion = m_completion.load(std::memory_order::memory_order_acquire);
-            size_t prepareCounter = m_prepareCounter.load(std::memory_order::memory_order_acquire);
+            const size_t prepareCounter = m_prepareCounter.load(std::memory_order::memory_order_acquire);
+            const bool completion = m_completion.load(std::memory_order::memory_order_relaxed);
             if (completion && local_counter == prepareCounter) {
                 break;
             }

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1163,8 +1163,8 @@ public:
             m_completion.store(true, std::memory_order::memory_order_relaxed);
             throw;
         }
-        m_completion.store(true, std::memory_order::memory_order_relaxed);
         m_prepareCounter.store(stop_indx, std::memory_order::memory_order_release);
+        m_completion.store(true, std::memory_order::memory_order_relaxed);
     }
 
     void updateDynParams(size_t node_indx, size_t /*unused*/) {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1160,17 +1160,17 @@ public:
             }
         }
         catch(...) {
-            m_completion.store(true, std::memory_order::memory_order_relaxed);
+            m_completion.store(true, std::memory_order::memory_order_release);
             throw;
         }
         m_prepareCounter.store(stop_indx, std::memory_order::memory_order_release);
-        m_completion.store(true, std::memory_order::memory_order_relaxed);
+        m_completion.store(true, std::memory_order::memory_order_release);
     }
 
     void updateDynParams(size_t node_indx, size_t /*unused*/) {
         size_t local_counter = node_indx;
         while (true) {
-            bool completion = m_completion.load(std::memory_order::memory_order_relaxed);
+            bool completion = m_completion.load(std::memory_order::memory_order_acquire);
             size_t prepareCounter = m_prepareCounter.load(std::memory_order::memory_order_acquire);
             if (completion && local_counter == prepareCounter) {
                 break;


### PR DESCRIPTION
There are various issues on ARM related to uninitialised operation executor.
The article https://www.arangodb.com/2021/02/cpp-memory-model-migrating-from-x86-to-arm/ says memory_order_relaxed does not guarantee that the initialization is executed before store on ARM.
Tickets: 
CVS-116674
CVS-115839
CVS-113372
CVS-112750