### PR TITLE
Remove legacy API from from template plugin

### DIFF
--- a/src/inference/dev_api/openvino/runtime/internal_properties.hpp
+++ b/src/inference/dev_api/openvino/runtime/internal_properties.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "openvino/runtime/properties.hpp"
+#include "openvino/runtime/threading/istreams_executor.hpp"
 
 namespace ov {
 
@@ -41,6 +42,33 @@ static constexpr Property<bool, PropertyMutability::RW> exclusive_async_requests
  * @ingroup ov_dev_api_plugin_api
  */
 static constexpr Property<std::string, PropertyMutability::WO> config_device_id{"CONFIG_DEVICE_ID"};
+
+/**
+ * @brief The name for setting CPU affinity per thread option.
+ *
+ * It is passed to Core::get_property()
+ * PluginConfigParams::NO (no pinning for CPU inference threads)
+ * PluginConfigParams::YES, which is default on the conventional CPUs (pinning threads to cores, best for static
+ * benchmarks),
+ *
+ * the following options are implemented only for the TBB as a threading option
+ * ov::threading::IStreamsExecutor::ThreadBindingType::NUMA (pinning threads to NUMA nodes, best for real-life,
+ * contented cases) on the Windows and MacOS* this option behaves as YES
+ * ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE (let the runtime to do pinning to the cores types,
+ * e.g. prefer the "big" cores for latency tasks) on the hybrid CPUs this option is default
+ *
+ * Also, the settings are ignored, if the OpenVINO compiled with OpenMP and any affinity-related OpenMP's
+ * environment variable is set (as affinity is configured explicitly)
+ * @ingroup ov_dev_api_plugin_api
+ */
+static constexpr Property<ov::threading::IStreamsExecutor::ThreadBindingType, PropertyMutability::RW> cpu_bind_thread{
+    "CPU_BIND_THREAD"};
+
+/**
+ * @brief Limit \#threads that are used by IStreamsExecutor to execute `parallel_for` calls
+ * @ingroup ov_dev_api_plugin_api
+ */
+static constexpr Property<size_t, PropertyMutability::RW> threads_per_stream{"THREADS_PER_STREAM"};
 
 }  // namespace internal
 OPENVINO_DEPRECATED(

--- a/src/inference/src/dev/converter_utils.cpp
+++ b/src/inference/src/dev/converter_utils.cpp
@@ -442,8 +442,10 @@ public:
                         (METRIC_KEY(SUPPORTED_CONFIG_KEYS) == name && prop.is_mutable()))
                         legacy_properties.emplace_back(prop);
                 }
-                legacy_properties.emplace_back(METRIC_KEY(SUPPORTED_METRICS));
-                legacy_properties.emplace_back(METRIC_KEY(SUPPORTED_CONFIG_KEYS));
+                if (METRIC_KEY(SUPPORTED_METRICS) == name) {
+                    legacy_properties.emplace_back(METRIC_KEY(SUPPORTED_METRICS));
+                    legacy_properties.emplace_back(METRIC_KEY(SUPPORTED_CONFIG_KEYS));
+                }
 
                 return legacy_properties;
             }

--- a/src/inference/src/dev/converter_utils.cpp
+++ b/src/inference/src/dev/converter_utils.cpp
@@ -430,6 +430,24 @@ public:
     }
 
     InferenceEngine::Parameter GetMetric(const std::string& name) const override {
+        // Add legacy supported properties
+        if (METRIC_KEY(SUPPORTED_METRICS) == name || METRIC_KEY(SUPPORTED_CONFIG_KEYS) == name) {
+            try {
+                return m_model->get_property(name);
+            } catch (const ov::Exception&) {
+                auto props = m_model->get_property(ov::supported_properties.name()).as<std::vector<PropertyName>>();
+                std::vector<std::string> legacy_properties;
+                for (const auto& prop : props) {
+                    if ((METRIC_KEY(SUPPORTED_METRICS) == name && !prop.is_mutable()) ||
+                        (METRIC_KEY(SUPPORTED_CONFIG_KEYS) == name && prop.is_mutable()))
+                        legacy_properties.emplace_back(prop);
+                }
+                legacy_properties.emplace_back(METRIC_KEY(SUPPORTED_METRICS));
+                legacy_properties.emplace_back(METRIC_KEY(SUPPORTED_CONFIG_KEYS));
+
+                return legacy_properties;
+            }
+        }
         return m_model->get_property(name);
     }
 

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1378,18 +1378,7 @@ bool ov::CoreImpl::device_supports_internal_property(const ov::Plugin& plugin, c
 }
 
 bool ov::CoreImpl::device_supports_model_caching(const ov::Plugin& plugin) const {
-    auto supportedMetricKeys = plugin.get_property(METRIC_KEY(SUPPORTED_METRICS), {}).as<std::vector<std::string>>();
-    auto supported = util::contains(supportedMetricKeys, METRIC_KEY(IMPORT_EXPORT_SUPPORT)) &&
-                     plugin.get_property(METRIC_KEY(IMPORT_EXPORT_SUPPORT), {}).as<bool>();
-    if (!supported) {
-        supported =
-            device_supports_property(plugin, ov::device::capabilities) &&
-            util::contains(plugin.get_property(ov::device::capabilities), ov::device::capability::EXPORT_IMPORT);
-    }
-    if (supported) {
-        supported = device_supports_internal_property(plugin, ov::internal::caching_properties);
-    }
-    return supported;
+    return plugin.supports_model_caching();
 }
 
 bool ov::CoreImpl::device_supports_cache_dir(const ov::Plugin& plugin) const {

--- a/src/inference/src/dev/plugin.cpp
+++ b/src/inference/src/dev/plugin.cpp
@@ -169,7 +169,7 @@ ov::Any ov::Plugin::get_property(const std::string& name, const AnyMap& argument
         if (METRIC_KEY(IMPORT_EXPORT_SUPPORT) == name) {
             try {
                 return {m_ptr->get_property(name, arguments), {m_so}};
-            } catch (const ov::Exception& ex) {
+            } catch (const ov::Exception&) {
                 if (!supports_model_caching(false))
                     throw;
                 // if device has ov::device::capability::EXPORT_IMPORT it means always true

--- a/src/inference/src/dev/plugin.hpp
+++ b/src/inference/src/dev/plugin.hpp
@@ -77,6 +77,7 @@ public:
     T get_property(const ov::Property<T, M>& property, const AnyMap& arguments) const {
         return get_property(property.name(), arguments).template as<T>();
     }
+    bool supports_model_caching(bool check_old_api = true) const;
 };
 
 }  // namespace ov

--- a/src/inference/src/dev/threading/istreams_executor.cpp
+++ b/src/inference/src/dev/threading/istreams_executor.cpp
@@ -151,7 +151,7 @@ void IStreamsExecutor::Config::set_property(const ov::AnyMap& property) {
             }
             _threadsPerStream = val_i;
         } else if (key == ov::internal::threads_per_stream) {
-            _threadsPerStream = value.as<size_t>();
+            _threadsPerStream = static_cast<int>(value.as<size_t>());
         } else if (key == CONFIG_KEY_INTERNAL(BIG_CORE_STREAMS)) {
             int val_i;
             try {

--- a/src/inference/src/dev/threading/istreams_executor.cpp
+++ b/src/inference/src/dev/threading/istreams_executor.cpp
@@ -12,6 +12,7 @@
 #include "cpp_interfaces/interface/ie_internal_plugin_config.hpp"
 #include "ie_plugin_config.hpp"
 #include "openvino/core/parallel.hpp"
+#include "openvino/runtime/internal_properties.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/runtime/threading/cpu_streams_info.hpp"
 #include "openvino/util/log.hpp"
@@ -149,6 +150,8 @@ void IStreamsExecutor::Config::set_property(const ov::AnyMap& property) {
                                ". Expected only non negative numbers (#threads)");
             }
             _threadsPerStream = val_i;
+        } else if (key == ov::internal::threads_per_stream) {
+            _threadsPerStream = value.as<size_t>();
         } else if (key == CONFIG_KEY_INTERNAL(BIG_CORE_STREAMS)) {
             int val_i;
             try {
@@ -255,6 +258,7 @@ ov::Any IStreamsExecutor::Config::get_property(const std::string& key) const {
             CONFIG_KEY_INTERNAL(ENABLE_HYPER_THREAD),
             ov::num_streams.name(),
             ov::inference_num_threads.name(),
+            ov::internal::threads_per_stream.name(),
             ov::affinity.name(),
         };
         OPENVINO_SUPPRESS_DEPRECATED_END
@@ -290,7 +294,7 @@ ov::Any IStreamsExecutor::Config::get_property(const std::string& key) const {
         return {std::to_string(_threads)};
     } else if (key == ov::inference_num_threads) {
         return decltype(ov::inference_num_threads)::value_type{_threads};
-    } else if (key == CONFIG_KEY_INTERNAL(CPU_THREADS_PER_STREAM)) {
+    } else if (key == CONFIG_KEY_INTERNAL(CPU_THREADS_PER_STREAM) || key == ov::internal::threads_per_stream) {
         return {std::to_string(_threadsPerStream)};
     } else if (key == CONFIG_KEY_INTERNAL(BIG_CORE_STREAMS)) {
         return {std::to_string(_big_core_streams)};

--- a/src/plugins/template/src/compiled_model.cpp
+++ b/src/plugins/template/src/compiled_model.cpp
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include "async_infer_request.hpp"
-#include "ie_plugin_config.hpp"
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/runtime/exec_model_info.hpp"
@@ -33,9 +32,6 @@ ov::template_plugin::CompiledModel::CompiledModel(const std::shared_ptr<ov::Mode
     // In this case, m_wait_executor should also be created per device.
     try {
         compile_model(m_model);
-    } catch (const InferenceEngine::Exception& e) {
-        // Some transformations can throw legacy exception
-        OPENVINO_THROW(e.what());
     } catch (const std::exception& e) {
         OPENVINO_THROW("Standard exception from compilation library: ", e.what());
     } catch (...) {
@@ -152,22 +148,7 @@ ov::Any ov::template_plugin::CompiledModel::get_property(const std::string& name
         }
         return ret;
     };
-    // TODO: return more supported values for metrics
-    if (EXEC_NETWORK_METRIC_KEY(SUPPORTED_METRICS) == name) {
-        auto metrics = default_ro_properties();
-        add_ro_properties(METRIC_KEY(SUPPORTED_METRICS), metrics);
-        add_ro_properties(METRIC_KEY(SUPPORTED_CONFIG_KEYS), metrics);
-        return to_string_vector(metrics);
-    } else if (EXEC_NETWORK_METRIC_KEY(SUPPORTED_CONFIG_KEYS) == name) {
-        auto configs = default_rw_properties();
-        auto streamExecutorConfigKeys = ov::threading::IStreamsExecutor::Config{}
-                                            .get_property(ov::supported_properties.name())
-                                            .as<std::vector<std::string>>();
-        for (auto&& configKey : streamExecutorConfigKeys) {
-            configs.emplace_back(configKey);
-        }
-        return to_string_vector(configs);
-    } else if (ov::model_name == name) {
+    if (ov::model_name == name) {
         auto model_name = m_model->get_friendly_name();
         return decltype(ov::model_name)::value_type(model_name);
     } else if (ov::loaded_from_cache == name) {

--- a/src/plugins/template/src/config.cpp
+++ b/src/plugins/template/src/config.cpp
@@ -4,9 +4,6 @@
 
 #include "config.hpp"
 
-#include <cpp_interfaces/interface/ie_internal_plugin_config.hpp>
-#include <ie_plugin_config.hpp>
-
 #include "openvino/runtime/internal_properties.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "template/properties.hpp"
@@ -61,11 +58,11 @@ ov::Any Configuration::Get(const std::string& name) const {
         return {disable_transformations};
     } else if (name == ov::num_streams) {
         return {std::to_string(streams_executor_config._streams)};
-    } else if (name == CONFIG_KEY(CPU_BIND_THREAD)) {
+    } else if (name == ov::internal::cpu_bind_thread) {
         return streams_executor_config.get_property(name);
-    } else if (name == CONFIG_KEY(CPU_THREADS_NUM)) {
+    } else if (name == ov::inference_num_threads) {
         return {std::to_string(streams_executor_config._threads)};
-    } else if (name == CONFIG_KEY_INTERNAL(CPU_THREADS_PER_STREAM)) {
+    } else if (name == ov::internal::threads_per_stream) {
         return {std::to_string(streams_executor_config._threadsPerStream)};
     } else if (name == ov::hint::performance_mode) {
         return performance_mode;

--- a/src/plugins/template/src/plugin.cpp
+++ b/src/plugins/template/src/plugin.cpp
@@ -6,7 +6,6 @@
 
 #include <memory>
 
-#include "ie_plugin_config.hpp"
 #include "itt.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/runtime/internal_properties.hpp"
@@ -244,25 +243,7 @@ ov::Any ov::template_plugin::Plugin::get_property(const std::string& name, const
         }
         return ret;
     };
-    if (METRIC_KEY(SUPPORTED_METRICS) == name) {
-        auto metrics = default_ro_properties();
-
-        add_ro_properties(METRIC_KEY(SUPPORTED_METRICS), metrics);
-        add_ro_properties(METRIC_KEY(SUPPORTED_CONFIG_KEYS), metrics);
-        add_ro_properties(METRIC_KEY(IMPORT_EXPORT_SUPPORT), metrics);
-        return to_string_vector(metrics);
-    } else if (METRIC_KEY(SUPPORTED_CONFIG_KEYS) == name) {
-        auto configs = default_rw_properties();
-        auto streamExecutorConfigKeys = ov::threading::IStreamsExecutor::Config{}
-                                            .get_property(ov::supported_properties.name())
-                                            .as<std::vector<std::string>>();
-        for (auto&& configKey : streamExecutorConfigKeys) {
-            if (configKey != InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS) {
-                configs.emplace_back(configKey);
-            }
-        }
-        return to_string_vector(configs);
-    } else if (ov::supported_properties == name) {
+    if (ov::supported_properties == name) {
         auto ro_properties = default_ro_properties();
         auto rw_properties = default_rw_properties();
 
@@ -282,8 +263,6 @@ ov::Any ov::template_plugin::Plugin::get_property(const std::string& name, const
     } else if (ov::device::full_name == name) {
         std::string device_name = "Template Device Full Name";
         return decltype(ov::device::full_name)::value_type(device_name);
-    } else if (METRIC_KEY(IMPORT_EXPORT_SUPPORT) == name) {
-        return true;
     } else if (ov::device::architecture == name) {
         // TODO: return device architecture for device specified by DEVICE_ID config
         std::string arch = "TEMPLATE";

--- a/src/plugins/template/src/variable_state.hpp
+++ b/src/plugins/template/src/variable_state.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include "openvino/runtime/itensor.hpp"
 #include "openvino/runtime/ivariable_state.hpp"
+#include "openvino/runtime/so_ptr.hpp"
 
 namespace ov {
 namespace template_plugin {


### PR DESCRIPTION
### Details:
 - Remove legacy metics from the template plugin
 - Move legacy supported metric for cases if plugin doesn't support specific legacy metrics to common part
 - Introduce new internal properties

### Tickets:
 - *ticket-id*
