### PR TITLE
[GPU] updates to initialize onednn attr a new onednn_impl is chosen

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -386,8 +386,16 @@ public:
     std::vector<fused_primitive_desc>& get_fused_primitives() { return fused_prims; }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-    const std::shared_ptr<dnnl::primitive_attr>& get_onednn_primitive_attributes() const { return onednn_attrs; }
-    std::shared_ptr<dnnl::primitive_attr>& get_onednn_primitive_attributes() { return onednn_attrs; }
+    const std::shared_ptr<dnnl::primitive_attr>& get_onednn_primitive_attributes() const {
+        if (onednn_attrs == nullptr)
+            const_cast<program_node*>(this)->init_onednn_primitive_attributes();
+        return onednn_attrs;
+    }
+    std::shared_ptr<dnnl::primitive_attr>& get_onednn_primitive_attributes() {
+        if (onednn_attrs == nullptr)
+            init_onednn_primitive_attributes();
+        return onednn_attrs;
+    }
 
     const std::vector<fused_primitive_desc_onednn>& get_fused_primitives_onednn() const { return fused_prims_onednn; }
     std::vector<fused_primitive_desc_onednn>& get_fused_primitives_onednn() { return fused_prims_onednn; }


### PR DESCRIPTION
### Details:
 - `onednn_impl` requires onednn attr to be initialized before `choose_impl`, and it's done by the `add_onednn_optimization_attributes` pass in the `pre_optimize_graph`.
 - If any `onednn_impl` is newly created in `update_impl`, its onednn attr can be in an uninitialized status.
 - This PR fixes this problem by initializing onednn attr in `get_onednn_primitive_attributes`.

### Tickets:
 - 116350
