### PR TITLE
[CI] [GHA] Do not append timestamp to a build cache

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,7 +126,7 @@ jobs:
           max-size: "2000M"
           # Should save cache only if run in the master branch of the base repo
           # github.ref_name is 'ref/PR_#' in case of the PR, and 'branch_name' when executed on push
-          # save: ${{ github.ref_name == 'master' && 'true' || 'false' }}
+          save: ${{ github.ref_name == 'master' && 'true' || 'false' }}
           verbose: 2
           key: ${{ github.job }}-linux
           append-timestamp: 'false'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,9 +126,10 @@ jobs:
           max-size: "2000M"
           # Should save cache only if run in the master branch of the base repo
           # github.ref_name is 'ref/PR_#' in case of the PR, and 'branch_name' when executed on push
-          save: ${{ github.ref_name == 'master' && 'true' || 'false'  }}
+          # save: ${{ github.ref_name == 'master' && 'true' || 'false' }}
           verbose: 2
           key: ${{ github.job }}-linux
+          append-timestamp: 'false'
           restore-keys: |
             ${{ github.job }}-linux
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,7 +126,7 @@ jobs:
           max-size: "2000M"
           # Should save cache only if run in the master branch of the base repo
           # github.ref_name is 'ref/PR_#' in case of the PR, and 'branch_name' when executed on push
-          save: ${{ github.ref_name == 'master' && 'true' || 'false' }}
+          # save: ${{ github.ref_name == 'master' && 'true' || 'false' }}
           verbose: 2
           key: ${{ github.job }}-linux
           append-timestamp: 'false'


### PR DESCRIPTION
### Details:
This PR removes the timestamp from the ccache cache uploaded to the GHA cache storage. This way the said storage is not "garbaged" by the unnecessary cache entries - we use only the latest one anyway, i.e., there is no need to store the old ones.
