### PR TITLE
CompressQuantizeWeights - handle decompressed inputs to FakeQuantize

### DIFF
--- a/src/common/transformations/tests/utils/compress_quantize_weights.cpp
+++ b/src/common/transformations/tests/utils/compress_quantize_weights.cpp
@@ -10,6 +10,7 @@
 #include <ngraph/opsets/opset8.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <transformations/init_node_info.hpp>
+#include <transformations/rt_info/decompression.hpp>
 #include <transformations/utils/utils.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
@@ -41,8 +42,10 @@ class CompressQuantizeWeightsTests
         std::tie(param, data_prc) = GetParam();
         {
             std::shared_ptr<Node> data = opset8::Constant::create(data_prc, param.shape, param.weights);
-            if (data_prc == element::f16)
+            if (data_prc == element::f16) {
                 data = std::make_shared<opset8::Convert>(data, element::f32);
+                ov::mark_as_decompression(data);
+            }
             auto input_low = opset8::Constant::create(element::f32, Shape{}, {param.in_low});
             auto input_high = opset8::Constant::create(element::f32, Shape{}, {param.in_high});
             auto output_low = opset8::Constant::create(element::f32, Shape{}, {param.out_low});
@@ -135,6 +138,41 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithDequantizationSubgraph) 
         auto output_low = opset8::Constant::create(element::f32, Shape{}, {-128});
         auto output_high = opset8::Constant::create(element::f32, Shape{}, {127});
         auto fq = std::make_shared<opset8::FakeQuantize>(data, input_low, input_high, output_low, output_high, 256);
+        auto convert = std::make_shared<opset8::Convert>(fq, element::i8);
+        auto second_convert = std::make_shared<opset8::Convert>(convert, element::f32);
+        auto scale = opset8::Constant::create(element::f32, Shape{}, {10.0 / 255});
+        auto zero_point = opset8::Constant::create(element::f32, Shape{}, {2 - 255.0 / 10});
+        auto sub = std::make_shared<opset8::Subtract>(second_convert, zero_point);
+        auto mul = std::make_shared<opset8::Multiply>(sub, scale);
+
+        function = std::make_shared<Function>(NodeVector{mul}, ParameterVector{});
+
+        manager.register_pass<pass::CompressQuantizeWeights>();
+    }
+    {
+        auto data = opset8::Constant::create(element::i8, Shape{2, 4, 1, 1}, {-128, -128, -128, -96, -64, -32, 0, 127});
+        auto convert = std::make_shared<opset8::Convert>(data, element::f32);
+        auto scale = opset8::Constant::create(element::f32, Shape{}, {10.0 / 255});
+        auto zero_point = opset8::Constant::create(element::f32, Shape{}, {2 - 255.0 / 10});
+        auto sub = std::make_shared<opset8::Subtract>(convert, zero_point);
+        auto mul = std::make_shared<opset8::Multiply>(sub, scale);
+        function_ref = std::make_shared<Function>(NodeVector{mul}, ParameterVector{});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
+}
+
+TEST_F(TransformationTestsF, CompressQuantizeWeightsWithDequantizationSubgraphFP16) {
+    {
+        auto data = opset8::Constant::create(element::f16, Shape{2, 4, 1, 1}, {-1, 0, 1, 2, 3, 4, 5, 11});
+        auto convert_to_f32 = std::make_shared<opset8::Convert>(data, element::f32);
+        ov::mark_as_decompression(convert_to_f32);
+        auto input_low = opset8::Constant::create(element::f32, Shape{}, {1});
+        auto input_high = opset8::Constant::create(element::f32, Shape{}, {9});
+        auto output_low = opset8::Constant::create(element::f32, Shape{}, {-128});
+        auto output_high = opset8::Constant::create(element::f32, Shape{}, {127});
+        auto fq =
+            std::make_shared<opset8::FakeQuantize>(convert_to_f32, input_low, input_high, output_low, output_high, 256);
         auto convert = std::make_shared<opset8::Convert>(fq, element::i8);
         auto second_convert = std::make_shared<opset8::Convert>(convert, element::f32);
         auto scale = opset8::Constant::create(element::f32, Shape{}, {10.0 / 255});


### PR DESCRIPTION
Decompression attribute (that is present in models with FP16 precision) prevents the weights to be constantfolded. Weights constantfolding is required by CompressQuantizeWeights to compress the weights to low precision format.

Ticket: CVS-117310