### PR TITLE
Corrected category in OVC telemetry events.

### DIFF
--- a/tools/ovc/openvino/tools/ovc/convert_impl.py
+++ b/tools/ovc/openvino/tools/ovc/convert_impl.py
@@ -140,8 +140,8 @@ def prepare_ir(argv: argparse.Namespace):
                                                         argv.placeholder_data_types,
                                                         getattr(argv, "example_input", None),
                                                         argv.share_weights)
-        t.send_event("mo", "conversion_method", moc_front_end.get_name() + "_frontend")
-        moc_front_end.add_extension(TelemetryExtension("mo", t.send_event, t.send_error, t.send_stack_trace))
+        t.send_event("ovc", "conversion_method", moc_front_end.get_name() + "_frontend")
+        moc_front_end.add_extension(TelemetryExtension("ovc", t.send_event, t.send_error, t.send_stack_trace))
         if new_extensions_used(argv):
             for extension in argv.extension:
                 moc_front_end.add_extension(extension)
@@ -407,8 +407,8 @@ def _convert(cli_parser: argparse.ArgumentParser, args, python_api_used):
         return None, None
     simplified_ie_version = VersionChecker().get_ie_simplified_version()
     telemetry = init_mo_telemetry()
-    telemetry.start_session('mo')
-    telemetry.send_event('mo', 'version', simplified_ie_version)
+    telemetry.start_session('ovc')
+    telemetry.send_event('ovc', 'version', simplified_ie_version)
     # Initialize logger with 'ERROR' as default level to be able to form nice messages
     # before arg parser deliver log_level requested by user
     init_logger('ERROR', False)

--- a/tools/ovc/openvino/tools/ovc/telemetry_utils.py
+++ b/tools/ovc/openvino/tools/ovc/telemetry_utils.py
@@ -25,7 +25,7 @@ def send_framework_info(framework: str):
     :param framework: framework name.
     """
     t = tm.Telemetry()
-    t.send_event('mo', 'framework', framework)
+    t.send_event('ovc', 'framework', framework)
 
 
 def get_tid():
@@ -37,8 +37,8 @@ def get_tid():
 
 def send_conversion_result(conversion_result: str, need_shutdown=False):
     t = tm.Telemetry()
-    t.send_event('mo', 'conversion_result', conversion_result)
-    t.end_session('mo')
+    t.send_event('ovc', 'conversion_result', conversion_result)
+    t.end_session('ovc')
     if need_shutdown:
         t.force_shutdown(1.0)
 
@@ -71,4 +71,4 @@ def send_params_info(argv: argparse.Namespace, cli_parser: argparse.ArgumentPars
             else:
                 param_str = arg + ":" + arg_to_str(arg_value)
 
-            t.send_event('mo', 'cli_parameters', param_str)
+            t.send_event('ovc', 'cli_parameters', param_str)

--- a/tools/ovc/openvino/tools/ovc/utils.py
+++ b/tools/ovc/openvino/tools/ovc/utils.py
@@ -21,7 +21,7 @@ dynamic_dimension = np.ma.masked
 def refer_to_faq_msg(question_num: int):
     try:
         t = tm.Telemetry()
-        t.send_event('mo', 'error_info', "faq:" + str(question_num))
+        t.send_event('ovc', 'error_info', "faq:" + str(question_num))
     except Exception:
         # Telemetry can be not initialized if it is used in MO IR Reader
         pass


### PR DESCRIPTION
Root cause analysis: 
OVC has wrong MO name in category of telemetry events.

Solution: 
Change category to OVC.

Ticket: -


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A
 

Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A