### PR TITLE
[DO NOT REVIEW] Add Clang `-fsanitize=cfi`

### DIFF
--- a/cmake/developer_package/compile_flags/sdl.cmake
+++ b/cmake/developer_package/compile_flags/sdl.cmake
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+function (ov_enable_cfi target)
+    if (ENABLE_LTO AND OV_COMPILER_IS_CLANG)
+        target_compile_options(${target} PRIVATE "$<$<CONFIG:Release>:-fsanitize=cfi>")
+    endif()
+endfunction(ov_enable_cfi)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG OR
     (UNIX AND CMAKE_CXX_COMPILER_ID STREQUAL "Intel"))
     set(OV_C_CXX_FLAGS "${OV_C_CXX_FLAGS} -Wformat -Wformat-security")
@@ -57,6 +63,9 @@ endif()
 if(ENABLE_INTEGRITYCHECK)
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /INTEGRITYCHECK")
 endif()
+
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_RELEASE} ${OV_C_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_RELEASE} ${OV_C_CXX_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${OV_C_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${OV_C_CXX_FLAGS}")

--- a/cmake/developer_package/frontends/frontends.cmake
+++ b/cmake/developer_package/frontends/frontends.cmake
@@ -244,6 +244,7 @@ macro(ov_add_frontend)
     # enable LTO
     set_target_properties(${TARGET_NAME} PROPERTIES
                           INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
+    ov_enable_cfi(${TARGET_NAME})
 
     if(OV_FRONTEND_SKIP_NCC_STYLE)
         # frontend's CMakeLists.txt must define its own custom 'ov_ncc_naming_style' step


### PR DESCRIPTION
### Details:
 - Performance overhead should be less than 1%. Binary size may increase (https://clang.llvm.org/docs/ControlFlowIntegrity.html#performance)

### Tickets:
 - CVS-115014
