### PR TITLE
Fix fill_tensor_random for real values:

### DIFF
--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
@@ -266,7 +266,7 @@ void inline fill_random_unique_sequence(T* rawBlobDataPtr,
  * - With k = 2 numbers resolution will 1/2 so outputs only .0 or .50
  * - With k = 4 numbers resolution will 1/4 so outputs only .0 .25 .50 0.75 and etc.
  */
-void fill_tensor_random(ov::Tensor& tensor, double range = 10, double start_from = 0, int32_t k = 1, int seed = 1);
+void fill_tensor_random(ov::Tensor& tensor, const double range = 10, const double start_from = 0, const int32_t k = 1, const int seed = 1);
 
 /** @brief Fill blob with random data.
  *

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
@@ -266,8 +266,7 @@ void inline fill_random_unique_sequence(T* rawBlobDataPtr,
  * - With k = 2 numbers resolution will 1/2 so outputs only .0 or .50
  * - With k = 4 numbers resolution will 1/4 so outputs only .0 .25 .50 0.75 and etc.
  */
-void fill_tensor_random(ov::Tensor& tensor, const uint32_t range = 10, int32_t start_from = 0,
-                               const int32_t k = 1, const int seed = 1);
+void fill_tensor_random(ov::Tensor& tensor, double range = 10, double start_from = 0, int32_t k = 1, int seed = 1);
 
 /** @brief Fill blob with random data.
  *

--- a/src/tests/test_utils/common_test_utils/src/data_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/data_utils.cpp
@@ -357,19 +357,19 @@ void fill_data_with_broadcast(ov::Tensor& tensor, size_t axis, std::vector<float
 }
 
 template<ov::element::Type_t DT>
-void fill_tensor_random(ov::Tensor& tensor, double range = 10, double start_from = 0, const int32_t k = 1, int seed = 1) {
+void fill_tensor_random(ov::Tensor& tensor, const uint32_t range, const int32_t start_from, const int32_t k, const int seed) {
     using T = typename ov::element_type_traits<DT>::value_type;
     auto *rawBlobDataPtr = static_cast<T*>(tensor.data());
     if (DT == ov::element::u4 || DT == ov::element::i4 ||
         DT == ov::element::u1) {
-        fill_data_random(rawBlobDataPtr, tensor.get_byte_size(), static_cast<uint32_t>(range), static_cast<int32_t>(start_from), k, seed);
+        fill_data_random(rawBlobDataPtr, tensor.get_byte_size(), range, start_from, k, seed);
     } else {
-        fill_data_random(rawBlobDataPtr, tensor.get_size(), static_cast<uint32_t>(range), static_cast<int32_t>(start_from), k, seed);
+        fill_data_random(rawBlobDataPtr, tensor.get_size(), range, start_from, k, seed);
     }
 }
 
 template<ov::element::Type_t DT>
-void fill_tensor_random_float(ov::Tensor& tensor, double range, double start_from, int32_t k, int seed = 1) {
+void fill_tensor_random_float(ov::Tensor& tensor, const double range, const double start_from, const int32_t k, const int seed) {
     using T = typename ov::element_type_traits<DT>::value_type;
     std::default_random_engine random(seed);
     // 1/k is the resolution of the floating point numbers
@@ -389,10 +389,10 @@ void fill_tensor_random_float(ov::Tensor& tensor, double range, double start_fro
     }
 }
 
-void fill_tensor_random(ov::Tensor& tensor, double range, double start_from, int32_t k, int seed) {
+void fill_tensor_random(ov::Tensor& tensor, const double range, const double start_from, const int32_t k, const int seed) {
     auto element_type = tensor.get_element_type();
 
-#define CASE(X) case X: fill_tensor_random<X>(tensor, range, start_from, k, seed); break;
+#define CASE(X) case X: fill_tensor_random<X>(tensor, static_cast<uint32_t>(range), static_cast<int32_t>(start_from), k, seed); break;
 #define CASE_FLOAT(X) case X: fill_tensor_random_float<X>(tensor, range, start_from, k, seed); break;
 
     switch (element_type) {

--- a/src/tests/test_utils/common_test_utils/src/data_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/data_utils.cpp
@@ -357,25 +357,23 @@ void fill_data_with_broadcast(ov::Tensor& tensor, size_t axis, std::vector<float
 }
 
 template<ov::element::Type_t DT>
-void fill_tensor_random(ov::Tensor& tensor, const uint32_t range = 10, int32_t start_from = 0,
-                               const int32_t k = 1, const int seed = 1) {
+void fill_tensor_random(ov::Tensor& tensor, double range = 10, double start_from = 0, const int32_t k = 1, int seed = 1) {
     using T = typename ov::element_type_traits<DT>::value_type;
     auto *rawBlobDataPtr = static_cast<T*>(tensor.data());
     if (DT == ov::element::u4 || DT == ov::element::i4 ||
         DT == ov::element::u1) {
-        fill_data_random(rawBlobDataPtr, tensor.get_byte_size(), range, start_from, k, seed);
+        fill_data_random(rawBlobDataPtr, tensor.get_byte_size(), static_cast<uint32_t>(range), static_cast<int32_t>(start_from), k, seed);
     } else {
-        fill_data_random(rawBlobDataPtr, tensor.get_size(), range, start_from, k, seed);
+        fill_data_random(rawBlobDataPtr, tensor.get_size(), static_cast<uint32_t>(range), static_cast<int32_t>(start_from), k, seed);
     }
 }
 
 template<ov::element::Type_t DT>
-void fill_tensor_random_float(ov::Tensor& tensor, const uint32_t range, int32_t start_from, const int32_t k,
-                         const int seed = 1) {
+void fill_tensor_random_float(ov::Tensor& tensor, double range, double start_from, int32_t k, int seed = 1) {
     using T = typename ov::element_type_traits<DT>::value_type;
     std::default_random_engine random(seed);
     // 1/k is the resolution of the floating point numbers
-    std::uniform_int_distribution<int32_t> distribution(k * start_from, k * (start_from + range));
+    std::uniform_real_distribution<double> distribution(k * start_from, k * (start_from + range));
 
     auto *rawBlobDataPtr = static_cast<T*>(tensor.data());
     for (size_t i = 0; i < tensor.get_size(); i++) {
@@ -391,8 +389,7 @@ void fill_tensor_random_float(ov::Tensor& tensor, const uint32_t range, int32_t 
     }
 }
 
-void fill_tensor_random(ov::Tensor& tensor, const uint32_t range, int32_t start_from,
-                               const int32_t k, const int seed) {
+void fill_tensor_random(ov::Tensor& tensor, double range, double start_from, int32_t k, int seed) {
     auto element_type = tensor.get_element_type();
 
 #define CASE(X) case X: fill_tensor_random<X>(tensor, range, start_from, k, seed); break;


### PR DESCRIPTION
### Details:
 - Improve fill_tensor_random func to work with real value boundaries

### Tickets:
 - [CVS-117139](https://jira.devtools.intel.com/browse/CVS-117139)
