### PR TITLE
[CPU] FullyConnected acceleration with 8bit weights decompression on SPR

### DIFF
--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -251,7 +251,22 @@ void DnnlPostOpsComposer::appendClip(const std::vector<float>& low, const std::v
     }
 }
 
-void DnnlPostOpsComposer::appendDecompressionScales(const std::vector<float>& scales) {
+MemoryPtr DnnlPostOpsComposer::prepackDecompressionParams(const std::vector<float>& params, size_t icBlock) {
+    // Prepacking params from [oc] to [oc, icBlock] layout, where for each icBlock corresponding parameter is duplicated
+    DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({icBlock * params.size()}));
+    auto mem = std::make_shared<Memory>(engine, memoryDesc);
+    size_t dstIdx = 0;
+    auto decomp_scales_buf = static_cast<float*>(mem->getData());
+    for (int oc = 0; oc < params.size(); oc++) {
+        for (int intIdx = 0; intIdx < icBlock; intIdx++) {
+            decomp_scales_buf[dstIdx] = params[oc];
+            dstIdx++;
+        }
+    }
+    return mem;
+}
+
+void DnnlPostOpsComposer::appendDecompressionScales(const std::vector<float>& scales, size_t icBlock) {
     if (scales.empty())
         return;
 
@@ -259,13 +274,10 @@ void DnnlPostOpsComposer::appendDecompressionScales(const std::vector<float>& sc
     DEBUG_LOG("Set weights scales mask ", "DNNL_ARG: ", DNNL_ARG_WEIGHTS, " mask: ", mask);
     attr.set_scales_mask(DNNL_ARG_WEIGHTS, mask);
 
-    DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({scales.size()}));
-    auto mem = std::make_shared<Memory>(engine, memoryDesc);
-    memcpy(mem->getData(), scales.data(), scales.size() * sizeof(float));
-    args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = mem;
+    args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = prepackDecompressionParams(scales, icBlock);
 }
 
-void DnnlPostOpsComposer::appendDecompressionZeroPoints(const std::vector<float>& zero_points) {
+void DnnlPostOpsComposer::appendDecompressionZeroPoints(const std::vector<float>& zero_points, size_t icBlock) {
     if (zero_points.empty())
         return;
 
@@ -273,10 +285,7 @@ void DnnlPostOpsComposer::appendDecompressionZeroPoints(const std::vector<float>
     DEBUG_LOG("Set weights zero points mask ", "DNNL_ARG: ", DNNL_ARG_WEIGHTS, " mask: ", mask);
     attr.set_zero_points_mask(DNNL_ARG_WEIGHTS, mask);
 
-    DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({zero_points.size()}));
-    auto mem = std::make_shared<Memory>(engine, memoryDesc);
-    memcpy(mem->getData(), zero_points.data(), zero_points.size() * sizeof(float));
-    args[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS] = mem;
+    args[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS] = prepackDecompressionParams(zero_points, icBlock);
 }
 
 }  // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -257,8 +257,8 @@ MemoryPtr DnnlPostOpsComposer::prepackDecompressionParams(const std::vector<floa
     auto mem = std::make_shared<Memory>(engine, memoryDesc);
     size_t dstIdx = 0;
     auto decomp_scales_buf = static_cast<float*>(mem->getData());
-    for (int oc = 0; oc < params.size(); oc++) {
-        for (int intIdx = 0; intIdx < icBlock; intIdx++) {
+    for (size_t oc = 0; oc < params.size(); oc++) {
+        for (size_t intIdx = 0; intIdx < icBlock; intIdx++) {
             decomp_scales_buf[dstIdx] = params[oc];
             dstIdx++;
         }

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.h
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.h
@@ -42,8 +42,8 @@ public:
     bool appendLinear(const std::vector<float>& scale, const std::vector<float>& shift, bool isLastPostOp, bool allowBinary = true);
     void appendClip(const std::vector<float>& low, const std::vector<float>& high);
 
-    void appendDecompressionScales(const std::vector<float>& scales);
-    void appendDecompressionZeroPoints(const std::vector<float>& zero_points);
+    void appendDecompressionScales(const std::vector<float>& scales, size_t icBlock);
+    void appendDecompressionZeroPoints(const std::vector<float>& zero_points, size_t icBlock);
 
     const VectorDims& getOutputDims() {
         return outputDims;
@@ -69,6 +69,7 @@ private:
 
     void updateWeiScales();
     void updateDestScales();
+    MemoryPtr prepackDecompressionParams(const std::vector<float>& params, size_t icBlock);
 };
 
 }  // namespace intel_cpu

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
@@ -208,14 +208,18 @@ TEST_P(MatmulWeightsDecompression, CompareWithRefs) {
 
 namespace {
 
-std::vector<std::map<std::string, std::string>> filterAdditionalConfig() {
-    std::vector<std::map<std::string, std::string>> additional_config;//{CPUTestUtils::cpuEmptyPluginConfig};
-    if (with_cpu_x86_avx512_core())
+std::vector<std::map<std::string, std::string>> filterAdditionalConfigBasic() {
+    std::vector<std::map<std::string, std::string>> additional_config = {CPUTestUtils::cpuEmptyPluginConfig};
+    return additional_config;
+}
+std::vector<std::map<std::string, std::string>> filterAdditionalConfigBig() {
+    std::vector<std::map<std::string, std::string>> additional_config = {CPUTestUtils::cpuEmptyPluginConfig};
+    if (with_cpu_x86_avx512_core_amx())
         additional_config.push_back({{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}});
     return additional_config;
 }
 
-bool shouldUseDecompressionKernel() {
+bool shouldUseDecompressionKernelBig() {
     // No decompression support on non-avx systems
     if (!with_cpu_x86_avx2())
         return false;
@@ -223,12 +227,12 @@ bool shouldUseDecompressionKernel() {
     return true;
 }
 
-bool shouldUseDecompressionKernelAMX() {
+bool shouldUseDecompressionKernelBasic() {
     // AMX decompression support has shape limitations
     if (with_cpu_x86_avx512_core_amx())
         return false;
 
-    return shouldUseDecompressionKernel();
+    return shouldUseDecompressionKernelBig();
 }
 
 const std::vector<ov::test::ElementType> weights_precisions = {ov::element::u8};
@@ -260,9 +264,9 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_basic,
                                             ::testing::Values(true),
                                             ::testing::Values(true),
                                             ::testing::Values(true),
-                                            ::testing::ValuesIn(filterAdditionalConfig()),
+                                            ::testing::ValuesIn(filterAdditionalConfigBasic()),
                                             ::testing::ValuesIn(fusingParamsSet),
-                                            ::testing::Values(shouldUseDecompressionKernelAMX())),
+                                            ::testing::Values(shouldUseDecompressionKernelBasic())),
                          MatmulWeightsDecompression::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_big,
@@ -272,9 +276,9 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_big,
                                             ::testing::Values(true),
                                             ::testing::Values(true),
                                             ::testing::Values(true),
-                                            ::testing::ValuesIn(filterAdditionalConfig()),
+                                            ::testing::ValuesIn(filterAdditionalConfigBig()),
                                             ::testing::ValuesIn(fusingParamsSet),
-                                            ::testing::Values(shouldUseDecompressionKernel())),
+                                            ::testing::Values(shouldUseDecompressionKernelBig())),
                          MatmulWeightsDecompression::getTestCaseName);
 
 const std::vector<std::vector<InputShape>> input_shapes_corner_cases_basic = {
@@ -296,9 +300,9 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_basic,
                                             ::testing::ValuesIn(transpose_weights),
                                             ::testing::ValuesIn(add_decompression_sub),
                                             ::testing::ValuesIn(reshape_on_decompression),
-                                            ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig),
+                                            ::testing::ValuesIn(filterAdditionalConfigBasic()),
                                             ::testing::Values(emptyFusingSpec),
-                                            ::testing::Values(shouldUseDecompressionKernelAMX())),
+                                            ::testing::Values(shouldUseDecompressionKernelBasic())),
                          MatmulWeightsDecompression::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_big,
@@ -308,9 +312,9 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_big,
                                             ::testing::ValuesIn(transpose_weights),
                                             ::testing::ValuesIn(add_decompression_sub),
                                             ::testing::ValuesIn(reshape_on_decompression),
-                                            ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig),
+                                            ::testing::ValuesIn(filterAdditionalConfigBig()),
                                             ::testing::Values(emptyFusingSpec),
-                                            ::testing::Values(shouldUseDecompressionKernel())),
+                                            ::testing::Values(shouldUseDecompressionKernelBig())),
                          MatmulWeightsDecompression::getTestCaseName);
 } // namespace
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
@@ -37,7 +37,8 @@ using MatmulWeightsDecompressionParams = std::tuple<std::vector<InputShape>,  //
                                                     bool,                     // decompression subtract
                                                     bool,                     // reshape on decompression constants
                                                     std::map<std::string, std::string>,  // additional config
-                                                    fusingSpecificParams>;
+                                                    fusingSpecificParams,
+                                                    bool>; // should use decompression implementation
 
 class MatmulWeightsDecompression : public testing::WithParamInterface<MatmulWeightsDecompressionParams>,
                                   virtual public SubgraphBaseTest,
@@ -51,6 +52,7 @@ public:
         bool reshape_on_decompression;
         std::map<std::string, std::string> additional_config;
         fusingSpecificParams fusing_params;
+        bool should_fuse;
 
         std::tie(inputShapes,
                  weights_precision,
@@ -58,7 +60,8 @@ public:
                  decompression_sub,
                  reshape_on_decompression,
                  additional_config,
-                 fusing_params) = obj.param;
+                 fusing_params,
+                 should_fuse) = obj.param;
 
         std::ostringstream result;
         for (const auto& shape : inputShapes) {
@@ -158,6 +161,7 @@ protected:
         bool reshape_on_decompression;
         std::map<std::string, std::string> additional_config;
         fusingSpecificParams fusing_params;
+        bool should_fuse;
 
         std::tie(inputShapes,
                  weights_precision,
@@ -165,15 +169,14 @@ protected:
                  decompression_sub,
                  reshape_on_decompression,
                  additional_config,
-                 fusing_params) = GetParam();
+                 fusing_params,
+                 should_fuse) = GetParam();
 
         configuration.insert(additional_config.begin(), additional_config.end());
         std::tie(postOpMgrPtr, fusedOps) = fusing_params;
         init_input_shapes(inputShapes);
 
         ElementType netType = element::f32;
-        if (additional_config[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES)
-            netType = ElementType::bf16;
         inType = outType = netType;
 
         function = initSubgraph(inputDynamicShapes, netType, weights_precision, transpose_weights, decompression_sub, reshape_on_decompression);
@@ -182,6 +185,7 @@ protected:
     void checkResults() {
         const auto& test_param = GetParam();
         ov::test::ElementType weights_precision = std::get<1>(test_param);
+        bool should_fuse = std::get<7>(test_param);
         for (const auto& n : compiledModel.get_runtime_model()->get_ordered_ops()) {
             if (n->get_friendly_name() == "Compressed_weights") {
                 ASSERT_EQ(n->get_output_element_type(0), weights_precision);
@@ -189,9 +193,7 @@ protected:
         }
 
         std::map<std::string, std::string> additional_config = std::get<5>(test_param);
-        const size_t expected_count =
-            InferenceEngine::with_cpu_x86_avx2() &&
-            additional_config[PluginConfigParams::KEY_ENFORCE_BF16] != PluginConfigParams::YES ? 0 : 1;
+        const size_t expected_count = should_fuse ? 0 : 1;
         CheckNumberOfNodesWithType(compiledModel, "Convert", expected_count);
         CheckNumberOfNodesWithType(compiledModel, "Eltwise", expected_count);
         CheckNumberOfNodesWithType(compiledModel, "Subgraph", 0);
@@ -207,10 +209,26 @@ TEST_P(MatmulWeightsDecompression, CompareWithRefs) {
 namespace {
 
 std::vector<std::map<std::string, std::string>> filterAdditionalConfig() {
-    std::vector<std::map<std::string, std::string>> additional_config{CPUTestUtils::cpuEmptyPluginConfig};
+    std::vector<std::map<std::string, std::string>> additional_config;//{CPUTestUtils::cpuEmptyPluginConfig};
     if (with_cpu_x86_avx512_core())
         additional_config.push_back({{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}});
     return additional_config;
+}
+
+bool shouldUseDecompressionKernel() {
+    // No decompression support on non-avx systems
+    if (!with_cpu_x86_avx2())
+        return false;
+
+    return true;
+}
+
+bool shouldUseDecompressionKernelAMX() {
+    // AMX decompression support has shape limitations
+    if (with_cpu_x86_avx512_core_amx())
+        return false;
+
+    return shouldUseDecompressionKernel();
 }
 
 const std::vector<ov::test::ElementType> weights_precisions = {ov::element::u8};
@@ -218,13 +236,17 @@ const std::vector<std::vector<InputShape>> input_shapes_basic = {
     {{{-1, -1, -1}, {{1, 4, 16}, {10, 16, 16}}}, {{}, {{16, 32}}}},
     {{{}, {{1, 4, 16}}}, {{}, {{1, 16, 32}}}},
     {{{}, {{10, 40, 496}}}, {{}, {{1, 496, 240}}}},
-    {{{}, {{1, 4, 32}}}, {{}, {{32, 256}}}},
     {{{}, {{1, 4, 48}}}, {{}, {{48, 256}}}},
+    {{{}, {{11, 339, 377}}}, {{}, {{377, 335}}}},
+};
+const std::vector<std::vector<InputShape>> input_shapes_big = {
+    {{{-1, -1, -1}, {{10, 40, 480}, {11, 40, 480}}}, {{}, {{1, 480, 256}}}},
+    {{{}, {{1, 4, 32}}}, {{}, {{32, 256}}}},
     {{{}, {{1, 4, 512}}}, {{}, {{512, 256}}}},
     {{{}, {{1, 16, 32}}}, {{}, {{32, 64}}}},
     {{{}, {{2, 4, 32}}}, {{}, {{32, 65}}}},
-    {{{}, {{11, 339, 377}}}, {{}, {{377, 335}}}},
     {{{}, {{3, 12, 768}}}, {{}, {{768, 1024}}}},
+    {{{}, {{11, 339, 577}}}, {{}, {{577, 335}}}},
 };
 const std::vector<fusingSpecificParams> fusingParamsSet {
     emptyFusingSpec,
@@ -239,26 +261,56 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_basic,
                                             ::testing::Values(true),
                                             ::testing::Values(true),
                                             ::testing::ValuesIn(filterAdditionalConfig()),
-                                            ::testing::ValuesIn(fusingParamsSet)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(shouldUseDecompressionKernelAMX())),
                          MatmulWeightsDecompression::getTestCaseName);
 
-const std::vector<std::vector<InputShape>> input_shapes_corner_cases = {
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_big,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_big),
+                                            ::testing::ValuesIn(weights_precisions),
+                                            ::testing::Values(true),
+                                            ::testing::Values(true),
+                                            ::testing::Values(true),
+                                            ::testing::ValuesIn(filterAdditionalConfig()),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(shouldUseDecompressionKernel())),
+                         MatmulWeightsDecompression::getTestCaseName);
+
+const std::vector<std::vector<InputShape>> input_shapes_corner_cases_basic = {
     {{{-1, -1, -1}, {{1, 4, 16}}}, {{}, {{1, 16, 32}}}},
     {{{-1, -1, -1}, {{1, 4, 16}}}, {{}, {{16, 32}}}},
 };
+const std::vector<std::vector<InputShape>> input_shapes_corner_cases_big = {
+    {{{-1, -1, -1}, {{10, 40, 480}, {11, 40, 480}}}, {{}, {{1, 480, 256}}}},
+};
+
 const std::vector<bool> transpose_weights = {true, false};
 const std::vector<bool> add_decompression_sub = {true, false};
 const std::vector<bool> reshape_on_decompression = {true, false};
 
-INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases,
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_basic,
                          MatmulWeightsDecompression,
-                         ::testing::Combine(::testing::ValuesIn(input_shapes_corner_cases),
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_corner_cases_basic),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(transpose_weights),
                                             ::testing::ValuesIn(add_decompression_sub),
                                             ::testing::ValuesIn(reshape_on_decompression),
                                             ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig),
-                                            ::testing::Values(emptyFusingSpec)),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::Values(shouldUseDecompressionKernelAMX())),
+                         MatmulWeightsDecompression::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_big,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_corner_cases_big),
+                                            ::testing::ValuesIn(weights_precisions),
+                                            ::testing::ValuesIn(transpose_weights),
+                                            ::testing::ValuesIn(add_decompression_sub),
+                                            ::testing::ValuesIn(reshape_on_decompression),
+                                            ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::Values(shouldUseDecompressionKernel())),
                          MatmulWeightsDecompression::getTestCaseName);
 } // namespace
 


### PR DESCRIPTION
### Details:
 - This PR adds runtime acceleration for LLMs with quantized weights on SPR Xeons
 - Supported cases:
 -- nodes: FullyConnected
 -- weights compression: unsigned 8bit
 -- isa: AMX
 - OneDNN PR: https://github.com/openvinotoolkit/oneDNN/pull/207

### Tickets:
 - *[CVS-113727](https://jira.devtools.intel.com/browse/CVS-113727)*

