### PR TITLE
[PyOV] Add `sympy` dependency for torchvision preprocessor tests

### DIFF
--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -44,3 +44,4 @@ torch
 torchvision; platform_machine == 'arm64' and python_version >= '3.8'
 torchvision; platform_machine != 'arm64'
 pillow
+sympy

--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -43,5 +43,6 @@ singledispatchmethod
 torch
 torchvision; platform_machine == 'arm64' and python_version >= '3.8'
 torchvision; platform_machine != 'arm64'
+sympy; platform_machine == 'arm64' and python_version >= '3.8'
+sympy; platform_machine != 'arm64'
 pillow
-sympy


### PR DESCRIPTION
### Details:
 - `torch` needs `sympy`, but does not formally require it as a dependency
 - it can be seen in https://github.com/pytorch/pytorch/blob/v2.0.1/torch/_guards.py#L11-L16
 - this causes sporadic errors in CI when running torchvision to OpenVINO preprocessor tests
 - PR forces `sympy` to be installed

### Tickets:
 - 117517
