### PR TITLE
[GNA] Temporary deactivation of sporadically failing tests

### DIFF
--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -100,5 +100,7 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_MultiHeteroOVGetMetricPropsTest.*OVGetMetricPropsTest.*(AVAILABLE_DEVICES|OPTIMIZATION_CAPABILITIES|RANGE_FOR_ASYNC_INFER_REQUESTS|RANGE_FOR_STREAMS).*)",
         // TODO: Issue: 111556
         R"(.*SplitConvTest.CompareWithRefImpl.*IS=\(1.(128|256)\).*IC=4.*OC=4.*configItem=GNA_DEVICE_MODE_GNA_SW_FP32)",
+        // TODO: Issue: 114149
+        R"(.*smoke_Decompose2DConv.*)",
     };
 }


### PR DESCRIPTION
### Details:
- Deactivate all smoke_Decompose2D tests,
- It will be reverted once the root cause is identified and resolved

### Tickets:
 - 114149
