### PR TITLE
[DOCS] Add numpy to installation instructions for 2023.0

### DIFF
--- a/docs/install_guides/installing-openvino-from-archive-linux.md
+++ b/docs/install_guides/installing-openvino-from-archive-linux.md
@@ -185,7 +185,20 @@ Step 1: Download and Install the OpenVINO Core Components
       cd /opt/intel/openvino_2023.0.1
       sudo -E ./install_dependencies/install_openvino_dependencies.sh
 
-6. For simplicity, it is useful to create a symbolic link as below:
+6. (Optional) Install *numpy* Python Library:
+
+   .. note::
+
+      This step is required only when you decide to use Python API.
+
+   You can use the ``requirements.txt`` file from the ``opt/intel/openvino_2023.0.1/python/python.<x>`` folder:
+
+   .. code-block:: sh
+
+      cd /opt/intel/openvino_2023.0.1
+      python3 -m pip install -r ./python/python3.<x>/requirements.txt
+
+7. For simplicity, it is useful to create a symbolic link as below:
    
    .. code-block:: sh
    

--- a/docs/install_guides/installing-openvino-from-archive-macos.md
+++ b/docs/install_guides/installing-openvino-from-archive-macos.md
@@ -83,8 +83,20 @@ Step 1: Install OpenVINO Core Components
             tar -xf openvino_2023.0.1.tgz
             sudo mv m_openvino_toolkit_macos_11_0_2023.0.1.11005.fa1c41994f3_arm64 /opt/intel/openvino_2023.0.1
 
+5. (Optional) Install *numpy* Python Library:
 
-5. For simplicity, it is useful to create a symbolic link as below:
+   .. note::
+
+      This step is required only when you decide to use Python API.
+
+   You can use the ``requirements.txt`` file from the ``opt/intel/openvino_2023.0.1/python/python.<x>`` folder:
+
+   .. code-block:: sh
+
+      cd /opt/intel/openvino_2023.0.1
+      python3 -m pip install -r ./python/python3.<x>/requirements.txt
+
+6. For simplicity, it is useful to create a symbolic link as below:
 
    .. code-block:: sh
 

--- a/docs/install_guides/installing-openvino-from-archive-windows.md
+++ b/docs/install_guides/installing-openvino-from-archive-windows.md
@@ -107,7 +107,21 @@ Step 1: Download and Install OpenVINO Core Components
       move openvino_2023.0.1 "C:\Program Files (x86)\Intel"
 
 
-4. For simplicity, it is useful to create a symbolic link. Open a command prompt window as administrator (see Step 1 for how to do this) and run the following commands:
+4. (Optional) Install *numpy* Python Library:
+
+   .. note::
+
+      This step is required only when you decide to use Python API.
+
+   You can use the ``requirements.txt`` file from the ``C:\Program Files (x86)\Intel\openvino_2023.0.1\python\python.<x>`` folder:
+
+   .. code-block:: sh
+
+      cd "C:\Program Files (x86)\Intel\openvino_2023.0.1"
+      python -m pip install -r .\python\python3.<x>\requirements.txt
+
+
+5. For simplicity, it is useful to create a symbolic link. Open a command prompt window as administrator (see Step 1 for how to do this) and run the following commands:
 
    .. code-block:: sh
 


### PR DESCRIPTION
Adding `Install "numpy" Python library` step in installation instructions. 

Porting: https://github.com/openvinotoolkit/openvino/pull/19093