### PR TITLE
[PT FE] Remove torch strides compensation

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/fx_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/fx_decoder.py
@@ -154,28 +154,6 @@ class TorchFXPythonDecoder (Decoder):
         else:
             return OVAny(OVType.f32)
 
-    def get_input_transpose_order(self, index):
-        return []
-        # TODO TBD
-
-        input = self._raw_input(index)
-        if input.type() is not None and input.type().kind() == 'TensorType':
-            strides = input.type().strides()
-            if strides is not None:
-                return [s[0] for s in sorted(enumerate(strides), key=lambda x:x[1], reverse=True)]
-        return []
-
-    def get_output_transpose_order(self, index):
-        return []
-
-        # old code
-        output = self._raw_output(index)
-        if output.type() is not None and output.type().kind() == 'TensorType':
-            strides = output.type().strides()
-            if strides is not None:
-                return [s[0] for s in sorted(enumerate(strides), key=lambda x:x[1], reverse=True)]
-        return []
-
     def get_subgraph_size(self):
         if issubclass(type(self.pt_module), torch.fx.Node):
             return 0

--- a/src/bindings/python/src/openvino/frontend/pytorch/ts_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/ts_decoder.py
@@ -258,22 +258,6 @@ class TorchScriptPythonDecoder (Decoder):
         full_type = self._get_known_type_for_value(value.type())
         return full_type
 
-    def get_input_transpose_order(self, index: int) -> list:
-        raw_input = self._raw_input(index)
-        if raw_input.type() is not None and raw_input.type().kind() == "TensorType":
-            strides = raw_input.type().strides()
-            if strides is not None:
-                return [s[0] for s in sorted(enumerate(strides), key=lambda x:x[1], reverse=True)]
-        return []
-
-    def get_output_transpose_order(self, index: int) -> list:
-        output = self._raw_output(index)
-        if output.type() is not None and output.type().kind() == "TensorType":
-            strides = output.type().strides()
-            if strides is not None:
-                return [s[0] for s in sorted(enumerate(strides), key=lambda x:x[1], reverse=True)]
-        return []
-
     def get_subgraph_size(self) -> int:
         if isinstance(self.graph_element, torch.Node):
             return len(self.get_subgraphs())

--- a/src/bindings/python/src/openvino/frontend/pytorch/utils.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/utils.py
@@ -67,20 +67,15 @@ def ivalue_to_constant(ivalue):
         return op.Constant(ov_type, Shape([len(ivalue)]), ivalue).outputs()
 
     if isinstance(ivalue, torch.Tensor):
-        ivalue = ivalue.to(memory_format=torch.contiguous_format)
+        ivalue = ivalue.contiguous()
         if ivalue.dtype == torch.bfloat16:
             # reinterpret bfloat16 data as float16 to allow conversion to numpy
             ivalue = ivalue.view(torch.float16)
             narr = ivalue.numpy(force=True)
-            if not narr.flags['C_CONTIGUOUS']:
-                narr = np.ascontiguousarray(narr)
-            # TODO: this tensor doesn't share memory with initial tensor
             tensor = Tensor(narr, ivalue.shape, OVType.bf16)
             ov_const = op.Constant(tensor, shared_memory=True)
         else:
             narr = ivalue.numpy(force=True)
-            if not narr.flags['C_CONTIGUOUS']:
-                narr = np.ascontiguousarray(narr)
             ov_const = op.Constant(narr, shared_memory=True)
         return ov_const.outputs()
     return None

--- a/src/bindings/python/src/pyopenvino/frontend/pytorch/decoder.hpp
+++ b/src/bindings/python/src/pyopenvino/frontend/pytorch/decoder.hpp
@@ -38,10 +38,6 @@ class PyDecoder : public ov::frontend::pytorch::TorchDecoder {
         PYBIND11_OVERRIDE_PURE(ov::Any, TorchDecoder, get_input_type, index);
     }
 
-    const std::vector<size_t>& get_input_transpose_order(size_t index) const override {
-        PYBIND11_OVERRIDE_PURE(const std::vector<size_t>&, TorchDecoder, get_input_transpose_order, index);
-    }
-
     const std::string& get_output_debug_name(size_t index) const override {
         PYBIND11_OVERRIDE_PURE(const std::string&, TorchDecoder, get_output_debug_name, index);
     }
@@ -52,10 +48,6 @@ class PyDecoder : public ov::frontend::pytorch::TorchDecoder {
 
     ov::Any get_output_type(size_t index) const override {
         PYBIND11_OVERRIDE_PURE(ov::Any, TorchDecoder, get_output_type, index);
-    }
-
-    const std::vector<size_t>& get_output_transpose_order(size_t index) const override {
-        PYBIND11_OVERRIDE_PURE(const std::vector<size_t>&, TorchDecoder, get_output_transpose_order, index);
     }
 
     bool input_is_none(size_t index) const override {

--- a/src/frontends/pytorch/include/openvino/frontend/pytorch/decoder.hpp
+++ b/src/frontends/pytorch/include/openvino/frontend/pytorch/decoder.hpp
@@ -44,9 +44,6 @@ public:
     // (see custom_type.hpp)
     virtual Any get_input_type(size_t index) const = 0;
 
-    // TODO: Consider deleting this method, probably it doesn't make sence outside Torch JIT execution
-    virtual const std::vector<size_t>& get_input_transpose_order(size_t index) const = 0;
-
     // Return debug name of the input tensor
     virtual const std::string& get_output_debug_name(size_t index) const = 0;
 
@@ -56,9 +53,6 @@ public:
     // Return element::Type when it the original type can be represented, otherwise returns PT-specific data type object
     // (see custom_type.hpp)
     virtual Any get_output_type(size_t index) const = 0;
-
-    // TODO: Consider deleting this method, probably it doesn't make sence outside Torch JIT execution
-    virtual const std::vector<size_t>& get_output_transpose_order(size_t index) const = 0;
     // ------------------------------
 
     // TODO: required? can be implemented in the context of a single node?

--- a/src/frontends/pytorch/src/utils.hpp
+++ b/src/frontends/pytorch/src/utils.hpp
@@ -161,9 +161,6 @@ public:
     virtual Any get_input_type(size_t index) const override {
         FRONT_END_NOT_IMPLEMENTED(get_input_type);
     }
-    virtual const std::vector<size_t>& get_input_transpose_order(size_t index) const override {
-        FRONT_END_NOT_IMPLEMENTED(get_input_transpose_order);
-    }
     virtual const std::string& get_output_debug_name(size_t index) const override {
         FRONT_END_NOT_IMPLEMENTED(get_output_debug_name);
     }
@@ -172,9 +169,6 @@ public:
     }
     virtual Any get_output_type(size_t index) const override {
         FRONT_END_NOT_IMPLEMENTED(get_output_type);
-    }
-    virtual const std::vector<size_t>& get_output_transpose_order(size_t index) const override {
-        FRONT_END_NOT_IMPLEMENTED(get_output_transpose_order);
     }
     virtual bool input_is_none(size_t index) const override {
         FRONT_END_NOT_IMPLEMENTED(input_is_none);

--- a/tests/layer_tests/pytorch_tests/pytorch_layer_test_class.py
+++ b/tests/layer_tests/pytorch_tests/pytorch_layer_test_class.py
@@ -136,7 +136,7 @@ class PytorchLayerTest:
                     assert 'quant_size' in kwargs, "quant size must be specified for quantized_ops flag"
                     quant_size = kwargs['quant_size']
             for i in range(len(infer_res)):
-                cur_fw_res = flatten_fw_res[i].to(memory_format=torch.contiguous_format).numpy(
+                cur_fw_res = flatten_fw_res[i].contiguous().numpy(
                 ) if isinstance(flatten_fw_res[i], torch.Tensor) else flatten_fw_res[i]
                 if np.array(cur_fw_res).size == 0:
                     continue

--- a/tests/layer_tests/pytorch_tests/test_quantized_convnd.py
+++ b/tests/layer_tests/pytorch_tests/test_quantized_convnd.py
@@ -41,7 +41,7 @@ class TestQuantizedConv2D(PytorchLayerTest):
                 x_quantized = torch.quantize_per_tensor(
                     x, 1.0, 0, torch.quint8)
                 conv = self.conv(x_quantized)
-                return torch.dequantize(conv).contiguous()
+                return torch.dequantize(conv)
 
         ref_net = None
         if not relu:
@@ -54,13 +54,8 @@ class TestQuantizedConv2D(PytorchLayerTest):
     @pytest.mark.parametrize(
         "params",
         [
-            pytest.param(
-                {"weights_shape": [1, 3, 3, 3], "strides": 1,
-                    "pads": 0, "dilations": 1, "groups": 1},
-                marks=pytest.mark.xfail(
-                    reason="Output channels equal to 1 creates output that fails to cast to contiguous."
-                ),
-            ),
+            {"weights_shape": [1, 3, 3, 3], "strides": 1,
+                "pads": 0, "dilations": 1, "groups": 1},
             {"weights_shape": [2, 3, 3, 3], "strides": 1,
                 "pads": 0, "dilations": 1, "groups": 1},
             {"weights_shape": [2, 3, 3, 3], "strides": 2,


### PR DESCRIPTION
### Details:
 - *This is a legacy POC artifact. Torch tensors can have non-contiguous strides, but openvino doesn't have this concept, we accept only contiguous tensors, so we do not need to correct strides of the input. The problem was found on models obtained without freezing, because freezing removes strides from graph.*

### Tickets:
 - *None*
