### PR TITLE
[GPU] Don't invalidate users after reorder insertion

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -200,6 +200,7 @@ void add_required_reorders::run(program& p) {
                             auto new_reorder = std::make_shared<reorder>(input.id() + "_padding_reorder_" + usr->id(), input.id(), layout_wo_padding);
                             auto& new_reorder_node = p.get_or_create(new_reorder);
                             p.add_intermediate(new_reorder_node, *usr, idx);
+                            new_reorder_node.recalc_output_layout(false);
                         } else {
                             continue;
                         }

--- a/src/plugins/intel_gpu/tests/unit/passes/add_required_reorders_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/add_required_reorders_test.cpp
@@ -147,6 +147,39 @@ TEST(add_required_reorders, prevent_input_dt_changing_for_convs) {
     ASSERT_EQ(prog->get_node("conv1").get_input_layout(0).data_type, data_types::u8);
 }
 
+TEST(add_required_reorders, prevent_users_invalidation) {
+    auto& engine = get_test_engine();
+
+    // Create padded input memory
+    auto input_mem_padded = engine.allocate_memory({ {1, 16, 8, 8}, data_types::f16, format::bfyx, padding{{0, 0, 2, 2}, 0} });
+    auto weights_mem = engine.allocate_memory({ {16, 16, 1, 1}, data_types::f16, format::bfyx });
+
+    auto input = input_layout("input", input_mem_padded->get_layout());
+    auto weights = data("weights", weights_mem);
+    auto conv = convolution("conv", input_info("input"), "weights", "", 1, { 1, 1 }, { 1, 1 }, { 1, 1 }, { 2, 2 }, false);
+
+    auto prog = program::build_program(engine,
+                                       topology(input, weights, conv),
+                                       get_test_default_config(engine),
+                                       false,
+                                       true);
+
+    ASSERT_NE(prog, nullptr);
+    ASSERT_TRUE(prog->has_node("conv"));
+
+    const auto& conv_node = prog->get_node("conv");
+
+    // Force OneDNN impl type to insert padded_layout -> non_padded_layout reorder
+    prog->get_node("conv").set_preferred_impl_type(impl_types::onednn);
+
+    program_wrapper::apply_opt_pass<add_required_reorders>(*prog);
+
+    const auto& conv_input = conv_node.get_dependency(0);
+
+    ASSERT_TRUE(conv_input.is_type<reorder>());
+    ASSERT_TRUE(conv_input.is_valid_output_layout());
+}
+
 TEST(add_required_reorders, skip_adding_reorder_batch_axis_padding) {
     auto& engine = get_test_engine();
 


### PR DESCRIPTION
### Details:
- This change marks output layout of inserted padded_layout -> non_padded_layout reorder as valid - this prevents incorrect format propagation of reorder's users. This patch fixes SD model (FP32) functional issue

### Tickets:
 - *ticket-id*
