### PR TITLE
benhcmark_app: fix -api sync -i multiple images

### DIFF
--- a/samples/cpp/benchmark_app/utils.cpp
+++ b/samples/cpp/benchmark_app/utils.cpp
@@ -109,7 +109,14 @@ std::vector<float> split_float(const std::string& s, char delim) {
 }
 
 bool can_measure_as_static(const std::vector<benchmark_app::InputsInfo>& app_input_info) {
-    return app_input_info.size() == 1;
+    for (const benchmark_app::InputsInfo& info : app_input_info) {
+        for (const auto& pair : info) {
+            if (pair.second.partialShape.is_dynamic() && app_input_info.size() > 1) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 static const std::vector<std::string> meta_plugins{"MULTI", "HETERO", "AUTO"};


### PR DESCRIPTION
The Python version uses `app_inputs_info` to represent different input configurations, but the C++ version extends that use case and uses `app_inputs_info` to represent different input images as well. That means that the assumption that if `app_input_info.size() > 1`, then input shape is dynamic, doesn’t always hold for C++

Ticket 117673
