### PR TITLE
[PyOV] Raise allowed diff value for torchvision preprocessor test

### DIFF
--- a/src/bindings/python/tests/test_torchvision_to_ov/test_preprocessor.py
+++ b/src/bindings/python/tests/test_torchvision_to_ov/test_preprocessor.py
@@ -95,7 +95,7 @@ def test_convertimagedtype():
         ],
     )
     torch_result, ov_result = _infer_pipelines(test_input, preprocess_pipeline)
-    assert np.max(np.absolute(torch_result - ov_result)) < 2e-04
+    assert np.max(np.absolute(torch_result - ov_result)) < 3e-04
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Details:
 - Current value causes sporadic numerical comparison errors in CI pipelines:
 `AssertionError: assert 0.00020426512 < 0.0002`

### Tickets:
 - 117643
