### PR TITLE
[CPU][ARM][FP16] Prefer Convert over Reorder for conversion

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -547,6 +547,14 @@ static bool isReorderAvailable(const MemoryDescPtr& parentDesc, const MemoryDesc
     dnnl_primitive_desc_t result = nullptr;
     auto status = dnnl_reorder_primitive_desc_create(&result, srcMemDesc.get(), eng.get(), dstMemDesc.get(), eng.get(),
                                                      attr.get());
+#if defined(OV_CPU_ARM_ENABLE_FP16)
+    // temporary WA for slow FP32->FP16 conversion reorder in oneDNN on ARM
+    // pretend the reorder is not available to use Convert node instead
+    if (result && parse_impl_name(result->impl()->name()) == ref_any) {
+        dnnl_primitive_desc_destroy(result);
+        return false;
+    }
+#endif
     if (result) {
         dnnl_primitive_desc_destroy(result);
     }


### PR DESCRIPTION
### Details:
 - oneDNN lacks jit reorder for FP16 precision on ARM and uses
   slow ref implementation
 - prefer Convert over Reorder for convert-only operation

### Tickets:
 - 117049

### TDB:
- [x] rebase on top of https://github.com/openvinotoolkit/openvino/pull/18973 first
- [x] regression check