### PR TITLE
[Core] TensorMemoryBlob: sync data handle on alloc call

### DIFF
--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -516,6 +516,10 @@ public:
     void setShape(const ie::SizeVector& dims) override {
         tensor->set_shape(dims);
         ie::TBlob<T>::getTensorDesc().setDims(dims);
+        allocate();
+    }
+
+    void allocate() noexcept override {
         if (ie::TBlob<T>::buffer() != tensor->data()) {
             ie::TBlob<T>::_allocator =
                 ie::details::make_pre_allocator(static_cast<T*>(tensor->data()), tensor->get_byte_size());

--- a/src/plugins/intel_cpu/src/infer_request.h
+++ b/src/plugins/intel_cpu/src/infer_request.h
@@ -93,6 +93,7 @@ protected:
 
         void update() {
             m_proxyMemMngr->setMemMngr(currentMemMngr());
+            m_blob->allocate(); // WA: update handle
         }
 
     private:


### PR DESCRIPTION
### Details:
TensorMemoryBlob doesn't synchronize the internal data pointer with the data pointer of the underlying ITensor object. To address the problem without changes to the `InferenceEngine::Blob` interface, `allocate` method was overloaded, so that it performs the synchronization on demand. 

### Tickets:
 - 117418
