### PR TITLE
[DOCS] Added a missing import keyword for 22.3

### DIFF
--- a/tools/pot/docs/AccuracyAwareQuantizationUsage.md
+++ b/tools/pot/docs/AccuracyAwareQuantizationUsage.md
@@ -114,7 +114,7 @@ The example code below shows a basic quantization workflow with accuracy control
 
 ```python
 from openvino.tools.pot import IEEngine
-from openvino.tools.pot load_model, save_model
+from openvino.tools.pot import load_model, save_model
 from openvino.tools.pot import compress_model_weights
 from openvino.tools.pot import create_pipeline
 

--- a/tools/pot/docs/DefaultQuantizationUsage.md
+++ b/tools/pot/docs/DefaultQuantizationUsage.md
@@ -81,7 +81,7 @@ An example code below shows a basic quantization workflow:
 
 ```python
 from openvino.tools.pot import IEEngine
-from openvino.tools.pot load_model, save_model
+from openvino.tools.pot import load_model, save_model
 from openvino.tools.pot import compress_model_weights
 from openvino.tools.pot import create_pipeline
 


### PR DESCRIPTION
### Details:

 - Couple of code blocks were missing an `import` keyword

Port from https://github.com/openvinotoolkit/openvino/pull/17271