### PR TITLE
Fix of confusing logs in convert_model().

### DIFF
--- a/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
@@ -19,11 +19,11 @@ def get_pytorch_decoder(model, input_shape, example_inputs, args):
         raise e
     try:
         if 'nncf' in sys.modules:
-            from nncf.torch.nncf_network import NNCFNetwork
+            from nncf.torch.nncf_network import NNCFNetwork # pylint: disable=undefined-variable
             from packaging import version
 
             if isinstance(model, NNCFNetwork):
-                if version.parse(nncf.__version__) < version.parse("2.6"):
+                if version.parse(nncf.__version__) < version.parse("2.6"): # pylint: disable=undefined-variable
                     raise RuntimeError(
                         "NNCF models produced by nncf<2.6 are not supported directly. Please upgrade nncf or export to ONNX first.")
     except:

--- a/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
@@ -20,14 +20,15 @@ def get_pytorch_decoder(model, input_shape, example_inputs, args):
         log.error("PyTorch frontend loading failed")
         raise e
     try:
-        import nncf
-        from nncf.torch.nncf_network import NNCFNetwork
-        from packaging import version
+        if 'nncf' in sys.modules:
+            import nncf
+            from nncf.torch.nncf_network import NNCFNetwork
+            from packaging import version
 
-        if isinstance(model, NNCFNetwork):
-            if version.parse(nncf.__version__) < version.parse("2.6"):
-                raise RuntimeError(
-                    "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
+            if isinstance(model, NNCFNetwork):
+                if version.parse(nncf.__version__) < version.parse("2.6"):
+                    raise RuntimeError(
+                        "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
     except:
         pass
     inputs = prepare_torch_inputs(example_inputs)

--- a/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
@@ -26,7 +26,7 @@ def get_pytorch_decoder(model, input_shape, example_inputs, args):
             if isinstance(model, NNCFNetwork):
                 if version.parse(nncf.__version__) < version.parse("2.6"):
                     raise RuntimeError(
-                        "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
+                        "NNCF models produced by nncf<2.6 are not supported directly. Please upgrade nncf or export to ONNX first.")
     except:
         pass
     inputs = prepare_torch_inputs(example_inputs)

--- a/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
@@ -19,7 +19,6 @@ def get_pytorch_decoder(model, input_shape, example_inputs, args):
         raise e
     try:
         if 'nncf' in sys.modules:
-            import nncf
             from nncf.torch.nncf_network import NNCFNetwork
             from packaging import version
 

--- a/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/pytorch_frontend_utils.py
@@ -2,15 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging as log
+import sys
 
 import numpy as np
 # pylint: disable=no-name-in-module,import-error
-from openvino.runtime import Tensor, Type, PartialShape
-from openvino.runtime.utils.types import get_element_type_str
+from openvino.runtime import Tensor, PartialShape
 
-from openvino.tools.mo.utils.cli_parser import input_to_input_cut_info, input_shape_to_input_cut_info
 from openvino.tools.mo.utils.error import Error
-from openvino.tools.mo.moc_frontend.shape_utils import get_static_shape
 
 
 def get_pytorch_decoder(model, input_shape, example_inputs, args):

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
@@ -19,11 +19,11 @@ def get_pytorch_decoder(model, example_inputs, args):
         raise e
     try:
         if 'nncf' in sys.modules:
-            from nncf.torch.nncf_network import NNCFNetwork
+            from nncf.torch.nncf_network import NNCFNetwork # pylint: disable=undefined-variable
             from packaging import version
 
             if isinstance(model, NNCFNetwork):
-                if version.parse(nncf.__version__) <= version.parse("2.6"):
+                if version.parse(nncf.__version__) <= version.parse("2.6"): # pylint: disable=undefined-variable
                     raise RuntimeError(
                         "NNCF models produced by nncf<2.6 are not supported directly. Please upgrade nncf or export to ONNX first.")
     except:

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
@@ -2,15 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging as log
+import sys
 
 import numpy as np
 # pylint: disable=no-name-in-module,import-error
-from openvino.runtime import Tensor, Type, PartialShape
-from openvino.runtime.utils.types import get_element_type_str
+from openvino.runtime import Tensor, PartialShape
 
-from openvino.tools.ovc.cli_parser import input_to_input_cut_info
 from openvino.tools.ovc.error import Error
-from openvino.tools.ovc.moc_frontend.shape_utils import get_static_shape
 
 
 def get_pytorch_decoder(model, example_inputs, args):
@@ -20,14 +18,15 @@ def get_pytorch_decoder(model, example_inputs, args):
         log.error("PyTorch frontend loading failed")
         raise e
     try:
-        import nncf
-        from nncf.torch.nncf_network import NNCFNetwork
-        from packaging import version
+        if 'nncf' in sys.modules:
+            import nncf
+            from nncf.torch.nncf_network import NNCFNetwork
+            from packaging import version
 
-        if isinstance(model, NNCFNetwork):
-            if version.parse(nncf.__version__) <= version.parse("2.6"):
-                raise RuntimeError(
-                    "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
+            if isinstance(model, NNCFNetwork):
+                if version.parse(nncf.__version__) <= version.parse("2.6"):
+                    raise RuntimeError(
+                        "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
     except:
         pass
     inputs = prepare_torch_inputs(example_inputs)

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
@@ -26,7 +26,7 @@ def get_pytorch_decoder(model, example_inputs, args):
             if isinstance(model, NNCFNetwork):
                 if version.parse(nncf.__version__) <= version.parse("2.6"):
                     raise RuntimeError(
-                        "NNCF models produced by nncf<2.6 are not supported directly. Please export to ONNX first.")
+                        "NNCF models produced by nncf<2.6 are not supported directly. Please upgrade nncf or export to ONNX first.")
     except:
         pass
     inputs = prepare_torch_inputs(example_inputs)

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pytorch_frontend_utils.py
@@ -19,7 +19,6 @@ def get_pytorch_decoder(model, example_inputs, args):
         raise e
     try:
         if 'nncf' in sys.modules:
-            import nncf
             from nncf.torch.nncf_network import NNCFNetwork
             from packaging import version
 


### PR DESCRIPTION
Root cause analysis: 
When nncf is imported it shows confusing logs from MO and OVC convert_model().

Solution: 
Check if nncf is in imported modules before importing.

Ticket: 117543


Code:
* [x]  Comments
* [x]  Code style (PEP8) - N/A
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A