### PR TITLE
[CPU] Disable gather inPlace for out of range indices

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -140,18 +140,37 @@ void Gather::initSupportedPrimitiveDescriptors() {
     // Let's check for the special inPlace memory use case
     // in place only makes sense when we split by dense blocks since strided tensors are not supported by most nodes
 
-    const auto& parentdDims = inputShapes[0].getDims();
-    if (isAxisInputConst &&
-        0 == batchDims &&
-        1 == constIndices.size() &&
-        parentdDims[axis] != Shape::UNDEFINED_DIM &&
-        std::all_of(parentdDims.begin(), parentdDims.begin() + axis, [](size_t dim) { return  dim == 1; })) {
-        addSupportedPrimDesc({{LayoutType::ncsp, dataPrecision},
-                        {LayoutType::ncsp, Precision::I32},
-                        {LayoutType::ncsp, Precision::I32, isAxisInputConst}},
-                        {{LayoutType::ncsp, dataPrecision, false, GATHER_DATA}},
-                        unknown);
+    if (!isAxisInputConst) {
+        return;
     }
+
+    if (batchDims != 0) {
+        return;
+    }
+
+    if (constIndices.size() != 1) {
+        return;
+    }
+
+    const auto& parentDims = inputShapes[0].getDims();
+    const auto axisDim = parentDims[axis];
+    if (Shape::UNDEFINED_DIM == axisDim) {
+        return;
+    }
+
+    if (constIndices.front() < 0 || constIndices.front() > static_cast<int64_t>(axisDim)) {
+        return;
+    }
+
+    if (std::any_of(parentDims.begin(), parentDims.begin() + axis, [](size_t dim) { return  dim != 1; })) {
+        return;
+    }
+
+    addSupportedPrimDesc({{LayoutType::ncsp, dataPrecision},
+                    {LayoutType::ncsp, Precision::I32},
+                    {LayoutType::ncsp, Precision::I32, isAxisInputConst}},
+                    {{LayoutType::ncsp, dataPrecision, false, GATHER_DATA}},
+                    unknown);
 }
 
 void Gather::createPrimitive() {
@@ -293,6 +312,9 @@ void Gather::prepareParams() {
 }
 
 void Gather::execute(dnnl::stream strm) {
+    if (isInPlace()) {
+        return;
+    }
 #if defined(OPENVINO_ARCH_X86_64)
     if (jitKernel && jitKernel->isSupportedConfiguration(afterAxisSize)) {
         const void* srcIndices = getParentEdgeAt(GATHER_INDICES)->getMemoryPtr()->getData();
@@ -349,6 +371,9 @@ void Gather::execute(dnnl::stream strm) {
 }
 
 void Gather::executeDynamicImpl(dnnl::stream strm) {
+    if (isInPlace()) {
+        return;
+    }
 #if defined(OPENVINO_ARCH_X86_64)
     if (jitKernel && jitKernel->isSupportedConfiguration(afterAxisSize)) {
         const void* srcIndices = getParentEdgeAt(GATHER_INDICES)->getMemoryPtr()->getData();
@@ -533,8 +558,7 @@ void Gather::resolveInPlaceEdges(Edge::LOOK look) {
     auto baseDim = inputShapes.front().getDims()[axis];
     IE_ASSERT(baseDim != Shape::UNDEFINED_DIM) << "Gather node: " << getName() << " can not use inPlace memory with splitting on dynamic dimention";
     auto baseMemMngr = getParentEdgesAtPort(inplaceInpIndx).front()->getMemory().getMemoryMngr();
-    auto index = constIndices.at(0);
-    ptrdiff_t offset = index < 0 ? baseDim + index : index;
+    ptrdiff_t offset = constIndices.at(0);
     const auto& childEdges = getChildEdgesAtPort(outputPort);
     for (auto& childEdge : childEdges) {
         IE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated) << " Unexpected edge status in node: " <<

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -158,7 +158,10 @@ void Gather::initSupportedPrimitiveDescriptors() {
         return;
     }
 
-    if (constIndices.front() < 0 || constIndices.front() > static_cast<int64_t>(axisDim)) {
+    const auto indx = constIndices.front();
+    const auto normIndex = indx < 0 ? static_cast<int64_t>(axisDim) + indx : indx;
+
+    if (normIndex < 0 || normIndex >= static_cast<int64_t>(axisDim)) {
         return;
     }
 
@@ -555,10 +558,11 @@ void Gather::resolveInPlaceEdges(Edge::LOOK look) {
 
     auto& config = selected_pd->getConfig();
     size_t inplaceInpIndx = selected_pd->getConfig().outConfs[outputPort].inPlace();
-    auto baseDim = inputShapes.front().getDims()[axis];
+    const auto baseDim = inputShapes.front().getDims()[axis];
     IE_ASSERT(baseDim != Shape::UNDEFINED_DIM) << "Gather node: " << getName() << " can not use inPlace memory with splitting on dynamic dimention";
     auto baseMemMngr = getParentEdgesAtPort(inplaceInpIndx).front()->getMemory().getMemoryMngr();
-    ptrdiff_t offset = constIndices.at(0);
+    const auto index = constIndices.front();
+    const ptrdiff_t offset = index < 0 ? baseDim + index : index;
     const auto& childEdges = getChildEdgesAtPort(outputPort);
     for (auto& childEdge : childEdges) {
         IE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated) << " Unexpected edge status in node: " <<

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -190,6 +190,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*(Auto|Multi|Hetero).*InferRequestPreprocessTest.*SetPreProcessToInferRequest.*)",
         // TODO: for 22.2 (Issue 68949)
         R"(.*smoke_AutoBatching_CPU/AutoBatching_Test_DetectionOutput.*)",
+        // Issue: 117837
+        R"(.*smoke_4D_out_of_range/GatherInPlaceLayerTestCPU.*_indices=\(\-15\).*)",
     };
 
 #if defined(OPENVINO_ARCH_X86)

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather.cpp
@@ -148,7 +148,7 @@ protected:
 
 typedef std::tuple<
         InputShape,                        // Input shapes
-        std::vector<size_t>,               // Indices
+        std::vector<int64_t>,              // Indices
         int,                               // Axis
         ElementType,                       // Network precision
         CPUSpecificParams                 // CPU specific params
@@ -159,7 +159,7 @@ class GatherInPlaceLayerTestCPU : public testing::WithParamInterface<GatherInPla
 public:
     static std::string getTestCaseName(testing::TestParamInfo<GatherInPlaceLayerTestCPUParams> obj) {
         InputShape inputShapes;
-        std::vector<size_t> indices;
+        std::vector<int64_t> indices;
         int axis;
         ElementType netPrecision;
         CPUSpecificParams cpuParams;
@@ -187,7 +187,7 @@ public:
 protected:
     void SetUp() override {
         InputShape inputShapes;
-        std::vector<size_t> indices;
+        std::vector<int64_t> indices;
         int axis;
         ElementType netPrecision;
         CPUSpecificParams cpuParams;
@@ -924,31 +924,40 @@ INSTANTIATE_TEST_SUITE_P(smoke_static_4D_ref8_Bmax, GatherLayerTestCPU,
 // InPlace
 
 const std::vector<ov::test::InputShape> shapesInPlace4D_0 = {
-    { {}, { {5, 4, 4, 19} } },   // Static shapes
-    { {5, 4, -1, -1}, { {5, 4, 4, 19}, {5, 4, 4, 25}, {5, 4, 2, 19} } },   // Static shapes
+    { {}, { {5, 4, 4, 19} } },
+    { {5, 4, -1, -1}, { {5, 4, 4, 19}, {5, 4, 4, 25}, {5, 4, 2, 19} } },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_inplace_4D_0, GatherInPlaceLayerTestCPU,
                 ::testing::Combine(
                     ::testing::ValuesIn(shapesInPlace4D_0),
-                    ::testing::Values(std::vector<size_t>{ 2 }),
+                    ::testing::Values(std::vector<int64_t>{ 2 }),
                     ::testing::Values(0),
                     ::testing::Values(ElementType::f32),
                     ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
                 GatherInPlaceLayerTestCPU::getTestCaseName);
 
 const std::vector<ov::test::InputShape> shapesInPlace4D_1 = {
-    { {}, { {1, 9, 4, 19} } },   // Static shapes
-    { {1, 9, -1, -1}, { {1, 9, 4, 19}, {1, 9, 4, 25}, {1, 9, 2, 19} } },   // Static shapes
+    { {}, { {1, 9, 4, 19} } },
+    { {1, 9, -1, -1}, { {1, 9, 4, 19}, {1, 9, 4, 25}, {1, 9, 2, 19} } },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_inplace_4D_1, GatherInPlaceLayerTestCPU,
                 ::testing::Combine(
                     ::testing::ValuesIn(shapesInPlace4D_1),
-                    ::testing::Values(std::vector<size_t>{ 4 }),
+                    ::testing::Values(std::vector<int64_t>{ -4 }, std::vector<int64_t>{ 5 }),
                     ::testing::Values(1),
                     ::testing::Values(ElementType::f32),
                     ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+                GatherInPlaceLayerTestCPU::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_4D_out_of_range, GatherInPlaceLayerTestCPU,
+                ::testing::Combine(
+                    ::testing::ValuesIn(shapesInPlace4D_1),
+                    ::testing::Values(std::vector<int64_t>{ 10 }), //std::vector<int64_t>{ -15 },
+                    ::testing::Values(1),
+                    ::testing::Values(ElementType::f32),
+                    ::testing::Values(cpuParamsRef)),
                 GatherInPlaceLayerTestCPU::getTestCaseName);
 
 } // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather.cpp
@@ -954,10 +954,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_inplace_4D_1, GatherInPlaceLayerTestCPU,
 INSTANTIATE_TEST_SUITE_P(smoke_4D_out_of_range, GatherInPlaceLayerTestCPU,
                 ::testing::Combine(
                     ::testing::ValuesIn(shapesInPlace4D_1),
-                    ::testing::Values(std::vector<int64_t>{ 10 }), //std::vector<int64_t>{ -15 },
+                    ::testing::Values(std::vector<int64_t>{ 10 }, std::vector<int64_t>{ -15 }),
                     ::testing::Values(1),
                     ::testing::Values(ElementType::f32),
-                    ::testing::Values(cpuParamsRef)),
+                    ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref_any"})),
                 GatherInPlaceLayerTestCPU::getTestCaseName);
 
 } // namespace


### PR DESCRIPTION
### Details:
Disable inplace memory usage for the case of indices out of the `[-data.shape[axis], data.shape[axis] - 1]` range. In that case the  output data for corresponding index shell be filled with zeros.

### Tickets:
 - 117378

### To Do
- [x] Properly disable failed test (create ticket)
- [x] Adjust the index range condition
