### PR TITLE
HOT FIX: fix manually setting Pcore+Ecore manually when model prefers Pcore only

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -151,7 +151,7 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
         ((input_streams_changed == true) && (input_streams == 1))) {
         n_streams = 1;
         if ((proc_type_table.size() == 1) && (model_prefer_threads > 0) &&
-            ((input_threads == 0) || (input_threads > model_prefer_threads))) {
+            ((input_threads == 0) || (input_threads == 0))) {
             stream_info[NUMBER_OF_STREAMS] = n_streams;
             if ((model_prefer_threads == proc_type_table[0][MAIN_CORE_PROC]) &&
                 (proc_type_table[0][MAIN_CORE_PROC] > 0)) {

--- a/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
@@ -1181,6 +1181,18 @@ StreamsCalculationTestCase _1sockets_14cores_tput_16 = {
     {{6, MAIN_CORE_PROC, 1, 0, 0}, {4, EFFICIENT_CORE_PROC, 2, 0, 0}, {1, HYPER_THREADING_PROC, 1, 0, 0}},
 };
 
+StreamsCalculationTestCase _1sockets_14cores_tput_17 = {
+    1,
+    true,
+    14,
+    0,
+    6,
+    "LATENCY",
+    ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
+    {{20, 6, 8, 6, 0, 0}},
+    {{1, ALL_PROC, 14, 0, 0}, {0, MAIN_CORE_PROC, 6, 0, 0}, {0, EFFICIENT_CORE_PROC, 8, 0, 0}},
+};
+
 StreamsCalculationTestCase _1sockets_10cores_latency_1 = {
     1,
     false,
@@ -1823,6 +1835,7 @@ INSTANTIATE_TEST_SUITE_P(StreamsInfoTable,
                                          _1sockets_14cores_tput_14,
                                          _1sockets_14cores_tput_15,
                                          _1sockets_14cores_tput_16,
+                                         _1sockets_14cores_tput_17,
                                          _1sockets_10cores_latency_1,
                                          _1sockets_10cores_latency_2,
                                          _1sockets_10cores_latency_3,


### PR DESCRIPTION
### Details:
 - *fix manually setting Pcore+Ecore manually when model prefers Pcore only*


### Tickets:
 - *ticket-id*
