### PR TITLE
Aligned target and files (libraries) names

### DIFF
--- a/cmake/developer_package/frontends/frontends.cmake
+++ b/cmake/developer_package/frontends/frontends.cmake
@@ -173,7 +173,7 @@ macro(ov_add_frontend)
 
     # Shutdown protobuf when unloading the frontend dynamic library
     if(proto_files AND BUILD_SHARED_LIBS)
-        target_link_libraries(${TARGET_NAME} PRIVATE ov_protobuf_shutdown)
+        target_link_libraries(${TARGET_NAME} PRIVATE openvino::protobuf_shutdown)
     endif()
 
     if(NOT BUILD_SHARED_LIBS)

--- a/cmake/templates/InferenceEngineDeveloperPackageConfig.cmake.in
+++ b/cmake/templates/InferenceEngineDeveloperPackageConfig.cmake.in
@@ -7,17 +7,31 @@
 include(CMakeFindDependencyMacro)
 
 # TODO: remove after changing [private plugins]
-set_and_check(OpenVINO_SOURCE_DIR "@OpenVINO_SOURCE_DIR@") # KMB
-set_and_check(OpenVINO_MAIN_SOURCE_DIR "@OpenVINO_SOURCE_DIR@") # KMB
+set_and_check(OpenVINO_SOURCE_DIR "@OpenVINO_SOURCE_DIR@") # NPU
+set_and_check(OpenVINO_MAIN_SOURCE_DIR "@OpenVINO_SOURCE_DIR@") # NPU
 
 # Variables to export in plugin's projects
 
 set(ie_options "@IE_OPTIONS@")
 list(APPEND ie_options CMAKE_CXX_COMPILER_LAUNCHER CMAKE_C_COMPILER_LAUNCHER
                        CMAKE_CXX_LINKER_LAUNCHER CMAKE_C_LINKER_LAUNCHER
-                       CMAKE_BUILD_TYPE CMAKE_SKIP_RPATH CMAKE_INSTALL_PREFIX
-                       CMAKE_OSX_ARCHITECTURES CMAKE_OSX_DEPLOYMENT_TARGET
-                       CMAKE_CONFIGURATION_TYPES CMAKE_DEFAULT_BUILD_TYPE)
+                       CMAKE_SKIP_RPATH CMAKE_INSTALL_PREFIX CPACK_GENERATOR)
+
+if(APPLE)
+    list(APPEND ie_options CMAKE_OSX_ARCHITECTURES CMAKE_OSX_DEPLOYMENT_TARGET)
+endif()
+
+get_property(_IE_GENERATOR_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_IE_GENERATOR_MULTI_CONFIG)
+    list(APPEND ie_options CMAKE_CONFIGURATION_TYPES)
+    if(CMAKE_GENERATOR MATCHES "^Ninja Multi-Config$")
+        list(APPEND ie_options CMAKE_DEFAULT_BUILD_TYPE)
+    endif()
+else()
+    list(APPEND ie_options CMAKE_BUILD_TYPE)
+endif()
+unset(_IE_GENERATOR_MULTI_CONFIG)
+
 file(TO_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}" cache_path)
 
 message(STATUS "The following CMake options are exported from Inference Engine Developer package")
@@ -88,6 +102,12 @@ if(TARGET IE::runtime::dev AND NOT TARGET openvino::runtime::dev)
     add_library(openvino::runtime::dev INTERFACE IMPORTED)
     set_target_properties(openvino::runtime::dev PROPERTIES
         INTERFACE_LINK_LIBRARIES IE::runtime::dev)
+endif()
+
+if(TARGET IE::reference AND NOT TARGET IE::ngraph_reference)
+    add_library(IE::ngraph_reference INTERFACE IMPORTED)
+    set_target_properties(IE::ngraph_reference PROPERTIES
+        INTERFACE_LINK_LIBRARIES IE::reference)
 endif()
 
 if(ENABLE_SYSTEM_PUGIXML)

--- a/cmake/templates/OpenVINODeveloperPackageConfig.cmake.in
+++ b/cmake/templates/OpenVINODeveloperPackageConfig.cmake.in
@@ -13,9 +13,23 @@ set_and_check(OpenVINO_SOURCE_DIR "@OpenVINO_SOURCE_DIR@")
 set(ov_options "@IE_OPTIONS@")
 list(APPEND ov_options CMAKE_CXX_COMPILER_LAUNCHER CMAKE_C_COMPILER_LAUNCHER
                        CMAKE_CXX_LINKER_LAUNCHER CMAKE_C_LINKER_LAUNCHER
-                       CMAKE_BUILD_TYPE CMAKE_SKIP_RPATH CMAKE_INSTALL_PREFIX
-                       CMAKE_OSX_ARCHITECTURES CMAKE_OSX_DEPLOYMENT_TARGET
-                       CPACK_GENERATOR)
+                       CMAKE_SKIP_RPATH CMAKE_INSTALL_PREFIX CPACK_GENERATOR)
+
+if(APPLE)
+    list(APPEND ov_options CMAKE_OSX_ARCHITECTURES CMAKE_OSX_DEPLOYMENT_TARGET)
+endif()
+
+get_property(_OV_GENERATOR_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_IE_GENERATOR_MULTI_CONFIG)
+    list(APPEND ov_options CMAKE_CONFIGURATION_TYPES)
+    if(CMAKE_GENERATOR MATCHES "^Ninja Multi-Config$")
+        list(APPEND ov_options CMAKE_DEFAULT_BUILD_TYPE)
+    endif()
+else()
+    list(APPEND ov_options CMAKE_BUILD_TYPE)
+endif()
+unset(_OV_GENERATOR_MULTI_CONFIG)
+
 file(TO_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}" cache_path)
 
 message(STATUS "The following CMake options are exported from OpenVINO Developer package")

--- a/src/cmake/openvino.cmake
+++ b/src/cmake/openvino.cmake
@@ -39,9 +39,9 @@ target_include_directories(${TARGET_NAME} PUBLIC
     $<BUILD_INTERFACE:${OpenVINO_SOURCE_DIR}/src/inference/include>
     $<BUILD_INTERFACE:${OpenVINO_SOURCE_DIR}/src/inference/include/ie>)
 
-target_link_libraries(${TARGET_NAME} PRIVATE ngraph_reference
-                                             ngraph_builders
-                                             ov_shape_inference
+target_link_libraries(${TARGET_NAME} PRIVATE openvino::reference
+                                             openvino::builders
+                                             openvino::shape_inference
                                              openvino::pugixml
                                              ${CMAKE_DL_LIBS}
                                              Threads::Threads)

--- a/src/common/itt/CMakeLists.txt
+++ b/src/common/itt/CMakeLists.txt
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TARGET_NAME itt)
+set(TARGET_NAME openvino_itt)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp" "src/*.hpp")
 
 add_library(${TARGET_NAME} STATIC ${SOURCES})
+
 add_library(openvino::itt ALIAS ${TARGET_NAME})
+set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME itt)
 
 target_link_libraries(${TARGET_NAME} PUBLIC openvino::util)
 

--- a/src/common/offline_transformations/CMakeLists.txt
+++ b/src/common/offline_transformations/CMakeLists.txt
@@ -19,7 +19,7 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
-target_link_libraries(${TARGET_NAME} PRIVATE openvino::runtime::dev openvino::itt openvino::pugixml ngraph::reference
+target_link_libraries(${TARGET_NAME} PRIVATE openvino::runtime::dev openvino::itt openvino::pugixml openvino::reference
                                              openvino::runtime)
 
 set_source_files_properties(INCLUDE_DIRECTORIES

--- a/src/common/snippets/CMakeLists.txt
+++ b/src/common/snippets/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set (TARGET_NAME "inference_engine_snippets")
+set (TARGET_NAME "openvino_snippets")
 
 set(PUBLIC_HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
@@ -21,12 +21,15 @@ add_library(${TARGET_NAME} STATIC
             ${LIBRARY_SRC}
             ${PUBLIC_HEADERS})
 
+add_library(openvino::snippets ALIAS ${TARGET_NAME})
+set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME snippets)
+
 ie_faster_build(${TARGET_NAME}
     UNITY
 )
 
 target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime
-                                     PRIVATE ngraph_reference openvino::runtime::dev)
+                                     PRIVATE openvino::reference openvino::runtime::dev)
 
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${PUBLIC_HEADERS_DIR}>
                                           PRIVATE $<BUILD_INTERFACE:${SHAPE_INFER_INCLUDE_DIR}>)

--- a/src/common/snippets/tests/CMakeLists.txt
+++ b/src/common/snippets/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ addIeTargetTest(
         ROOT ${CMAKE_CURRENT_SOURCE_DIR}
         INCLUDES
             ${CMAKE_CURRENT_SOURCE_DIR}/include
-            $<TARGET_PROPERTY:inference_engine_snippets,INTERFACE_INCLUDE_DIRECTORIES>
+            $<TARGET_PROPERTY:openvino::snippets,INTERFACE_INCLUDE_DIRECTORIES>
         LINK_LIBRARIES
             openvino::runtime::dev
             common_test_utils

--- a/src/common/transformations/CMakeLists.txt
+++ b/src/common/transformations/CMakeLists.txt
@@ -25,7 +25,7 @@ ie_faster_build(${TARGET_NAME}_obj
     PCH PRIVATE "src/precomp.hpp"
 )
 
-target_link_libraries(${TARGET_NAME}_obj PRIVATE ngraph_reference openvino::itt ngraph::builder openvino::core::dev ov_shape_inference)
+target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::reference openvino::itt openvino::builders openvino::core::dev openvino::shape_inference)
 
 target_include_directories(${TARGET_NAME}_obj PRIVATE $<BUILD_INTERFACE:${PUBLIC_HEADERS_DIR}>
                                                      "${CMAKE_CURRENT_SOURCE_DIR}/src")

--- a/src/common/util/CMakeLists.txt
+++ b/src/common/util/CMakeLists.txt
@@ -35,6 +35,7 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
 add_library(openvino::util ALIAS ${TARGET_NAME})
+set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME util)
 
 target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS})
 if (WIN32)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -86,8 +86,8 @@ ie_faster_build(ngraph_obj
 
 ov_add_version_defines(src/version.cpp ngraph_obj)
 
-target_link_libraries(ngraph_obj PRIVATE ngraph::builder ngraph::reference openvino::util
-                                         openvino::pugixml ov_shape_inference openvino::core::dev)
+target_link_libraries(ngraph_obj PRIVATE openvino::builders openvino::reference openvino::util
+                                         openvino::pugixml openvino::shape_inference openvino::core::dev)
 
 ie_mark_target_as_cc(ngraph_obj)
 
@@ -104,12 +104,12 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    # ngraph is linked against ngraph_builders, ngraph_reference, ov_shape_inference static libraries
+    # ngraph is linked against openvino::builders, openvino::reference, openvino::shape_inference static libraries
     # which include ngraph headers with dllimport attribute. Linker complains about it
     # but no way to fix this: linking with no attribute defaults to dllexport and we have
     # multiple defitions for ngraph symbols.
     #
-    # The possible way is to use object libraries for ngraph_builders, ngraph_reference
+    # The possible way is to use object libraries for openvino::builders, openvino::reference
     # but it's not convinient since these libraries are exported from build tree
     # and it's better to use them as static libraries in 3rd party projects
     if(BUILD_SHARED_LIBS)

--- a/src/core/builder/CMakeLists.txt
+++ b/src/core/builder/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TARGET_NAME "ngraph_builders")
+set(TARGET_NAME "openvino_builders")
 
 file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
@@ -18,6 +18,9 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 # Create static library
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+add_library(openvino::builders ALIAS ${TARGET_NAME})
+set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME builders)
+
 ie_faster_build(${TARGET_NAME}
     UNITY
     PCH PRIVATE "src/precomp.hpp")
@@ -32,11 +35,8 @@ endif()
 
 add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
 
-# Add an alias so that library can be used inside the build tree, e.g. when testing
-add_library(ngraph::builder ALIAS ${TARGET_NAME})
-
-ov_install_static_lib(ngraph_builders ${OV_CPACK_COMP_CORE})
+ov_install_static_lib(openvino_builders ${OV_CPACK_COMP_CORE})
 
 # developer package
 
-openvino_developer_export_targets(COMPONENT core TARGETS ngraph::builder)
+openvino_developer_export_targets(COMPONENT core TARGETS openvino::builders)

--- a/src/core/reference/CMakeLists.txt
+++ b/src/core/reference/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TARGET_NAME "ngraph_reference")
+set(TARGET_NAME "openvino_reference")
 
 file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
@@ -17,6 +17,9 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 
 # Create static library
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
+
+add_library(openvino::reference ALIAS ${TARGET_NAME})
+set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME reference)
 
 ie_faster_build(${TARGET_NAME}
     UNITY
@@ -42,10 +45,7 @@ target_link_libraries(${TARGET_NAME} PRIVATE Threads::Threads)
 
 add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
 
-# Add an alias so that library can be used inside the build tree, e.g. when testing
-add_library(ngraph::reference ALIAS ${TARGET_NAME})
-
 ov_install_static_lib(${TARGET_NAME} ${OV_CPACK_COMP_CORE})
 
 # developer package
-openvino_developer_export_targets(COMPONENT core TARGETS ngraph::reference)
+openvino_developer_export_targets(COMPONENT core TARGETS openvino::reference)

--- a/src/core/shape_inference/CMakeLists.txt
+++ b/src/core/shape_inference/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TARGET_NAME "ov_shape_inference")
+set(TARGET_NAME "openvino_shape_inference")
 
 file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
@@ -17,6 +17,9 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 
 # Create static library
 add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
+
+add_library(openvino::shape_inference ALIAS ${TARGET_NAME})
+set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME shape_inference)
 
 target_include_directories(${TARGET_NAME} PUBLIC
     $<BUILD_INTERFACE:${SHAPE_INFER_INCLUDE_DIR}>

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -39,10 +39,10 @@ ov_add_test_target(
             test_model_zoo
         LINK_LIBRARIES
             common_test_utils
-            ngraph_reference
-            ngraph::builder
+            openvino::reference
+            openvino::builders
             openvino::util
-            ov_shape_inference
+            openvino::shape_inference
             ${CMAKE_DL_LIBS}
             Threads::Threads
             openvino::conditional_compilation

--- a/src/frontends/common/shutdown_protobuf/CMakeLists.txt
+++ b/src/frontends/common/shutdown_protobuf/CMakeLists.txt
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TARGET_NAME ov_protobuf_shutdown)
+set(TARGET_NAME openvino_protobuf_shutdown)
 
 add_library(${TARGET_NAME} STATIC shutdown_protobuf.cpp)
+
+add_library(openvino::protobuf_shutdown ALIAS ${TARGET_NAME})
+set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME protobuf_shutdown)
 
 target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
     $<BUILD_INTERFACE:$<TARGET_PROPERTY:protobuf::libprotobuf,INTERFACE_INCLUDE_DIRECTORIES>>)

--- a/src/frontends/onnx/frontend/CMakeLists.txt
+++ b/src/frontends/onnx/frontend/CMakeLists.txt
@@ -7,7 +7,7 @@ ov_add_frontend(NAME onnx
                 PROTOBUF_LITE
                 SKIP_NCC_STYLE
                 FILEDESCRIPTION "FrontEnd to load and convert ONNX file format"
-                LINK_LIBRARIES ngraph::builder onnx_common openvino::core::dev)
+                LINK_LIBRARIES openvino::builders openvino_onnx_common openvino::core::dev)
 
 set(ONNX_OPSET_VERSION 18 CACHE INTERNAL "Supported version of ONNX operator set")
 target_compile_definitions(${TARGET_NAME} PRIVATE ONNX_OPSET_VERSION=${ONNX_OPSET_VERSION})

--- a/src/frontends/onnx/onnx_common/CMakeLists.txt
+++ b/src/frontends/onnx/onnx_common/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TARGET_NAME "onnx_common")
+set(TARGET_NAME "openvino_onnx_common")
 
 file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)

--- a/src/frontends/onnx/tests/CMakeLists.txt
+++ b/src/frontends/onnx/tests/CMakeLists.txt
@@ -138,7 +138,7 @@ if(ONNX_TESTS_DEPENDENCIES)
 endif()
 
 target_link_libraries(ov_onnx_frontend_tests PRIVATE gtest_main_manifest openvino::runtime::dev
-    openvino_onnx_frontend onnx_common func_test_utils)
+    openvino_onnx_frontend openvino_onnx_common func_test_utils)
 
 # It's needed by onnx_import_library.cpp and onnx_import_exceptions.cpp tests to include onnx_pb.h.
 # Not linking statically to libprotobuf (linked into libonnx) avoids false-failing onnx_editor tests.

--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -116,8 +116,8 @@ endif()
 ie_mark_target_as_cc(${TARGET_NAME})
 
 target_link_libraries(${TARGET_NAME} PRIVATE dnnl
-                                             ov_shape_inference
-                                             inference_engine_snippets)
+                                             openvino::shape_inference
+                                             openvino::snippets)
 
 target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_INFERENCE_EXTENSION_API)
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -161,8 +161,8 @@ if(BUILD_SHARED_LIBS)
         PRIVATE
             $<TARGET_PROPERTY:openvino::runtime::dev,INTERFACE_INCLUDE_DIRECTORIES>
             $<TARGET_PROPERTY:openvino::itt,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:ov_shape_inference,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:inference_engine_snippets,INTERFACE_INCLUDE_DIRECTORIES>
+            $<TARGET_PROPERTY:openvino::shape_inference,INTERFACE_INCLUDE_DIRECTORIES>
+            $<TARGET_PROPERTY:openvino::snippets,INTERFACE_INCLUDE_DIRECTORIES>
         PUBLIC
             ${CMAKE_CURRENT_SOURCE_DIR}/src
             $<TARGET_PROPERTY:openvino::conditional_compilation,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(cpuSpecificRtInfo PRIVATE openvino::runtime)
 
 set(INCLUDES ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/src)
 set(DEPENDENCIES openvino_intel_cpu_plugin template_extension)
-set(LINK_LIBRARIES funcSharedTests cpuSpecificRtInfo inference_engine_snippets snippetsNgraphFunctions)
+set(LINK_LIBRARIES funcSharedTests cpuSpecificRtInfo openvino::snippets snippetsNgraphFunctions)
 
 if(ENABLE_OV_ONNX_FRONTEND)
     list(APPEND DEFINES TEST_MODELS="${TEST_MODEL_ZOO}")

--- a/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
@@ -42,7 +42,7 @@ addIeTargetTest(
                 $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/thirdparty/onednn/src
                 $<TARGET_PROPERTY:openvino::conditional_compilation,INTERFACE_INCLUDE_DIRECTORIES>
             PRIVATE
-                $<TARGET_PROPERTY:inference_engine_snippets,SOURCE_DIR>/include
+                $<TARGET_PROPERTY:openvino::snippets,SOURCE_DIR>/include
         EXCLUDED_SOURCE_PATHS
             ${EXCLUDED_SOURCE_PATHS_FOR_UNIT_TEST}
         OBJECT_FILES
@@ -54,7 +54,7 @@ addIeTargetTest(
             dnnl
             inference_engine_transformations
             inference_engine_lp_transformations
-            ov_shape_inference
+            openvino::shape_inference
             inference_engine_s
             unit_test_utils
             ngraphFunctions

--- a/src/plugins/intel_gpu/src/graph/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
@@ -33,7 +33,7 @@ target_include_directories(${TARGET_NAME} PUBLIC
 target_compile_options(${TARGET_NAME} PRIVATE
   $<$<CONFIG:Release>:$<IF:$<CXX_COMPILER_ID:MSVC>,/Os,-Os>>)
 
-target_link_libraries(${TARGET_NAME} PUBLIC OpenCL::OpenCL ov_shape_inference)
+target_link_libraries(${TARGET_NAME} PUBLIC OpenCL::OpenCL openvino::shape_inference)
 target_link_libraries(${TARGET_NAME} PRIVATE openvino_intel_gpu_kernels
                                              openvino_intel_gpu_runtime
                                              openvino::itt

--- a/src/plugins/intel_gpu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_gpu/tests/unit/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(${TARGET_NAME} PRIVATE openvino_intel_gpu_graph
                                              gtest
                                              gtest_main
                                              gflags
-                                             ngraph_reference
+                                             openvino::reference
                                              inference_engine_transformations
                                              gmock)
 

--- a/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
@@ -104,7 +104,7 @@ if(ENABLE_ONEDNN_FOR_GPU)
                 "-DDNNL_TARGET_ARCH=${ONEDNN_TARGET_ARCH}"
                 "-DDNNL_CPU_RUNTIME=NONE"
                 "-DDNNL_GPU_RUNTIME=OCL"
-                "-DDNNL_LIBRARY_NAME=onednn_gpu"
+                "-DDNNL_LIBRARY_NAME=openvino_onednn_gpu"
                 "-DCMAKE_INSTALL_PREFIX=${ONEDNN_INSTALL_DIR}"
                 "-DCMAKE_INSTALL_LIBDIR=lib/$<CONFIG>"
                 "-DDNNL_ENABLE_CONCURRENT_EXEC=ON"
@@ -127,7 +127,7 @@ if(ENABLE_ONEDNN_FOR_GPU)
         add_library(onednn_gpu_tgt INTERFACE)
         set_target_properties(onednn_gpu_tgt PROPERTIES
             INTERFACE_LINK_DIRECTORIES "${ONEDNN_INSTALL_DIR}/lib/$<CONFIG>"
-            INTERFACE_LINK_LIBRARIES "onednn_gpu"
+            INTERFACE_LINK_LIBRARIES "openvino_onednn_gpu"
             INTERFACE_INCLUDE_DIRECTORIES "${ONEDNN_INSTALL_DIR}/include"
             INTERFACE_COMPILE_DEFINITIONS ENABLE_ONEDNN_FOR_GPU
         )

--- a/src/plugins/proxy/CMakeLists.txt
+++ b/src/plugins/proxy/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Copyright (C) 2018-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
+
 if (NOT ENABLE_PROXY)
     return()
 endif()
-
 
 set(TARGET_NAME "openvino_proxy_plugin_obj")
 

--- a/src/plugins/template/backend/CMakeLists.txt
+++ b/src/plugins/template/backend/CMakeLists.txt
@@ -39,7 +39,7 @@ target_compile_definitions(interpreter_backend
         SHARED_LIB_PREFIX="${CMAKE_SHARED_LIBRARY_PREFIX}"
         SHARED_LIB_SUFFIX="${IE_BUILD_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}"
 )
-target_link_libraries(interpreter_backend PRIVATE ngraph::builder ngraph::reference openvino::util openvino::runtime::dev ov_shape_inference)
+target_link_libraries(interpreter_backend PRIVATE openvino::builders openvino::reference openvino::util openvino::runtime::dev openvino::shape_inference)
 
 target_include_directories(interpreter_backend PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ops/>)
 

--- a/src/plugins/template/src/CMakeLists.txt
+++ b/src/plugins/template/src/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(${TARGET_NAME} PRIVATE
 # link common Inference Engine libraries
 target_link_libraries(${TARGET_NAME} PRIVATE
     openvino::interpreter_backend
-    openvino::ngraph_reference)
+    openvino::reference)
 
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 

--- a/src/tests/functional/plugin/shared/CMakeLists.txt
+++ b/src/tests/functional/plugin/shared/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
     set(EXCLUDED_SOURCE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src/onnx)
 endif()
 
-if (TARGET inference_engine_snippets)
+if (TARGET openvino::snippets)
     list(APPEND LINK_LIBRARIES_PRIVATE snippetsNgraphFunctions)
 else()
     list(APPEND EXCLUDED_SOURCE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src/snippets)

--- a/src/tests/ngraph_helpers/CMakeLists.txt
+++ b/src/tests/ngraph_helpers/CMakeLists.txt
@@ -5,6 +5,6 @@
 add_subdirectory(ngraph_functions)
 add_subdirectory(lpt_ngraph_functions)
 
-if(TARGET inference_engine_snippets)
+if(TARGET openvino::snippets)
     add_subdirectory(snippets_ngraph_functions)
 endif()

--- a/src/tests/ngraph_helpers/ngraph_functions/CMakeLists.txt
+++ b/src/tests/ngraph_helpers/ngraph_functions/CMakeLists.txt
@@ -18,7 +18,7 @@ addIeTarget(
         LINK_LIBRARIES
             PUBLIC
                 openvino::runtime
-                ngraph_reference
+                openvino::reference
                 interpreter_backend
                 openvino::runtime::dev
         ADD_CPPLINT

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/CMakeLists.txt
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/CMakeLists.txt
@@ -5,7 +5,7 @@
 set(TARGET_NAME snippetsNgraphFunctions)
 
 set(PUBLIC_HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
-set(SNIPPETS_INCLUDES "$<TARGET_PROPERTY:inference_engine_snippets,SOURCE_DIR>/include")
+set(SNIPPETS_INCLUDES "$<TARGET_PROPERTY:openvino::snippets,SOURCE_DIR>/include")
 set(COMMON_TEST_UTILS_INCLUDES "$<TARGET_PROPERTY:common_test_utils,INTERFACE_INCLUDE_DIRECTORIES>")
 addIeTarget(
         NAME ${TARGET_NAME}
@@ -24,7 +24,7 @@ addIeTarget(
             PUBLIC
                 openvino::runtime::dev
                 common_test_utils
-                inference_engine_snippets
+                openvino::snippets
                 lptNgraphFunctions
         ADD_CPPLINT
         DEVELOPER_PACKAGE

--- a/src/tests/test_utils/common_test_utils/CMakeLists.txt
+++ b/src/tests/test_utils/common_test_utils/CMakeLists.txt
@@ -35,7 +35,7 @@ function(add_common_utils ADD_TARGET_NAME)
                     openvino::runtime::dev
                 PRIVATE
                     openvino::util
-                    ov_shape_inference
+                    openvino::shape_inference
                 INCLUDES
                     PUBLIC
                         "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/tools/mo/unit_tests/mock_mo_frontend/mock_mo_frontend/CMakeLists.txt
+++ b/tools/mo/unit_tests/mock_mo_frontend/mock_mo_frontend/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(${TARGET_FE_NAME} SHARED ${LIBRARY_SRC} ${LIBRARY_HEADERS})
 
 target_include_directories(${TARGET_FE_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(${TARGET_FE_NAME} PUBLIC openvino::runtime PRIVATE ngraph::builder)
+target_link_libraries(${TARGET_FE_NAME} PUBLIC openvino::runtime PRIVATE openvino::builders)
 
 add_clang_format_target(${TARGET_FE_NAME}_clang FOR_TARGETS ${TARGET_FE_NAME})
 


### PR DESCRIPTION
### Details:
 - Currently, OpenVINO static libs are named on files system as "ngraph_reference", "itt", "openvino_util", "ngraph_builders", "ov_shape_inference", which is not aligned. And generic target names like "itt" might conflict with other libraries in other products, so it's better to have unique names.
 - It's useful to have alignment when users use our static build and manual libraries linking (e.g. Conan scenario)
