### PR TITLE
Fixed build without protobuf-lite

### DIFF
--- a/cmake/developer_package/frontends/frontends.cmake
+++ b/cmake/developer_package/frontends/frontends.cmake
@@ -201,6 +201,10 @@ macro(ov_add_frontend)
     if(FORCE_FRONTENDS_USE_PROTOBUF)
         set(OV_FRONTEND_PROTOBUF_LITE OFF)
     endif()
+    # if protobuf::libprotobuf-lite is not available, use protobuf::libprotobuf
+    if(NOT TARGET protobuf::libprotobuf-lite)
+        set(OV_FRONTEND_PROTOBUF_LITE OFF)
+    endif()
 
     if(proto_files)
         if(OV_FRONTEND_PROTOBUF_LITE)

--- a/thirdparty/dependencies.cmake
+++ b/thirdparty/dependencies.cmake
@@ -435,7 +435,7 @@ if(ENABLE_OV_PADDLE_FRONTEND OR ENABLE_OV_ONNX_FRONTEND OR ENABLE_OV_TF_FRONTEND
     set(Protobuf_IN_FRONTEND ON)
 
     # set public / interface compile options
-    foreach(target_name protobuf::libprotobuf protobuf::libprotobuf-lite)
+    function(_ov_fix_protobuf_warnings target_name)
         set(link_type PUBLIC)
         if(ENABLE_SYSTEM_PROTOBUF)
             set(link_type INTERFACE)
@@ -448,7 +448,12 @@ if(ENABLE_OV_PADDLE_FRONTEND OR ENABLE_OV_ONNX_FRONTEND OR ENABLE_OV_TF_FRONTEND
             endif()
             target_compile_options(${target_name} ${link_type} -Wno-undef)
         endif()
-    endforeach()
+    endfunction()
+
+    _ov_fix_protobuf_warnings(protobuf::libprotobuf)
+    if(TARGET protobuf::libprotobuf-lite)
+        _ov_fix_protobuf_warnings(protobuf::libprotobuf-lite)
+    endif()
 endif()
 
 #


### PR DESCRIPTION
### Details:
 - Our cmake should expect that protobuf-lite can be unavailable 