### PR TITLE
Removed 'wheel' upper bound in requirements.txt

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -11,7 +11,7 @@ pytest-timeout==2.1.0
 py>=1.9.0
 pygments>=2.8.1
 setuptools>=53.0.0
-wheel>=0.38.1,<=0.41.0
+wheel>=0.38.1
 
 # Frontends
 docopt~=0.6.2

--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,3 @@
 setuptools>=65.6.1
-wheel>=0.38.1,<=0.41.0
+wheel>=0.38.1
 patchelf<=0.17.2.1; sys_platform == 'linux' and platform_machine == 'x86_64'

--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -615,6 +615,10 @@ def concat_files(input_files, output_file):
 
 OPENVINO_VERSION = WHEEL_VERSION = os.getenv("WHEEL_VERSION", "0.0.0")
 PACKAGE_DIR = get_package_dir(PY_INSTALL_CFG)
+# need to create package dir, because since https://github.com/pypa/wheel/commit/e43f2fcb296c2ac63e8bac2549ab596ab79accd0
+# egg_info command works in this folder, because it's being created automatically
+os.makedirs(PACKAGE_DIR, exist_ok=True)
+
 packages = find_namespace_packages(PACKAGE_DIR)
 package_data: typing.Dict[str, list] = {}
 ext_modules = find_prebuilt_extensions(get_install_dirs_list(PY_INSTALL_CFG))

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -7,7 +7,7 @@ pandas>=1.3.5
 pymongo>=3.12.0
 PyYAML>=5.4.1
 scipy>=1.7
-wheel>=0.38.1,<=0.41.0
+wheel>=0.38.1
 defusedxml>=0.7.1
 fastjsonschema~=2.17.1
 test-generator==0.1.2


### PR DESCRIPTION
### Details:
 - Since `wheel` 0.41.1 we have to create package dir, because since https://github.com/pypa/wheel/commit/e43f2fcb296c2ac63e8bac2549ab596ab79accd0 `egg_info` command works in this folder, because it's being created automatically

### Validation:
- Let's also wait conda-forge build to complete to make sure the issue is fixed there https://github.com/conda-forge/openvino-feedstock/pull/34

### Tickets:
- CVS-117193