### PR TITLE
Fixed 'output_model' logic in OVC.

### DIFF
--- a/tests/layer_tests/common/utils/tf_utils.py
+++ b/tests/layer_tests/common/utils/tf_utils.py
@@ -174,8 +174,8 @@ def transpose_nhwc_to_nchw(data, use_new_frontend, use_old_api):
         return data
 
 
-def save_to_pb(tf_model, path_to_saved_tf_model):
-    tf.io.write_graph(tf_model, path_to_saved_tf_model, 'model.pb', False)
-    assert os.path.isfile(os.path.join(path_to_saved_tf_model, 'model.pb')), "model.pb haven't been saved " \
+def save_to_pb(tf_model, path_to_saved_tf_model, model_name = 'model.pb'):
+    tf.io.write_graph(tf_model, path_to_saved_tf_model, model_name, False)
+    assert os.path.isfile(os.path.join(path_to_saved_tf_model, model_name)), "model.pb haven't been saved " \
                                                                              "here: {}".format(path_to_saved_tf_model)
-    return os.path.join(path_to_saved_tf_model, 'model.pb')
+    return os.path.join(path_to_saved_tf_model, model_name)

--- a/tests/layer_tests/ovc_python_api_tests/test_ovc_cli_tool.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_ovc_cli_tool.py
@@ -72,7 +72,7 @@ class TestOVCTool(CommonMOConvertTest):
             tf_net = sess.graph_def
 
         # save model to .pb and return path to the model
-        return save_to_pb(tf_net, tmp_dir)
+        return save_to_pb(tf_net, tmp_dir, 'model2.pb')
 
     def create_tf_saved_model_dir(self, temp_dir):
         import tensorflow as tf
@@ -85,7 +85,7 @@ class TestOVCTool(CommonMOConvertTest):
         y = tf.nn.sigmoid(tf.nn.relu(x1 + x2))
         keras_net = tf.keras.Model(inputs=[x1, x2], outputs=[y])
 
-        tf.saved_model.save(keras_net, temp_dir + "/model")
+        tf.saved_model.save(keras_net, temp_dir + "/test_model")
 
         shape = PartialShape([-1, 1, 2, 3])
         param1 = ov.opset8.parameter(shape, name="Input1:0", dtype=np.float32)
@@ -97,7 +97,7 @@ class TestOVCTool(CommonMOConvertTest):
         parameter_list = [param1, param2]
         model_ref = Model([sigm], parameter_list, "test")
 
-        return temp_dir + "/model", model_ref
+        return temp_dir + "/test_model", model_ref
 
 
     def test_ovc_tool(self, ie_device, precision, ir_version, temp_dir, use_new_frontend, use_old_api):
@@ -108,10 +108,10 @@ class TestOVCTool(CommonMOConvertTest):
         core = Core()
 
         # tests for MO cli tool
-        exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_path, "output_model": temp_dir + os.sep + "model"})
+        exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_path, "output_model": temp_dir + os.sep + "model1"})
         assert not exit_code
 
-        ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
+        ov_model = core.read_model(os.path.join(temp_dir, "model1.xml"))
         flag, msg = compare_functions(ov_model, create_ref_graph(), False)
         assert flag, msg
 
@@ -126,7 +126,7 @@ class TestOVCTool(CommonMOConvertTest):
         exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_path, "output_model": temp_dir})
         assert not exit_code
 
-        ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
+        ov_model = core.read_model(os.path.join(temp_dir, "model2.xml"))
         flag, msg = compare_functions(ov_model, create_ref_graph(), False)
         assert flag, msg
 
@@ -139,7 +139,7 @@ class TestOVCTool(CommonMOConvertTest):
         exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir, "output_model": temp_dir})
         assert not exit_code
 
-        ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
+        ov_model = core.read_model(os.path.join(temp_dir, "test_model.xml"))
         flag, msg = compare_functions(ov_model, ref_model, False)
         assert flag, msg
 
@@ -152,6 +152,6 @@ class TestOVCTool(CommonMOConvertTest):
         exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir + os.sep, "output_model": temp_dir})
         assert not exit_code
 
-        ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
+        ov_model = core.read_model(os.path.join(temp_dir, "test_model.xml"))
         flag, msg = compare_functions(ov_model, ref_model, False)
         assert flag, msg

--- a/tests/layer_tests/ovc_python_api_tests/test_ovc_cli_tool.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_ovc_cli_tool.py
@@ -74,6 +74,31 @@ class TestOVCTool(CommonMOConvertTest):
         # save model to .pb and return path to the model
         return save_to_pb(tf_net, tmp_dir)
 
+    def create_tf_saved_model_dir(self, temp_dir):
+        import tensorflow as tf
+
+        input_names = ["Input1", "Input2"]
+        input_shape = [1, 2, 3]
+
+        x1 = tf.keras.Input(shape=input_shape, name=input_names[0])
+        x2 = tf.keras.Input(shape=input_shape, name=input_names[1])
+        y = tf.nn.sigmoid(tf.nn.relu(x1 + x2))
+        keras_net = tf.keras.Model(inputs=[x1, x2], outputs=[y])
+
+        tf.saved_model.save(keras_net, temp_dir + "/model")
+
+        shape = PartialShape([-1, 1, 2, 3])
+        param1 = ov.opset8.parameter(shape, name="Input1:0", dtype=np.float32)
+        param2 = ov.opset8.parameter(shape, name="Input2:0", dtype=np.float32)
+        add = ov.opset8.add(param1, param2)
+        relu = ov.opset8.relu(add)
+        sigm = ov.opset8.sigmoid(relu)
+
+        parameter_list = [param1, param2]
+        model_ref = Model([sigm], parameter_list, "test")
+
+        return temp_dir + "/model", model_ref
+
 
     def test_ovc_tool(self, ie_device, precision, ir_version, temp_dir, use_new_frontend, use_old_api):
         from openvino.runtime import Core
@@ -103,4 +128,47 @@ class TestOVCTool(CommonMOConvertTest):
 
         ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
         flag, msg = compare_functions(ov_model, create_ref_graph(), False)
+        assert flag, msg
+
+        # model_dir, ref_model = self.create_tf_saved_model_dir(temp_dir)
+        #
+        # exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir + os.sep, "output_model": temp_dir})
+        # assert not exit_code
+        #
+        # ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
+        # flag, msg = compare_functions(ov_model, ref_model, False)
+        # assert flag, msg
+        #
+        #
+        # exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir, "output_model": temp_dir})
+        # assert not exit_code
+        #
+        # ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
+        # flag, msg = compare_functions(ov_model, ref_model, False)
+        # assert flag, msg
+
+    def test_ovc_tool_saved_model_dir(self, ie_device, precision, ir_version, temp_dir, use_new_frontend, use_old_api):
+        from openvino.runtime import Core
+        core = Core()
+
+        model_dir, ref_model = self.create_tf_saved_model_dir(temp_dir)
+
+        exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir, "output_model": temp_dir})
+        assert not exit_code
+
+        ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
+        flag, msg = compare_functions(ov_model, ref_model, False)
+        assert flag, msg
+
+    def test_ovc_tool_saved_model_dir_with_sep_at_path_end(self, ie_device, precision, ir_version, temp_dir, use_new_frontend, use_old_api):
+        from openvino.runtime import Core
+        core = Core()
+
+        model_dir, ref_model = self.create_tf_saved_model_dir(temp_dir)
+
+        exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir + os.sep, "output_model": temp_dir})
+        assert not exit_code
+
+        ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
+        flag, msg = compare_functions(ov_model, ref_model, False)
         assert flag, msg

--- a/tests/layer_tests/ovc_python_api_tests/test_ovc_cli_tool.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_ovc_cli_tool.py
@@ -130,23 +130,6 @@ class TestOVCTool(CommonMOConvertTest):
         flag, msg = compare_functions(ov_model, create_ref_graph(), False)
         assert flag, msg
 
-        # model_dir, ref_model = self.create_tf_saved_model_dir(temp_dir)
-        #
-        # exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir + os.sep, "output_model": temp_dir})
-        # assert not exit_code
-        #
-        # ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
-        # flag, msg = compare_functions(ov_model, ref_model, False)
-        # assert flag, msg
-        #
-        #
-        # exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir, "output_model": temp_dir})
-        # assert not exit_code
-        #
-        # ov_model = core.read_model(os.path.join(temp_dir, "model.xml"))
-        # flag, msg = compare_functions(ov_model, ref_model, False)
-        # assert flag, msg
-
     def test_ovc_tool_saved_model_dir(self, ie_device, precision, ir_version, temp_dir, use_new_frontend, use_old_api):
         from openvino.runtime import Core
         core = Core()

--- a/tools/ovc/openvino/tools/ovc/cli_parser.py
+++ b/tools/ovc/openvino/tools/ovc/cli_parser.py
@@ -871,13 +871,22 @@ def get_model_name_from_args(argv: argparse.Namespace):
     if not isinstance(input_model, (str, pathlib.Path)):
         return output_dir
 
-    input_model_split = os.path.split(input_model)
-    while len(input_model_split[0]) > 0 and len(input_model_split) > 1 and (input_model_split[1] == '' or input_model_split[1] == '.'):
-        input_model_split = os.path.split(input_model_split[0])
+    # get file name
+    input_model_name = os.path.split(input_model)[1]
 
-    input_model_name = os.path.splitext(input_model_split[1])[0]
-    if input_model_name == '.' or input_model_name == '':
+    # get base directory name if file name is empty
+    while input_model_name == '' and len(input_model) > 0:
+        input_model_name = os.path.basename(input_model)
+        input_model = os.path.split(input_model)[0]
+
+    # remove extension if exists
+    input_model_name = os.path.splitext(input_model_name)[0]
+
+    # if no valid name exists in input path set name to 'model'
+    if input_model_name == '' or input_model_name == '.':
         input_model_name = "model"
+
+    # add .xml extension
     return os.path.join(output_dir, input_model_name + ".xml")
 
 

--- a/tools/ovc/openvino/tools/ovc/cli_parser.py
+++ b/tools/ovc/openvino/tools/ovc/cli_parser.py
@@ -871,7 +871,13 @@ def get_model_name_from_args(argv: argparse.Namespace):
     if not isinstance(input_model, (str, pathlib.Path)):
         return output_dir
 
-    input_model_name = os.path.splitext(os.path.split(input_model)[1])[0]
+    input_model_split = os.path.split(input_model)
+    while len(input_model_split[0]) > 0 and len(input_model_split) > 1 and (input_model_split[1] == '' or input_model_split[1] == '.'):
+        input_model_split = os.path.split(input_model_split[0])
+
+    input_model_name = os.path.splitext(input_model_split[1])[0]
+    if input_model_name == '.' or input_model_name == '':
+        input_model_name = "model"
     return os.path.join(output_dir, input_model_name + ".xml")
 
 

--- a/tools/ovc/openvino/tools/ovc/cli_parser.py
+++ b/tools/ovc/openvino/tools/ovc/cli_parser.py
@@ -871,13 +871,9 @@ def get_model_name_from_args(argv: argparse.Namespace):
     if not isinstance(input_model, (str, pathlib.Path)):
         return output_dir
 
-    # get file name
-    input_model_name = os.path.split(input_model)[1]
-
-    # get base directory name if file name is empty
-    while input_model_name == '' and len(input_model) > 0:
-        input_model_name = os.path.basename(input_model)
-        input_model = os.path.split(input_model)[0]
+    input_model_name = os.path.basename(input_model)
+    if input_model_name == '':
+        input_model_name = os.path.basename(os.path.dirname(input_model))
 
     # remove extension if exists
     input_model_name = os.path.splitext(input_model_name)[0]


### PR DESCRIPTION
Root cause analysis: 
Output model is deduced incorrectly if saved model directory is used with separator in the end.
Solution: 
Split input directory in cycle until non-zero name is found.
If no name can be deduced from input directory, set model name to "model".

Ticket: _CVS-117820_


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A


Validation:
* [x]  Unit tests
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A
