### PR TITLE
[GPU] KV cache optimization

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
@@ -38,6 +38,7 @@ struct kernel_impl_params {
     std::shared_ptr<const primitive> desc;
     size_t unique_id;
     bool _can_be_optimized = false;
+    bool force_realloc = false;
     std::vector<layout> input_layouts;
     std::vector<layout> output_layouts;
     std::vector<tensor> input_offsets;

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
@@ -38,7 +38,7 @@ struct kernel_impl_params {
     std::shared_ptr<const primitive> desc;
     size_t unique_id;
     bool _can_be_optimized = false;
-    bool force_realloc = false;
+    bool output_buffer_used_for_next_input = false;
     std::vector<layout> input_layouts;
     std::vector<layout> output_layouts;
     std::vector<tensor> input_offsets;

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
@@ -38,7 +38,7 @@ struct kernel_impl_params {
     std::shared_ptr<const primitive> desc;
     size_t unique_id;
     bool _can_be_optimized = false;
-    bool output_buffer_used_for_next_input = false;
+    primitive_id output_buffer_used_for_next_input = "";
     std::vector<layout> input_layouts;
     std::vector<layout> output_layouts;
     std::vector<tensor> input_offsets;

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -130,7 +130,7 @@ public:
     engine& get_engine() const { return _engine; }
 
     void reset_execution(bool wait = true);
-    event::ptr set_input_data(const primitive_id& id, memory::ptr data, bool reuse_prev_output = false);
+    event::ptr set_input_data(const primitive_id& id, memory::ptr data, bool use_prev_output_buffer = false);
     std::vector<event::ptr> set_output_memory(const primitive_id& id, memory::ptr mem);
 
     std::vector<std::shared_ptr<primitive_inst>> const& get_outputs() { return _outputs; }

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -130,8 +130,10 @@ public:
     engine& get_engine() const { return _engine; }
 
     void reset_execution(bool wait = true);
-    event::ptr set_input_data(const primitive_id& id, memory::ptr data, bool use_prev_output_buffer = false);
+    event::ptr set_input_data(const primitive_id& id, memory::ptr data);
     std::vector<event::ptr> set_output_memory(const primitive_id& id, memory::ptr mem);
+
+    void set_output_buffer_used_for_next_input(const primitive_id& out_prim, const primitive_id& in_prim);
 
     std::vector<std::shared_ptr<primitive_inst>> const& get_outputs() { return _outputs; }
 

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -130,7 +130,7 @@ public:
     engine& get_engine() const { return _engine; }
 
     void reset_execution(bool wait = true);
-    event::ptr set_input_data(const primitive_id& id, memory::ptr data);
+    event::ptr set_input_data(const primitive_id& id, memory::ptr data, bool reuse_prev_output = false);
     std::vector<event::ptr> set_output_memory(const primitive_id& id, memory::ptr mem);
 
     std::vector<std::shared_ptr<primitive_inst>> const& get_outputs() { return _outputs; }
@@ -145,6 +145,7 @@ public:
             evt = get_primitive_event(output_id);
         return network_output(evt, get_output_memory(output_id), get_stream_ptr(), get_output_layout(output_id));
     }
+
     layout get_node_output_layout(const primitive_id& output_id) const;
     memory::ptr get_output_memory(const primitive_id& output_id);
     layout get_output_layout(const primitive_id& output_id) const;

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -212,6 +212,12 @@ public:
     void build_deps();
     void do_runtime_skip_reorder();
     void do_runtime_in_place_concat();
+    void force_realloc_mem() {
+        force_realloc = true;
+    }
+    bool is_forced_realloc_mem() const {
+        return force_realloc;
+    }
     void configure_shape_of_dependencies();
 
     memory::ptr fused_memory(size_t dep_id) const {
@@ -277,6 +283,7 @@ protected:
 
     bool update_shape_done_by_other = false;
     bool allocation_done_by_other = false;
+    bool force_realloc = false;
     std::unique_ptr<kernel_impl_params> _impl_params;
     std::unique_ptr<primitive_impl> _impl;
     std::unique_ptr<primitive_impl> _dynamic_impl = nullptr;

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -212,12 +212,10 @@ public:
     void build_deps();
     void do_runtime_skip_reorder();
     void do_runtime_in_place_concat();
-    void set_output_buffer_used_for_next_input() {
-        _impl_params->output_buffer_used_for_next_input = true;
+    void set_output_buffer_used_for_next_input(const primitive_id& input_prim) {
+        _impl_params->output_buffer_used_for_next_input = input_prim;
     }
-    bool is_output_buffer_used_for_next_input() const {
-        return _impl_params->output_buffer_used_for_next_input;
-    }
+
     void configure_shape_of_dependencies();
 
     memory::ptr fused_memory(size_t dep_id) const {

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -212,11 +212,11 @@ public:
     void build_deps();
     void do_runtime_skip_reorder();
     void do_runtime_in_place_concat();
-    void force_realloc_mem() {
-        _impl_params->force_realloc = true;
+    void set_output_buffer_used_for_next_input() {
+        _impl_params->output_buffer_used_for_next_input = true;
     }
-    bool is_forced_realloc_mem() const {
-        return _impl_params->force_realloc;
+    bool is_output_buffer_used_for_next_input() const {
+        return _impl_params->output_buffer_used_for_next_input;
     }
     void configure_shape_of_dependencies();
 

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -213,10 +213,10 @@ public:
     void do_runtime_skip_reorder();
     void do_runtime_in_place_concat();
     void force_realloc_mem() {
-        force_realloc = true;
+        _impl_params->force_realloc = true;
     }
     bool is_forced_realloc_mem() const {
-        return force_realloc;
+        return _impl_params->force_realloc;
     }
     void configure_shape_of_dependencies();
 
@@ -283,7 +283,6 @@ protected:
 
     bool update_shape_done_by_other = false;
     bool allocation_done_by_other = false;
-    bool force_realloc = false;
     std::unique_ptr<kernel_impl_params> _impl_params;
     std::unique_ptr<primitive_impl> _impl;
     std::unique_ptr<primitive_impl> _dynamic_impl = nullptr;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -416,8 +416,18 @@ event::ptr primitive_inst::realloc_if_needed() {
 
     // If the node's output memory is used as next input memory for the same node,
     // the buffer should be allocated newly every time to prevent data corruption
-    bool can_reuse_buffer = _outputs[0] && actual_layout.count() <= max_output_layout_size &&
-                            !_impl_params->output_buffer_used_for_next_input;
+    bool output_used_as_its_input_at_next_iter = false;
+    if (_impl_params->output_buffer_used_for_next_input != "") {
+        for (auto dep : _deps) {
+            if (dep.first->id() == _impl_params->output_buffer_used_for_next_input) {
+                output_used_as_its_input_at_next_iter = true;
+            }
+        }
+    }
+
+    bool can_reuse_buffer = _outputs[0] &&
+                            (actual_layout.count() <= max_output_layout_size) &&
+                            (!output_used_as_its_input_at_next_iter);
 
     // Handle runtime dynamic concat optimization
     if (_node->is_type<concatenation>() && can_be_optimized() && allocation_done_by_other) {
@@ -1262,7 +1272,7 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
         usm_device_allocatable = false;
 
     bool reusable_across_network = (runtime_alloc && _node.is_dynamic_output_layout())
-                                       ? (!reset && !impl_params.output_buffer_used_for_next_input)
+                                       ? (!reset && (impl_params.output_buffer_used_for_next_input == ""))
                                        : !user_requesting_mem_reuse_false(_node);
 
     // Do not use memory pool for nodes from shape_of subgraphs, because such nodes mostly use CPU impls and may be
@@ -1276,7 +1286,8 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
     // Also if the successor of a node is an cpu, then memory needs to be lockable.
     bool is_cpu = _node.get_selected_impl() ? _node.get_selected_impl()->is_cpu() : false;
     auto use_lockable_memory =
-        (is_output_buffer && !impl_params.output_buffer_used_for_next_input) || is_cpu ||
+        (is_output_buffer && (impl_params.output_buffer_used_for_next_input == "")) ||
+        is_cpu ||
         has_any_cpu_user_not_shape_of(_node.get_users()) ||
         !_engine.supports_allocation(allocation_type::usm_device) ||
         (_node.is_shape_infer_dep() && _engine.get_device_info().dev_type == device_type::integrated_gpu);

--- a/src/plugins/intel_gpu/src/plugin/infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/infer_request.cpp
@@ -395,7 +395,6 @@ void InferRequest::enqueue_notify() {
 }
 
 void InferRequest::enqueue() {
-//    std::cout << "##########Infer " << std::endl;
     // set input and output memory from request blob maps
     // into the network object primitives
     std::vector<cldnn::event::ptr> dependencies;
@@ -835,7 +834,7 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
     auto inputLayoutItr = m_graph->GetInputLayouts().find(inputName);
     OPENVINO_ASSERT(inputLayoutItr != m_graph->GetInputLayouts().end(), "[GPU] Input name mismatch");
 
-    auto input_layout = inputLayoutItr->second;
+    auto node_input_layout = inputLayoutItr->second;
     auto& prec = inputBlob->getTensorDesc().getPrecision();
     auto remote_ptr = inputBlob->as<gpu::ClBlob>();
     auto& stream = m_graph->GetNetwork()->get_stream();
@@ -856,26 +855,30 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
     };
 
     auto _nw_ptr = m_graph->GetNetwork();
-    if (input_layout.is_dynamic()) {
-        if (std::getenv("REUSE") != nullptr) {
-            for (auto omem : _outputs) {
-                auto out_ptr = omem.second->cbuffer().as<void*>();
-                auto in_ptr = inputBlob->cbuffer().as<void*>();
-                if (out_ptr == in_ptr) {
-                    //         std::cout << "prev output " << omem.first << " is used as current input " << inputName <<
-                    //         std::endl;
-                    const cldnn::primitive_id internalName = "parameter:" + inputName;
-                    auto outputID = outputsMap.empty() ? m_graph->MapOutputName(omem.first) : outputsMap.at(omem.first);
-                    auto in_layout = cldnn::layout{ov::PartialShape(inputBlob->getTensorDesc().getDims()),
-                                                cldnn::data_types::f16,
-                                                cldnn::format::bfyx};
-                    auto prev_output_mem = internal_outputs.at(outputID).get_memory(false);
-                    auto prev_output_layout = internal_outputs.at(outputID).get_layout();
-                    OPENVINO_ASSERT(prev_output_layout == in_layout);
+    if (node_input_layout.is_dynamic()) {
+        // Reuse previous output usm buffer as current input, if the original user memories for them are same
+        // (i.e., an external loop)
+        for (auto out_mem : _outputs) {
+            auto out_ptr = out_mem.second->cbuffer().as<void*>();
+            auto in_ptr = inputBlob->cbuffer().as<void*>();
+            if (out_ptr == in_ptr) {
+                const cldnn::primitive_id internalInputName = "parameter:" + inputName;
+                auto outputID = outputsMap.empty() ? m_graph->MapOutputName(out_mem.first) : outputsMap.at(out_mem.first);
+                auto inDesc = inputBlob->getTensorDesc();
+                auto in_format = FormatFromLayout(inDesc.getLayout());
+                auto in_dt = DataTypeFromPrecision(inDesc.getPrecision());
+                auto in_layout = cldnn::layout{ov::PartialShape(inDesc.getDims()), in_dt, in_format};
+                auto prev_output_mem = internal_outputs.at(outputID).get_memory(false);
+                auto prev_output_layout = internal_outputs.at(outputID).get_layout();
+                GPU_DEBUG_TRACE_DETAIL << "Use previous output memory of " << outputID
+                                       << " as current input memory for " << internalInputName << std::endl;
+                if (prev_output_layout == in_layout) {
                     if (prev_output_mem->get_layout() != prev_output_layout) {
-                        prev_output_mem = m_graph->get_engine().reinterpret_buffer(*prev_output_mem, prev_output_layout);
+                        prev_output_mem =
+                            m_graph->get_engine().reinterpret_buffer(*prev_output_mem, prev_output_layout);
                     }
-                    dependencies.push_back(_nw_ptr->set_input_data(internalName, prev_output_mem, true));
+                    dependencies.push_back(
+                        _nw_ptr->set_input_data(internalInputName, prev_output_mem, true /*use prev output mem*/));
                     return;
                 }
             }
@@ -897,8 +900,8 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
 
         if (should_allocate_device_blob) {
             auto preallocation_shape = prealloc_info.second;
-            auto can_preallocate_buffer =
-                prealloc_info.first && sp.can_preallocate(ov::shape_size(preallocation_shape) * dt_size);
+            auto can_preallocate_buffer = prealloc_info.first &&
+                                          sp.can_preallocate(ov::shape_size(preallocation_shape) * dt_size);
 
             if (can_preallocate_buffer) {
                 auto new_tensor_desc = tensor_desc;
@@ -911,14 +914,11 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
         } else {
             _deviceInputs[inputName] = reinterpret_device_blob(_deviceInputs[inputName], inputBlob->getTensorDesc());
         }
-    } else if (input_layout.is_static() && !is_dev_input && can_use_usm) {
-        allocate_dev_mem_if_needed(_deviceInputs, inputBlob, inputName, input_layout, (conv_to_supported_prec(prec) != prec));
+    } else if (node_input_layout.is_static() && !is_dev_input && can_use_usm) {
+        allocate_dev_mem_if_needed(_deviceInputs, inputBlob, inputName, node_input_layout, (conv_to_supported_prec(prec) != prec));
     }
 
-    OPENVINO_ASSERT(_deviceInputs.find(inputName) != _deviceInputs.end(),
-                    "[GPU] Couldn't find device blob allocated for ",
-                    inputName,
-                    " input");
+    OPENVINO_ASSERT(_deviceInputs.find(inputName) != _deviceInputs.end(), "[GPU] Couldn't find device blob allocated for ", inputName, " input");
     auto reqBlob = _deviceInputs.at(inputName)->as<gpu::ClBlob>();
     const cldnn::primitive_id internalName = "parameter:" + inputName;
 

--- a/src/plugins/intel_gpu/src/plugin/infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/infer_request.cpp
@@ -877,8 +877,9 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
                         prev_output_mem =
                             m_graph->get_engine().reinterpret_buffer(*prev_output_mem, prev_output_layout);
                     }
+                    _nw_ptr->set_output_buffer_used_for_next_input(outputID, internalInputName);
                     dependencies.push_back(
-                        _nw_ptr->set_input_data(internalInputName, prev_output_mem, true /*use prev output mem*/));
+                        _nw_ptr->set_input_data(internalInputName, prev_output_mem));
                     return;
                 }
             }
@@ -975,7 +976,6 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
                     auto src_lock = inputBlob->cbuffer();
                     auto src_ptr = src_lock.as<uint8_t*>();
                     if (!same_host_mem(inputMem, src_ptr)) {
-//                        std::cout << inputName << " copy input mem" << std::endl;
                         auto ev = inputMem->copy_from(stream, src_ptr, false);
                         dependencies.push_back(ev);
                     }


### PR DESCRIPTION
### Details:
 -  If the user sets the next input  with previous output, we can set the current input primitive with the corresponding previous output's usm memory,  so that we can skip copying data from user blob to current input primitive.

### Tickets:
 - 116112
