### PR TITLE
Adds constant folding in ConvertInterpolate11ToInterpolate4

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_interpolate11_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_interpolate11_downgrade.cpp
@@ -13,6 +13,7 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/interpolate.hpp"
 #include "openvino/op/shape_of.hpp"
+#include "transformations/utils/utils.hpp"
 #include "utils.hpp"
 
 namespace {
@@ -25,23 +26,23 @@ std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>> make_v4_inputs(
 
     if (interpolate->get_input_size() == 3) {
         // broadcast dummy constant to the shape of axes
-        broadcast_shape = registry.make<ov::op::v3::ShapeOf>(interpolate->input_value(2));
+        broadcast_shape = registry.add(ov::op::util::make_try_fold<ov::op::v3::ShapeOf>(interpolate->input_value(2)));
     } else {
         // broadcast dummy constant to the rank of data
-        broadcast_shape = registry.make<ov::op::v3::ShapeOf>(interpolate->input_value(0));
-        broadcast_shape = registry.make<ov::op::v3::ShapeOf>(broadcast_shape);
+        broadcast_shape = registry.add(ov::op::util::make_try_fold<ov::op::v3::ShapeOf>(interpolate->input_value(0)));
+        broadcast_shape = registry.add(ov::op::util::make_try_fold<ov::op::v3::ShapeOf>(broadcast_shape));
     }
 
     if (interpolate->get_attrs().shape_calculation_mode == ov::op::util::InterpolateBase::ShapeCalcMode::SCALES) {
         ret.second = interpolate->input_value(1);
         std::shared_ptr<ov::Node> sizes_input = registry.make<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, 1);
-        sizes_input = registry.make<ov::op::v3::Broadcast>(sizes_input, broadcast_shape);
+        sizes_input = registry.add(ov::op::util::make_try_fold<ov::op::v3::Broadcast>(sizes_input, broadcast_shape));
         ret.first = sizes_input;
     } else {
         ret.first = interpolate->input_value(1);
         std::shared_ptr<ov::Node> scales_input =
             registry.make<ov::op::v0::Constant>(ov::element::f32, ov::Shape{}, 1.0f);
-        scales_input = registry.make<ov::op::v3::Broadcast>(scales_input, broadcast_shape);
+        scales_input = registry.add(ov::op::util::make_try_fold<ov::op::v3::Broadcast>(scales_input, broadcast_shape));
         ret.second = scales_input;
     }
 

--- a/src/common/transformations/tests/op_conversions/convert_interpolate11_downgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_interpolate11_downgrade_test.cpp
@@ -74,23 +74,28 @@ std::shared_ptr<ov::Model> create_v4_model(const bool with_axes,
         model_params.push_back(std::dynamic_pointer_cast<ov::opset4::Parameter>(scales));
         output_shape = ov::opset4::Constant::create(ov::element::i32, ov::Shape{}, {1});
         if (with_axes) {
-            output_shape =
-                std::make_shared<ov::opset4::Broadcast>(output_shape, std::make_shared<ov::opset4::ShapeOf>(axes));
-        } else {
-            output_shape = std::make_shared<ov::opset4::Broadcast>(
+            output_shape = ov::op::util::make_try_fold<ov::opset4::Broadcast>(
                 output_shape,
-                std::make_shared<ov::opset4::ShapeOf>(std::make_shared<ov::opset4::ShapeOf>(input)));
+                ov::op::util::make_try_fold<ov::opset4::ShapeOf>(axes));
+        } else {
+            output_shape = ov::op::util::make_try_fold<ov::opset4::Broadcast>(
+                output_shape,
+                ov::op::util::make_try_fold<ov::opset4::ShapeOf>(
+                    ov::op::util::make_try_fold<ov::opset4::ShapeOf>(input)));
         }
     } else {
         output_shape = std::make_shared<ov::opset4::Parameter>(ov::element::i32, ov::Shape{num_scales_or_sizes});
         model_params.push_back(std::dynamic_pointer_cast<ov::opset4::Parameter>(output_shape));
         scales = ov::opset4::Constant::create(ov::element::f32, ov::Shape{}, {1.0f});
         if (with_axes) {
-            scales = std::make_shared<ov::opset4::Broadcast>(scales, std::make_shared<ov::opset4::ShapeOf>(axes));
-        } else {
-            scales = std::make_shared<ov::opset4::Broadcast>(
+            scales = ov::op::util::make_try_fold<ov::opset4::Broadcast>(
                 scales,
-                std::make_shared<ov::opset4::ShapeOf>(std::make_shared<ov::opset4::ShapeOf>(input)));
+                ov::op::util::make_try_fold<ov::opset4::ShapeOf>(axes));
+        } else {
+            scales = ov::op::util::make_try_fold<ov::opset4::Broadcast>(
+                scales,
+                ov::op::util::make_try_fold<ov::opset4::ShapeOf>(
+                    ov::op::util::make_try_fold<ov::opset4::ShapeOf>(input)));
         }
     }
 


### PR DESCRIPTION
### Details:
CommonTransformations pass doesn't call ConstantFolding at the end of pipeline, we expect that all transformations after the last ConstantFolding in the pipeline do not insert ShapeOf subgraph in case of static shapes. 
So we decided to add ConstantFolding in ConvertInterpolate11ToInterpolate4 transformation.
 

### Tickets:
 - *117863*
