### PR TITLE
[CPU] Add OV_CPU_DUMP_MODELS and OV_CPU_PROFILE

### DIFF
--- a/src/plugins/intel_cpu/docs/debug_capabilities/graph_serialization.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/graph_serialization.md
@@ -13,6 +13,8 @@ Possible serialization options:
 Serialize to console output.
 * \<path\>.xml\
 Serialize graph into .xml and .bin files. Can be opened using, for example, *netron* app.
+* \<path\>.cpp\
+Serialize to c++11 pseudo-code style source file.
 * **TBD**: \<path\>.dot\
 Serialize graph into .dot file. Can be inspected using, for example, *graphviz* tools.
 

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -216,10 +216,12 @@ void serialize(const Graph &graph) {
 
     if (path == "cout")
         serializeToCout(graph);
-    else if (!path.compare(path.size() - 4, 4, ".xml"))
+    else if (path.size() >= 4 && !path.compare(path.size() - 4, 4, ".xml"))
         serializeToXML(graph, path);
+    else if (path.size() >= 4 && !path.compare(path.size() - 4, 4, ".cpp"))
+        DEBUG_DUMP_GRAPH(graph, path);
     else
-        IE_THROW() << "Unknown serialize format. Should be either 'cout' or '*.xml'. Got " << path;
+        IE_THROW() << "Unknown serialize format. Should be either 'cout' or '*.xml' or 'cpp'. Got " << path;
 }
 
 void serializeToXML(const Graph &graph, const std::string& path) {

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -489,7 +489,7 @@ Engine::LoadExeNetworkImpl(const InferenceEngine::CNNNetwork &network, const std
 
     auto nGraphFunc = clonedNetwork.getFunction();
 
-    DEBUG_LOG(PrintableModel(*nGraphFunc, "org_"));
+    DEBUG_DUMP_MODEL(nGraphFunc, "ngraph_org.cpp");
 
     Transformations transformations(nGraphFunc, enableLPT, inferencePrecision, isLegacyAPI(), snippetsMode, engConfig);
     transformations.UpToCpuSpecificOpSet();
@@ -509,7 +509,7 @@ Engine::LoadExeNetworkImpl(const InferenceEngine::CNNNetwork &network, const std
     }
     transformations.CpuSpecificOpSet();
 
-    DEBUG_LOG(PrintableModel(*nGraphFunc, "cpu_"));
+    DEBUG_DUMP_MODEL(nGraphFunc, "ngraph_cpu.cpp");
 
     // update the props after the perf mode translated to configs
     // TODO: Clarify the behavior of SetConfig method. Skip eng_config or not?

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.h
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.h
@@ -8,12 +8,14 @@
 #include <string>
 #include <iostream>
 #include <sstream>
+#include <fstream>
 #include <chrono>
 
 #include <onednn/dnnl.h>
 #include <dnnl_debug.h>
 #include "onednn/iml_type_mapper.h"
 #include "openvino/core/model.hpp"
+#include "openvino/pass/pass.hpp"
 #include "edge.h"
 
 namespace ov {
@@ -45,14 +47,7 @@ class NodeDesc;
 class MemoryDesc;
 class Node;
 class Edge;
-
-class PrintableModel {
-public:
-    PrintableModel(const ov::Model& model, std::string tag = "", std::string prefix = "") : model(model), tag(tag), prefix(prefix) {}
-    const ov::Model& model;
-    const std::string tag;
-    const std::string prefix;
-};
+class Graph;
 
 template<typename T>
 class PrintableVector {
@@ -92,9 +87,9 @@ public:
 
 std::ostream & operator<<(std::ostream & os, const NodeDesc& desc);
 std::ostream & operator<<(std::ostream & os, const Node& node);
+std::ostream & operator<<(std::ostream & os, const ov::intel_cpu::Graph& graph);
 std::ostream & operator<<(std::ostream & os, const MemoryDesc& desc);
 std::ostream & operator<<(std::ostream & os, const Edge& edge);
-std::ostream & operator<<(std::ostream & os, const PrintableModel& model);
 std::ostream & operator<<(std::ostream & os, const PrintableDelta& us);
 std::ostream & operator<<(std::ostream & os, const Edge::ReorderStatus reorderStatus);
 
@@ -106,8 +101,36 @@ std::ostream & operator<<(std::ostream & os, const dnnl::memory::format_tag dtyp
 std::ostream & operator<<(std::ostream & os, const dnnl::primitive_attr& attr);
 std::ostream & operator<<(std::ostream & os, const dnnl::algorithm& alg);
 
-template<typename T>
-std::ostream & operator<<(std::ostream & os, const PrintableVector<T>& vec) {
+class DumpModel : public ov::pass::ModelPass {
+public:
+    OPENVINO_RTTI("DumpModel");
+    DumpModel(std::string file_name);
+    ~DumpModel() {}
+    void dump_cpp_style(std::ostream & os, const std::shared_ptr<ov::Model>& model);
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+    bool run_on_graph(const ov::intel_cpu::Graph& graph);
+
+protected:
+    std::string file_name;
+};
+
+#    define DEBUG_DUMP_MODEL_REGISTER_PASS(passManager, dump_file_name) \
+        CPU_REGISTER_PASS_X64(passManager, DumpModel, dump_file_name)
+
+#    define DEBUG_DUMP_MODEL(model_shptr, dump_file_name)     \
+        do {                                                  \
+            ov::intel_cpu::DumpModel dumpper(dump_file_name); \
+            dumpper.run_on_model(model_shptr);                \
+        } while (0)
+
+#    define DEBUG_DUMP_GRAPH(graph, dump_file_name)     \
+        do {                                                  \
+            ov::intel_cpu::DumpModel dumpper(dump_file_name); \
+            dumpper.run_on_graph(graph);                \
+        } while (0)
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const PrintableVector<T>& vec) {
     std::stringstream ss;
     auto N = vec.values.size();
     for (size_t i = 0; i < N; i++) {
@@ -197,6 +220,10 @@ struct EnforceInferPrcDebug {
 };
 
 #else // !CPU_DEBUG_CAPS
+
+#define DEBUG_DUMP_MODEL_REGISTER_PASS(passManager, dump_file_name) do {} while (0)
+#define DEBUG_DUMP_MODEL(model, dump_file_name) do {} while (0)
+#define DEBUG_DUMP_GRAPH(graph, dump_file_name) do {} while (0)
 
 #define CPU_DEBUG_CAP_ENABLE(...)
 #define CPU_DEBUG_CAPS_ALWAYS_TRUE(x) x


### PR DESCRIPTION
### Details:
 -  add *.cpp option to `OV_CPU_EXEC_GRAPH_PATH`  to dump model in pseudo-code style text file (and IR format):
    - this helps developing big models when viewing IR using netron takes so much time and almost unfeasible.
    - the pseudo-code can be used directly as pattern for ngraph transformation (with following PRs implementing the API)

### Tickets:
 - *ticket-id*
