### PR TITLE
[GPU] Make gemm_tiled_opt support outer axis

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -23,6 +23,7 @@ ParamsKey GemmKernelTiledOpt::GetSupportedKey() const {
     k.EnableInputLayout(DataLayout::bfwzyx);
     k.EnableOutputLayout(DataLayout::bfwzyx);
 
+    k.EnableTensorOffset();
     k.EnableBatching();
     k.EnableDifferentTypes();
     k.EnableDynamicShapesSupport();
@@ -234,6 +235,13 @@ bool GemmKernelTiledOpt::Validate(const Params& params, const optional_params& o
         return false;
 
     const auto& gmm_params = static_cast<const gemm_params&>(params);
+    for (auto input : gmm_params.inputs) {
+        // Only supports outer padding as first element offset
+        if (input.X().pad.Total() != 0 || input.Y().pad.Total() != 0 || input.Z().pad.Total() != 0 ||
+            input.Feature().pad.Total() != 0)
+            return false;
+    }
+
     bool gemm_leftovers = gmm_params.inputs[0].X().v % 16 || gmm_params.inputs[0].Y().v % 16 ||
                           gmm_params.inputs[1].X().v % 16 || gmm_params.inputs[1].Y().v % 16;
     // If gmm_params has dynamic inputs, the correct dimension value cannot be obtained


### PR DESCRIPTION
+ Resolved perf regression from propagation of padded input

### Details:
 - gemm selected gemm_ref kernel by propagated padded input
 - padded input is propagated along 'implicit crop - reorder -reshape - matmul'

### Tickets:
 - CVS-117532
