### PR TITLE
Handle unspecified type in wrap_tensor function

### DIFF
--- a/src/core/src/tensor_conversion_util.cpp
+++ b/src/core/src/tensor_conversion_util.cpp
@@ -13,7 +13,7 @@ Tensor wrap_tensor(const ngraph::HostTensorPtr& t) {
     const auto& et = t->get_element_type();
     const auto& p_shape = t->get_partial_shape();
 
-    if (et.is_dynamic()) {
+    if (et.is_dynamic() || et == element::undefined) {
         return {};
     } else if (p_shape.is_static()) {
         return {et, p_shape.to_shape(), t->get_data_ptr()};
@@ -26,7 +26,7 @@ Tensor wrap_tensor(const Output<Node>& output) {
     const auto& et = output.get_element_type();
     const auto& p_shape = output.get_partial_shape();
 
-    if (et.is_dynamic()) {
+    if (et.is_dynamic() || et == element::undefined) {
         return {};
     } else if (p_shape.is_static()) {
         return {et, p_shape.to_shape()};

--- a/src/core/tests/constant_folding.cpp
+++ b/src/core/tests/constant_folding.cpp
@@ -3911,3 +3911,10 @@ TEST(constant_folding, gather_with_dynamic_shapes_in_data_input) {
     check_names(strided_slice, {"strided_slice"}, "strided_slice");
     check_names(res, {"result"}, "result");
 }
+
+TEST(constant_folding, parameter_with_unspecified_type_from_host_tensor) {
+    auto param = std::make_shared<ov::op::v0::Parameter>(element::undefined, ov::PartialShape{});
+    auto res = std::make_shared<ov::op::v0::Result>(param);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{res}, ov::ParameterVector{param});
+    EXPECT_NO_THROW(run_constant_folding(model));
+}

--- a/src/core/tests/tensor.cpp
+++ b/src/core/tests/tensor.cpp
@@ -14,6 +14,7 @@
 #include "ngraph/ngraph.hpp"
 #include "ngraph/opsets/opset6.hpp"
 #include "ngraph/pass/manager.hpp"
+#include "tensor_conversion_util.hpp"
 
 NGRAPH_SUPPRESS_DEPRECATED_START
 
@@ -34,4 +35,18 @@ TEST(tensor, tensor_names) {
     ASSERT_EQ(arg0->get_output_tensor(0).get_names(), relu->input_value(0).get_tensor().get_names());
     ASSERT_EQ(f0->get_result()->get_input_tensor(0).get_names(), relu->get_output_tensor(0).get_names());
     ASSERT_EQ(f0->get_result()->input_value(0).get_tensor().get_names(), relu->get_output_tensor(0).get_names());
+}
+
+TEST(tensor, wrap_tensor_with_unspecified_type) {
+    auto param = std::make_shared<ov::op::v0::Parameter>(element::undefined, ov::PartialShape{});
+    auto tensor = ov::util::wrap_tensor(param->output(0));
+    // !tensor means that the tensor is not initialized
+    EXPECT_EQ(!tensor, true);
+}
+
+TEST(tensor, wrap_tensor_with_unspecified_type_from_host_tensor) {
+    auto host_tensor = std::make_shared<ngraph::HostTensor>(element::undefined, ov::PartialShape{});
+    auto tensor = ov::util::wrap_tensor(host_tensor);
+    // !tensor means that the tensor is not initialized
+    EXPECT_EQ(!tensor, true);
 }


### PR DESCRIPTION
### Details:
 - The original model contains Parameter node with "unspecified" type. ConstantFolding tries to create ViewTensor via wrap_tensor function with "unspecified" type. ViewTensor ctor contains an assert for this case. So "unspecified" type was handled in wrap_tensor function.

### Tickets:
 - *CVS-111263*
