### PR TITLE
Fix TransposeSinking when the data input is broadcasted

### DIFF
--- a/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
@@ -257,9 +257,9 @@ NodeVector InsertOutputTransposes(const NodePtr& main_node, const TransposeInput
     NodeVector new_nodes;
 
     for (size_t i = 0; i < main_node->get_output_size(); ++i) {
-        auto new_transpose_const = std::make_shared<ov::op::v0::Constant>(transpose_element_type,
-                                                                          Shape{transpose_axis_order.size()},
-                                                                          transpose_axis_order);
+        auto aligned_order = AlignTransposeOrder(main_node->output(i), transpose_input_info);
+        auto new_transpose_const =
+            std::make_shared<ov::op::v0::Constant>(transpose_element_type, Shape{aligned_order.size()}, aligned_order);
         auto main_node_consumers = main_node->output(i).get_target_inputs();
         auto new_transpose = std::make_shared<ov::op::v1::Transpose>(main_node->output(i), new_transpose_const);
         for (auto& consumer : main_node_consumers) {


### PR DESCRIPTION
### Details:
 - *Handle the case when the input with the target transpose op is broadcasted
     The inserted Transpose after TS had only 2 values in the order input.
```
    Input1 (2, 3) -> Transpose -----
                                       Add (out: 1, 2, 3) -> 
    Input2 (1, 1, 1) ----------------- 
```
 



### Tickets:
 - *CVS-111267*
