### PR TITLE
[CPU][ARM] Choose eltwise layout based on model type

### DIFF
--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -69,7 +69,7 @@ void Config::applyDebugCapsProperties() {
 }
 #endif
 
-void Config::readProperties(const std::map<std::string, std::string> &prop, ModelType modelType) {
+void Config::readProperties(const std::map<std::string, std::string> &prop, const ModelType modelType) {
     const auto streamExecutorConfigKeys = streamExecutorConfig.SupportedKeys();
     const auto hintsConfigKeys = perfHintsConfig.SupportedKeys();
     for (const auto& kvp : prop) {
@@ -267,6 +267,7 @@ void Config::readProperties(const std::map<std::string, std::string> &prop, Mode
     streamExecutorConfig._streams = 1;
     streamExecutorConfig._streams_changed = true;
 #endif
+    this->modelType = modelType;
 
     CPU_DEBUG_CAP_ENABLE(applyDebugCapsProperties());
     updateProperties();

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -88,7 +88,7 @@ struct Config {
     // is reserved.
     bool DAZOn = false;
 
-    void readProperties(const std::map<std::string, std::string> &config, ModelType modelType = ModelType::Unknown);
+    void readProperties(const std::map<std::string, std::string> &config, const ModelType modelType = ModelType::Unknown);
     void updateProperties();
 
     std::map<std::string, std::string> _config;
@@ -96,6 +96,7 @@ struct Config {
     bool isLegacyApi = false;
 
     int modelPreferThreads = -1;
+    ModelType modelType = ModelType::Unknown;
 
 #ifdef CPU_DEBUG_CAPS
     DebugCapsConfig debugCaps;


### PR DESCRIPTION
### Details:
 - Eltwise order of the supported primitive descriptors affects the
performance of the model.
Often only one of the port descriptors matches with the layout
of the parent descriptors, i.e. when two parent ports have mixed
layout "nchw nhwc".
So either nchw or nhwc layout will be used for the eltwise node
and reorder will be used for either of the ports.
The shape of the ports also can be different (when one of the inputs is
broadcasted). So reorders on different ports have different
performance impact.
- The layout of the eltwise node child has an effect on the performance
as well, since it may or may not require reorder on input.

### Tickets:
 - 118088