### PR TITLE
OVC and ov.convert_model() documentation.

### DIFF
--- a/docs/Documentation/model_introduction.md
+++ b/docs/Documentation/model_introduction.md
@@ -44,7 +44,7 @@ Model conversion API, specifically, the ``ov.convert_model()`` method converts a
    :alt: model conversion diagram
 
 Convert a model with ``ovc`` (OpenVino Conversion) command-line tool
-#############################################
+####################################################################
 
 Another option to convert a model is to use ``ovc`` command-line tool. ``ovc`` is a cross-platform tool that facilitates the transition between training and deployment environments, performs static model analysis, and adjusts deep learning models for optimal execution on end-point target devices in the same measure, as the ``ov.convert_model`` method.
 

--- a/docs/Documentation/model_introduction.md
+++ b/docs/Documentation/model_introduction.md
@@ -17,7 +17,19 @@
 
 Every deep learning workflow begins with obtaining a model. You can choose to prepare a custom one, use a ready-made solution and adjust it to your needs, or even download and run a pre-trained network from an online database, such as `TensorFlow Hub <https://tfhub.dev/>`__, `Hugging Face <https://huggingface.co/>`__, `Torchvision models <https://pytorch.org/hub/>`__.
 
-:doc:`OpenVINO™ supports several model formats <Supported_Model_Formats>` and allows converting them to it's own, `openvino.runtime.Model <api/ie_python_api/_autosummary/openvino.runtime.Model.html>`__ (`ov.Model <api/ie_python_api/_autosummary/openvino.runtime.Model.html>`__ ), providing a tool dedicated to this task.
+:doc:`OpenVINO™ supports several model formats <Supported_Model_Formats>` and allows converting them to it's own, `openvino.Model <api/ie_python_api/_autosummary/openvino.Model.html>`__ (`ov.Model <api/ie_python_api/_autosummary/openvino.runtime.Model.html>`__ ), providing a tool dedicated to this task.
+
+
+.. note::
+
+   In most of the Python tutorials and Python examples ``openvino`` namespace is replaced with short alias ``ov``.
+
+   Example:
+
+  .. code-block:: py
+
+     import openvino as ov
+
 
 There are several options to convert a model from original framework to OpenVINO model format (``ov.Model``).
 
@@ -26,21 +38,22 @@ The ``read_model()`` method reads a model from a file and produces ``ov.Model``.
 Convert a model in Python
 ######################################
 
-Model conversion API, specifically, the ``mo.convert_model()`` method converts a model from original framework to ``ov.Model``. ``mo.convert_model()`` returns ``ov.Model`` object in memory so the ``read_model()`` method is not required. The resulting ``ov.Model`` can be inferred in the same training environment (python script or Jupiter Notebook). ``mo.convert_model()`` provides a convenient way to quickly switch from framework-based code to OpenVINO-based code in your inference application. In addition to model files, ``mo.convert_model()`` can take OpenVINO extension objects constructed directly in Python for easier conversion of operations that are not supported in OpenVINO. The ``mo.convert_model()`` method also has a set of parameters to :doc:`cut the model <openvino_docs_MO_DG_prepare_model_convert_model_Cutting_Model>`, :doc:`set input shapes or layout <openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model>`, :doc:`add preprocessing <openvino_docs_MO_DG_Additional_Optimization_Use_Cases>`, etc.
+Model conversion API, specifically, the ``ov.convert_model()`` method converts a model from original framework to ``ov.Model``. ``ov.convert_model()`` returns ``ov.Model`` object in memory so the ``read_model()`` method is not required. The resulting ``ov.Model`` can be inferred in the same training environment (python script or Jupiter Notebook). ``ov.convert_model()`` provides a convenient way to quickly switch from framework-based code to OpenVINO-based code in your inference application. In addition to model files, ``ov.convert_model()`` can take OpenVINO extension objects constructed directly in Python for easier conversion of operations that are not supported in OpenVINO.
 
 .. image:: _static/images/model_conversion_diagram.svg
    :alt: model conversion diagram
 
-Convert a model with ``mo`` command-line tool
+Convert a model with ``ovc`` (OpenVino Conversion) command-line tool
 #############################################
 
-Another option to convert a model is to use ``mo`` command-line tool. ``mo`` is a cross-platform tool that facilitates the transition between training and deployment environments, performs static model analysis, and adjusts deep learning models for optimal execution on end-point target devices in the same measure, as the ``mo.convert_model`` method.
+Another option to convert a model is to use ``ovc`` command-line tool. ``ovc`` is a cross-platform tool that facilitates the transition between training and deployment environments, performs static model analysis, and adjusts deep learning models for optimal execution on end-point target devices in the same measure, as the ``ov.convert_model`` method.
 
-``mo`` requires the use of a pre-trained deep learning model in one of the supported formats: TensorFlow, TensorFlow Lite, PaddlePaddle, or ONNX. ``mo`` converts the model to the OpenVINO Intermediate Representation format (IR), which needs to be read with the ``ov.read_model()`` method. Then, you can compile and infer the ``ov.Model`` later with :doc:`OpenVINO™ Runtime <openvino_docs_OV_UG_OV_Runtime_User_Guide>`.
+``ovc`` requires the use of a pre-trained deep learning model in one of the supported formats: TensorFlow, TensorFlow Lite, PaddlePaddle, or ONNX. ``ovc`` converts the model to the OpenVINO Intermediate Representation format (IR), which needs to be read with the ``ov.read_model()`` method. Then, you can compile and infer the ``ov.Model`` later with :doc:`OpenVINO™ Runtime <openvino_docs_OV_UG_OV_Runtime_User_Guide>`.
 
 
 The figure below illustrates the typical workflow for deploying a trained deep learning model:
 
+#TODO: Update BASIC_FLOW_MO_simplified.svg and replace 'mo' with 'ovc'
 .. image:: _static/images/BASIC_FLOW_MO_simplified.svg
 
 where IR is a pair of files describing the model:
@@ -49,14 +62,15 @@ where IR is a pair of files describing the model:
 * ``.bin`` - Contains the weights and biases binary data.
 
 
-Model files (not Python objects) from ONNX, PaddlePaddle, TensorFlow and TensorFlow Lite  (check :doc:`TensorFlow Frontend Capabilities and Limitations <openvino_docs_MO_DG_TensorFlow_Frontend>`) do not require a separate step for model conversion, that is ``mo.convert_model``. OpenVINO provides C++ and Python APIs for importing the models to OpenVINO Runtime directly by just calling the ``read_model`` method. 
+Model files (not Python objects) from ONNX, PaddlePaddle, TensorFlow and TensorFlow Lite  (check :doc:`TensorFlow Frontend Capabilities and Limitations <openvino_docs_MO_DG_TensorFlow_Frontend>`) do not require a separate step for model conversion, that is ``ov.convert_model``. OpenVINO provides C++ and Python APIs for importing the models to OpenVINO Runtime directly by just calling the ``read_model`` method. 
 
-The results of both ``mo`` and ``mo.convert_model()`` conversion methods described above are the same. You can choose one of them, depending on what is most convenient for you. Keep in mind that there should not be any differences in the results of model conversion if the same set of parameters is used.
+The results of both ``ovc`` and ``ov.convert_model()`` conversion methods described above are the same. You can choose one of them, depending on what is most convenient for you. Keep in mind that there should not be any differences in the results of model conversion if the same set of parameters is used.
 
 This section describes how to obtain and prepare your model for work with OpenVINO to get the best inference results:
 
 * :doc:`See the supported formats and how to use them in your project <Supported_Model_Formats>`.
 * :doc:`Convert different model formats to the ov.Model format <openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide>`.
+* :doc:`Transition guide from MO / ov.tools.mo.convert_model() to OVC / ov.convert_model() <openvino_docs_MO_DG_prepare_model_convert_model_MO_OVC_transition>`
 
 @endsphinxdirective
 

--- a/docs/Documentation/model_introduction.md
+++ b/docs/Documentation/model_introduction.md
@@ -10,6 +10,7 @@
    :maxdepth: 1
    :hidden:
 
+   openvino_docs_MO_DG_prepare_model_convert_model_MO_OVC_transition
    Supported_Model_Formats
    openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide
    omz_tools_downloader

--- a/docs/MO_DG/Deep_Learning_Model_Optimizer_DevGuide.md
+++ b/docs/MO_DG/Deep_Learning_Model_Optimizer_DevGuide.md
@@ -16,7 +16,7 @@
    openvino_docs_MO_DG_prepare_model_Model_Optimizer_FAQ
 
 .. meta::
-   :description: Model conversion (MO) furthers the transition between training and 
+   :description: Model conversion (OVC) furthers the transition between training and 
                  deployment environments, it adjusts deep learning models for 
                  optimal execution on target devices.
 
@@ -31,7 +31,7 @@ To convert a model to OpenVINO model format (``ov.Model``), you can use the foll
        .. code-block:: py
           :force:
 
-          from openvino.tools.mo import convert_model
+          from openvino import convert_model
           ov_model = convert_model(INPUT_MODEL)
 
     .. tab-item:: CLI
@@ -39,12 +39,13 @@ To convert a model to OpenVINO model format (``ov.Model``), you can use the foll
 
        .. code-block:: sh
 
-          mo --input_model INPUT_MODEL
+          ovc --input_model INPUT_MODEL
 
 
-If the out-of-the-box conversion (only the ``input_model`` parameter is specified) is not successful, use the parameters mentioned below to override input shapes and cut the model:
+If the out-of-the-box conversion (only the ``input_model`` parameter is specified) is not successful, use convert_model from openvino.tools.mo (mo.convert_model()). 
+mo.convert_model() provides a wide range of parameters for model preprocessing, which are described below.
 
-- model conversion API provides two parameters to override original input shapes for model conversion: ``input`` and ``input_shape``.
+- mo.convert_model() provides two parameters to override original input shapes for model conversion: ``input`` and ``input_shape``.
   For more information about these parameters, refer to the :doc:`Setting Input Shapes <openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model>` guide.
 
 - To cut off unwanted parts of a model (such as unsupported operations and training sub-graphs),
@@ -55,7 +56,7 @@ You can also insert additional input pre-processing sub-graphs into the converte
 the ``mean_values``, ``scales_values``, ``layout``, and other parameters described
 in the :doc:`Embedding Preprocessing Computation <openvino_docs_MO_DG_Additional_Optimization_Use_Cases>` article.
 
-The ``compress_to_fp16`` compression parameter in ``mo`` command-line tool allows generating IR with constants (for example, weights for convolutions and matrix multiplications) compressed to ``FP16`` data type. For more details, refer to the :doc:`Compression of a Model to FP16 <openvino_docs_MO_DG_FP16_Compression>` guide.
+The ``compress_to_fp16`` compression parameter in ``ovc`` and ``mo`` command-line tool allows generating IR with constants (for example, weights for convolutions and matrix multiplications) compressed to ``FP16`` data type. For more details, refer to the :doc:`Compression of a Model to FP16 <openvino_docs_MO_DG_FP16_Compression>` guide.
 
 To get the full list of conversion parameters, run the following command:
 
@@ -77,6 +78,7 @@ To get the full list of conversion parameters, run the following command:
 
           mo --help
 
+# TODO: Update examples to most topical and arrange in following order: PyTorch, TF, ONNX, Paddle
 
 Examples of model conversion parameters
 #######################################

--- a/docs/MO_DG/prepare_model/convert_model/MO_OVC_transition.md
+++ b/docs/MO_DG/prepare_model/convert_model/MO_OVC_transition.md
@@ -397,3 +397,6 @@ MO vs OVC model formats
 
 ov.convert_model() and OVC tool support conversion from PyTorch, TF, TF Lite, ONNX, PaddlePaddle.
 Following frameworks are supported only in MO and mo.convert_model(): Caffe, MxNet, Kaldi.
+
+@endsphinxdirective
+

--- a/docs/MO_DG/prepare_model/convert_model/MO_OVC_transition.md
+++ b/docs/MO_DG/prepare_model/convert_model/MO_OVC_transition.md
@@ -1,7 +1,16 @@
 # Transition guide from MO / mo.convert_model() to OVC / ov.convert_model() {#openvino_docs_MO_DG_prepare_model_convert_model_MO_OVC_transition}
 
+@sphinxdirective
+
+.. meta::
+   :description: Transition guide from MO / mo.convert_model() to OVC / ov.convert_model().
+
+
 In 2023.1 OpenVino release new OVC (OpenVino Conversion) tool was introduced with corresponding Python API (ov.convert_model() method). OVC and ov.convert_model() represent 
 lightweight analog of MO and mo.convert_model() (openvino.tools.mo.convert_model()). In this article all the differences between MO and OVC are summarized and transition guide from MO to OVC is presented.
+
+MO vs OVC parameters comparison
+###############################
 
 The comparison of parameters between ov.convert_model() / OVC and mo.convert_model() / MO.
 
@@ -180,6 +189,7 @@ The comparison of parameters between ov.convert_model() / OVC and mo.convert_mod
 
     
 Preprocessing of model using mo.convert_model() vs using ov.convert_model().
+############################################################################
 
 mo.convert_model() provides a wide range of preprocessing parameters. Most of these parameters have analogs in ``ov.PrePostProcessor`` class.
 Here is the list of MO parameters which can be replaced with usage of ``ov.PrePostProcessor`` class.
@@ -367,8 +377,8 @@ Here is the list of MO parameters which can be replaced with usage of ``ov.PrePo
              
              from openvino.preprocess import PrePostProcessor
              prep = PrePostProcessor(ov_model)
-             prep.input('input.1').model().set_layout(Layout("nchw"))
-             prep.input('input.1').tensor().set_layout(Layout("nhwc"))
+             prep.input(input_name).model().set_layout(Layout("nchw"))
+             prep.input(input_name).tensor().set_layout(Layout("nhwc"))
              ov_model = prep.build()
 
        .. tab-item:: mo.convert_model()
@@ -380,3 +390,10 @@ Here is the list of MO parameters which can be replaced with usage of ``ov.PrePo
              from openvino import Layout
              from openvino.tools.mo import convert_model, LayoutMap
              ov_model = convert_model(model, layout={input_name: LayoutMap("nchw", "nhwc")})
+
+
+MO vs OVC model formats
+####################### 
+
+ov.convert_model() and OVC tool support conversion from PyTorch, TF, TF Lite, ONNX, PaddlePaddle.
+Following frameworks are supported only in MO and mo.convert_model(): Caffe, MxNet, Kaldi.

--- a/docs/MO_DG/prepare_model/convert_model/MO_OVC_transition.md
+++ b/docs/MO_DG/prepare_model/convert_model/MO_OVC_transition.md
@@ -1,0 +1,382 @@
+# Transition guide from MO / mo.convert_model() to OVC / ov.convert_model() {#openvino_docs_MO_DG_prepare_model_convert_model_MO_OVC_transition}
+
+In 2023.1 OpenVino release new OVC (OpenVino Conversion) tool was introduced with corresponding Python API (ov.convert_model() method). OVC and ov.convert_model() represent 
+lightweight analog of MO and mo.convert_model() (openvino.tools.mo.convert_model()). In this article all the differences between MO and OVC are summarized and transition guide from MO to OVC is presented.
+
+The comparison of parameters between ov.convert_model() / OVC and mo.convert_model() / MO.
+
+.. list-table::
+   :widths: 20 25 55
+   :header-rows: 1
+
+   * - Parameter name in mo.convert_model() / MO
+     - Parameter name in ov.convert_model() / OVC
+     - Differences description
+   * - input_model
+     - input_model
+     - Along with model object or path to input model ov.convert_model() accepts list of model parts, for example path to Tensorflow weights plus path to Tensorflow checkpoint. OVC tool accepts unnamed input model.
+   * - output_dir
+     - output_model
+     - output_model in OVC tool sets both output model name and output directory.
+   * - model_name
+     - output_model
+     - output_model in OVC tool sets both output model name and output directory.
+   * - input 
+     - input
+     - ov.convert_model() accepts tuples for setting multiple parameters. OVC tool 'input' does not have type setting and freezing functionality. ov.convert_model() does not allow input cut.
+   * - output
+     - output
+     - ov.convert_model() does not allow output cut.
+   * - input_shape
+     - -
+     - -
+   * - example_input
+     - example_input
+     - -
+   * - batch
+     - -
+     - -
+   * - mean_values
+     - -
+     - -
+   * - scale_values
+     - -
+     - -
+   * - scale
+     - -
+     - -
+   * - reverse_input_channels
+     - -
+     - -
+   * - source_layout
+     - -
+     - -
+   * - target_layout
+     - -
+     - -
+   * - layout
+     - -
+     - -
+   * - compress_to_fp16
+     - compress_to_fp16
+     - OVC provides 'compress_to_fp16' for command line tool only, as compression is performed during saving a model to IR (Intermediate Representation). 
+   * - extensions
+     - extension
+     - -
+   * - transform
+     - -
+     - -
+   * - transformations_config
+     - -
+     - -
+   * - static_shape
+     - -
+     - -
+   * - freeze_placeholder_with_value
+     - -
+     - -
+   * - use_legacy_frontend
+     - -
+     - -
+   * - use_legacy_frontend
+     - -
+     - -
+   * - silent
+     - verbose
+     - OVC / ov.convert_model provides 'verbose' parameter instead of 'silent' for printing of detailed conversion information if 'verbose' is set to True.
+   * - log_level
+     - -
+     - -
+   * - version
+     - version
+     - -
+   * - progress
+     - -
+     - -
+   * - stream_output
+     - -
+     - -
+   * - share_weights
+     - share_weights
+     - -
+   * - framework
+     - -
+     - -
+   * - help / -h
+     - help / -h
+     - OVC provides help parameter only in command line tool.
+   * - example_output
+     - output
+     - OVC / ov.convert_model 'output' parameter includes capabilities of MO 'example_output' parameter.
+   * - input_model_is_text
+     - -
+     - -
+   * - input_checkpoint
+     - input_model
+     - All supported model formats can be passed to 'input_model'. 
+   * - input_meta_graph
+     - input_model
+     - All supported model formats can be passed to 'input_model'. 
+   * - saved_model_dir
+     - input_model
+     - All supported model formats can be passed to 'input_model'. 
+   * - saved_model_tags
+     - -
+     - -
+   * - tensorflow_custom_operations_config_update
+     - -
+     - -
+   * - tensorflow_object_detection_api_pipeline_config
+     - -
+     - -
+   * - tensorboard_logdir
+     - -
+     - -
+   * - tensorflow_custom_layer_libraries
+     - -
+     - -
+   * - input_symbol
+     - -
+     - -
+   * - nd_prefix_name
+     - -
+     - -
+   * - pretrained_model_name
+     - -
+     - -
+   * - save_params_from_nd
+     - -
+     - -
+   * - legacy_mxnet_model
+     - -
+     - -
+   * - enable_ssd_gluoncv
+     - -
+     - -
+   * - input_proto
+     - -
+     - -
+   * - caffe_parser_path
+     - -
+     - -
+   * - k
+     - -
+     - -
+   * - disable_omitting_optional
+     - -
+     - -
+   * - enable_flattening_nested_params
+     - -
+     - -
+   * - counts
+     - -
+     - -
+   * - remove_output_softmax
+     - -
+     - -
+   * - remove_memory
+     - -
+     - -
+
+    
+Preprocessing of model using mo.convert_model() vs using ov.convert_model().
+
+mo.convert_model() provides a wide range of preprocessing parameters. Most of these parameters have analogs in ``ov.PrePostProcessor`` class.
+Here is the list of MO parameters which can be replaced with usage of ``ov.PrePostProcessor`` class.
+
+
+* mean_value parameter:
+
+   .. tab-set::
+
+       .. tab-item:: ov.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+               
+             from openvino import convert_model
+             ov_model = convert_model(model)
+             
+             from openvino.preprocess import PrePostProcessor
+             prep = PrePostProcessor(ov_model)
+             prep.input(input_name).preprocess().mean([0.5, 0.5, 0.5])
+             ov_model = prep.build()
+
+       .. tab-item:: mo.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+
+             from openvino.tools.mo import convert_model
+             ov_model = convert_model(model, mean_values=[0.5, 0.5, 0.5])
+
+* scale_value parameter:
+
+   .. tab-set::
+
+       .. tab-item:: ov.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+               
+             from openvino import convert_model
+             ov_model = convert_model(model)
+             
+             from openvino.preprocess import PrePostProcessor
+             prep = PrePostProcessor(ov_model)
+             prep.input(input_name).preprocess().scale([255., 255., 255.])
+             ov_model = prep.build()
+
+       .. tab-item:: mo.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+
+             from openvino.tools.mo import convert_model
+             ov_model = convert_model(model, scale_value=[255., 255., 255.])
+
+* scale parameter:
+
+   .. tab-set::
+
+       .. tab-item:: ov.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+               
+             from openvino import convert_model
+             ov_model = convert_model(model)
+             
+             from openvino.preprocess import PrePostProcessor
+             prep = PrePostProcessor(ov_model)
+             prep.input(input_name).preprocess().scale(255.)
+             ov_model = prep.build()
+
+       .. tab-item:: mo.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+
+             from openvino.tools.mo import convert_model
+             ov_model = convert_model(model, scale=255.)
+
+* reverse_input_channels parameter:
+
+   .. tab-set::
+
+       .. tab-item:: ov.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+               
+             from openvino import convert_model
+             ov_model = convert_model(model)
+             
+             from openvino.preprocess import PrePostProcessor
+             prep = PrePostProcessor(ov_model)
+             prep.input(input_name).preprocess().reverse_channels()
+             ov_model = prep.build()
+
+       .. tab-item:: mo.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+
+             from openvino.tools.mo import convert_model
+             ov_model = convert_model(model, reverse_input_channels=True)
+
+* source_layout parameter:
+
+   .. tab-set::
+
+       .. tab-item:: ov.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+               
+             from openvino import convert_model, Layout
+             ov_model = convert_model(model)
+             
+             from openvino.preprocess import PrePostProcessor
+             prep = PrePostProcessor(ov_model)
+             prep.input(input_name).model().set_layout(Layout("nhwc"))
+             ov_model = prep.build()
+
+       .. tab-item:: mo.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+
+             from openvino import Layout
+             from openvino.tools.mo import convert_model
+             ov_model = convert_model(model, source_layout={input_name: Layout("nhwc")})
+
+
+* target_layout parameter:
+
+   .. tab-set::
+
+       .. tab-item:: ov.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+               
+             from openvino import convert_model, Layout
+             ov_model = convert_model(model)
+             
+             from openvino.preprocess import PrePostProcessor
+             prep = PrePostProcessor(ov_model)
+             prep.input(input_name).tensor().set_layout(Layout("nhwc"))
+             ov_model = prep.build()
+
+       .. tab-item:: mo.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+
+             from openvino import Layout
+             from openvino.tools.mo import convert_model
+             ov_model = convert_model(model, target_layout={input_name: Layout("nhwc")})
+
+
+
+* layout parameter:
+
+   .. tab-set::
+
+       .. tab-item:: ov.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+               
+             from openvino import convert_model, Layout
+             ov_model = convert_model(model)
+             
+             from openvino.preprocess import PrePostProcessor
+             prep = PrePostProcessor(ov_model)
+             prep.input('input.1').model().set_layout(Layout("nchw"))
+             prep.input('input.1').tensor().set_layout(Layout("nhwc"))
+             ov_model = prep.build()
+
+       .. tab-item:: mo.convert_model()
+          :sync: py
+
+          .. code-block:: py
+             :force:
+
+             from openvino import Layout
+             from openvino.tools.mo import convert_model, LayoutMap
+             ov_model = convert_model(model, layout={input_name: LayoutMap("nchw", "nhwc")})


### PR DESCRIPTION
Description: 
OVC and ov.convert_model() documentation.

Tickets: 117328, 117327


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update