### PR TITLE
TorchFX bugfix missing core object in get_device()

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/compile.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/compile.py
@@ -49,6 +49,7 @@ def cache_root_path():
     return cache_root
 
 def get_device():
+    core = Core()
     device = "CPU"
 
     if os.getenv("OPENVINO_TORCH_BACKEND_DEVICE") is not None:


### PR DESCRIPTION
### Details:
- BugFix in TorchFX
- Missing core object in get_device()