### PR TITLE
[CPU]Use parallel_nt_static to WA cpu scheduling issue

### DIFF
--- a/src/plugins/intel_cpu/src/mlas/thread_pool.cpp
+++ b/src/plugins/intel_cpu/src/mlas/thread_pool.cpp
@@ -21,7 +21,7 @@ size_t OVMlasThreadPool::DegreeOfParallelism() {
 }
 
 void OVMlasThreadPool::TrySimpleParallelFor(const std::ptrdiff_t total, const std::function<void(std::ptrdiff_t)>& fn) {
-    ov::parallel_nt(threadNum, [&](const size_t ithr, const size_t nthr) {
+    ov::parallel_nt_static(threadNum, [&](const size_t ithr, const size_t nthr) {
         std::ptrdiff_t start = 0, end = 0;
         ov::splitter(total, nthr, ithr, start, end);
         for (std::ptrdiff_t i = start; i < end; i++) {


### PR DESCRIPTION
### Details:
 - *The parallel_nt doesn't use tbb::static_partitioner, it uses tbb::auto_partitioner, it allows work-stealing, which causes overhead in Xeon-Gold platform.*

### Tickets:
 - *CVS-118282*
