### PR TITLE
[TF FE] Use regular Convolution in case dynamic input channels (#19253)

### DIFF
--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -749,3 +749,29 @@ TEST_F(FrontEndConversionWithReferenceTestsF, TF1IfWithNonExistentOpInBranch) {
         model_ref = make_shared<Model>(OutputVector{mul}, ParameterVector{y, ind});
     }
 }
+
+TEST_F(FrontEndConversionWithReferenceTestsF, ConvolutionWithDynamicInputChannel) {
+    // This test aims to check conversion of a model with convolution of dynamic input channel
+    // Namely, the resulted model must contain the regular convolution, not grouped convolution
+    { model = convert_model("conv_with_dynamic_input_channel"); }
+    {
+        auto input = make_shared<Parameter>(f32, PartialShape{Dimension::dynamic(), 10, 10, Dimension::dynamic()});
+
+        auto transpose_order = make_shared<Constant>(i64, Shape{4}, vector<int32_t>{0, 3, 1, 2});
+        auto transpose = make_shared<Transpose>(input, transpose_order);
+
+        auto filter = make_shared<Constant>(element::f32, Shape{6, 6, 3, 3}, vector<float>(6 * 6 * 3 * 3, 0.0f));
+        auto conv = make_shared<Convolution>(transpose,
+                                             filter,
+                                             Strides{1, 1},
+                                             CoordinateDiff{0, 0},
+                                             CoordinateDiff{0, 0},
+                                             Strides{1, 1},
+                                             op::PadType::SAME_UPPER);
+
+        auto transpose_order_back = make_shared<Constant>(i64, Shape{4}, vector<int32_t>{0, 2, 3, 1});
+        auto transpose_back = make_shared<Transpose>(conv, transpose_order_back);
+
+        model_ref = make_shared<Model>(OutputVector{transpose_back}, ParameterVector{input});
+    }
+}

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_conv_with_dynamic_input_channel.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_conv_with_dynamic_input_channel.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import tensorflow as tf
+
+# Create the graph and model
+tf.compat.v1.reset_default_graph()
+with tf.compat.v1.Session() as sess:
+    filter = tf.constant(value=0, shape=[3, 3, 6, 6], dtype=tf.float32)
+    input = tf.compat.v1.placeholder(dtype=tf.float32, shape=[None, 10, 10, None], name='input')
+    conv = tf.raw_ops.Conv2D(input=input,
+                             filter=filter,
+                             strides=[1, 1, 1, 1],
+                             padding='SAME')
+    tf.compat.v1.saved_model.simple_save(sess, os.path.join(sys.argv[1], "conv_with_dynamic_input_channel"),
+                                         inputs={'input': input}, outputs={'conv': conv})

--- a/tools/mo/unit_tests/moc_tf_fe/conversion_with_layout_test.py
+++ b/tools/mo/unit_tests/moc_tf_fe/conversion_with_layout_test.py
@@ -68,7 +68,7 @@ class TestConversionWithBatchAndLayout(unittest.TestCase):
         *[
             (
                     "model_with_convolution_dynamic_rank.pbtxt", 7, "x(n???),kernel(????)",
-                    {"x": PartialShape([7, Dimension.dynamic(), Dimension.dynamic(), Dimension.dynamic()]),
+                    {"x": PartialShape([7, Dimension.dynamic(), Dimension.dynamic(), 3]),
                      "kernel": PartialShape([2, 2, 3, 1])},
             ),
             (


### PR DESCRIPTION
**Details:** This solution is aligned with the legacy frontend but it has limitation. This is a temporal solution until the core obtains more precise ShapeOf evaluator.
Back-port of https://github.com/openvinotoolkit/openvino/pull/19253

**Ticket:** 102611

