### PR TITLE
[CPU] Added bfloat16.hpp include to MHA node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/mha.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mha.cpp
@@ -17,6 +17,7 @@
 #include "transformations/cpu_opset/x64/op/mha.hpp"
 #include "dnnl_extension_utils.h"
 #include <ie_ngraph_utils.hpp>
+#include "utils/bfloat16.hpp"
 
 using namespace InferenceEngine;
 using namespace InferenceEngine::details;


### PR DESCRIPTION
### Details:
Without the proposed change the following error is raised on Apple M2:
```
openvino/src/plugins/intel_cpu/src/nodes/mha.cpp:1427:36: error: reference to 'bfloat16_t' is ambiguous
        mhaImpl<bfloat16_t>();
                        ^
/opt/homebrew/Cellar/llvm/16.0.6/lib/clang/16/include/arm_neon.h:38:16: note: candidate found by name lookup is 'bfloat16_t'
typedef __bf16 bfloat16_t;
               ^
openvino/src/plugins/intel_cpu/thirdparty/onednn/src/common/bfloat16.hpp:40:8: note: candidate found by name lookup is 'dnnl::impl::bfloat16_t'
struct bfloat16_t {
       ^
openvino/src/plugins/intel_cpu/src/nodes/mha.cpp:1427:36: error: reference to 'bfloat16_t' is ambiguous
        mhaImpl<bfloat16_t>();
                        ^
/opt/homebrew/Cellar/llvm/16.0.6/lib/clang/16/include/arm_neon.h:38:16: note: candidate found by name lookup is 'bfloat16_t'
typedef __bf16 bfloat16_t;
               ^
openvino/src/plugins/intel_cpu/thirdparty/onednn/src/common/bfloat16.hpp:40:8: note: candidate found by name lookup is 'dnnl::impl::bfloat16_t'
struct bfloat16_t {
       ^
2 errors generated.
```
