### PR TITLE
[CPU] Number of streams calculation heuristic moved after LPT

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.h
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.h
@@ -39,8 +39,10 @@ public:
             CPU_DEBUG_CAPS_MAYBE_UNUSED(this->config);
           }
 
-    void UpToCpuSpecificOpSet();
+    void UpToLpt();
     void CpuSpecificOpSet();
+    void PostLpt();
+    void Snippets(void);
 
 private:
     std::shared_ptr<ov::Model> model;
@@ -54,13 +56,9 @@ private:
 
     void Lpt(const bool hasINT16orINT32Levels, const std::vector<ov::element::Type>& defaultPrecisions);
 
-    void PostLpt();
-
     void MainSnippets(void);
 
     void PostSnippets(void);
-
-    void Snippets(void);
 
     static bool fuse_type_to_convert(const std::shared_ptr<ngraph::Node>& node, const precisions_map& precisions);
 };


### PR DESCRIPTION
### Details:
Earlier, streams calculation logic has been moved before all transformations. This led to performance degradations in `hint=tput` mode on some INT8 models.
In this PR, number of streams calculation heuristic moved after LPT in plugin pipeline. This allows to take into account the precision of the weights when heuristic is applied.

### Tickets:
 - *CVS-117971*

PR to release branch: #19312 