### PR TITLE
[Snippets] Fixed memory leak in LinearIR

### DIFF
--- a/src/common/snippets/include/snippets/lowered/expression_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_port.hpp
@@ -26,7 +26,7 @@ public:
     ExpressionPort() = default;
     explicit ExpressionPort(const std::shared_ptr<Expression>& expr, Type type, size_t port);
 
-    const std::shared_ptr<Expression>& get_expr() const { return m_expr; }
+    std::shared_ptr<Expression> get_expr() const;
     Type get_type() const { return m_type; }
     size_t get_index() const { return m_port_index; }
 
@@ -42,7 +42,7 @@ public:
     friend bool operator<(const ExpressionPort& lhs, const ExpressionPort& rhs);
 
 private:
-    std::shared_ptr<Expression> m_expr;
+    std::weak_ptr<Expression> m_expr;
     Type m_type = Type::Output;
     size_t m_port_index = 0;
 };

--- a/src/common/snippets/src/lowered/expression_factory.cpp
+++ b/src/common/snippets/src/lowered/expression_factory.cpp
@@ -57,7 +57,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::op::
                                                   const LinearIR& linear_ir, const std::shared_ptr<ov::Model>& model) {
     // Note: ctor of shared_ptr isn't friend class for Expression -> we cannot use directly make_shared<Expression>(args)
     OPENVINO_ASSERT(model != nullptr, "To create IOExpression from Parameter there must be inited model!");
-    auto expr = std::make_shared<IOExpression>(IOExpression(par, model->get_parameter_index(par)));
+    auto expr = std::shared_ptr<IOExpression>(new IOExpression(IOExpression(par, model->get_parameter_index(par))));
     create_expression_outputs(expr);
     expr->validate();
     return expr;
@@ -67,7 +67,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::op::
                                                   const LinearIR& linear_ir, const std::shared_ptr<ov::Model>& model) {
     // Note: ctor of shared_ptr isn't friend class for Expression -> we cannot use directly make_shared<Expression>(args)
     OPENVINO_ASSERT(model != nullptr, "To create IOExpression from Result there must be inited model!");
-    auto expr = std::make_shared<IOExpression>(IOExpression(res, model->get_result_index(res)));
+    auto expr = std::shared_ptr<IOExpression>(new IOExpression(res, model->get_result_index(res)));
     create_expression_inputs(linear_ir, expr);
     // The Result node don't need output port (because of sense of the node). But each node in ngraph must have one output at least.
     // The port descriptors are automatically created in constructor. We manually clean output ports.
@@ -80,7 +80,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::Node
                                                   const std::shared_ptr<ov::Model>& model) {
     OPENVINO_ASSERT(!ov::is_type<op::LoopBase>(n), "Default expression builder doesn't support LoopBegin and LoopEnd");
     // Note: ctor of shared_ptr isn't friend class for Expression
-    auto expr = std::make_shared<Expression>(Expression(n));
+    auto expr = std::shared_ptr<Expression>(new Expression(n));
     create_expression_inputs(linear_ir, expr);
     create_expression_outputs(expr);
     expr->validate();
@@ -97,7 +97,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::Loop
 }
 
 ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::LoopEnd>& n, const std::vector<PortConnectorPtr>& inputs) {
-    auto expr = std::make_shared<Expression>(Expression(n));
+    auto expr = std::shared_ptr<Expression>(new Expression(n));
     expr->m_input_port_descriptors.resize(inputs.size(), nullptr);
     for (size_t i = 0; i < inputs.size() - 1; ++i) {
         expr->m_input_port_descriptors[i] = std::make_shared<PortDescriptor>();
@@ -117,7 +117,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::Node
     OPENVINO_ASSERT(!ov::is_type<ov::op::v0::Parameter>(n) &&
                     !ov::is_type<ov::op::v0::Result>(n),
                     "Expression builder with inputs doesn't support Result and Parameter");
-    auto expr = std::make_shared<Expression>(Expression(n));
+    auto expr = std::shared_ptr<Expression>(new Expression(n));
     init_expression_inputs(expr, inputs);
     create_expression_outputs(expr);
     expr->validate();

--- a/src/common/snippets/src/lowered/expression_factory.cpp
+++ b/src/common/snippets/src/lowered/expression_factory.cpp
@@ -57,7 +57,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::op::
                                                   const LinearIR& linear_ir, const std::shared_ptr<ov::Model>& model) {
     // Note: ctor of shared_ptr isn't friend class for Expression -> we cannot use directly make_shared<Expression>(args)
     OPENVINO_ASSERT(model != nullptr, "To create IOExpression from Parameter there must be inited model!");
-    auto expr = std::shared_ptr<IOExpression>(new IOExpression(IOExpression(par, model->get_parameter_index(par))));
+    auto expr = std::shared_ptr<IOExpression>(new IOExpression(par, model->get_parameter_index(par)));
     create_expression_outputs(expr);
     expr->validate();
     return expr;

--- a/src/common/snippets/src/lowered/expression_port.cpp
+++ b/src/common/snippets/src/lowered/expression_port.cpp
@@ -14,26 +14,32 @@ namespace lowered {
 ExpressionPort::ExpressionPort(const std::shared_ptr<Expression>& expr, Type type, size_t port)
         : m_expr(expr), m_type(type), m_port_index(port) {}
 
+std::shared_ptr<Expression> ExpressionPort::get_expr() const {
+    const auto expr_ptr = m_expr.lock();
+    OPENVINO_ASSERT(expr_ptr != nullptr, "ExpressionPort has invalid expression pointer");
+    return expr_ptr;
+}
+
 const PortDescriptorPtr& ExpressionPort::get_descriptor_ptr() const {
-    const auto& descs = m_type == Type::Input ? m_expr->m_input_port_descriptors
-                                              : m_expr->m_output_port_descriptors;
+    const auto& descs = m_type == Type::Input ? get_expr()->m_input_port_descriptors
+                                              : get_expr()->m_output_port_descriptors;
     OPENVINO_ASSERT(m_port_index < descs.size(), "Incorrect index of port");
     return descs[m_port_index];
 }
 
 const std::shared_ptr<PortConnector>& ExpressionPort::get_port_connector_ptr() const {
-    const auto& connectors = m_type == Type::Input ? m_expr->m_input_port_connectors
-                                                : m_expr->m_output_port_connectors;
+    const auto& connectors = m_type == Type::Input ? get_expr()->m_input_port_connectors
+                                                   : get_expr()->m_output_port_connectors;
     OPENVINO_ASSERT(m_port_index < connectors.size(), "Incorrect index of port");
     return connectors[m_port_index];
 }
 
 std::set<ExpressionPort> ExpressionPort::get_connected_ports() const {
     if (ExpressionPort::m_type == Type::Input) {
-        return { m_expr->m_input_port_connectors[m_port_index]->get_source() };
+        return { get_expr()->m_input_port_connectors[m_port_index]->get_source() };
     }
     if (ExpressionPort::m_type == Type::Output) {
-        return m_expr->m_output_port_connectors[m_port_index]->get_consumers();
+        return get_expr()->m_output_port_connectors[m_port_index]->get_consumers();
     }
     OPENVINO_THROW("ExpressionPort supports only Input and Output types");
 }


### PR DESCRIPTION
### Details:
 - *Changed `shared_ptr<Expression>` in `ExpressionPort` to `weak_ptr<Expression>` to remove retain cycle in Linear IR*
![image](https://github.com/openvinotoolkit/openvino/assets/43129309/14f2485a-eebe-47d2-bfbc-98347534c681)

 - *[PR](https://github.com/openvinotoolkit/openvino/pull/19317) to release branch*

### Tickets:
 - *117366*
