### PR TITLE
[Snippets] Brgemm blocking by KN dims at the LIR level

### DIFF
--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -63,7 +63,7 @@ public:
     LinearIR() = default;
     LinearIR(const std::shared_ptr<ov::Model>& m, const std::shared_ptr<IShapeInferSnippetsFactory>& factory, Config config = {});
 
-    ExpressionPtr create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& inputs);
+    ExpressionPtr create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& inputs) const;
 
     std::shared_ptr<LinearIR> clone() const;
     static LinearIR::container deep_copy_range(LinearIR::container::const_iterator begin,

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -21,18 +21,7 @@ public:
 
     struct LoopPort {
         LoopPort() = default;
-        LoopPort(const ExpressionPort& port, bool is_incremented = true, size_t dim_idx = 0)
-            : expr_port(std::make_shared<ExpressionPort>(port)),
-              is_incremented(is_incremented),
-              dim_idx(dim_idx) {
-            OPENVINO_ASSERT(dim_idx < port.get_descriptor_ptr()->get_shape().size(),
-                            "LoopPort dim_idx (",
-                            dim_idx,
-                            ") must be less than the corresponding expression port shape rank (",
-                            port.get_descriptor_ptr()->get_shape().size(),
-                            ")");
-        }
-
+        LoopPort(const ExpressionPort& port, bool is_incremented = true, size_t dim_idx = 0);
         std::shared_ptr<LoopPort> clone_with_new_expr(const ExpressionPtr& new_expr) const;
 
         friend bool operator==(const LoopPort& lhs, const LoopPort& rhs);
@@ -51,35 +40,63 @@ public:
 
     class LoopInfo {
     public:
+        enum {UNDEFINED_DIM_IDX = std::numeric_limits<size_t>::max()};
         LoopInfo() = default;
         LoopInfo(size_t work_amount, size_t increment,
                  const std::vector<LoopPort>& entries,
-                 const std::vector<LoopPort>& exits)
-            : work_amount(work_amount), increment(increment),
-              entry_points(entries), exit_points(exits), outer_splited_loop(false) {}
+                 const std::vector<LoopPort>& exits,
+                 bool outer_splited_loop = false)
+            : m_work_amount(work_amount), m_increment(increment),
+              m_entry_points(entries), m_exit_points(exits), m_outer_splited_loop(outer_splited_loop) {}
         LoopInfo(size_t work_amount, size_t increment,
                  const std::vector<ExpressionPort>& entries,
-                 const std::vector<ExpressionPort>& exits);
+                 const std::vector<ExpressionPort>& exits,
+                 bool outer_splited_loop = false);
 
         std::shared_ptr<LoopInfo> clone_with_new_expr(const ExressionMap& expr_map) const;
-        // Returns dimension index if dimension indices for all entry and exit points are equal, and SIZE_MAX otherwise
+
+        // Returns dimension index if dimension indices for all entry and exit points are equal, and UNDEFINED_DIM_IDX otherwise
         size_t get_dim_idx() const;
+        size_t get_work_amount() const;
+        size_t get_increment() const;
+        const std::vector<LoopPort>& get_entry_points() const;
+        const std::vector<LoopPort>& get_exit_points() const;
+        bool get_outer_splited_loop() const;
 
-        // TODO: replace this temporary solution when ticket 119851 is implemented
+        /**
+         * \brief Inserts a separate body for first loop iteration processing if needed.
+         * Can also modify both main and first iter loop bodies.
+         * TODO: replace this temporary solution when ticket 119851 is implemented
+         *
+         * \param linear_ir LIR which should be modified
+         * \param loop_end_it iterator on LoopEnd expression for which the handler is called
+         *
+         * \return bool value which indicates whether the linear_ir was changed or not.
+         */
         using FirstIterHandler = std::function<bool(LinearIR&, LinearIR::constExprIt)>;
-        void set_first_iter_handler(FirstIterHandler handler);
-        FirstIterHandler fst_iter_handler = nullptr;
+        const FirstIterHandler& get_first_iter_handler() const;
 
-        size_t work_amount = 0;
-        size_t increment = 0;
+        // Sets dim_idx to all entry and exit points
+        void set_dim_idx(size_t dim_idx);
+        void set_work_amount(size_t work_amount);
+        void set_increment(size_t increment);
+        void set_entry_points(std::vector<LoopPort> entry_points);
+        void set_exit_points(std::vector<LoopPort> exit_points);
+        void set_outer_splited_loop(bool outer_splited_loop);
+        void set_first_iter_handler(FirstIterHandler handler);
+
+    private:
+        size_t m_work_amount = 0;
+        size_t m_increment = 0;
         // The order of entry and exit expressions is important:
         //     - The position before first entry expr is Loop Begin position
         //     - The position after last exit expr is Loop End position
         // Note: Scalars aren't entry expressions but can be before first entry expr in Linear IR
-        std::vector<LoopPort> entry_points = {};
-        std::vector<LoopPort> exit_points = {};
+        std::vector<LoopPort> m_entry_points = {};
+        std::vector<LoopPort> m_exit_points = {};
         // True if this Loop is outer Loop for nested Loops that splits the same dimension
-        bool outer_splited_loop = false;
+        bool m_outer_splited_loop = false;
+        FirstIterHandler m_first_iter_handler = nullptr;
     };
     using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 
@@ -106,12 +123,7 @@ public:
                      const std::vector<T>& entries,
                      const std::vector<T>& exits) {
         const auto loop_info = std::make_shared<LoopManager::LoopInfo>(work_amount, work_amount_increment, entries, exits);
-        auto set_common_dim_idx = [dim_idx](std::vector<LoopPort>& ports) {
-            for (auto& port : ports)
-                port.dim_idx = dim_idx;
-        };
-        set_common_dim_idx(loop_info->entry_points);
-        set_common_dim_idx(loop_info->exit_points);
+        loop_info->set_dim_idx(dim_idx);
         const auto loop_id = this->add_loop_info(loop_info);
         for (auto expr_it = loop_begin_pos; expr_it != loop_end_pos; ++expr_it) {
             insert_loop_id(*expr_it, loop_id);
@@ -134,13 +146,14 @@ public:
         return loop_id;
     }
 
-    size_t mark_loop_with_old_loop_replacement(LinearIR::constExprIt loop_begin_pos,
-                                               LinearIR::constExprIt loop_end_pos,
-                                               size_t work_amount,
-                                               size_t increment,
-                                               const std::vector<LoopPort>& entries,
-                                               const std::vector<LoopPort>& exits,
-                                               const size_t old_id);
+    size_t replace_with_new_loop(const LinearIR& linear_ir,
+                                 LinearIR::constExprIt loop_begin_pos,
+                                 LinearIR::constExprIt loop_end_pos,
+                                 size_t work_amount,
+                                 size_t increment,
+                                 const std::vector<LoopPort>& entries,
+                                 const std::vector<LoopPort>& exits,
+                                 const size_t old_id);
 
     void fuse_loops(const LinearIR& linear_ir, size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper = true);
     void fuse_loops(LinearIR::constExprIt loop_begin_target, LinearIR::constExprIt loop_end_target,

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -25,14 +25,9 @@ public:
     bool run(LinearIR& linear_ir) override;
 
 private:
-    static void init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
-                                    std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
-                                    size_t work_amount);
-    static void init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
-                                          std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
-                                          size_t work_amount);
-    static void init_element_type_sizes(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
-                                        std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs);
+    static void init_ptr_increments(const LinearIR::LoopManager::LoopInfoPtr& loop_info);
+    static void init_finalization_offsets(const LinearIR::LoopManager::LoopInfoPtr& loop_info);
+    static void init_element_type_sizes(const LinearIR::LoopManager::LoopInfoPtr& loop_info);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -27,7 +27,7 @@ public:
 private:
     static void init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
                                     std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
-                                    size_t work_amount, size_t dim_idx);
+                                    size_t work_amount);
     static void init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
                                           std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
                                           size_t work_amount);

--- a/src/common/snippets/include/snippets/lowered/pass/insert_tail_loop.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_tail_loop.hpp
@@ -7,6 +7,7 @@
 #include "pass.hpp"
 
 #include "snippets/op/loop.hpp"
+#include "snippets/lowered/loop_manager.hpp"
 
 namespace ov {
 namespace snippets {
@@ -23,21 +24,24 @@ class InsertTailLoop : public Pass {
 public:
     OPENVINO_RTTI("InsertTailLoop", "Pass")
     bool run(LinearIR& linear_ir) override;
+    static LinearIR::container copy_loop(const LinearIR& linear_ir, const size_t loop_id);
+    static void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
+                                                         const LinearIR::LoopManager::LoopInfoPtr& loop_info,
+                                                         LinearIR::container::const_iterator begin,
+                                                         LinearIR::container::const_iterator end,
+                                                         const size_t new_dim_value = SIZE_MAX);
 
 private:
-    static std::shared_ptr<op::LoopEnd> create_tail_loop(LinearIR& linear_ir,
-                                                         LinearIR::constExprIt vector_begin,
-                                                         LinearIR::constExprIt vector_end,
-                                                         LinearIR::constExprIt& tail_begin,
-                                                         LinearIR::constExprIt& tail_end,
-                                                         const std::shared_ptr<op::LoopEnd>& vector_loop_end,
-                                                         bool need_vector_loop,
-                                                         size_t tail_size, const std::vector<int64_t>& tail_finalization_offsets);
+    static void create_tail_loop(LinearIR& linear_ir,
+                                 LinearIR::constExprIt begin,
+                                 LinearIR::constExprIt end,
+                                 const std::shared_ptr<op::LoopEnd>& loop_end,
+                                 bool need_vector_loop,
+                                 size_t tail_size);
     static void tail_transformations(LinearIR& linear_ir,
                                      LinearIR::constExprIt tail_begin,
                                      LinearIR::constExprIt tail_end,
                                      size_t tail_size);
-    static bool optimize_single_evaluation(const std::shared_ptr<op::LoopEnd>& loop);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/insert_tail_loop.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_tail_loop.hpp
@@ -25,11 +25,13 @@ public:
     OPENVINO_RTTI("InsertTailLoop", "Pass")
     bool run(LinearIR& linear_ir) override;
     static LinearIR::container copy_loop(const LinearIR& linear_ir, const size_t loop_id);
+
+    static constexpr size_t existing_subtensor_value = SIZE_MAX;
     static void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
                                                          const LinearIR::LoopManager::LoopInfoPtr& loop_info,
                                                          LinearIR::container::const_iterator begin,
                                                          LinearIR::container::const_iterator end,
-                                                         const size_t new_dim_value = SIZE_MAX);
+                                                         const size_t new_dim_value = existing_subtensor_value);
 
 private:
     static void create_tail_loop(LinearIR& linear_ir,

--- a/src/common/snippets/include/snippets/lowered/pass/optimize_loop_single_evaluation.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/optimize_loop_single_evaluation.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "pass.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+/**
+ * @interface OptimizeLoopSingleEvaluation
+ * @brief Does the following optimizations if the Loop body can be executed only once:
+ *        - sets evaluate_once parameter to true
+ *        - moves all ptr arithmetic to finalization offsets
+ * @ingroup snippets
+ */
+class OptimizeLoopSingleEvaluation : public Pass {
+public:
+    OPENVINO_RTTI("OptimizeLoopSingleEvaluation", "Pass")
+    bool run(LinearIR& linear_ir) override;
+};
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/op/broadcastload.hpp
+++ b/src/common/snippets/include/snippets/op/broadcastload.hpp
@@ -21,7 +21,7 @@ class BroadcastLoad : public MemoryAccess {
 public:
     OPENVINO_OP("BroadcastLoad", "SnippetsOpset", ov::snippets::op::MemoryAccess);
 
-    BroadcastLoad(const Output<Node>& x, ov::PartialShape output_shape, size_t offset = 0lu);
+    BroadcastLoad(const Output<Node>& x, ov::Dimension bcast_dimension, size_t offset = 0lu);
     BroadcastLoad() = default;
 
     size_t get_offset() const { return get_input_offset(0); }
@@ -29,7 +29,8 @@ public:
     bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
     void validate_and_infer_types() override;
-    ov::PartialShape get_output_shape() {return output_shape;}
+    const ov::Dimension& get_bcast_dimension() {return bcast_dimension;}
+    void set_bcast_dimension(const ov::Dimension new_dim) {bcast_dimension = new_dim;}
 
     // Note:BroadcastMove and BroadcastLoad are implemented as separate classes,
     // but have identical shapeInfer semantics. In order to avoid code duplication,
@@ -39,7 +40,7 @@ public:
         explicit ShapeInfer(const std::shared_ptr<Node>& n) : BroadcastShapeInfer<BroadcastLoad>(n) {}
     };
 private:
-    ov::PartialShape output_shape;
+    ov::Dimension bcast_dimension;
 };
 
 } // namespace op

--- a/src/common/snippets/include/snippets/op/broadcastload.hpp
+++ b/src/common/snippets/include/snippets/op/broadcastload.hpp
@@ -30,7 +30,7 @@ public:
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
     void validate_and_infer_types() override;
     const ov::Dimension& get_bcast_dimension() {return bcast_dimension;}
-    void set_bcast_dimension(const ov::Dimension new_dim) {bcast_dimension = new_dim;}
+    void set_bcast_dimension(ov::Dimension new_dim) {bcast_dimension = std::move(new_dim);}
 
     // Note:BroadcastMove and BroadcastLoad are implemented as separate classes,
     // but have identical shapeInfer semantics. In order to avoid code duplication,

--- a/src/common/snippets/include/snippets/op/broadcastmove.hpp
+++ b/src/common/snippets/include/snippets/op/broadcastmove.hpp
@@ -29,7 +29,7 @@ public:
 
     void validate_and_infer_types() override;
     const ov::Dimension& get_bcast_dimension() {return bcast_dimension;}
-    void set_bcast_dimension(const ov::Dimension new_dim) {bcast_dimension = new_dim;}
+    void set_bcast_dimension(ov::Dimension new_dim) {bcast_dimension = std::move(new_dim);}
     // Note:BroadcastMove and BroadcastLoad are implemented as separate classes,
     // but have identical shapeInfer semantics. In order to avoid code duplication,
     // we created dummy ShapeInfer classes that are essentially instantiations

--- a/src/common/snippets/include/snippets/op/broadcastmove.hpp
+++ b/src/common/snippets/include/snippets/op/broadcastmove.hpp
@@ -20,7 +20,7 @@ class BroadcastMove : public ov::op::Op {
 public:
     OPENVINO_OP("BroadcastMove", "SnippetsOpset");
 
-    BroadcastMove(const Output<Node>& x, ov::PartialShape output_shape);
+    BroadcastMove(const Output<Node>& x, ov::Dimension bcast_dimension);
     BroadcastMove() = default;
 
     bool visit_attributes(AttributeVisitor& visitor) override;
@@ -28,7 +28,8 @@ public:
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
     void validate_and_infer_types() override;
-    ov::PartialShape get_output_shape() {return output_shape;}
+    const ov::Dimension& get_bcast_dimension() {return bcast_dimension;}
+    void set_bcast_dimension(const ov::Dimension new_dim) {bcast_dimension = new_dim;}
     // Note:BroadcastMove and BroadcastLoad are implemented as separate classes,
     // but have identical shapeInfer semantics. In order to avoid code duplication,
     // we created dummy ShapeInfer classes that are essentially instantiations
@@ -38,7 +39,7 @@ public:
     };
 
 protected:
-    ov::PartialShape output_shape;
+    ov::Dimension bcast_dimension;
 };
 
 } // namespace op

--- a/src/common/snippets/include/snippets/op/buffer.hpp
+++ b/src/common/snippets/include/snippets/op/buffer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "openvino/op/op.hpp"
+#include "snippets/shape_inference/shape_inference.hpp"
 
 namespace ov {
 namespace snippets {
@@ -13,13 +14,10 @@ namespace op {
 /**
  * @interface Buffer
  * @brief This is a base class for memory storage.
- *        If Buffer has a parent, the operation is for intermediate data storage - IntermediateMemory type.
- *        Otherwise, the operation is for allocation of new empty memory with shape `m_shape` - NewMemory type
  *        Notes:
  *               - All buffers with the same ID in a graph have the same memory pointer. So if we have a few buffers,
  *                 each the corresponding MemoryAccess op for Buffer should have offset for common memory pointer of this Buffer
  *               - Buffer should be a single consumer for operation output port
- * @param m_type - type of Buffer: IntermediateMemory/NewMemory
  * @param m_shape - output allocation shape for Buffer with type NewMemory
  * @param m_offset - offset in common Buffer scratchpad
  * @param m_id - Buffer ID in common Buffer system
@@ -29,21 +27,11 @@ class Buffer : public ov::op::Op {
 public:
     OPENVINO_OP("Buffer", "SnippetsOpset");
     Buffer() = default;
-    Buffer(const ov::Shape& shape, ov::element::Type element_type = ov::element::u8, size_t id = 0);
-    Buffer(const ov::Output<ov::Node>& arg, const ov::Shape& shape, size_t id = 0);
-    Buffer(const ov::Output<ov::Node>& arg, int32_t allocation_rank = -1, size_t id = 0);
+    Buffer(const OutputVector& arguments, const ov::Shape& shape, size_t id, ov::element::Type element_type = ov::element::u8);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
-    void validate_and_infer_types() override;
-    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-
-    enum Type {
-        NewMemory,
-        IntermediateMemory
-    };
 
     size_t get_id() const { return m_id; }
-    Type get_type() const { return m_type; }
     int64_t get_offset() const { return m_offset; }
     void set_id(size_t id) { m_id = id; }
     const ov::Shape& get_allocation_shape() const { return m_shape; }
@@ -51,17 +39,55 @@ public:
     void set_offset(int64_t offset) { m_offset = offset; }
     size_t get_byte_size() const;
 
-    void set_element_type(ov::element::Type element_type);
-
-    bool is_intermediate_memory() const { return m_type == Type::IntermediateMemory; }
-    bool is_new_memory() const { return m_type == Type::NewMemory; }
-
-private:
-    Type m_type = Type::IntermediateMemory;
+protected:
     ov::Shape m_shape = {};
-    int64_t m_offset = 0;
     size_t m_id = 0;  // Default ID - 0. All Buffers are from the same set
     ov::element::Type m_element_type = ov::element::u8;  // u8 - default 1 byte
+    int64_t m_offset = 0;
+};
+
+/**
+ * @interface IntermediateMemoryBuffer
+ * @brief Represents an intermediate memory storage operation. It always has a parent.
+ * @ingroup snippets
+ *
+ */
+class IntermediateMemoryBuffer : public Buffer {
+public:
+    OPENVINO_OP("IntermediateMemoryBuffer", "SnippetsOpset", Buffer);
+    IntermediateMemoryBuffer() = default;
+    IntermediateMemoryBuffer(const ov::Output<ov::Node>& arg, const ov::Shape& shape, size_t id = 0);
+    IntermediateMemoryBuffer(const ov::Output<ov::Node>& arg, int32_t allocation_rank = -1, size_t id = 0);
+
+    void validate_and_infer_types() override;
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+
+private:
+    ov::Shape compute_shape_from_allocation_rank(const ov::Output<ov::Node>& arg, int32_t allocation_rank);
+};
+
+/**
+ * @interface NewMemoryBuffer
+ * @brief Represents a new empty memory for allocation with specified shape. It has no parent operations.
+ * @ingroup snippets
+ *
+ */
+class NewMemoryBuffer : public Buffer {
+public:
+    OPENVINO_OP("NewMemoryBuffer", "SnippetsOpset", Buffer);
+    NewMemoryBuffer() = default;
+    NewMemoryBuffer(const ov::Shape& shape, size_t id = 0, ov::element::Type element_type = ov::element::u8);
+
+    void validate_and_infer_types() override;
+    void set_element_type(ov::element::Type element_type);
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+
+    class ShapeInfer : public IShapeInferSnippets {
+        ov::Shape m_shape;
+    public:
+        explicit ShapeInfer(const std::shared_ptr<ov::Node>& n);
+        Result infer(const std::vector<VectorDimsRef>& input_shapes) override;
+    };
 };
 
 } // namespace op

--- a/src/common/snippets/include/snippets/op/loop.hpp
+++ b/src/common/snippets/include/snippets/op/loop.hpp
@@ -56,11 +56,8 @@ private:
  * @param args vector of input values + LoopBegin, all values except for the LoopBegin are passed directly to output.
  * @param work_amount total number of evaluations to be processed by the loop
  * @param increment number of evaluations processed in one iteration of the loop.
- * @param apply_increment describes which data pointers attributed to the loop should be incremented on every iteration.
- * should be used when Loop is connected to Parameters and/or Results. If apply_increment[i] == true then i-th i/o data
- * pointer will be incremented by work_amount*data_size on every iteration.
- * @param ptr_increments specifies i/o pointer increment performed on every iteration. This is an alternative to
- * apply_increments, which enables more flexibility.
+ * @param is_incremented describes which data pointers attributed to the loop should be incremented on every iteration.
+ * @param ptr_increments specifies i/o pointer increment performed on every iteration if the following is_incremented[i] is true
  * @param finalization_offsets pointer increments that are be applied to i/o pointers before exiting the loop
  * @param id the identifier of Loop in Loop system in LoopManager
  * @ingroup snippets
@@ -69,16 +66,14 @@ class LoopEnd : public LoopBase {
 public:
     OPENVINO_OP("LoopEnd", "SnippetsOpset", LoopBase);
     LoopEnd(const Output<Node>& loop_begin, size_t work_amount, size_t work_amount_increment,
-              std::vector<bool> apply_increment, std::vector<int64_t> finalization_offsets,
-              std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num, size_t id);
-    LoopEnd(const Output<Node>& loop_begin, size_t work_amount, size_t work_amount_increment,
-            std::vector<int64_t> ptr_increments, std::vector<int64_t> finalization_offsets,
+            std::vector<bool> is_incremented, std::vector<int64_t> ptr_increments, std::vector<int64_t> finalization_offsets,
             std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num, size_t id);
     LoopEnd() = default;
     std::shared_ptr<LoopBegin> get_loop_begin();
     void validate_and_infer_types() override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& inputs)  const override;
     const std::vector<int64_t>& get_finalization_offsets() const;
+    const std::vector<bool>& get_is_incremented() const;
     const std::vector<int64_t>& get_ptr_increments() const;
     const std::vector<int64_t>& get_element_type_sizes() const;
     size_t get_input_num() const;
@@ -91,6 +86,7 @@ public:
     void set_work_amount(size_t new_work_amount);
     void set_increment(size_t new_increment);
     void set_evaluate_once(bool once);
+    void set_id(size_t new_id);
     // Used to propagate information about Loop structure, needed to simplify some optimizations. For example,
     // to skip pointer increments when outer Loop is empty, and work_amount == vector_size (one inner vector Loop)
     // true by default, the optimizations enabled if it's false;
@@ -102,6 +98,7 @@ public:
     bool visit_attributes(AttributeVisitor& visitor) override;
 
 private:
+    std::vector<bool> m_is_incremented = {};
     std::vector<int64_t> m_ptr_increments = {};
     std::vector<int64_t> m_finalization_offsets = {};
     std::vector<int64_t> m_element_type_sizes = {};

--- a/src/common/snippets/include/snippets/shape_inference/shape_infer_instances.hpp
+++ b/src/common/snippets/include/snippets/shape_inference/shape_infer_instances.hpp
@@ -21,7 +21,7 @@ public:
 
 template<class BroadcastOP>
 class BroadcastShapeInfer : public IShapeInferSnippets {
-    VectorDims::value_type m_broadcasted_dim;
+    std::shared_ptr<BroadcastOP> broadcast_op;
 public:
     explicit BroadcastShapeInfer(const std::shared_ptr<Node>& n);
     Result infer(const std::vector<VectorDimsRef>& input_shapes) override;

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -6,7 +6,9 @@
 
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/lowered/pass/assign_registers.hpp"
+#include "snippets/lowered/pass/cleanup_loop_offsets.hpp"
 #include "snippets/lowered/pass/insert_tail_loop.hpp"
+#include "snippets/lowered/pass/optimize_loop_single_evaluation.hpp"
 
 #include "snippets/op/kernel.hpp"
 
@@ -27,6 +29,8 @@ void Generator::generate(lowered::LinearIR& linear_ir, LoweringResult& result, c
     lowered::pass::PassPipeline lowered_pipeline;
     lowered_pipeline.register_pass<lowered::pass::AssignRegisters>(reg_type_mapper);
     lowered_pipeline.register_pass<lowered::pass::InsertTailLoop>();
+    lowered_pipeline.register_pass<lowered::pass::CleanupLoopOffsets>();
+    lowered_pipeline.register_pass<lowered::pass::OptimizeLoopSingleEvaluation>();
     lowered_pipeline.run(linear_ir);
     linear_ir.init_emitters(target);
 

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -77,7 +77,8 @@ Generator::opRegType Generator::get_op_reg_type(const std::shared_ptr<Node>& op)
         std::dynamic_pointer_cast<op::LoopBegin>(op) ||
         std::dynamic_pointer_cast<op::LoopEnd>(op) ||
         std::dynamic_pointer_cast<op::Brgemm>(op) ||
-        std::dynamic_pointer_cast<op::Buffer>(op) ||
+        std::dynamic_pointer_cast<op::IntermediateMemoryBuffer>(op) ||
+        std::dynamic_pointer_cast<op::NewMemoryBuffer>(op) ||
         std::dynamic_pointer_cast<op::RankNormalization>(op) ||
         std::dynamic_pointer_cast<op::PerfCountBeginBase>(op) ||
         std::dynamic_pointer_cast<op::PerfCountEndBase>(op))

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -67,7 +67,7 @@ ExpressionPtr LinearIR::create_expression(const std::shared_ptr<Node>& n, const 
     return ExpressionFactory::build(n, *this, model);
 }
 
-ExpressionPtr LinearIR::create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& inputs) {
+ExpressionPtr LinearIR::create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& inputs) const {
     return ExpressionFactory::build(n, inputs, *this);
 }
 
@@ -124,8 +124,9 @@ LinearIR::container LinearIR::deep_copy_range(LinearIR::container::const_iterato
     OPENVINO_ASSERT(expression_map.empty(), "deep_copy_range expects empty expression_map as an input");
     LinearIR::container result;
     NodeVector original_nodes;
-    for (auto it = begin; it != end; it++)
+    for (auto it = begin; it != end; it++) {
         original_nodes.push_back((*it)->get_node());
+    }
 
     // node_map and expr_map map original node pointer (expression) to a new pointer (expression)
     ngraph::NodeMap node_map;

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -66,8 +66,7 @@ std::shared_ptr<LoopManager> LoopManager::clone_with_new_expr(const ExressionMap
 }
 
 size_t LinearIR::LoopManager::LoopInfo::get_dim_idx() const {
-    if (entry_points.empty())
-        return SIZE_MAX;
+    OPENVINO_ASSERT(!entry_points.empty(), "Loop info must have at least one entry point");
     auto equal_dim_idxes = [&](const LinearIR::LoopManager::LoopPort& p) {
         return p.dim_idx == entry_points[0].dim_idx;
     };

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -19,21 +19,38 @@ using LoopManager = LinearIR::LoopManager;
 using LoopPort = LoopManager::LoopPort;
 using LoopInfo = LoopManager::LoopInfo;
 
+LoopPort::LoopPort(const ExpressionPort& port, bool is_incremented, size_t dim_idx)
+    : expr_port(std::make_shared<ExpressionPort>(port)),
+      is_incremented(is_incremented),
+      dim_idx(dim_idx) {
+    OPENVINO_ASSERT(dim_idx < port.get_descriptor_ptr()->get_shape().size(),
+                    "LoopPort dim_idx (",
+                    dim_idx,
+                    ") must be less than the corresponding expression port shape rank (",
+                    port.get_descriptor_ptr()->get_shape().size(),
+                    ")");
+}
+
 std::shared_ptr<LoopPort> LoopPort::clone_with_new_expr(const ExpressionPtr& new_expr) const {
     auto new_loop_port = std::make_shared<LoopPort>(*this);
     new_loop_port->expr_port = expr_port->clone_with_new_expr(new_expr);
     return new_loop_port;
 }
 
-LinearIR::LoopManager::LoopInfo::LoopInfo(size_t work_amount, size_t increment,
-                                          const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits)
-    : work_amount(work_amount), increment(increment), outer_splited_loop(false) {
-    entry_points.reserve(entries.size());
-    exit_points.reserve(exits.size());
+LinearIR::LoopManager::LoopInfo::LoopInfo(size_t work_amount,
+                                          size_t increment,
+                                          const std::vector<ExpressionPort>& entries,
+                                          const std::vector<ExpressionPort>& exits,
+                                          bool outer_splited_loop)
+    : m_work_amount(work_amount),
+      m_increment(increment),
+      m_outer_splited_loop(outer_splited_loop) {
+    m_entry_points.reserve(entries.size());
+    m_exit_points.reserve(exits.size());
     for (const auto& port : entries)
-        entry_points.emplace_back(port);
+        m_entry_points.emplace_back(port);
     for (const auto& port : exits)
-        exit_points.emplace_back(port);
+        m_exit_points.emplace_back(port);
 }
 
 std::shared_ptr<LoopInfo> LoopInfo::clone_with_new_expr(const ExressionMap& expr_map) const {
@@ -48,38 +65,80 @@ std::shared_ptr<LoopInfo> LoopInfo::clone_with_new_expr(const ExressionMap& expr
         }
         return cloned_port_points;
     };
-    const auto& new_entry_points = clone_loop_ports(entry_points);
-    const auto& new_exit_points = clone_loop_ports(exit_points);
+    const auto& new_entry_points = clone_loop_ports(m_entry_points);
+    const auto& new_exit_points = clone_loop_ports(m_exit_points);
 
-    auto new_loop_info = std::make_shared<LoopInfo>(work_amount, increment, new_entry_points, new_exit_points);
-    new_loop_info->outer_splited_loop = outer_splited_loop;
-
-    return new_loop_info;
+    return std::make_shared<LoopInfo>(m_work_amount, m_increment, new_entry_points, new_exit_points, m_outer_splited_loop);
 }
 
-std::shared_ptr<LoopManager> LoopManager::clone_with_new_expr(const ExressionMap& expr_map) const {
-    auto new_loop_manager = std::make_shared<LoopManager>();
-    for (const auto& id_info : m_map)
-        new_loop_manager->m_map.insert({id_info.first, id_info.second->clone_with_new_expr(expr_map)});
-    new_loop_manager->next_id = next_id;
-    return new_loop_manager;
+size_t LoopInfo::get_work_amount() const {
+    return m_work_amount;
+}
+
+size_t LoopInfo::get_increment() const {
+    return m_increment;
+}
+
+const std::vector<LoopPort>& LoopInfo::get_entry_points() const {
+    return m_entry_points;
+}
+
+const std::vector<LoopPort>& LoopInfo::get_exit_points() const {
+    return m_exit_points;
+}
+
+bool LoopInfo::get_outer_splited_loop() const {
+    return m_outer_splited_loop;
+}
+
+const LoopInfo::FirstIterHandler& LoopInfo::get_first_iter_handler() const {
+    return m_first_iter_handler;
 }
 
 size_t LinearIR::LoopManager::LoopInfo::get_dim_idx() const {
-    OPENVINO_ASSERT(!entry_points.empty(), "Loop info must have at least one entry point");
+    OPENVINO_ASSERT(!m_entry_points.empty(), "Loop info must have at least one entry point");
     auto equal_dim_idxes = [&](const LinearIR::LoopManager::LoopPort& p) {
-        return p.dim_idx == entry_points[0].dim_idx;
+        return p.dim_idx == m_entry_points[0].dim_idx;
     };
-    if (std::all_of(entry_points.begin(), entry_points.end(), equal_dim_idxes) &&
-        std::all_of(exit_points.begin(), exit_points.end(), equal_dim_idxes)) {
-        return entry_points[0].dim_idx;
+    if (std::all_of(m_entry_points.begin(), m_entry_points.end(), equal_dim_idxes) &&
+        std::all_of(m_exit_points.begin(), m_exit_points.end(), equal_dim_idxes)) {
+        return m_entry_points[0].dim_idx;
     } else {
-        return SIZE_MAX;
+        return UNDEFINED_DIM_IDX;
     }
 }
 
-void LinearIR::LoopManager::LoopInfo::set_first_iter_handler(FirstIterHandler handler) {
-    fst_iter_handler = std::move(handler);
+void LoopInfo::set_dim_idx(size_t dim_idx) {
+    auto set_common_dim_idx = [dim_idx](std::vector<LoopPort>& ports) {
+        for (auto& port : ports)
+            port.dim_idx = dim_idx;
+    };
+    set_common_dim_idx(m_entry_points);
+    set_common_dim_idx(m_exit_points);
+}
+
+void LoopInfo::set_work_amount(size_t work_amount) {
+    m_work_amount = work_amount;
+}
+
+void LoopInfo::set_increment(size_t increment) {
+    m_increment = increment;
+}
+
+void LoopInfo::set_entry_points(std::vector<LoopPort> entry_points) {
+    m_entry_points = std::move(entry_points);
+}
+
+void LoopInfo::set_exit_points(std::vector<LoopPort> exit_points) {
+    m_exit_points = std::move(exit_points);;
+}
+
+void LoopInfo::set_outer_splited_loop(bool outer_splited_loop) {
+    m_outer_splited_loop = outer_splited_loop;
+}
+
+void LoopInfo::set_first_iter_handler(LoopInfo::FirstIterHandler first_iter_handler) {
+    m_first_iter_handler = std::move(first_iter_handler);
 }
 
 bool operator==(const LinearIR::LoopManager::LoopPort& lhs, const LinearIR::LoopManager::LoopPort& rhs) {
@@ -95,6 +154,14 @@ bool operator<(const LinearIR::LoopManager::LoopPort& lhs, const LinearIR::LoopM
            (lhs.expr_port == rhs.expr_port &&
             (lhs.is_incremented < rhs.is_incremented ||
              (lhs.is_incremented == rhs.is_incremented && lhs.dim_idx < rhs.dim_idx)));
+}
+
+std::shared_ptr<LoopManager> LoopManager::clone_with_new_expr(const ExressionMap& expr_map) const {
+    auto new_loop_manager = std::make_shared<LoopManager>();
+    for (const auto& id_info : m_map)
+        new_loop_manager->m_map.insert({id_info.first, id_info.second->clone_with_new_expr(expr_map)});
+    new_loop_manager->next_id = next_id;
+    return new_loop_manager;
 }
 
 size_t LinearIR::LoopManager::add_loop_info(const LoopInfoPtr &loop) {
@@ -133,7 +200,7 @@ void LinearIR::LoopManager::get_loop_bounds(const LinearIR &linear_ir,
                                             LinearIR::constExprIt &loop_end_pos,
                                             bool loop_ops_inserted) const {
     const auto loop_info = get_loop_info(loop_id);
-    get_loop_bounds(linear_ir, loop_info->entry_points, loop_info->exit_points, loop_begin_pos, loop_end_pos, loop_id, loop_ops_inserted);
+    get_loop_bounds(linear_ir, loop_info->get_entry_points(), loop_info->get_exit_points(), loop_begin_pos, loop_end_pos, loop_id, loop_ops_inserted);
 }
 
 void LinearIR::LoopManager::get_loop_bounds(const LinearIR &linear_ir,
@@ -177,8 +244,8 @@ LinearIR::LoopManager::LoopPort LinearIR::LoopManager::get_loop_port_by_expr_por
         return *it;
     };
     const auto& loop_info = get_loop_info(loop_id);
-    return expr_port.get_type() == ExpressionPort::Input ? get_loop_port(loop_info->entry_points)
-                                                         : get_loop_port(loop_info->exit_points);
+    return expr_port.get_type() == ExpressionPort::Input ? get_loop_port(loop_info->get_entry_points())
+                                                         : get_loop_port(loop_info->get_exit_points());
 }
 
 void LinearIR::LoopManager::get_io_loop_ports(LinearIR::constExprIt loop_begin_pos,
@@ -278,17 +345,27 @@ void LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
     }
 }
 
-size_t LinearIR::LoopManager::mark_loop_with_old_loop_replacement(LinearIR::constExprIt loop_begin_pos,
-                                                                  LinearIR::constExprIt loop_end_pos,
-                                                                  size_t work_amount,
-                                                                  size_t increment,
-                                                                  const std::vector<LoopPort>& entries,
-                                                                  const std::vector<LoopPort>& exits,
-                                                                  const size_t old_id) {
+size_t LinearIR::LoopManager::replace_with_new_loop(const LinearIR& linear_ir,
+                                                    LinearIR::constExprIt loop_begin_pos,
+                                                    LinearIR::constExprIt loop_end_pos,
+                                                    size_t work_amount,
+                                                    size_t increment,
+                                                    const std::vector<LoopPort>& entries,
+                                                    const std::vector<LoopPort>& exits,
+                                                    const size_t old_id) {
     const auto loop_info = std::make_shared<LoopManager::LoopInfo>(work_amount, increment, entries, exits);
     const auto loop_id = this->add_loop_info(loop_info);
     for (auto expr_it = loop_begin_pos; expr_it != loop_end_pos; ++expr_it) {
         replace_loop_id(*expr_it, old_id, loop_id);
+    }
+
+    const auto old_loop_info = this->get_loop_info(old_id);
+    const auto old_loop_begin_pos = linear_ir.find(old_loop_info->get_entry_points().front().expr_port->get_expr());
+    const auto old_loop_end_pos = linear_ir.find(old_loop_info->get_exit_points().back().expr_port->get_expr());
+    // If new bounds are equal to old loop bounds, this means that old Loop is removed totally from LIR
+    // In this case old loop info must be completely removed from loop manager
+    if (loop_begin_pos == old_loop_begin_pos && loop_end_pos == old_loop_end_pos) {
+        this->remove_loop_info(old_id);
     }
     return loop_id;
 }
@@ -307,10 +384,10 @@ void LinearIR::LoopManager::fuse_loops(LinearIR::constExprIt loop_begin_target, 
     const auto& loop_info_upper = m_map[loop_id_upper];
     const auto& loop_info_lower = m_map[loop_id_lower];
 
-    auto entry_points_upper = loop_info_upper->entry_points;
-    auto exit_points_upper = loop_info_upper->exit_points;
-    auto entry_points_lower = loop_info_lower->entry_points;
-    auto exit_points_lower = loop_info_lower->exit_points;
+    auto entry_points_upper = loop_info_upper->get_entry_points();
+    auto exit_points_upper = loop_info_upper->get_exit_points();
+    auto entry_points_lower = loop_info_lower->get_entry_points();
+    auto exit_points_lower = loop_info_lower->get_exit_points();
     fuse_loop_ports(exit_points_upper, entry_points_lower, loop_id_upper);
 
     std::vector<LoopManager::LoopPort> new_entries = entry_points_upper;
@@ -319,8 +396,8 @@ void LinearIR::LoopManager::fuse_loops(LinearIR::constExprIt loop_begin_target, 
     new_exits.insert(new_exits.end(), exit_points_lower.begin(), exit_points_lower.end());
 
     auto& loop_info = fuse_into_upper ? loop_info_upper : loop_info_lower;
-    loop_info->entry_points = new_entries;
-    loop_info->exit_points = new_exits;
+    loop_info->set_entry_points(new_entries);
+    loop_info->set_exit_points(new_exits);
 
     const auto& from = fuse_into_upper ? loop_id_lower : loop_id_upper;
     const auto& to = fuse_into_upper ? loop_id_upper : loop_id_lower;
@@ -382,7 +459,7 @@ template<>
 void LinearIR::LoopManager::update_loop_port(size_t loop_id, const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports,
                                              bool is_entry) {
     const auto& loop_info = get_loop_info(loop_id);
-    auto& ports = is_entry ? loop_info->entry_points : loop_info->exit_points;
+    auto ports = is_entry ? loop_info->get_entry_points() : loop_info->get_exit_points();
     auto port_it = std::find_if(ports.begin(), ports.end(),
                                 [&actual_port](const LoopPort& point) { return *point.expr_port.get() == actual_port; });
     // In some cases actual ExpressionPort may not be LoopPort. We shouldn't throw exception here since ExpressionPort is not strong condition as LoopPort
@@ -400,18 +477,20 @@ void LinearIR::LoopManager::update_loop_port(size_t loop_id, const ExpressionPor
                    });
     port_it = ports.erase(port_it);
     ports.insert(port_it, target_loop_ports.cbegin(), target_loop_ports.cend());
+    is_entry ? loop_info->set_entry_points(ports) : loop_info->set_exit_points(ports);
 }
 
 template<>
 void LinearIR::LoopManager::update_loop_port(size_t loop_id, const LoopPort& actual_port, const std::vector<LoopPort>& target_ports,
                                              bool is_entry) {
     const auto& loop_info = get_loop_info(loop_id);
-    auto& ports = is_entry ? loop_info->entry_points : loop_info->exit_points;
+    auto ports = is_entry ? loop_info->get_entry_points() : loop_info->get_exit_points();
     auto port_it = std::find_if(ports.begin(), ports.end(),
                                 [&actual_port](const LoopPort& point) { return point == actual_port; });
     OPENVINO_ASSERT(port_it != ports.end(), "Failed update_loop_port: existing loop ports has not been found");
     port_it = ports.erase(port_it);
     ports.insert(port_it, target_ports.cbegin(), target_ports.cend());
+    is_entry ? loop_info->set_entry_points(ports) : loop_info->set_exit_points(ports);
 }
 
 void LinearIR::LoopManager::expression_replacement(constExprIt new_expr_begin, constExprIt new_expr_end, const ExpressionPtr& decomposed_expr,
@@ -446,8 +525,8 @@ void LinearIR::LoopManager::sort_loop_ports(LinearIR::constExprIt& loop_begin_po
         }
     };
     auto loop_info = get_loop_info(loop_id);
-    const auto& loop_entries = loop_info->entry_points;
-    const auto& loop_exits = loop_info->exit_points;
+    const auto& loop_entries = loop_info->get_entry_points();
+    const auto& loop_exits = loop_info->get_exit_points();
     std::vector<LoopPort> entries, exits;
     entries.reserve(loop_entries.size());
     exits.reserve(loop_exits.size());
@@ -456,8 +535,8 @@ void LinearIR::LoopManager::sort_loop_ports(LinearIR::constExprIt& loop_begin_po
         push(loop_entries, entries, expr);
         push(loop_exits, exits, expr);
     }
-    loop_info->entry_points = entries;
-    loop_info->exit_points = exits;
+    loop_info->set_entry_points(entries);
+    loop_info->set_exit_points(exits);
 }
 
 void LinearIR::LoopManager::insert_loop_id(const ExpressionPtr& expr, size_t new_id, bool before, size_t target_id) {

--- a/src/common/snippets/src/lowered/pass/assign_registers.cpp
+++ b/src/common/snippets/src/lowered/pass/assign_registers.cpp
@@ -64,7 +64,7 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
         } else if (const auto& buffer = ov::as_type_ptr<op::Buffer>(op)) {
             const auto buffer_id = buffer->get_id();
             // All buffers have one common data pointer
-            if (buffer->is_intermediate_memory()) {
+            if (ov::is_type<op::IntermediateMemoryBuffer>(buffer)) {
                 manually_assigned_gprs[expr->get_input_port_connector(0)] =
                         static_cast<Reg>(num_results + num_parameters + buffer_id);
             }

--- a/src/common/snippets/src/lowered/pass/cleanup_loop_offsets.cpp
+++ b/src/common/snippets/src/lowered/pass/cleanup_loop_offsets.cpp
@@ -35,7 +35,6 @@ bool CleanupLoopOffsets::run(LinearIR& linear_ir) {
                 }
                 if (auto outer_loop_end = as_type_ptr<op::LoopEnd>(next_node)) {
                     auto fin_offsets = loop_end->get_finalization_offsets();
-                    const auto& is_incremented = loop_end->get_is_incremented();
                     std::unordered_map<PortConnectorPtr, size_t> per_port_connector_offset;
                     const auto& loop_inputs = expr_it->get()->get_input_port_connectors();
                     for (size_t i = 0; i < fin_offsets.size(); i++)
@@ -43,15 +42,11 @@ bool CleanupLoopOffsets::run(LinearIR& linear_ir) {
 
                     const auto outer_increment = static_cast<int64_t>(outer_loop_end->get_increment());
                     auto outer_ptr_increments = outer_loop_end->get_ptr_increments();
-                    const auto& outer_is_incremented = outer_loop_end->get_is_incremented();
                     const auto& outer_loop_inputs = next_expr_it->get()->get_input_port_connectors();
                     for (size_t i = 0; i < outer_ptr_increments.size(); i++) {
-                        if (outer_is_incremented[i] == false)
-                            continue;
-
                         const auto& managed_connector = outer_loop_inputs[i];
                         const auto& found = per_port_connector_offset.find(managed_connector);
-                        if (found != per_port_connector_offset.end() && is_incremented[found->second] == true) {
+                        if (found != per_port_connector_offset.end()) {
                             // Since data ptr is incremented on [ptr_increment x increment],
                             // we should guarantee proportionality of ptr shifts.
                             // If the data ptr can't be proportionally shifted, the optimization is not applied

--- a/src/common/snippets/src/lowered/pass/cleanup_loop_offsets.cpp
+++ b/src/common/snippets/src/lowered/pass/cleanup_loop_offsets.cpp
@@ -35,6 +35,7 @@ bool CleanupLoopOffsets::run(LinearIR& linear_ir) {
                 }
                 if (auto outer_loop_end = as_type_ptr<op::LoopEnd>(next_node)) {
                     auto fin_offsets = loop_end->get_finalization_offsets();
+                    const auto& is_incremented = loop_end->get_is_incremented();
                     std::unordered_map<PortConnectorPtr, size_t> per_port_connector_offset;
                     const auto& loop_inputs = expr_it->get()->get_input_port_connectors();
                     for (size_t i = 0; i < fin_offsets.size(); i++)
@@ -42,22 +43,33 @@ bool CleanupLoopOffsets::run(LinearIR& linear_ir) {
 
                     const auto outer_increment = static_cast<int64_t>(outer_loop_end->get_increment());
                     auto outer_ptr_increments = outer_loop_end->get_ptr_increments();
+                    const auto& outer_is_incremented = outer_loop_end->get_is_incremented();
                     const auto& outer_loop_inputs = next_expr_it->get()->get_input_port_connectors();
                     for (size_t i = 0; i < outer_ptr_increments.size(); i++) {
+                        if (outer_is_incremented[i] == false)
+                            continue;
+
                         const auto& managed_connector = outer_loop_inputs[i];
                         const auto& found = per_port_connector_offset.find(managed_connector);
-                        if (found != per_port_connector_offset.end()) {
+                        if (found != per_port_connector_offset.end() && is_incremented[found->second] == true) {
                             // Since data ptr is incremented on [ptr_increment x increment],
-                            // we should guarantee proportionality of ptr shifts
+                            // we should guarantee proportionality of ptr shifts.
+                            // If the data ptr can't be proportionally shifted, the optimization is not applied
                             // For example,
                             // Inner Loop: WA = 32, Inc = 1, ptr_increment[0] = 20, final_offset[0] = -640
                             // Outer Loop: WA = 70, Inc = 32, ptr_increment[0] = 20, final_offset[0] = -1400
                             // To save data ptr shift proportionality, we have to calculate so:
                             //    outer_ptr_increment[0] = (inner_final_offset[0] + outer_ptr_increment[0] * outer_Inc) / outer_Inc
                             //    outer_ptr_increment[0] = (-640 + 20 x 32) / 32 = 0
-                            outer_ptr_increments[i] = (fin_offsets[found->second] + outer_ptr_increments[i] * outer_increment) / outer_increment;
-                            fin_offsets[found->second] = 0;
-                            is_modified = true;
+
+                            const auto full_outer_increment = outer_ptr_increments[i] * outer_increment;
+                            const auto new_final_outer_increment = full_outer_increment + fin_offsets[found->second];
+
+                            if (new_final_outer_increment % outer_increment == 0) {
+                                outer_ptr_increments[i] = new_final_outer_increment / outer_increment;
+                                fin_offsets[found->second] = 0;
+                                is_modified = true;
+                            }
                         }
                     }
                     outer_loop_end->set_ptr_increments(outer_ptr_increments);

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -28,7 +28,7 @@ bool FuseLoops::loop_ports_are_compatible(const LinearIR::LoopManagerPtr& loop_m
                                           const size_t loop_lower_id,
                                           const size_t loop_upper_id) {
     const auto loop_lower = loop_manager->get_loop_info(loop_lower_id);
-    for (const auto& entry : loop_lower->entry_points) {
+    for (const auto& entry : loop_lower->get_entry_points()) {
         const auto& src_port = entry.expr_port->get_port_connector_ptr()->get_source();
         if (is_loop_id_found(src_port.get_expr()->get_loop_ids(), loop_upper_id)) {
             if (!entry.is_incremented)
@@ -44,8 +44,8 @@ bool FuseLoops::loop_ports_are_compatible(const LinearIR::LoopManagerPtr& loop_m
 }
 
 bool FuseLoops::can_be_fused(const LoopInfoPtr& loop_current, const LoopInfoPtr& loop_target) {
-    auto current_work_amount = loop_current->work_amount;
-    auto target_work_amount = loop_target->work_amount;
+    auto current_work_amount = loop_current->get_work_amount();
+    auto target_work_amount = loop_target->get_work_amount();
     // Loop fusion is supported only if Loops have equal increments and the equal/broadcastable work amounts.
     // Note: For example, Broadcastable work amounts are possible in the following case:
     //     Relu_0 [16x1]     Relu_1 [16x128]
@@ -56,7 +56,7 @@ bool FuseLoops::can_be_fused(const LoopInfoPtr& loop_current, const LoopInfoPtr&
     //  - Relu_1 and Add with work amount `128` and increment `vector size`
     // We can fuse them into one Loop with work amount `128` and increment `vector size`
     const auto supported_work_amount = current_work_amount == target_work_amount || current_work_amount == 1 || target_work_amount == 1;
-    const auto supported_increment = loop_current->increment == loop_target->increment;
+    const auto supported_increment = loop_current->get_increment() == loop_target->get_increment();
     return supported_work_amount && supported_increment;
 }
 
@@ -103,8 +103,8 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::Loo
     // We can fuse Loop_up to Loop_down only in cases when other consumers of Loop_up are after Loop_down
     // Because Loop_up should be explicitly moved before Loop_down in linear IR, and we must save control dependency
     bool is_fusion_allowed = true;
-    for (size_t i = 0; i < loop_target->exit_points.size() && is_fusion_allowed; ++i) {
-        const auto target_exit_point = loop_target->exit_points[i];
+    for (size_t i = 0; i < loop_target->get_exit_points().size() && is_fusion_allowed; ++i) {
+        const auto target_exit_point = loop_target->get_exit_points()[i];
         const auto consumer_inputs = target_exit_point.expr_port->get_connected_ports();
         for (const auto& consumer_input : consumer_inputs) {
             const auto& consumer = consumer_input.get_expr();
@@ -125,10 +125,10 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::Loo
     loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
     loop_manager->fuse_loops(target_loop_begin_pos, target_loop_end_pos, target_loop_id, current_loop_id, false);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
-    loop_current->work_amount = std::max(loop_current->work_amount, loop_target->work_amount);
+    loop_current->set_work_amount(std::max(loop_current->get_work_amount(), loop_target->get_work_amount()));
     // If one of the Loops is outer for nested loops that splits the same dimension,
     // after fusion new common Loop save this status
-    loop_current->outer_splited_loop = loop_current->outer_splited_loop || loop_target->outer_splited_loop;
+    loop_current->set_outer_splited_loop(loop_current->get_outer_splited_loop() || loop_target->get_outer_splited_loop());
 
     const auto insertion_place = current_loop_begin_pos;
     const auto is_move_needed = target_loop_end_pos != current_loop_begin_pos;
@@ -153,8 +153,8 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::Loo
     // We can fuse Loop_down to Loop_up only in cases when other parents of Loop_down are before Loop_up
     // Because Loop_down should be explicitly moved after Loop_up in linear IR, and we must save control dependency
     bool is_fusion_allowed = true;
-    for (size_t i = 0; i < loop_target->entry_points.size() && is_fusion_allowed; ++i) {
-        const auto target_entry_port = loop_target->entry_points[i];
+    for (size_t i = 0; i < loop_target->get_entry_points().size() && is_fusion_allowed; ++i) {
+        const auto target_entry_port = loop_target->get_entry_points()[i];
         const auto parent_expr_output = *target_entry_port.expr_port->get_connected_ports().begin();
         const auto& parent_expr = parent_expr_output.get_expr();
         if (ov::is_type<ov::op::v0::Parameter>(parent_expr->get_node()) || parent_expr == current_exit_point->get_expr())
@@ -170,10 +170,10 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::Loo
     loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
     loop_manager->fuse_loops(target_loop_begin_pos, target_loop_end_pos, current_loop_id, target_loop_id);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
-    loop_current->work_amount = std::max(loop_current->work_amount, loop_target->work_amount);
+    loop_current->set_work_amount(std::max(loop_current->get_work_amount(), loop_target->get_work_amount()));
     // If one of the Loops is outer for nested loops that splits the same dimension,
     // after fusion new common Loop save this status
-    loop_current->outer_splited_loop = loop_current->outer_splited_loop || loop_target->outer_splited_loop;
+    loop_current->set_outer_splited_loop(loop_current->get_outer_splited_loop() || loop_target->get_outer_splited_loop());
 
     const auto insertion_place = current_loop_end_pos;
     const auto is_move_needed = insertion_place != target_loop_begin_pos;
@@ -222,7 +222,7 @@ bool FuseLoops::run(LinearIR& linear_ir) {
                 // Loop_0 (Upper)                 |
                 //   |               =>           |
                 // Loop_1 (Current)     Loop_0 + Loop_1 => new `Loop_1`
-                auto entry_points = current_loop_info->entry_points;
+                auto entry_points = current_loop_info->get_entry_points();
                 bool was_fusion_up = false;
                 for (size_t in_port = 0; in_port < entry_points.size() && !was_fusion_up; ++in_port) {
                     const auto entry_point = entry_points[in_port];
@@ -260,13 +260,13 @@ bool FuseLoops::run(LinearIR& linear_ir) {
                 }
 
                 // If Loops were fused and there are new entry_points, we should check for possible fusion again
-                if (was_fusion_up && entry_points != current_loop_info->entry_points)
+                if (was_fusion_up && entry_points != current_loop_info->get_entry_points())
                     continue;
 
                 // Loop_0 (Current)    Loop_0 + Loop_1 => new `Loop_0`
                 //   |               =>           |
                 // Loop_1 (Lower)                 |
-                auto exit_points = current_loop_info->exit_points;
+                auto exit_points = current_loop_info->get_exit_points();
                 bool was_fusion_down = false;
                 for (size_t out_port = 0; out_port < exit_points.size() && !was_fusion_down; ++out_port) {
                     const auto exit_point = exit_points[out_port];

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -36,6 +36,8 @@ bool FuseLoops::loop_ports_are_compatible(const LinearIR::LoopManagerPtr& loop_m
             auto src_loop_port = loop_manager->get_loop_port_by_expr_port(src_port, loop_upper_id);
             if (!src_loop_port.is_incremented)
                 return false;
+            if (entry.dim_idx != src_loop_port.dim_idx)
+                return false;
         }
     }
     return true;
@@ -55,8 +57,7 @@ bool FuseLoops::can_be_fused(const LoopInfoPtr& loop_current, const LoopInfoPtr&
     // We can fuse them into one Loop with work amount `128` and increment `vector size`
     const auto supported_work_amount = current_work_amount == target_work_amount || current_work_amount == 1 || target_work_amount == 1;
     const auto supported_increment = loop_current->increment == loop_target->increment;
-    const auto supported_dim_idxs = loop_current->dim_idx == loop_target->dim_idx;
-    return supported_work_amount && supported_increment && supported_dim_idxs;
+    return supported_work_amount && supported_increment;
 }
 
 void FuseLoops::move(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id,

--- a/src/common/snippets/src/lowered/pass/identify_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/identify_buffers.cpp
@@ -89,33 +89,6 @@ std::vector<bool> IdentifyBuffers::create_adjacency_matrix(const LinearIR& linea
 
     for (auto expr_it = linear_ir.cbegin(); expr_it != linear_ir.cend(); expr_it++) {
         const auto &expr = *expr_it;
-        if (const auto brgemm = ov::as_type_ptr<op::Brgemm>(expr->get_node())) {
-            const auto consumers = expr->get_output_port_connector(0)->get_consumers();
-
-            auto buffer_it = std::find_if(consumers.begin(), consumers.end(), is_buffer);
-            if (buffer_it == consumers.end())
-                continue;
-            OPENVINO_ASSERT(std::count_if(consumers.begin(), consumers.end(), is_buffer) == 1, "Brgemm mustn't have more than 1 consumer buffer");
-
-            BufferPool adjacency_buffers;
-            adjacency_buffers.push_back(buffer_it->get_expr());
-
-            for (const auto& input_connector : expr->get_input_port_connectors()) {
-                const auto parent_expr = input_connector->get_source().get_expr();
-                if (ov::is_type<op::Buffer>(parent_expr->get_node())) {
-                    adjacency_buffers.push_back(parent_expr);
-                }
-            }
-            for (auto buffer_it = adjacency_buffers.begin(); buffer_it != adjacency_buffers.end(); ++buffer_it) {
-                for (auto neighbour_it = std::next(buffer_it); neighbour_it != adjacency_buffers.end(); ++neighbour_it) {
-                    const auto buffer_idx = get_buffer_idx(*buffer_it, pool);
-                    const auto neighbour_idx = get_buffer_idx(*neighbour_it, pool);
-                    adj[index(size, neighbour_idx, buffer_idx)] = adj[index(size, buffer_idx, neighbour_idx)] = true;
-                }
-            }
-            continue;
-        }
-
         const auto& loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node());
         if (!loop_end)
             continue;

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -37,63 +37,75 @@ int64_t get_output_stride(size_t dim, const VectorDims& shape) {
 
 InitLoops::InitLoops() : Pass() {}
 
-void InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_inputs, std::vector<LoopPort>& loop_outputs, size_t work_amount) {
-    for (auto& loop_input : loop_inputs) {
-        loop_input.ptr_increment = 0;
-        if (loop_input.is_incremented) {
-            const auto& port = loop_input.expr_port;
+void InitLoops::init_ptr_increments(const LinearIR::LoopManager::LoopInfoPtr& loop_info) {
+    const auto work_amount = loop_info->get_work_amount();
+    auto loop_entries = loop_info->get_entry_points();
+    auto loop_exits = loop_info->get_exit_points();
+
+    for (auto& loop_entry : loop_entries) {
+        loop_entry.ptr_increment = 0;
+        if (loop_entry.is_incremented) {
+            const auto& port = loop_entry.expr_port;
             const auto source = *port->get_connected_ports().begin();
             const auto loop_ids = port->get_expr()->get_loop_ids();
             const auto& layout = port->get_descriptor_ptr()->get_layout();
             const auto& shape = port->get_descriptor_ptr()->get_shape();
-            const auto& dim = *(layout.rbegin() + loop_input.dim_idx);
+            const auto& dim = *(layout.rbegin() + loop_entry.dim_idx);
             // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
             if (!(shape[dim] == 1 && work_amount != 1)) {
                 // Input layout shows how we should read data by which order and strides
-                loop_input.ptr_increment = get_input_stride(dim, source.get_descriptor_ptr()->get_layout(), shape);
+                loop_entry.ptr_increment = get_input_stride(dim, source.get_descriptor_ptr()->get_layout(), shape);
             }
         }
     }
 
-    for (auto& loop_output : loop_outputs) {
-        loop_output.ptr_increment = 0;
-        if (loop_output.is_incremented) {
-            const auto& port = loop_output.expr_port;
+    for (auto& loop_exit : loop_exits) {
+        loop_exit.ptr_increment = 0;
+        if (loop_exit.is_incremented) {
+            const auto& port = loop_exit.expr_port;
             const auto loop_ids = port->get_expr()->get_loop_ids();
             const auto& layout = port->get_descriptor_ptr()->get_layout();
             const auto& shape = port->get_descriptor_ptr()->get_shape();
-            const auto original_dim = layout.size() - 1 - loop_output.dim_idx;
+            const auto original_dim = layout.size() - 1 - loop_exit.dim_idx;
             const auto& dim = std::distance(layout.cbegin(), std::find(layout.cbegin(), layout.cend(), original_dim));
             // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
             if (!(shape[dim] == 1 && work_amount != 1)) {
                 // Output layout shows how we already written data by which order and strides
-                loop_output.ptr_increment = get_output_stride(dim, shape);
+                loop_exit.ptr_increment = get_output_stride(dim, shape);
             }
         }
     }
+    loop_info->set_entry_points(loop_entries);
+    loop_info->set_exit_points(loop_exits);
 }
 
-void InitLoops::init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
-                                          std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
-                                          size_t work_amount) {
-    for (auto& loop_input : loop_inputs) {
-        loop_input.finalization_offset = -1 * loop_input.ptr_increment * work_amount;
+void InitLoops::init_finalization_offsets(const LinearIR::LoopManager::LoopInfoPtr& loop_info) {
+    const auto work_amount = loop_info->get_work_amount();
+    auto loop_entries = loop_info->get_entry_points();
+    auto loop_exits = loop_info->get_exit_points();
+    for (auto& loop_entry : loop_entries) {
+        loop_entry.finalization_offset = -1 * loop_entry.ptr_increment * work_amount;
     }
-    for (auto& loop_output : loop_outputs) {
-        loop_output.finalization_offset = -1 * loop_output.ptr_increment * work_amount;
+    for (auto& loop_exit : loop_exits) {
+        loop_exit.finalization_offset = -1 * loop_exit.ptr_increment * work_amount;
     }
+    loop_info->set_entry_points(loop_entries);
+    loop_info->set_exit_points(loop_exits);
 }
 
-void InitLoops::init_element_type_sizes(std::vector<LoopPort>& loop_inputs,
-                                        std::vector<LoopPort>& loop_outputs) {
-    for (auto& loop_input : loop_inputs) {
-        const auto& port = loop_input.expr_port;
-        loop_input.data_size = static_cast<int64_t>(port->get_expr()->get_node()->get_input_element_type(port->get_index()).size());
+void InitLoops::init_element_type_sizes(const LinearIR::LoopManager::LoopInfoPtr& loop_info) {
+    auto loop_entries = loop_info->get_entry_points();
+    auto loop_exits = loop_info->get_exit_points();
+    for (auto& loop_entry : loop_entries) {
+        const auto& port = loop_entry.expr_port;
+        loop_entry.data_size = static_cast<int64_t>(port->get_expr()->get_node()->get_input_element_type(port->get_index()).size());
     }
-    for (auto& loop_output : loop_outputs) {
-        const auto& port = loop_output.expr_port;
-        loop_output.data_size = static_cast<int64_t>(port->get_expr()->get_node()->get_output_element_type(port->get_index()).size());
+    for (auto& loop_exit : loop_exits) {
+        const auto& port = loop_exit.expr_port;
+        loop_exit.data_size = static_cast<int64_t>(port->get_expr()->get_node()->get_output_element_type(port->get_index()).size());
     }
+    loop_info->set_entry_points(loop_entries);
+    loop_info->set_exit_points(loop_exits);
 }
 
 bool InitLoops::run(LinearIR& linear_ir) {
@@ -105,9 +117,9 @@ bool InitLoops::run(LinearIR& linear_ir) {
     const auto& loops = loop_manager->get_map();
     for (const auto& loop : loops) {
         const auto loop_info = loop.second;
-        init_ptr_increments(loop_info->entry_points, loop_info->exit_points, loop_info->work_amount);
-        init_finalization_offsets(loop_info->entry_points, loop_info->exit_points, loop_info->work_amount);
-        init_element_type_sizes(loop_info->entry_points, loop_info->exit_points);
+        init_ptr_increments(loop_info);
+        init_finalization_offsets(loop_info);
+        init_element_type_sizes(loop_info);
     }
 
     return true;

--- a/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
@@ -56,12 +56,8 @@ bool InsertBroadcastMove::run(LinearIR& linear_ir) {
                 OPENVINO_ASSERT(last_dims[i] == 1,
                                 "Attempt to broadcast non-1 dimension. Target dim: ", broadcasted_dim,
                                 " This dim: ", last_dims[i]);
-                auto input_shape = descriptors[i]->get_shape();
-                // Note that input_shape could be empty (aka ngraph scalar), so we can't just replace the last dim
-                if (input_shape.empty())
-                    input_shape.resize(1);
-                input_shape.back() = last_dims[i];
-                const auto broadcast = std::make_shared<op::BroadcastMove>(node->get_input_source_output(i), utils::vdims_to_pshape(input_shape));
+                const auto bcast_dim = ov::Dimension(last_dims[i]);
+                const auto broadcast = std::make_shared<op::BroadcastMove>(node->get_input_source_output(i), bcast_dim);
 
                 PortDescriptorUtils::set_port_descriptor_ptr(broadcast->output(0), connectors[i]->get_source().get_descriptor_ptr()->clone());
                 const auto broadcast_expr = linear_ir.create_expression(broadcast, {connectors[i]});

--- a/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
@@ -56,8 +56,7 @@ bool InsertBroadcastMove::run(LinearIR& linear_ir) {
                 OPENVINO_ASSERT(last_dims[i] == 1,
                                 "Attempt to broadcast non-1 dimension. Target dim: ", broadcasted_dim,
                                 " This dim: ", last_dims[i]);
-                const auto bcast_dim = ov::Dimension(last_dims[i]);
-                const auto broadcast = std::make_shared<op::BroadcastMove>(node->get_input_source_output(i), bcast_dim);
+                const auto broadcast = std::make_shared<op::BroadcastMove>(node->get_input_source_output(i), broadcasted_dim);
 
                 PortDescriptorUtils::set_port_descriptor_ptr(broadcast->output(0), connectors[i]->get_source().get_descriptor_ptr()->clone());
                 const auto broadcast_expr = linear_ir.create_expression(broadcast, {connectors[i]});

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -61,12 +61,12 @@ ov::Shape compute_allocation_shape(const LinearIR::LoopManagerPtr& loop_manager,
     // TODO: Use general logic with the help of memory counts for allocation shape computation
     if (buffer_loop_ids.back() == parent_loop_ids.back()) {
         const auto buffer_loop = loop_manager->get_loop_info(buffer_loop_ids.back());
-        *(allocation_shape.rbegin() + 1) = buffer_loop->increment;
+        *(allocation_shape.rbegin() + 1) = buffer_loop->get_increment();
         set_rest_dims_to_ones(2);
     } else {
         for (size_t i = 0; i < std::min(rank, parent_loop_ids.size()); ++i) {
             const auto loop = loop_manager->get_loop_info(*(parent_loop_ids.rbegin() + i));
-            *(allocation_shape.rbegin() + i) = loop->work_amount;
+            *(allocation_shape.rbegin() + i) = loop->get_work_amount();
         }
         set_rest_dims_to_ones(static_cast<int>(parent_loop_ids.size()));
     }
@@ -275,8 +275,8 @@ bool InsertBuffers::run(LinearIR& linear_ir) {
     const auto loop_data_map = loop_manager->get_map();
     for (const auto& loop_data : loop_data_map) {
         const auto loop_info = loop_data.second;
-        const auto loop_entries = loop_info->entry_points;
-        const auto loop_exits = loop_info->exit_points;
+        const auto loop_entries = loop_info->get_entry_points();
+        const auto loop_exits = loop_info->get_exit_points();
         // using begin() as expr_it because we work with LoopInfo, not expressions in Linear IR
         insertion(linear_ir, linear_ir.cbegin(), loop_manager, loop_entries, loop_exits);
     }

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -49,26 +49,52 @@ ov::Shape compute_allocation_shape(const LinearIR::LoopManagerPtr& loop_manager,
         return allocation_shape;
     }
 
-    auto set_rest_dims_to_ones = [&](const int filled_dims_count) {
-        for (int i = 0; i < static_cast<int>(allocation_shape.size()) - filled_dims_count; ++i) {
-            allocation_shape[i] = 1;
+    // If subtensor is set, its information is used for allocation shape computation. Two situations are possible:
+    // 1. Buffer is outside the parent loop: the corresponding subtensor value is ignored, parent loop work amount is set instead
+    // 2. Buffer is inside the parent loop: the corresponding subtensor value is used in allocation shape.
+    // Since we can defenitely know which subtensor value corresponds to the loop only for 1st case
+    // (we can extract this info from loop exit port), we copy subtensor, and then replace subtensor values with parent loop work amount if needed.
+    // Example:
+    // Parent subtensor: [M_blk, N_blk]
+    // Buffer loop idces: [M_loop_idx], parent loop idces: [M_loop_idx, N_loop_idx]
+    //
+    // 1. Allocation shape is set to subtensor: [M_blk, N_blk]
+    // 2. Buffer is inside M_loop_idx loop => allocation shape is not changed
+    // 3. Buffer is outside N_loop_idx loop => the corresponding allocation shape value is replaced with N loop work amount
+    // So the result allocation shape is [M_blk, N_loop_work_amount]
+    const auto& subtensor =  expr_port.get_descriptor_ptr()->get_subtensor();
+    if (!subtensor.empty()) {
+        for (size_t i = 0; i < std::min(rank, subtensor.size()); ++i) {
+            auto& cur_val = *(allocation_shape.rbegin() + i);
+            const auto& subtensor_val = *(subtensor.rbegin() + i);
+            cur_val = std::min(cur_val, subtensor_val);
         }
-    };
-
-    // In some cases it's possible to allocate less shape
-    // 1. Buffer and its parent are in the same loop: allocation size for the outer dimension can be extracted from loop increment
-    // 2. Buffer is outside the parent's loops: allocation size can be extracted from the corresponding loop work amount
-    // TODO: Use general logic with the help of memory counts for allocation shape computation
-    if (buffer_loop_ids.back() == parent_loop_ids.back()) {
-        const auto buffer_loop = loop_manager->get_loop_info(buffer_loop_ids.back());
-        *(allocation_shape.rbegin() + 1) = buffer_loop->get_increment();
-        set_rest_dims_to_ones(2);
+        for (const auto& parent_loop : parent_loop_ids) {
+            if (std::find(buffer_loop_ids.begin(), buffer_loop_ids.end(), parent_loop) == buffer_loop_ids.end()) {
+                const auto loop_info = loop_manager->get_loop_info(parent_loop);
+                const auto& exit_points = loop_info->get_exit_points();
+                auto it = std::find_if(exit_points.begin(),
+                                       exit_points.end(),
+                                       [&expr_port](const LinearIR::LoopManager::LoopPort& port) {
+                                           return *port.expr_port == expr_port;
+                                       });
+                OPENVINO_ASSERT(it != exit_points.end(), "compute_allocation_shape: exit point of parent loop can not be found");
+                const auto& loop_port = *it;
+                if (loop_port.is_incremented && loop_port.dim_idx < allocation_shape.size()) {
+                    *(allocation_shape.rbegin() + loop_port.dim_idx) = loop_info->get_work_amount();
+                }
+            }
+        }
     } else {
+        // WA: In case of empty subtensors another information have to be used to update allocation shape.
         for (size_t i = 0; i < std::min(rank, parent_loop_ids.size()); ++i) {
             const auto loop = loop_manager->get_loop_info(*(parent_loop_ids.rbegin() + i));
+            OPENVINO_ASSERT(loop->get_dim_idx() == i, "compute_allocation_shape: eltwise loop has unexpected dimension index");
             *(allocation_shape.rbegin() + i) = loop->get_work_amount();
         }
-        set_rest_dims_to_ones(static_cast<int>(parent_loop_ids.size()));
+        for (int i = 0; i < allocation_rank - static_cast<int>(parent_loop_ids.size()); ++i) {
+            allocation_shape[i] = 1;
+        }
     }
     return allocation_shape;
 }

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -155,7 +155,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
                                                                    parent_loops,
                                                                    parent_expr_output,
                                                                    m_buffer_allocation_rank);
-            const auto buffer = std::make_shared<op::Buffer>(parent->output(parent_port), allocation_shape);
+            const auto buffer = std::make_shared<op::IntermediateMemoryBuffer>(parent->output(parent_port), allocation_shape);
             PortDescriptorUtils::set_port_descriptor_ptr(buffer->output(0), parent_expr_output.get_descriptor_ptr()->clone());
             // Output connector is automatically filled from PortDescriptor
             const auto buffer_expr = linear_ir.create_expression(buffer, {input_connector});
@@ -248,7 +248,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
                                                                    current_loops,
                                                                    *exit_port,
                                                                    m_buffer_allocation_rank);
-            auto buffer = std::make_shared<op::Buffer>(node->output(port_idx), allocation_shape);
+            auto buffer = std::make_shared<op::IntermediateMemoryBuffer>(node->output(port_idx), allocation_shape);
             PortDescriptorUtils::set_port_descriptor_ptr(buffer->output(0), exit_port->get_descriptor_ptr()->clone());
             // We cannot insert Node output connector on Buffer output because not all consumers of Node needs Buffer
             //  Example:

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -122,9 +122,9 @@ bool InsertLoadStore::run(LinearIR& linear_ir) {
             modified |= insert_load(linear_ir, expr_it);
         } else if (ov::is_type<ov::op::v0::Result>(node)) {
             modified |= insert_store(linear_ir, expr_it);
-        } else if (auto buffer = ov::as_type_ptr<op::Buffer>(node)) {
+        } else if (ov::is_type<op::Buffer>(node)) {
             modified |= insert_load(linear_ir, expr_it);
-            if (buffer->is_intermediate_memory())
+            if (ov::is_type<op::IntermediateMemoryBuffer>(node))
                 modified |= insert_store(linear_ir, expr_it);
         }
     }

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -55,10 +55,10 @@ void InsertLoops::filter_ports(std::vector<LoopPort>& loop_entries, std::vector<
 
 void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop) {
     const auto loop_info = loop_manager->get_loop_info(loop_id);
-    auto loop_entries = loop_info->entry_points;
-    auto loop_exits = loop_info->exit_points;
-    const auto work_amount = loop_info->work_amount;
-    const auto work_amount_increment = loop_info->increment;
+    auto loop_entries = loop_info->get_entry_points();
+    auto loop_exits = loop_info->get_exit_points();
+    const auto work_amount = loop_info->get_work_amount();
+    const auto work_amount_increment = loop_info->get_increment();
 
     LinearIR::constExprIt loop_begin_pos, loop_end_pos;
     loop_manager->get_loop_bounds(linear_ir, loop_id, loop_begin_pos, loop_end_pos);

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -337,7 +337,7 @@ bool InsertTailLoop::run(LinearIR& linear_ir) {
             continue;
 
         const auto loop_info = loop_manager->get_loop_info(loop_end->get_id());
-        if (loop_info->fst_iter_handler != nullptr) {
+        if (loop_info->fst_iter_handler) {
             modified |= loop_info->fst_iter_handler(linear_ir, expr_it);
             continue;
         }

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -8,48 +8,230 @@
 #include "snippets/lowered/loop_manager.hpp"
 #include "snippets/lowered/pass/init_loops.hpp"
 #include "snippets/snippets_isa.hpp"
+#include "snippets/utils.hpp"
 #include "snippets/itt.hpp"
 
 namespace ov {
 namespace snippets {
 namespace lowered {
 namespace pass {
+void InsertTailLoop::propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
+                                                              const LinearIR::LoopManager::LoopInfoPtr& loop_info,
+                                                              LinearIR::container::const_iterator begin,
+                                                              LinearIR::container::const_iterator end,
+                                                              const size_t new_dim_value) {
+    std::map<lowered::PortDescriptorPtr, snippets::VectorDims> original_shapes;
+    // First step: set new dim value to the corresponding entry_points' dimensions
+    if (new_dim_value != SIZE_MAX) {
+        for (const auto& port : loop_info->entry_points) {
+            if (port.is_incremented) {
+                const auto& expr = port.expr_port->get_expr();
+                const auto node = expr->get_node();
+                auto desc = port.expr_port->get_descriptor_ptr();
+                auto subtensor = desc->get_subtensor();
+                if (port.dim_idx < subtensor.size()) {
+                    *(subtensor.rbegin() + port.dim_idx) = new_dim_value;
+                    desc->set_subtensor(subtensor);
+                }
 
-std::shared_ptr<op::LoopEnd> InsertTailLoop::create_tail_loop(LinearIR& linear_ir,
-                                                              LinearIR::constExprIt vector_begin,
-                                                              LinearIR::constExprIt vector_end,
-                                                              LinearIR::constExprIt& tail_begin,
-                                                              LinearIR::constExprIt& tail_end,
-                                                              const std::shared_ptr<op::LoopEnd>& vector_loop_end,
-                                                              bool need_vector_loop,
-                                                              size_t tail_size,
-                                                              const std::vector<int64_t>& tail_finalization_offsets) {
+                const auto parent_desc = expr->get_input_port_connector(port.expr_port->get_index())->get_source().get_descriptor_ptr();
+                const auto& layout = parent_desc->get_layout();
+                const auto& shape = parent_desc->get_shape();
+                if (original_shapes.find(parent_desc) == original_shapes.end()) {
+                    original_shapes[parent_desc] = shape;
+                }
+                auto new_shape = shape;
+                new_shape[*(layout.rbegin() + port.dim_idx)] = new_dim_value;
+                parent_desc->set_shape(new_shape);
+            }
+        }
+    }
+
+    auto update_only_dim_idx_with_subtensor_value = [&](const LinearIR::LoopManager::LoopPort& port) {
+        if (port.is_incremented) {
+            auto desc = port.expr_port->get_descriptor_ptr();
+            const auto expr = port.expr_port->get_expr();
+            const auto parent_desc = expr->get_input_port_connector(port.expr_port->get_index())->get_source().get_descriptor_ptr();
+
+            const auto& layout = parent_desc->get_layout();
+            const auto& shape = parent_desc->get_shape();
+            const auto& desc_subtensor = desc->get_subtensor();
+            if (port.dim_idx < desc_subtensor.size()) {
+                if (original_shapes.find(parent_desc) == original_shapes.end()) {
+                    original_shapes[parent_desc] = shape;
+                }
+                auto new_shape = shape;
+                new_shape[*(layout.rbegin() + port.dim_idx)] = *(desc_subtensor.rbegin() + port.dim_idx);
+                parent_desc->set_shape(new_shape);
+            }
+        }
+    };
+
+    auto update_subtensors = [](const std::vector<PortDescriptorPtr>& descs) {
+        for (const auto& desc : descs) {
+            const auto& subtensor = desc->get_subtensor();
+            if (!subtensor.empty()) {
+                auto planar_dims = snippets::utils::get_planar_vdims(desc->get_shape(), desc->get_layout());
+                const size_t subtensor_start = planar_dims.size() - subtensor.size();
+                VectorDims new_subtensor(planar_dims.begin() + subtensor_start, planar_dims.end());
+                for (size_t i = 0; i < new_subtensor.size(); ++i) {
+                    new_subtensor[i] = std::min(new_subtensor[i], subtensor[i]);
+                }
+                desc->set_subtensor(new_subtensor);
+            }
+        }
+    };
+
+    auto shape_inference_end_it = end;
+    const bool loop_by_last_dim = loop_info->get_dim_idx() == 0;
+    // Subtensors are updated using shape inference infrastructure:
+    // For inner loops propagation function is called recursively
+    for (auto expr_it = begin; expr_it != end; expr_it++) {
+        const auto expr = *expr_it;
+        if (ov::is_type<snippets::op::LoopEnd>(expr->get_node()))
+            continue;
+        if (auto loop_begin = ov::as_type_ptr<snippets::op::LoopBegin>(expr->get_node())) {
+            const auto loop_end = loop_begin->get_loop_end();
+            const auto inner_loop_info = linear_ir.get_loop_manager()->get_loop_info(loop_end->get_id());
+            const auto inner_begin = std::next(expr_it);
+            const auto inner_end = linear_ir.find(linear_ir.get_expr_by_node(loop_end));
+
+            // The corresponding shapes of inner loops entry points must be updated using existing subtensor values
+            if (new_dim_value == SIZE_MAX) {
+                for (const auto& port : loop_info->entry_points)
+                    update_only_dim_idx_with_subtensor_value(port);
+            }
+            propagate_updated_subtensor_through_loop(linear_ir, inner_loop_info, inner_begin, inner_end);
+            expr_it = inner_end;
+            continue;
+        }
+        if ((ov::is_type<snippets::op::BroadcastMove>(expr_it->get()->get_node()) ||
+            ov::is_type<snippets::op::BroadcastLoad>(expr_it->get()->get_node())) &&
+            loop_by_last_dim) {
+            // WA: we have to break subtensor propagation if we try to propagate new last dim through Broadcast nodes
+            // which broadcast last dim in original dimension value anyway
+            // This workaround might be avoided if blocked shape are used for tail size propagation
+            shape_inference_end_it = expr_it;
+            break;
+        }
+        expr->updateShapes();
+        update_subtensors(expr->get_input_port_descriptors());
+        update_subtensors(expr->get_output_port_descriptors());
+    }
+
+    // After subtensor propagation, the original shapes must be restored
+    for (const auto& elem : original_shapes)
+        elem.first->set_shape(elem.second);
+    for (auto expr_it = begin; expr_it != shape_inference_end_it; expr_it++)
+        (*expr_it)->updateShapes();
+}
+
+LinearIR::container InsertTailLoop::copy_loop(const LinearIR& linear_ir, const size_t loop_id) {
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    LinearIR::constExprIt loop_begin_pos, loop_end_pos;
+    loop_manager->get_loop_bounds(linear_ir, loop_id, loop_begin_pos, loop_end_pos, true);
+    ExressionMap expression_map;
+    auto loop_copy_range = LinearIR::deep_copy_range(loop_begin_pos, std::next(loop_end_pos), expression_map);
+
+    auto update_loop_ports = [](const ExpressionPtr& expr,
+                                const ExpressionPtr& tail_expr,
+                                std::vector<LinearIR::LoopManager::LoopPort>& ports) {
+        auto find_if_predicate = [&](const LinearIR::LoopManager::LoopPort& port) {
+            return port.expr_port->get_expr()->get_node() == expr->get_node();
+        };
+        auto pos = std::find_if(ports.begin(), ports.end(), find_if_predicate);
+        while (pos != ports.end()) {
+            pos->expr_port = std::make_shared<ExpressionPort>(tail_expr, pos->expr_port->get_type(), pos->expr_port->get_index());
+            pos = std::find_if(pos, ports.end(), find_if_predicate);
+        }
+    };
+
+    const auto original_loop_info = loop_manager->get_loop_info(loop_id);
+    auto new_entry_points = original_loop_info->entry_points;
+    auto new_exit_points = original_loop_info->exit_points;
+    for (const auto& elem : expression_map) {
+        const auto expr = elem.first->shared_from_this();
+        const auto& new_expr = elem.second;
+        // Loop begin/end ops can't be loop ports
+        if (ov::is_type<op::LoopBase>(expr->get_node()))
+            continue;
+        // Clone loop ports from original loop info to new loop info
+        update_loop_ports(expr, new_expr, new_entry_points);
+        update_loop_ports(expr, new_expr, new_exit_points);
+
+        // Update loop info of all outer loops with new loop ports
+        const auto outer_loop_ids = LinearIR::LoopManager::get_outer_expr_loops(expr, loop_id);
+        for (size_t i = 0; i < expr->get_input_count(); ++i)
+            loop_manager->update_loops_port(outer_loop_ids, expr->get_input_port(i), {expr->get_input_port(i), new_expr->get_input_port(i)}, true);
+        for (size_t i = 0; i < expr->get_output_count(); ++i)
+            loop_manager->update_loops_port(outer_loop_ids, expr->get_output_port(i), {expr->get_output_port(i), new_expr->get_output_port(i)}, false);
+    }
+
+    const auto new_loop_begin_pos = loop_copy_range.begin();
+    const auto new_loop_end_pos = loop_copy_range.end();
+    const auto new_id = loop_manager->mark_loop_with_old_loop_replacement(std::next(new_loop_begin_pos),
+                                                                          std::prev(new_loop_end_pos),
+                                                                          original_loop_info->work_amount,
+                                                                          original_loop_info->increment,
+                                                                          new_entry_points,
+                                                                          new_exit_points,
+                                                                          loop_id);
+    const auto loop_end = ov::as_type_ptr<op::LoopEnd>(std::prev(new_loop_end_pos)->get()->get_node());
+    OPENVINO_ASSERT(loop_end, "Cloned Loop does not contain LoopEnd op at the expected place.");
+    loop_end->set_id(new_id);
+    return loop_copy_range;
+}
+
+void InsertTailLoop::create_tail_loop(LinearIR& linear_ir,
+                                      LinearIR::constExprIt begin,
+                                      LinearIR::constExprIt end,
+                                      const std::shared_ptr<op::LoopEnd>& loop_end,
+                                      bool need_vector_loop,
+                                      size_t tail_size) {
     // tail is required => transform the body into a tail representation
     // tail loop is fake loop because for tail we should calculate only
     // finalization offsets which are supported by LoopEnd.
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    const auto original_loop_id = loop_end->get_id();
+    auto original_loop_info = loop_manager->get_loop_info(original_loop_id);
+    auto tail_loop_info = original_loop_info;
     if (need_vector_loop) {
-        ExressionMap expression_map;
-        auto vector_loop_deep_copy = LinearIR::deep_copy_range(vector_begin, vector_end, expression_map);
-        tail_begin = linear_ir.insert(vector_end, vector_loop_deep_copy.begin(), vector_loop_deep_copy.end());
-        tail_end = vector_end;
-    } else {
-        tail_begin = vector_begin;
-        tail_end = vector_end;
+        const auto new_loop_range = copy_loop(linear_ir, original_loop_id);
+        const auto new_loop_end = ov::as_type_ptr<op::LoopEnd>(std::prev(new_loop_range.end())->get()->get_node());
+        OPENVINO_ASSERT(new_loop_end, "Cloned Loop does not contain LoopEnd op at the expected place.");
+        tail_loop_info = original_loop_info;
+        original_loop_info = loop_manager->get_loop_info(new_loop_end->get_id());
+
+        // Note: new loop body is inserted before the original loop
+        // So new loop becomes a main vector loop, the original loop becomes tail loop
+        linear_ir.insert(begin, new_loop_range.begin(), new_loop_range.end());
+
+        const auto new_vector_loop_wa = original_loop_info->work_amount - tail_size;
+        original_loop_info->work_amount = new_vector_loop_wa;
+        new_loop_end->set_work_amount(new_vector_loop_wa);
+        original_loop_info->outer_splited_loop = tail_loop_info->outer_splited_loop;
+        // Note that finalization offsets should be applied after the last iteration.
+        // So if there is a tail, then we should apply offsets after it, but not now.
+        new_loop_end->set_finalization_offsets(std::vector<int64_t>(loop_end->get_finalization_offsets().size(), 0));
     }
+    loop_end->set_increment(tail_size);
+    loop_end->set_work_amount(tail_size);
+    tail_loop_info->increment = tail_size;
+    tail_loop_info->work_amount = tail_size;
 
     // We have to check the loop body for any nested loops that work on the same dimension
     // and rescale their work_amount and increment accordingly
-    const auto& loop_manager = linear_ir.get_loop_manager();
-    const auto& current_loop_Info = loop_manager->get_loop_info(vector_loop_end->get_id());
-    if (current_loop_Info->outer_splited_loop) {
-        const auto current_dim_idx = current_loop_Info->dim_idx;
-        for (auto it = std::next(tail_begin); it != std::prev(tail_end); ++it) {
+    if (original_loop_info->outer_splited_loop) {
+        const auto current_dim_idx = original_loop_info->get_dim_idx();
+        OPENVINO_ASSERT(current_dim_idx != SIZE_MAX, "Outer splitted loop unexpectedly iterates by several dimension indices");
+        for (auto it = std::next(begin); it != std::prev(end); ++it) {
             const auto& expr = *it;
             const auto inner_loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node());
             if (!inner_loop_end)
                 continue;
-            const auto loop_info = loop_manager->get_loop_info(inner_loop_end->get_id());
-            if (loop_info->dim_idx != current_dim_idx)
+            const auto inner_loop_info = loop_manager->get_loop_info(inner_loop_end->get_id());
+            const auto inner_dim_idx = inner_loop_info->get_dim_idx();
+            if (inner_dim_idx != current_dim_idx)
                 continue;
             const auto inner_loop_begin = inner_loop_end->get_loop_begin();
             const auto inner_tail_work_amount = static_cast<int64_t>(inner_loop_end->get_work_amount());
@@ -61,21 +243,14 @@ std::shared_ptr<op::LoopEnd> InsertTailLoop::create_tail_loop(LinearIR& linear_i
             inner_loop_end->set_work_amount(tail_size);
             inner_loop_end->set_increment(std::min(inner_tail_increment, tail_size));
             inner_loop_end->set_finalization_offsets(inner_finalization_offsets);
-            const auto inner_loop_begin_it = std::find(tail_begin, it, linear_ir.get_expr_by_node(inner_loop_begin));
-            const auto inner_loop_end_it = std::next(tail_end);
+            const auto inner_loop_begin_it = std::find(begin, it, linear_ir.get_expr_by_node(inner_loop_begin));
+            const auto inner_loop_end_it = std::next(end);
             OPENVINO_ASSERT(inner_loop_begin_it != it, "LoopBegin has not been found!");
             tail_transformations(linear_ir, inner_loop_begin_it, inner_loop_end_it, tail_size);
         }
     }
-
-    tail_transformations(linear_ir, tail_begin, tail_end, tail_size);
-    std::shared_ptr<op::LoopEnd> tail_loop_end = ov::as_type_ptr<op::LoopBegin>((*tail_begin)->get_node())->get_loop_end();
-    tail_loop_end->set_increment(tail_size);
-    // ptr increments were set to the old increment, need to update them in accordance with the new one
-    tail_loop_end->set_work_amount(tail_size);
-    tail_loop_end->set_finalization_offsets(tail_finalization_offsets);
-    tail_loop_end->has_outer_loop = vector_loop_end->has_outer_loop;
-    return tail_loop_end;
+    tail_transformations(linear_ir, begin, end, tail_size);
+    propagate_updated_subtensor_through_loop(linear_ir, tail_loop_info, std::next(begin), end, tail_size);
 }
 
 void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
@@ -106,21 +281,30 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
         // correct math calculations for ReduceMax and ReduceSum in scalar case.
         // Note: We find Maximum and Add ops because HorizonMax and HorizonSum are outside Loop,
         //       so they are missed in <tail>
-        auto op = (*expr_it)->get_node();
+        const auto& expr = *expr_it;
+        const auto op = expr->get_node();
         if (config.m_need_fill_tail_register &&
             (ov::is_type<ov::op::v1::Maximum>(op) ||
              ov::is_type<ov::op::v1::Add>(op))) {
             for (size_t i = 0; i < op->inputs().size(); ++i) {
                 if (auto fill = insertFill(op->input(i))) {
-                    const auto& input = expr_it->get()->get_input_port_connector(i);
+                    const auto& input = expr->get_input_port_connector(i);
                     const auto consumers = input->get_consumers();
+                    // If there are several consumers, fill expression must be inserted before first of them
+                    auto fst_consumer = std::min_element(consumers.cbegin(), consumers.cend(), [&](ExpressionPort lhs, ExpressionPort rhs) {
+                        auto lhs_it = linear_ir.find(lhs.get_expr());
+                        auto rhs_it = linear_ir.find(rhs.get_expr());
+                        return std::distance(linear_ir.cbegin(), lhs_it) < std::distance(linear_ir.cbegin(), rhs_it);
+                    });
+                    const auto insert_pos = linear_ir.find(fst_consumer->get_expr());
                     auto fill_expr = linear_ir.create_expression(fill, {input});
-                    linear_ir.insert(expr_it, fill_expr);
+                    linear_ir.insert(insert_pos, fill_expr);
                     linear_ir.replace_input(consumers, fill_expr->get_output_port_connector(0));
                     // in_reg == out_reg since we want to modify vector reg inplace
-                    const auto reg = expr_it->get()->get_input_port_descriptor(0)->get_reg();
+                    const auto reg = expr->get_input_port_descriptor(0)->get_reg();
                     fill_expr->get_input_port_descriptor(0)->set_reg(reg);
                     fill_expr->get_output_port_descriptor(0)->set_reg(reg);
+                    fill_expr->set_loop_ids(expr->get_loop_ids());
                 }
             }
         } else if (const auto memory_access = std::dynamic_pointer_cast<ov::snippets::op::MemoryAccess>(op)) {
@@ -140,28 +324,6 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
     }
 }
 
-bool InsertTailLoop::optimize_single_evaluation(const std::shared_ptr<op::LoopEnd>& loop) {
-    // *1* solo vector/tail loop + empty outer loop
-    //      => skip increments (both counter & ptr) : set evaluate_once flag
-    // *2* solo vector/tail loop + non-empty outer loop
-    //      => skip counter increments but perform ptr increments : set evaluate_once,
-    //         and perform pointer increments through finalization offsets
-    // *3* vector loop(s) + one tail loop
-    //      => vector as usual, tail depends on outer loop, see *1* and *2*
-    if (loop->get_work_amount() >= 2 * loop->get_increment())
-        return false;
-
-    std::vector<int64_t> new_finalization_offsets(loop->get_finalization_offsets());
-    const auto& ptr_increments = loop->get_ptr_increments();
-    const auto work_amount_incr = static_cast<int64_t>(loop->get_increment());
-    for (size_t i = 0; i < new_finalization_offsets.size(); i++) {
-        new_finalization_offsets[i] += ptr_increments[i] * work_amount_incr;
-    }
-    loop->set_finalization_offsets(new_finalization_offsets);
-    loop->set_evaluate_once(true);
-    return true;
-}
-
 bool InsertTailLoop::run(LinearIR& linear_ir) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::insertTailLoop")
     const auto& loop_manager = linear_ir.get_loop_manager();
@@ -174,37 +336,24 @@ bool InsertTailLoop::run(LinearIR& linear_ir) {
         if (!loop_end)
             continue;
 
+        const auto loop_info = loop_manager->get_loop_info(loop_end->get_id());
+        if (loop_info->fst_iter_handler != nullptr) {
+            modified |= loop_info->fst_iter_handler(linear_ir, expr_it);
+            continue;
+        }
+
         const auto work_amount = loop_end->get_work_amount();
         const auto increment = loop_end->get_increment();
-        const auto loop_info = loop_manager->get_loop_info(loop_end->get_id());
         const auto tail_size = work_amount % increment;
-        const auto need_tail = tail_size != 0;
-        const auto need_vector_loop = work_amount >= increment;
-        // Note, that finalization_offsets could be modified inside optimize_single_evaluation,
-        // so need to save them here to cover (evaluate_once vector with non-zero finalization_offsets + tail)
-        const auto tail_finalization_offsets = need_tail ? loop_end->get_finalization_offsets() : std::vector<int64_t>{};
-        // vector loops are required => Just copy the body, original loop is already a vector one
-        if (need_vector_loop) {
-            // Note that finalization offsets should be applied after the last iteration.
-            // So if there is a tail, then we should apply offsets after it, but not now.
-            if (need_tail)
-                loop_end->set_finalization_offsets(std::vector<int64_t>(tail_finalization_offsets.size(), 0));
-
-            optimize_single_evaluation(loop_end);
-        }
 
         // tail is required => transform the body into a tail representation
         // tail loop is fake loop because for tail we should calculate only
         // finalization offsets which are supported by LoopEnd.
-        if (need_tail) {
+        if (tail_size != 0) {
             const auto loop_begin = loop_end->get_loop_begin();
             const auto begin_it = linear_ir.find(linear_ir.get_expr_by_node(loop_begin));
-            LinearIR::constExprIt tail_begin, tail_end;
-            const auto tail_loop_end = create_tail_loop(linear_ir, begin_it, std::next(expr_it), tail_begin, tail_end,
-                                                        loop_end, need_vector_loop, tail_size, tail_finalization_offsets);
-            optimize_single_evaluation(tail_loop_end);
-            // Skip new tail loop. Note: tail_end refs to the next expression after LoopEnd of tail
-            expr_it = std::prev(tail_end);
+            const auto need_vector_loop = work_amount >= increment;
+            create_tail_loop(linear_ir, begin_it, std::next(expr_it), loop_end, need_vector_loop, tail_size);
         }
         modified = true;
     }

--- a/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
+++ b/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
@@ -44,7 +44,7 @@ bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
                 continue;
 
             const auto& outshape = move_broadcast->get_output_partial_shape(0);
-            const auto broadcastload = std::make_shared<snippets::op::BroadcastLoad>(load->input_value(0), outshape, load->get_offset());
+            const auto broadcastload = std::make_shared<snippets::op::BroadcastLoad>(load->input_value(0), *outshape.rbegin(), load->get_offset());
             const auto move_consumers = expr->get_output_port_connector(0)->get_consumers();
             PortDescriptorUtils::set_port_descriptor_ptr(broadcastload->output(0), expr->get_output_port(0).get_descriptor_ptr()->clone());
             const auto broadcastload_expr = linear_ir.create_expression(broadcastload, { parent_expr->get_input_port_connector(0) });

--- a/src/common/snippets/src/lowered/pass/optimize_loop_single_evaluation.cpp
+++ b/src/common/snippets/src/lowered/pass/optimize_loop_single_evaluation.cpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/lowered/pass/optimize_loop_single_evaluation.hpp"
+
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/snippets_isa.hpp"
+#include "snippets/itt.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+bool OptimizeLoopSingleEvaluation::run(LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::OptimizeLoopSingleEvaluation")
+    if (linear_ir.empty())
+        return false;
+
+    bool is_modified = false;
+    for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end(); expr_it++) {
+        if (auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr_it->get()->get_node())) {
+            // *1* solo vector/tail loop + empty outer loop
+            //      => skip increments (both counter & ptr) : set evaluate_once flag
+            // *2* solo vector/tail loop + non-empty outer loop
+            //      => skip counter increments but perform ptr increments : set evaluate_once,
+            //         and perform pointer increments through finalization offsets
+            // *3* vector loop(s) + one tail loop
+            //      => vector as usual, tail depends on outer loop, see *1* and *2*
+            if (loop_end->get_work_amount() >= 2 * loop_end->get_increment())
+                continue;
+
+            auto new_finalization_offsets = loop_end->get_finalization_offsets();
+            const auto& ptr_increments = loop_end->get_ptr_increments();
+            const auto work_amount_incr = static_cast<int64_t>(loop_end->get_increment());
+            for (size_t i = 0; i < new_finalization_offsets.size(); i++) {
+                new_finalization_offsets[i] += ptr_increments[i] * work_amount_incr;
+            }
+            loop_end->set_finalization_offsets(new_finalization_offsets);
+            loop_end->set_ptr_increments(std::vector<int64_t>(new_finalization_offsets.size(), 0));
+            loop_end->set_evaluate_once(true);
+            is_modified = true;
+        }
+    }
+    return is_modified;
+}
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov
+

--- a/src/common/snippets/src/lowered/pass/optimize_loop_single_evaluation.cpp
+++ b/src/common/snippets/src/lowered/pass/optimize_loop_single_evaluation.cpp
@@ -19,8 +19,8 @@ bool OptimizeLoopSingleEvaluation::run(LinearIR& linear_ir) {
         return false;
 
     bool is_modified = false;
-    for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end(); expr_it++) {
-        if (auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr_it->get()->get_node())) {
+    for (const auto& expr : linear_ir) {
+        if (auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node())) {
             // *1* solo vector/tail loop + empty outer loop
             //      => skip increments (both counter & ptr) : set evaluate_once flag
             // *2* solo vector/tail loop + non-empty outer loop

--- a/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
@@ -52,7 +52,7 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
                     expr->get()->updateShapes();
                 return std::make_pair(expr, n);
             };
-            const ov::PartialShape broadcasted_shape(softmax_expr->get_input_port_descriptor(0)->get_shape());
+            const ov::Dimension broadcasted_dim(*(softmax_expr->get_input_port_descriptor(0)->get_shape().rbegin()));
             // Note: VectorBuffer is a special case, since it should go before the initial Load. So we handle it separately
             const auto& vector_buffer_max = push_node(std::make_shared<op::VectorBuffer>());
             // Init value of vector buffer for ReduceMax is -FLOAT_MIN.
@@ -67,8 +67,7 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
                                     std::vector<ExpressionPort>{(*max.first)->get_input_port(0),
                                                                 (*max.first)->get_input_port(1)},
                                     std::vector<ExpressionPort>{(*max.first)->get_output_port(0)});
-            const auto broadcast_horizon_max = push_node(
-                    std::make_shared<op::BroadcastMove>(horizon_max.second, broadcasted_shape));
+            const auto broadcast_horizon_max = push_node(std::make_shared<op::BroadcastMove>(horizon_max.second, broadcasted_dim));
             const auto vector_buffer_sum = push_node(std::make_shared<op::VectorBuffer>());
             // Init value of vector buffer for ReduceSum is zero.
             const auto fill_sum = push_node(std::make_shared<op::Fill>(vector_buffer_sum.second, 0, zero_constant));
@@ -90,7 +89,7 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
 
             // Divide is expensive operation, so we decompose it into 1 / x * y, where 1 / x is executed outside loop
             const auto pow = push_node(std::make_shared<op::PowerStatic>(horizon_sum.second, -1.f));
-            const auto broadcast_pow = push_node(std::make_shared<op::BroadcastMove>(pow.second, broadcasted_shape));
+            const auto broadcast_pow = push_node(std::make_shared<op::BroadcastMove>(pow.second, broadcasted_dim));
 
             // Mul (pseudo-Divide loop)
             const auto mul = push_node(std::make_shared<ov::op::v1::Multiply>(exp.second, broadcast_pow.second));

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -20,8 +20,10 @@ using LoopInfoPtr = LoopManager::LoopInfoPtr;
 SplitLoops::SplitLoops() : Pass() {}
 
 bool SplitLoops::can_be_split(const LoopInfoPtr& current, const LoopInfoPtr& parent) {
-    return current->work_amount == parent->work_amount && current->dim_idx == parent->dim_idx &&
-           current->increment != parent->increment;
+    const auto current_dim_idx = current->get_dim_idx();
+    const auto parent_dim_idx = parent->get_dim_idx();
+    const bool equal_dim_idxes = current_dim_idx != SIZE_MAX && current_dim_idx == parent_dim_idx;
+    return current->work_amount == parent->work_amount && current->increment != parent->increment && equal_dim_idxes;
 }
 
 bool SplitLoops::run(LinearIR& linear_ir) {
@@ -75,7 +77,7 @@ bool SplitLoops::run(LinearIR& linear_ir) {
                                                                    loop_end_pos,
                                                                    loop_to_fuse->work_amount,
                                                                    loop_to_fuse->increment,
-                                                                   loop_to_split->dim_idx,
+                                                                   loop_to_split->get_dim_idx(),
                                                                    loop_to_split->entry_points,
                                                                    loop_to_split->exit_points);
                 loop_manager->get_loop_info(split_loop_id)->outer_splited_loop = true;

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -15,6 +15,7 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 using LoopManager = LinearIR::LoopManager;
+using LoopInfo = LoopManager::LoopInfo;
 using LoopInfoPtr = LoopManager::LoopInfoPtr;
 
 SplitLoops::SplitLoops() : Pass() {}
@@ -22,8 +23,8 @@ SplitLoops::SplitLoops() : Pass() {}
 bool SplitLoops::can_be_split(const LoopInfoPtr& current, const LoopInfoPtr& parent) {
     const auto current_dim_idx = current->get_dim_idx();
     const auto parent_dim_idx = parent->get_dim_idx();
-    const bool equal_dim_idxes = current_dim_idx != SIZE_MAX && current_dim_idx == parent_dim_idx;
-    return current->work_amount == parent->work_amount && current->increment != parent->increment && equal_dim_idxes;
+    const bool equal_dim_idxes = current_dim_idx != LoopInfo::UNDEFINED_DIM_IDX && current_dim_idx == parent_dim_idx;
+    return current->get_work_amount() == parent->get_work_amount() && current->get_increment() != parent->get_increment() && equal_dim_idxes;
 }
 
 bool SplitLoops::run(LinearIR& linear_ir) {
@@ -44,7 +45,7 @@ bool SplitLoops::run(LinearIR& linear_ir) {
         // be in the same set of outer loops. Otherwise they won't be fused.
         const auto& loop_id = loop_ids.front();
         const auto loop = loop_manager->get_loop_info(loop_id);
-        for (const auto& entry_point : loop->entry_points) {
+        for (const auto& entry_point : loop->get_entry_points()) {
             const auto& parent_port = entry_point.expr_port->get_port_connector_ptr()->get_source();
             const auto& parent_expr = parent_port.get_expr();
             const auto parent_loop_ids = parent_expr->get_loop_ids();
@@ -60,27 +61,27 @@ bool SplitLoops::run(LinearIR& linear_ir) {
             const auto parent_loop = loop_manager->get_loop_info(parent_loop_id);
             if (can_be_split(loop, parent_loop)) {
                 loop_was_split = true;
-                const bool split_parent = parent_loop->increment < loop->increment;
+                const bool split_parent = parent_loop->get_increment() < loop->get_increment();
                 const auto& loop_to_split = split_parent ? parent_loop : loop;
                 const auto& loop_to_split_id = split_parent ? parent_loop_id : loop_id;
                 const auto& loop_to_fuse = !split_parent ? parent_loop : loop;
-                loop_to_split->work_amount = loop_to_fuse->increment;
+                loop_to_split->set_work_amount(loop_to_fuse->get_increment());
 
                 LinearIR::constExprIt loop_begin_pos, loop_end_pos;
                 LoopManager::get_loop_bounds(linear_ir,
-                                             loop_to_split->entry_points,
-                                             loop_to_split->exit_points,
+                                             loop_to_split->get_entry_points(),
+                                             loop_to_split->get_exit_points(),
                                              loop_begin_pos,
                                              loop_end_pos,
                                              loop_to_split_id);
                 const auto split_loop_id = loop_manager->mark_loop(loop_begin_pos,
                                                                    loop_end_pos,
-                                                                   loop_to_fuse->work_amount,
-                                                                   loop_to_fuse->increment,
+                                                                   loop_to_fuse->get_work_amount(),
+                                                                   loop_to_fuse->get_increment(),
                                                                    loop_to_split->get_dim_idx(),
-                                                                   loop_to_split->entry_points,
-                                                                   loop_to_split->exit_points);
-                loop_manager->get_loop_info(split_loop_id)->outer_splited_loop = true;
+                                                                   loop_to_split->get_entry_points(),
+                                                                   loop_to_split->get_exit_points());
+                loop_manager->get_loop_info(split_loop_id)->set_outer_splited_loop(true);
                 break;
             }
         }

--- a/src/common/snippets/src/lowered/pass/validate_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_loops.cpp
@@ -53,7 +53,10 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
             // Outer Loop -> Inner Loop
             for (size_t i = 0; i < loop_ids.size(); ++i) {
                 const auto id = loop_ids[i];
-                const auto dim_idx = loop_manager->get_loop_info(id)->dim_idx;
+                const auto dim_idx = loop_manager->get_loop_info(id)->get_dim_idx();
+                // if the loop has different dimension indexes, it don't have to meet the next requirements
+                if (dim_idx == SIZE_MAX)
+                    continue;
                 if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) != dim_indexes.cend()) {
                     OPENVINO_ASSERT(*dim_indexes.rbegin() == dim_idx,
                                     "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
@@ -62,8 +65,6 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
                     OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->outer_splited_loop,
                                     "Incorrect Loop ID configuration: the outer Loop with splitted dimension should have `outer_splited_loop=True`");
                 }
-                OPENVINO_ASSERT(i == 0 || loop_manager->get_loop_info(loop_ids[i - 1])->dim_idx >= dim_idx,
-                                "Incorrect Loop ID configuration: dim_idx should be sorted in accordance with loop nesting");
                 dim_indexes.push_back(dim_idx);
             }
             validated_nested_loops.insert(loop_ids);

--- a/src/common/snippets/src/lowered/pass/validate_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_loops.cpp
@@ -4,9 +4,10 @@
 
 #include "snippets/lowered/pass/validate_loops.hpp"
 
+#include "snippets/itt.hpp"
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/lowered/loop_manager.hpp"
-#include "snippets/itt.hpp"
+#include "snippets/utils.hpp"
 
 namespace ov {
 namespace snippets {
@@ -40,8 +41,8 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
 
     std::vector<size_t> dim_indexes;
 
-    auto validate_loop_ports = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](std::vector<LoopPort>& loop_ports) {
-        for (auto& loop_port : loop_ports) {
+    auto validate_loop_ports = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](const std::vector<LoopPort>& loop_ports) {
+        for (const auto& loop_port : loop_ports) {
             const auto expr = loop_port.expr_port->get_expr();
             const auto loop_ids = expr->get_loop_ids();
             // If loop_ids of the current port is subsequence of already validated IDs, skip
@@ -54,15 +55,15 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
             for (size_t i = 0; i < loop_ids.size(); ++i) {
                 const auto id = loop_ids[i];
                 const auto dim_idx = loop_manager->get_loop_info(id)->get_dim_idx();
-                // if the loop has different dimension indexes, it don't have to meet the next requirements
-                if (dim_idx == SIZE_MAX)
+                // if the loop has different dimension indexes, it don't have to meet the split loop related requirements
+                if (dim_idx == LinearIR::LoopManager::LoopInfo::UNDEFINED_DIM_IDX)
                     continue;
                 if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) != dim_indexes.cend()) {
                     OPENVINO_ASSERT(*dim_indexes.rbegin() == dim_idx,
                                     "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
-                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->increment == loop_manager->get_loop_info(id)->work_amount,
+                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->get_increment() == loop_manager->get_loop_info(id)->get_work_amount(),
                                     "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
-                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->outer_splited_loop,
+                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->get_outer_splited_loop(),
                                     "Incorrect Loop ID configuration: the outer Loop with splitted dimension should have `outer_splited_loop=True`");
                 }
                 dim_indexes.push_back(dim_idx);
@@ -71,10 +72,31 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
         }
     };
 
+    auto add_ports_dims_to_unique_dims = [](const std::vector<LoopPort>& loop_ports, std::set<size_t>& unique_dims, bool is_entry) {
+        for (const auto& loop_port : loop_ports) {
+            if (!loop_port.is_incremented)
+                continue;
+            const auto planar_shape = is_entry ? ov::snippets::utils::get_planar_vdims(*loop_port.expr_port)
+                                               : ov::snippets::utils::get_preordered_vdims(*loop_port.expr_port);
+            const auto& dim = *(planar_shape.rbegin() + loop_port.dim_idx);
+            // Since dim == 1 can be broadcasted to any value, it's not necessary to add it to unique dims
+            if (dim != 1)
+                unique_dims.insert(dim);
+        }
+    };
+
     for (const auto& pair : loops) {
         const auto& loop_info = pair.second;
-        validate_loop_ports(loop_info->entry_points);
-        validate_loop_ports(loop_info->exit_points);
+        const auto& entry_points = loop_info->get_entry_points();
+        const auto& exit_points = loop_info->get_exit_points();
+        validate_loop_ports(entry_points);
+        validate_loop_ports(exit_points);
+
+        std::set<size_t> unique_dimensions;
+        add_ports_dims_to_unique_dims(entry_points, unique_dimensions, true);
+        add_ports_dims_to_unique_dims(exit_points, unique_dimensions, false);
+        OPENVINO_ASSERT(unique_dimensions.size() <= 1,
+                        "Loop ports have incompatible dimensions, by which the loop iterates");
     }
 
     return true;

--- a/src/common/snippets/src/op/buffer.cpp
+++ b/src/common/snippets/src/op/buffer.cpp
@@ -13,25 +13,8 @@ namespace ov {
 namespace snippets {
 namespace op {
 
-
-Buffer::Buffer(const ov::Shape& shape, ov::element::Type element_type, size_t id)
-    : Op(), m_type(Type::NewMemory), m_shape(shape), m_offset(0), m_id(id), m_element_type(std::move(element_type)) {
-    constructor_validate_and_infer_types();
-}
-
-Buffer::Buffer(const ov::Output<ov::Node>& arg, const ov::Shape& shape, size_t id)
-    : Op({arg}), m_type(Type::IntermediateMemory), m_shape(shape), m_offset(0), m_id(id) {
-    constructor_validate_and_infer_types();
-}
-
-Buffer::Buffer(const ov::Output<ov::Node>& arg, int32_t allocation_rank, size_t id)
-    : Op({arg}), m_type(Type::IntermediateMemory), m_offset(0), m_id(id) {
-    const auto& pshape = arg.get_partial_shape();
-    OPENVINO_ASSERT(pshape.is_static(), "Buffer supports only static input shape");
-    const auto shape = pshape.get_shape();
-    const auto normalize_rank = utils::normalize_rank(static_cast<int32_t>(allocation_rank), shape.size());
-    const auto offset = static_cast<int32_t>(shape.size()) - normalize_rank;
-    m_shape = {shape.begin() + offset, shape.end()};
+Buffer::Buffer(const OutputVector& arguments, const ov::Shape& shape, size_t id, ov::element::Type element_type)
+    : Op(arguments), m_shape(shape), m_id(id), m_element_type(std::move(element_type)), m_offset(0) {
     constructor_validate_and_infer_types();
 }
 
@@ -44,46 +27,80 @@ bool Buffer::visit_attributes(AttributeVisitor& visitor) {
     return true;
 }
 
-void Buffer::validate_and_infer_types() {
+size_t Buffer::get_byte_size() const {
+    const auto shape = get_allocation_shape();
+    return ov::shape_size(shape) * m_element_type.size();
+}
+
+IntermediateMemoryBuffer::IntermediateMemoryBuffer(const ov::Output<ov::Node>& arg, const ov::Shape& shape, size_t id)
+    : Buffer({arg}, shape, id) {
+    constructor_validate_and_infer_types();
+}
+
+IntermediateMemoryBuffer::IntermediateMemoryBuffer(const ov::Output<ov::Node>& arg, int32_t allocation_rank, size_t id)
+    : Buffer({arg}, compute_shape_from_allocation_rank(arg, allocation_rank), id) {
+    constructor_validate_and_infer_types();
+}
+
+ov::Shape IntermediateMemoryBuffer::compute_shape_from_allocation_rank(const ov::Output<ov::Node>& arg, int32_t allocation_rank) {
+    const auto& pshape = arg.get_partial_shape();
+    OPENVINO_ASSERT(pshape.is_static(), "Buffer supports only static input shape");
+    const auto shape = pshape.get_shape();
+    const auto normalize_rank = utils::normalize_rank(static_cast<int32_t>(allocation_rank), shape.size());
+    const auto offset = static_cast<int32_t>(shape.size()) - normalize_rank;
+    return ov::Shape{shape.begin() + offset, shape.end()};
+}
+
+void IntermediateMemoryBuffer::validate_and_infer_types() {
     INTERNAL_OP_SCOPE(Buffer_validate_and_infer_types);
     ov::PartialShape output_shape;
-    if (m_type == Type::NewMemory) {
-        OPENVINO_ASSERT(get_input_size() == 0, "Buffer with new allocated memory must to not have arguments!");
-        output_shape = m_shape;
-    } else if (m_type == Type::IntermediateMemory) {
-        m_element_type = get_input_element_type(0);
-        output_shape = get_input_partial_shape(0);
-    } else {
-        OPENVINO_THROW("Buffer supports only the following types: NewMemory and IntermediateMemory");
-    }
+    m_element_type = get_input_element_type(0);
+    output_shape = get_input_partial_shape(0);
     set_output_type(0, m_element_type, output_shape);
 }
 
-std::shared_ptr<Node> Buffer::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> IntermediateMemoryBuffer::clone_with_new_inputs(const OutputVector& new_args) const {
     INTERNAL_OP_SCOPE(Buffer_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    std::shared_ptr<op::Buffer> new_buffer = nullptr;
-    if (m_type == Type::NewMemory) {
-        new_buffer = std::make_shared<Buffer>(m_shape, m_element_type, m_id);
-    } else if (m_type == Type::IntermediateMemory) {
-        new_buffer = std::make_shared<Buffer>(new_args.at(0), m_shape, m_id);
-    } else {
-        OPENVINO_THROW("Buffer supports only the following types: NewMemory and IntermediateMemory");
-    }
-    new_buffer->m_offset = m_offset;
+    auto new_buffer = std::make_shared<IntermediateMemoryBuffer>(new_args.at(0), m_shape, m_id);
+    new_buffer->set_offset(m_offset);
     return new_buffer;
 }
 
-size_t Buffer::get_byte_size() const {
-    const auto shape = get_allocation_shape();
-    return ov::shape_size(shape) * get_element_type().size();
+NewMemoryBuffer::NewMemoryBuffer(const ov::Shape& shape, size_t id, ov::element::Type element_type)
+    : Buffer({}, shape, id, element_type) {
+    constructor_validate_and_infer_types();
 }
 
-void Buffer::set_element_type(ov::element::Type element_type) {
-    OPENVINO_ASSERT(is_new_memory(), "Only Buffer with NewMemory can change his output precision!");
+void NewMemoryBuffer::validate_and_infer_types() {
+    INTERNAL_OP_SCOPE(Buffer_validate_and_infer_types);
+    OPENVINO_ASSERT(get_input_size() == 0, "Buffer with new allocated memory mustn't have arguments!");
+    set_output_type(0, m_element_type, m_shape);
+}
+
+std::shared_ptr<Node> NewMemoryBuffer::clone_with_new_inputs(const OutputVector& new_args) const {
+    INTERNAL_OP_SCOPE(Buffer_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    auto new_buffer = std::make_shared<NewMemoryBuffer>(m_shape, m_id, m_element_type);
+    new_buffer->set_offset(m_offset);
+    return new_buffer;
+}
+
+void NewMemoryBuffer::set_element_type(ov::element::Type element_type) {
     m_element_type = std::move(element_type);
     // Apply the change
     validate_and_infer_types();
+}
+
+NewMemoryBuffer::ShapeInfer::ShapeInfer(const std::shared_ptr<ov::Node>& n) {
+    const auto& buffer = ov::as_type_ptr<NewMemoryBuffer>(n);
+    OPENVINO_ASSERT(buffer, "Got invalid node in NewMemoryBuffer::ShapeInfer");
+    m_shape = buffer->get_shape();
+}
+
+IShapeInferSnippets::Result NewMemoryBuffer::ShapeInfer::infer(const std::vector<VectorDimsRef>& input_shapes) {
+    OPENVINO_ASSERT(input_shapes.empty(), "NewMemoryBuffer shape inference mustn't have input shapes");
+    return {{m_shape}, ShapeInferStatus::success};
 }
 
 } // namespace op

--- a/src/common/snippets/src/op/serialization_node.cpp
+++ b/src/common/snippets/src/op/serialization_node.cpp
@@ -23,7 +23,7 @@ SerializationNode::SerializationNode(const ov::OutputVector& args, const std::sh
 }
 
 void SerializationNode::validate_and_infer_types() {
-    set_output_type(0, element::f32, {});
+    set_output_type(0, element::f32, ov::PartialShape{});
 }
 
 std::shared_ptr<Node> SerializationNode::clone_with_new_inputs(const OutputVector &new_args) const {

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -34,7 +34,6 @@
 #include "snippets/lowered/pass/load_movebroadcast_to_broadcastload.hpp"
 #include "snippets/lowered/pass/allocate_buffers.hpp"
 #include "snippets/lowered/pass/propagate_layout.hpp"
-#include "snippets/lowered/pass/cleanup_loop_offsets.hpp"
 #include "snippets/lowered/pass/softmax_decomposition.hpp"
 #include "snippets/lowered/pass/move_scalar_to_consumer.hpp"
 #include "snippets/lowered/pass/move_result_out_of_loop.hpp"
@@ -429,12 +428,15 @@ void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
     const size_t vector_size = get_generator()->get_target_machine()->get_lanes();
     const int32_t buffer_allocation_rank = static_cast<int32_t>(linear_ir.get_config().m_loop_depth);
 
+    lowered::pass::PassPipeline markup_pipeline;
+    markup_pipeline.register_pass<lowered::pass::MarkLoops>(vector_size);
+    markup_pipeline.run(linear_ir);
+
     // Ticket: 113666
     // TODO: Make pass pipeline with backend passes more flexible
     backend_passes_pre_common.run(linear_ir);
 
     lowered::pass::PassPipeline common_pipeline;
-    common_pipeline.register_pass<lowered::pass::MarkLoops>(vector_size);
     common_pipeline.register_pass<lowered::pass::SoftmaxDecomposition>(vector_size);
     common_pipeline.register_pass<lowered::pass::FuseLoops>();
     common_pipeline.register_pass<lowered::pass::SplitLoops>();
@@ -458,7 +460,6 @@ void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
     final_pipeline.register_pass<lowered::pass::AllocateBuffers>(lowering_result.buffer_scratchpad_size, linear_ir.get_config().m_are_buffers_optimized);
     final_pipeline.register_pass<lowered::pass::CleanRepeatedDataPointerShifts>();
     final_pipeline.register_pass<lowered::pass::PropagateLayout>();
-    final_pipeline.register_pass<lowered::pass::CleanupLoopOffsets>();
     final_pipeline.run(linear_ir);
 }
 

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -428,6 +428,10 @@ void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
     const size_t vector_size = get_generator()->get_target_machine()->get_lanes();
     const int32_t buffer_allocation_rank = static_cast<int32_t>(linear_ir.get_config().m_loop_depth);
 
+    // We have to call MarkLoops before backend markup passes
+    // because these passes can update subtensor but not insert Loop (e.g. when loop increment is equal to the corresponding dim)
+    // If MarkLoops is called on such LIR, it inserts Eltwise-like loops which might not reflect backend expectations
+    // It should be fixed by ticket 113666
     lowered::pass::PassPipeline markup_pipeline;
     markup_pipeline.register_pass<lowered::pass::MarkLoops>(vector_size);
     markup_pipeline.run(linear_ir);

--- a/src/common/snippets/src/pass/broadcast_to_movebroadcast.cpp
+++ b/src/common/snippets/src/pass/broadcast_to_movebroadcast.cpp
@@ -35,9 +35,8 @@ ov::snippets::pass::BroadcastToMoveBroadcast::BroadcastToMoveBroadcast() {
         // will be handled by pointer arithmetics. Note that this behavior should be changed in case of full op::Boradcast support.
         Output<ov::Node> in_value = root->input_value(0);
         if (*target_shape.rbegin() != *value_shape.rbegin()) {
-            auto broadcasted_shape = value_shape;
-            *broadcasted_shape.rbegin() = *target_shape.rbegin();
-            const auto& broadcast_node = std::make_shared<ov::snippets::op::BroadcastMove>(in_value, broadcasted_shape);
+            auto broadcasted_dim = ov::Dimension(*target_shape.rbegin());
+            const auto& broadcast_node = std::make_shared<ov::snippets::op::BroadcastMove>(in_value, broadcasted_dim);
             in_value = broadcast_node->output(0);
         }
 

--- a/src/common/snippets/src/pass/insert_movebroadcast.cpp
+++ b/src/common/snippets/src/pass/insert_movebroadcast.cpp
@@ -44,8 +44,7 @@ ov::Output<ov::Node> ov::snippets::pass::InsertMoveBroadcast::BroadcastNodeLastD
     // will be handled by pointer arithmetics inside outer LoopEmitter
     if (*target_shape.rbegin() != *normalized_shape.rbegin()) {
         ov::PartialShape broadcasted_shape = normalized_shape;
-        *broadcasted_shape.rbegin() = *target_shape.rbegin();
-        const auto broadcast_node = std::make_shared<ov::snippets::op::BroadcastMove>(value, broadcasted_shape);
+        const auto broadcast_node = std::make_shared<ov::snippets::op::BroadcastMove>(value, *target_shape.rbegin());
         copy_runtime_info(value.get_node_shared_ptr(), broadcast_node);
 
         return broadcast_node->output(0);

--- a/src/common/snippets/src/shape_inference/shape_inference.cpp
+++ b/src/common/snippets/src/shape_inference/shape_inference.cpp
@@ -39,7 +39,7 @@ const IShapeInferSnippetsFactory::TRegistry IShapeInferSnippetsFactory::registry
         SHAPE_INFER_PREDEFINED(op::ConvertSaturation, PassThroughShapeInfer),
         SHAPE_INFER_PREDEFINED(op::Load, PassThroughShapeInfer),
         SHAPE_INFER_PREDEFINED(op::Store, PassThroughShapeInfer),
-        SHAPE_INFER_PREDEFINED(op::Buffer, PassThroughShapeInfer),
+        SHAPE_INFER_PREDEFINED(op::IntermediateMemoryBuffer, PassThroughShapeInfer),
         SHAPE_INFER_PREDEFINED(op::Fill, PassThroughShapeInfer),
         SHAPE_INFER_PREDEFINED(ov::op::v0::Parameter, PassThroughShapeInfer),
         // Note: We should remove Softmax shape infers after the decomposition activity,
@@ -68,6 +68,7 @@ const IShapeInferSnippetsFactory::TRegistry IShapeInferSnippetsFactory::registry
         SHAPE_INFER_OP_SPECIFIC(op::RankNormalization),
         SHAPE_INFER_OP_SPECIFIC(op::BroadcastLoad),
         SHAPE_INFER_OP_SPECIFIC(op::BroadcastMove),
+        SHAPE_INFER_OP_SPECIFIC(op::NewMemoryBuffer),
 };
 #undef SHAPE_INFER_OP_SPECIFIC_EXTERNAL
 #undef SHAPE_INFER_OP_SPECIFIC

--- a/src/common/snippets/tests/src/lowered/pass/buffer_allocation.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/buffer_allocation.cpp
@@ -92,9 +92,9 @@ std::shared_ptr<ov::Model> EltwiseBufferAllocationTest::GetModel() const {
     const auto parameter0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape({1, 3, 100, 100}));
     const auto parameter1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape({1, 3, 100, 100}));
     const auto add = std::make_shared<ov::op::v1::Add>(parameter0, parameter1);
-    const auto buffer0 = std::make_shared<ov::snippets::op::Buffer>(add, static_cast<int32_t>(subtensor_buffer.size()));
+    const auto buffer0 = std::make_shared<ov::snippets::op::IntermediateMemoryBuffer>(add, static_cast<int32_t>(subtensor_buffer.size()));
     const auto relu = std::make_shared<ov::op::v0::Relu>(buffer0);
-    const auto buffer1 = std::make_shared<ov::snippets::op::Buffer>(relu, static_cast<int32_t>(subtensor_buffer.size()));
+    const auto buffer1 = std::make_shared<ov::snippets::op::IntermediateMemoryBuffer>(relu, static_cast<int32_t>(subtensor_buffer.size()));
     const auto exp = std::make_shared<ov::op::v0::Exp>(buffer1);
     const auto body = std::make_shared<ov::Model>(std::make_shared<ov::op::v0::Result>(exp), ov::ParameterVector{parameter0, parameter1});
 
@@ -119,7 +119,7 @@ void MHABufferAllocationTest::MarkBrgemm(const std::shared_ptr<ov::snippets::op:
 }
 
 std::shared_ptr<ov::Model> MHABufferAllocationTest::GetModel() const {
-    const auto subtensor_scalar = std::vector<size_t>{1, 1};
+    const auto subtensor_scalar = std::vector<size_t>{1};
     const auto subtensor_eltwise = std::vector<size_t>{1, m_vector_size};
     const auto subtensor_brgemm = std::vector<size_t>{32, ov::snippets::lowered::PortDescriptor::ServiceDimensions::FULL_DIM};
     const auto subtensor_softmax = std::vector<size_t>{1, ov::snippets::lowered::PortDescriptor::ServiceDimensions::FULL_DIM};
@@ -187,7 +187,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_BufferAllocation_MHAOptimizedWSplit, MHA
                                  ::testing::Values(true),
                                  ::testing::Values(true),
                                  ::testing::Values(57344), // (Buffer before brgemm) + (between brgemms) + (after brgemm)
-                                 ::testing::Values(3)), // (Buffer before brgemm) + (between brgemms) + (after brgemm)
+                                 ::testing::Values(2)), // (Buffer before brgemm0 and after brgemm1) + (between brgemms)
                          BufferAllocationTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_BufferAllocation_MHANotOptimizedWOSplit, MHABufferAllocationTest,

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -46,7 +46,7 @@ static void init_linear_ir(const std::vector<ov::PartialShape>& in_shapes, Linea
     loop_manager->mark_loop(expr_it, std::next(expr_it), inner_wa, inner_inc, 0, loop_entry_points, loop_exit_points);
     loop_manager->mark_loop(expr_it, std::next(expr_it), blocked_wa, blocked_inc, 1, loop_entry_points, loop_exit_points);
     const auto loop_id = loop_manager->mark_loop(expr_it, std::next(expr_it), outer_wa, outer_inc, 1, loop_entry_points, loop_exit_points);
-    loop_manager->get_loop_info(loop_id)->outer_splited_loop = true;
+    loop_manager->get_loop_info(loop_id)->set_outer_splited_loop(true);
 }
 
 static void init_pipeline(pass::PassPipeline& pass_pipeline) {

--- a/src/common/snippets/tests/src/lowering_utils.cpp
+++ b/src/common/snippets/tests/src/lowering_utils.cpp
@@ -44,7 +44,8 @@ DummyTargetMachine::DummyTargetMachine(const std::vector<ov::Node::type_info_t>&
     jitters[ov::snippets::op::PerfCountBegin::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::PerfCountEnd::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::Brgemm::get_type_info_static()] = dummy_functor;
-    jitters[ov::snippets::op::Buffer::get_type_info_static()] = dummy_functor;
+    jitters[ov::snippets::op::IntermediateMemoryBuffer::get_type_info_static()] = dummy_functor;
+    jitters[ov::snippets::op::NewMemoryBuffer::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::VectorBuffer::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::Fill::get_type_info_static()] = dummy_functor;
 

--- a/src/common/snippets/tests/src/pass/movebroadcast.cpp
+++ b/src/common/snippets/tests/src/pass/movebroadcast.cpp
@@ -28,7 +28,7 @@ TEST_F(TransformationTestsF, InsertBroadcastMove) {
     {
         auto data0 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 3});
         auto data1 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 1});
-        auto move1 = std::make_shared<snippets::isa::BroadcastMove>(data1, Shape{1, 2, 3});
+        auto move1 = std::make_shared<snippets::isa::BroadcastMove>(data1, ov::Dimension{3});
         auto add = std::make_shared<ov::op::v1::Add>(data0, move1);
         model_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{data0, data1});
     }

--- a/src/plugins/intel_cpu/src/emitters/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/cpu_generator.cpp
@@ -66,7 +66,8 @@ intel_cpu::CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t ho
     // data movement
     jitters[op::v0::Parameter::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
     jitters[op::v0::Result::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
-    jitters[snippets::op::Buffer::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
+    jitters[snippets::op::IntermediateMemoryBuffer::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
+    jitters[snippets::op::NewMemoryBuffer::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
     jitters[snippets::op::VectorBuffer::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
     jitters[snippets::op::RankNormalization::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(NopEmitter);
     // jitters[op::v1::Constant::get_type_info_static()] = CREATE_CPU_EMITTER(); // Not supported

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.cpp
@@ -729,9 +729,6 @@ void StoreConvertEmitter::emit_isa(const std::vector<size_t> &in, const std::vec
 void StoreConvertEmitter::emit_data() const {
     store_emitter->emit_data();
 }
-size_t BrgemmEmitter::getBrgIdx(size_t kIdx, size_t nIdx) {
-    return kIdx * BRGEMM_N_KERNEL_NUM + nIdx;
-}
 
 size_t BrgemmEmitter::get_in_leading_dim(const VectorDims& shape, const std::vector<size_t>& layout) {
     // Input shape is original, so we need to correctly read this data by order
@@ -761,17 +758,12 @@ size_t BrgemmEmitter::get_out_leading_dim(const VectorDims& shape, const std::ve
 }
 
 BrgemmEmitter::BrgemmEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr) : jit_emitter(h, isa) {
-    m_brgCtxs.fill(brgemmCtx());
-    std::generate(m_brgKernels.begin(), m_brgKernels.end(), [](){ return nullptr; });
     in_out_type_ = emitter_in_out_map::gpr_to_gpr;
     const auto& brgemm_node = as_type_ptr<ov::intel_cpu::BrgemmCPU>(expr->get_node());
     if (brgemm_node->is_dynamic())
         OPENVINO_THROW("Snippets don't support code generation for dynamic Brgemm");
-    const auto brgemm_copy = brgemm_node->is_with_data_repacking() ? brgemm_node->get_brgemm_copy() : nullptr;
 
     std::vector<size_t> leading_dimensions;
-    std::vector<std::vector<size_t>> io_layouts;
-
      auto get_layout = [](const std::vector<size_t>& layout, const snippets::VectorDims& io_shape) {
         if (!layout.empty()) return layout;
         std::vector<size_t> default_layout(io_shape.size());
@@ -780,45 +772,36 @@ BrgemmEmitter::BrgemmEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPt
     };
 
     auto init_in_scheduling_params = [&](const snippets::lowered::PortDescriptorPtr& input) {
-        io_layouts.push_back(get_layout(input->get_layout(), input->get_shape()));
-        leading_dimensions.push_back(get_in_leading_dim(input->get_shape(), io_layouts.back()));
+        const auto& layout = get_layout(input->get_layout(), input->get_shape());
+        leading_dimensions.push_back(get_in_leading_dim(input->get_shape(), layout));
     };
     auto init_out_scheduling_params = [&](const snippets::lowered::PortDescriptorPtr& output) {
-        io_layouts.push_back(get_layout(output->get_layout(), output->get_shape()));
-        leading_dimensions.push_back(get_out_leading_dim(output->get_shape(), io_layouts.back()));
+        const auto& layout = get_layout(output->get_layout(), output->get_shape());
+        leading_dimensions.push_back(get_out_leading_dim(output->get_shape(), layout));
     };
-    init_in_scheduling_params(expr->get_input_port_descriptor(0));
+
+    const auto& input_0_desc = expr->get_input_port_descriptor(0);
+    const auto& input_1_desc = expr->get_input_port_descriptor(1);
+    const auto& output_desc = expr->get_output_port_descriptor(0);
+
+    init_in_scheduling_params(input_0_desc);
     if (brgemm_node->is_with_data_repacking()) {
-        io_layouts.push_back(std::vector<size_t>{});
-        leading_dimensions.push_back(0);
+        const auto& brgemm_copy = brgemm_node->get_brgemm_copy();
+        const auto& allocated_shape = brgemm_copy->get_data_repacking_shape(input_1_desc->get_shape());
+        leading_dimensions.push_back(*allocated_shape.rbegin());
     } else {
-        init_in_scheduling_params(expr->get_input_port_descriptor(1));
+        init_in_scheduling_params(input_1_desc);
     }
-    init_out_scheduling_params(expr->get_output_port_descriptor(0));
+    init_out_scheduling_params(output_desc);
 
-    const auto& A_shape = expr->get_input_port_descriptor(0)->get_shape();
-    const auto& A_layout = io_layouts[0];
-    const auto& C_shape = expr->get_output_port_descriptor(0)->get_shape();
-    const auto& C_layout = io_layouts[2];
+    const auto& output_subtensor = output_desc->get_subtensor();
+    const auto& input_0_subtensor = input_0_desc->get_subtensor();
+    m_K = *input_0_subtensor.rbegin();
+    m_M = *(output_subtensor.rbegin() + 1);
+    m_N = *output_subtensor.rbegin();
 
-    // We need find original M,N,K having layouts and ordered shapes
-    // Layout:  0, 1, 2, 3   =>   New layout: 0, 2, 1, 3
-    // Shape:   1, 3, 5, 9   =>   New Shape:  1, 5, 3, 9
-    // To find original 2nd dimension, we should find index of position value `2` in new layout
-    // and get dimension from new shape by this index
-    auto get_ordered_idx = [](const std::vector<size_t>& layout, size_t idx) {
-        return std::distance(layout.begin(), std::find(layout.begin(), layout.end(), idx));
-    };
-
-    m_K = A_shape[get_ordered_idx(A_layout, A_layout.size() - 1)];
-    m_M = brgemm_node->get_input_count(0);
-    m_N = C_shape[get_ordered_idx(C_layout, C_layout.size() - 1)];
-
-    if (brgemm_node->is_with_data_repacking())
-        leading_dimensions[1] = rnd_up(m_N, brgemm_copy->get_n_block_size());
-    auto brg0Prc = brgemm_node->get_input_element_type(0);
-    auto brg1Prc = brgemm_node->get_input_element_type(1);
-    m_brg0VnniFactor = 4 / brg0Prc.size();
+    auto brg0Prc = InferenceEngine::details::convertPrecision(brgemm_node->get_input_element_type(0));
+    auto brg1Prc = InferenceEngine::details::convertPrecision(brgemm_node->get_input_element_type(1));
     bool brgWithAMX = brgemm_node->is_amx();
 
     io_data_size = {brg0Prc.size(), brg1Prc.size()};
@@ -829,59 +812,17 @@ BrgemmEmitter::BrgemmEmitter(jit_generator* h, cpu_isa_t isa, const ExpressionPt
     m_with_comp = brgemm_node->is_with_compensations();
     m_with_scratch = brgemm_node->is_with_scratchpad();
 
-    m_N_blk = brgemm_node->get_n_block_size();
-    m_K_blk = brgemm_node->get_k_block_size();
-    m_N_tail = m_N % m_N_blk;
-    m_K_tail = m_K % m_K_blk;
+    m_brgCtx.M = m_M;
+    m_brgCtx.N = m_N;
+    m_brgCtx.K = m_K;
+    m_brgCtx.LDA = leading_dimensions[0];
+    m_brgCtx.LDB = leading_dimensions[1];
+    m_brgCtx.LDC = leading_dimensions[2];
+    m_brgCtx.dt_in0 = static_cast<dnnl_data_type_t>(DnnlExtensionUtils::IEPrecisionToDataType(brg0Prc));
+    m_brgCtx.dt_in1 = static_cast<dnnl_data_type_t>(DnnlExtensionUtils::IEPrecisionToDataType(brg1Prc));
+    m_brgCtx.beta = brgemm_node->get_beta();
 
-    m_N_blk_loop = m_N >= 2 * m_N_blk;
-    m_K_blk_loop = m_K >= 3 * m_K_blk;
-    OPENVINO_ASSERT((!brgemm_node->is_with_data_repacking()) || (!m_N_blk_loop && !m_K_blk_loop),
-                    "BrgemmEmitter doesn't support blocking by K, N dimensions when data repacking is needed!");
-
-    auto N = [&](size_t n) {
-        switch (n) {
-            case 0: return m_N_blk;
-            case 1: return m_N_tail;
-            default: OPENVINO_THROW("BrgemmEmitter detected unsupported N value");
-        }
-    };
-    auto K = [&](size_t k) {
-        switch (k) {
-            case 0: return m_K_blk;
-            case 1: return m_K >= 2 * m_K_blk ? m_K_blk : 0;
-            case 2: return m_K_tail;
-            default:  OPENVINO_THROW("BrgemmEmitter detected unsupported K value");
-        }
-    };
-
-    bool has_K_kernel = false;
-    for (size_t k = 0; k < BRGEMM_K_KERNEL_NUM; k++) {
-        bool has_N_kernel = false;
-        for (size_t n = 0; n < BRGEMM_N_KERNEL_NUM; n++) {
-            const size_t kernel_idx = getBrgIdx(k, n);
-            auto& brgemmCtx = m_brgCtxs[kernel_idx];
-
-            brgemmCtx.M = m_M;
-            brgemmCtx.N = N(n);
-            brgemmCtx.K = K(k);
-            brgemmCtx.LDA = leading_dimensions[0];
-            brgemmCtx.LDB = leading_dimensions[1];
-            brgemmCtx.LDC = leading_dimensions[2];
-            brgemmCtx.dt_in0 = static_cast<dnnl_data_type_t>(DnnlExtensionUtils::ElementTypeToDataType(brg0Prc));
-            brgemmCtx.dt_in1 = static_cast<dnnl_data_type_t>(DnnlExtensionUtils::ElementTypeToDataType(brg1Prc));
-            brgemmCtx.beta = has_K_kernel ? 1 : 0;
-
-            if (brgemmCtx.N == 0 || brgemmCtx.N > m_N ||
-                brgemmCtx.K == 0 || brgemmCtx.K > m_K)
-                continue;
-
-            initBrgemm(brgemmCtx, m_brgKernels[kernel_idx], brgWithAMX);
-            has_N_kernel = true;
-        }
-        if (has_N_kernel)
-            has_K_kernel = true;
-    }
+    initBrgemm(m_brgCtx, m_brgKernel, brgWithAMX);
 
     m_load_offset_a = brgemm_node->get_offset_a();
     m_load_offset_b = brgemm_node->get_offset_b();
@@ -918,14 +859,6 @@ void BrgemmEmitter::validate_arguments(const std::vector<size_t> &in, const std:
         unique_ids_count++;
     };
 
-    if (m_N_blk_loop || m_K_blk_loop) {
-        if (aux_gpr_idxs.size() < static_cast<size_t>(m_N_blk_loop) + static_cast<size_t>(m_K_blk_loop))
-            OPENVINO_THROW("BRGEMM Emitter requires extra gpr which was not allocated");
-        if (m_N_blk_loop)
-            add_reg_to_unique_ids(aux_gpr_idxs[0]);
-        if (m_K_blk_loop)
-            add_reg_to_unique_ids(aux_gpr_idxs[m_N_blk_loop]);
-    }
     if (m_with_scratch) {
         if (in.size() != 3)
             OPENVINO_THROW("BRGEMM Emitter expects 3 inputs if there are compensations/wsp");
@@ -960,118 +893,24 @@ void BrgemmEmitter::initBrgemm(brgemmCtx& ctx, std::unique_ptr<brgemm_kernel_t>&
     brgKernel.reset(brgKernel_);
 }
 
-size_t BrgemmEmitter::aux_gprs_count() const {
-    return m_N_blk_loop + m_K_blk_loop;
-}
-
-void BrgemmEmitter::emit_N_blocking_loops(size_t k_kernel_id,
-                                          const Xbyak::Reg64& input_0, const Xbyak::Reg64& input_1,
-                                          const Xbyak::Reg64& input_2, const Xbyak::Reg64& output_0,
-                                          const Xbyak::Reg64& work_amount_N) const {
-    // Blocked N loop
-    size_t kernel_idx = getBrgIdx(k_kernel_id, 0);
-    if (m_brgKernels[kernel_idx]) {
-        const auto& brgemmCtx = m_brgCtxs[kernel_idx];
-        Label N_loop_begin;
-        if (m_N_blk_loop) {
-            h->mov(work_amount_N, m_N);
-            h->L(N_loop_begin);
-        }
-
-        emit_brgemm_kernel_call(m_brgKernels[kernel_idx].get(), brgemmCtx, input_0, input_1, input_2, output_0);
-        // We don't need to increment pointers if we cover full N dimension in one kernel call
-        if (m_N_blk_loop || m_N_tail != 0) {
-            h->add(output_0, brgemmCtx.N * io_data_size.back());
-            h->add(input_1, brgemmCtx.N * io_data_size[1]);
-            if (m_with_scratch && m_with_comp)
-                h->add(input_2, brgemmCtx.N * io_data_size[2]);
-        }
-
-        if (m_N_blk_loop) {
-            h->sub(work_amount_N, brgemmCtx.N);
-            h->cmp(work_amount_N, brgemmCtx.N);
-            h->jge(N_loop_begin);
-        }
-    }
-    // N loop tail
-    kernel_idx = getBrgIdx(k_kernel_id, 1);
-    if (m_brgKernels[kernel_idx])
-        emit_brgemm_kernel_call(m_brgKernels[kernel_idx].get(), m_brgCtxs[kernel_idx], input_0, input_1, input_2, output_0);
-
-    if (m_N_blk_loop || m_N_tail != 0) {
-        h->sub(input_1, (m_N - m_N_tail) * io_data_size[1]);
-        h->sub(output_0, (m_N - m_N_tail) * io_data_size.back());
-        if (m_with_scratch && m_with_comp)
-            h->sub(input_2, (m_N - m_N_tail) * io_data_size[2]);
-    }
-}
-
 void BrgemmEmitter::emit_impl(const std::vector<size_t>& in,
                               const std::vector<size_t>& out) const {
     validate_arguments(in, out);
     if (host_isa_ == cpu::x64::avx512_core) {
         Xbyak::Reg64 input_0(static_cast<int>(in[0]));
         Xbyak::Reg64 input_1(static_cast<int>(in[1]));
-        Xbyak::Reg64 input_2(static_cast<int>(0));  // scratch. Default reg index is 0 if there isn't scratch
+        Xbyak::Reg64 input_2(static_cast<int>(m_with_scratch ? in[2] : 0));  // scratch. Default reg index is 0 if there isn't scratch
         Xbyak::Reg64 output_0(static_cast<int>(out[0]));
-        Xbyak::Reg64 work_amount_N(m_N_blk_loop ? static_cast<int>(aux_gpr_idxs[0]) : 0);
-        Xbyak::Reg64 work_amount_K(m_K_blk_loop ? static_cast<int>(aux_gpr_idxs[m_N_blk_loop]) : 0);
-        h->add(input_0, m_load_offset_a);
-        h->add(input_1, m_load_offset_b);
-        h->add(output_0, m_store_offset_c);
-        if (m_with_scratch) {
-            input_2 = Xbyak::Reg64(static_cast<int>(in[2]));
-            h->add(input_2, m_load_offset_scratch);
-        }
-
-        // fills kernel_idx with the first idx of non-empty K kernel or returns false
-        auto get_K_kernel_idx = [&](size_t k_kernel_id, size_t& kernel_idx) {
-            for (size_t n = 0; n < BRGEMM_N_KERNEL_NUM; n++) {
-                const auto idx = getBrgIdx(k_kernel_id, n);
-                if (m_brgKernels[idx]) {
-                    kernel_idx = idx;
-                    return true;
-                }
-            }
-            return false;
-        };
-        // Blocked K loop
-        const auto k_tail_id = BRGEMM_K_KERNEL_NUM - 1;
-        size_t total_K_work_amount = m_K;
-        size_t kernel_idx = SIZE_MAX;
-        for (size_t k_blocked_id = 0; k_blocked_id < k_tail_id; k_blocked_id++) {
-            if (get_K_kernel_idx(k_blocked_id, kernel_idx)) {
-                const auto& brgemmCtx = m_brgCtxs[kernel_idx];
-                Label K_loop_begin;
-                // Note: we never emit loop for the first blocked kernel, since it always executed only once.
-                // The purpose of the first blocked K kernel is to initializes output, because it has beta = 0
-                if (k_blocked_id == 0) {
-                    total_K_work_amount -= brgemmCtx.K;
-                } else if (m_K_blk_loop) {
-                    h->mov(work_amount_K, total_K_work_amount);
-                    h->L(K_loop_begin);
-                }
-
-                emit_N_blocking_loops(k_blocked_id, input_0, input_1, input_2, output_0, work_amount_N);
-                h->add(input_0, brgemmCtx.K * io_data_size[0]);
-                h->add(input_1, (brgemmCtx.K * brgemmCtx.LDB) * io_data_size[1]);
-                if (m_K_blk_loop && k_blocked_id) {
-                    h->sub(work_amount_K, brgemmCtx.K);
-                    h->cmp(work_amount_K, brgemmCtx.K);
-                    h->jge(K_loop_begin);
-                }
-            }
-        }
-        // K loop tail
-        if (get_K_kernel_idx(k_tail_id, kernel_idx)) {
-            emit_N_blocking_loops(k_tail_id, input_0, input_1, input_2, output_0, work_amount_N);
-        }
-
-        h->sub(input_0, m_load_offset_a + (m_K - m_K_tail) * io_data_size[0]);
-        h->sub(input_1, m_load_offset_b + (m_K - m_K_tail) * m_brgCtxs[0].LDB * io_data_size[1]);
-        if (m_with_scratch)
-            h->sub(input_2, m_load_offset_scratch);
-        h->sub(output_0, m_store_offset_c);
+        emit_brgemm_kernel_call(m_brgKernel.get(),
+                                m_brgCtx,
+                                input_0,
+                                input_1,
+                                input_2,
+                                output_0,
+                                m_load_offset_a,
+                                m_load_offset_b,
+                                m_load_offset_scratch,
+                                m_store_offset_c);
     } else {
         OPENVINO_THROW("BrgemmEmitter requires at least avx512_core instruction set");
     }

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.cpp
@@ -852,20 +852,8 @@ std::set<std::vector<element::Type>> BrgemmEmitter::get_supported_precisions(con
 }
 
 void BrgemmEmitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
-    std::set<size_t> unique_ids{in[0], in[1], out[0]};
-    size_t unique_ids_count = 3;
-    auto add_reg_to_unique_ids = [&](const size_t reg_number) {
-        unique_ids.insert(reg_number);
-        unique_ids_count++;
-    };
-
-    if (m_with_scratch) {
-        if (in.size() != 3)
-            OPENVINO_THROW("BRGEMM Emitter expects 3 inputs if there are compensations/wsp");
-        add_reg_to_unique_ids(in[2]);
-    }
-    if (unique_ids.size() != unique_ids_count) {
-        OPENVINO_THROW("BRGEMM Emitter expects that all input/output registers are unique");
+    if (m_with_scratch && in.size() != 3) {
+        IE_THROW() << "BRGEMM Emitter expects 3 inputs if there are compensations/wsp";
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
@@ -396,10 +396,6 @@ private:
     brgemmCtx m_brgCtx;
     std::unique_ptr<dnnl::impl::cpu::x64::brgemm_kernel_t> m_brgKernel = nullptr;
 
-    size_t m_M = 0lu;
-    size_t m_K = 0lu;
-    size_t m_N = 0lu;
-
     bool m_with_scratch = false;
     bool m_with_comp = false;
 

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
@@ -365,7 +365,6 @@ public:
 
     size_t get_inputs_num() const override { return m_with_scratch ? 3 : 2; }
     static std::set<std::vector<element::Type>> get_supported_precisions(const std::shared_ptr<ov::Node>& node = nullptr);
-    size_t aux_gprs_count() const override;
 
     static size_t get_in_leading_dim(const VectorDims& shape, const std::vector<size_t>& layout);
     static size_t get_out_leading_dim(const VectorDims& shape, const std::vector<size_t>& layout);
@@ -387,30 +386,19 @@ private:
         float beta;
     };
     static void initBrgemm(brgemmCtx& ctx, std::unique_ptr<dnnl::impl::cpu::x64::brgemm_kernel_t>& brgKernel, bool use_amx);
-    static size_t getBrgIdx(size_t kIdx, size_t nIdx);
 
     void emit_brgemm_kernel_call(const dnnl::impl::cpu::x64::brgemm_kernel_t* brg_kernel, const brgemmCtx& ctx,
                                  Xbyak::Reg64 addr_A, Xbyak::Reg64 addr_B, Xbyak::Reg64 scratch, Xbyak::Reg64 addr_C,
                                  size_t in0_kernel_offset = 0, size_t in1_kernel_offset = 0,
                                  size_t in2_kernel_offset = 0, size_t out0_kernel_offset = 0) const;
     static void kernel_execute(const dnnl::impl::cpu::x64::brgemm_kernel_t *brg_kernel, const void *A, const void *B, void *C, void *scratch, int with_comp);
-    void emit_N_blocking_loops(size_t k_kernel_id,
-                               const Xbyak::Reg64& input_0, const Xbyak::Reg64& input_1,
-                               const Xbyak::Reg64& input_2, const Xbyak::Reg64& output_0,
-                               const Xbyak::Reg64& work_amount_N) const;
 
-    // Note: K dimension is covered by TWO blocked kernels (with beta = 0 and 1) + 1 for tail
-    static constexpr size_t BRGEMM_K_KERNEL_NUM = 3;
-    static constexpr size_t BRGEMM_N_KERNEL_NUM = 2;
-    std::array<brgemmCtx, BRGEMM_K_KERNEL_NUM * BRGEMM_N_KERNEL_NUM> m_brgCtxs;
-    std::array<std::unique_ptr<dnnl::impl::cpu::x64::brgemm_kernel_t>, BRGEMM_K_KERNEL_NUM * BRGEMM_N_KERNEL_NUM> m_brgKernels;
+    brgemmCtx m_brgCtx;
+    std::unique_ptr<dnnl::impl::cpu::x64::brgemm_kernel_t> m_brgKernel = nullptr;
 
-    size_t m_M;
-    size_t m_K, m_K_blk, m_K_tail;
-    size_t m_N, m_N_blk, m_N_tail;
-    size_t m_brg0VnniFactor;
-    bool m_N_blk_loop = false;
-    bool m_K_blk_loop = false;
+    size_t m_M = 0lu;
+    size_t m_K = 0lu;
+    size_t m_N = 0lu;
 
     bool m_with_scratch = false;
     bool m_with_comp = false;

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -140,7 +140,6 @@ std::map<std::string, ngraph::OpSet> Extension::getOpSets() {
 
 #define NGRAPH_OP(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
         NGRAPH_OP(Brgemm, ov::snippets::op)
-        NGRAPH_OP(Buffer, ov::snippets::op)
         NGRAPH_OP(BroadcastLoad, ov::snippets::op)
         NGRAPH_OP(BroadcastMove, ov::snippets::op)
         NGRAPH_OP(ConvertSaturation, ov::snippets::op)
@@ -149,10 +148,12 @@ std::map<std::string, ngraph::OpSet> Extension::getOpSets() {
         NGRAPH_OP(HorizonMax, ov::snippets::op)
         NGRAPH_OP(HorizonSum, ov::snippets::op)
         NGRAPH_OP(Kernel, ov::snippets::op)
+        NGRAPH_OP(IntermediateMemoryBuffer, ov::snippets::op)
         NGRAPH_OP(Load, ov::snippets::op)
         NGRAPH_OP(LoadReshape, ov::snippets::op)
         NGRAPH_OP(LoopBegin, ov::snippets::op)
         NGRAPH_OP(LoopEnd, ov::snippets::op)
+        NGRAPH_OP(NewMemoryBuffer, ov::snippets::op)
         NGRAPH_OP(Nop, ov::snippets::op)
         NGRAPH_OP(PowerStatic, ov::snippets::op)
         NGRAPH_OP(Scalar, ov::snippets::op)

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.cpp
@@ -57,32 +57,31 @@ void BrgemmCopyB::custom_constructor_validate_and_infer_types(std::vector<size_t
     // During ctor call, BrgemmCopyB doesn't know his port descriptors.
     // So we use port descs from source inputs
     const auto element_type = get_input_element_type(0);
-    const auto& pshape = get_input_partial_shape(0);
+    validate_element_type(element_type);
     // The data always store in planar shape after repacking
-    const auto planar_pshape = snippets::utils::get_planar_pshape(pshape, layout_input);
+    const auto planar_pshape = snippets::utils::get_planar_pshape(get_input_partial_shape(0), layout_input);
     // data repacking output
     set_output_type(0, element_type, planar_pshape);
     // If compensations are needed, they are provided in 2nd output (which is used in BrgemmCPU)
     if (is_with_compensations()) {
         set_output_type(1, ov::element::f32, planar_pshape);
     }
-    validate(planar_pshape, element_type);
 }
 
 void BrgemmCopyB::validate_and_infer_types() {
     INTERNAL_OP_SCOPE(BrgemmRepack_validate_and_infer_types);
+    const auto& element_type = get_input_element_type(0);
+    validate_element_type(element_type);
     const auto port = snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(input(0));
     const auto shape = ov::Shape(port->get_shape());
-    const auto& element_type = get_input_element_type(0);
     const auto& planar_pshape = snippets::utils::get_planar_pshape(shape, port->get_layout());
     set_output_type(0, element_type, planar_pshape);
     if (is_with_compensations()) {
         set_output_type(1, ov::element::f32, planar_pshape);
     }
-    validate(planar_pshape, element_type);
 }
 
-void BrgemmCopyB::validate(const ov::PartialShape& planar_pshape, const ov::element::Type& element_type) {
+void BrgemmCopyB::validate_element_type(const ov::element::Type& element_type) {
     OPENVINO_ASSERT(one_of(element_type, element::bf16, element::i8),
                     "BrgemmCopyB doesn't support element type" + element_type.get_type_name());
 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
@@ -67,7 +67,7 @@ public:
 
 private:
     void custom_constructor_validate_and_infer_types(std::vector<size_t> layout_input = {});
-    void validate(const ov::PartialShape& planar_pshape, const ov::element::Type& element_type);
+    void validate_element_type(const ov::element::Type& element_type);
     void compute_block_size_values(const size_t blk_size_k, const size_t blk_size_n);
 
     Type m_type = Type::OnlyRepacking;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.cpp
@@ -16,7 +16,7 @@ namespace intel_cpu {
 BrgemmCPU::BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Type type,
                      const size_t offset_a, const size_t offset_b, const size_t offset_c,
                      std::vector<size_t> layout_a, std::vector<size_t> layout_b, std::vector<size_t> layout_c,
-                     const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n)
+                     const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n, const float beta)
     : Brgemm(), m_type(type) {
     // We call default ctor of Brgemm class to avoid incorrect shape infer in constructor_validate_and_type_infer() call
     set_arguments({A, B});
@@ -32,8 +32,8 @@ BrgemmCPU::BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Type ty
 BrgemmCPU::BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Output<Node>& scratch, const Type type,
                      const size_t offset_a, const size_t offset_b, const size_t offset_scratch, const size_t offset_c,
                      std::vector<size_t> layout_a, std::vector<size_t> layout_b, std::vector<size_t> layout_c,
-                     const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n)
-    : Brgemm(), m_type(type) {
+                     const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n, const float beta)
+    : Brgemm(), m_type(type), m_beta(beta) {
     set_arguments({A, B, scratch});
     set_output_size(1);
     ctor_initialize(std::set<size_t>{0, 1, 2}, std::set<size_t>{0});
@@ -48,8 +48,8 @@ BrgemmCPU::BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Output<
 BrgemmCPU::BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Type type,
                      const PortDescriptor& desc_a, const PortDescriptor& desc_b, const PortDescriptor& desc_c,
                      std::vector<size_t> layout_a, std::vector<size_t> layout_b, std::vector<size_t> layout_c,
-                     const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n)
-    : Brgemm(), m_type(type) {
+                     const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n, const float beta)
+    : Brgemm(), m_type(type), m_beta(beta) {
     set_arguments({A, B});
     set_output_size(1);
     m_input_ports = {{0, desc_a}, {1, desc_b}};
@@ -61,8 +61,8 @@ BrgemmCPU::BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Type ty
 BrgemmCPU::BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Output<Node>& scratch, const Type type,
                      const PortDescriptor& desc_a, const PortDescriptor& desc_b, const PortDescriptor& desc_scratch, const PortDescriptor& desc_c,
                      std::vector<size_t> layout_a, std::vector<size_t> layout_b, std::vector<size_t> layout_c,
-                     const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n)
-    : Brgemm(), m_type(type) {
+                     const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n, const float beta)
+    : Brgemm(), m_type(type), m_beta(beta) {
     set_arguments({A, B, scratch});
     set_output_size(1);
     m_input_ports = {{0, desc_a}, {1, desc_b}, {2, desc_scratch}};
@@ -136,22 +136,20 @@ std::shared_ptr<Node> BrgemmCPU::clone_with_new_inputs(const OutputVector& new_a
     check_new_args_count(this, new_args);
     std::shared_ptr<BrgemmCPU> brgemm;
     if (!is_with_scratchpad()) {
-        brgemm = std::make_shared<BrgemmCPU>(new_args.at(0), new_args.at(1), m_type,
+        return std::make_shared<BrgemmCPU>(new_args.at(0), new_args.at(1), m_type,
                                            get_input_port_descriptor(0), get_input_port_descriptor(1), get_output_port_descriptor(0),
                                            snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(input(0))->get_layout(),
                                            snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(input(1))->get_layout(),
                                            snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(output(0))->get_layout(),
-                                           m_M_blk, m_K_blk, m_N_blk);
+                                           m_M_blk, m_K_blk, m_N_blk, m_beta);
     } else {
-        brgemm = std::make_shared<BrgemmCPU>(new_args.at(0), new_args.at(1), new_args.at(2), m_type,
+        return std::make_shared<BrgemmCPU>(new_args.at(0), new_args.at(1), new_args.at(2), m_type,
             get_input_port_descriptor(0), get_input_port_descriptor(1), get_input_port_descriptor(2), get_output_port_descriptor(0),
             snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(input(0))->get_layout(),
             snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(input(1))->get_layout(),
             snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(output(0))->get_layout(),
-            m_M_blk, m_K_blk, m_N_blk);
+            m_M_blk, m_K_blk, m_N_blk, m_beta);
     }
-    brgemm->set_beta(get_beta());
-    return brgemm;
 }
 
 std::shared_ptr<BrgemmCopyB> BrgemmCPU::get_brgemm_copy() const {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.cpp
@@ -17,7 +17,7 @@ BrgemmCPU::BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Type ty
                      const size_t offset_a, const size_t offset_b, const size_t offset_c,
                      std::vector<size_t> layout_a, std::vector<size_t> layout_b, std::vector<size_t> layout_c,
                      const size_t blk_size_m, const size_t blk_size_k, const size_t blk_size_n, const float beta)
-    : Brgemm(), m_type(type) {
+    : Brgemm(), m_type(type), m_beta(beta) {
     // We call default ctor of Brgemm class to avoid incorrect shape infer in constructor_validate_and_type_infer() call
     set_arguments({A, B});
     set_output_size(1);

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.cpp
@@ -158,7 +158,7 @@ std::shared_ptr<BrgemmCopyB> BrgemmCPU::get_brgemm_copy() const {
     if (const auto brgemm_copy_b = ov::as_type_ptr<BrgemmCopyB>(b_input_node)) {
         return brgemm_copy_b;
     }
-    if (ov::is_type<snippets::op::Buffer>(b_input_node)) {
+    if (ov::is_type<snippets::op::IntermediateMemoryBuffer>(b_input_node)) {
         if (const auto brgemm_copy_b = ov::as_type_ptr<BrgemmCopyB>(b_input_node->get_input_node_shared_ptr(0))) {
             return brgemm_copy_b;
         }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
@@ -54,10 +54,12 @@ public:
     size_t get_m_block_size() const { return m_M_blk; }
     size_t get_k_block_size() const { return m_K_blk; }
     size_t get_n_block_size() const { return m_N_blk; }
+    float get_beta() const { return m_beta; }
 
     void set_m_block_size(size_t block_size) { m_M_blk = block_size; }
     void set_k_block_size(size_t block_size) { m_K_blk = block_size; }
     void set_n_block_size(size_t block_size) { m_N_blk = block_size; }
+    void set_beta(float beta) { m_beta = beta; }
 
     bool is_with_compensations() const { return m_type == Type::WithCompensations; }
     bool is_with_data_repacking() const { return m_type != Type::Floating; }
@@ -66,6 +68,8 @@ public:
 
     size_t get_offset_scratch() const;
     std::shared_ptr<BrgemmCopyB> get_brgemm_copy() const;
+
+    bool visit_attributes(AttributeVisitor& visitor) override;
 
     constexpr static size_t SCRATCH_BYTE_SIZE = 32 * 1024;
 
@@ -79,6 +83,7 @@ private:
     size_t m_M_blk = 0;
     size_t m_K_blk = 0;
     size_t m_N_blk = 0;
+    float m_beta = 0.f;
 };
 
 } // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
@@ -32,19 +32,19 @@ public:
     BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Type type,
               const size_t offset_a = 0, const size_t offset_b = 0, const size_t offset_c = 0,
               std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {},
-              const size_t blk_size_m = 0, const size_t blk_size_k = 0, const size_t blk_size_n = 0);
+              const size_t blk_size_m = 0, const size_t blk_size_k = 0, const size_t blk_size_n = 0, const float beta = 0.f);
     BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Output<Node>& scratch, const Type type,
               const size_t offset_a = 0, const size_t offset_b = 0, const size_t offset_scratch = 0, const size_t offset_c = 0,
               std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {},
-              const size_t blk_size_m = 0, const size_t blk_size_k = 0, const size_t blk_size_n = 0);
+              const size_t blk_size_m = 0, const size_t blk_size_k = 0, const size_t blk_size_n = 0, const float beta = 0.f);
     BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Type type,
               const PortDescriptor& desc_a, const PortDescriptor& desc_b, const PortDescriptor& desc_c,
               std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {},
-              const size_t blk_size_m = 0, const size_t blk_size_k = 0, const size_t blk_size_n = 0);
+              const size_t blk_size_m = 0, const size_t blk_size_k = 0, const size_t blk_size_n = 0, const float beta = 0.f);
     BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Output<Node>& scratch, const Type type,
               const PortDescriptor& desc_a, const PortDescriptor& desc_b, const PortDescriptor& desc_scratch, const PortDescriptor& desc_c,
               std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {},
-              const size_t blk_size_m = 0, const size_t blk_size_k = 0, const size_t blk_size_n = 0);
+              const size_t blk_size_m = 0, const size_t blk_size_k = 0, const size_t blk_size_n = 0, const float beta = 0.f);
     BrgemmCPU() = default;
 
     void validate_and_infer_types() override;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.cpp
@@ -92,7 +92,7 @@ pass::BrgemmToBrgemmCPU::BrgemmToBrgemmCPU() {
             set_full_port_desc(brgemm_repacking->output(0));
 
             if (with_amx) {
-                const auto scratch = std::make_shared<snippets::op::Buffer>(ov::Shape{BrgemmCPU::SCRATCH_BYTE_SIZE});
+                const auto scratch = std::make_shared<snippets::op::NewMemoryBuffer>(ov::Shape{BrgemmCPU::SCRATCH_BYTE_SIZE});
                 brgemm_cpu = std::make_shared<BrgemmCPU>(brgemm->input_value(0), brgemm_repacking->output(0), scratch, BrgemmCPU::Type::AMX,
                                                          offset_a, offset_b, 0, offset_c,
                                                          brgemm_in0_desc->get_layout(), std::vector<size_t>{}, brgemm_out_desc->get_layout());

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
@@ -9,6 +9,7 @@
 #include "snippets/itt.hpp"
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/lowered/loop_manager.hpp"
+#include "snippets/lowered/pass/insert_tail_loop.hpp"
 #include "snippets/snippets_isa.hpp"
 #include "transformations/snippets/x64/op/brgemm_cpu.hpp"
 
@@ -16,9 +17,9 @@
 namespace ov {
 namespace intel_cpu {
 namespace pass {
-using LoopManager = snippets::lowered::LinearIR::LoopManager;
-using LoopInfoPtr = LoopManager::LoopInfoPtr;
-using LoopPort = LoopManager::LoopPort;
+using LinearIR = snippets::lowered::LinearIR;
+using LoopPort = LinearIR::LoopManager::LoopPort;
+using ExpressionPtr = ov::snippets::lowered::ExpressionPtr;
 
 BrgemmBlocking::BrgemmBlocking() : Pass() {}
 
@@ -36,24 +37,22 @@ void BrgemmBlocking::move_new_memory_buffer(snippets::lowered::LinearIR& linear_
     }
 }
 
-bool BrgemmBlocking::run(snippets::lowered::LinearIR& linear_ir) {
+bool BrgemmBlocking::run(LinearIR& linear_ir) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::BrgemmBlocking")
     if (linear_ir.empty())
         return false;
 
-
     const auto& loop_manager = linear_ir.get_loop_manager();
-    const size_t dim_idx = 1;
+    auto blocking_loop_exists = [&](const ExpressionPtr& brgemm_expr, const std::shared_ptr<ov::intel_cpu::BrgemmCPU>& brgemm) {
+        auto check_port = [&](const LoopPort& p) {
+            return p.expr_port->get_expr() == brgemm_expr && (p.dim_idx == 0 || p.dim_idx == 1);
+        };
 
-    auto blocking_loop_exists = [&](const ov::snippets::lowered::ExpressionPtr& expr,
-                                    const std::shared_ptr<ov::intel_cpu::BrgemmCPU>& brgemm) {
-        const auto& loop_ids = expr->get_loop_ids();
+        const auto& loop_ids = brgemm_expr->get_loop_ids();
         for (const auto& id : loop_ids) {
             const auto loop = loop_manager->get_loop_info(id);
-            if (loop->dim_idx == dim_idx) {
-                OPENVINO_ASSERT(brgemm->get_input_count(0) == loop->increment,
-                                "Brgemm ", brgemm, " has input count (", brgemm->get_input_count(0),
-                                ") which doesn't match the increment(", loop->increment, ") of loop by M");
+            if (std::any_of(loop->entry_points.begin(), loop->entry_points.end(), check_port) ||
+                std::any_of(loop->exit_points.begin(), loop->exit_points.end(), check_port)) {
                 return true;
             }
         }
@@ -62,34 +61,135 @@ bool BrgemmBlocking::run(snippets::lowered::LinearIR& linear_ir) {
 
     bool modified = false;
     for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end(); expr_it++) {
-        const auto& expr = *expr_it;
-        const auto brgemm = ov::as_type_ptr<ov::intel_cpu::BrgemmCPU>(expr->get_node());
-        if (!brgemm || blocking_loop_exists(expr, brgemm))
+        const auto& brgemm_expr = *expr_it;
+        const auto brgemm = ov::as_type_ptr<ov::intel_cpu::BrgemmCPU>(brgemm_expr->get_node());
+        if (!brgemm || blocking_loop_exists(brgemm_expr, brgemm))
             continue;
 
-        const auto& input_shape_0 = expr->get_input_port_descriptor(0)->get_shape();
-        const auto& input_layout_0 = expr->get_input_port_descriptor(0)->get_layout();
-        const auto& dim = *(input_layout_0.rbegin() + dim_idx);
-        const auto& m = input_shape_0[dim];
+        const auto& input_0_desc = brgemm_expr->get_input_port_descriptor(0);
+        const auto& input_1_desc = brgemm_expr->get_input_port_descriptor(1);
+        const auto& output_desc = brgemm_expr->get_output_port_descriptor(0);
 
-        const auto block_size = brgemm->get_m_block_size();
-        brgemm->set_input_count(block_size);
+        auto input_0_subtensor = input_0_desc->get_subtensor();
+        auto input_1_subtensor = input_1_desc->get_subtensor();
+        auto output_subtensor = output_desc->get_subtensor();
 
-        const auto work_amount = m;
-        const auto increment = block_size;
+        auto apply_m_blocking = [&]() {
+            const auto& output_shape = output_desc->get_shape();
+            const auto& output_layout = output_desc->get_layout();
 
-        auto loop_begin_it = expr_it, loop_end_it = std::next(expr_it);
-        std::vector<LoopPort> entries{LoopPort(expr->get_input_port(0), true), LoopPort(expr->get_input_port(1), false)};
-        // Scratchpad for AMX scenario is needed only as temporary buffer for each M block - it means that the Buffer should be in this loop.
-        // Other scratchpads (that after BrgemmCopyB) should be the loop outside.
-        if (brgemm->is_with_compensations()) {
-            entries.emplace_back(expr->get_input_port(2), false);
-        } else if (brgemm->is_amx()) {
-            move_new_memory_buffer(linear_ir, expr_it);
-            loop_begin_it = std::prev(expr_it);
-        }
-        std::vector<LoopPort> exits{LoopPort(expr->get_output_port(0), true)};
-        loop_manager->mark_loop(loop_begin_it, loop_end_it, work_amount, increment, dim_idx, entries, exits);
+            const auto& m_idx = *(output_layout.rbegin() + 1);
+            const auto& m = output_shape[m_idx];
+            const auto block_size_m = brgemm->get_m_block_size();
+            if (block_size_m >= m) {
+                *(input_0_subtensor.rbegin() + 1) = m;
+                *(output_subtensor.rbegin() + 1) = m;
+            } else {
+                *(input_0_subtensor.rbegin() + 1) = block_size_m;
+                *(output_subtensor.rbegin() + 1) = block_size_m;
+
+                std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), true), LoopPort(brgemm_expr->get_input_port(1), false)};
+                if (brgemm->is_with_scratchpad())
+                    entries.emplace_back(brgemm_expr->get_input_port(2), false);
+                std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), true)};
+                loop_manager->mark_loop(expr_it, std::next(expr_it), m, block_size_m, 1, entries, exits);
+            }
+        };
+
+        auto apply_n_blocking = [&]() {
+            const auto& output_shape = output_desc->get_shape();
+            const auto& output_layout = output_desc->get_layout();
+
+            const auto& n_idx = *output_layout.rbegin();
+            const auto& n = output_shape[n_idx];
+            const auto block_size_n = brgemm->get_n_block_size();
+            if (block_size_n >= n) {
+                *input_1_subtensor.rbegin() = n;
+                *output_subtensor.rbegin() = n;
+            } else {
+                *input_1_subtensor.rbegin() = block_size_n;
+                *output_subtensor.rbegin() = block_size_n;
+
+                std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), false),
+                                              LoopPort(brgemm_expr->get_input_port(1), true)};
+                if (brgemm->is_with_scratchpad())
+                    entries.emplace_back(brgemm_expr->get_input_port(2), true);
+                std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), true)};
+                loop_manager->mark_loop(expr_it, std::next(expr_it), n, block_size_n, 0, entries, exits);
+            }
+        };
+
+        auto apply_k_blocking = [&]() {
+            const auto& input_shape_0 = input_0_desc->get_shape();
+            const auto& input_layout_0 = input_0_desc->get_layout();
+
+            const auto& k_idx = *input_layout_0.rbegin();
+            const auto& k = input_shape_0[k_idx];
+            const auto block_size_k = brgemm->get_k_block_size();
+            if (block_size_k >= k) {
+                *input_0_subtensor.rbegin() = k;
+                *(input_1_subtensor.rbegin() + 1) = k;
+            } else {
+                *input_0_subtensor.rbegin() = block_size_k;
+                *(input_1_subtensor.rbegin() + 1) = block_size_k;
+
+                std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), true, 0),
+                                              LoopPort(brgemm_expr->get_input_port(1), true, 1)};
+                if (brgemm->is_with_scratchpad())
+                    entries.emplace_back(brgemm_expr->get_input_port(2), false, 1);
+                std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), false)};
+                auto loop_id = loop_manager->mark_loop(expr_it, std::next(expr_it), k, block_size_k, entries, exits);
+                const auto loop_info = loop_manager->get_loop_info(loop_id);
+
+                auto first_iter_handler = [](LinearIR& linear_ir, LinearIR::constExprIt expr_it) {
+                    const auto loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(expr_it->get()->get_node());
+                    const auto loop_id = loop_end->get_id();
+                    const auto& loop_manager = linear_ir.get_loop_manager();
+                    const auto& loop_info = loop_manager->get_loop_info(loop_id);
+                    const auto work_amount = loop_info->work_amount;
+                    const auto increment = loop_info->increment;
+                    if (work_amount <= increment)
+                        return false;
+
+                    auto new_loop_range = snippets::lowered::pass::InsertTailLoop::copy_loop(linear_ir, loop_id);
+                    const auto new_loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(std::prev(new_loop_range.end())->get()->get_node());
+                    auto new_loop_info = loop_manager->get_loop_info(new_loop_end->get_id());
+                    const auto new_work_amount = work_amount - increment;
+                    new_loop_end->set_work_amount(new_work_amount);
+                    new_loop_info->work_amount = new_work_amount;
+                    for (const auto& expr : new_loop_range) {
+                        if (const auto brgemm = ov::as_type_ptr<ov::intel_cpu::BrgemmCPU>(expr->get_node())) {
+                            brgemm->set_beta(1.f);
+                        }
+                    }
+
+                    linear_ir.insert(std::next(expr_it), new_loop_range.begin(), new_loop_range.end());
+
+                    loop_info->work_amount = increment;
+                    loop_end->set_work_amount(increment);
+                    loop_end->set_finalization_offsets(std::vector<int64_t>(loop_end->get_finalization_offsets().size(), 0));
+                    const auto begin_it = linear_ir.find(linear_ir.get_expr_by_node(new_loop_end->get_loop_begin()));
+                    const auto end_it = linear_ir.find(linear_ir.get_expr_by_node(new_loop_end));
+                    snippets::lowered::pass::InsertTailLoop::propagate_updated_subtensor_through_loop(
+                        linear_ir,
+                        new_loop_info,
+                        std::next(begin_it),
+                        end_it,
+                        increment);
+                    return true;
+                };
+                loop_info->set_first_iter_handler(first_iter_handler);
+            }
+        };
+
+        apply_k_blocking();
+        apply_n_blocking();
+        apply_m_blocking();
+
+        brgemm_expr->get_input_port_descriptor(0)->set_subtensor(input_0_subtensor);
+        brgemm_expr->get_input_port_descriptor(1)->set_subtensor(input_1_subtensor);
+        brgemm_expr->get_output_port_descriptor(0)->set_subtensor(output_subtensor);
+        modified = true;
     }
 
     return modified;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
@@ -7,6 +7,7 @@
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "snippets/itt.hpp"
+#include "snippets/utils.hpp"
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/lowered/loop_manager.hpp"
 #include "snippets/lowered/pass/insert_tail_loop.hpp"
@@ -28,8 +29,6 @@ void BrgemmBlocking::move_new_memory_buffer(snippets::lowered::LinearIR& linear_
     const auto wsp_expr = brgemm_expr->get_input_port_connector(2)->get_source().get_expr();
     const auto wsp_buffer = ov::as_type_ptr<ov::snippets::op::Buffer>(wsp_expr->get_node());
     OPENVINO_ASSERT(wsp_buffer && wsp_buffer->is_new_memory(), "Incorrect Scratchpad buffer for Brgemm AMX");
-    // [115164] Should be fully supported by explicit loops of blocking by K, N
-    OPENVINO_ASSERT(brgemm_expr->get_loop_ids().empty() && wsp_expr->get_loop_ids().empty(), "Incorrect blocking loop marking for Brgemm AMX");
     // If scratchpad with temp memory is not explicitly before Brgemm, need to move to there.
     if (wsp_expr != *std::prev(brgemm_it)) {
         const auto wsp_it = linear_ir.find(wsp_expr);
@@ -45,7 +44,7 @@ bool BrgemmBlocking::run(LinearIR& linear_ir) {
     const auto& loop_manager = linear_ir.get_loop_manager();
     auto blocking_loop_exists = [&](const ExpressionPtr& brgemm_expr, const std::shared_ptr<ov::intel_cpu::BrgemmCPU>& brgemm) {
         auto check_port = [&](const LoopPort& p) {
-            return p.expr_port->get_expr() == brgemm_expr && (p.dim_idx == 0 || p.dim_idx == 1);
+            return p.expr_port->get_expr() == brgemm_expr && ov::snippets::utils::one_of(p.dim_idx, 0ul, 1ul);
         };
 
         const auto& loop_ids = brgemm_expr->get_loop_ids();
@@ -88,11 +87,17 @@ bool BrgemmBlocking::run(LinearIR& linear_ir) {
                 *(input_0_subtensor.rbegin() + 1) = block_size_m;
                 *(output_subtensor.rbegin() + 1) = block_size_m;
 
-                std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), true), LoopPort(brgemm_expr->get_input_port(1), false)};
-                if (brgemm->is_with_scratchpad())
+                auto loop_begin_it = expr_it, loop_end_it = std::next(expr_it);
+                std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), true),
+                                              LoopPort(brgemm_expr->get_input_port(1), false)};
+                if (brgemm->is_with_compensations()) {
                     entries.emplace_back(brgemm_expr->get_input_port(2), false);
+                } else if (brgemm->is_amx()) {
+                    move_new_memory_buffer(linear_ir, expr_it);
+                    loop_begin_it = std::prev(expr_it);
+                }
                 std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), true)};
-                loop_manager->mark_loop(expr_it, std::next(expr_it), m, block_size_m, 1, entries, exits);
+                loop_manager->mark_loop(loop_begin_it, loop_end_it, m, block_size_m, 1, entries, exits);
             }
         };
 
@@ -110,12 +115,17 @@ bool BrgemmBlocking::run(LinearIR& linear_ir) {
                 *input_1_subtensor.rbegin() = block_size_n;
                 *output_subtensor.rbegin() = block_size_n;
 
+                auto loop_begin_it = expr_it, loop_end_it = std::next(expr_it);
                 std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), false),
                                               LoopPort(brgemm_expr->get_input_port(1), true)};
-                if (brgemm->is_with_scratchpad())
+                if (brgemm->is_with_compensations()) {
                     entries.emplace_back(brgemm_expr->get_input_port(2), true);
+                } else if (brgemm->is_amx()) {
+                    move_new_memory_buffer(linear_ir, expr_it);
+                    loop_begin_it = std::prev(expr_it);
+                }
                 std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), true)};
-                loop_manager->mark_loop(expr_it, std::next(expr_it), n, block_size_n, 0, entries, exits);
+                loop_manager->mark_loop(loop_begin_it, loop_end_it, n, block_size_n, 0, entries, exits);
             }
         };
 
@@ -133,16 +143,22 @@ bool BrgemmBlocking::run(LinearIR& linear_ir) {
                 *input_0_subtensor.rbegin() = block_size_k;
                 *(input_1_subtensor.rbegin() + 1) = block_size_k;
 
+                auto loop_begin_it = expr_it, loop_end_it = std::next(expr_it);
                 std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), true, 0),
                                               LoopPort(brgemm_expr->get_input_port(1), true, 1)};
-                if (brgemm->is_with_scratchpad())
+                if (brgemm->is_with_compensations()) {
                     entries.emplace_back(brgemm_expr->get_input_port(2), false, 1);
+                } else if (brgemm->is_amx()) {
+                    move_new_memory_buffer(linear_ir, expr_it);
+                    loop_begin_it = std::prev(expr_it);
+                }
                 std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), false)};
-                auto loop_id = loop_manager->mark_loop(expr_it, std::next(expr_it), k, block_size_k, entries, exits);
+                auto loop_id = loop_manager->mark_loop(loop_begin_it, loop_end_it, k, block_size_k, entries, exits);
                 const auto loop_info = loop_manager->get_loop_info(loop_id);
 
                 auto first_iter_handler = [](LinearIR& linear_ir, LinearIR::constExprIt expr_it) {
                     const auto loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(expr_it->get()->get_node());
+                    OPENVINO_ASSERT(loop_end, "First loop iteraton handler must be called on LoopEnd expression");
                     const auto loop_id = loop_end->get_id();
                     const auto& loop_manager = linear_ir.get_loop_manager();
                     const auto& loop_info = loop_manager->get_loop_info(loop_id);

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
@@ -27,8 +27,8 @@ BrgemmBlocking::BrgemmBlocking() : Pass() {}
 void BrgemmBlocking::move_new_memory_buffer(snippets::lowered::LinearIR& linear_ir, const snippets::lowered::LinearIR::constExprIt& brgemm_it) {
     const auto& brgemm_expr = brgemm_it->get();
     const auto wsp_expr = brgemm_expr->get_input_port_connector(2)->get_source().get_expr();
-    const auto wsp_buffer = ov::as_type_ptr<ov::snippets::op::Buffer>(wsp_expr->get_node());
-    OPENVINO_ASSERT(wsp_buffer && wsp_buffer->is_new_memory(), "Incorrect Scratchpad buffer for Brgemm AMX");
+    const auto wsp_buffer = ov::as_type_ptr<ov::snippets::op::NewMemoryBuffer>(wsp_expr->get_node());
+    OPENVINO_ASSERT(wsp_buffer, "Incorrect Scratchpad buffer for Brgemm AMX");
     // If scratchpad with temp memory is not explicitly before Brgemm, need to move to there.
     if (wsp_expr != *std::prev(brgemm_it)) {
         const auto wsp_it = linear_ir.find(wsp_expr);

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.hpp
@@ -12,7 +12,7 @@ namespace pass {
 
 /**
  * @interface BrgemmBlocking
- * @brief Covers BrgemmCPU with blocking loop by M
+ * @brief Covers BrgemmCPU with blocking loops
  * @ingroup snippets
  */
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
@@ -6,6 +6,7 @@
 
 #include "fuse_load_store_and_convert.hpp"
 #include "snippets/snippets_isa.hpp"
+#include "snippets/lowered/loop_manager.hpp"
 
 #include "transformations/snippets/x64/op/load_convert.hpp"
 #include "transformations/snippets/x64/op/store_convert.hpp"
@@ -32,13 +33,13 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowe
         return false;
 
     std::shared_ptr<ov::Node> load_convert = nullptr;
-    if (const auto convert_saturation = ov::as_type_ptr<snippets::op::ConvertSaturation>(convert)) {
+    if (ov::is_type<snippets::op::ConvertSaturation>(convert)) {
         load_convert = std::make_shared<ov::intel_cpu::LoadConvertSaturation>(load->input_value(0),
-                                                                              convert_saturation->get_destination_type(),
+                                                                              convert->get_destination_type(),
                                                                               load->get_count(), load->get_offset());
-    } else if (const auto convert_truncation = ov::as_type_ptr<snippets::op::ConvertTruncation>(convert)) {
+    } else if (ov::is_type<snippets::op::ConvertTruncation>(convert)) {
         load_convert = std::make_shared<ov::intel_cpu::LoadConvertTruncation>(load->input_value(0),
-                                                                              convert_truncation->get_destination_type(),
+                                                                              convert->get_destination_type(),
                                                                               load->get_count(), load->get_offset());
     } else {
         OPENVINO_THROW("Type of Convert op is undefined. Supports only fusing Load and ConvertTruncation or ConvertSaturation ops");
@@ -51,6 +52,13 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowe
     const auto convert_expr_it = convert_it;
     const auto insertion_pos = std::next(convert_it);
     convert_it = linear_ir.insert(insertion_pos, load_convert_expr);
+
+    const auto& load_loop_ids = load_expr->get_loop_ids();
+    load_convert_expr->set_loop_ids(load_loop_ids);
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    loop_manager->update_loops_port(load_loop_ids, load_expr->get_input_port(0), {load_convert_expr->get_input_port(0)}, true);
+    loop_manager->update_loops_port(load_loop_ids, convert_expr->get_output_port(0), {load_convert_expr->get_output_port(0)}, false);
+
     linear_ir.erase(std::find(linear_ir.cbegin(), convert_expr_it, load_expr));
     linear_ir.erase(convert_expr_it);
     linear_ir.replace_input(convert_consumers, load_convert_expr->get_output_port_connector(0));
@@ -60,7 +68,7 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowe
 bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::lowered::LinearIR& linear_ir,
                                                                    snippets::lowered::LinearIR::constExprIt& convert_it) {
     const auto& convert_expr = *convert_it;
-    const auto& convert = convert_expr->get_node();
+    const auto& convert = ov::as_type_ptr<ov::op::v0::Convert>(convert_expr->get_node());
     const auto& input_connector = convert_expr->get_input_port_connector(0);
     const auto& output_connector = convert_expr->get_output_port_connector(0);
     if (convert->get_input_element_type(0) != ov::element::f32 && convert->get_input_element_type(0) != ov::element::i32)
@@ -77,13 +85,13 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::low
         return false;
 
     std::shared_ptr<ov::Node> store_convert = nullptr;
-    if (const auto convert_saturation = ov::as_type_ptr<snippets::op::ConvertSaturation>(convert)) {
+    if (ov::is_type<snippets::op::ConvertSaturation>(convert)) {
         store_convert = std::make_shared<ov::intel_cpu::StoreConvertSaturation>(convert->input_value(0),
-                                                                                convert_saturation->get_destination_type(),
+                                                                                convert->get_destination_type(),
                                                                                 store->get_count(), store->get_offset());
-    } else if (const auto convert_truncation = ov::as_type_ptr<snippets::op::ConvertTruncation>(convert)) {
+    } else if (ov::is_type<snippets::op::ConvertTruncation>(convert)) {
         store_convert = std::make_shared<ov::intel_cpu::StoreConvertTruncation>(convert->input_value(0),
-                                                                                convert_truncation->get_destination_type(),
+                                                                                convert->get_destination_type(),
                                                                                 store->get_count(), store->get_offset());
     } else {
         OPENVINO_THROW("Type of Convert op is undefined. Supports only fusing Store and ConvertTruncation or ConvertSaturation ops");
@@ -96,6 +104,13 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::low
     const auto convert_expr_it = convert_it;
     const auto insertion_pos = std::next(convert_it);
     convert_it = linear_ir.insert(insertion_pos, store_convert_expr);
+
+    const auto& convert_loop_ids = convert_expr->get_loop_ids();
+    store_convert_expr->set_loop_ids(convert_loop_ids);
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    loop_manager->update_loops_port(convert_loop_ids, convert_expr->get_input_port(0), {store_convert_expr->get_input_port(0)}, true);
+    loop_manager->update_loops_port(convert_loop_ids, store_expr->get_output_port(0), {store_convert_expr->get_output_port(0)}, false);
+
     linear_ir.erase(std::find(convert_expr_it, linear_ir.cend(), store_expr));
     linear_ir.erase(convert_expr_it);
     linear_ir.replace_input(store_consumers, store_convert_expr->get_output_port_connector(0));

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/set_brgemm_copy_b_buffers_shape.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/set_brgemm_copy_b_buffers_shape.cpp
@@ -16,7 +16,7 @@ bool ov::intel_cpu::pass::SetBrgemmCopyBBuffersShape::run(snippets::lowered::Lin
     auto get_buffer_from_output = [](const snippets::lowered::ExpressionPtr& expr, const size_t out_idx) {
         const auto& consumers = expr->get_output_port_connector(out_idx)->get_consumers();
         OPENVINO_ASSERT(consumers.size() == 1, "BrgemmCopyB must have only 1 consumer");
-        const auto buffer = ov::as_type_ptr<ov::snippets::op::Buffer>(consumers.begin()->get_expr()->get_node());
+        const auto buffer = ov::as_type_ptr<ov::snippets::op::IntermediateMemoryBuffer>(consumers.begin()->get_expr()->get_node());
         OPENVINO_ASSERT(buffer, "BrgemmCopyB consumer must be Buffer");
         return buffer;
     };

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/set_brgemm_copy_b_buffers_shape.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/set_brgemm_copy_b_buffers_shape.hpp
@@ -13,7 +13,7 @@ namespace pass {
 /**
  * @interface SetBrgemmCopyBBuffersShape
  * @brief Sets the allocation shape for the Buffers after BrgemmCopyB node using BrgemmCopyB parameters
- *        This pass is a workaround until we have Buffer memory allocation based on subtensors
+ *        This pass may be deprecated when a more generic memory management approach is introduced.
  *        Ticket: 113744
  * @ingroup snippets
  */

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/set_brgemm_copy_b_buffers_shape.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/set_brgemm_copy_b_buffers_shape.hpp
@@ -13,6 +13,8 @@ namespace pass {
 /**
  * @interface SetBrgemmCopyBBuffersShape
  * @brief Sets the allocation shape for the Buffers after BrgemmCopyB node using BrgemmCopyB parameters
+ *        This pass is a workaround until we have Buffer memory allocation based on subtensors
+ *        Ticket: 113744
  * @ingroup snippets
  */
 class SetBrgemmCopyBBuffersShape: public snippets::lowered::pass::Pass {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/set_brgemm_cpu_blocking_params.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/set_brgemm_cpu_blocking_params.cpp
@@ -19,7 +19,6 @@
 #include "cpu_shape.h"
 #include "utils/general_utils.h"
 
-
 namespace ov {
 namespace intel_cpu {
 pass::SetBrgemmCPUBlockingParams::SetBrgemmCPUBlockingParams() {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/set_brgemm_cpu_blocking_params.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/set_brgemm_cpu_blocking_params.cpp
@@ -35,42 +35,43 @@ pass::SetBrgemmCPUBlockingParams::SetBrgemmCPUBlockingParams() {
             return false;
         }
 
-        const auto dimsMatMulIn0 = snippets::utils::get_planar_pshape(brgemm->input(0)).get_shape();
-        const auto dimsMatMulIn1 = snippets::utils::get_planar_pshape(brgemm->input(1)).get_shape();
-        const auto K = *dimsMatMulIn0.rbegin();
-        const auto N = *dimsMatMulIn1.rbegin();
-
         const auto& input_1_precision = brgemm->get_input_element_type(1);
-
         // Ticket: 113745
         // TODO: extend block size selection heuristics
-        const size_t brgemm_block_size_m = 32;
-        const size_t brgemm_block_size_k = [&]() {
+        auto get_block_size_m = [&](const size_t M) {
+            return 32;
+        };
+        auto get_block_size_k = [&](const size_t K) {
             if (input_1_precision != ov::element::f32)
                 return K;
             return K > 1024 ? 1024 : K > 512 ? 512 : K;
-        }();
-        const size_t brgemm_block_size_n = input_1_precision != ov::element::f32 ? N : 64;
+        };
+        auto get_block_size_n = [&](const size_t N) {
+            return input_1_precision != ov::element::f32 ? N : 64;
+        };
 
-        brgemm->set_m_block_size(brgemm_block_size_m);
-        brgemm->set_k_block_size(brgemm_block_size_k);
-        brgemm->set_n_block_size(brgemm_block_size_n);
-
+        const auto brgemm_in0_dims = snippets::utils::get_planar_pshape(brgemm->input(0)).get_shape();
+        const auto M = *(brgemm_in0_dims.rbegin() + 1);
+        const auto K = *brgemm_in0_dims.rbegin();
+        const auto brgemm_in1_dims = snippets::utils::get_planar_pshape(brgemm->input(1)).get_shape();
+        const auto N = *brgemm_in1_dims.rbegin();
         if (brgemm->is_with_data_repacking()) {
             const auto brgemm_copy_b = brgemm->get_brgemm_copy();
-
             const bool isAMXSupported = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx);
             const auto precision = brgemm_copy_b->get_src_element_type();
             const auto brgemmVNNIFactor = brgemm_copy_b->get_brgemm_vnni_factor();
             const bool use_amx = isAMXSupported && precision != ov::element::f32 && (K % brgemmVNNIFactor == 0) && (N % brgemmVNNIFactor == 0);
 
-            const size_t copy_b_block_size_k = use_amx ? brgemm_block_size_k : K;
+            const size_t copy_b_block_size_k = use_amx ? get_block_size_k(K) : K;
             const size_t copy_b_block_size_n = 64;
 
             brgemm_copy_b->set_k_block_size(copy_b_block_size_k);
             brgemm_copy_b->set_n_block_size(copy_b_block_size_n);
         }
 
+        brgemm->set_m_block_size(get_block_size_m(M));
+        brgemm->set_k_block_size(get_block_size_k(K));
+        brgemm->set_n_block_size(get_block_size_n(N));
         return false;
     };
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
@@ -20,6 +20,7 @@ std::vector<std::vector<ov::PartialShape>> input_shapes{
         {{1, 1, 32, 23}, {1, 1, 23, 68}},
         {{1, 16, 384, 64}, {1, 16, 64, 384}},
         {{1, 1, 100, 700}, {1, 1, 700, 100}},
+        {{1, 1, 100, 2500}, {1, 1, 2500, 100}},
 };
 
 static inline std::vector<std::vector<element::Type>> quantized_precisions() {

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/lowered/buffer_allocation.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/lowered/buffer_allocation.cpp
@@ -70,8 +70,8 @@ protected:
 
     void ApplyTransformations(bool is_optimized, bool with_split_loops) {
         ov::snippets::lowered::pass::PassPipeline pipeline;
-        pipeline.register_pass<ov::intel_cpu::pass::BrgemmBlocking>();
         pipeline.register_pass<ov::snippets::lowered::pass::MarkLoops>(m_vector_size);
+        pipeline.register_pass<ov::intel_cpu::pass::BrgemmBlocking>();
         pipeline.register_pass<ov::snippets::lowered::pass::SoftmaxDecomposition>(m_vector_size);
         pipeline.register_pass<ov::snippets::lowered::pass::FuseLoops>();
         if (with_split_loops)
@@ -120,7 +120,7 @@ protected:
 class MHABF16AMXBufferAllocationTest : public BufferAllocationCPUTest {
 protected:
     std::shared_ptr<ov::Model> GetModel() const override {
-        const auto subtensor_scalar = std::vector<size_t>{1, 1};
+        const auto subtensor_scalar = std::vector<size_t>{1};
         const auto subtensor_softmax = std::vector<size_t>{1, ov::snippets::lowered::PortDescriptor::ServiceDimensions::FULL_DIM};
         const auto subtensor_full = std::vector<size_t>(2, ov::snippets::lowered::PortDescriptor::ServiceDimensions::FULL_DIM);
 
@@ -136,10 +136,12 @@ protected:
 
         const auto brgemm_copyb0 = std::make_shared<ov::intel_cpu::BrgemmCopyB>(
             convert1, ov::element::bf16, ov::intel_cpu::BrgemmCopyB::OnlyRepacking, 0, 0, 0);
-        const auto scratch0 = std::make_shared<ov::snippets::op::Buffer>(ov::Shape{ov::intel_cpu::BrgemmCPU::SCRATCH_BYTE_SIZE});
+        const auto scratch0 = std::make_shared<ov::snippets::op::NewMemoryBuffer>(ov::Shape{ov::intel_cpu::BrgemmCPU::SCRATCH_BYTE_SIZE});
         const auto brgemm_cpu0 = std::make_shared<ov::intel_cpu::BrgemmCPU>(
             parameter0, brgemm_copyb0->output(0), scratch0, ov::intel_cpu::BrgemmCPU::Type::AMX);
         brgemm_cpu0->set_m_block_size(32);
+        brgemm_cpu0->set_k_block_size(16);
+        brgemm_cpu0->set_n_block_size(64);
 
         const auto relu1 = std::make_shared<ov::op::v0::Relu>(brgemm_cpu0);
         const auto softmax = std::make_shared<ov::op::v1::Softmax>(relu1, 3);
@@ -147,10 +149,12 @@ protected:
 
         const auto brgemm_copyb1 = std::make_shared<ov::intel_cpu::BrgemmCopyB>(
             parameter2, ov::element::bf16, ov::intel_cpu::BrgemmCopyB::OnlyRepacking, 0, 0, 0);
-        const auto scratch1 = std::make_shared<ov::snippets::op::Buffer>(ov::Shape{ov::intel_cpu::BrgemmCPU::SCRATCH_BYTE_SIZE});
+        const auto scratch1 = std::make_shared<ov::snippets::op::NewMemoryBuffer>(ov::Shape{ov::intel_cpu::BrgemmCPU::SCRATCH_BYTE_SIZE});
         const auto brgemm_cpu1 = std::make_shared<ov::intel_cpu::BrgemmCPU>(
             convert2, brgemm_copyb1->output(0), scratch1, ov::intel_cpu::BrgemmCPU::Type::AMX);
         brgemm_cpu1->set_m_block_size(32);
+        brgemm_cpu1->set_k_block_size(16);
+        brgemm_cpu1->set_n_block_size(64);
 
         const auto relu2 = std::make_shared<ov::op::v0::Relu>(brgemm_cpu1);
 
@@ -191,7 +195,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_BufferAllocation_MHAOptimizedWSplit, MHA
                                  ::testing::Values(true),
                                  ::testing::Values(true),
                                  ::testing::Values(90112),
-                                 ::testing::Values(4)),
+                                 ::testing::Values(5)),
                          BufferAllocationCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_BufferAllocation_MHANotOptimizedWOSplit, MHABF16AMXBufferAllocationTest,

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/mul_add_to_fma.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/mul_add_to_fma.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <subgraph_simple.hpp>
 #include <transformations/snippets/x64/pass/mul_add_to_fma.hpp>
+#include <transformations/snippets/x64/shape_inference.hpp>
 #include <transformations/snippets/x64/op/fused_mul_add.hpp>
 #include <transformations/snippets/x64/shape_inference.hpp>
 #include "snippets/op/scalar.hpp"

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_lowered.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_lowered.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<ov::Model> AddFunctionLoweredBroadcast::initLowered() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     std::shared_ptr<Node> add_input0 = nullptr;
     if (!broadcast_shapes[0].empty() && broadcast_shapes[0].back() != input_shapes[0].rbegin()->get_length()) {
-        add_input0 = std::make_shared<ov::snippets::op::BroadcastLoad>(data0, broadcast_shapes[0]);
+        add_input0 = std::make_shared<ov::snippets::op::BroadcastLoad>(data0, *broadcast_shapes[0].rbegin());
     } else {
         add_input0 = std::make_shared<ov::snippets::op::Load>(data0);
     }
@@ -23,7 +23,7 @@ std::shared_ptr<ov::Model> AddFunctionLoweredBroadcast::initLowered() const {
     auto data1 = std::make_shared<op::v0::Parameter>(precision, input_shapes[1]);
     std::shared_ptr<Node> add_input1 = nullptr;
     if (!broadcast_shapes[1].empty() && broadcast_shapes[1].back() != input_shapes[1].rbegin()->get_length()) {
-        add_input1 = std::make_shared<ov::snippets::op::BroadcastLoad>(data1, broadcast_shapes[1]);
+        add_input1 = std::make_shared<ov::snippets::op::BroadcastLoad>(data1, *broadcast_shapes[1].rbegin());
     } else {
         add_input1 = std::make_shared<ov::snippets::op::Load>(data1);
     }
@@ -45,13 +45,13 @@ std::shared_ptr<ov::Model> EltwiseThreeInputsLoweredFunction::initLowered() cons
         } else {
             // The last dim is processed by vector Tile, so BroadcastLoad is required if the last dim being broadcasted
             if (input_shapes[i].rbegin()->get_length() == 1 && broadcast_shapes[i].back() != 1) {
-                return std::make_shared<ov::snippets::op::BroadcastLoad>(input_params[i], broadcast_shapes[i]);
+                return std::make_shared<ov::snippets::op::BroadcastLoad>(input_params[i], *broadcast_shapes[i].rbegin());
             // Todo: Cover this logics with functional tests, Review FakeBroadcast Emitter
             // Broadcasting of other dims is handled by BroadcastMove. Strictly speaking, broadcasting is achieved via
             // appropriate pointer arithmetics in this case.
             } else {
                 auto load = std::make_shared<ov::snippets::op::Load>(input_params[i]);
-                return std::make_shared<ov::snippets::op::BroadcastMove>(load, broadcast_shapes[i]);
+                return std::make_shared<ov::snippets::op::BroadcastMove>(load, *broadcast_shapes[i].rbegin());
             }
         }
     };
@@ -66,7 +66,7 @@ std::shared_ptr<ov::Model> EltwiseThreeInputsLoweredFunction::initLowered() cons
     if (broadcast_shapes[2].empty())
         sub_out = sub;
     else
-        sub_out = std::make_shared<ov::snippets::op::BroadcastMove>(sub, broadcast_shapes[2]);
+        sub_out = std::make_shared<ov::snippets::op::BroadcastMove>(sub, *broadcast_shapes[2].rbegin());
     auto mul = std::make_shared<op::v1::Multiply>(add, sub_out);
     auto store = std::make_shared<ov::snippets::op::Store>(mul);
     return std::make_shared<ov::Model>(NodeVector{store}, input_params);
@@ -119,9 +119,7 @@ std::shared_ptr<ov::Model> BroadcastAddLoweredFunction::initLowered() const {
     ov::NodeVector loads(datas.size(), nullptr);
     for (auto i = 0; i < datas.size(); i++) {
         if (input_shapes[i].get_shape().back() != last_dim) {
-            auto new_shape = input_shapes[i];
-            new_shape[new_shape.size() - 1] = last_dim;
-            loads[i] = std::make_shared<ov::snippets::op::BroadcastLoad>(datas[i], new_shape);
+            loads[i] = std::make_shared<ov::snippets::op::BroadcastLoad>(datas[i], ov::Dimension(last_dim));
         } else {
             loads[i] = std::make_shared<ov::snippets::op::Load>(datas[i]);
         }


### PR DESCRIPTION
### Details:
 - *Brgemm KN blocking removed from BrgemmCPU emitter*
 - *Brgemm blocking implemented on Linear IR level*
 - *InsertTailLoop rework: added a mechanism for subtensor propagation via shape inference infrastructure*
 - *`dim_idx` moved from `LoopInfo` to `LoopPort`*
 - *Several fixes*


### Tickets:
 - *115164*
 - *112122*

### Prerequisites:
- [x] [Snippets] Changed BrgemmCopyB shape inference #19957
- [x] [Snippets] Deep copy interface #20242 
- [x] [Snippets] Refactored Buffer memory allocation #19644
