### PR TITLE
Avoid creating new threads when converting legacy inference request to API 2.0

### DIFF
--- a/src/inference/src/dev/icompiled_model_wrapper.cpp
+++ b/src/inference/src/dev/icompiled_model_wrapper.cpp
@@ -10,7 +10,7 @@
 
 InferenceEngine::ICompiledModelWrapper::ICompiledModelWrapper(
     const std::shared_ptr<InferenceEngine::IExecutableNetworkInternal>& model)
-    : ov::ICompiledModel(nullptr, ov::legacy_convert::convert_plugin(model->_plugin)),
+    : ov::ICompiledModel(nullptr, ov::legacy_convert::convert_plugin(model->_plugin), nullptr, nullptr),
       m_model(model) {
     std::vector<ov::Output<const ov::Node>> inputs, outputs;
     for (const auto& input : m_model->getInputs()) {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -214,11 +214,6 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(smoke_NegativeQuantizedMatMulMultiplyFusion.*)");
     // int8 specific
     retVector.emplace_back(R"(smoke_Quantized.*)");
-    // TODO: Issue 115961
-    retVector.emplace_back(R"(.*compareAutoBatchingToSingleBatch/CPU_get_blob_batch_size_4_num_streams_1_num_req_64*)");
-    retVector.emplace_back(R"(.*compareAutoBatchingToSingleBatch/CPU_get_blob_batch_size_4_num_streams_2_num_req_64*)");
-    retVector.emplace_back(R"(.*compareAutoBatchingToSingleBatch/CPU_set_blob_batch_size_4_num_streams_1_num_req_64*)");
-    retVector.emplace_back(R"(.*compareAutoBatchingToSingleBatch/CPU_set_blob_batch_size_4_num_streams_2_num_req_64*)");
 #endif
 
 #if defined(OPENVINO_ARCH_ARM)


### PR DESCRIPTION
### Details:
 - Fix 2 new threads created in 1.0 req convert to 2.0 req issue

### Tickets:
 - 115961
