### PR TITLE
Fix incorrect output for float to bf16 in avx2 isa

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/x64/jit_bf16_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_bf16_emitters.hpp
@@ -78,7 +78,6 @@ private:
                 h->vpermq(Ymm(aux.getIdx()), Ymm(aux.getIdx()), 0xD8); //11 01 10 00
                 h->vextracti128(out, Ymm(aux.getIdx()), 0);
             } else {
-                h->pshufd(Xmm(aux.getIdx()), Xmm(aux.getIdx()), 0xD8); //11 01 10 00
                 h->uni_vmovups(out, aux);
             }
         }

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_bf16_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_bf16_emitters.hpp
@@ -75,8 +75,10 @@ private:
             h->uni_vpackusdw(aux, aux, aux);
 
             if (host_isa_ == dnnl::impl::cpu::x64::cpu_isa_t::avx2) {
+                h->vpermq(Ymm(aux.getIdx()), Ymm(aux.getIdx()), 0xD8); //11 01 10 00
                 h->vextracti128(out, Ymm(aux.getIdx()), 0);
             } else {
+                h->pshufd(Xmm(aux.getIdx()), Xmm(aux.getIdx()), 0xD8); //11 01 10 00
                 h->uni_vmovups(out, aux);
             }
         }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -241,6 +241,10 @@ std::vector<std::string> disabledTestPatterns() {
 #endif
 
     if (!InferenceEngine::with_cpu_x86_avx512_core()) {
+        // on platforms which do not support bfloat16, we are disabling bf16 tests since there are no bf16 primitives,
+        // tests are useless on such platforms
+        retVector.emplace_back(R"(.*(BF|bf)16.*)");
+        retVector.emplace_back(R"(.*bfloat16.*)");
         // MatMul in Snippets uses BRGEMM that is supported only on AVX512 platforms
         // Disabled Snippets MHA tests as well because MHA pattern contains MatMul
         retVector.emplace_back(R"(.*Snippets.*MHA.*)");

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -241,10 +241,6 @@ std::vector<std::string> disabledTestPatterns() {
 #endif
 
     if (!InferenceEngine::with_cpu_x86_avx512_core()) {
-        // on platforms which do not support bfloat16, we are disabling bf16 tests since there are no bf16 primitives,
-        // tests are useless on such platforms
-        retVector.emplace_back(R"(.*(BF|bf)16.*)");
-        retVector.emplace_back(R"(.*bfloat16.*)");
         // MatMul in Snippets uses BRGEMM that is supported only on AVX512 platforms
         // Disabled Snippets MHA tests as well because MHA pattern contains MatMul
         retVector.emplace_back(R"(.*Snippets.*MHA.*)");

--- a/src/plugins/intel_cpu/tests/unit/jit_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/jit_kernel_test.cpp
@@ -272,20 +272,19 @@ struct jit_variable_load_store_test_kernel {
         size_t size;
     };
 
-    template<size_t N, bool is_src>
+    template<size_t N, size_t M, bool is_src>
     void test() {
         kernel_impl<N, is_src> kernel;
         kernel.init();
-
-        const size_t size = 3;
+        ASSERT_GE(N, M);
 
         std::array<SrcT, N> src {};
         std::array<DstT, N> result {};
 
-        Params args = { src.data(), result.data(), size };
+        Params args = { src.data(), result.data(), M };
 
         src.fill(static_cast<SrcT>(42));
-        for (size_t i = 0; i < size; ++i) {
+        for (size_t i = 0; i < M; ++i) {
             src[i] = static_cast<SrcT>(i);
         }
 
@@ -293,7 +292,7 @@ struct jit_variable_load_store_test_kernel {
 
         std::array<DstT, N> expected_result {};
 
-        for (size_t i = 0; i < size; ++i) {
+        for (size_t i = 0; i < M; ++i) {
             expected_result[i] = static_cast<DstT>(i);
         }
 
@@ -325,52 +324,52 @@ TEST(JitKernel, variable_load_and_store) {
     {
         jit_variable_load_store_test_kernel<uint8_t, float> kernel;
         if (mayiuse(cpu_isa_t::avx512_core)) {
-            kernel.test<16, false>();
+            kernel.test<16, 11, false>();
         }
         if (mayiuse(cpu_isa_t::avx2)) {
-            kernel.test<8, false>();
+            kernel.test<8, 5, false>();
         }
         if (mayiuse(cpu_isa_t::sse41)) {
-            kernel.test<4, false>();
+            kernel.test<4, 3, false>();
         }
     }
 
     {
         jit_variable_load_store_test_kernel<int8_t, int8_t> kernel;
         if (mayiuse(cpu_isa_t::avx512_core)) {
-            kernel.test<16, false>();
+            kernel.test<16, 11, false>();
         }
         if (mayiuse(cpu_isa_t::avx2)) {
-            kernel.test<8, false>();
+            kernel.test<8, 5, false>();
         }
         if (mayiuse(cpu_isa_t::sse41)) {
-            kernel.test<4, false>();
+            kernel.test<4, 3, false>();
         }
     }
 
     {
         jit_variable_load_store_test_kernel<float, bfloat16_t> kernel;
         if (mayiuse(cpu_isa_t::avx512_core)) {
-            kernel.test<16, true>();
+            kernel.test<16, 11, true>();
         }
         if (mayiuse(cpu_isa_t::avx2)) {
-            kernel.test<8, true>();
+            kernel.test<8, 5, true>();
         }
         if (mayiuse(cpu_isa_t::sse41)) {
-            kernel.test<4, true>();
+            kernel.test<4, 3, true>();
         }
     }
 
     {
         jit_variable_load_store_test_kernel<int32_t, bfloat16_t> kernel;
         if (mayiuse(cpu_isa_t::avx512_core)) {
-            kernel.test<16, true>();
+            kernel.test<16, 11, true>();
         }
         if (mayiuse(cpu_isa_t::avx2)) {
-            kernel.test<8, true>();
+            kernel.test<8, 5, true>();
         }
         if (mayiuse(cpu_isa_t::sse41)) {
-            kernel.test<4, true>();
+            kernel.test<4, 3, true>();
         }
     }
 }


### PR DESCRIPTION
### Details:
 - Fix incorrect output for float to bf16 in avx2 isa

### Tickets:
 - 118588, 117486
