### PR TITLE
[C API] Fix the BOOLEAN in ov_element_type conflict with the typedefine in Windows.h

### DIFF
--- a/src/bindings/c/include/openvino/c/openvino.h
+++ b/src/bindings/c/include/openvino/c/openvino.h
@@ -16,9 +16,10 @@
 #pragma once
 
 #ifdef _WINDOWS_
-#pragma message("The BOOLEAN define in ov_element_type_e conflict with Windows.h BOOLEAN define. Here redifine the BOOLEAN of Windows.h to WIN_BOOLEAN & the BOOLEAN of ov_element_type_e to OV_BOOLEAN.")
+#    pragma message( \
+        "The BOOLEAN define in ov_element_type_e conflict with Windows.h BOOLEAN define. Here redifine the BOOLEAN of Windows.h to WIN_BOOLEAN & the BOOLEAN of ov_element_type_e to OV_BOOLEAN.")
 typedef BOOLEAN WIN_BOOLEAN;
-#define BOOLEAN OV_BOOLEAN
+#    define BOOLEAN OV_BOOLEAN
 #endif
 
 #include "openvino/c/auto/properties.h"

--- a/src/bindings/c/include/openvino/c/openvino.h
+++ b/src/bindings/c/include/openvino/c/openvino.h
@@ -15,12 +15,12 @@
  **/
 #pragma once
 
-#define BOOLEAN OV_BOOLEAN
 #ifdef _WINDOWS_
 #    pragma message( \
         "The BOOLEAN define in ov_element_type_e conflict with Windows.h BOOLEAN define. Here redifine the BOOLEAN of Windows.h to WIN_BOOLEAN & the BOOLEAN of ov_element_type_e to OV_BOOLEAN.")
 typedef BOOLEAN WIN_BOOLEAN;
 #endif
+#define BOOLEAN OV_BOOLEAN
 
 #include "openvino/c/auto/properties.h"
 #include "openvino/c/ov_common.h"

--- a/src/bindings/c/include/openvino/c/openvino.h
+++ b/src/bindings/c/include/openvino/c/openvino.h
@@ -15,6 +15,12 @@
  **/
 #pragma once
 
+#ifdef _WINDOWS_
+#pragma message("The BOOLEAN define in ov_element_type_e conflict with Windows.h BOOLEAN define. Here redifine the BOOLEAN of Windows.h to WIN_BOOLEAN & the BOOLEAN of ov_element_type_e to OV_BOOLEAN.")
+typedef BOOLEAN WIN_BOOLEAN;
+#define BOOLEAN OV_BOOLEAN
+#endif
+
 #include "openvino/c/auto/properties.h"
 #include "openvino/c/ov_common.h"
 #include "openvino/c/ov_compiled_model.h"

--- a/src/bindings/c/include/openvino/c/openvino.h
+++ b/src/bindings/c/include/openvino/c/openvino.h
@@ -17,8 +17,7 @@
 
 #ifdef _WINDOWS_
 #    pragma message( \
-        "The BOOLEAN define in ov_element_type_e conflict with Windows.h BOOLEAN define. Here redifine the BOOLEAN of Windows.h to WIN_BOOLEAN & the BOOLEAN of ov_element_type_e to OV_BOOLEAN.")
-typedef BOOLEAN WIN_BOOLEAN;
+        "The BOOLEAN define in ov_element_type_e conflict with Windows.h BOOLEAN define. The BOOLEAN of ov_element_type_e redefine to OV_BOOLEAN here. If you want to use BOOLEAN of Windows.h, pls redefine befor include openvino/c/openvino.h, such as typedef BOOLEAN WIN_BOOLEAN")
 #endif
 #define BOOLEAN OV_BOOLEAN
 

--- a/src/bindings/c/include/openvino/c/openvino.h
+++ b/src/bindings/c/include/openvino/c/openvino.h
@@ -15,11 +15,11 @@
  **/
 #pragma once
 
+#define BOOLEAN OV_BOOLEAN
 #ifdef _WINDOWS_
 #    pragma message( \
         "The BOOLEAN define in ov_element_type_e conflict with Windows.h BOOLEAN define. Here redifine the BOOLEAN of Windows.h to WIN_BOOLEAN & the BOOLEAN of ov_element_type_e to OV_BOOLEAN.")
 typedef BOOLEAN WIN_BOOLEAN;
-#    define BOOLEAN OV_BOOLEAN
 #endif
 
 #include "openvino/c/auto/properties.h"

--- a/src/bindings/c/tests/ov_windows_conflict_test.cpp
+++ b/src/bindings/c/tests/ov_windows_conflict_test.cpp
@@ -9,13 +9,21 @@
  * "OV_BOOLEAN"
  */
 
-#if defined(_MSC_VER)
-#    include <Windows.h>
+#if defined(_WIN32)
+#    include <gtest/gtest.h>
+#    include <windows.h>
 
-#    include "ov_test.hpp"
+#    include "openvino/c/openvino.h"
+
+#    ifndef UNUSED
+#        define UNUSED(x) ((void)(x))
+#    endif
+
 TEST(ov_windows_conflict_test, ov_windows_boolean_conflict) {
-    EXPECT_NO_THROW(ov_element_type_e element_type =
-                        OV_BOOLEAN);           // The BOOLEAN from ov_element_type_e will be replaced by OV_BOOLEAN
-    EXPECT_NO_THROW(WIN_BOOLEAN win_boolean);  // The BOOLEAN from Windows.h will be replaced by WIN_BOOLEAN
+    ov_element_type_e element_type = OV_BOOLEAN;  // The BOOLEAN from ov_element_type_e will be replaced by OV_BOOLEAN
+    WIN_BOOLEAN win_boolean;                      // The BOOLEAN from Windows.h will be replaced by WIN_BOOLEAN
+
+    UNUSED(win_boolean);
+    UNUSED(element_type);
 }
 #endif

--- a/src/bindings/c/tests/ov_windows_conflict_test.cpp
+++ b/src/bindings/c/tests/ov_windows_conflict_test.cpp
@@ -21,9 +21,6 @@
 
 TEST(ov_windows_conflict_test, ov_windows_boolean_conflict) {
     ov_element_type_e element_type = OV_BOOLEAN;  // The BOOLEAN from ov_element_type_e will be replaced by OV_BOOLEAN
-    WIN_BOOLEAN win_boolean;                      // The BOOLEAN from Windows.h will be replaced by WIN_BOOLEAN
-
-    UNUSED(win_boolean);
     UNUSED(element_type);
 }
 #endif

--- a/src/bindings/c/tests/ov_windows_conflict_test.cpp
+++ b/src/bindings/c/tests/ov_windows_conflict_test.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/*
+* This test only for Windows, which caused by the BOOLEAN define conflict between Windows.h and openvino.h (ov_element_type_e).
+* Sollution: 
+* 1) check Windows.h was used or not in openvino.h for windows OS
+* 2) if YES, will redefine the "BOOLEAN" from Windows.h to "WIN_BOOLEAN" and also redefine the "BOOLEAN" from openvino.h to "OV_BOOLEAN"
+*/
+
+#if defined(_MSC_VER)
+#include <Windows.h>
+#include "ov_test.hpp"
+TEST(ov_windows_conflict_test, ov_windows_boolean_conflict) {
+    EXPECT_NO_THROW(ov_element_type_e element_type = OV_BOOLEAN);    // The BOOLEAN from ov_element_type_e will be replaced by OV_BOOLEAN
+    EXPECT_NO_THROW(WIN_BOOLEAN win_boolean);                        // The BOOLEAN from Windows.h will be replaced by WIN_BOOLEAN
+}
+#endif

--- a/src/bindings/c/tests/ov_windows_conflict_test.cpp
+++ b/src/bindings/c/tests/ov_windows_conflict_test.cpp
@@ -3,17 +3,19 @@
 //
 
 /*
-* This test only for Windows, which caused by the BOOLEAN define conflict between Windows.h and openvino.h (ov_element_type_e).
-* Sollution: 
-* 1) check Windows.h was used or not in openvino.h for windows OS
-* 2) if YES, will redefine the "BOOLEAN" from Windows.h to "WIN_BOOLEAN" and also redefine the "BOOLEAN" from openvino.h to "OV_BOOLEAN"
-*/
+ * This test only for Windows, which caused by the BOOLEAN define conflict between Windows.h and openvino.h
+ * (ov_element_type_e). Sollution: 1) check Windows.h was used or not in openvino.h for windows OS 2) if YES, will
+ * redefine the "BOOLEAN" from Windows.h to "WIN_BOOLEAN" and also redefine the "BOOLEAN" from openvino.h to
+ * "OV_BOOLEAN"
+ */
 
 #if defined(_MSC_VER)
-#include <Windows.h>
-#include "ov_test.hpp"
+#    include <Windows.h>
+
+#    include "ov_test.hpp"
 TEST(ov_windows_conflict_test, ov_windows_boolean_conflict) {
-    EXPECT_NO_THROW(ov_element_type_e element_type = OV_BOOLEAN);    // The BOOLEAN from ov_element_type_e will be replaced by OV_BOOLEAN
-    EXPECT_NO_THROW(WIN_BOOLEAN win_boolean);                        // The BOOLEAN from Windows.h will be replaced by WIN_BOOLEAN
+    EXPECT_NO_THROW(ov_element_type_e element_type =
+                        OV_BOOLEAN);           // The BOOLEAN from ov_element_type_e will be replaced by OV_BOOLEAN
+    EXPECT_NO_THROW(WIN_BOOLEAN win_boolean);  // The BOOLEAN from Windows.h will be replaced by WIN_BOOLEAN
 }
 #endif


### PR DESCRIPTION
### Details:
 - Fix conflict of "BOOLEAN", after include header file "Windows.h"

### Tickets:
 - 117890
