### PR TITLE
[conformance] Read models only matching with shape_mode

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
@@ -55,6 +55,9 @@ std::string ReadIRTest::getTestCaseName(const testing::TestParamInfo<ReadIRParam
     std::reverse(splittedFilename.begin(), splittedFilename.end());
     bool is_valid_path_format = true;
 
+    std::string subgrapth_dir = "subgraph";
+    std::vector<std::string> graphConvertLogicTypes = { "fused_names", "repeat_pattern" };
+
     // Check that op is valid
     if (splittedFilename.size() > 2) {
         auto pos = splittedFilename[2].find('-');
@@ -72,22 +75,34 @@ std::string ReadIRTest::getTestCaseName(const testing::TestParamInfo<ReadIRParam
             }
             message += "_";
             result << message;
-        } else {
+        } else if (splittedFilename[2] != subgrapth_dir) {
             is_valid_path_format = false;
         }
     }
+
     // Check the element_type
     if (splittedFilename.size() > 1) {
         if (std::find(ov::test::conformance::element_type_names.begin(),
                       ov::test::conformance::element_type_names.end(),
                       splittedFilename[1]) != ov::test::conformance::element_type_names.end()) {
             result << "Type=" << splittedFilename[1] << "_";
+        } else if (std::find(graphConvertLogicTypes.begin(),
+                             graphConvertLogicTypes.end(),
+                             splittedFilename[1]) != graphConvertLogicTypes.end()) {
+            result << "ConvertLogic=" << splittedFilename[1] << "_";
         } else {
             is_valid_path_format = false;
         }
     }
     result << "IR=" << (is_valid_path_format ? ov::test::utils::replaceExt(splittedFilename[0], "") : path_to_model) << "_";
     result << "Device=" << deviceName << "_";
+
+    std::vector<std::string> shapeModes = { "static", "dynamic" };
+    // Check the shape type
+    if (splittedFilename.size() > 3 &&
+        std::find(shapeModes.begin(), shapeModes.end(), splittedFilename[3]) != shapeModes.end()) {
+        result << "Shape=" << splittedFilename[3] << "_";
+    }
     result << "Config=(";
     auto configItem = config.begin();
     while (configItem != config.end()) {


### PR DESCRIPTION
### Details:
 - *Fix issue with duplicated test names for DLB based conformance run*
![image](https://github.com/openvinotoolkit/openvino/assets/22008923/e7dbf935-3c05-45f5-aab7-972564648dcd)

### Tickets:
 - *https://jira.devtools.intel.com/browse/CVS-118876*
