### PR TITLE
enable cpu pinning on Windows by setting property affinity CORE

### DIFF
--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -81,8 +81,11 @@ void Config::readProperties(const std::map<std::string, std::string> &prop, cons
             streamExecutorConfig.SetConfig(key, val);
             if (key == ov::affinity.name()) {
                 const auto affinity_val = ov::util::from_string(val, ov::affinity);
-                if (affinity_val == ov::Affinity::CORE) {
+                if (affinity_val == ov::Affinity::CORE || affinity_val == ov::Affinity::HYBRID_AWARE) {
                     enableCpuPinning = true;
+                    changedCpuPinning = true;
+                } else if (affinity_val == ov::Affinity::NUMA) {
+                    enableCpuPinning = false;
                     changedCpuPinning = true;
                 }
             }

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -79,6 +79,13 @@ void Config::readProperties(const std::map<std::string, std::string> &prop, cons
         if (streamExecutorConfigKeys.end() !=
             std::find(std::begin(streamExecutorConfigKeys), std::end(streamExecutorConfigKeys), key)) {
             streamExecutorConfig.SetConfig(key, val);
+            if (key == ov::affinity.name()) {
+                const auto affinity_val = ov::util::from_string(val, ov::affinity);
+                if (affinity_val == ov::Affinity::CORE) {
+                    enableCpuPinning = true;
+                    changedCpuPinning = true;
+                }
+            }
         } else if (hintsConfigKeys.end() != std::find(hintsConfigKeys.begin(), hintsConfigKeys.end(), key)) {
             perfHintsConfig.SetConfig(key, val);
         } else if (key == ov::hint::enable_cpu_pinning.name()) {

--- a/src/plugins/intel_cpu/src/cpu_map_scheduling.cpp
+++ b/src/plugins/intel_cpu/src/cpu_map_scheduling.cpp
@@ -81,6 +81,7 @@ bool get_cpu_pinning(bool& input_value,
     if (input_changed) {
         result_value = input_value;
     } else {
+        result_value = true;
         if (proc_type_table[0][EFFICIENT_CORE_PROC] > 0 &&
             proc_type_table[0][EFFICIENT_CORE_PROC] < proc_type_table[0][ALL_PROC]) {
             result_value = latency ? false : true;

--- a/src/plugins/intel_cpu/src/cpu_map_scheduling.cpp
+++ b/src/plugins/intel_cpu/src/cpu_map_scheduling.cpp
@@ -72,23 +72,19 @@ std::vector<std::vector<int>> apply_hyper_threading(bool& input_ht_hint,
 bool get_cpu_pinning(bool& input_value,
                      const bool input_changed,
                      const int num_streams,
-                     const threading::IStreamsExecutor::ThreadBindingType bind_type,
                      const Config::LatencyThreadingMode latency_threading_mode,
                      const std::vector<std::vector<int>>& proc_type_table) {
     int result_value;
     int num_sockets = get_default_latency_streams(latency_threading_mode);
     bool latency = num_streams <= num_sockets && num_streams > 0;
 
-    if (proc_type_table[0][EFFICIENT_CORE_PROC] > 0 &&
-        proc_type_table[0][EFFICIENT_CORE_PROC] < proc_type_table[0][ALL_PROC]) {
-        result_value =
-            input_changed
-                ? input_value
-                : ((latency || bind_type == threading::IStreamsExecutor::ThreadBindingType::NUMA) ? false : true);
+    if (input_changed) {
+        result_value = input_value;
     } else {
-        result_value = input_changed
-                           ? input_value
-                           : (bind_type == threading::IStreamsExecutor::ThreadBindingType::NUMA ? false : true);
+        if (proc_type_table[0][EFFICIENT_CORE_PROC] > 0 &&
+            proc_type_table[0][EFFICIENT_CORE_PROC] < proc_type_table[0][ALL_PROC]) {
+            result_value = latency ? false : true;
+        }
     }
 #if (IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO)
 #    if defined(__APPLE__) || defined(_WIN32)

--- a/src/plugins/intel_cpu/src/cpu_map_scheduling.hpp
+++ b/src/plugins/intel_cpu/src/cpu_map_scheduling.hpp
@@ -45,7 +45,6 @@ std::vector<std::vector<int>> apply_hyper_threading(bool& input_ht_hint,
  * @param[in]  input_type indicate value of property enableCpuPinning.
  * @param[in]  input_changed indicate if value is set by user.
  * @param[in]  num_streams number of streams
- * @param[in]  bind_type thread binding core type
  * @param[in]  latency_threading_mode is the scope of candidate processors per stream for latency hint
  * @param[in]  proc_type_table candidate processors available at this time
  * @return     whether pinning threads to cpu cores
@@ -53,7 +52,6 @@ std::vector<std::vector<int>> apply_hyper_threading(bool& input_ht_hint,
 bool get_cpu_pinning(bool& input_value,
                      const bool input_changed,
                      const int num_streams,
-                     const threading::IStreamsExecutor::ThreadBindingType bind_type,
                      const Config::LatencyThreadingMode latency_threading_mode,
                      const std::vector<std::vector<int>>& proc_type_table);
 

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -502,7 +502,6 @@ std::vector<std::vector<int>> generate_stream_info(const int streams,
     executor_config._cpu_reservation = get_cpu_pinning(config.enableCpuPinning,
                                                        config.changedCpuPinning,
                                                        streams,
-                                                       executor_config._threadBindingType,
                                                        config.latencyThreadingMode,
                                                        proc_type_table);
     if (-1 == preferred_nthreads_per_stream) {

--- a/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
@@ -153,6 +153,16 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginSetConfigAffinity) {
     ASSERT_EQ(affinity, value);
 }
 
+TEST_F(OVClassConfigTestCPU, smoke_PluginSetConfigAffinityCore) {
+    ov::Core ie;
+    ov::Affinity affinity = ov::Affinity::CORE;
+    bool value = false;
+
+    ASSERT_NO_THROW(ie.set_property("CPU", ov::affinity(affinity)));
+    ASSERT_NO_THROW(value = ie.get_property("CPU", ov::hint::enable_cpu_pinning));
+    ASSERT_EQ(true, value);
+}
+
 TEST_F(OVClassConfigTestCPU, smoke_PluginSetConfigHintInferencePrecision) {
     ov::Core ie;
     auto value = ov::element::f32;

--- a/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
@@ -161,6 +161,16 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginSetConfigAffinityCore) {
     ASSERT_NO_THROW(ie.set_property("CPU", ov::affinity(affinity)));
     ASSERT_NO_THROW(value = ie.get_property("CPU", ov::hint::enable_cpu_pinning));
     ASSERT_EQ(true, value);
+
+    affinity = ov::Affinity::HYBRID_AWARE;
+    ASSERT_NO_THROW(ie.set_property("CPU", ov::affinity(affinity)));
+    ASSERT_NO_THROW(value = ie.get_property("CPU", ov::hint::enable_cpu_pinning));
+    ASSERT_EQ(true, value);
+
+    affinity = ov::Affinity::NUMA;
+    ASSERT_NO_THROW(ie.set_property("CPU", ov::affinity(affinity)));
+    ASSERT_NO_THROW(value = ie.get_property("CPU", ov::hint::enable_cpu_pinning));
+    ASSERT_EQ(false, value);
 }
 
 TEST_F(OVClassConfigTestCPU, smoke_PluginSetConfigHintInferencePrecision) {

--- a/src/plugins/intel_cpu/tests/unit/streams_info/streams_e2e_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/streams_e2e_test.cpp
@@ -29,7 +29,6 @@ struct StreamGenerateionTestCase {
     bool input_cpu_changed;
     ov::hint::PerformanceMode input_pm_hint;
     ov::intel_cpu::Config::LatencyThreadingMode input_latency_threading_mode;
-    ov::threading::IStreamsExecutor::ThreadBindingType input_binding_type;
     std::vector<std::vector<int>> input_proc_type_table;
     ov::hint::SchedulingCoreType output_type;
     bool output_ht_value;
@@ -51,7 +50,6 @@ void make_config(StreamGenerateionTestCase& test_data, ov::intel_cpu::Config& co
     config.streamExecutorConfig._streams = test_data.input_stream;
     config.streamExecutorConfig._streams_changed = test_data.input_stream_changed;
     config.streamExecutorConfig._threads = test_data.input_thread;
-    config.streamExecutorConfig._threadBindingType = test_data.input_binding_type;
 }
 
 class StreamGenerationTests : public ov::test::TestsCommon,
@@ -95,8 +93,6 @@ StreamGenerateionTestCase generation_latency_1sockets_14cores_1_pinning = {
     ov::hint::PerformanceMode::LATENCY,      // param[in]: simulated setting for performance mode (throughput/latency)
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,  // param[in]: simulated setting for scope of candidate
                                                               // processors on latency mode
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,  // param[in]: simulated setting for
-                                                                       // threadBindingType
     {{20, 6, 8, 6, 0, 0}},  // param[in]: simulated proc_type_table for platform which has one socket, 6 Pcores, 8
                             // Ecores and hyper threading enabled
     ov::hint::SchedulingCoreType::ANY_CORE,  // param[expected out]: scheduling core type needs to be the same as input
@@ -125,7 +121,6 @@ StreamGenerateionTestCase generation_latency_1sockets_14cores_2_pinning = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{14, 6, 8, 0, 0, 0}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     false,
@@ -148,7 +143,6 @@ StreamGenerateionTestCase generation_tput_1sockets_14cores_1_pinning = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{20, 6, 8, 6, 0, 0}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     true,
@@ -171,7 +165,6 @@ StreamGenerateionTestCase generation_latency_1sockets_14cores_1_unpinning = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{20, 6, 8, 6, 0, 0}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     true,
@@ -197,7 +190,6 @@ StreamGenerateionTestCase generation_latency_1sockets_14cores_2_unpinning = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{14, 6, 8, 0, 0, 0}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     false,
@@ -220,7 +212,6 @@ StreamGenerateionTestCase generation_tput_1sockets_14cores_1_unpinning = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{20, 6, 8, 6, 0, 0}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     true,
@@ -243,7 +234,6 @@ StreamGenerateionTestCase generation_latency_1sockets_14cores_3 = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{14, 6, 8, 0, 0, 0}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     false,
@@ -266,7 +256,6 @@ StreamGenerateionTestCase generation_latency_1sockets_14cores_4 = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{20, 6, 8, 6, 0, 0}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     true,
@@ -289,7 +278,6 @@ StreamGenerateionTestCase generation_latency_1sockets_14cores_5 = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{20, 6, 8, 6, 0, 0}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     false,
@@ -312,7 +300,6 @@ StreamGenerateionTestCase generation_latency_2sockets_48cores_6 = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{96, 48, 0, 48, -1, -1}, {48, 24, 0, 24, 0, 0}, {48, 24, 0, 24, 1, 1}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     false,
@@ -335,7 +322,6 @@ StreamGenerateionTestCase generation_latency_2sockets_48cores_7 = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{48, 48, 0, 0, -1, -1}, {24, 24, 0, 0, 0, 0}, {24, 24, 0, 0, 1, 1}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     false,
@@ -358,7 +344,6 @@ StreamGenerateionTestCase generation_latency_2sockets_48cores_8 = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{96, 48, 0, 48, -1, -1}, {48, 24, 0, 24, 0, 0}, {48, 24, 0, 24, 1, 1}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     false,
@@ -381,7 +366,6 @@ StreamGenerateionTestCase generation_latency_2sockets_48cores_9 = {
     true,
     ov::hint::PerformanceMode::LATENCY,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::HYBRID_AWARE,
     {{48, 48, 0, 0, -1, -1}, {24, 24, 0, 0, 0, 0}, {24, 24, 0, 0, 1, 1}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     false,
@@ -404,7 +388,6 @@ StreamGenerateionTestCase generation_tput_1sockets_14cores_2 = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::CORES,
     {{20, 6, 8, 6, 0, 0}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     false,
@@ -427,7 +410,6 @@ StreamGenerateionTestCase generation_tput_1sockets_14cores_3 = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::CORES,
     {{20, 6, 8, 6, 0, 0}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     true,
@@ -450,7 +432,6 @@ StreamGenerateionTestCase generation_tput_1sockets_14cores_4 = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::CORES,
     {{20, 6, 8, 6, 0, 0}},
     ov::hint::SchedulingCoreType::PCORE_ONLY,
     true,
@@ -473,7 +454,6 @@ StreamGenerateionTestCase generation_tput_2sockets_48cores_5 = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::CORES,
     {{96, 48, 0, 48, -1, -1}, {48, 24, 0, 24, 0, 0}, {48, 24, 0, 24, 1, 1}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     true,
@@ -499,7 +479,6 @@ StreamGenerateionTestCase generation_tput_2sockets_48cores_6 = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::CORES,
     {{96, 48, 0, 48, -1, -1}, {48, 24, 0, 24, 0, 0}, {48, 24, 0, 24, 1, 1}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     false,
@@ -522,7 +501,6 @@ StreamGenerateionTestCase generation_tput_2sockets_48cores_7 = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::CORES,
     {{96, 48, 0, 48, -1, -1}, {48, 24, 0, 24, 0, 0}, {48, 24, 0, 24, 1, 1}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     false,
@@ -545,7 +523,6 @@ StreamGenerateionTestCase generation_tput_2sockets_48cores_8 = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::CORES,
     {{96, 48, 0, 48, -1, -1}, {48, 24, 0, 24, 0, 0}, {48, 24, 0, 24, 1, 1}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     false,
@@ -568,7 +545,6 @@ StreamGenerateionTestCase generation_tput_2sockets_48cores_9 = {
     true,
     ov::hint::PerformanceMode::THROUGHPUT,
     ov::intel_cpu::Config::LatencyThreadingMode::PER_SOCKET,
-    ov::threading::IStreamsExecutor::ThreadBindingType::CORES,
     {{96, 48, 0, 48, -1, -1}, {48, 24, 0, 24, 0, 0}, {48, 24, 0, 24, 1, 1}},
     ov::hint::SchedulingCoreType::ANY_CORE,
     false,


### PR DESCRIPTION
### Details:
 - *enable cpu pinning by setting command  '-pin YES' or '-pin CORE'*

### Tickets:
 - *ticket-id*
