### PR TITLE
LPT opset12::Pad negative indexes support

### DIFF
--- a/src/common/low_precision_transformations/src/pad.cpp
+++ b/src/common/low_precision_transformations/src/pad.cpp
@@ -178,15 +178,22 @@ bool PadTransformation::canBeTransformed(const TransformationContext& context, s
         return false;
     }
 
-    if (!hasPositiveIndexes(pad))
-        return true;
-
     const auto dequantization = NetworkHelper::getDequantization(op, defaultPrecisions);
     if (dequantization.empty()) {
         return false;
     }
 
     const auto mode = pad->get_pad_mode();
+    if (mode != op::PadMode::CONSTANT &&
+        mode != op::PadMode::EDGE &&
+        mode != op::PadMode::REFLECT &&
+        mode != op::PadMode::SYMMETRIC) {
+        return false;
+    }
+
+    if (!hasPositiveIndexes(pad))
+        return true;
+
     if (mode == op::PadMode::CONSTANT) {
         auto padAndDqByTheSameDimension = [&](const std::shared_ptr<ov::opset1::Constant>& deqConst) {
             const auto padsBegin = pad->get_pads_begin();

--- a/src/common/low_precision_transformations/src/pad.cpp
+++ b/src/common/low_precision_transformations/src/pad.cpp
@@ -178,16 +178,16 @@ bool PadTransformation::canBeTransformed(const TransformationContext& context, s
         return false;
     }
 
-    const auto dequantization = NetworkHelper::getDequantization(op, defaultPrecisions);
-    if (dequantization.empty()) {
-        return false;
-    }
-
     const auto mode = pad->get_pad_mode();
     if (mode != op::PadMode::CONSTANT &&
         mode != op::PadMode::EDGE &&
         mode != op::PadMode::REFLECT &&
         mode != op::PadMode::SYMMETRIC) {
+        return false;
+    }
+
+    const auto dequantization = NetworkHelper::getDequantization(op, defaultPrecisions);
+    if (dequantization.empty()) {
         return false;
     }
 

--- a/src/common/low_precision_transformations/src/pad.cpp
+++ b/src/common/low_precision_transformations/src/pad.cpp
@@ -37,6 +37,21 @@ PadTransformation::PadTransformation(const Params& params) : LayerTransformation
     this->register_matcher(m, callback);
 }
 
+namespace {
+    bool hasNegativeIndexes(const std::shared_ptr<ov::op::util::PadBase>& pad) {
+        const auto padsBegin = pad->get_pads_begin();
+        const auto padsEnd = pad->get_pads_end();
+        auto pred = [](int64_t a) {
+            return a < 0;
+        };
+        if (std::any_of(padsBegin.begin(), padsBegin.end(), pred) ||
+            std::any_of(padsEnd.begin(), padsEnd.end(), pred)) {
+            return true;
+        }
+        return false;
+    }
+} // namespace
+
 bool PadTransformation::transform(TransformationContext& context, ov::pass::pattern::Matcher& m) {
     if (!canBeTransformed(context, m.get_match_root())) {
         return false;
@@ -52,7 +67,7 @@ bool PadTransformation::transform(TransformationContext& context, ov::pass::patt
 
     auto dequantization = NetworkHelper::getDequantization(pad, defaultPrecisions);
 
-    if (padMode == op::PadMode::CONSTANT) {
+    if (padMode == op::PadMode::CONSTANT && !hasNegativeIndexes(pad)) {
         auto bcastConstant = [&](const std::shared_ptr<ov::opset1::Constant> &constant) {
             size_t padIdx = 0;
             for (size_t i = 0; i < padsBegin.size(); ++i) {
@@ -94,8 +109,8 @@ bool PadTransformation::transform(TransformationContext& context, ov::pass::patt
             return NetworkHelper::toScalar(constant);
         }
 
-        std::vector<size_t> padsForConstantBegin(constantShape.size(), 0ul);
-        std::vector<size_t> padsForConstantEnd(constantShape.size(), 0ul);
+        std::vector<int64_t> padsForConstantBegin(constantShape.size(), 0ul);
+        std::vector<int64_t> padsForConstantEnd(constantShape.size(), 0ul);
         bool foldingIsNecessary = false;
 
         // folding is necessary when dequantization and padding by the same dimension
@@ -112,9 +127,10 @@ bool PadTransformation::transform(TransformationContext& context, ov::pass::patt
         }
 
         if (foldingIsNecessary) {
-            const auto beginConst = ov::opset1::Constant::create(element::u32, { padsForConstantBegin.size() }, padsForConstantBegin);
-            const auto endConst = ov::opset1::Constant::create(element::u32, { padsForConstantEnd.size() }, padsForConstantEnd);
+            const auto beginConst = ov::opset1::Constant::create(element::i32, { padsForConstantBegin.size() }, padsForConstantBegin);
+            const auto endConst = ov::opset1::Constant::create(element::i32, { padsForConstantEnd.size() }, padsForConstantEnd);
             const auto padValueConstant = ov::opset1::Constant::create(constant->get_element_type(), Shape{}, { padVal });
+
             const auto foldedConstant = fold<ov::opset12::Pad>(constant, beginConst, endConst, padValueConstant, padMode);
             return ov::as_type_ptr<ov::opset1::Constant>(foldedConstant);
         } else {
@@ -151,23 +167,9 @@ bool PadTransformation::transform(TransformationContext& context, ov::pass::patt
     pad->set_argument(3, convertedZero);
 
     moveDequantizationAfter(context, pad, dequantization, true);
+
     return true;
 }
-
-namespace {
-    bool hasNegativeIndexes(const std::shared_ptr<ov::op::util::PadBase>& pad) {
-        const auto padsBegin = pad->get_pads_begin();
-        const auto padsEnd = pad->get_pads_end();
-        auto pred = [](int64_t a) {
-            return a < 0;
-        };
-        if (std::any_of(padsBegin.begin(), padsBegin.end(), pred) ||
-            std::any_of(padsEnd.begin(), padsEnd.end(), pred)) {
-            return true;
-        }
-        return false;
-    }
-} // namespace
 
 bool PadTransformation::canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> op) const {
     if (!LayerTransformation::canBeTransformedSpatialDimension(context, op)) {
@@ -176,10 +178,6 @@ bool PadTransformation::canBeTransformed(const TransformationContext& context, s
 
     const auto pad = ov::as_type_ptr<ov::op::util::PadBase>(op);
     if (!pad) {
-        return false;
-    }
-
-    if (hasNegativeIndexes(pad)) {
         return false;
     }
 

--- a/src/common/low_precision_transformations/tests/pad_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/pad_transformation.cpp
@@ -16,6 +16,8 @@
 #include "lpt_ngraph_functions/pad_function.hpp"
 #include "simple_low_precision_transformer.hpp"
 
+#include "openvino/pass/visualize_tree.hpp"
+
 namespace {
 using namespace testing;
 using namespace ov;
@@ -45,7 +47,7 @@ public:
 typedef std::tuple <
     ov::PartialShape, // input Shape
     std::pair<std::vector<int64_t>, std::vector<int64_t>>, // pads begin, pads end
-    ngraph::op::PadMode, // pads mode
+    ov::op::PadMode, // pads mode
     float, // pads value (used if mode == CONSTANT)
     PadTransformationTestValues> PadTransformationParams;
 
@@ -54,7 +56,7 @@ public:
     void SetUp() override {
         const ov::PartialShape inputShape = std::get<0>(GetParam());
         const auto pads = std::get<1>(GetParam());
-        const ngraph::op::PadMode padsMode = std::get<2>(GetParam());
+        const ov::op::PadMode padsMode = std::get<2>(GetParam());
         const float padsValue = std::get<3>(GetParam());
         const PadTransformationTestValues testValues = std::get<4>(GetParam());
 
@@ -71,6 +73,8 @@ public:
             padsValue,
             precisionAfterActualOp,
             { {}, {}, {} });
+
+        auto actualFunctionReference = actualFunction->clone();
 
         SimpleLowPrecisionTransformer transformer;
         transformer.add<ov::pass::low_precision::PadTransformation, ov::op::v1::Pad>(testValues.params);
@@ -91,13 +95,13 @@ public:
     static std::string getTestCaseName(testing::TestParamInfo<PadTransformationParams> obj) {
         const ov::PartialShape inputShape = std::get<0>(obj.param);
         const auto pads = std::get<1>(obj.param);
-        const ngraph::op::PadMode padsMode = std::get<2>(obj.param);
+        const ov::op::PadMode padsMode = std::get<2>(obj.param);
         const float padsValue = std::get<3>(obj.param);
         const PadTransformationTestValues testValues = std::get<4>(obj.param);
 
         std::ostringstream result;
         result << "mode_" << padsMode << "_";
-        if (padsMode == ngraph::op::PadMode::CONSTANT) {
+        if (padsMode == ov::op::PadMode::CONSTANT) {
             result << "pad_value_{ " << padsValue << " }";
         }
 
@@ -129,7 +133,7 @@ const std::vector<ov::PartialShape> inputShapes = {
 
 const std::vector<std::pair<std::vector<int64_t>, std::vector<int64_t>>> padsBySpatialDimensions = {
     {{0, 0, 2, 1}, {0, 0, 1, 2}},
-    {{0, 0, -2, -1}, {0, 0, -1, -2}}
+    {{0, 0, -1, -1}, {0, 0, 2, 2}}
 };
 
 const std::pair<std::vector<int64_t>, std::vector<int64_t>> padsPositiveBySpatialDimensions = {
@@ -154,11 +158,11 @@ const std::vector<ov::PartialShape> commonInputShapes = {
     {-1, -1, -1, -1}
 };
 
-std::vector<ngraph::op::PadMode> allModes = {
-    ngraph::op::PadMode::EDGE,
-    ngraph::op::PadMode::REFLECT,
-    ngraph::op::PadMode::SYMMETRIC,
-    ngraph::op::PadMode::CONSTANT,
+std::vector<ov::op::PadMode> allModes = {
+    ov::op::PadMode::EDGE,
+    ov::op::PadMode::REFLECT,
+    ov::op::PadMode::SYMMETRIC,
+    ov::op::PadMode::CONSTANT,
 };
 
 const std::vector<PadTransformationTestValues> deqWithoutSub = {
@@ -270,10 +274,10 @@ INSTANTIATE_TEST_SUITE_P(
 // test-cases with common logic for "EDGE", "REFLECT", and "SYMMETRIC" modes:
 // pads by spatial dimensions, dequantization with subtract
 namespace dqWithSubtract {
-std::vector<ngraph::op::PadMode> modesInWhichSubPropagated = {
-    ngraph::op::PadMode::EDGE,
-    ngraph::op::PadMode::REFLECT,
-    ngraph::op::PadMode::SYMMETRIC,
+std::vector<ov::op::PadMode> modesInWhichSubPropagated = {
+    ov::op::PadMode::EDGE,
+    ov::op::PadMode::REFLECT,
+    ov::op::PadMode::SYMMETRIC,
 };
 
 const std::vector<PadTransformationTestValues> deqWithSub = {
@@ -416,7 +420,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsPositiveBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::CONSTANT),
+        ::testing::Values(ov::op::PadMode::CONSTANT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForConstantMode)),
     PadTransformation::getTestCaseName);
@@ -445,7 +449,7 @@ namespace negative {
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsNegativeBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::CONSTANT),
+        ::testing::Values(ov::op::PadMode::CONSTANT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForConstantMode)),
     PadTransformation::getTestCaseName);
@@ -456,14 +460,14 @@ namespace mixed {
         {
         LayerTransformation::createParamsU8I8(),
         {
-            ngraph::element::u8,
-            {{ngraph::element::f32}, {}, {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}}}
+            ov::element::u8,
+            {{ov::element::f32}, {}, {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}}}
         },
         {
-            ngraph::element::u8,
+            ov::element::u8,
             {{}, {}, {}},
-            ngraph::element::u8,
-            {{ngraph::element::f32}, {}, {{1.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 7, 1}}}
+            ov::element::u8,
+            {{ov::element::f32}, {}, {{1.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 7, 1}}}
         }
         }
     };
@@ -474,7 +478,7 @@ namespace mixed {
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsMixedBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::CONSTANT),
+        ::testing::Values(ov::op::PadMode::CONSTANT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForConstantMode)),
     PadTransformation::getTestCaseName);
@@ -485,7 +489,7 @@ namespace mixed {
 // dequantization with "CONSTANT" mode (non zero value) and non unique pad dimension: dequantization isn't propagated
 namespace testCasesForConstantModeWithNonZeroValues {
 const std::vector<PadTransformationTestValues> testValuesForConstantMode2 = {
-    {
+     {
         LayerTransformation::createParamsI8I8(),
         {
             ov::element::i8,
@@ -532,7 +536,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::ValuesIn(padsBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::CONSTANT),
+        ::testing::Values(ov::op::PadMode::CONSTANT),
         ::testing::Values(1.f),
         ::testing::ValuesIn(testValuesForConstantMode2)),
     PadTransformation::getTestCaseName);
@@ -596,7 +600,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsPositiveByUniqueDimension),
-        ::testing::Values(ngraph::op::PadMode::CONSTANT),
+        ::testing::Values(ov::op::PadMode::CONSTANT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForConstantMode)),
     PadTransformation::getTestCaseName);
@@ -611,21 +615,21 @@ const std::vector<PadTransformationTestValues> testValuesForConstantMode = {
     {
         LayerTransformation::createParamsI8I8(),
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{64.f, 64.f, 64.f, 32.f, 32.f, 32.f}, ngraph::element::f32, {1, 1, 6, 1}},
-                {{3.f, 3.f, 3.f, 2.f, 2.f, 2.f}, ngraph::element::f32, {1, 1, 6, 1}}
+                {ov::element::f32},
+                {{64.f, 64.f, 64.f, 32.f, 32.f, 32.f}, ov::element::f32, {1, 1, 6, 1}},
+                {{3.f, 3.f, 3.f, 2.f, 2.f, 2.f}, ov::element::f32, {1, 1, 6, 1}}
             }
         },
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {},
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{64.f, 32.f, 32.f}, ngraph::element::f32, {1, 1, 3, 1}},
-                {{3.f, 2.f, 2.f}, ngraph::element::f32, {1, 1, 3, 1}}
+                {ov::element::f32},
+                {{64.f, 32.f, 32.f}, ov::element::f32, {1, 1, 3, 1}},
+                {{3.f, 2.f, 2.f}, ov::element::f32, {1, 1, 3, 1}}
             }
         }
     }
@@ -633,19 +637,19 @@ const std::vector<PadTransformationTestValues> testValuesForConstantMode = {
     {
         LayerTransformation::createParamsI8I8(),
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
+                {ov::element::f32},
                 {64.f},
                 {3.f}
             }
         },
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {},
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
+                {ov::element::f32},
                 {64.f},
                 {3.f}
             }
@@ -659,7 +663,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsNegativeByUniqueDimension),
-        ::testing::Values(ngraph::op::PadMode::CONSTANT),
+        ::testing::Values(ov::op::PadMode::CONSTANT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForConstantMode)),
     PadTransformation::getTestCaseName);
@@ -674,21 +678,21 @@ const std::vector<PadTransformationTestValues> testValuesForConstantMode = {
     {
         LayerTransformation::createParamsI8I8(),
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{64.f, 64.f, 64.f, 32.f, 32.f, 32.f}, ngraph::element::f32, {1, 1, 6, 1}},
-                {{3.f, 3.f, 3.f, 2.f, 2.f, 2.f}, ngraph::element::f32, {1, 1, 6, 1}}
+                {ov::element::f32},
+                {{64.f, 64.f, 64.f, 32.f, 32.f, 32.f}, ov::element::f32, {1, 1, 6, 1}},
+                {{3.f, 3.f, 3.f, 2.f, 2.f, 2.f}, ov::element::f32, {1, 1, 6, 1}}
             }
         },
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {},
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{0.f, 0.f, 64.f, 64.f, 64.f, 32.f, 32.f}, ngraph::element::f32, {1, 1, 7, 1}},
-                {{1.f, 1.f, 3.f, 3.f, 3.f, 2.f, 2.f}, ngraph::element::f32, {1, 1, 7, 1}}
+                {ov::element::f32},
+                {{0.f, 0.f, 64.f, 64.f, 64.f, 32.f, 32.f}, ov::element::f32, {1, 1, 7, 1}},
+                {{1.f, 1.f, 3.f, 3.f, 3.f, 2.f, 2.f}, ov::element::f32, {1, 1, 7, 1}}
             }
         }
     }
@@ -700,7 +704,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsMixedByUniqueDimension),
-        ::testing::Values(ngraph::op::PadMode::CONSTANT),
+        ::testing::Values(ov::op::PadMode::CONSTANT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForConstantMode)),
     PadTransformation::getTestCaseName);
@@ -765,7 +769,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsByUniqueDimension),
-        ::testing::Values(ngraph::op::PadMode::CONSTANT),
+        ::testing::Values(ov::op::PadMode::CONSTANT),
         ::testing::Values(2.f),
         ::testing::ValuesIn(testValuesForConstantMode)),
     PadTransformation::getTestCaseName);
@@ -802,7 +806,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsPositiveBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::EDGE),
+        ::testing::Values(ov::op::PadMode::EDGE),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForEdgeMode)),
     PadTransformation::getTestCaseName);
@@ -813,21 +817,21 @@ const std::vector<PadTransformationTestValues> testValuesForEdgeMode = {
     {
         LayerTransformation::createParamsI8I8(),
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}},
-                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}}
+                {ov::element::f32},
+                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}},
+                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}}
             }
         },
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {{}, {}, {}},
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 3, 1}},
-                {{3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 3, 1}}
+                {ov::element::f32},
+                {{3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 3, 1}},
+                {{3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 3, 1}}
             }
         }
     },
@@ -839,7 +843,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsNegativeBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::EDGE),
+        ::testing::Values(ov::op::PadMode::EDGE),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForEdgeMode)),
     PadTransformation::getTestCaseName);
@@ -850,21 +854,21 @@ const std::vector<PadTransformationTestValues> testValuesForEdgeMode = {
     {
         LayerTransformation::createParamsI8I8(),
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}},
-                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}}
+                {ov::element::f32},
+                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}},
+                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}}
             }
         },
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {{}, {}, {}},
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{1.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 7, 1}},
-                {{1.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 7, 1}}
+                {ov::element::f32},
+                {{1.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 7, 1}},
+                {{1.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 7, 1}}
             }
         }
     },
@@ -876,7 +880,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsMixedBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::EDGE),
+        ::testing::Values(ov::op::PadMode::EDGE),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForEdgeMode)),
     PadTransformation::getTestCaseName);
@@ -913,7 +917,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::ValuesIn(padsBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::REFLECT),
+        ::testing::Values(ov::op::PadMode::REFLECT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForReflectMode)),
     PadTransformation::getTestCaseName);
@@ -952,7 +956,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsPositiveBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::SYMMETRIC),
+        ::testing::Values(ov::op::PadMode::SYMMETRIC),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForSymetricMode)),
     PadTransformation::getTestCaseName);
@@ -963,22 +967,22 @@ const std::vector<PadTransformationTestValues> testValuesForSymetricMode = {
     {
         LayerTransformation::createParamsI8I8(),
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}},
-                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}}
+                {ov::element::f32},
+                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}},
+                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}}
             }
         },
 
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {{}, {}, {}},
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 3, 1}},
-                {{3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 3, 1}}
+                {ov::element::f32},
+                {{3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 3, 1}},
+                {{3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 3, 1}}
             }
         }
     },
@@ -990,7 +994,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsNegativeBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::SYMMETRIC),
+        ::testing::Values(ov::op::PadMode::SYMMETRIC),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForSymetricMode)),
     PadTransformation::getTestCaseName);
@@ -1001,22 +1005,22 @@ const std::vector<PadTransformationTestValues> testValuesForSymetricMode = {
     {
         LayerTransformation::createParamsI8I8(),
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}},
-                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ngraph::element::f32, {1, 1, 6, 1}}
+                {ov::element::f32},
+                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}},
+                {{1.f, 2.f, 3.f, 4.f, 5.f, 6.f}, ov::element::f32, {1, 1, 6, 1}}
             }
         },
 
         {
-            ngraph::element::i8,
+            ov::element::i8,
             {{}, {}, {}},
-            ngraph::element::i8,
+            ov::element::i8,
             {
-                {ngraph::element::f32},
-                {{2.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 7, 1}},
-                {{2.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ngraph::element::f32, {1, 1, 7, 1}}
+                {ov::element::f32},
+                {{2.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 7, 1}},
+                {{2.f, 1.f, 1.f, 2.f, 3.f, 4.f, 5.f}, ov::element::f32, {1, 1, 7, 1}}
             }
         }
     },
@@ -1028,7 +1032,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
         ::testing::Values(padsMixedBySpatialDimensions),
-        ::testing::Values(ngraph::op::PadMode::SYMMETRIC),
+        ::testing::Values(ov::op::PadMode::SYMMETRIC),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForSymetricMode)),
     PadTransformation::getTestCaseName);
@@ -1039,11 +1043,11 @@ const std::vector<ov::PartialShape> inputShapesWithDynamicRank = {
     ov::PartialShape::dynamic()
 };
 
-std::vector<ngraph::op::PadMode> allModes = {
-    ngraph::op::PadMode::EDGE,
-    ngraph::op::PadMode::REFLECT,
-    ngraph::op::PadMode::SYMMETRIC,
-    ngraph::op::PadMode::CONSTANT,
+std::vector<ov::op::PadMode> allModes = {
+    ov::op::PadMode::EDGE,
+    ov::op::PadMode::REFLECT,
+    ov::op::PadMode::SYMMETRIC,
+    ov::op::PadMode::CONSTANT,
 };
 
 const std::vector<PadTransformationTestValues> testValuesForDynamicRank = {

--- a/src/common/low_precision_transformations/tests/pad_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/pad_transformation.cpp
@@ -72,8 +72,6 @@ public:
             precisionAfterActualOp,
             { {}, {}, {} });
 
-        auto actualFunctionReference = actualFunction->clone();
-
         SimpleLowPrecisionTransformer transformer;
         transformer.add<ov::pass::low_precision::PadTransformation, ov::op::v1::Pad>(testValues.params);
         transformer.transform(actualFunction);

--- a/src/common/low_precision_transformations/tests/pad_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/pad_transformation.cpp
@@ -16,8 +16,6 @@
 #include "lpt_ngraph_functions/pad_function.hpp"
 #include "simple_low_precision_transformer.hpp"
 
-#include "openvino/pass/visualize_tree.hpp"
-
 namespace {
 using namespace testing;
 using namespace ov;

--- a/src/common/low_precision_transformations/tests/pad_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/pad_transformation.cpp
@@ -45,7 +45,7 @@ public:
 
 typedef std::tuple <
     ov::PartialShape, // input Shape
-    std::pair<std::vector<uint64_t>, std::vector<uint64_t>>, // pads begin, pads end
+    std::pair<std::vector<int64_t>, std::vector<int64_t>>, // pads begin, pads end
     ngraph::op::PadMode, // pads mode
     float, // pads value (used if mode == CONSTANT)
     PadTransformationTestValues> PadTransformationParams;
@@ -127,9 +127,9 @@ const std::vector<ov::PartialShape> inputShapes = {
     {-1, 3, 6, -1}
 };
 
-const std::pair<std::vector<uint64_t>, std::vector<uint64_t>> padsBySpatialDimensions = {
-    {0, 0, 2, 1},
-    {0, 0, 1, 2}
+const std::vector<std::pair<std::vector<int64_t>, std::vector<int64_t>>> padsBySpatialDimensions = {
+    {{0, 0, 2, 1}, {0, 0, 1, 2}},
+    {{0, 0, -1, -1}, {0, 0, -1, -1}}
 };
 
 // test-cases with common logic for all modes
@@ -247,7 +247,7 @@ INSTANTIATE_TEST_SUITE_P(
     PadTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(commonInputShapes),
-        ::testing::Values(padsBySpatialDimensions),
+        ::testing::ValuesIn(padsBySpatialDimensions),
         ::testing::ValuesIn(allModes),
         ::testing::Values(0.f),
         ::testing::ValuesIn(deqWithoutSub)),
@@ -345,7 +345,7 @@ INSTANTIATE_TEST_SUITE_P(
     PadTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
-        ::testing::Values(padsBySpatialDimensions),
+        ::testing::ValuesIn(padsBySpatialDimensions),
         ::testing::ValuesIn(modesInWhichSubPropagated),
         ::testing::Values(0.f),
         ::testing::ValuesIn(deqWithSub)),
@@ -414,7 +414,7 @@ INSTANTIATE_TEST_SUITE_P(
     PadTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
-        ::testing::Values(padsBySpatialDimensions),
+        ::testing::ValuesIn(padsBySpatialDimensions),
         ::testing::Values(ngraph::op::PadMode::CONSTANT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForConstantMode)),
@@ -470,7 +470,7 @@ INSTANTIATE_TEST_SUITE_P(
     PadTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
-        ::testing::Values(padsBySpatialDimensions),
+        ::testing::ValuesIn(padsBySpatialDimensions),
         ::testing::Values(ngraph::op::PadMode::CONSTANT),
         ::testing::Values(1.f),
         ::testing::ValuesIn(testValuesForConstantMode2)),
@@ -478,7 +478,7 @@ INSTANTIATE_TEST_SUITE_P(
 } // namespace testCasesForConstantModeWithNonZeroValues
 
 namespace testCasesForConstantModeAndUniquePadDimension {
-const std::pair<std::vector<uint64_t>, std::vector<uint64_t>> padsByUniqueDimension = {
+const std::pair<std::vector<int64_t>, std::vector<int64_t>> padsByUniqueDimension = {
     {0, 0, 2, 0},
     {0, 0, 1, 0}
 };
@@ -541,7 +541,7 @@ INSTANTIATE_TEST_SUITE_P(
 } // namespace testCasesForConstantModeAndUniquePadDimension
 
 namespace testCasesForNonZeroConstantModeAndUniquePadDimension {
-const std::pair<std::vector<uint64_t>, std::vector<uint64_t>> padsByUniqueDimension = {
+const std::pair<std::vector<int64_t>, std::vector<int64_t>> padsByUniqueDimension = {
     {0, 0, 2, 0},
     {0, 0, 1, 0}
 };
@@ -633,7 +633,7 @@ INSTANTIATE_TEST_SUITE_P(
     PadTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
-        ::testing::Values(padsBySpatialDimensions),
+        ::testing::ValuesIn(padsBySpatialDimensions),
         ::testing::Values(ngraph::op::PadMode::EDGE),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForEdgeMode)),
@@ -670,7 +670,7 @@ INSTANTIATE_TEST_SUITE_P(
     PadTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
-        ::testing::Values(padsBySpatialDimensions),
+        ::testing::ValuesIn(padsBySpatialDimensions),
         ::testing::Values(ngraph::op::PadMode::REFLECT),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForReflectMode)),
@@ -707,7 +707,7 @@ INSTANTIATE_TEST_SUITE_P(
     PadTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(inputShapes),
-        ::testing::Values(padsBySpatialDimensions),
+        ::testing::ValuesIn(padsBySpatialDimensions),
         ::testing::Values(ngraph::op::PadMode::SYMMETRIC),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForSymetricMode)),
@@ -760,7 +760,7 @@ INSTANTIATE_TEST_SUITE_P(
     PadTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(inputShapesWithDynamicRank),
-        ::testing::Values(padsBySpatialDimensions),
+        ::testing::ValuesIn(padsBySpatialDimensions),
         ::testing::ValuesIn(allModes),
         ::testing::Values(0.f),
         ::testing::ValuesIn(testValuesForDynamicRank)),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/pad_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/pad_transformation.cpp
@@ -99,6 +99,22 @@ const std::vector<LayerTestsDefinitions::PadTransformationParam> params = {
         "Pad",
         "FP32"
     },
+    {
+            { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { -2.f }, { 10.5f }, { -2.f }, { 10.5f } },
+            { 0, 0, -1, 1 },
+            { 0, 0, 1, -1 },
+            0.f,
+            "Pad",
+            "FP32"
+    },
+    {
+            { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { -2.f }, { 10.5f }, { -2.f }, { 10.5f } },
+            { 0, 0, 0, 0 },
+            { 0, 0, -1, -1 },
+            0.f,
+            "Pad",
+            "U8"
+    },
     // tensor quantization with subtract, non zero padValue and pad by unique dimension
     {
         { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 25.5f }, { 0.f }, { 12.8f } },
@@ -107,6 +123,23 @@ const std::vector<LayerTestsDefinitions::PadTransformationParam> params = {
         2.f,
         "Pad",
         "U8"
+    },
+
+    {
+            { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 25.5f }, { 0.f }, { 12.8f } },
+            { 0, 0, 2, 0 },
+            { 0, 0, -1, 0 },
+            2.f,
+            "Pad",
+            "U8"
+    },
+    {
+            { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { 0.f }, { 25.5f }, { 0.f }, { 12.8f } },
+            { 0, 0, -1, 0 },
+            { 0, 0, -1, 0 },
+            2.f,
+            "Pad",
+            "U8"
     },
     // per-channel quantization with different values, non zero padValue and pad by channel
     {
@@ -124,6 +157,36 @@ const std::vector<LayerTestsDefinitions::PadTransformationParam> params = {
         "Pad",
         "U8"
     },
+    {
+            {
+                    256ul,
+                    ngraph::Shape{ 1, 3, 1, 1 },
+                    { -127.f, 0.f, 128.f / 2.f },
+                    { 128.f / 4.f, 128.f / 2.f, 128.f },
+                    { 0.f, 0.f, 0.f },
+                    { 255.f / 4.f, 255.f / 2.f, 255.f }
+            },
+            { 0, 1, 0, 0 },
+            { 0, -1, 0, 0 },
+            2.f,
+            "Pad",
+            "U8"
+    },
+    {
+            {
+                    256ul,
+                    ngraph::Shape{ 1, 3, 1, 1 },
+                    { -127.f, 0.f, 128.f / 2.f },
+                    { 128.f / 4.f, 128.f / 2.f, 128.f },
+                    { 0.f, 0.f, 0.f },
+                    { 255.f / 4.f, 255.f / 2.f, 255.f }
+            },
+            { 0, -1, 0, 0 },
+            { 0, -1, 0, 0 },
+            2.f,
+            "Pad",
+            "U8"
+    },
     // per-channel quantization with subtract
     {
         {
@@ -137,6 +200,32 @@ const std::vector<LayerTestsDefinitions::PadTransformationParam> params = {
         0.f,
         "Pad",
         "FP32"
+    },
+    {
+            {
+                    256ul,
+                    ngraph::Shape{ 1, 3, 1, 1 },
+                    { -2.f, -4.f, -6.f }, { 10.5f, 8.5f, 6.5f },
+                    { -2.f, -4.f, -6.f }, { 10.5f, 8.5f, 6.5f }
+            },
+            { 0, 0, -1, 1 },
+            { 0, 0, 1, -1 },
+            0.f,
+            "Pad",
+            "FP32"
+    },
+    {
+            {
+                    256ul,
+                    ngraph::Shape{ 1, 3, 1, 1 },
+                    { -2.f, -4.f, -6.f }, { 10.5f, 8.5f, 6.5f },
+                    { -2.f, -4.f, -6.f }, { 10.5f, 8.5f, 6.5f }
+            },
+            { 0, 0, -1, -1 },
+            { 0, 0, -1, -1 },
+            0.f,
+            "Pad",
+            "U8"
     },
 };
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/pad_transformation.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/pad_transformation.cpp
@@ -76,6 +76,16 @@ const std::vector<LayerTestsDefinitions::PadTransformationParam> params = {
         { 0, 0, 1, 1 },
         { 0, 0, 1, 1 },
     },
+    {
+            { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { -2.f }, { 10.5f }, { -2.f }, { 10.5f } },
+            { 0, 0, -1, 1 },
+            { 0, 0, 1, -1 },
+    },
+    {
+            { 256ul, ngraph::Shape{ 1, 1, 1, 1 }, { -2.f }, { 10.5f }, { -2.f }, { 10.5f } },
+            { 0, 0, -1, -1 },
+            { 0, 0, -1, -1 },
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_LPT, PadTransformation,

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/pad_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/pad_transformation.hpp
@@ -11,8 +11,8 @@ namespace LayerTestsDefinitions {
 class PadTransformationParam {
 public:
     ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
-    std::vector<uint64_t> padsBegin;
-    std::vector<uint64_t> padsEnd;
+    std::vector<int64_t> padsBegin;
+    std::vector<int64_t> padsEnd;
     float padValue;
     std::string layerName;
     std::string expectedKernelType;

--- a/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/pad_function.hpp
+++ b/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/pad_function.hpp
@@ -16,7 +16,7 @@ namespace subgraph {
 
 class PadFunction {
 public:
-static std::shared_ptr<ngraph::Function> get(
+static std::shared_ptr<ov::Model> get(
     const PartialShape& inputShape,
     const element::Type precisionBeforeDequantization,
     const builder::subgraph::DequantizationOperations& dequantizationBefore,

--- a/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/pad_function.hpp
+++ b/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/pad_function.hpp
@@ -20,8 +20,8 @@ static std::shared_ptr<ngraph::Function> get(
     const PartialShape& inputShape,
     const element::Type precisionBeforeDequantization,
     const builder::subgraph::DequantizationOperations& dequantizationBefore,
-    const std::vector<uint64_t>& padsBegin,
-    const std::vector<uint64_t>& padsEnd,
+    const std::vector<int64_t>& padsBegin,
+    const std::vector<int64_t>& padsEnd,
     const op::PadMode mode,
     const float padValue,
     const element::Type precisionAfterOperation,
@@ -31,8 +31,8 @@ static std::shared_ptr<Function> get(
     const PartialShape& inputShape,
     const element::Type inputPrecision,
     const builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
-    const std::vector<uint64_t>& padsBegin,
-    const std::vector<uint64_t>& padsEnd,
+    const std::vector<int64_t>& padsBegin,
+    const std::vector<int64_t>& padsEnd,
     const op::PadMode mode,
     const float padValue = 0.f);
 };

--- a/src/tests/ngraph_helpers/lpt_ngraph_functions/src/pad_function.cpp
+++ b/src/tests/ngraph_helpers/lpt_ngraph_functions/src/pad_function.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/ngraph.hpp>
 
 
-#include <ngraph/opsets/opset1.hpp>
+#include "openvino/opsets/opset12.hpp"
 #include "ngraph_functions/subgraph_builders.hpp"
 #include "lpt_ngraph_functions/common/builders.hpp"
 #include "lpt_ngraph_functions/pad_function.hpp"
@@ -20,8 +20,8 @@ std::shared_ptr<ngraph::Function> PadFunction::get(
     const PartialShape& inputShape,
     const element::Type precisionBeforeDequantization,
     const builder::subgraph::DequantizationOperations& dequantizationBefore,
-    const std::vector<uint64_t>& padsBegin,
-    const std::vector<uint64_t>& padsEnd,
+    const std::vector<int64_t>& padsBegin,
+    const std::vector<int64_t>& padsEnd,
     const op::PadMode mode,
     const float padValue,
     const element::Type precisionAfterOperation,
@@ -29,16 +29,16 @@ std::shared_ptr<ngraph::Function> PadFunction::get(
     const auto input = std::make_shared<opset1::Parameter>(precisionBeforeDequantization, inputShape);
     const auto deqBefore = makeDequantization(input, dequantizationBefore);
 
-    const auto padsBeginConst = opset1::Constant::create(element::u64, Shape{ padsBegin.size() }, padsBegin);
-    const auto padsEndConst = opset1::Constant::create(element::u64, Shape{ padsEnd.size() }, padsEnd);
+    const auto padsBeginConst = opset1::Constant::create(element::i64, Shape{ padsBegin.size() }, padsBegin);
+    const auto padsEndConst = opset1::Constant::create(element::i64, Shape{ padsEnd.size() }, padsEnd);
     const auto padsValueConst = opset1::Constant::create(deqBefore->get_output_element_type(0), Shape{}, { padValue });
 
-    const auto pad = std::make_shared<ov::op::TypeRelaxed<opset1::Pad>>(
+    const auto pad = std::make_shared<ov::op::TypeRelaxed<ov::op::v12::Pad>>(
         std::vector<element::Type>{ precisionAfterOperation, element::u64, element::u64, precisionAfterOperation},
         std::vector<element::Type>{ precisionAfterOperation },
         ov::op::TemporaryReplaceOutputType(deqBefore, precisionAfterOperation).get(),
-        ov::op::TemporaryReplaceOutputType(padsBeginConst, element::u64).get(),
-        ov::op::TemporaryReplaceOutputType(padsEndConst, element::u64).get(),
+        ov::op::TemporaryReplaceOutputType(padsBeginConst, element::i64).get(),
+        ov::op::TemporaryReplaceOutputType(padsEndConst, element::i64).get(),
         ov::op::TemporaryReplaceOutputType(padsValueConst, precisionAfterOperation).get(),
         mode);
 
@@ -56,17 +56,17 @@ std::shared_ptr<Function> PadFunction::get(
     const PartialShape& inputShape,
     const element::Type inputPrecision,
     const builder::subgraph::FakeQuantizeOnData& fakeQuantize,
-    const std::vector<uint64_t>& padsBegin,
-    const std::vector<uint64_t>& padsEnd,
+    const std::vector<int64_t>& padsBegin,
+    const std::vector<int64_t>& padsEnd,
     const op::PadMode mode,
     const float padValue) {
     const auto input = std::make_shared<opset1::Parameter>(inputPrecision, inputShape);
     const auto fqOnData = makeFakeQuantize(input, inputPrecision, fakeQuantize);
 
-    const auto padsBeginConst = opset1::Constant::create(element::u64, Shape{ padsBegin.size() }, padsBegin);
-    const auto padsEndConst = opset1::Constant::create(element::u64, Shape{ padsEnd.size() }, padsEnd);
+    const auto padsBeginConst = opset1::Constant::create(element::i64, Shape{ padsBegin.size() }, padsBegin);
+    const auto padsEndConst = opset1::Constant::create(element::i64, Shape{ padsEnd.size() }, padsEnd);
     const auto padsValueConst = opset1::Constant::create(inputPrecision, Shape{}, { padValue });
-    const auto pad = std::make_shared<opset1::Pad>(fqOnData, padsBeginConst, padsEndConst, padsValueConst, mode);
+    const auto pad = std::make_shared<ov::op::v12::Pad>(fqOnData, padsBeginConst, padsEndConst, padsValueConst, mode);
     pad->set_friendly_name("Pad");
 
     const auto function = std::make_shared<Function>(


### PR DESCRIPTION
### Details:
 - Update LPT PadTransformation to support v12::Pad negative indexes
 - Add unit test for negative and mixed cases

### Tickets:
 - 115474
