### PR TITLE
[GPU] Fixed reordered memory cache not to contain original weight memory

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
@@ -149,7 +149,14 @@ public:
 
     memory::ptr weights_memory() const {
         if (is_dynamic()) {
-            auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
+            memory::ptr weights_mem = nullptr;
+            auto weights_layout = *_impl_params->weights_layout;
+            auto weights_idx = node->get_deform_conv_dep_offset() + 1;
+            if (weights_layout.compatible(get_node().get_input_layout(weights_idx))) {
+                weights_mem = dep_memory_ptr(weights_idx);
+            } else {
+                weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
+            }
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
         } else {  // all weights are in one buffer

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -81,7 +81,14 @@ public:
 
     memory::ptr weights_memory() const {
         if (is_dynamic()) {
-            auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
+            memory::ptr weights_mem = nullptr;
+            auto weights_layout = *_impl_params->weights_layout;
+            size_t weights_idx = 1;
+            if (weights_layout.compatible(get_node().get_input_layout(weights_idx))) {
+                weights_mem = dep_memory_ptr(weights_idx);
+            } else {
+                weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
+            }
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
         } else {

--- a/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
@@ -54,7 +54,15 @@ public:
 
     memory::ptr weights_memory() const {
         if (is_dynamic()) {
-            auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
+            memory::ptr weights_mem = nullptr;
+            auto weights_layout = *_impl_params->weights_layout;
+            size_t weights_idx = 1;
+            if (weights_layout.compatible(get_node().get_input_layout(weights_idx))) {
+                weights_mem = dep_memory_ptr(weights_idx);
+            } else {
+                weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
+            }
+
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
         } else {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1152,7 +1152,7 @@ event::ptr primitive_inst::update_weights() {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
             GPU_DEBUG_TRACE_DETAIL << id() << ": reinterpret original weights memory from " << original_layout.to_short_string()
                                            << " to " << expected_layout.to_short_string() << std::endl;
-            _impl_params->weights_layout = optional_layout(original_layout);
+            _impl_params->weights_layout = optional_layout(expected_layout);
             return nullptr;
         } else {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(false);

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1137,7 +1137,6 @@ event::ptr primitive_inst::update_weights() {
     if (!reorder_kernel_params) {
         // If kernel doesn't says that it doesn't require weights reorder, but weights were reordered previously, then
         // incorrect memory buffer may be assigned, so reset cached weights for such case
-        _reordered_weights_cache.add(original_layout, original_weights_memory);
         _impl_params->weights_layout = optional_layout(original_layout);
     } else {
         auto expected_layout = reorder_kernel_params->get_output_layout();
@@ -1153,7 +1152,7 @@ event::ptr primitive_inst::update_weights() {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
             GPU_DEBUG_TRACE_DETAIL << id() << ": reinterpret original weights memory from " << original_layout.to_short_string()
                                            << " to " << expected_layout.to_short_string() << std::endl;
-            _reordered_weights_cache.add(expected_layout, engine.reinterpret_buffer(*original_weights_memory, expected_layout));
+            _impl_params->weights_layout = optional_layout(original_layout);
             return nullptr;
         } else {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(false);
@@ -1186,7 +1185,7 @@ event::ptr primitive_inst::update_weights() {
             memory::ptr weights_memory = nullptr;
             if (_reordered_weights_cache.is_full()) {
                 weights_memory = _reordered_weights_cache.get_lru_element().second;
-                can_reuse = weights_memory->size() <= expected_layout.bytes_count() && (weights_memory->buffer_ptr() != original_weights_memory->buffer_ptr());
+                can_reuse = weights_memory->size() <= expected_layout.bytes_count();
             }
 
             if (can_reuse) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1152,7 +1152,6 @@ event::ptr primitive_inst::update_weights() {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
             GPU_DEBUG_TRACE_DETAIL << id() << ": reinterpret original weights memory from " << original_layout.to_short_string()
                                            << " to " << expected_layout.to_short_string() << std::endl;
-            _impl_params->weights_layout = optional_layout(expected_layout);
             return nullptr;
         } else {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(false);


### PR DESCRIPTION
### Details:
 - Previously reordered_weights_cache contained original memory too, which is just reinterpreted
 - It is waste of reordered_weights_cache slot, and causes eviction of actually reordered weights which may be needed in the future. 
-  Fixed above issue 
### Tickets:
 - 119145
