### PR TITLE
Improve acos ref accuracy for integral types

### DIFF
--- a/src/core/reference/include/openvino/reference/acos.hpp
+++ b/src/core/reference/include/openvino/reference/acos.hpp
@@ -7,8 +7,21 @@
 #include <algorithm>
 #include <cmath>
 
+#include "openvino/reference/utils/type_util.hpp"
+
 namespace ov {
 namespace reference {
+namespace func {
+template <class T, typename std::enable_if<ov::is_floating_point<T>()>::type* = nullptr>
+T acos(const T in) {
+    return std::acos(in);
+}
+
+template <class T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+T acos(const T in) {
+    return static_cast<T>(std::round(std::acos(in)));
+}
+}  // namespace func
 
 /**
  * @brief Reference implementation of Acos operator.
@@ -17,11 +30,9 @@ namespace reference {
  * @param out    Output buffer pointer with results.
  * @param count  Number of elements in input buffer.
  */
-template <typename T>
+template <class T>
 void acos(const T* arg, T* out, const size_t count) {
-    std::transform(arg, arg + count, out, [](T in) {
-        return static_cast<T>(std::acos(in));
-    });
+    std::transform(arg, arg + count, out, &func::acos<T>);
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/reference/include/openvino/reference/acosh.hpp
+++ b/src/core/reference/include/openvino/reference/acosh.hpp
@@ -24,7 +24,7 @@ T acosh(const T in) {
 }  // namespace func
 
 /**
- * @brief Reference implementation of Acos operator.
+ * @brief Reference implementation of Acosh operator.
  *
  * @param arg    Input buffer pointer with input data.
  * @param out    Output buffer pointer with results.

--- a/src/plugins/template/tests/functional/op_reference/acos.cpp
+++ b/src/plugins/template/tests/functional/op_reference/acos.cpp
@@ -68,15 +68,15 @@ INSTANTIATE_TEST_SUITE_P(
                                                                                      0.00000000f}}),
                       Builder {}
                           .input({{3}, element::i32, std::vector<int32_t> {-1, 0, 1}})
-                          .expected({{3}, element::i32, std::vector<int32_t> {3, 1, 0}}),
+                          .expected({{3}, element::i32, std::vector<int32_t> {3, 2, 0}}),
                       Builder {}
                           .input({{3}, element::i64, std::vector<int64_t> {-1, 0, 1}})
-                          .expected({{3}, element::i64, std::vector<int64_t> {3, 1, 0}}),
+                          .expected({{3}, element::i64, std::vector<int64_t> {3, 2, 0}}),
                       Builder {}
                           .input({{2}, element::u32, std::vector<uint32_t> {0, 1}})
-                          .expected({{2}, element::u32, std::vector<uint32_t> {1, 0}}),
+                          .expected({{2}, element::u32, std::vector<uint32_t> {2, 0}}),
                       Builder {}
                           .input({{2}, element::u64, std::vector<uint64_t> {0, 1}})
-                          .expected({{2}, element::u64, std::vector<uint64_t> {1, 0}})),
+                          .expected({{2}, element::u64, std::vector<uint64_t> {2, 0}})),
     ReferenceAcosLayerTest::getTestCaseName);
 }  // namespace reference_tests


### PR DESCRIPTION
### Details:
 - Improve `Acos` operator reference  accuracy for integral types by replace cast by round. 

### Tickets:
 - N/A
