### PR TITLE
Override Slice::constant_folding to allow to extract static dimensions from ShapeOf subgraphs

### DIFF
--- a/src/core/include/openvino/op/slice.hpp
+++ b/src/core/include/openvino/op/slice.hpp
@@ -51,6 +51,7 @@ public:
     bool evaluate_lower(TensorVector& outputs) const override;
     bool evaluate_upper(TensorVector& outputs) const override;
     bool evaluate_label(TensorLabelVector& output_labels) const override;
+    bool constant_fold(OutputVector& output_values, const OutputVector& input_values) override;
 
     std::shared_ptr<v0::Constant> get_default_const_axes(const Output<Node>& start) const;
 };


### PR DESCRIPTION
Some subgraphs like ShapeOf->StridedSlice/Slice can be constantfolded if slicing is done on static dimensions. We have this functionality in StridedSlice::constant_fold, but it's missing in Slice.

Ticket: CVS-118902