### PR TITLE
[DRAFT][GPU][CONFORMANCE]Fix OVInferRequestCheckTensorPrecision

### DIFF
--- a/src/plugins/hetero/src/sync_infer_request.cpp
+++ b/src/plugins/hetero/src/sync_infer_request.cpp
@@ -127,7 +127,7 @@ std::vector<ov::ProfilingInfo> ov::hetero::InferRequest::get_profiling_info() co
     for (size_t i = 0; i < m_subrequests.size(); ++i) {
         auto&& subreq_info = m_subrequests[i]->get_profiling_info();
         for (auto&& rec : subreq_info)
-            rec.node_name = std::string("subgraph") + std::to_string(i) + ": " + rec.node_name;
+            rec.node_name = std::string("subgraph") + std::to_string(i) + ": " + rec.node_name + "_";
         info.insert(info.end(), subreq_info.begin(), subreq_info.end());
     }
     return info;

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -173,7 +173,7 @@ auto check_inputs = [](InferenceEngine::InputsDataMap _networkInputs) {
             input_precision != InferenceEngine::Precision::I64 &&
             input_precision != InferenceEngine::Precision::U64 &&
             input_precision != InferenceEngine::Precision::BOOL) {
-            OPENVINO_THROW("Input image format ", input_precision, " is not supported yet...");
+            OPENVINO_THROW("The plugin does not support input precision ", input_precision);
         }
     }
 };

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/gflag_config.hpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/gflag_config.hpp
@@ -60,7 +60,7 @@ DEFINE_string(output_folder, ".", output_folder_message);
 DEFINE_string(skip_config_path, "", skip_config_path_message);
 DEFINE_string(config_path, "", config_path_message);
 DEFINE_uint32(save_report_timeout, 60, save_report_timeout_message);
-DEFINE_bool(disable_test_config, true, disable_test_config_message);
+DEFINE_bool(disable_test_config, false, disable_test_config_message);
 DEFINE_bool(extend_report, false, extend_report_config_message);
 DEFINE_bool(report_unique_name, false, report_unique_name_message);
 DEFINE_bool(extract_body, false, extract_body_message);

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/skip_tests_config.cpp
@@ -18,7 +18,10 @@ const char *targetPluginName = "";
 const char *refCachePath = "";
 
 std::vector<std::string> IRFolderPaths = {};
-std::vector<std::string> disabledTests = {};
+std::vector<std::string> disabledTests = {
+    // GPU plugin does not support BF16
+    R"(.*OVInferRequestCheckTensorPrecision.*get(Input|Output|Inputs|Outputs)From.*FunctionWith(Single|Several).*type=(bf16)_target_device=.*GPU.*)",
+};
 
 ov::AnyMap pluginConfig = {};
 


### PR DESCRIPTION
Fix OVInferRequestCheckTensorPrecision: BF16 is not supported by GPU plugin.

Ticket CVS-119087