### PR TITLE
Improve and fix fill_tensor_random impl

### DIFF
--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
@@ -256,18 +256,6 @@ void inline fill_random_unique_sequence(T* rawBlobDataPtr,
     std::copy(elems.begin(), elems.end(), rawBlobDataPtr);
 }
 
-/** @brief Fill tensor with random data.
- *
- * @param tensor Target tensor
- * @param range Values range
- * @param start_from Value from which range should start
- * @param k Resolution of floating point numbers.
- * - With k = 1 every random number will be basically integer number.
- * - With k = 2 numbers resolution will 1/2 so outputs only .0 or .50
- * - With k = 4 numbers resolution will 1/4 so outputs only .0 .25 .50 0.75 and etc.
- */
-void fill_tensor_random(ov::Tensor& tensor, const double range = 10, const double start_from = 0, const int32_t k = 1, const int seed = 1);
-
 /** @brief Fill blob with random data.
  *
  * @param blob Target blob

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/ov_tensor_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/ov_tensor_utils.hpp
@@ -54,6 +54,11 @@ void compare(
         const ov::Tensor &actual,
         const double abs_threshold = std::numeric_limits<double>::max(),
         const double rel_threshold = std::numeric_limits<double>::max());
+
+void fill_tensor_random(ov::Tensor& tensor, const uint32_t range = 10, const int32_t start_from = 0, const int32_t k = 1, const int seed = 1);
+
+void fill_tensor_random_real(ov::Tensor& tensor, const double range = 10, const double start_from = 0, const int seed = 1);
+
 }  // namespace utils
 }  // namespace test
 }  // namespace ov

--- a/src/tests/test_utils/common_test_utils/src/data_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/data_utils.cpp
@@ -356,68 +356,6 @@ void fill_data_with_broadcast(ov::Tensor& tensor, size_t axis, std::vector<float
     fill_data_with_broadcast(tensor, values_tensor);
 }
 
-template<ov::element::Type_t DT>
-void fill_tensor_random(ov::Tensor& tensor, const uint32_t range, const int32_t start_from, const int32_t k, const int seed) {
-    using T = typename ov::element_type_traits<DT>::value_type;
-    auto *rawBlobDataPtr = static_cast<T*>(tensor.data());
-    if (DT == ov::element::u4 || DT == ov::element::i4 ||
-        DT == ov::element::u1) {
-        fill_data_random(rawBlobDataPtr, tensor.get_byte_size(), range, start_from, k, seed);
-    } else {
-        fill_data_random(rawBlobDataPtr, tensor.get_size(), range, start_from, k, seed);
-    }
-}
-
-template<ov::element::Type_t DT>
-void fill_tensor_random_float(ov::Tensor& tensor, const double range, const double start_from, const int32_t k, const int seed) {
-    using T = typename ov::element_type_traits<DT>::value_type;
-    std::default_random_engine random(seed);
-    // 1/k is the resolution of the floating point numbers
-    std::uniform_real_distribution<double> distribution(k * start_from, k * (start_from + range));
-
-    auto *rawBlobDataPtr = static_cast<T*>(tensor.data());
-    for (size_t i = 0; i < tensor.get_size(); i++) {
-        auto value = static_cast<float>(distribution(random));
-        value /= static_cast<float>(k);
-        if (DT == ov::element::Type_t::f16) {
-            rawBlobDataPtr[i] = static_cast<T>(ngraph::float16(value).to_bits());
-        } else if (DT == ov::element::Type_t::bf16) {
-            rawBlobDataPtr[i] = static_cast<T>(ngraph::bfloat16(value).to_bits());
-        } else {
-            rawBlobDataPtr[i] = static_cast<T>(value);
-        }
-    }
-}
-
-void fill_tensor_random(ov::Tensor& tensor, const double range, const double start_from, const int32_t k, const int seed) {
-    auto element_type = tensor.get_element_type();
-
-#define CASE(X) case X: fill_tensor_random<X>(tensor, static_cast<uint32_t>(range), static_cast<int32_t>(start_from), k, seed); break;
-#define CASE_FLOAT(X) case X: fill_tensor_random_float<X>(tensor, range, start_from, k, seed); break;
-
-    switch (element_type) {
-        CASE_FLOAT(ov::element::f64)
-        CASE_FLOAT(ov::element::f32)
-        CASE_FLOAT(ov::element::f16)
-        CASE_FLOAT(ov::element::bf16)
-        CASE(ov::element::u1)
-        CASE(ov::element::u4)
-        CASE(ov::element::u8)
-        CASE(ov::element::u32)
-        CASE(ov::element::u16)
-        CASE(ov::element::u64)
-        CASE(ov::element::i4)
-        CASE(ov::element::i8)
-        CASE(ov::element::i16)
-        CASE(ov::element::i32)
-        CASE(ov::element::i64)
-        default:
-            OPENVINO_THROW("Wrong precision specified: ", element_type);
-    }
-#undef CASE
-#undef CASE_FLOAT
-}
-
 }  // namespace utils
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Improve behavior of fill_tensor_random. By default it generates values using integer random generator and resolution value for floats.
 - Extract real value generator to fill_tensor_random_real

### Tickets:
 - [CVS-111364](https://jira.devtools.intel.com/browse/CVS-111364)
