### PR TITLE
Squeeze fix

### DIFF
--- a/src/core/shape_inference/include/squeeze_shape_inference.hpp
+++ b/src/core/shape_inference/include/squeeze_shape_inference.hpp
@@ -56,8 +56,7 @@ std::vector<TRShape> shape_infer(const Squeeze* op,
                 OPENVINO_SUPPRESS_DEPRECATED_END
                 unique_axes.reset(new std::set<int64_t>(axes->cbegin(), axes->cend()));
             } else if (arg_rank.get_length() > 0 && shape_size(axes_shape.to_shape()) == 1) {
-                // The `axes` input must be a Parameter with single element to ensure uniqueness of axes
-                // only rank is deduced
+                // The `axes` input is a single element tensor which is unique by definition, deducing output rank
                 NODE_VALIDATION_CHECK(op,
                                       std::any_of(arg_shape.cbegin(),
                                                   arg_shape.cend(),
@@ -80,14 +79,21 @@ std::vector<TRShape> shape_infer(const Squeeze* op,
     if (arg_rank.is_static() && (unique_axes != nullptr)) {
         output_shape.resize(0);
         if (unique_axes->empty()) {
-            // According to specification, if only first input provided` or axes are empty
-            // remove all dimensions equal to 1.
-            std::copy_if(arg_shape.cbegin(),
-                         arg_shape.cend(),
-                         std::back_inserter(output_shape),
-                         [](const DimType& dim) {
-                             return !dim.compatible(1);
-                         });
+            // if only first input provided or axes are empty remove all dimensions equal to 1.
+            if (std::any_of(arg_shape.cbegin(), arg_shape.cend(), [](const DimType& d) {
+                    return d.is_dynamic() && d.compatible(1);
+                })) {
+                // we are unsure if dynamic dimensions would be equal to 1 or not, so we set dynamic output rank
+                output_shape = PartialShape::dynamic();
+                return output_shapes;
+            } else {
+                std::copy_if(arg_shape.cbegin(),
+                             arg_shape.cend(),
+                             std::back_inserter(output_shape),
+                             [](const DimType& dim) {
+                                 return !dim.compatible(1);
+                             });
+            }
         } else {
             int64_t idx = 0;
             auto rm_axis_iter = unique_axes->cbegin();
@@ -110,12 +116,6 @@ std::vector<TRShape> shape_infer(const Squeeze* op,
                          arg_shape.cend(),
                          std::back_inserter(output_shape),
                          not_squeezable_at_axis);
-        }
-        // When arg shape has got static rank but shape is dynamic and output shape dimensions is empty (scalar)
-        // make dynamic output except the case when arg_shape is 1-D shape with 0 or 1 element then should be scalar.
-        if (arg_shape.is_dynamic() && (output_shape.size() == 0) &&
-            !(arg_rank.get_length() == 1 && arg_shape[0].get_max_length() <= 1)) {
-            output_shape = PartialShape::dynamic();
         }
     } else {
         output_shape = PartialShape::dynamic();

--- a/src/core/tests/type_prop/squeeze.cpp
+++ b/src/core/tests/type_prop/squeeze.cpp
@@ -27,6 +27,12 @@ TEST(type_prop, squeeze_axes_invalid_value) {
                     HasSubstr("provided axis value is invalid. Only axes of size 1 may be removed."));
 }
 
+TEST(type_prop, squeeze_single_input) {
+    auto param = make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{1, -1, 3, 4});
+    auto s = make_shared<op::v0::Squeeze>(param);
+    EXPECT_EQ(s->get_output_partial_shape(0), PartialShape::dynamic());
+}
+
 TEST(type_prop, squeeze_axes_invalid_rank) {
     auto param = make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 3, 4});
     auto axes_node = make_shared<ov::op::v0::Constant>(element::i32, Shape{2, 1}, vector<int32_t>{0, 2});
@@ -254,7 +260,7 @@ const auto empty_axes_test_values =
                            std::vector<int64_t>{},
                            PartialShape{Dimension(2, 5), Dimension(3, 4), 6}),
            std::make_tuple(PartialShape::dynamic(6), std::vector<int64_t>{}, PartialShape::dynamic()),
-           std::make_tuple(PartialShape{Dimension(0, 1)}, std::vector<int64_t>{}, PartialShape{}),
+           std::make_tuple(PartialShape{Dimension(0, 1)}, std::vector<int64_t>{}, PartialShape::dynamic()),
            std::make_tuple(PartialShape{Dimension::dynamic(), 1, Dimension::dynamic()},
                            std::vector<int64_t>{},
                            PartialShape::dynamic()),


### PR DESCRIPTION
### Details:
 - *Fixes shape inference of Squeeze operation. Previously Squeeze of tensor with shape [1, 2, -1, 4] had output shape of [2, 4]. Now we recognize that dynamic dimensions may become 1 or may become another dimension. This is why with current changes such Squeeze would have output shape of dynamic rank*
 - *Squeeze shape inference was previously altered to suite PDPD FE needs expressing unique behavior of Slice operation. I removed unnecessary change in the common Squeeze operation and put all the specifics of the PDPD operator in the translation rule*

### Tickets:
 - *CVS-119569*
