### PR TITLE
Unlock custom creation of PLATFORM_TAG

### DIFF
--- a/src/bindings/python/wheel/CMakeLists.txt
+++ b/src/bindings/python/wheel/CMakeLists.txt
@@ -58,24 +58,19 @@ if(APPLE)
 elseif(LINUX)
     _ov_platform_arch()
 
-    if(CMAKE_CROSSCOMPILING)
-        # TODO: think which proper tag is needed for arm / aarch64
-        set(PLATFORM_TAG "linux_${_arch}")
-    else()
-        string(REPLACE "." "_" _ov_glibc_version "${OV_GLIBC_VERSION}")
-        set(manylinux "manylinux_${_ov_glibc_version}")
+    string(REPLACE "." "_" _ov_glibc_version "${OV_GLIBC_VERSION}")
+    set(manylinux "manylinux_${_ov_glibc_version}")
 
-        # convert to well-known formats according to PEP 600
-        if(manylinux STREQUAL "manylinux_2_5")
-            set(manylinux "manylinux1")
-        elseif(manylinux STREQUAL "manylinux_2_12")
-            set(manylinux "manylinux2010")
-        elseif(manylinux STREQUAL "manylinux_2_17")
-            set(manylinux "manylinux2014")
-        endif()
-
-        set(PLATFORM_TAG "${manylinux}_${_arch}")
+    # convert to well-known formats according to PEP 600
+    if(manylinux STREQUAL "manylinux_2_5")
+        set(manylinux "manylinux1")
+    elseif(manylinux STREQUAL "manylinux_2_12")
+        set(manylinux "manylinux2010")
+    elseif(manylinux STREQUAL "manylinux_2_17")
+        set(manylinux "manylinux2014")
     endif()
+
+    set(PLATFORM_TAG "${manylinux}_${_arch}")
 endif()
 
 set(openvino_wheel_name "openvino-${WHEEL_VERSION}-${WHEEL_BUILD}-${PYTHON_TAG}-${ABI_TAG}-${PLATFORM_TAG}.whl")


### PR DESCRIPTION
### Details:
 - To try to build `manylinux_2_24_aarch64` from Debian 9 system.
