### PR TITLE
Refactor AdaPool, BatchToSpace, and BatchNorm shared tests

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/adaptive_pooling.cpp
@@ -4,55 +4,62 @@
 
 #include <vector>
 
-#include "single_layer_tests/adaptive_pooling.hpp"
+#include "single_op_tests/adaptive_pooling.hpp"
 #include "common_test_utils/test_constants.hpp"
 
-using namespace LayerTestsDefinitions;
+namespace {
+using ov::test::AdaPoolLayerTest;
 
-
-const std::vector<InferenceEngine::Precision> netPRCs = {
-        InferenceEngine::Precision::FP16,
-        InferenceEngine::Precision::FP32
+const std::vector<ov::element::Type> types = {
+        ov::element::f16,
+        ov::element::f32
 };
 
-const auto AdaPool3DCases = ::testing::Combine(
-        ::testing::ValuesIn(
-                std::vector<std::vector<size_t>> {
-                        { 1, 2, 1},
-                        { 1, 1, 3 },
-                        { 3, 17, 5 }}),
+const std::vector<std::vector<ov::Shape>> input_shapes_3d_static = {
+        {{ 1, 2, 1}},
+        {{ 1, 1, 3 }},
+        {{ 3, 17, 5 }}
+};
+
+const auto ada_pool_3d_cases = ::testing::Combine(
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_3d_static)),
         ::testing::ValuesIn(std::vector<std::vector<int>>{ {1}, {3}, {5} }),
         ::testing::ValuesIn(std::vector<std::string>{"max", "avg"}),
-        ::testing::ValuesIn(netPRCs),
+        ::testing::ValuesIn(types),
         ::testing::Values(ov::test::utils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_TestsAdaPool3D, AdaPoolLayerTest, AdaPool3DCases, AdaPoolLayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_TestsAdaPool3D, AdaPoolLayerTest, ada_pool_3d_cases, AdaPoolLayerTest::getTestCaseName);
 
-const auto AdaPool4DCases = ::testing::Combine(
-        ::testing::ValuesIn(
-                std::vector<std::vector<size_t>> {
-                        { 1, 2, 1, 2},
-                        { 1, 1, 3, 2},
-                        { 3, 17, 5, 1}}),
+const std::vector<std::vector<ov::Shape>> input_shapes_4d_static = {
+        {{ 1, 2, 1, 2 }},
+        {{ 1, 1, 3, 2 }},
+        {{ 3, 17, 5, 1 }}
+};
+
+const auto ada_pool_4d_cases = ::testing::Combine(
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_4d_static)),
         ::testing::ValuesIn(std::vector<std::vector<int>>{ {1, 1}, {3, 5}, {5, 5} }),
         ::testing::ValuesIn(std::vector<std::string>{"max", "avg"}),
-        ::testing::ValuesIn(netPRCs),
+        ::testing::ValuesIn(types),
         ::testing::Values(ov::test::utils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_TestsAdaPool4D, AdaPoolLayerTest, AdaPool4DCases, AdaPoolLayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_TestsAdaPool4D, AdaPoolLayerTest, ada_pool_4d_cases, AdaPoolLayerTest::getTestCaseName);
 
-const auto AdaPool5DCases = ::testing::Combine(
-        ::testing::ValuesIn(
-                std::vector<std::vector<size_t>> {
-                        { 1, 2, 1, 2, 2},
-                        { 1, 1, 3, 2, 3},
-                        { 3, 17, 5, 1, 2}}),
+const std::vector<std::vector<ov::Shape>> input_shapes_5d_static = {
+        {{ 1, 2, 1, 2, 2 }},
+        {{ 1, 1, 3, 2, 3 }},
+        {{ 3, 17, 5, 1, 2 }}
+};
+
+const auto ada_pool_5d_cases = ::testing::Combine(
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_5d_static)),
         ::testing::ValuesIn(std::vector<std::vector<int>>{ {1, 1, 1}, {3, 5, 3}, {5, 5, 5} }),
         ::testing::ValuesIn(std::vector<std::string>{"max", "avg"}),
-        ::testing::ValuesIn(netPRCs),
+        ::testing::ValuesIn(types),
         ::testing::Values(ov::test::utils::DEVICE_CPU)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_TestsAdaPool5D, AdaPoolLayerTest, AdaPool5DCases, AdaPoolLayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_TestsAdaPool5D, AdaPoolLayerTest, ada_pool_5d_cases, AdaPoolLayerTest::getTestCaseName);
+} //  namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
@@ -9,7 +9,7 @@
 namespace {
 using ov::test::BatchNormLayerTest;
 
-const std::vector<ov::element::Type> in_type = {
+const std::vector<ov::element::Type> model_type = {
         ov::element::f32,
         ov::element::f16
 };
@@ -31,7 +31,7 @@ const std::vector<std::vector<ov::Shape>> input_shapes_static = {
 
 const auto batch_norm_params = testing::Combine(
         testing::ValuesIn(epsilon),
-        testing::ValuesIn(in_type),
+        testing::ValuesIn(model_type),
         testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
         testing::Values(ov::test::utils::DEVICE_CPU)
 );

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
@@ -9,7 +9,7 @@
 namespace {
 using ov::test::BatchNormLayerTest;
 
-const std::vector<ov::element::Type> netType = {
+const std::vector<ov::element::Type> in_type = {
         ov::element::f32,
         ov::element::f16
 };
@@ -31,9 +31,7 @@ const std::vector<std::vector<ov::Shape>> input_shapes_static = {
 
 const auto batch_norm_params = testing::Combine(
         testing::ValuesIn(epsilon),
-        testing::ValuesIn(netType),
-        testing::Values(ov::element::undefined),
-        testing::Values(ov::element::undefined),
+        testing::ValuesIn(in_type),
         testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
         testing::Values(ov::test::utils::DEVICE_CPU)
 );

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_norm.cpp
@@ -4,14 +4,14 @@
 
 #include <vector>
 
-#include "single_layer_tests/batch_norm.hpp"
-
-using namespace LayerTestsDefinitions;
+#include "single_op_tests/batch_norm.hpp"
 
 namespace {
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::FP16
+using ov::test::BatchNormLayerTest;
+
+const std::vector<ov::element::Type> netType = {
+        ov::element::f32,
+        ov::element::f16
 };
 
 const std::vector<double> epsilon = {
@@ -20,30 +20,28 @@ const std::vector<double> epsilon = {
     1e-5,
     1e-4
 };
-const std::vector<std::vector<size_t>> inputShapes = {
-        {1, 3},
-        {2, 5},
-        {1, 3, 10},
-        {1, 3, 1, 1},
-        {2, 5, 4, 4},
+const std::vector<std::vector<ov::Shape>> input_shapes_static = {
+        {{1, 3}},
+        {{2, 5}},
+        {{1, 3, 10}},
+        {{1, 3, 1, 1}},
+        {{2, 5, 4, 4}},
 };
 
 
-const auto batchNormParams = testing::Combine(
+const auto batch_norm_params = testing::Combine(
         testing::ValuesIn(epsilon),
-        testing::ValuesIn(netPrecisions),
-        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        testing::Values(InferenceEngine::Layout::ANY),
-        testing::Values(InferenceEngine::Layout::ANY),
-        testing::ValuesIn(inputShapes),
+        testing::ValuesIn(netType),
+        testing::Values(ov::element::undefined),
+        testing::Values(ov::element::undefined),
+        testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
         testing::Values(ov::test::utils::DEVICE_CPU)
 );
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_BatchNorm,
         BatchNormLayerTest,
-        batchNormParams,
+        batch_norm_params,
         BatchNormLayerTest::getTestCaseName
 );
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_to_space.cpp
@@ -34,8 +34,6 @@ const auto batch_to_space_2d_tests = ::testing::Combine(
         ::testing::ValuesIn(crops_2D),
         ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_2D_static)),
         ::testing::ValuesIn(net_types),
-        ::testing::Values(ov::element::undefined),
-        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -73,8 +71,6 @@ const auto batch_to_space_4d_spatial_dims_tests = ::testing::Combine(
         ::testing::ValuesIn(crops_end_4D),
         ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_4D_static)),
         ::testing::ValuesIn(net_types),
-        ::testing::Values(ov::element::undefined),
-        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 const auto batch_to_space_4d_channel_dim_tests = ::testing::Combine(
@@ -83,8 +79,6 @@ const auto batch_to_space_4d_channel_dim_tests = ::testing::Combine(
         ::testing::Values(crops_end_4D[0]),
         ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_4D_static)),
         ::testing::ValuesIn(net_types),
-        ::testing::Values(ov::element::undefined),
-        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -126,8 +120,6 @@ const auto batch_to_space_5d_spatial_dims_tests = ::testing::Combine(
         ::testing::ValuesIn(crops_end_5D),
         ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_5D_static)),
         ::testing::ValuesIn(net_types),
-        ::testing::Values(ov::element::undefined),
-        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 const auto batch_to_space_5d_channel_dim_tests = ::testing::Combine(
@@ -136,8 +128,6 @@ const auto batch_to_space_5d_channel_dim_tests = ::testing::Combine(
         ::testing::Values(crops_end_5D[0]),
         ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_5D_static)),
         ::testing::ValuesIn(net_types),
-        ::testing::Values(ov::element::undefined),
-        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/batch_to_space.cpp
@@ -2,23 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <vector>
-
-#include "single_layer_tests/batch_to_space.hpp"
+#include "single_op_tests/batch_to_space.hpp"
 #include "common_test_utils/test_constants.hpp"
 
-using namespace LayerTestsDefinitions;
-
 namespace {
+using ov::test::BatchToSpaceLayerTest;
 
-const std::vector<InferenceEngine::Precision> net_precisions = {
-        InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::I32
+const std::vector<ov::element::Type> net_types = {
+        ov::element::f32,
+        ov::element::i32
 };
 
-const std::vector<std::vector<size_t>> data_shapes_2D = {
-        {12, 4},
-        {48, 3}
+const std::vector<std::vector<ov::Shape>> data_shapes_2D_static = {
+        {{12, 4}},
+        {{48, 3}}
 };
 
 const std::vector<std::vector<int64_t>> block_shapes_2D = {
@@ -35,12 +32,10 @@ const auto batch_to_space_2d_tests = ::testing::Combine(
         ::testing::ValuesIn(block_shapes_2D),
         ::testing::ValuesIn(crops_2D),
         ::testing::ValuesIn(crops_2D),
-        ::testing::ValuesIn(data_shapes_2D),
-        ::testing::ValuesIn(net_precisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_2D_static)),
+        ::testing::ValuesIn(net_types),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -49,10 +44,10 @@ INSTANTIATE_TEST_SUITE_P(
         batch_to_space_2d_tests,
         BatchToSpaceLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t>> data_shapes_4D = {
-        {4, 1, 2, 2},
-        {4, 3, 2, 2},
-        {8, 1, 3, 2}
+const std::vector<std::vector<ov::Shape>> data_shapes_4D_static = {
+        {{4, 1, 2, 2}},
+        {{4, 3, 2, 2}},
+        {{8, 1, 3, 2}}
 };
 
 const std::vector<std::vector<int64_t>> block_shapes_4D = {
@@ -76,24 +71,20 @@ const auto batch_to_space_4d_spatial_dims_tests = ::testing::Combine(
         ::testing::Values(block_shapes_4D[0]),
         ::testing::ValuesIn(crops_begin_4D),
         ::testing::ValuesIn(crops_end_4D),
-        ::testing::ValuesIn(data_shapes_4D),
-        ::testing::ValuesIn(net_precisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_4D_static)),
+        ::testing::ValuesIn(net_types),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 const auto batch_to_space_4d_channel_dim_tests = ::testing::Combine(
         ::testing::Values(block_shapes_4D[1]),
         ::testing::Values(crops_begin_4D[0]),
         ::testing::Values(crops_end_4D[0]),
-        ::testing::ValuesIn(data_shapes_4D),
-        ::testing::ValuesIn(net_precisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_4D_static)),
+        ::testing::ValuesIn(net_types),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -108,8 +99,8 @@ INSTANTIATE_TEST_SUITE_P(
         batch_to_space_4d_channel_dim_tests,
         BatchToSpaceLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t>> data_shapes_5D = {
-        {12, 1, 2, 1, 2}
+const std::vector<std::vector<ov::Shape>> data_shapes_5D_static = {
+        {{12, 1, 2, 1, 2}}
 };
 
 const std::vector<std::vector<int64_t>> block_shapes_5D = {
@@ -133,24 +124,20 @@ const auto batch_to_space_5d_spatial_dims_tests = ::testing::Combine(
         ::testing::Values(block_shapes_5D[0]),
         ::testing::ValuesIn(crops_begin_5D),
         ::testing::ValuesIn(crops_end_5D),
-        ::testing::ValuesIn(data_shapes_5D),
-        ::testing::ValuesIn(net_precisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_5D_static)),
+        ::testing::ValuesIn(net_types),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 const auto batch_to_space_5d_channel_dim_tests = ::testing::Combine(
         ::testing::Values(block_shapes_5D[1]),
         ::testing::Values(crops_begin_5D[0]),
         ::testing::Values(crops_end_5D[0]),
-        ::testing::ValuesIn(data_shapes_5D),
-        ::testing::ValuesIn(net_precisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(data_shapes_5D_static)),
+        ::testing::ValuesIn(net_types),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/tests/functional/plugin/shared/include/single_layer_tests/adaptive_pooling.hpp
+++ b/src/tests/functional/plugin/shared/include/single_layer_tests/adaptive_pooling.hpp
@@ -9,7 +9,7 @@
 namespace LayerTestsDefinitions {
 
 TEST_P(AdaPoolLayerTest, CompareWithRefs) {
-Run();
+    Run();
 }
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/single_op_tests/adaptive_pooling.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/adaptive_pooling.hpp
@@ -8,7 +8,7 @@
 
 namespace ov {
 namespace test {
-TEST_P(AdaPoolLayerTest, CompareWithRefs) {
+TEST_P(AdaPoolLayerTest, Inference) {
     run();
 }
 }  // namespace test

--- a/src/tests/functional/plugin/shared/include/single_op_tests/adaptive_pooling.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/adaptive_pooling.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/adaptive_pooling.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(AdaPoolLayerTest, CompareWithRefs) {
+    run();
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/include/single_op_tests/batch_norm.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/batch_norm.hpp
@@ -8,7 +8,7 @@
 
 namespace ov {
 namespace test {
-TEST_P(BatchNormLayerTest, CompareWithRefs) {
+TEST_P(BatchNormLayerTest, Inference) {
     run();
 }
 }  // namespace test

--- a/src/tests/functional/plugin/shared/include/single_op_tests/batch_norm.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/batch_norm.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/batch_norm.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(BatchNormLayerTest, CompareWithRefs) {
+    run();
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/include/single_op_tests/batch_to_space.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/batch_to_space.hpp
@@ -9,7 +9,7 @@
 namespace ov {
 namespace test {
 
-TEST_P(BatchToSpaceLayerTest, CompareWithRefs) {
+TEST_P(BatchToSpaceLayerTest, Inference) {
     run();
 };
 

--- a/src/tests/functional/plugin/shared/include/single_op_tests/batch_to_space.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/batch_to_space.hpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/batch_to_space.hpp"
+
+namespace ov {
+namespace test {
+
+TEST_P(BatchToSpaceLayerTest, CompareWithRefs) {
+    run();
+};
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/adaptive_pooling.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/adaptive_pooling.hpp
@@ -12,7 +12,7 @@ using adapoolParams = std::tuple<
         std::vector<InputShape>,            // feature map shape
         std::vector<int>,                   // pooled spatial shape
         std::string,                        // pooling mode
-        ov::element::Type,                  // net type
+        ov::element::Type,                  // model type
         std::string>;                       // device name
 
 class AdaPoolLayerTest : public testing::WithParamInterface<adapoolParams>,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/adaptive_pooling.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/adaptive_pooling.hpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+using adapoolParams = std::tuple<
+        std::vector<InputShape>,            // feature map shape
+        std::vector<int>,                   // pooled spatial shape
+        std::string,                        // pooling mode
+        ov::element::Type,                  // net type
+        std::string>;                       // device name
+
+class AdaPoolLayerTest : public testing::WithParamInterface<adapoolParams>,
+                         virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<adapoolParams>& obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_norm.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_norm.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+typedef std::tuple<
+        double,                        // epsilon
+        ov::element::Type,             // Net type
+        ov::element::Type,             // Input type
+        ov::element::Type,             // Output type
+        std::vector<InputShape>,       // Input shape
+        std::string                    // Target device name
+> BatchNormLayerTestParams;
+
+class BatchNormLayerTest : public testing::WithParamInterface<BatchNormLayerTestParams>,
+                           virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<BatchNormLayerTestParams>& obj);
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
+protected:
+    void SetUp() override;
+};
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_norm.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_norm.hpp
@@ -10,7 +10,7 @@ namespace ov {
 namespace test {
 typedef std::tuple<
         double,                        // epsilon
-        ov::element::Type,             // Input type
+        ov::element::Type,             // Model type
         std::vector<InputShape>,       // Input shape
         std::string                    // Target device name
 > BatchNormLayerTestParams;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_norm.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_norm.hpp
@@ -10,9 +10,7 @@ namespace ov {
 namespace test {
 typedef std::tuple<
         double,                        // epsilon
-        ov::element::Type,             // Net type
         ov::element::Type,             // Input type
-        ov::element::Type,             // Output type
         std::vector<InputShape>,       // Input shape
         std::string                    // Target device name
 > BatchNormLayerTestParams;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_norm.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_norm.hpp
@@ -19,8 +19,6 @@ class BatchNormLayerTest : public testing::WithParamInterface<BatchNormLayerTest
                            virtual public ov::test::SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<BatchNormLayerTestParams>& obj);
-
-    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
 protected:
     void SetUp() override;
 };

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_to_space.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_to_space.hpp
@@ -17,7 +17,7 @@ using batchToSpaceParamsTuple = typename std::tuple<
         std::vector<int64_t>,              // crops begin
         std::vector<int64_t>,              // crops end
         std::vector<InputShape>,           // Input shapes
-        ov::element::Type,                 // Input precision
+        ov::element::Type,                 // Model type
         std::string>;                      // Device name>;
 
 class BatchToSpaceLayerTest : public testing::WithParamInterface<batchToSpaceParamsTuple>,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_to_space.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_to_space.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+using batchToSpaceParamsTuple = typename std::tuple<
+        std::vector<int64_t>,              // block shape
+        std::vector<int64_t>,              // crops begin
+        std::vector<int64_t>,              // crops end
+        std::vector<InputShape>,           // Input shapes
+        ov::element::Type,                 // Network precision
+        ov::element::Type,                 // Input precision
+        ov::element::Type,                 // Output precision
+        std::string>;                      // Device name>;
+
+class BatchToSpaceLayerTest : public testing::WithParamInterface<batchToSpaceParamsTuple>,
+                              virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_to_space.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/batch_to_space.hpp
@@ -17,9 +17,7 @@ using batchToSpaceParamsTuple = typename std::tuple<
         std::vector<int64_t>,              // crops begin
         std::vector<int64_t>,              // crops end
         std::vector<InputShape>,           // Input shapes
-        ov::element::Type,                 // Network precision
         ov::element::Type,                 // Input precision
-        ov::element::Type,                 // Output precision
         std::string>;                      // Device name>;
 
 class BatchToSpaceLayerTest : public testing::WithParamInterface<batchToSpaceParamsTuple>,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/comparison.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/comparison.hpp
@@ -26,10 +26,8 @@ typedef std::tuple<
 
 class ComparisonLayerTest : public testing::WithParamInterface<ComparisonTestParams>,
     virtual public ov::test::SubgraphBaseTest {
-    ngraph::helpers::ComparisonTypes comparison_op_type;
 protected:
     void SetUp() override;
-    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ComparisonTestParams> &obj);
 };

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/gru_sequence.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/gru_sequence.hpp
@@ -30,9 +30,6 @@ public:
 
 protected:
     void SetUp() override;
-    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
-    ov::test::utils::SequenceTestsMode m_mode;
-    int64_t m_max_seq_len = 0;
 };
 } //  namespace test
 } //  namespace ov

--- a/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
@@ -963,6 +963,50 @@ ov::runtime::Tensor generate(const
     return tensor;
 }
 
+namespace comparison {
+
+void fill_tensor(ov::Tensor& tensor) {
+    auto data_ptr = static_cast<float*>(tensor.data());
+    auto data_ptr_int = static_cast<int*>(tensor.data());
+    auto range = tensor.get_size();
+    auto start = -static_cast<float>(range) / 2.f;
+    testing::internal::Random random(1);
+    for (size_t i = 0; i < range; i++) {
+        if (i % 7 == 0) {
+            data_ptr[i] = std::numeric_limits<float>::infinity();
+        } else if (i % 7 == 1) {
+            data_ptr[i] = -std::numeric_limits<float>::infinity();
+        } else if (i % 7 == 2) {
+            data_ptr_int[i] = 0x7F800000 + random.Generate(range);
+        } else if (i % 7 == 3) {
+            data_ptr[i] = std::numeric_limits<double>::quiet_NaN();
+        } else if (i % 7 == 5) {
+            data_ptr[i] = -std::numeric_limits<double>::quiet_NaN();
+        } else {
+            data_ptr[i] = start + static_cast<float>(random.Generate(range));
+        }
+    }
+}
+ov::runtime::Tensor generate(const
+                             std::shared_ptr<ov::op::v10::IsFinite>& node,
+                             size_t port,
+                             const ov::element::Type& elemType,
+                             const ov::Shape& targetShape) {
+    ov::Tensor tensor(elemType, targetShape);
+    fill_tensor(tensor);
+    return tensor;
+}
+ov::runtime::Tensor generate(const
+                             std::shared_ptr<ov::op::v10::IsNaN>& node,
+                             size_t port,
+                             const ov::element::Type& elemType,
+                             const ov::Shape& targetShape) {
+    ov::Tensor tensor{elemType, targetShape};
+    fill_tensor(tensor);
+    return tensor;
+}
+} // namespace comparison
+
 template<typename T>
 ov::runtime::Tensor generateInput(const std::shared_ptr<ov::Node>& node,
                                   size_t port,

--- a/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
@@ -964,7 +964,6 @@ ov::runtime::Tensor generate(const
 }
 
 namespace comparison {
-
 void fill_tensor(ov::Tensor& tensor) {
     auto data_ptr = static_cast<float*>(tensor.data());
     auto data_ptr_int = static_cast<int*>(tensor.data());
@@ -987,25 +986,27 @@ void fill_tensor(ov::Tensor& tensor) {
         }
     }
 }
+} // namespace comparison
+
 ov::runtime::Tensor generate(const
                              std::shared_ptr<ov::op::v10::IsFinite>& node,
                              size_t port,
                              const ov::element::Type& elemType,
                              const ov::Shape& targetShape) {
     ov::Tensor tensor(elemType, targetShape);
-    fill_tensor(tensor);
+    comparison::fill_tensor(tensor);
     return tensor;
 }
+
 ov::runtime::Tensor generate(const
                              std::shared_ptr<ov::op::v10::IsNaN>& node,
                              size_t port,
                              const ov::element::Type& elemType,
                              const ov::Shape& targetShape) {
     ov::Tensor tensor{elemType, targetShape};
-    fill_tensor(tensor);
+    comparison::fill_tensor(tensor);
     return tensor;
 }
-} // namespace comparison
 
 template<typename T>
 ov::runtime::Tensor generateInput(const std::shared_ptr<ov::Node>& node,

--- a/src/tests/functional/shared_test_classes/src/single_op/adaptive_pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/adaptive_pooling.cpp
@@ -45,11 +45,11 @@ void AdaPoolLayerTest::SetUp() {
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
 
-    ngraph::Shape pooled_shape = {pooled_spatial_shape.size()};
-    auto pooled_param = std::make_shared<ov::op::v0::Constant>(ngraph::element::i32, pooled_shape, pooled_spatial_shape);
+    ov::Shape pooled_shape = {pooled_spatial_shape.size()};
+    auto pooled_param = std::make_shared<ov::op::v0::Constant>(ov::element::i32, pooled_shape, pooled_spatial_shape);
 
     // we cannot create abstract Op to use polymorphism
-    auto adapoolMax = std::make_shared<ov::op::v8::AdaptiveMaxPool>(params[0], pooled_param, ngraph::element::i32);
+    auto adapoolMax = std::make_shared<ov::op::v8::AdaptiveMaxPool>(params[0], pooled_param, ov::element::i32);
     auto adapoolAvg = std::make_shared<ov::op::v8::AdaptiveAvgPool>(params[0], pooled_param);
 
     function = (pooling_mode == "max" ?

--- a/src/tests/functional/shared_test_classes/src/single_op/adaptive_pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/adaptive_pooling.cpp
@@ -41,6 +41,7 @@ void AdaPoolLayerTest::SetUp() {
     std::string pooling_mode;
     std::tie(shapes, pooled_spatial_shape, pooling_mode, inType, targetDevice) = this->GetParam();
     init_input_shapes(shapes);
+    outType = inType;
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front())};
 

--- a/src/tests/functional/shared_test_classes/src/single_op/adaptive_pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/adaptive_pooling.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/adaptive_pooling.hpp"
+
+namespace ov {
+namespace test {
+
+std::string AdaPoolLayerTest::getTestCaseName(const testing::TestParamInfo<adapoolParams>& obj) {
+    std::vector<InputShape> shapes;
+    std::vector<int> pooled_spatial_shape;
+
+    std::string pooling_mode;
+    ov::element::Type type;
+    std::string target_device;
+    std::tie(shapes, pooled_spatial_shape, pooling_mode, type, target_device) = obj.param;
+
+    std::ostringstream result;
+
+    result << "IS=(";
+    for (const auto& shape : shapes) {
+        result << ov::test::utils::partialShape2str({shape.first}) << "_";
+    }
+    result << ")_TS=(";
+    for (const auto& shape : shapes) {
+        for (const auto& item : shape.second) {
+            result << ov::test::utils::vec2str(item) << "_";
+        }
+    }
+    result << "pooled_spatial_shape=" << ov::test::utils::vec2str(pooled_spatial_shape) << "_";
+    result << "mode=" << pooling_mode << "_";
+    result << "IT=" << type.get_type_name() << "_";
+    result << "dev=" << target_device;
+    return result.str();
+}
+
+void AdaPoolLayerTest::SetUp() {
+    std::vector<InputShape> shapes;
+    std::vector<int> pooled_spatial_shape;
+    std::string pooling_mode;
+    std::tie(shapes, pooled_spatial_shape, pooling_mode, inType, targetDevice) = this->GetParam();
+    init_input_shapes(shapes);
+
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front())};
+
+    ngraph::Shape pooled_shape = {pooled_spatial_shape.size()};
+    auto pooled_param = std::make_shared<ov::op::v0::Constant>(ngraph::element::i32, pooled_shape, pooled_spatial_shape);
+
+    // we cannot create abstract Op to use polymorphism
+    auto adapoolMax = std::make_shared<ov::op::v8::AdaptiveMaxPool>(params[0], pooled_param, ngraph::element::i32);
+    auto adapoolAvg = std::make_shared<ov::op::v8::AdaptiveAvgPool>(params[0], pooled_param);
+
+    function = (pooling_mode == "max" ?
+                std::make_shared<ov::Model>(adapoolMax->outputs(), params, "AdaPoolMax") :
+                std::make_shared<ov::Model>(adapoolAvg->outputs(), params, "AdaPoolAvg"));
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/adaptive_pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/adaptive_pooling.cpp
@@ -12,9 +12,9 @@ std::string AdaPoolLayerTest::getTestCaseName(const testing::TestParamInfo<adapo
     std::vector<int> pooled_spatial_shape;
 
     std::string pooling_mode;
-    ov::element::Type type;
+    ov::element::Type model_type;
     std::string target_device;
-    std::tie(shapes, pooled_spatial_shape, pooling_mode, type, target_device) = obj.param;
+    std::tie(shapes, pooled_spatial_shape, pooling_mode, model_type, target_device) = obj.param;
 
     std::ostringstream result;
 
@@ -30,7 +30,7 @@ std::string AdaPoolLayerTest::getTestCaseName(const testing::TestParamInfo<adapo
     }
     result << "pooled_spatial_shape=" << ov::test::utils::vec2str(pooled_spatial_shape) << "_";
     result << "mode=" << pooling_mode << "_";
-    result << "IT=" << type.get_type_name() << "_";
+    result << "IT=" << model_type.get_type_name() << "_";
     result << "dev=" << target_device;
     return result.str();
 }
@@ -39,11 +39,11 @@ void AdaPoolLayerTest::SetUp() {
     std::vector<InputShape> shapes;
     std::vector<int> pooled_spatial_shape;
     std::string pooling_mode;
-    std::tie(shapes, pooled_spatial_shape, pooling_mode, inType, targetDevice) = this->GetParam();
+    ov::element::Type model_type;
+    std::tie(shapes, pooled_spatial_shape, pooling_mode, model_type, targetDevice) = this->GetParam();
     init_input_shapes(shapes);
-    outType = inType;
 
-    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front())};
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
 
     ngraph::Shape pooled_shape = {pooled_spatial_shape.size()};
     auto pooled_param = std::make_shared<ov::op::v0::Constant>(ngraph::element::i32, pooled_shape, pooled_spatial_shape);

--- a/src/tests/functional/shared_test_classes/src/single_op/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/batch_norm.cpp
@@ -9,11 +9,11 @@
 namespace ov {
 namespace test {
 std::string BatchNormLayerTest::getTestCaseName(const testing::TestParamInfo<BatchNormLayerTestParams>& obj) {
-    ov::element::Type in_type;
+    ov::element::Type model_type;
     std::vector<InputShape> shapes;
     double epsilon;
     std::string target_device;
-    std::tie(epsilon, in_type, shapes, target_device) = obj.param;
+    std::tie(epsilon, model_type, shapes, target_device) = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -26,7 +26,7 @@ std::string BatchNormLayerTest::getTestCaseName(const testing::TestParamInfo<Bat
             result << ov::test::utils::vec2str(item) << "_";
         }
     }
-    result << "inT=" << in_type.get_type_name() << "_";
+    result << "inT=" << model_type.get_type_name() << "_";
     result << "epsilon=" << epsilon << "_";
     result << "trgDev=" << target_device;
     return result.str();
@@ -43,26 +43,25 @@ void BatchNormLayerTest::generate_inputs(const std::vector<ov::Shape>& target_in
 }
 
 void BatchNormLayerTest::SetUp() {
-    ov::element::Type inType;
+    ov::element::Type model_type;
     std::vector<InputShape> shapes;
     double epsilon;
-    std::tie(epsilon, inType, shapes, targetDevice) = this->GetParam();
+    std::tie(epsilon, model_type, shapes, targetDevice) = this->GetParam();
     init_input_shapes(shapes);
-    outType = inType;
-    ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front())};
+    ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
 
     auto constant_shape = ov::Shape{params[0]->get_shape().at(1)};
-    auto gamma_tensor = ov::test::utils::create_and_fill_tensor(inType, constant_shape, 1, 0);
+    auto gamma_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
     auto gamma = std::make_shared<ov::op::v0::Constant>(gamma_tensor);
 
-    auto beta_tensor = ov::test::utils::create_and_fill_tensor(inType, constant_shape, 1, 0);
+    auto beta_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
     auto beta = std::make_shared<ov::op::v0::Constant>(beta_tensor);
 
-    auto mean_tensor = ov::test::utils::create_and_fill_tensor(inType, constant_shape, 1, 0);
+    auto mean_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
     auto mean = std::make_shared<ov::op::v0::Constant>(mean_tensor);
 
     // Fill the vector for variance with positive values
-    auto variance_tensor = ov::test::utils::create_and_fill_tensor(inType, constant_shape, 10, 0);
+    auto variance_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 10, 0);
     auto variance = std::make_shared<ov::op::v0::Constant>(variance_tensor);
     auto batch_norm = std::make_shared<ov::op::v5::BatchNormInference>(params[0], gamma, beta, mean, variance, epsilon);
 

--- a/src/tests/functional/shared_test_classes/src/single_op/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/batch_norm.cpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/batch_norm.hpp"
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+
+namespace ov {
+namespace test {
+std::string BatchNormLayerTest::getTestCaseName(const testing::TestParamInfo<BatchNormLayerTestParams>& obj) {
+    ov::element::Type model_type;
+    ov::element::Type in_type, out_type;
+    std::vector<InputShape> shapes;
+    double epsilon;
+    std::string target_device;
+    std::tie(epsilon, model_type, in_type, out_type, shapes, target_device) = obj.param;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (const auto& shape : shapes) {
+        result << ov::test::utils::partialShape2str({shape.first}) << "_";
+    }
+    result << ")_TS=(";
+    for (const auto& shape : shapes) {
+        for (const auto& item : shape.second) {
+            result << ov::test::utils::vec2str(item) << "_";
+        }
+    }
+    result << "IT=" << model_type.get_type_name() << "_";
+    result << "inT=" << in_type.get_type_name() << "_";
+    result << "outT=" << out_type.get_type_name() << "_";
+    result << "epsilon=" << epsilon << "_";
+    result << "trgDev=" << target_device;
+    return result.str();
+}
+
+void BatchNormLayerTest::generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) {
+    inputs.clear();
+    auto params = function->get_parameters();
+    OPENVINO_ASSERT(target_input_static_shapes.size() >= params.size());
+    for (int i = 0; i < params.size(); i++) {
+        auto tensor = ov::test::utils::create_and_fill_tensor_consistently(params[i]->get_element_type(), target_input_static_shapes[i], 3, 0, 1);
+        inputs.insert({params[i], tensor});
+    }
+}
+
+void BatchNormLayerTest::SetUp() {
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    double epsilon;
+    std::tie(epsilon, model_type, inType, outType, shapes, targetDevice) = this->GetParam();
+    init_input_shapes(shapes);
+
+    ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
+
+    auto constant_shape = ov::Shape{params[0]->get_shape().at(1)};
+    auto gamma_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
+    auto gamma = std::make_shared<ov::op::v0::Constant>(gamma_tensor);
+
+    auto beta_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
+    auto beta = std::make_shared<ov::op::v0::Constant>(beta_tensor);
+
+    auto mean_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
+    auto mean = std::make_shared<ov::op::v0::Constant>(mean_tensor);
+
+    // Fill the vector for variance with positive values
+    auto variance_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 10, 0);
+    auto variance = std::make_shared<ov::op::v0::Constant>(variance_tensor);
+    auto batch_norm = std::make_shared<ov::op::v5::BatchNormInference>(params[0], gamma, beta, mean, variance, epsilon);
+
+    function = std::make_shared<ov::Model>(ov::OutputVector{batch_norm}, params, "BatchNormInference");
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/batch_norm.cpp
@@ -9,12 +9,11 @@
 namespace ov {
 namespace test {
 std::string BatchNormLayerTest::getTestCaseName(const testing::TestParamInfo<BatchNormLayerTestParams>& obj) {
-    ov::element::Type model_type;
-    ov::element::Type in_type, out_type;
+    ov::element::Type in_type;
     std::vector<InputShape> shapes;
     double epsilon;
     std::string target_device;
-    std::tie(epsilon, model_type, in_type, out_type, shapes, target_device) = obj.param;
+    std::tie(epsilon, in_type, shapes, target_device) = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -27,9 +26,7 @@ std::string BatchNormLayerTest::getTestCaseName(const testing::TestParamInfo<Bat
             result << ov::test::utils::vec2str(item) << "_";
         }
     }
-    result << "IT=" << model_type.get_type_name() << "_";
     result << "inT=" << in_type.get_type_name() << "_";
-    result << "outT=" << out_type.get_type_name() << "_";
     result << "epsilon=" << epsilon << "_";
     result << "trgDev=" << target_device;
     return result.str();
@@ -46,26 +43,26 @@ void BatchNormLayerTest::generate_inputs(const std::vector<ov::Shape>& target_in
 }
 
 void BatchNormLayerTest::SetUp() {
-    ov::element::Type model_type;
+    ov::element::Type inType;
     std::vector<InputShape> shapes;
     double epsilon;
-    std::tie(epsilon, model_type, inType, outType, shapes, targetDevice) = this->GetParam();
+    std::tie(epsilon, inType, shapes, targetDevice) = this->GetParam();
     init_input_shapes(shapes);
-
-    ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
+    outType = inType;
+    ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front())};
 
     auto constant_shape = ov::Shape{params[0]->get_shape().at(1)};
-    auto gamma_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
+    auto gamma_tensor = ov::test::utils::create_and_fill_tensor(inType, constant_shape, 1, 0);
     auto gamma = std::make_shared<ov::op::v0::Constant>(gamma_tensor);
 
-    auto beta_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
+    auto beta_tensor = ov::test::utils::create_and_fill_tensor(inType, constant_shape, 1, 0);
     auto beta = std::make_shared<ov::op::v0::Constant>(beta_tensor);
 
-    auto mean_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 1, 0);
+    auto mean_tensor = ov::test::utils::create_and_fill_tensor(inType, constant_shape, 1, 0);
     auto mean = std::make_shared<ov::op::v0::Constant>(mean_tensor);
 
     // Fill the vector for variance with positive values
-    auto variance_tensor = ov::test::utils::create_and_fill_tensor(model_type, constant_shape, 10, 0);
+    auto variance_tensor = ov::test::utils::create_and_fill_tensor(inType, constant_shape, 10, 0);
     auto variance = std::make_shared<ov::op::v0::Constant>(variance_tensor);
     auto batch_norm = std::make_shared<ov::op::v5::BatchNormInference>(params[0], gamma, beta, mean, variance, epsilon);
 

--- a/src/tests/functional/shared_test_classes/src/single_op/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/batch_norm.cpp
@@ -32,16 +32,6 @@ std::string BatchNormLayerTest::getTestCaseName(const testing::TestParamInfo<Bat
     return result.str();
 }
 
-void BatchNormLayerTest::generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) {
-    inputs.clear();
-    auto params = function->get_parameters();
-    OPENVINO_ASSERT(target_input_static_shapes.size() >= params.size());
-    for (int i = 0; i < params.size(); i++) {
-        auto tensor = ov::test::utils::create_and_fill_tensor_consistently(params[i]->get_element_type(), target_input_static_shapes[i], 3, 0, 1);
-        inputs.insert({params[i], tensor});
-    }
-}
-
 void BatchNormLayerTest::SetUp() {
     ov::element::Type model_type;
     std::vector<InputShape> shapes;

--- a/src/tests/functional/shared_test_classes/src/single_op/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/batch_to_space.cpp
@@ -9,10 +9,9 @@ namespace test {
 std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj) {
     std::vector<InputShape> shapes;
     std::vector<int64_t> block_shape, crops_begin, crops_end;
-    ov::element::Type model_type;
-    ov::element::Type in_type, out_type;
+    ov::element::Type in_type;
     std::string target_name;
-    std::tie(block_shape, crops_begin, crops_end, shapes, model_type, in_type, out_type, target_name) = obj.param;
+    std::tie(block_shape, crops_begin, crops_end, shapes, in_type, target_name) = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (const auto& shape : shapes) {
@@ -24,9 +23,7 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
             result << ov::test::utils::vec2str(item) << "_";
         }
     }
-    result << "IT=" << model_type.get_type_name() << "_";
     result << "inT=" << in_type.get_type_name() << "_";
-    result << "outT=" << out_type.get_type_name() << "_";
     result << "BS=" << ov::test::utils::vec2str(block_shape) << "_";
     result << "CB=" << ov::test::utils::vec2str(crops_begin) << "_";
     result << "CE=" << ov::test::utils::vec2str(crops_end) << "_";
@@ -37,11 +34,11 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
 void BatchToSpaceLayerTest::SetUp() {
     std::vector<InputShape> shapes;
     std::vector<int64_t> block_shape, crops_begin, crops_end;
-    ov::element::Type model_type;
-    std::tie(block_shape, crops_begin, crops_end, shapes, model_type, inType, outType, targetDevice) = this->GetParam();
+    std::tie(block_shape, crops_begin, crops_end, shapes, inType, targetDevice) = this->GetParam();
     init_input_shapes(shapes);
+    outType = inType;
 
-    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front())};
 
     auto const_shape = ov::Shape{inputDynamicShapes.front().size()};
     auto block_shape_node = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, const_shape, block_shape.data());

--- a/src/tests/functional/shared_test_classes/src/single_op/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/batch_to_space.cpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/batch_to_space.hpp"
+
+namespace ov {
+namespace test {
+std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj) {
+    std::vector<InputShape> shapes;
+    std::vector<int64_t> block_shape, crops_begin, crops_end;
+    ov::element::Type model_type;
+    ov::element::Type in_type, out_type;
+    std::string target_name;
+    std::tie(block_shape, crops_begin, crops_end, shapes, model_type, in_type, out_type, target_name) = obj.param;
+    std::ostringstream result;
+    result << "IS=(";
+    for (const auto& shape : shapes) {
+        result << ov::test::utils::partialShape2str({shape.first}) << "_";
+    }
+    result << ")_TS=(";
+    for (const auto& shape : shapes) {
+        for (const auto& item : shape.second) {
+            result << ov::test::utils::vec2str(item) << "_";
+        }
+    }
+    result << "IT=" << model_type.get_type_name() << "_";
+    result << "inT=" << in_type.get_type_name() << "_";
+    result << "outT=" << out_type.get_type_name() << "_";
+    result << "BS=" << ov::test::utils::vec2str(block_shape) << "_";
+    result << "CB=" << ov::test::utils::vec2str(crops_begin) << "_";
+    result << "CE=" << ov::test::utils::vec2str(crops_end) << "_";
+    result << "trgDev=" << target_name << "_";
+    return result.str();
+}
+
+void BatchToSpaceLayerTest::SetUp() {
+    std::vector<InputShape> shapes;
+    std::vector<int64_t> block_shape, crops_begin, crops_end;
+    ov::element::Type model_type;
+    std::tie(block_shape, crops_begin, crops_end, shapes, model_type, inType, outType, targetDevice) = this->GetParam();
+    init_input_shapes(shapes);
+
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
+
+    auto const_shape = ov::Shape{inputDynamicShapes.front().size()};
+    auto block_shape_node = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, const_shape, block_shape.data());
+    auto crops_begin_node = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, const_shape, crops_begin.data());
+    auto crops_end_node = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, const_shape, crops_end.data());
+
+    auto b2s = std::make_shared<ov::op::v1::BatchToSpace>(params[0], block_shape_node, crops_begin_node, crops_end_node);
+    ov::OutputVector results{std::make_shared<ov::op::v0::Result>(b2s)};
+    function = std::make_shared<ngraph::Function>(results, params, "BatchToSpace");
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/batch_to_space.cpp
@@ -41,13 +41,13 @@ void BatchToSpaceLayerTest::SetUp() {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
 
     auto const_shape = ov::Shape{inputDynamicShapes.front().size()};
-    auto block_shape_node = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, const_shape, block_shape.data());
-    auto crops_begin_node = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, const_shape, crops_begin.data());
-    auto crops_end_node = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, const_shape, crops_end.data());
+    auto block_shape_node = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape, block_shape.data());
+    auto crops_begin_node = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape, crops_begin.data());
+    auto crops_end_node = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape, crops_end.data());
 
     auto b2s = std::make_shared<ov::op::v1::BatchToSpace>(params[0], block_shape_node, crops_begin_node, crops_end_node);
     ov::OutputVector results{std::make_shared<ov::op::v0::Result>(b2s)};
-    function = std::make_shared<ngraph::Function>(results, params, "BatchToSpace");
+    function = std::make_shared<ov::Model>(results, params, "BatchToSpace");
 }
 }  // namespace test
 }  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/batch_to_space.cpp
@@ -9,9 +9,9 @@ namespace test {
 std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj) {
     std::vector<InputShape> shapes;
     std::vector<int64_t> block_shape, crops_begin, crops_end;
-    ov::element::Type in_type;
+    ov::element::Type model_type;
     std::string target_name;
-    std::tie(block_shape, crops_begin, crops_end, shapes, in_type, target_name) = obj.param;
+    std::tie(block_shape, crops_begin, crops_end, shapes, model_type, target_name) = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (const auto& shape : shapes) {
@@ -23,7 +23,7 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
             result << ov::test::utils::vec2str(item) << "_";
         }
     }
-    result << "inT=" << in_type.get_type_name() << "_";
+    result << "inT=" << model_type.get_type_name() << "_";
     result << "BS=" << ov::test::utils::vec2str(block_shape) << "_";
     result << "CB=" << ov::test::utils::vec2str(crops_begin) << "_";
     result << "CE=" << ov::test::utils::vec2str(crops_end) << "_";
@@ -34,11 +34,11 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
 void BatchToSpaceLayerTest::SetUp() {
     std::vector<InputShape> shapes;
     std::vector<int64_t> block_shape, crops_begin, crops_end;
-    std::tie(block_shape, crops_begin, crops_end, shapes, inType, targetDevice) = this->GetParam();
+    ov::element::Type model_type;
+    std::tie(block_shape, crops_begin, crops_end, shapes, model_type, targetDevice) = this->GetParam();
     init_input_shapes(shapes);
-    outType = inType;
 
-    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front())};
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
 
     auto const_shape = ov::Shape{inputDynamicShapes.front().size()};
     auto block_shape_node = std::make_shared<ov::op::v0::Constant>(ngraph::element::i64, const_shape, block_shape.data());

--- a/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
@@ -51,6 +51,7 @@ void ComparisonLayerTest::SetUp() {
     InputLayerType second_input_type;
     std::map<std::string, std::string> additional_config;
     ov::element::Type model_type;
+    ngraph::helpers::ComparisonTypes comparison_op_type;
     std::tie(shapes,
              comparison_op_type,
              second_input_type,
@@ -74,40 +75,5 @@ void ComparisonLayerTest::SetUp() {
     auto comparisonNode = ngraph::builder::makeComparison(inputs[0], second_input, comparison_op_type);
     function = std::make_shared<ov::Model>(comparisonNode, inputs, "Comparison");
 }
-
-void ComparisonLayerTest::generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) {
-    if (comparison_op_type == ComparisonTypes::IS_FINITE || comparison_op_type == ComparisonTypes::IS_NAN) {
-        inputs.clear();
-        auto params = function->get_parameters();
-        OPENVINO_ASSERT(target_input_static_shapes.size() >= params.size());
-        for (int i = 0; i < params.size(); i++) {
-            ov::Tensor tensor(params[i]->get_element_type(), target_input_static_shapes[i]);
-            auto data_ptr = static_cast<float*>(tensor.data());
-            auto data_ptr_int = static_cast<int*>(tensor.data());
-            auto range = tensor.get_size();
-            auto start = -static_cast<float>(range) / 2.f;
-            testing::internal::Random random(1);
-            for (size_t i = 0; i < range; i++) {
-                if (i % 7 == 0) {
-                    data_ptr[i] = std::numeric_limits<float>::infinity();
-                } else if (i % 7 == 1) {
-                    data_ptr[i] = -std::numeric_limits<float>::infinity();
-                } else if (i % 7 == 2) {
-                    data_ptr_int[i] = 0x7F800000 + random.Generate(range);
-                } else if (i % 7 == 3) {
-                    data_ptr[i] = std::numeric_limits<double>::quiet_NaN();
-                } else if (i % 7 == 5) {
-                    data_ptr[i] = -std::numeric_limits<double>::quiet_NaN();
-                } else {
-                    data_ptr[i] = start + static_cast<float>(random.Generate(range));
-                }
-            }
-            inputs.insert({params[i], tensor});
-        }
-    } else {
-        SubgraphBaseTest::generate_inputs(target_input_static_shapes);
-    }
-}
-
 } // namespace test
 } // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/gru_sequence.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/gru_sequence.cpp
@@ -61,7 +61,8 @@ void GRUSequenceTest::SetUp() {
     bool linear_before_reset;
     ov::op::RecurrentSequenceDirection direction;
     InputLayerType wbr_type;
-    std::tie(m_mode, shapes, activations, clip, linear_before_reset, direction, wbr_type,
+    ov::test::utils::SequenceTestsMode mode;
+    std::tie(mode, shapes, activations, clip, linear_before_reset, direction, wbr_type,
             inType, targetDevice) = this->GetParam();
     outType = inType;
     init_input_shapes(shapes);
@@ -87,15 +88,15 @@ void GRUSequenceTest::SetUp() {
     const auto& b_shape = ov::Shape{num_directions, (linear_before_reset ? 4 : 3) * hidden_size};
 
     std::shared_ptr<ov::Node> seq_lengths_node;
-    if (m_mode == SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM ||
-        m_mode == SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM ||
-        m_mode == SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_PARAM) {
+    if (mode == SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM ||
+        mode == SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM ||
+        mode == SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_PARAM) {
         auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputDynamicShapes[2]);
         param->set_friendly_name("seq_lengths");
         params.push_back(param);
         seq_lengths_node = param;
-    } else if (m_mode == SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_CONST ||
-               m_mode == SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_CONST) {
+    } else if (mode == SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_CONST ||
+               mode == SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_CONST) {
         auto tensor = ov::test::utils::create_and_fill_tensor(ov::element::i64, targetStaticShapes[0][2], seq_lengths, 0);
         seq_lengths_node = std::make_shared<ov::op::v0::Constant>(tensor);
     } else {
@@ -131,9 +132,9 @@ void GRUSequenceTest::SetUp() {
                              std::make_shared<ov::op::v0::Result>(gru_sequence->output(1))};
     function = std::make_shared<ov::Model>(results, params, "gru_sequence");
 
-    bool is_pure_sequence = (m_mode == SequenceTestsMode::PURE_SEQ ||
-                             m_mode == SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_PARAM ||
-                             m_mode == SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_CONST);
+    bool is_pure_sequence = (mode == SequenceTestsMode::PURE_SEQ ||
+                             mode == SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_PARAM ||
+                             mode == SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_CONST);
     if (!is_pure_sequence) {
         ov::pass::Manager manager;
         if (direction == ov::op::RecurrentSequenceDirection::BIDIRECTIONAL)
@@ -145,16 +146,6 @@ void GRUSequenceTest::SetUp() {
     } else {
         bool ti_found = is_tensor_iterator_exist(function);
         EXPECT_EQ(ti_found, false);
-    }
-}
-
-void GRUSequenceTest::generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) {
-    inputs.clear();
-    auto params = function->get_parameters();
-    OPENVINO_ASSERT(target_input_static_shapes.size() >= params.size());
-    for (int i = 0; i < params.size(); i++) {
-        auto tensor = ov::test::utils::create_and_fill_tensor(params[i]->get_element_type(), target_input_static_shapes[i], m_max_seq_len, 0);
-        inputs.insert({params[i], tensor});
     }
 }
 } //  namespace test


### PR DESCRIPTION
### Details:
- Refactor AdaPool, BatchToSpace, and BatchNorm layer tests to use SubgraphBaseTest
- Update cpu plugin instantiation of these tests to use new implementation
- Gtest requires to have test fixture class name which is not equal to old class. That's why new tests are placed to new directory. This way we can use the same names and don't mix old and new tests together in Gtest


### Tickets:
 - [CVS-111364](https://jira.devtools.intel.com/browse/CVS-111364)
