### PR TITLE
[GPU] Use preferred output format if node impl type is onednn

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -161,9 +161,7 @@ std::vector<layout> fully_connected_inst::calc_output_layouts(fully_connected_no
     format::type output_format = is_static && !allow_new_shape_infer ? get_preferred_format(node, impl_param) :
                                               input_layout.format.value;
 
-    // Select preferred output format if the impl_type of FC node is onednn.
-    if (node.get_preferred_impl_type() == impl_types::onednn
-        && node.get_preferred_output_fmt() != format::any)
+    if (node.get_preferred_output_fmt() != format::any)
         output_format = node.get_preferred_output_fmt();
 
     return { layout{output_shapes[0], output_type, output_format} };

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -161,6 +161,11 @@ std::vector<layout> fully_connected_inst::calc_output_layouts(fully_connected_no
     format::type output_format = is_static && !allow_new_shape_infer ? get_preferred_format(node, impl_param) :
                                               input_layout.format.value;
 
+    // Select preferred output format if the impl_type of FC node is onednn.
+    if (node.get_preferred_impl_type() == impl_types::onednn
+        && node.get_preferred_output_fmt() != format::any)
+        output_format = node.get_preferred_output_fmt();
+
     return { layout{output_shapes[0], output_type, output_format} };
 }
 

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -108,10 +108,8 @@ std::vector<layout> gemm_inst::calc_output_layouts(gemm_node const& node, const 
 
     std::vector<ShapeType> output_shapes = ov::op::v0::shape_infer(&op, input_shapes);
 
-    // Select preferred output format if the impl_type of gemm node is onednn.
     cldnn::format output_format = input0_layout.format;
-    if (node.get_preferred_impl_type() == impl_types::onednn
-        && node.get_preferred_output_fmt() != format::any)
+    if (node.get_preferred_output_fmt() != format::any)
         output_format = node.get_preferred_output_fmt();
 
     return { layout{output_shapes[0], output_type, output_format, prim->output_paddings[0]} };

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -85,7 +85,7 @@ layout gemm_inst::calc_output_layout(gemm_node const& node, kernel_impl_params c
 }
 
 template<typename ShapeType>
-std::vector<layout> gemm_inst::calc_output_layouts(gemm_node const& /*node*/, const kernel_impl_params& impl_param) {
+std::vector<layout> gemm_inst::calc_output_layouts(gemm_node const& node, const kernel_impl_params& impl_param) {
     auto prim = impl_param.typed_desc<gemm>();
     auto input0_layout = impl_param.get_input_layout(0);
     auto input1_layout = impl_param.get_input_layout(1);
@@ -108,7 +108,13 @@ std::vector<layout> gemm_inst::calc_output_layouts(gemm_node const& /*node*/, co
 
     std::vector<ShapeType> output_shapes = ov::op::v0::shape_infer(&op, input_shapes);
 
-    return { layout{output_shapes[0], output_type, input0_layout.format, prim->output_paddings[0]} };
+    // Select preferred output format if the impl_type of gemm node is onednn.
+    cldnn::format output_format = input0_layout.format;
+    if (node.get_preferred_impl_type() == impl_types::onednn
+        && node.get_preferred_output_fmt() != format::any)
+        output_format = node.get_preferred_output_fmt();
+
+    return { layout{output_shapes[0], output_type, output_format, prim->output_paddings[0]} };
 }
 
 template std::vector<layout> gemm_inst::calc_output_layouts<ov::PartialShape>(gemm_node const& node, const kernel_impl_params& impl_param);

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/matmul_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/matmul_si_test.cpp
@@ -12,6 +12,7 @@
 #include "gemm_inst.h"
 #include "fully_connected_inst.h"
 
+#include "pass_manager.h"
 #include "program_wrapper.h"
 
 #include <cmath>
@@ -117,6 +118,79 @@ INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_test,
             layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx},
             data_types::f32, false, false,
             layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx}
+        }
+    }));
+
+class fully_connected_test_preferred_output_format : public testing::TestWithParam<matmul_test_params> {};
+TEST_P(fully_connected_test_preferred_output_format, shape_infer) {
+    auto p = GetParam();
+
+    auto& engine = get_test_engine();
+
+    auto matrix_a_layout_prim = std::make_shared<input_layout>("matrix_a", p.matrix_a_layout);
+    auto matrix_b_layout_prim = std::make_shared<input_layout>("matrix_b", p.matrix_b_layout);
+    auto fully_connected_prim = std::make_shared<fully_connected>("output", input_info("matrix_a"), "matrix_b", "", p.data_type);
+
+    cldnn::program prog(engine, {ov::intel_gpu::allow_new_shape_infer(true)});
+
+    auto& matrix_a_node = prog.get_or_create(matrix_a_layout_prim);
+    auto& matrix_b_node = prog.get_or_create(matrix_b_layout_prim);
+    auto& fully_connected_node = prog.get_or_create(fully_connected_prim);
+    program_wrapper::add_connection(prog, matrix_a_node, fully_connected_node);
+    program_wrapper::add_connection(prog, matrix_b_node, fully_connected_node);
+
+    fully_connected_node.set_preferred_output_fmt(0, cldnn::format::b_fs_yx_fsv16);
+
+    auto res = fully_connected_inst::calc_output_layouts<ov::PartialShape>(fully_connected_node, *fully_connected_node.get_kernel_impl_params());
+
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res[0], p.expected_layout);
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_test_preferred_output_format,
+    testing::ValuesIn(std::vector<matmul_test_params>{
+        {
+            layout{ov::PartialShape{10, 1024}, data_types::i8, format::bfyx},
+            layout{ov::PartialShape{1000, 1024}, data_types::i8, format::bfyx},
+            data_types::f16, false, false,
+            layout{ov::PartialShape{10, 1000}, data_types::f16, format::b_fs_yx_fsv16}
+        }
+    }));
+
+class gemm_test_preferred_output_format : public testing::TestWithParam<matmul_test_params> {};
+TEST_P(gemm_test_preferred_output_format, shape_infer) {
+    auto p = GetParam();
+
+    auto& engine = get_test_engine();
+
+    auto matrix_a_layout_prim = std::make_shared<input_layout>("matrix_a", p.matrix_a_layout);
+    auto matrix_b_layout_prim = std::make_shared<input_layout>("matrix_b", p.matrix_b_layout);
+    auto gemm_prim = std::make_shared<gemm>("output", std::vector<input_info>{ input_info("matrix_a"), input_info("matrix_b") },
+                                            p.data_type, p.transpose_a, p.transpose_b);
+
+    cldnn::program prog(engine, {ov::intel_gpu::allow_new_shape_infer(true)});
+
+    auto& matrix_a_node = prog.get_or_create(matrix_a_layout_prim);
+    auto& matrix_b_node = prog.get_or_create(matrix_b_layout_prim);
+    auto& gemm_node = prog.get_or_create(gemm_prim);
+    program_wrapper::add_connection(prog, matrix_a_node, gemm_node);
+    program_wrapper::add_connection(prog, matrix_b_node, gemm_node);
+
+    gemm_node.set_preferred_output_fmt(0, cldnn::format::b_fs_yx_fsv16);
+
+    auto res = gemm_inst::calc_output_layouts<ov::PartialShape>(gemm_node, *gemm_node.get_kernel_impl_params());
+
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res[0], p.expected_layout);
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, gemm_test_preferred_output_format,
+    testing::ValuesIn(std::vector<matmul_test_params>{
+        {
+            layout{ov::PartialShape{5, 10, 1024}, data_types::i8, format::bfyx},
+            layout{ov::PartialShape{1000,  1024}, data_types::i8, format::bfyx},
+            data_types::f16, false, true,
+            layout{ov::PartialShape{5, 10, 1000}, data_types::f16, format::b_fs_yx_fsv16}
         }
     }));
 


### PR DESCRIPTION
### Details:
 - *Conditions*
   - onednn is enabled on dGPU.
   - The model is partial dynamic shape.
   - The impl type of gemm and FC node is selected to onednn.
 - *Problems*
   - The input format of reshape is selected to b_fs_yx_fsv16.
   - To reshape from b_fs_yx_fsv16 to bfwzyx is not supported.
   - This is due to not selecting a preferred format in gemm and fc nodes.
   - Target pattern
     - Expected: MatMul (bfyx) -> Reshape (bfwzyx)
     - Actual:     MatMul (b_fs_yx_fsv16) -> Reshape (bfwzyx)

### Tickets:
 - *117969*
