### PR TITLE
When CPU processors is less than or equal to 4, throughput mode use 1 thread per stream

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -237,7 +237,9 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
                     n_proc = std::min(n_threads, n_proc);
                 }
 
-                if (0 == n_proc % 4) {
+                if (proc_type_table[0][ALL_PROC] <= 4) {
+                    n_threads_per_stream = 1;
+                } else if (0 == n_proc % 4) {
                     n_threads_per_stream = 4;
                 } else if (0 == n_proc % 5) {
                     n_threads_per_stream = 5;

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -273,14 +273,19 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
                 n_streams = input_infer_requests > 0 ? std::min(n_streams, input_infer_requests) : n_streams;
                 n_threads_per_stream = -1;
             } else {
-                n_streams = ((n_threads + model_prefer_threads - 1) / model_prefer_threads);
-                if ((input_infer_requests > 0) && (n_streams > input_infer_requests)) {
-                    n_streams = input_infer_requests;
-                    n_threads_per_stream = static_cast<int>(n_threads / n_streams);
-                    check_threads_per_stream();
+                if (proc_type_table[0][ALL_PROC] <= 4) {
+                    n_threads_per_stream = 1;
+                    n_streams = proc_type_table[0][ALL_PROC];
                 } else {
-                    n_threads_per_stream =
-                        model_prefer_threads > 0 ? model_prefer_threads : static_cast<int>(n_threads / n_streams);
+                    n_streams = ((n_threads + model_prefer_threads - 1) / model_prefer_threads);
+                    if ((input_infer_requests > 0) && (n_streams > input_infer_requests)) {
+                        n_streams = input_infer_requests;
+                        n_threads_per_stream = static_cast<int>(n_threads / n_streams);
+                        check_threads_per_stream();
+                    } else {
+                        n_threads_per_stream =
+                            model_prefer_threads > 0 ? model_prefer_threads : static_cast<int>(n_threads / n_streams);
+                    }
                 }
             }
         }

--- a/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
@@ -1748,6 +1748,18 @@ StreamsCalculationTestCase _1sockets_mock_tput_1 = {
     {{6, MAIN_CORE_PROC, 1, 0, 0}, {3, EFFICIENT_CORE_PROC, 2, 0, 0}, {3, HYPER_THREADING_PROC, 1, 0, 0}},
 };
 
+StreamsCalculationTestCase _1sockets_mock_tput_2 = {
+    0,
+    false,
+    0,
+    0,
+    0,
+    "THROUGHPUT",
+    ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
+    {{4, 4, 0, 0, 0, 0}},
+    {{4, MAIN_CORE_PROC, 1, 0, 0}},
+};
+
 TEST_P(StreamsCalculationTests, StreamsCalculation) {}
 
 INSTANTIATE_TEST_SUITE_P(StreamsInfoTable,
@@ -1880,6 +1892,7 @@ INSTANTIATE_TEST_SUITE_P(StreamsInfoTable,
                                          _1sockets_ecores_tput_3,
                                          _1sockets_ecores_tput_4,
                                          _1sockets_ecores_tput_5,
-                                         _1sockets_mock_tput_1));
+                                         _1sockets_mock_tput_1,
+                                         _1sockets_mock_tput_2));
 
 }  // namespace

--- a/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
@@ -1628,6 +1628,30 @@ StreamsCalculationTestCase _1sockets_6cores_tput_4 = {
     {{6, MAIN_CORE_PROC, 1, 0, 0}, {6, HYPER_THREADING_PROC, 1, 0, 0}},
 };
 
+StreamsCalculationTestCase _1sockets_4cores_latency_1 = {
+    1,
+    false,
+    0,
+    0,
+    0,
+    "LATENCY",
+    ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
+    {{4, 4, 0, 0, 0, 0}},
+    {{1, MAIN_CORE_PROC, 4, 0, 0}},
+};
+
+StreamsCalculationTestCase _1sockets_4cores_tput_1 = {
+    1,
+    false,
+    0,
+    0,
+    0,
+    "THROUGHPUT",
+    ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
+    {{4, 4, 0, 0, 0, 0}},
+    {{4, MAIN_CORE_PROC, 1, 0, 0}},
+};
+
 StreamsCalculationTestCase _1sockets_ecores_latency_1 = {
     1,
     false,
@@ -1746,18 +1770,6 @@ StreamsCalculationTestCase _1sockets_mock_tput_1 = {
     ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
     {{20, 6, 7, 6, 0, 0}},
     {{6, MAIN_CORE_PROC, 1, 0, 0}, {3, EFFICIENT_CORE_PROC, 2, 0, 0}, {3, HYPER_THREADING_PROC, 1, 0, 0}},
-};
-
-StreamsCalculationTestCase _1sockets_mock_tput_2 = {
-    0,
-    false,
-    0,
-    0,
-    0,
-    "THROUGHPUT",
-    ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
-    {{4, 4, 0, 0, 0, 0}},
-    {{4, MAIN_CORE_PROC, 1, 0, 0}},
 };
 
 TEST_P(StreamsCalculationTests, StreamsCalculation) {}
@@ -1883,6 +1895,8 @@ INSTANTIATE_TEST_SUITE_P(StreamsInfoTable,
                                          _1sockets_6cores_tput_2,
                                          _1sockets_6cores_tput_3,
                                          _1sockets_6cores_tput_4,
+                                         _1sockets_4cores_latency_1,
+                                         _1sockets_4cores_tput_1,
                                          _1sockets_ecores_latency_1,
                                          _1sockets_ecores_latency_2,
                                          _1sockets_ecores_latency_3,
@@ -1892,7 +1906,6 @@ INSTANTIATE_TEST_SUITE_P(StreamsInfoTable,
                                          _1sockets_ecores_tput_3,
                                          _1sockets_ecores_tput_4,
                                          _1sockets_ecores_tput_5,
-                                         _1sockets_mock_tput_1,
-                                         _1sockets_mock_tput_2));
+                                         _1sockets_mock_tput_1));
 
 }  // namespace

--- a/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
@@ -1652,6 +1652,43 @@ StreamsCalculationTestCase _1sockets_4cores_tput_1 = {
     {{4, MAIN_CORE_PROC, 1, 0, 0}},
 };
 
+StreamsCalculationTestCase _1sockets_2cores_latency_1 = {
+    1,
+    false,
+    0,
+    0,
+    0,
+    "LATENCY",
+    ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
+    {{2, 2, 0, 0, 0, 0}},
+    {{1, MAIN_CORE_PROC, 2, 0, 0}},
+};
+
+StreamsCalculationTestCase _1sockets_2cores_tput_1 = {
+    1,
+    false,
+    0,
+    0,
+    0,
+    "THROUGHPUT",
+    ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
+    {{2, 2, 0, 0, 0, 0}},
+    {{2, MAIN_CORE_PROC, 1, 0, 0}},
+};
+
+
+StreamsCalculationTestCase _1sockets_2cores_tput_2 = {
+    1,
+    false,
+    0,
+    0,
+    2,
+    "THROUGHPUT",
+    ov::intel_cpu::Config::LatencyThreadingMode::PER_PLATFORM,
+    {{2, 2, 0, 0, 0, 0}},
+    {{2, MAIN_CORE_PROC, 1, 0, 0}},
+};
+
 StreamsCalculationTestCase _1sockets_ecores_latency_1 = {
     1,
     false,
@@ -1897,6 +1934,9 @@ INSTANTIATE_TEST_SUITE_P(StreamsInfoTable,
                                          _1sockets_6cores_tput_4,
                                          _1sockets_4cores_latency_1,
                                          _1sockets_4cores_tput_1,
+                                         _1sockets_2cores_latency_1,
+                                         _1sockets_2cores_tput_1,
+                                         _1sockets_2cores_tput_2,
                                          _1sockets_ecores_latency_1,
                                          _1sockets_ecores_latency_2,
                                          _1sockets_ecores_latency_3,


### PR DESCRIPTION
### Details:
 - *When CPU processors is less than or equal to 4, throughput mode use 1 thread per stream*

### Tickets:
 - *119769*
