### PR TITLE
EISW-92926 func abs threshold

### DIFF
--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -488,7 +488,7 @@ std::vector<InferenceEngine::Blob::Ptr> LayerTestsCommon::GetOutputs() {
 
 void LayerTestsCommon::Compare(const std::vector<std::pair<ngraph::element::Type, std::vector<std::uint8_t>>> &expectedOutputs,
                                const std::vector<InferenceEngine::Blob::Ptr> &actualOutputs) {
-    Compare(expectedOutputs, actualOutputs, threshold);
+    Compare(expectedOutputs, actualOutputs, threshold, abs_threshold);
 }
 
 void LayerTestsCommon::Validate() {


### PR DESCRIPTION
### Details:
 - *Testing adding usage of abs_threshold explicitly, to enforce usage if the threshold is defined by the test*

### Tickets:
 - *https://jira.devtools.intel.com/browse/EISW-92926*
