### PR TITLE
Fixed CPU plugin compilation

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_tensor.cpp
+++ b/src/plugins/intel_cpu/src/cpu_tensor.cpp
@@ -68,8 +68,9 @@ void Tensor::update_strides() const {
     OPENVINO_ASSERT(blocked_desc, "not a valid blocked memory descriptor.");
     auto& strides = blocked_desc->getStrides();
     m_strides.resize(strides.size());
-    std::transform(strides.cbegin(), strides.cend(), m_strides.begin(),
-                std::bind1st(std::multiplies<size_t>(), m_element_type.size()));
+    std::transform(strides.cbegin(), strides.cend(), m_strides.begin(), [this] (const size_t stride) {
+        return stride * m_element_type.size();
+    });
 }
 
 void* Tensor::data(const element::Type& element_type) const {


### PR DESCRIPTION
### Details:
- With c++17 we cannot use `std::bind1st` because it's removed 
```
[ 85%] Building CXX object src/plugins/intel_cpu/CMakeFiles/openvino_intel_cpu_plugin.dir/src/dnnl_extension_utils.cpp.o
/Users/jenkins/w/prod-v2/bsr/2397/bacfb/p/openv277e958eae47e/s/src/src/plugins/intel_cpu/src/cpu_tensor.cpp:72:22: error: no member named 'bind1st' in namespace 'std'
                std::bind1st(std::multiplies<size_t>(), m_element_type.size()));
                ~~~~~^
[ 85%] Building CXX object src/plugins/intel_cpu/CMakeFiles/openvino_intel_cpu_plugin.dir/src/dnnl_postops_composer.cpp.o
18 warnings and 1 error generated.
make[3]: *** [src/plugins/intel_cpu/CMakeFiles/openvino_intel_cpu_plugin.dir/src/cpu_tensor.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
```
- Fixed cross-compilation from macOS arm64 to x86_64 for MLAS (see https://github.com/openvinotoolkit/mlas/pull/7)