### PR TITLE
[CPU][ARM] Reorder FullyConnected weights in scope of compile_model

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -399,7 +399,7 @@ static dnnl::primitive_desc createPrimitiveDesc(const FCKey& key, const dnnl::en
         const bool found = DnnlExtensionUtils::find_implementation(prim_desc, brgconv_avx512_1x1);
 
         if (found)
-            return prim_desc;
+            return std::move(prim_desc);
     }
 
     // fallback to normal inner product primitive
@@ -441,9 +441,9 @@ static dnnl::primitive_desc createPrimitiveDesc(const FCKey& key, const dnnl::en
     const bool found = DnnlExtensionUtils::find_implementation(prim_desc, key.implType);
 
     if (found)
-        return prim_desc;
+        return std::move(prim_desc);
 
-    return first_desc;
+    return std::move(first_desc);
 }
 
 #if defined(OV_CPU_WITH_ACL)

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -457,7 +457,7 @@ void FullyConnected::prepareWeightsUsingDummyShape() {
         IE_THROW() << "Preferable primitive descriptor is not set for node " << getName() << ".";
 
     auto inDesc = MemoryDescUtils::convertToDnnlMemoryDesc(MemoryDescUtils::makeDummyDesc(*getBaseMemDescAtInputPort(DATA_ID)));
-    auto weightDesc = MemoryDescUtils::convertToDnnlMemoryDesc(getBaseMemDescAtInputPort(WEIGHTS_ID));
+    auto weightDesc = MemoryDescUtils::convertToDnnlMemoryDesc(weightDescIP);
     auto biasDesc = withBiases ? MemoryDescUtils::convertToDnnlMemoryDesc(getBaseMemDescAtInputPort(BIAS_ID)) : nullptr;
     auto outDesc = MemoryDescUtils::convertToDnnlMemoryDesc(MemoryDescUtils::makeDummyDesc(*getBaseMemDescAtOutputPort(0)));
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -117,14 +117,16 @@ private:
     void executeMLAS();
     void prepackMLASWeight();
 #endif
-
+#if defined(OV_CPU_WITH_ACL)
+    void prepareWeightsUsingDummyShape();
+#endif
     bool useWeightsDecompressionImpl = false;
     std::vector<float> decompressionSubtract;
     std::vector<float> decompressionMultiply;
 
     // FC with transposed weights
     bool weightsNonTransposed = false;
-    DnnlMemoryDescPtr makeTransposedWeightDescriptor();
+    DnnlMemoryDescPtr makeTransposedWeightDescriptor(DnnlMemoryDescPtr desc);
 };
 
 }   // namespace node


### PR DESCRIPTION
### Details:
 - Basically move weights reordering from first inference to compile_model

### Tickets:
 - *ticket-id*