### PR TITLE
Revert "[GPU] Fixed reordered memory cache not to contain original we…

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
@@ -149,14 +149,7 @@ public:
 
     memory::ptr weights_memory() const {
         if (is_dynamic()) {
-            memory::ptr weights_mem = nullptr;
-            auto weights_layout = *_impl_params->weights_layout;
-            auto weights_idx = node->get_deform_conv_dep_offset() + 1;
-            if (weights_layout.compatible(get_node().get_input_layout(weights_idx))) {
-                weights_mem = dep_memory_ptr(weights_idx);
-            } else {
-                weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
-            }
+            auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
         } else {  // all weights are in one buffer

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -81,14 +81,7 @@ public:
 
     memory::ptr weights_memory() const {
         if (is_dynamic()) {
-            memory::ptr weights_mem = nullptr;
-            auto weights_layout = *_impl_params->weights_layout;
-            size_t weights_idx = 1;
-            if (weights_layout.compatible(get_node().get_input_layout(weights_idx))) {
-                weights_mem = dep_memory_ptr(weights_idx);
-            } else {
-                weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
-            }
+            auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
         } else {

--- a/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
@@ -54,15 +54,7 @@ public:
 
     memory::ptr weights_memory() const {
         if (is_dynamic()) {
-            memory::ptr weights_mem = nullptr;
-            auto weights_layout = *_impl_params->weights_layout;
-            size_t weights_idx = 1;
-            if (weights_layout.compatible(get_node().get_input_layout(weights_idx))) {
-                weights_mem = dep_memory_ptr(weights_idx);
-            } else {
-                weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
-            }
-
+            auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
         } else {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1137,6 +1137,7 @@ event::ptr primitive_inst::update_weights() {
     if (!reorder_kernel_params) {
         // If kernel doesn't says that it doesn't require weights reorder, but weights were reordered previously, then
         // incorrect memory buffer may be assigned, so reset cached weights for such case
+        _reordered_weights_cache.add(original_layout, original_weights_memory);
         _impl_params->weights_layout = optional_layout(original_layout);
     } else {
         auto expected_layout = reorder_kernel_params->get_output_layout();
@@ -1152,6 +1153,7 @@ event::ptr primitive_inst::update_weights() {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
             GPU_DEBUG_TRACE_DETAIL << id() << ": reinterpret original weights memory from " << original_layout.to_short_string()
                                            << " to " << expected_layout.to_short_string() << std::endl;
+            _reordered_weights_cache.add(expected_layout, engine.reinterpret_buffer(*original_weights_memory, expected_layout));
             return nullptr;
         } else {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(false);
@@ -1184,7 +1186,7 @@ event::ptr primitive_inst::update_weights() {
             memory::ptr weights_memory = nullptr;
             if (_reordered_weights_cache.is_full()) {
                 weights_memory = _reordered_weights_cache.get_lru_element().second;
-                can_reuse = weights_memory->size() <= expected_layout.bytes_count();
+                can_reuse = weights_memory->size() <= expected_layout.bytes_count() && (weights_memory->buffer_ptr() != original_weights_memory->buffer_ptr());
             }
 
             if (can_reuse) {


### PR DESCRIPTION
### Details:
 - Revert https://github.com/openvinotoolkit/openvino/pull/19465
 - PR19465 fixed not to release already reordered weights due to the original weights, because original weights can be referred from the original weight node always.
 - However it caused regression for some scenario, with small input size + large weights in dGPU. In such cases, most of the time, the fc/gemm kernels are selected as onednn (bfyx formats). So no big gain with keeping reordered weights while it resulted in reduced chance of memory prealloc when the weight data is large. 
- The original target issue will be resolved by reimplementing fc opt shape agnostic kernel to use plain weight format. 
