### PR TITLE
[PyOV] Add upper bound for `setuptools`

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -10,7 +10,7 @@ pytest-timeout==2.1.0
 # Python bindings
 py>=1.9.0
 pygments>=2.8.1
-setuptools>=53.0.0
+setuptools>=53.0.0,<=68.1.2
 wheel>=0.38.1
 
 # Frontends

--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,3 @@
-setuptools>=65.6.1
+setuptools>=65.6.1,<=68.1.2
 wheel>=0.38.1
 patchelf<=0.17.2.1; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
### Details:
 - There are errors on some CI jobs (`openvino-lin` at https://github.com/openvinotoolkit/openvino/pull/19534 for example)
 - It's most likely due to today's release of `setuptools` - https://pypi.org/project/setuptools/#history
 - This PR is a hotfix for unblocking precommit while the issue is investigated

### Tickets:
 - N/A
