### PR TITLE
[PyOV] Expose missed properties

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -40,6 +40,7 @@ void regmodule_properties(py::module m) {
     wrap_property_RO(m_properties, ov::optimal_batch_size, "optimal_batch_size");
     wrap_property_RO(m_properties, ov::max_batch_size, "max_batch_size");
     wrap_property_RO(m_properties, ov::range_for_async_infer_requests, "range_for_async_infer_requests");
+    wrap_property_RO(m_properties, ov::execution_devices, "execution_devices");
 
     // Submodule hint
     py::module m_hint =


### PR DESCRIPTION
### Details:
 - added missed property: ov::execution_devices

### Tickets:
 - CVS-119380
