### PR TITLE
Refactor ComparisonLayerTest, ClampLayerTest

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/clamp.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/clamp.cpp
@@ -4,16 +4,18 @@
 
 #include <vector>
 
-#include "single_layer_tests/clamp.hpp"
+#include "single_op_tests/clamp.hpp"
 #include "common_test_utils/test_constants.hpp"
 
-using namespace LayerTestsDefinitions;
+namespace {
+using ov::test::ClampLayerTest;
 
-const std::vector<std::vector<size_t>> inShapes = {
-    {50},
-    {10, 10},
-    {1, 20, 20}
+const std::vector<std::vector<ov::Shape>> input_shapes_static = {
+    {{ 50 }},
+    {{ 10, 10 }},
+    {{ 1, 20, 20 }}
 };
+
 
 const std::vector<std::pair<float, float>> intervals = {
     {-20.1, -10.5},
@@ -27,26 +29,27 @@ const std::vector<std::pair<float, float>> intervals_unsigned = {
     {10.6, 20.6}
 };
 
-const std::vector<InferenceEngine::Precision> netPrc = {
-    InferenceEngine::Precision::FP32,
-    InferenceEngine::Precision::FP16,
-    InferenceEngine::Precision::I64,
-    InferenceEngine::Precision::I32
+const std::vector<ov::element::Type> netPrc = {
+    ov::element::f32,
+    ov::element::f16,
+    ov::element::i64,
+    ov::element::i32
 };
 
 const auto test_Clamp_signed = ::testing::Combine(
-    ::testing::ValuesIn(inShapes),
+    ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
     ::testing::ValuesIn(intervals),
     ::testing::ValuesIn(netPrc),
     ::testing::Values(ov::test::utils::DEVICE_CPU)
 );
 
 const auto test_Clamp_unsigned = ::testing::Combine(
-    ::testing::ValuesIn(inShapes),
+    ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
     ::testing::ValuesIn(intervals_unsigned),
-    ::testing::Values(InferenceEngine::Precision::U64),
+    ::testing::Values(ov::element::u64),
     ::testing::Values(ov::test::utils::DEVICE_CPU)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsClamp_signed, ClampLayerTest, test_Clamp_signed, ClampLayerTest::getTestCaseName);
 INSTANTIATE_TEST_SUITE_P(smoke_TestsClamp_unsigned, ClampLayerTest, test_Clamp_unsigned, ClampLayerTest::getTestCaseName);
+} // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/clamp.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/clamp.cpp
@@ -29,7 +29,7 @@ const std::vector<std::pair<float, float>> intervals_unsigned = {
     {10.6, 20.6}
 };
 
-const std::vector<ov::element::Type> netPrc = {
+const std::vector<ov::element::Type> model_type = {
     ov::element::f32,
     ov::element::f16,
     ov::element::i64,
@@ -39,7 +39,7 @@ const std::vector<ov::element::Type> netPrc = {
 const auto test_Clamp_signed = ::testing::Combine(
     ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
     ::testing::ValuesIn(intervals),
-    ::testing::ValuesIn(netPrc),
+    ::testing::ValuesIn(model_type),
     ::testing::Values(ov::test::utils::DEVICE_CPU)
 );
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
@@ -30,7 +30,7 @@ auto converter = [] (const std::vector<std::pair<ov::Shape, ov::Shape>>& shapes)
 
 auto input_shapes_static = converter(input_shapes_pair_vector);
 
-std::vector<ov::element::Type> inputsPrecisions = {
+std::vector<ov::element::Type> inputs_type = {
         ov::element::f32,
         ov::element::f16,
         ov::element::i32,
@@ -55,11 +55,9 @@ std::map<std::string, std::string> additional_config = {};
 
 const auto ComparisonTestParams = ::testing::Combine(
         ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
-        ::testing::ValuesIn(inputsPrecisions),
         ::testing::ValuesIn(comparisonOpTypes),
         ::testing::ValuesIn(secondInputTypes),
-        ::testing::Values(ov::element::undefined),
-        ::testing::Values(ov::element::undefined),
+        ::testing::ValuesIn(inputs_type),
         ::testing::Values(ov::test::utils::DEVICE_CPU),
         ::testing::Values(additional_config));
 
@@ -90,11 +88,9 @@ std::vector<ngraph::helpers::ComparisonTypes> comparisonOpTypesIs = {
 
 const auto ComparisonTestParamsIs = ::testing::Combine(
         ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_is_ops_static)),
-        ::testing::Values(ov::element::f32),
         ::testing::ValuesIn(comparisonOpTypesIs),
         ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-        ::testing::Values(ov::element::undefined),
-        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::f32),
         ::testing::Values(ov::test::utils::DEVICE_CPU),
         ::testing::Values(additional_config));
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
@@ -3,15 +3,13 @@
 //
 
 #include <vector>
-#include "single_layer_tests/comparison.hpp"
+#include "single_op_tests/comparison.hpp"
 #include "common_test_utils/test_constants.hpp"
 
-using namespace LayerTestsDefinitions;
-using namespace LayerTestsDefinitions::ComparisonParams;
-
 namespace {
+using ov::test::ComparisonLayerTest;
 
-std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> inputShapes = {
+std::map<ov::Shape, std::vector<ov::Shape>> input_shapes_combinations = {
         {{1}, {{1}, {17}, {1, 1}, {2, 18}, {1, 1, 2}, {2, 2, 3}, {1, 1, 2, 3}}},
         {{5}, {{1}, {1, 1}, {2, 5}, {1, 1, 1}, {2, 2, 5}}},
         {{2, 200}, {{1}, {200}, {1, 200}, {2, 200}, {2, 2, 200}}},
@@ -20,11 +18,23 @@ std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> inputShapes = {
         {{2, 1, 1, 3, 1}, {{1}, {1, 3, 4}, {2, 1, 3, 4}, {1, 1, 1, 1, 1}}},
 };
 
-std::vector<InferenceEngine::Precision> inputsPrecisions = {
-        InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::FP16,
-        InferenceEngine::Precision::I32,
-        InferenceEngine::Precision::BOOL,
+auto input_shapes_pair_vector = ov::test::utils::combineParams(input_shapes_combinations);
+
+auto converter = [] (const std::vector<std::pair<ov::Shape, ov::Shape>>& shapes) {
+    std::vector<std::vector<ov::Shape>> result;
+    for (const auto& shape : shapes) {
+        result.push_back({shape.first, shape.second});
+    }
+    return result;
+};
+
+auto input_shapes_static = converter(input_shapes_pair_vector);
+
+std::vector<ov::element::Type> inputsPrecisions = {
+        ov::element::f32,
+        ov::element::f16,
+        ov::element::i32,
+        ov::element::boolean,
 };
 
 std::vector<ngraph::helpers::ComparisonTypes> comparisonOpTypes = {
@@ -44,19 +54,19 @@ std::vector<ngraph::helpers::InputLayerType> secondInputTypes = {
 std::map<std::string, std::string> additional_config = {};
 
 const auto ComparisonTestParams = ::testing::Combine(
-        ::testing::ValuesIn(ov::test::utils::combineParams(inputShapes)),
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
         ::testing::ValuesIn(inputsPrecisions),
         ::testing::ValuesIn(comparisonOpTypes),
         ::testing::ValuesIn(secondInputTypes),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU),
         ::testing::Values(additional_config));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs, ComparisonLayerTest, ComparisonTestParams, ComparisonLayerTest::getTestCaseName);
 
 
-std::vector<InputShapesTuple> inputShapesIsOps = {
+std::vector<std::vector<ov::Shape>> input_shapes_is_ops_static = {
         {{1}, {1}},
         {{1, 2}, {1}},
         {{3, 1}, {1}},
@@ -79,12 +89,12 @@ std::vector<ngraph::helpers::ComparisonTypes> comparisonOpTypesIs = {
 };
 
 const auto ComparisonTestParamsIs = ::testing::Combine(
-        ::testing::ValuesIn(inputShapesIsOps),
-        ::testing::Values(InferenceEngine::Precision::FP32),
+        ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_is_ops_static)),
+        ::testing::Values(ov::element::f32),
         ::testing::ValuesIn(comparisonOpTypesIs),
         ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::test::utils::DEVICE_CPU),
         ::testing::Values(additional_config));
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
@@ -30,7 +30,7 @@ auto converter = [] (const std::vector<std::pair<ov::Shape, ov::Shape>>& shapes)
 
 auto input_shapes_static = converter(input_shapes_pair_vector);
 
-std::vector<ov::element::Type> inputs_type = {
+std::vector<ov::element::Type> model_type = {
         ov::element::f32,
         ov::element::f16,
         ov::element::i32,
@@ -57,7 +57,7 @@ const auto ComparisonTestParams = ::testing::Combine(
         ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
         ::testing::ValuesIn(comparisonOpTypes),
         ::testing::ValuesIn(secondInputTypes),
-        ::testing::ValuesIn(inputs_type),
+        ::testing::ValuesIn(model_type),
         ::testing::Values(ov::test::utils::DEVICE_CPU),
         ::testing::Values(additional_config));
 

--- a/src/tests/functional/plugin/shared/include/single_op_tests/clamp.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/clamp.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/clamp.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(ClampLayerTest, Inference) {
+    run();
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/include/single_op_tests/comparison.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/comparison.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <shared_test_classes/single_op/comparison.hpp>
+
+namespace ov {
+namespace test {
+TEST_P(ComparisonLayerTest, Inference) {
+    run();
+}
+} // namespace test
+} // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/clamp.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/clamp.hpp
@@ -15,7 +15,7 @@ namespace test {
 using clampParamsTuple = std::tuple<
     std::vector<InputShape>,        // Input shape
     std::pair<float, float>,        // Interval [min, max]
-    ov::element::Type,              // In precision
+    ov::element::Type,              // Model precision
     std::string>;                   // Device name
 
 class ClampLayerTest : public testing::WithParamInterface<clampParamsTuple>,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/clamp.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/clamp.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+
+using clampParamsTuple = std::tuple<
+    std::vector<InputShape>,        // Input shape
+    std::pair<float, float>,        // Interval [min, max]
+    ov::element::Type,              // Net precision
+    std::string>;                   // Device name
+
+class ClampLayerTest : public testing::WithParamInterface<clampParamsTuple>,
+                       virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<clampParamsTuple>& obj);
+protected:
+    void SetUp() override;
+};
+
+} // namespace test
+} // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/clamp.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/clamp.hpp
@@ -15,7 +15,7 @@ namespace test {
 using clampParamsTuple = std::tuple<
     std::vector<InputShape>,        // Input shape
     std::pair<float, float>,        // Interval [min, max]
-    ov::element::Type,              // Net precision
+    ov::element::Type,              // In precision
     std::string>;                   // Device name
 
 class ClampLayerTest : public testing::WithParamInterface<clampParamsTuple>,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/comparison.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/comparison.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+
+#include <map>
+
+#include "gtest/gtest.h"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+namespace ov {
+namespace test {
+
+typedef std::tuple<
+    std::vector<InputShape>,             // Input shapes tuple
+    ov::element::Type,                   // NG Inputs precision
+    ngraph::helpers::ComparisonTypes,    // Comparison op type
+    ngraph::helpers::InputLayerType,     // Second input type
+    ov::element::Type,                   // IE in precision
+    ov::element::Type,                   // IE out precision
+    std::string,                         // Device name
+    std::map<std::string, std::string>   // Additional network configuration
+> ComparisonTestParams;
+
+class ComparisonLayerTest : public testing::WithParamInterface<ComparisonTestParams>,
+    virtual public ov::test::SubgraphBaseTest {
+    ngraph::helpers::ComparisonTypes comparison_op_type;
+protected:
+    void SetUp() override;
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<ComparisonTestParams> &obj);
+};
+} // namespace test
+} // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/comparison.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/comparison.hpp
@@ -19,7 +19,7 @@ typedef std::tuple<
     std::vector<InputShape>,             // Input shapes tuple
     ngraph::helpers::ComparisonTypes,    // Comparison op type
     ngraph::helpers::InputLayerType,     // Second input type
-    ov::element::Type,                   // In type
+    ov::element::Type,                   // Model type
     std::string,                         // Device name
     std::map<std::string, std::string>   // Additional network configuration
 > ComparisonTestParams;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/comparison.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/comparison.hpp
@@ -17,11 +17,9 @@ namespace test {
 
 typedef std::tuple<
     std::vector<InputShape>,             // Input shapes tuple
-    ov::element::Type,                   // NG Inputs precision
     ngraph::helpers::ComparisonTypes,    // Comparison op type
     ngraph::helpers::InputLayerType,     // Second input type
-    ov::element::Type,                   // IE in precision
-    ov::element::Type,                   // IE out precision
+    ov::element::Type,                   // In type
     std::string,                         // Device name
     std::map<std::string, std::string>   // Additional network configuration
 > ComparisonTestParams;

--- a/src/tests/functional/shared_test_classes/src/single_op/clamp.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/clamp.cpp
@@ -1,5 +1,4 @@
 // Copyright (C) 2018-2023 Intel Corporation
-//
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/src/tests/functional/shared_test_classes/src/single_op/clamp.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/clamp.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2018-2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/clamp.hpp"
+
+namespace ov {
+namespace test {
+std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampParamsTuple>& obj) {
+    std::vector<InputShape> shapes;
+    std::pair<float, float> interval;
+    ov::element::Type model_type;
+    std::string target_device;
+
+    std::tie(shapes, interval, model_type, target_device) = obj.param;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (size_t i = 0lu; i < shapes.size(); i++) {
+        result << ov::test::utils::partialShape2str({shapes[i].first}) << (i < shapes.size() - 1lu ? "_" : "");
+    }
+    result << ")_TS=";
+    for (size_t i = 0lu; i < shapes.front().second.size(); i++) {
+        result << "{";
+        for (size_t j = 0lu; j < shapes.size(); j++) {
+            result << ov::test::utils::vec2str(shapes[j].second[i]) << (j < shapes.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+    }
+    result << "min=" << interval.first << "_";
+    result << "max=" << interval.second << "_";
+    result << "netPrc=" << model_type.get_type_name() << "_";
+    result << "trgDev=" << target_device;
+    return result.str();
+}
+
+void ClampLayerTest::SetUp() {
+    std::vector<InputShape> shapes;
+    std::pair<float, float> interval;
+    ov::element::Type model_type;
+    std::tie(shapes, interval, model_type, targetDevice) = this->GetParam();
+    init_input_shapes(shapes);
+
+    auto input = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
+    auto clamp = std::make_shared<ov::op::v0::Clamp>(input, interval.first, interval.second);
+    auto result = std::make_shared<ov::op::v0::Result>(clamp);
+    function = std::make_shared<ov::Model>(result, ngraph::ParameterVector{input});
+}
+} // namespace test
+} // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/clamp.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/clamp.cpp
@@ -9,10 +9,10 @@ namespace test {
 std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampParamsTuple>& obj) {
     std::vector<InputShape> shapes;
     std::pair<float, float> interval;
-    ov::element::Type model_type;
+    ov::element::Type in_type;
     std::string target_device;
 
-    std::tie(shapes, interval, model_type, target_device) = obj.param;
+    std::tie(shapes, interval, in_type, target_device) = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -29,7 +29,7 @@ std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampPa
     }
     result << "min=" << interval.first << "_";
     result << "max=" << interval.second << "_";
-    result << "netPrc=" << model_type.get_type_name() << "_";
+    result << "netPrc=" << in_type.get_type_name() << "_";
     result << "trgDev=" << target_device;
     return result.str();
 }
@@ -37,11 +37,11 @@ std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampPa
 void ClampLayerTest::SetUp() {
     std::vector<InputShape> shapes;
     std::pair<float, float> interval;
-    ov::element::Type model_type;
-    std::tie(shapes, interval, model_type, targetDevice) = this->GetParam();
+    std::tie(shapes, interval, inType, targetDevice) = this->GetParam();
     init_input_shapes(shapes);
+    outType = inType;
 
-    auto input = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
+    auto input = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front());
     auto clamp = std::make_shared<ov::op::v0::Clamp>(input, interval.first, interval.second);
     auto result = std::make_shared<ov::op::v0::Result>(clamp);
     function = std::make_shared<ov::Model>(result, ngraph::ParameterVector{input});

--- a/src/tests/functional/shared_test_classes/src/single_op/clamp.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/clamp.cpp
@@ -9,10 +9,10 @@ namespace test {
 std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampParamsTuple>& obj) {
     std::vector<InputShape> shapes;
     std::pair<float, float> interval;
-    ov::element::Type in_type;
+    ov::element::Type model_type;
     std::string target_device;
 
-    std::tie(shapes, interval, in_type, target_device) = obj.param;
+    std::tie(shapes, interval, model_type, target_device) = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -29,7 +29,7 @@ std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampPa
     }
     result << "min=" << interval.first << "_";
     result << "max=" << interval.second << "_";
-    result << "netPrc=" << in_type.get_type_name() << "_";
+    result << "netPrc=" << model_type.get_type_name() << "_";
     result << "trgDev=" << target_device;
     return result.str();
 }
@@ -37,11 +37,11 @@ std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampPa
 void ClampLayerTest::SetUp() {
     std::vector<InputShape> shapes;
     std::pair<float, float> interval;
-    std::tie(shapes, interval, inType, targetDevice) = this->GetParam();
+    ov::element::Type model_type;
+    std::tie(shapes, interval, model_type, targetDevice) = this->GetParam();
     init_input_shapes(shapes);
-    outType = inType;
 
-    auto input = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes.front());
+    auto input = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
     auto clamp = std::make_shared<ov::op::v0::Clamp>(input, interval.first, interval.second);
     auto result = std::make_shared<ov::op::v0::Result>(clamp);
     function = std::make_shared<ov::Model>(result, ngraph::ParameterVector{input});

--- a/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
@@ -14,19 +14,15 @@ using ngraph::helpers::InputLayerType;
 
 std::string ComparisonLayerTest::getTestCaseName(const testing::TestParamInfo<ComparisonTestParams> &obj) {
     std::vector<InputShape> shapes;
-    ov::element::Type model_type;
     ComparisonTypes comparison_op_type;
     InputLayerType second_input_type;
     ov::element::Type in_type;
-    ov::element::Type out_type;
     std::string device_name;
     std::map<std::string, std::string> additional_config;
     std::tie(shapes,
-             model_type,
              comparison_op_type,
              second_input_type,
              in_type,
-             out_type,
              device_name,
              additional_config) = obj.param;
 
@@ -43,39 +39,35 @@ std::string ComparisonLayerTest::getTestCaseName(const testing::TestParamInfo<Co
         }
         result << "}_";
     }
-    result << "inputsPRC=" << model_type.get_type_name() << "_";
     result << "comparisonOpType=" << comparison_op_type << "_";
     result << "secondInputType=" << second_input_type << "_";
     result << "in_type=" << in_type.get_type_name() << "_";
-    result << "out_type=" << out_type.get_type_name() << "_";
     result << "targetDevice=" << device_name;
     return result.str();
 }
 
 void ComparisonLayerTest::SetUp() {
     std::vector<InputShape> shapes;
-    ov::element::Type model_type;
     InputLayerType second_input_type;
     std::map<std::string, std::string> additional_config;
     std::tie(shapes,
-             model_type,
              comparison_op_type,
              second_input_type,
              inType,
-             outType,
              targetDevice,
              additional_config) = this->GetParam();
     configuration.insert(additional_config.begin(), additional_config.end());
     init_input_shapes(shapes);
+    outType = inType;
 
-    ov::ParameterVector inputs {std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0])};
+    ov::ParameterVector inputs {std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[0])};
 
     std::shared_ptr<ov::Node> second_input;
     if (second_input_type == InputLayerType::PARAMETER) {
-        second_input = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[1]);
+        second_input = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[1]);
         inputs.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(second_input));
     } else {
-        ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(model_type, targetStaticShapes.front()[1]);
+        ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(inType, targetStaticShapes.front()[1]);
         second_input = std::make_shared<ov::op::v0::Constant>(tensor);
     }
 

--- a/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
@@ -90,7 +90,6 @@ void ComparisonLayerTest::generate_inputs(const std::vector<ov::Shape>& target_i
         OPENVINO_ASSERT(target_input_static_shapes.size() >= params.size());
         for (int i = 0; i < params.size(); i++) {
             ov::Tensor tensor(params[i]->get_element_type(), target_input_static_shapes[i]);
-            //auto tensor = ov::test::utils::create_and_fill_tensor_consistently(params[i]->get_element_type(), target_input_static_shapes[i], 3, 0, 1);
             auto data_ptr = static_cast<float*>(tensor.data());
             auto data_ptr_int = static_cast<int*>(tensor.data());
             auto range = tensor.get_size();

--- a/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
@@ -1,0 +1,122 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/comparison.hpp"
+
+#include "ngraph_functions/builders.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
+
+namespace ov {
+namespace test {
+using ngraph::helpers::ComparisonTypes;
+using ngraph::helpers::InputLayerType;
+
+std::string ComparisonLayerTest::getTestCaseName(const testing::TestParamInfo<ComparisonTestParams> &obj) {
+    std::vector<InputShape> shapes;
+    ov::element::Type model_type;
+    ComparisonTypes comparison_op_type;
+    InputLayerType second_input_type;
+    ov::element::Type in_type;
+    ov::element::Type out_type;
+    std::string device_name;
+    std::map<std::string, std::string> additional_config;
+    std::tie(shapes,
+             model_type,
+             comparison_op_type,
+             second_input_type,
+             in_type,
+             out_type,
+             device_name,
+             additional_config) = obj.param;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (size_t i = 0lu; i < shapes.size(); i++) {
+        result << ov::test::utils::partialShape2str({shapes[i].first}) << (i < shapes.size() - 1lu ? "_" : "");
+    }
+    result << ")_TS=";
+    for (size_t i = 0lu; i < shapes.front().second.size(); i++) {
+        result << "{";
+        for (size_t j = 0lu; j < shapes.size(); j++) {
+            result << ov::test::utils::vec2str(shapes[j].second[i]) << (j < shapes.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+    }
+    result << "inputsPRC=" << model_type.get_type_name() << "_";
+    result << "comparisonOpType=" << comparison_op_type << "_";
+    result << "secondInputType=" << second_input_type << "_";
+    result << "in_type=" << in_type.get_type_name() << "_";
+    result << "out_type=" << out_type.get_type_name() << "_";
+    result << "targetDevice=" << device_name;
+    return result.str();
+}
+
+void ComparisonLayerTest::SetUp() {
+    std::vector<InputShape> shapes;
+    ov::element::Type model_type;
+    InputLayerType second_input_type;
+    std::map<std::string, std::string> additional_config;
+    std::tie(shapes,
+             model_type,
+             comparison_op_type,
+             second_input_type,
+             inType,
+             outType,
+             targetDevice,
+             additional_config) = this->GetParam();
+    configuration.insert(additional_config.begin(), additional_config.end());
+    init_input_shapes(shapes);
+
+    ov::ParameterVector inputs {std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0])};
+
+    std::shared_ptr<ov::Node> second_input;
+    if (second_input_type == InputLayerType::PARAMETER) {
+        second_input = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[1]);
+        inputs.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(second_input));
+    } else {
+        ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(model_type, targetStaticShapes.front()[1]);
+        second_input = std::make_shared<ov::op::v0::Constant>(tensor);
+    }
+
+    auto comparisonNode = ngraph::builder::makeComparison(inputs[0], second_input, comparison_op_type);
+    function = std::make_shared<ov::Model>(comparisonNode, inputs, "Comparison");
+}
+
+void ComparisonLayerTest::generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) {
+    if (comparison_op_type == ComparisonTypes::IS_FINITE || comparison_op_type == ComparisonTypes::IS_NAN) {
+        inputs.clear();
+        auto params = function->get_parameters();
+        OPENVINO_ASSERT(target_input_static_shapes.size() >= params.size());
+        for (int i = 0; i < params.size(); i++) {
+            ov::Tensor tensor(params[i]->get_element_type(), target_input_static_shapes[i]);
+            //auto tensor = ov::test::utils::create_and_fill_tensor_consistently(params[i]->get_element_type(), target_input_static_shapes[i], 3, 0, 1);
+            auto data_ptr = static_cast<float*>(tensor.data());
+            auto data_ptr_int = static_cast<int*>(tensor.data());
+            auto range = tensor.get_size();
+            auto start = -static_cast<float>(range) / 2.f;
+            testing::internal::Random random(1);
+            for (size_t i = 0; i < range; i++) {
+                if (i % 7 == 0) {
+                    data_ptr[i] = std::numeric_limits<float>::infinity();
+                } else if (i % 7 == 1) {
+                    data_ptr[i] = -std::numeric_limits<float>::infinity();
+                } else if (i % 7 == 2) {
+                    data_ptr_int[i] = 0x7F800000 + random.Generate(range);
+                } else if (i % 7 == 3) {
+                    data_ptr[i] = std::numeric_limits<double>::quiet_NaN();
+                } else if (i % 7 == 5) {
+                    data_ptr[i] = -std::numeric_limits<double>::quiet_NaN();
+                } else {
+                    data_ptr[i] = start + static_cast<float>(random.Generate(range));
+                }
+            }
+            inputs.insert({params[i], tensor});
+        }
+    } else {
+        SubgraphBaseTest::generate_inputs(target_input_static_shapes);
+    }
+}
+
+} // namespace test
+} // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/comparison.cpp
@@ -16,13 +16,13 @@ std::string ComparisonLayerTest::getTestCaseName(const testing::TestParamInfo<Co
     std::vector<InputShape> shapes;
     ComparisonTypes comparison_op_type;
     InputLayerType second_input_type;
-    ov::element::Type in_type;
+    ov::element::Type model_type;
     std::string device_name;
     std::map<std::string, std::string> additional_config;
     std::tie(shapes,
              comparison_op_type,
              second_input_type,
-             in_type,
+             model_type,
              device_name,
              additional_config) = obj.param;
 
@@ -41,7 +41,7 @@ std::string ComparisonLayerTest::getTestCaseName(const testing::TestParamInfo<Co
     }
     result << "comparisonOpType=" << comparison_op_type << "_";
     result << "secondInputType=" << second_input_type << "_";
-    result << "in_type=" << in_type.get_type_name() << "_";
+    result << "in_type=" << model_type.get_type_name() << "_";
     result << "targetDevice=" << device_name;
     return result.str();
 }
@@ -50,24 +50,24 @@ void ComparisonLayerTest::SetUp() {
     std::vector<InputShape> shapes;
     InputLayerType second_input_type;
     std::map<std::string, std::string> additional_config;
+    ov::element::Type model_type;
     std::tie(shapes,
              comparison_op_type,
              second_input_type,
-             inType,
+             model_type,
              targetDevice,
              additional_config) = this->GetParam();
     configuration.insert(additional_config.begin(), additional_config.end());
     init_input_shapes(shapes);
-    outType = inType;
 
-    ov::ParameterVector inputs {std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[0])};
+    ov::ParameterVector inputs {std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0])};
 
     std::shared_ptr<ov::Node> second_input;
     if (second_input_type == InputLayerType::PARAMETER) {
-        second_input = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[1]);
+        second_input = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[1]);
         inputs.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(second_input));
     } else {
-        ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(inType, targetStaticShapes.front()[1]);
+        ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(model_type, targetStaticShapes.front()[1]);
         second_input = std::make_shared<ov::op::v0::Constant>(tensor);
     }
 


### PR DESCRIPTION
### Details:
- Refactor ComparisonLayerTestand, ClampLayerTest to use SubgraphBaseTest
- Update cpu plugin instantiation of these tests to use new implementation


### Tickets:
 - [CVS-111364](https://jira.devtools.intel.com/browse/CVS-111364)
