### PR TITLE
Fixed GPU plugin compilation with gcc-13.2

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <vector>
 #include <set>
+#include <string>
 
 namespace ov {
 namespace intel_gpu {


### PR DESCRIPTION
### Details:
 - Missed include for `std::string`
 
### Tickets:
 - *ticket-id*
