### PR TITLE
[DOCS] Torch.compile() image fix for 23.1

### DIFF
--- a/docs/_static/images/torch_compile_backend_openvino.svg
+++ b/docs/_static/images/torch_compile_backend_openvino.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e26fe889ada0e02a3bbc03e451a7e1d4b06037723349971efff1d721b5e13f6
-size 117253
+oid sha256:7c5ba73be918d2105b54e2afe36aa99e8fc5313489afc08f1a92ff75580667ba
+size 173373

--- a/docs/_static/images/torch_compile_backend_openvino_ts.svg
+++ b/docs/_static/images/torch_compile_backend_openvino_ts.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c5ba73be918d2105b54e2afe36aa99e8fc5313489afc08f1a92ff75580667ba
-size 173373
+oid sha256:0e26fe889ada0e02a3bbc03e451a7e1d4b06037723349971efff1d721b5e13f6
+size 117253


### PR DESCRIPTION
Port from https://github.com/openvinotoolkit/openvino/pull/19699

Image fix for torch.compile documentation as mentioned in https://github.com/openvinotoolkit/openvino/pull/19540#pullrequestreview-1617354770
