### PR TITLE
[GPU] Fix GatherND shape agnostic ref kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_ref.cpp
@@ -119,7 +119,7 @@ JitConstants GatherNDKernelRef::GetJitConstants(const gather_nd_params& params) 
     jit.AddConstant(MakeJitConstant("INDICES_RANK", params.indices_rank));
     jit.AddConstant(MakeJitConstant("BATCH_DIMS", params.batch_dims));
     jit.AddConstant(MakeJitConstant("BATCH_MERGED_OUTPUT", params.batch_merged_output));
-    jit.AddConstant(MakeJitConstant("WI_SLICE_SIZE_STATIC", GetSliceSize(params)));
+    jit.AddConstant(MakeJitConstant("WI_SLICE_SIZE", GetSliceSize(params)));
     jit.AddConstant(MakeJitConstant("INDICES_LAST_DIM", GetIndicesLastDim(params)));
 
     if (!params.fused_ops.empty()) {

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/gather_nd.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/gather_nd.cpp
@@ -132,6 +132,11 @@ const std::vector<GatherNDShapeParams> dynamicInputShapeConstTargetShape = {
         1
     },
     {
+        ov::test::InputShape(ov::PartialShape({-1, -1}), {{10, 14}}),
+        ov::test::InputShape(ov::PartialShape({}), {{3, 2}}),
+        0
+    },
+    {
         ov::test::InputShape(ov::PartialShape({-1, -1, -1}), {{2, 3, 4}, {3, 4, 5}}),
         ov::test::InputShape(ov::PartialShape({}), {{2, 1}}),
         0


### PR DESCRIPTION
### Details:
 - Fix the case where the calculation of `wi_slice`(the number of output data processed by 1 WI) is incorrect

### Tickets:
 - 116597, 118222
