### PR TITLE
Added python3 vcpkg port dependecies to GHA workflow

### DIFF
--- a/.github/workflows/linux_android_arm64.yml
+++ b/.github/workflows/linux_android_arm64.yml
@@ -93,7 +93,10 @@ jobs:
           
           # vcpkg's tool dependencies
           sudo -E apt --assume-yes install curl zip unzip tar
-          
+
+          # vcpkg 'python3' port dependencies
+          sudo -E apt --assume-yes install autoconf libtool autoconf-archive
+
           # vcpkg tree of dependencies require extra packages
           sudo -E apt --assume-yes install pkg-config linux-libc-dev
           


### PR DESCRIPTION
### Details:
 - Sync with https://github.com/openvinotoolkit/openvino/commit/888d4e96332925c8cfe0528940682d53b7ccde2b
