### PR TITLE
No exception throws when getting version from unregistered plugin

### DIFF
--- a/src/core/src/version.cpp
+++ b/src/core/src/version.cpp
@@ -11,6 +11,12 @@ const char* NGRAPH_VERSION_NUMBER = CI_BUILD_NUMBER;
 using namespace std;
 
 std::ostream& ov::operator<<(std::ostream& s, const Version& version) {
+    if (!version.description) {
+        s << std::endl;
+        s << "    Version : not registered in OpenVINO Runtime" << std::endl;
+        s << "    Build   : not registered in OpenVINO Runtime" << std::endl;
+        return s;
+    }
     s << version.description << std::endl;
     s << "    Version : ";
     s << OPENVINO_VERSION_MAJOR << "." << OPENVINO_VERSION_MINOR << "." << OPENVINO_VERSION_PATCH;
@@ -22,7 +28,10 @@ std::ostream& ov::operator<<(std::ostream& s, const Version& version) {
 
 std::ostream& ov::operator<<(std::ostream& s, const std::map<std::string, Version>& versions) {
     for (auto&& version : versions) {
-        s << version.second << std::endl;
+        if (version.second.description)
+            s << version.second << std::endl;
+        else
+            s << version.first << version.second << std::endl;
     }
     return s;
 }

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -553,7 +553,8 @@ ov::Plugin ov::CoreImpl::get_plugin(const std::string& pluginName) const {
         it = pluginRegistry.find(deviceName);
         if (it == pluginRegistry.end()) {
             if (pluginName == ov::DEFAULT_DEVICE_NAME)
-                OPENVINO_THROW("No device is provided, so AUTO device is used by default, which failed loading.");
+                OPENVINO_THROW("No device is provided, so AUTO device is used by default, which is not registered in "
+                               "the OpenVINO Runtime.");
             else
                 OPENVINO_THROW("Device with \"", deviceName, "\" name is not registered in the OpenVINO Runtime");
         }

--- a/src/inference/tests/functional/ov_register_plugin_test.cpp
+++ b/src/inference/tests/functional/ov_register_plugin_test.cpp
@@ -9,6 +9,7 @@
 #include "openvino/runtime/properties.hpp"
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/shared_object.hpp"
+#include "unit_test_utils/mocks/openvino/runtime/mock_iplugin.hpp"
 
 using namespace ::testing;
 using namespace std;
@@ -32,6 +33,48 @@ inline void mockPlugin(ov::Core& core, std::shared_ptr<ov::IPlugin>& plugin, std
         ov::test::utils::make_std_function<void(ov::IPlugin*)>(m_so, "InjectPlugin");
 
     injectProxyEngine(plugin.get());
+}
+
+TEST(RegisterPluginTests, getVersionforRegisteredPluginThrows) {
+    ov::Core core;
+    auto plugin = std::make_shared<ov::test::utils::MockPlugin>();
+    std::shared_ptr<ov::IPlugin> base_plugin = plugin;
+    std::shared_ptr<void> m_so;
+    mockPlugin(core, base_plugin, m_so);
+    std::string mock_plugin_name{"MOCK_REGISTERED_HARDWARE"};
+    // Registered plugin with invalid so here
+    ASSERT_NO_THROW(core.register_plugin(
+        ov::util::make_plugin_library_name(ov::test::utils::getExecutableDirectory(),
+                                           std::string("mock_registered_engine") + IE_BUILD_POSTFIX),
+        mock_plugin_name));
+    ASSERT_THROW(core.get_versions("MOCK_REGISTERED_HARDWARE"), ov::Exception);
+}
+
+TEST(RegisterPluginTests, getVersionforNoRegisteredPluginNoThrows) {
+    ov::Core core;
+    ASSERT_NO_THROW(core.get_versions("unkown_device"));
+
+    auto plugin = std::make_shared<NiceMock<ov::MockIPlugin>>();
+
+    ON_CALL(*plugin.get(), get_property(ov::supported_properties.name(), _))
+        .WillByDefault(Return(std::vector<ov::PropertyName>{}));
+
+    ON_CALL(*plugin.get(), get_property(ov::internal::supported_properties.name(), _))
+        .WillByDefault(Return(std::vector<ov::PropertyName>{}));
+
+    ON_CALL(*plugin.get(), set_property(_)).WillByDefault(Return());
+
+    std::shared_ptr<ov::IPlugin> base_plugin = plugin;
+    std::shared_ptr<void> m_so;
+    mockPlugin(core, base_plugin, m_so);
+
+    std::string mock_plugin_name{"MOCK_HARDWARE"};
+
+    ASSERT_NO_THROW(
+        core.register_plugin(ov::util::make_plugin_library_name(ov::test::utils::getExecutableDirectory(),
+                                                                std::string("mock_engine") + IE_BUILD_POSTFIX),
+                             mock_plugin_name));
+    ASSERT_NO_THROW(core.get_versions("MOCK_HARDWARE"));
 }
 
 TEST(RegisterPluginTests, registerNewPluginNoThrows) {


### PR DESCRIPTION

### Details:
 -For the valid plugin, return the version if the plugin is already registered
 -For the unregistered plugin, return the prompt message indicating that the plugin is not registered.
 -Throw exception if failed to get version from the registered plugin

### Tickets:
 - 118759
