### PR TITLE
[DOCS] Link fix for PyPI install guide for 23.1

### DIFF
--- a/docs/install_guides/installing-openvino-pip.md
+++ b/docs/install_guides/installing-openvino-pip.md
@@ -22,7 +22,7 @@
 
       | Full requirement listing is available in:
       | `System Requirements Page <https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit/system-requirements.html>`__
-      | 'PyPi OpenVINO page <https://pypi.org/project/openvino/>`__
+      | `PyPi OpenVINO page <https://pypi.org/project/openvino/>`__
    
    
    .. tab-item:: Processor Notes


### PR DESCRIPTION
Port from https://github.com/openvinotoolkit/openvino/pull/19726

Fix for link in PyPI install guide