### PR TITLE
[CPU] Empty tensor used with a custom op leads to CPU plugin exception.

### DIFF
--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -42,6 +42,7 @@
 #include "nodes/executors/executor.hpp"
 
 #define THROW_CPU_NODE_ERR(...) OPENVINO_THROW(getTypeStr(), " node with name '", getName(), "' ", __VA_ARGS__)
+#define CPU_NODE_ASSERT(condition, ...) OPENVINO_ASSERT(condition, getTypeStr(), " node with name '", getName(), "' ", __VA_ARGS__)
 
 namespace ov {
 namespace intel_cpu {

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -123,7 +123,11 @@ ov::TensorVector Reference::prepareOutputs() const {
         void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().getData();
         ov::Shape shape = ovCoreNode->get_output_partial_shape(i).rank().get_length() == 0 ?
                 ov::Shape{} : getChildEdgesAtPort(i)[0]->getMemory().getStaticDims();
-        outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape, dstDataPtr));
+        if (dstDataPtr != nullptr) {
+            outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape, dstDataPtr));
+        } else {
+            outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape));
+        }
     }
     return outputs;
 }

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -116,9 +116,7 @@ ov::TensorVector Reference::prepareInputs() const {
         if (std::any_of(shape.begin(), shape.end(), [](const size_t dim) { return dim == 0lu; } )) {
             inputs.push_back(ov::Tensor(ovCoreNode->get_input_element_type(i), shape));
         } else {
-            if (!srcDataPtr) {
-                THROW_CPU_NODE_ERR("has empty input data on port ", i);
-            }
+            CPU_NODE_ASSERT(srcDataPtr, "has empty input data on port ", i);
             inputs.push_back(ov::Tensor(ovCoreNode->get_input_element_type(i), shape, srcDataPtr));
         }
     }
@@ -135,9 +133,7 @@ ov::TensorVector Reference::prepareOutputs() const {
         if (std::any_of(shape.begin(), shape.end(), [](const size_t dim) { return dim == 0lu; } )) {
             outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape));
         } else {
-            if (!dstDataPtr) {
-                THROW_CPU_NODE_ERR("has empty output data on port ", i);
-            }
+            CPU_NODE_ASSERT(dstDataPtr, "has empty output data on port ", i);
             outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape, dstDataPtr));
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -108,25 +108,37 @@ bool Reference::needShapeInfer() const {
 
 ov::TensorVector Reference::prepareInputs() const {
     ov::TensorVector inputs;
-    for (size_t i = 0; i < inputShapes.size(); i++) {
+    for (size_t i = 0lu; i < inputShapes.size(); i++) {
         void *srcDataPtr = getParentEdgesAtPort(i)[0]->getMemory().getData();
         ov::Shape shape = ovCoreNode->get_input_partial_shape(i).rank().get_length() == 0 ?
                 ov::Shape{} : getParentEdgesAtPort(i)[0]->getMemory().getStaticDims();
-        inputs.push_back(ov::Tensor(ovCoreNode->get_input_element_type(i), shape, srcDataPtr));
+
+        if (std::any_of(shape.begin(), shape.end(), [](const size_t dim) { return dim == 0lu; } )) {
+            inputs.push_back(ov::Tensor(ovCoreNode->get_input_element_type(i), shape));
+        } else {
+            if (!srcDataPtr) {
+                THROW_CPU_NODE_ERR("has empty input data on port ", i);
+            }
+            inputs.push_back(ov::Tensor(ovCoreNode->get_input_element_type(i), shape, srcDataPtr));
+        }
     }
     return inputs;
 }
 
 ov::TensorVector Reference::prepareOutputs() const {
     ov::TensorVector outputs;
-    for (size_t i = 0; i < outputShapes.size(); i++) {
+    for (size_t i = 0lu; i < outputShapes.size(); i++) {
         void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().getData();
         ov::Shape shape = ovCoreNode->get_output_partial_shape(i).rank().get_length() == 0 ?
                 ov::Shape{} : getChildEdgesAtPort(i)[0]->getMemory().getStaticDims();
-        if (dstDataPtr != nullptr) {
-            outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape, dstDataPtr));
-        } else {
+
+        if (std::any_of(shape.begin(), shape.end(), [](const size_t dim) { return dim == 0lu; } )) {
             outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape));
+        } else {
+            if (!dstDataPtr) {
+                THROW_CPU_NODE_ERR("has empty output data on port ", i);
+            }
+            outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape, dstDataPtr));
         }
     }
     return outputs;

--- a/src/plugins/intel_cpu/src/nodes/reference.h
+++ b/src/plugins/intel_cpu/src/nodes/reference.h
@@ -22,6 +22,7 @@ public:
 
     bool needShapeInfer() const override;
     bool needPrepareParams() const override { return false; }
+    bool isExecutable() const override { return true; }
     void executeDynamicImpl(dnnl::stream strm) override;
 
 private:

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/custom_op_scalar.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/custom_op_scalar.cpp
@@ -140,6 +140,7 @@ TEST_P(CustomOpScalarCPUTest, CompareWithRefs) {
 
 const std::vector<InputShape> inputShapes = {
     {{}, {{2, 3, 16}}},
+    {{2, 3, -1}, {{2, 3, 0}}},
     {{}, {{}}}
 };
 


### PR DESCRIPTION
### Details:
 - *Reference node was not executed if one of input tensor was empty.*

### Tickets:
 - *113021*
