### PR TITLE
[GPU] Do not use usm_host memory buffers for PVC as a device inputs

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -28,6 +28,19 @@
 
 namespace {
 
+inline bool can_use_usm_host(const cldnn::engine& engine) {
+    auto can_use_usm = engine.use_unified_shared_memory();
+
+    // WA: Disable USM host memory for infer request`s tensors for PVC as
+    // it has performance issues in case of host <-> device data transfers inside kernels
+    // Use unsupported SIMD8 as unique attribute of PVC
+    auto supported_simd_sizes = engine.get_device_info().supported_simd_sizes;
+    if (std::find(supported_simd_sizes.begin(), supported_simd_sizes.end(), 8) == supported_simd_sizes.end())
+        can_use_usm = false;
+
+    return can_use_usm;
+}
+
 inline std::string get_port_name(const ov::Output<const ov::Node>& port, const bool is_legacy_api) {
     std::string name;
     // TODO: Should use tensor name as the port name, but many legacy tests still use legacy name
@@ -480,6 +493,10 @@ std::shared_ptr<ov::ITensor> SyncInferRequest::create_device_tensor(const ov::Sh
         tensor_type = TensorType::BT_BUF_INTERNAL;
     }
 
+    // Create OpenCL buffer for PVC if lockable memory is needed due to performance issue with usm host
+    if (!can_use_usm_host(m_graph->get_engine()) && need_lockable_memory)
+        tensor_type = TensorType::BT_BUF_INTERNAL;
+
     // Currently, clDeviceMemAllocINTEL returns memory address allocated to other input blob if the current blob is empty
     // W/A for this issue:
     // Allocate with non-empty shape and then reinterprete with original shape
@@ -512,7 +529,9 @@ TensorWrapper SyncInferRequest::create_or_share_device_tensor(const TensorWrappe
     auto input_ptr = user_tensor->data();
     const auto alloc_type = m_graph->get_engine().detect_usm_allocation_type(input_ptr);
     const auto is_usm_host = alloc_type == cldnn::allocation_type::usm_host;
-    bool can_share = is_usm_host && !is_convert_required(user_tensor->get_element_type(), element_type);
+    bool can_share = is_usm_host &&
+                     !is_convert_required(user_tensor->get_element_type(), element_type) &&
+                     can_use_usm_host(m_graph->get_engine());
 
     if (can_share) {
         // For USM case we create host blob using custom USM host allocator


### PR DESCRIPTION
### Details:
 - This PR prohibits usm_host memory buffers usage as a device inputs since sometimes it causes significant perf degradations 
 
### Tickets:
 - 121649
