### PR TITLE
[GPU] Fixed static init order for serialization

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/binary_buffer.hpp
@@ -104,12 +104,10 @@ public:
 
 #define ASSIGN_TYPE_NAME(cls_name) \
             namespace cldnn {                            \
-            const std::string cls_name::type_for_serialization = #cls_name; \
             }
 
 #define BIND_BINARY_BUFFER_WITH_TYPE(cls_name) \
             namespace cldnn {                            \
-            const std::string cls_name::type_for_serialization = #cls_name; \
             BIND_TO_BUFFER(BinaryOutputBuffer, cls_name) \
             BIND_TO_BUFFER(BinaryInputBuffer, cls_name)  \
             }

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/polymorphic_serializer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/polymorphic_serializer.hpp
@@ -18,7 +18,7 @@ template <typename BufferType, typename T>
 class Serializer<BufferType, std::unique_ptr<T>, typename std::enable_if<std::is_base_of<OutputBuffer<BufferType>, BufferType>::value>::type> {
 public:
     static void save(BufferType& buffer, const std::unique_ptr<T>& ptr) {
-        const auto& type = ptr->get_type();
+        const auto& type = ptr->get_type_info();
         buffer << type;
         const auto save_func = saver_storage<BufferType>::instance().get_save_function(type);
         save_func(buffer, ptr.get());
@@ -51,7 +51,7 @@ template <typename BufferType, typename T>
 class Serializer<BufferType, std::shared_ptr<T>, typename std::enable_if<std::is_base_of<OutputBuffer<BufferType>, BufferType>::value>::type> {
 public:
     static void save(BufferType& buffer, const std::shared_ptr<T>& ptr) {
-        const std::string& type = ptr->get_type();
+        const std::string& type = ptr->get_type_info();
         buffer << type;
         if (type.compare("NONE") != 0) {
             const auto save_func = saver_storage<BufferType>::instance().get_save_function(type);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/activation.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/activation.hpp
@@ -82,8 +82,6 @@ struct activation : public primitive_base<activation> {
                    activation_function(activation_func::none),
                    additional_params({0.f, 0.f}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs Relu primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
@@ -20,8 +20,6 @@ struct adaptive_pooling : public primitive_base<adaptive_pooling> {
                          mode{adaptive_pooling_mode::average},
                          output_size{} {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs AdaptiveAvgPooling primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/arg_max_min.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/arg_max_min.hpp
@@ -27,8 +27,6 @@ struct arg_max_min : public primitive_base<arg_max_min> {
                     values_first(false),
                     stable(false) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs arg_max_min primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/assign.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/assign.hpp
@@ -17,8 +17,6 @@ struct assign : public primitive_base<assign> {
 
     assign() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs Assign primitive.
     /// @param id This primitive id
     /// @param inputs Input parameters ids

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/batch_to_space.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/batch_to_space.hpp
@@ -42,8 +42,6 @@ struct batch_to_space : public primitive_base<batch_to_space> {
 
     batch_to_space() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs batch_to_space primitive.
     /// @param id This primitive id.
     /// @param input Input data primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/binary_convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/binary_convolution.hpp
@@ -16,8 +16,6 @@ struct binary_convolution : public primitive_base<binary_convolution> {
 
     binary_convolution() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs binary_convolution primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/border.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/border.hpp
@@ -26,8 +26,6 @@ struct border : public primitive_base<border> {
 
     border() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief whether the input is const or not
     enum PAD_NON_CONST_INPUT {
         BEGIN = 0x1,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/broadcast.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/broadcast.hpp
@@ -56,8 +56,6 @@ struct broadcast : public primitive_base<broadcast> {
 
     broadcast() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs broadcast primitive / layer.
     ///
     /// @param id              An identifier of new primitive.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/bucketize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/bucketize.hpp
@@ -13,8 +13,6 @@ struct bucketize : primitive_base<bucketize> {
 
     bucketize() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs bucketize primitive.
     /// @param id This primitive id.
     /// @param inputs Input primitives ids.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/concatenation.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/concatenation.hpp
@@ -35,8 +35,6 @@ struct concatenation : public primitive_base<concatenation> {
 
     concatenation() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @li Constructs concatenation primitive.
     /// @param id This primitive id.
     /// @param input Vector of input primitives ids.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convert_color.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convert_color.hpp
@@ -14,8 +14,6 @@ struct convert_color : public primitive_base<convert_color> {
 
     convert_color() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     enum color_format : uint32_t {
         RGB,       ///< RGB color format
         BGR,       ///< BGR color format, default in OpenVINO

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
@@ -15,8 +15,6 @@ struct convolution : public primitive_base<convolution> {
 
     convolution() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs convolution primitive
     /// @param id This primitive id.
     /// @param input Input primitive id.
@@ -313,8 +311,6 @@ struct deformable_interp : public primitive_base<deformable_interp> {
 
     deformable_interp() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     deformable_interp(const primitive_id& id,
                       const std::vector<input_info>& inputs,
                       uint32_t groups,
@@ -429,8 +425,6 @@ struct deformable_conv : public primitive_base<deformable_conv> {
     CLDNN_DECLARE_PRIMITIVE(deformable_conv)
 
     deformable_conv() : primitive_base("", {}) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     deformable_conv(const primitive_id& id,
                     const input_info& input,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/crop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/crop.hpp
@@ -46,8 +46,6 @@ struct crop : public primitive_base<crop> {
 
     crop() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs crop primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/ctc_greedy_decoder.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/ctc_greedy_decoder.hpp
@@ -13,8 +13,6 @@ struct ctc_greedy_decoder : public primitive_base<ctc_greedy_decoder> {
 
     ctc_greedy_decoder() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs ctc_greedy_decoder primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id (input, sequence_indicators, second_output(optional)).

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/ctc_loss.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/ctc_loss.hpp
@@ -15,8 +15,6 @@ struct ctc_loss : primitive_base<ctc_loss> {
 
     ctc_loss() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs ctc_loss primitive.
     /// @param id This primitive id.
     /// @param inputs Input primitives ids.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/cum_sum.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/cum_sum.hpp
@@ -6,14 +6,10 @@
 #include "primitive.hpp"
 
 namespace cldnn {
-
-
 struct cum_sum : public primitive_base<cum_sum> {
     CLDNN_DECLARE_PRIMITIVE(cum_sum)
 
     cum_sum() : primitive_base("", {}) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     /// @brief Constructs cum_sum primitive.
     /// @param id This primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
@@ -18,8 +18,6 @@ struct custom_gpu_primitive : public primitive_base<custom_gpu_primitive> {
 
     custom_gpu_primitive() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Custom primitive kernel argument type
     enum arg_type {
         arg_input,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -17,8 +17,6 @@ struct data : public primitive_base<data> {
 
     data() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs data primitive.
     /// @param id This primitive id.
     /// @param mem @ref memory object which contains data.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
@@ -20,8 +20,6 @@ struct deconvolution : public primitive_base<deconvolution> {
 
     deconvolution() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs deconvolution primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/depth_to_space.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/depth_to_space.hpp
@@ -22,8 +22,6 @@ struct depth_to_space : public primitive_base<depth_to_space> {
 
     depth_to_space() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs depth_to_space primitive.
     /// @param id This primitive id.
     /// @param input Input dictionary primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/detection_output.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/detection_output.hpp
@@ -42,8 +42,6 @@ struct detection_output : public primitive_base<detection_output> {
           clip_after_nms(false),
           objectness_score(0.0f) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs detection output primitive.
     /// @param id This primitive id.
     /// @param inputs Inputs for primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/dft.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/dft.hpp
@@ -29,8 +29,6 @@ struct dft : public primitive_base<dft> {
 
     dft() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs DFT primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/eltwise.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/eltwise.hpp
@@ -71,8 +71,6 @@ struct eltwise : public primitive_base<eltwise> {
 
     eltwise() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs eltwise primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/embedding_bag.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/embedding_bag.hpp
@@ -14,8 +14,6 @@ struct embedding_bag : public primitive_base<embedding_bag> {
 
     embedding_bag() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Select type of embedding_bag operation
     enum embedding_bag_type {
         packed_sum,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
@@ -16,8 +16,6 @@ struct experimental_detectron_detection_output : public primitive_base<experimen
 
     experimental_detectron_detection_output() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs experimental_detectron_detection_output primitive
     /// @param id This primitive id
     /// @param input_rois input rois

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
@@ -15,8 +15,6 @@ struct experimental_detectron_generate_proposals_single_image
 
     experimental_detectron_generate_proposals_single_image() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs experimental_detectron_generate_proposals_single_image primitive
     /// @param id This primitive id
     /// @param input_im_info image size info

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_prior_grid_generator.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_prior_grid_generator.hpp
@@ -8,16 +8,12 @@
 
 namespace cldnn {
 
-
-
 /// @brief Constructs experimental_detectron_prior_grid_generator primitive.
 struct experimental_detectron_prior_grid_generator
     : public primitive_base<experimental_detectron_prior_grid_generator> {
     CLDNN_DECLARE_PRIMITIVE(experimental_detectron_prior_grid_generator)
 
     experimental_detectron_prior_grid_generator() : primitive_base("", {}) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     experimental_detectron_prior_grid_generator(const primitive_id& id,
                                                 const std::vector<input_info>& inputs,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_roi_feature_extractor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_roi_feature_extractor.hpp
@@ -14,8 +14,6 @@ struct experimental_detectron_roi_feature_extractor : public primitive_base<expe
 
     experimental_detectron_roi_feature_extractor() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs experimental_detectron_roi_feature_extractor primitive
     /// @param id This primitive id
     /// @param inputs Inputs for primitive id (ROIs, {pyramid levels, ...}, second_output)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_topk_rois.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_topk_rois.hpp
@@ -10,16 +10,12 @@
 
 namespace cldnn {
 
-
-
 /// @brief ExperimentalDetectronTopKROIs-6 primitive
 /// @details
 struct experimental_detectron_topk_rois : public primitive_base<experimental_detectron_topk_rois> {
     CLDNN_DECLARE_PRIMITIVE(experimental_detectron_topk_rois)
 
     experimental_detectron_topk_rois() : primitive_base("", {}) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     /**
      * Construct ExperimentalDetectronTopKROIs privitive.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/extract_image_patches.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/extract_image_patches.hpp
@@ -23,8 +23,6 @@ struct extract_image_patches : public primitive_base<extract_image_patches> {
 
     extract_image_patches() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs select primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id containing input 4-D tensor.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/eye.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/eye.hpp
@@ -14,8 +14,6 @@ struct eye : public primitive_base<eye> {
 
     eye() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs eye primitive.
     /// @param id This primitive id.
     /// @param inputs List of primitive ids.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -35,8 +35,6 @@ struct fully_connected : public primitive_base<fully_connected> {
 
     fully_connected() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs fully connected layer.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
@@ -16,8 +16,6 @@ struct gather : public primitive_base<gather> {
 
     gather() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs gather primitive.
     /// @param id This primitive id.
     /// @param dict Input dictionary primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_elements.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_elements.hpp
@@ -14,8 +14,6 @@ struct gather_elements : public primitive_base<gather_elements> {
 
     gather_elements() : primitive_base("", {}), output_format({}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs gather_elements primitive.
     /// @param id This primitive id.
     /// @param data Input data primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_nd.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_nd.hpp
@@ -14,8 +14,6 @@ struct gather_nd : public primitive_base<gather_nd> {
 
     gather_nd() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs gather_nd primitive.
     ///
     /// @param id                   This primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_tree.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_tree.hpp
@@ -15,8 +15,6 @@ struct gather_tree : public primitive_base<gather_tree> {
 
     gather_tree() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs gather tree primitive / layer.
     ///
     /// @param id                      An identifier of new primitive.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
@@ -27,8 +27,6 @@ struct gemm : public primitive_base<gemm> {
 
     gemm() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs gemm layer.
     /// @brief Primitive id containing first matrix
     /// @brief Primitive id containing second matrix

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/generate_proposals.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/generate_proposals.hpp
@@ -15,8 +15,6 @@ struct generate_proposals
 
     generate_proposals() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs generate_proposals primitive
     /// @param id This primitive id
     /// @param input_im_info image size info

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/grid_sample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/grid_sample.hpp
@@ -10,8 +10,6 @@
 #include "primitive.hpp"
 
 namespace cldnn {
-
-
 using GridSampleOp = ov::op::v9::GridSample;
 
 /// @brief GridSample-9 primitive.
@@ -19,8 +17,6 @@ struct grid_sample : primitive_base<grid_sample> {
     CLDNN_DECLARE_PRIMITIVE(grid_sample)
 
     grid_sample() : primitive_base("", {}) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     /// @brief Constructs grid_sample primitive.
     /// @param id This primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/grn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/grn.hpp
@@ -13,8 +13,6 @@ struct grn : public primitive_base<grn> {
 
     grn() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs grn primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/input_layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/input_layout.hpp
@@ -20,8 +20,6 @@ struct input_layout : public primitive_base<input_layout> {
 
     input_layout() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs input layout primitive.
     /// @param id This primitive id.
     /// @param layout Defines layout for the data will be passed to network.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
@@ -55,8 +55,6 @@ struct loop : public primitive_base<loop> {
     loop() : primitive_base("", {}),
              max_iteration(0) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     struct io_primitive_map {
         /// @brief Constructs a mapping from external input/output primitive to input/output primitive in body topology
         ///

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lrn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lrn.hpp
@@ -6,8 +6,6 @@
 #include "primitive.hpp"
 
 namespace cldnn {
-
-
 typedef enum { /*:int32_t*/
     lrn_norm_region_across_channel,
     lrn_norm_region_within_channel
@@ -28,8 +26,6 @@ struct lrn : public primitive_base<lrn> {
     CLDNN_DECLARE_PRIMITIVE(lrn)
 
     lrn() : primitive_base("", {}) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     /// @brief Constructs LRN primitive.
     /// @param id This primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm.hpp
@@ -53,8 +53,6 @@ struct lstm : public primitive_base<lstm> {
 
     lstm() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs lstm layer.
     /// @param id This primitive id.
     /// @param input Vector of primitive id.
@@ -230,8 +228,6 @@ struct lstm_gemm : public primitive_base<lstm_gemm> {
     lstm_gemm() : primitive_base("", {}),
                   direction(0) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs lstm layer.
     /// @param id This primitive id.
     /// @param input input primitive id.
@@ -318,8 +314,6 @@ struct lstm_elt : public primitive_base<lstm_elt> {
     CLDNN_DECLARE_PRIMITIVE(lstm_elt)
 
     lstm_elt() : primitive_base("", {}), clip(0), input_forget(0), offset_order(lstm_weights_order::iofz), direction(0) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     using vec_activation = std::vector<activation_func>;
     using vec_activation_param = std::vector<activation_additional_params>;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic.hpp
@@ -22,8 +22,6 @@ struct lstm_dynamic : public primitive_base<lstm_dynamic> {
 
     lstm_dynamic() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs lstm_dynamic layer.
     /// @param id This primitive id.
     /// @param input Primitive id of input layer.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic_input.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic_input.hpp
@@ -22,8 +22,6 @@ struct lstm_dynamic_input : public primitive_base<lstm_dynamic_input> {
 
     lstm_dynamic_input() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs lstm_dynamic layer.
     /// @param id This primitive id.
     /// @param input Primitive id of input layer.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic_timeloop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic_timeloop.hpp
@@ -23,8 +23,6 @@ struct lstm_dynamic_timeloop
 
     lstm_dynamic_timeloop() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs lstm_dynamic layer.
     /// @param id This primitive id.
     /// @param input Primitive id of input layer.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/matrix_nms.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/matrix_nms.hpp
@@ -16,8 +16,6 @@ struct matrix_nms : public primitive_base<matrix_nms> {
 
     matrix_nms() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     enum decay_function { gaussian, linear };
 
     enum sort_result_type {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/multiclass_nms.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/multiclass_nms.hpp
@@ -19,8 +19,6 @@ struct multiclass_nms : public primitive_base<multiclass_nms> {
 
     multiclass_nms() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     enum class sort_result_type : int32_t {
         classid,  // sort selected boxes by class id (ascending) in each batch element
         score,    // sort selected boxes by score (descending) in each batch element

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/mutable_data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/mutable_data.hpp
@@ -18,8 +18,6 @@ struct mutable_data : public primitive_base<mutable_data> {
 
     mutable_data() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Enum type to specify function for data filling.
     enum filler_type { no_fill, zero, one, xavier };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/mvn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/mvn.hpp
@@ -14,8 +14,6 @@ struct mvn : public primitive_base<mvn> {
 
     mvn() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs mvn primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
@@ -22,8 +22,6 @@ struct non_max_suppression : public primitive_base<non_max_suppression> {
                             center_point_box(false),
                             sort_result_descending(false) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Creates non max suppression primitive.
     /// @param id This primitive id.
     /// @param boxes_positions Id of primitive with bounding boxes.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/non_zero.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/non_zero.hpp
@@ -13,8 +13,6 @@ struct count_nonzero : public primitive_base<count_nonzero> {
 
     count_nonzero() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs count_nonzero primitive.
     /// @param id This primitive id.
     /// @param data Input data primitive id.
@@ -32,8 +30,6 @@ struct gather_nonzero : public primitive_base<gather_nonzero> {
     CLDNN_DECLARE_PRIMITIVE(gather_nonzero)
 
     gather_nonzero() : primitive_base("", {}) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     /// @brief Constructs gather_nonzero primitive.
     /// @param id This primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/normalize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/normalize.hpp
@@ -29,8 +29,6 @@ struct normalize : public primitive_base<normalize> {
 
     normalize() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs normalize primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/one_hot.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/one_hot.hpp
@@ -35,8 +35,6 @@ struct one_hot : public primitive_base<one_hot> {
 
     one_hot() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs one-hot primitive layer.
     /// @param id              An identifier of new primitive.
     /// @param input           An identifier of primitive which is an input for newly created one-hot primitive.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/permute.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/permute.hpp
@@ -21,8 +21,6 @@ struct permute : public primitive_base<permute> {
 
     permute() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs permute primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
@@ -34,8 +34,6 @@ struct pooling : public primitive_base<pooling> {
 
     pooling() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs pooling primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
@@ -203,7 +203,7 @@ public:
 
     size_t num_outputs;
 
-    virtual std::string get_type() const { return "NONE"; }
+    virtual const std::string& get_type_info() const = 0;
     virtual void save(BinaryOutputBuffer& ob) const {
         ob << type_string();
         ob << id;
@@ -313,6 +313,7 @@ struct primitive_info {
     }
 
 #define CLDNN_DECLARE_PRIMITIVE(PType)       \
+    DECLARE_OBJECT_TYPE_SERIALIZATION(PType) \
     CLDNN_DEFINE_TYPE_ID(PType)              \
     CLDNN_DEFINE_TYPE_STRING(PType)
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/prior_box.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/prior_box.hpp
@@ -23,8 +23,6 @@ struct prior_box : public primitive_base<prior_box> {
 
     prior_box() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     using PriorBoxV0Op = ov::op::v0::PriorBox;
     using PriorBoxV8Op = ov::op::v8::PriorBox;
     using PriorBoxClusteredOp = ov::op::v0::PriorBoxClustered;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/proposal.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/proposal.hpp
@@ -10,8 +10,6 @@
 #include "intel_gpu/graph/serialization/vector_serializer.hpp"
 
 namespace cldnn {
-
-
 #define CLDNN_ROI_VECTOR_SIZE 5
 
 struct proposal : public primitive_base<proposal> {
@@ -36,8 +34,6 @@ struct proposal : public primitive_base<proposal> {
                  round_ratios(true),
                  shift_anchors(false),
                  normalize(false) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     proposal(const primitive_id& id,
              const input_info& cls_scores,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/pyramid_roi_align.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/pyramid_roi_align.hpp
@@ -26,8 +26,6 @@ struct pyramid_roi_align : public primitive_base<pyramid_roi_align> {
 
     pyramid_roi_align() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @param id This primitive id.
     /// @param rois Input RoI boxes as tuple [x1, y1, x2, y2] describing two opposite corners of the region.
     /// @param P2 First level of the image pyramid.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/quantize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/quantize.hpp
@@ -38,8 +38,6 @@ struct quantize : public primitive_base<quantize> {
 
     quantize() : primitive_base("", {}), levels(0) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief levels The number of quantization levels.
     int levels;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/random_uniform.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/random_uniform.hpp
@@ -10,8 +10,6 @@
 
 namespace cldnn {
 
-
-
 /// @brief RandomUniform-8 primitive
 /// @details
 struct random_uniform : public primitive_base<random_uniform> {
@@ -21,8 +19,6 @@ struct random_uniform : public primitive_base<random_uniform> {
                        global_seed(0),
                        op_seed(0),
                        output_shape{} {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     /**
      * Construct Random Uniform privitive.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/range.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/range.hpp
@@ -12,8 +12,6 @@ struct range: public primitive_base<range> {
 
     range() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs range primitive.
     /// @param id This primitive id.
     /// @param inputs Input primitive id vector.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/read_value.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/read_value.hpp
@@ -17,8 +17,6 @@ struct read_value : public primitive_base<read_value> {
 
     read_value() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs ReadValue primitive.
     /// @param id This primitive id
     /// @param inputs Input parameters ids

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reduce.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reduce.hpp
@@ -44,8 +44,6 @@ struct reduce : public primitive_base<reduce> {
 
     reduce() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs reduce primitive
     /// @param id This primitive id
     /// @param input Input primitive id

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/region_yolo.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/region_yolo.hpp
@@ -16,8 +16,6 @@ struct region_yolo : public primitive_base<region_yolo> {
 
     region_yolo() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs region_yolo primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reorder.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reorder.hpp
@@ -69,8 +69,6 @@ struct reorder : public primitive_base<reorder> {
                 output_format(format::any),
                 mean_mode(reorder_mean_mode::subtract) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief reorder memory types
     enum class memory_type {
         buffer,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reorg_yolo.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reorg_yolo.hpp
@@ -16,8 +16,6 @@ struct reorg_yolo : public primitive_base<reorg_yolo> {
 
     reorg_yolo() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs region_yolo primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -17,8 +17,6 @@ struct resample : public primitive_base<resample> {
 
     resample() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     using InterpolateOp = ov::op::util::InterpolateBase;
 
     /// @brief Constructs Resample primitive.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reshape.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reshape.hpp
@@ -17,8 +17,6 @@ struct reshape : public primitive_base<reshape> {
 
     reshape() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     enum reshape_mode : uint32_t {
         base,
         squeeze,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reverse.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reverse.hpp
@@ -15,8 +15,6 @@ struct reverse : public primitive_base<reverse> {
 
     reverse() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs reverse primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reverse_sequence.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reverse_sequence.hpp
@@ -15,8 +15,6 @@ struct reverse_sequence : public primitive_base<reverse_sequence> {
 
     reverse_sequence() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs reverse_sequence primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_align.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_align.hpp
@@ -15,8 +15,6 @@ struct roi_align : public primitive_base<roi_align> {
 
     roi_align() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Pooling mode for the @ref roi_align
     enum PoolingMode { max, avg };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_pooling.hpp
@@ -8,8 +8,6 @@
 #include <vector>
 
 namespace cldnn {
-
-
 struct roi_pooling : public primitive_base<roi_pooling> {
     CLDNN_DECLARE_PRIMITIVE(roi_pooling)
 
@@ -26,8 +24,6 @@ struct roi_pooling : public primitive_base<roi_pooling> {
                     group_size(0),
                     spatial_bins_x(1),
                     spatial_bins_y(1) {}
-
-    DECLARE_OBJECT_TYPE_SERIALIZATION
 
     roi_pooling(const primitive_id& id,
                 const input_info& input_data,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roll.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roll.hpp
@@ -15,8 +15,6 @@ struct roll : primitive_base<roll> {
 
     roll() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs roll primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_elements_update.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_elements_update.hpp
@@ -14,8 +14,6 @@ struct scatter_elements_update : public primitive_base<scatter_elements_update> 
 
     scatter_elements_update() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs scatter_elements_update primitive.
     /// @param id This primitive id.
     /// @param dict Input data primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_nd_update.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_nd_update.hpp
@@ -14,8 +14,6 @@ struct scatter_nd_update : public primitive_base<scatter_nd_update> {
 
     scatter_nd_update() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs scatter_nd_update primitive.
     /// @param id This primitive id.
     /// @param dict Input data primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_update.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_update.hpp
@@ -14,8 +14,6 @@ struct scatter_update : public primitive_base<scatter_update> {
 
     scatter_update() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     enum scatter_update_axis {
         along_b,
         along_f,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/select.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/select.hpp
@@ -22,8 +22,6 @@ struct select : public primitive_base<select> {
 
     select() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs select primitive.
     /// @param id This primitive id.
     /// @param mask Input primitive id with values needed for select computation.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/shape_of.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/shape_of.hpp
@@ -14,8 +14,6 @@ struct shape_of : public primitive_base<shape_of> {
 
     shape_of() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs shape_of primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/shuffle_channels.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/shuffle_channels.hpp
@@ -15,8 +15,6 @@ struct shuffle_channels : public primitive_base<shuffle_channels> {
 
     shuffle_channels() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs shuffle_channels primitive.
     /// @param id This primitive id.
     /// @param input Input dictionary primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/slice.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/slice.hpp
@@ -14,8 +14,6 @@ struct slice : public primitive_base<slice> {
 
     slice() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs slice primitive.
     /// @param id This primitive id.
     /// @param inputs List of primitive ids.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/softmax.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/softmax.hpp
@@ -20,8 +20,6 @@ struct softmax : public primitive_base<softmax> {
 
     softmax() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs softmax primitive.
     /// @param id This primitive id.
     /// @param input Input primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/space_to_batch.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/space_to_batch.hpp
@@ -38,8 +38,6 @@ struct space_to_batch : public primitive_base<space_to_batch> {
 
     space_to_batch() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs space_to_batch primitive.
     /// @param id This primitive id.
     /// @param input Input data primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/space_to_depth.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/space_to_depth.hpp
@@ -44,8 +44,6 @@ struct space_to_depth : public primitive_base<space_to_depth> {
 
     space_to_depth() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     enum depth_mode {
         depth_first,
         blocks_first

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/strided_slice.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/strided_slice.hpp
@@ -16,8 +16,6 @@ struct strided_slice : public primitive_base<strided_slice> {
 
     strided_slice() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs strided_slice primitive.
     /// @param id This primitive id.
     /// @param input Input data primitive id.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/tile.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/tile.hpp
@@ -14,8 +14,6 @@ struct tile : public primitive_base<tile> {
 
     tile() : primitive_base("", {}) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
-
     /// @brief Constructs tile primitive with static input.
     /// @param id This primitive id.
     /// @param repeats Per-dimension replication factor.

--- a/src/plugins/intel_gpu/src/graph/impls/common/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/condition.cpp
@@ -13,7 +13,7 @@ namespace cldnn {
 namespace common {
 
 struct condition_impl : typed_primitive_impl<condition> {
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::common::condition_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<condition_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
@@ -16,7 +16,7 @@ struct loop_impl : typed_primitive_impl<loop> {
     using parent = typed_primitive_impl<loop>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::common::loop_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<loop_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/common/wait_for_events.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/wait_for_events.cpp
@@ -23,7 +23,7 @@ public:
 
     wait_for_events_impl() : primitive_impl() {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::common::wait_for_events_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<wait_for_events_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/activation.cpp
@@ -58,7 +58,7 @@ struct activation_impl : public typed_primitive_impl<activation> {
 
     std::shared_ptr<ov::op::Op> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::activation_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<activation_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/assign.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/assign.cpp
@@ -16,7 +16,7 @@ struct assign_impl : public typed_primitive_impl<assign> {
 
     std::string variable_id;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::assign_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<assign_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/broadcast.cpp
@@ -23,7 +23,7 @@ struct broadcast_impl : public typed_primitive_impl<broadcast> {
 
     std::shared_ptr<ov::op::v3::Broadcast> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::broadcast_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<broadcast_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/concat.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/concat.cpp
@@ -21,7 +21,7 @@ struct concatenation_impl : public typed_primitive_impl<concatenation> {
 
     std::shared_ptr<ov::op::v0::Concat> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::concatenation_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<concatenation_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/crop.cpp
@@ -21,7 +21,7 @@ struct crop_impl : public typed_primitive_impl<crop> {
 
     std::shared_ptr<ov::op::Op> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::crop_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<crop_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
@@ -43,7 +43,7 @@ public:
     enum NMSType {CAFFE, MXNET};
     NMSType nms_type = NMSType::CAFFE;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::detection_output_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<detection_output_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/eltwise.cpp
@@ -44,7 +44,7 @@ struct eltwise_impl : public typed_primitive_impl<eltwise> {
 
     std::shared_ptr<ov::op::Op> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::eltwise_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<eltwise_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/gather.cpp
@@ -22,7 +22,7 @@ struct gather_impl : public typed_primitive_impl<gather> {
 
     std::shared_ptr<ov::op::v8::Gather> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::gather_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<gather_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/non_max_suppression.cpp
@@ -394,7 +394,7 @@ void run(non_max_suppression_inst& instance) {
 struct non_max_suppression_impl : typed_primitive_impl<non_max_suppression> {
     using parent = typed_primitive_impl<non_max_suppression>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::non_max_suppression_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<non_max_suppression_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/proposal.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/proposal.cpp
@@ -191,7 +191,7 @@ struct proposal_impl : typed_primitive_impl<proposal> {
 
     explicit proposal_impl(const proposal_node& arg) {}
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::proposal_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<proposal_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/range.cpp
@@ -19,7 +19,7 @@ struct range_impl : public typed_primitive_impl<range> {
 
     std::shared_ptr<ov::op::v4::Range> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::range_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<range_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
@@ -16,7 +16,7 @@ struct read_value_impl : public typed_primitive_impl<read_value> {
 
     std::string variable_id;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::read_value_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<read_value_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/reorder.cpp
@@ -19,7 +19,7 @@ struct reorder_impl : public typed_primitive_impl<reorder> {
 
     std::shared_ptr<ov::op::v0::Convert> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::reorder_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<reorder_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/scatter_update.cpp
@@ -21,7 +21,7 @@ struct scatter_update_impl : public typed_primitive_impl<scatter_update> {
 
     std::shared_ptr<ov::op::v3::ScatterUpdate> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::scatter_update_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<scatter_update_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/shape_of.cpp
@@ -20,7 +20,7 @@ struct shape_of_impl : public typed_primitive_impl<shape_of> {
     std::string variable_id;
     bool calculated = false;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::shape_of_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<shape_of_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
@@ -29,7 +29,7 @@ struct strided_slice_impl : public typed_primitive_impl<strided_slice> {
 
     std::shared_ptr<ov::op::v1::StridedSlice> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::strided_slice_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<strided_slice_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/tile.cpp
@@ -21,7 +21,7 @@ struct tile_impl : public typed_primitive_impl<tile> {
 
     std::shared_ptr<ov::op::v0::Tile> op;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::cpu::tile_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<tile_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -25,7 +25,7 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
     using kernel_selector_t = kernel_selector::activation_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::activation_params, kernel_selector::activation_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::activation_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<activation_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -16,7 +16,7 @@ struct adaptive_pooling_impl : public typed_primitive_impl_ocl<adaptive_pooling>
     using kernel_selector_t = kernel_selector::adaptive_pooling_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::adaptive_pooling_params, kernel_selector::adaptive_pooling_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::adaptive_pooling_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<adaptive_pooling_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -39,7 +39,7 @@ struct arg_max_min_impl : typed_primitive_impl_ocl<arg_max_min> {
     using kernel_selector_t = kernel_selector::arg_max_min_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::arg_max_min_params, kernel_selector::arg_max_min_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::arg_max_min_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<arg_max_min_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
@@ -15,7 +15,7 @@ struct batch_to_space_impl : typed_primitive_impl_ocl<batch_to_space> {
     using kernel_selector_t = kernel_selector::batch_to_space_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::batch_to_space_params, kernel_selector::batch_to_space_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::batch_to_space_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<batch_to_space_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
@@ -17,7 +17,7 @@ struct binary_convolution_impl : typed_primitive_impl_ocl<binary_convolution> {
     using kernel_selector_t = kernel_selector::binary_convolution_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::binary_convolution_params, kernel_selector::binary_convolution_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::binary_convolution_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<binary_convolution_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
@@ -18,7 +18,7 @@ struct border_impl : typed_primitive_impl_ocl<border> {
     using kernel_selector_t = kernel_selector::border_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::border_params, kernel_selector::border_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::border_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<border_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -17,7 +17,7 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
     using kernel_selector_t = kernel_selector::broadcast_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::broadcast_params, kernel_selector::broadcast_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::broadcast_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<broadcast_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
@@ -17,7 +17,7 @@ struct bucketize_impl : typed_primitive_impl_ocl<bucketize> {
     using kernel_selector_t = kernel_selector::bucketize_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::bucketize_params, kernel_selector::bucketize_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::bucketize_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<bucketize_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -47,7 +47,7 @@ struct concatenation_impl : typed_primitive_impl_ocl<concatenation> {
     using kernel_selector_t = kernel_selector::concatenation_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::concatenation_params, kernel_selector::concatenation_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::concatenation_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<concatenation_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
@@ -16,7 +16,7 @@ struct convert_color_impl : typed_primitive_impl_ocl<convert_color> {
     using kernel_selector_t = kernel_selector::convert_color_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::convert_color_params, kernel_selector::convert_color_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::convert_color_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<convert_color_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -18,7 +18,7 @@ struct convolution_impl : typed_primitive_impl_ocl<convolution> {
     using kernel_selector_t = kernel_selector::convolution_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::convolution_params, kernel_selector::convolution_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::convolution_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<convolution_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
@@ -17,7 +17,7 @@ struct crop_impl : typed_primitive_impl_ocl<crop> {
     using kernel_selector_t = kernel_selector::eltwise_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::eltwise_params, kernel_selector::eltwise_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::crop_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<crop_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
@@ -17,7 +17,7 @@ struct ctc_greedy_decoder_impl : typed_primitive_impl_ocl<ctc_greedy_decoder> {
     using kernel_selector_t = kernel_selector::ctc_greedy_decoder_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::ctc_greedy_decoder_params, kernel_selector::ctc_greedy_decoder_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::ctc_greedy_decoder_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<ctc_greedy_decoder_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
@@ -17,7 +17,7 @@ struct ctc_loss_impl : typed_primitive_impl_ocl<ctc_loss> {
     using kernel_selector_t = kernel_selector::ctc_loss_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::ctc_loss_params, kernel_selector::ctc_loss_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::ctc_loss_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<ctc_loss_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
@@ -50,7 +50,7 @@ struct cum_sum_impl : typed_primitive_impl_ocl<cum_sum> {
     using kernel_selector_t = kernel_selector::cum_sum_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::cum_sum_params, kernel_selector::cum_sum_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::cum_sum_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<cum_sum_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -24,7 +24,7 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
     using parent = typed_primitive_impl<custom_gpu_primitive>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::custom_gpu_primitive_impl)
 
     std::shared_ptr<kernel_selector::cl_kernel_data> cl_kernel;
     std::vector<kernel::ptr> _kernels;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -17,7 +17,7 @@ struct deconvolution_impl : typed_primitive_impl_ocl<deconvolution> {
     using kernel_selector_t = kernel_selector::deconvolution_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::deconvolution_params, kernel_selector::deconvolution_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::deconvolution_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<deconvolution_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deformable_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deformable_convolution.cpp
@@ -17,7 +17,7 @@ struct deformable_conv_impl : typed_primitive_impl_ocl<deformable_conv> {
     using kernel_selector_t = kernel_selector::deformable_conv_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::convolution_params, kernel_selector::convolution_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::deformable_conv_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<deformable_conv_impl>(*this);
@@ -61,7 +61,7 @@ struct deformable_interp_impl : typed_primitive_impl_ocl<deformable_interp> {
     using kernel_selector_t = kernel_selector::deformable_interp_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::convolution_params, kernel_selector::convolution_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::deformable_interp_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<deformable_interp_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
@@ -16,7 +16,7 @@ struct depth_to_space_impl : typed_primitive_impl_ocl<depth_to_space> {
     using kernel_selector_t = kernel_selector::depth_to_space_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::depth_to_space_params, kernel_selector::depth_to_space_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::depth_to_space_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<depth_to_space_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
@@ -17,7 +17,7 @@ struct detection_output_impl : typed_primitive_impl_ocl<detection_output> {
     using kernel_selector_t = kernel_selector::detection_output_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::detection_output_params, kernel_selector::detection_output_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::detection_output_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<detection_output_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -16,7 +16,7 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
     using kernel_selector_t = kernel_selector::dft_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::dft_params, kernel_selector::dft_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::dft_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<dft_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -17,7 +17,7 @@ struct eltwise_impl : typed_primitive_impl_ocl<eltwise> {
     using kernel_selector_t = kernel_selector::eltwise_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::eltwise_params, kernel_selector::eltwise_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::eltwise_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<eltwise_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
@@ -16,7 +16,7 @@ struct embedding_bag_impl : typed_primitive_impl_ocl<embedding_bag> {
     using kernel_selector_t = kernel_selector::embedding_bag_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::embedding_bag_params, kernel_selector::embedding_bag_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::embedding_bag_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<embedding_bag_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
@@ -18,7 +18,7 @@ struct experimental_detectron_detection_output_impl
     using kernel_params_t = std::pair<kernel_selector::experimental_detectron_detection_output_params,
                                       kernel_selector::experimental_detectron_detection_output_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_detection_output_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<experimental_detectron_detection_output_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
@@ -18,7 +18,7 @@ struct experimental_detectron_generate_proposals_single_image_impl
     using kernel_params_t = std::pair<kernel_selector::experimental_detectron_generate_proposals_single_image_params,
                                       kernel_selector::experimental_detectron_generate_proposals_single_image_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_generate_proposals_single_image_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<experimental_detectron_generate_proposals_single_image_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
@@ -19,7 +19,7 @@ struct experimental_detectron_prior_grid_generator_impl
     using kernel_params_t = std::pair<kernel_selector::experimental_detectron_prior_grid_generator_params,
                                       kernel_selector::experimental_detectron_prior_grid_generator_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_prior_grid_generator_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<experimental_detectron_prior_grid_generator_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
@@ -17,7 +17,7 @@ struct experimental_detectron_roi_feature_extractor_impl : public typed_primitiv
     using kernel_params_t = std::pair<kernel_selector::experimental_detectron_roi_feature_extractor_params,
                                       kernel_selector::experimental_detectron_roi_feature_extractor_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_roi_feature_extractor_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<experimental_detectron_roi_feature_extractor_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
@@ -18,7 +18,7 @@ struct experimental_detectron_topk_rois_impl : typed_primitive_impl_ocl<experime
     using kernel_params_t = std::pair<kernel_selector::experimental_detectron_topk_roi_params,
                                       kernel_selector::experimental_detectron_topk_roi_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_topk_rois_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<experimental_detectron_topk_rois_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
@@ -17,7 +17,7 @@ struct extract_image_patches_impl : typed_primitive_impl_ocl<extract_image_patch
     using kernel_selector_t = kernel_selector::extract_image_patches_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::extract_image_patches_params, kernel_selector::extract_image_patches_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::extract_image_patches_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<extract_image_patches_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
@@ -17,7 +17,7 @@ struct eye_impl : typed_primitive_impl_ocl<eye> {
     using kernel_selector_t = kernel_selector::eye_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::eye_params, kernel_selector::eye_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::eye_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<eye_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -17,7 +17,7 @@ struct fully_connected_impl : typed_primitive_impl_ocl<fully_connected> {
     using kernel_selector_t = kernel_selector::fully_connected_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::fully_connected_params, kernel_selector::fully_connected_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::fully_connected_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<fully_connected_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -61,7 +61,7 @@ struct gather_impl : typed_primitive_impl_ocl<gather> {
     using kernel_selector_t = kernel_selector::gather_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::gather_params, kernel_selector::gather_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<gather_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
@@ -48,7 +48,7 @@ struct gather_elements_impl : typed_primitive_impl_ocl<gather_elements> {
     using kernel_selector_t = kernel_selector::gather_elements_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::gather_elements_params, kernel_selector::gather_elements_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_elements_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<gather_elements_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
@@ -17,7 +17,7 @@ struct gather_nd_impl : typed_primitive_impl_ocl<gather_nd> {
     using kernel_selector_t = kernel_selector::gather_nd_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::gather_nd_params, kernel_selector::gather_nd_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_nd_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<gather_nd_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
@@ -17,7 +17,7 @@ struct gather_tree_impl : typed_primitive_impl_ocl<gather_tree> {
     using kernel_selector_t = kernel_selector::gather_tree_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::gather_tree_params, kernel_selector::gather_tree_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_tree_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<gather_tree_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -17,7 +17,7 @@ struct gemm_impl : typed_primitive_impl_ocl<gemm> {
     using kernel_selector_t = kernel_selector::gemm_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::gemm_params, kernel_selector::gemm_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gemm_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<gemm_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
@@ -17,7 +17,7 @@ struct generate_proposals_impl
     using kernel_selector_t = kernel_selector::generate_proposals_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::generate_proposals_params, kernel_selector::generate_proposals_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::generate_proposals_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<generate_proposals_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grid_sample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grid_sample.cpp
@@ -46,7 +46,7 @@ struct grid_sample_impl : public typed_primitive_impl_ocl<grid_sample> {
     using kernel_params_t = std::pair<kernel_selector::grid_sample_params, kernel_selector::grid_sample_optional_params>;
 
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::grid_sample_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<grid_sample_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
@@ -17,7 +17,7 @@ struct grn_impl : typed_primitive_impl_ocl<grn> {
     using kernel_selector_t = kernel_selector::grn_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::grn_params, kernel_selector::grn_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::grn_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<grn_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
@@ -17,7 +17,7 @@ struct lrn_impl : typed_primitive_impl_ocl<lrn> {
     using kernel_selector_t = kernel_selector::lrn_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::lrn_params, kernel_selector::lrn_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::lrn_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<lrn_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_input.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_input.cpp
@@ -17,7 +17,7 @@ struct lstm_dynamic_input_impl : typed_primitive_impl_ocl<lstm_dynamic_input> {
     using kernel_selector_t = kernel_selector::lstm_dynamic_input_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::lstm_dynamic_input_params, kernel_selector::lstm_dynamic_input_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::lstm_dynamic_input_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<lstm_dynamic_input_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_timeloop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_timeloop.cpp
@@ -17,7 +17,7 @@ struct lstm_dynamic_timeloop_impl : typed_primitive_impl_ocl<lstm_dynamic_timelo
     using kernel_selector_t = kernel_selector::lstm_dynamic_timeloop_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::lstm_dynamic_timeloop_params, kernel_selector::lstm_dynamic_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::lstm_dynamic_timeloop_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<lstm_dynamic_timeloop_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
@@ -17,7 +17,7 @@ struct lstm_elt_impl : typed_primitive_impl_ocl<lstm_elt> {
     using kernel_selector_t = kernel_selector::lstm_elt_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::lstm_elt_params, kernel_selector::lstm_elt_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::lstm_elt_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<lstm_elt_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_gemm.cpp
@@ -17,7 +17,7 @@ struct lstm_gemm_impl : typed_primitive_impl_ocl<lstm_gemm> {
     using kernel_selector_t = kernel_selector::lstm_gemm_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::lstm_gemm_params, kernel_selector::lstm_gemm_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::lstm_gemm_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<lstm_gemm_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/matrix_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/matrix_nms.cpp
@@ -41,7 +41,7 @@ struct matrix_nms_impl : typed_primitive_impl_ocl<matrix_nms> {
     using kernel_selector_t = kernel_selector::matrix_nms_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::matrix_nms_params, kernel_selector::matrix_nms_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::matrix_nms_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<matrix_nms_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multiclass_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multiclass_nms.cpp
@@ -51,7 +51,7 @@ struct multiclass_nms_impl : public typed_primitive_impl_ocl<multiclass_nms> {
     using kernel_selector_t = kernel_selector::multiclass_nms_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::multiclass_nms_params, kernel_selector::multiclass_nms_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::multiclass_nms_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<multiclass_nms_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mutable_data.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mutable_data.cpp
@@ -13,7 +13,7 @@ struct mutable_data_impl : public typed_primitive_impl_ocl<mutable_data> {
     using parent = typed_primitive_impl_ocl<mutable_data>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::mutable_data_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<mutable_data_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -17,7 +17,7 @@ struct mvn_impl : typed_primitive_impl_ocl<mvn> {
     using kernel_selector_t = kernel_selector::mvn_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::mvn_params, kernel_selector::mvn_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::mvn_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<mvn_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
@@ -17,7 +17,7 @@ struct non_max_suppression_impl : typed_primitive_impl_ocl<non_max_suppression> 
     using kernel_selector_t = kernel_selector::non_max_suppression_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::non_max_suppression_params, kernel_selector::non_max_suppression_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::non_max_suppression_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<non_max_suppression_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -19,7 +19,7 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
     using kernel_selector_t = kernel_selector::count_nonzero_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::count_nonzero_params, kernel_selector::count_nonzero_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::count_nonzero_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<count_nonzero_impl>(*this);
@@ -43,7 +43,7 @@ struct gather_nonzero_impl : typed_primitive_impl_ocl<gather_nonzero> {
     using kernel_selector_t = kernel_selector::gather_nonzero_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::gather_nonzero_params, kernel_selector::gather_nonzero_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_nonzero_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<gather_nonzero_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
@@ -17,7 +17,7 @@ struct normalize_impl : typed_primitive_impl_ocl<normalize> {
     using kernel_selector_t = kernel_selector::normalize_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::normalize_params, kernel_selector::normalize_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::normalize_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<normalize_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
@@ -17,7 +17,7 @@ struct one_hot_impl : typed_primitive_impl_ocl<one_hot> {
     using kernel_selector_t = kernel_selector::one_hot_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::one_hot_params, kernel_selector::one_hot_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::one_hot_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<one_hot_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
@@ -44,7 +44,7 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
     using kernel_selector_t = kernel_selector::permute_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::permute_params, kernel_selector::permute_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::permute_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<permute_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
@@ -48,7 +48,7 @@ struct pooling_impl : typed_primitive_impl_ocl<pooling> {
     using kernel_selector_t = kernel_selector::pooling_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::pooling_params, kernel_selector::pooling_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::pooling_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<pooling_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
@@ -17,7 +17,7 @@ struct prior_box_impl : typed_primitive_impl_ocl<prior_box> {
     using kernel_selector_t = kernel_selector::prior_box_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::prior_box_params, kernel_selector::prior_box_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::prior_box_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<prior_box_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
@@ -19,7 +19,7 @@ struct pyramid_roi_align_impl : typed_primitive_impl_ocl<pyramid_roi_align> {
     using kernel_selector_t = kernel_selector::PyramidROIAlign_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::PyramidROIAlign_params, kernel_selector::PyramidROIAlign_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::pyramid_roi_align_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<pyramid_roi_align_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
@@ -17,7 +17,7 @@ struct quantize_impl : typed_primitive_impl_ocl<quantize> {
     using kernel_selector_t = kernel_selector::quantize_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::quantize_params, kernel_selector::quantize_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::quantize_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<quantize_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
@@ -17,7 +17,7 @@ struct random_uniform_impl : typed_primitive_impl_ocl<random_uniform> {
     using kernel_selector_t = kernel_selector::random_uniform_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::random_uniform_params, kernel_selector::random_uniform_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::random_uniform_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<random_uniform_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -17,7 +17,7 @@ struct range_impl : typed_primitive_impl_ocl<range> {
     using kernel_selector_t = kernel_selector::range_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::range_params, kernel_selector::range_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::range_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<range_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
@@ -66,7 +66,7 @@ struct reduce_impl : typed_primitive_impl_ocl<reduce> {
     using kernel_selector_t = kernel_selector::reduce_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::reduce_params, kernel_selector::reduce_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reduce_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<reduce_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
@@ -17,7 +17,7 @@ struct region_yolo_impl : typed_primitive_impl_ocl<region_yolo> {
     using kernel_selector_t = kernel_selector::region_yolo_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::region_yolo_params, kernel_selector::region_yolo_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::region_yolo_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<region_yolo_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -18,7 +18,7 @@ struct reorder_impl : typed_primitive_impl_ocl<reorder> {
     using kernel_selector_t = kernel_selector::reorder_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::reorder_params, kernel_selector::reorder_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reorder_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<reorder_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
@@ -17,7 +17,7 @@ struct reorg_yolo_impl : typed_primitive_impl_ocl<reorg_yolo> {
     using kernel_selector_t = kernel_selector::reorg_yolo_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::reorg_yolo_params, kernel_selector::reorg_yolo_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reorg_yolo_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<reorg_yolo_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
@@ -134,7 +134,7 @@ struct resample_impl : typed_primitive_impl_ocl<resample> {
     using kernel_selector_t = kernel_selector::resample_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::resample_params, kernel_selector::resample_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::resample_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<resample_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
@@ -17,7 +17,7 @@ struct reshape_impl : public typed_primitive_impl_ocl<reshape> {
     using kernel_selector_t = kernel_selector::reshape_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::reshape_params, kernel_selector::reshape_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reshape_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<reshape_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
@@ -17,7 +17,7 @@ struct reverse_impl : typed_primitive_impl_ocl<reverse> {
     using kernel_selector_t = kernel_selector::reverse_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::reverse_params, kernel_selector::reverse_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reverse_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<reverse_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
@@ -16,7 +16,7 @@ struct reverse_sequence_impl : typed_primitive_impl_ocl<reverse_sequence> {
     using kernel_selector_t = kernel_selector::reverse_sequence_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::reverse_sequence_params, kernel_selector::reverse_sequence_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reverse_sequence_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<reverse_sequence_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
@@ -41,7 +41,7 @@ struct roi_align_impl : typed_primitive_impl_ocl<roi_align> {
     using kernel_selector_t = kernel_selector::roi_align_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::roi_align_params, kernel_selector::roi_align_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::roi_align_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<roi_align_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
@@ -37,7 +37,7 @@ struct roi_pooling_impl : typed_primitive_impl_ocl<roi_pooling> {
     using kernel_selector_t = kernel_selector::roi_pooling_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::roi_pooling_params, kernel_selector::roi_pooling_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::roi_pooling_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<roi_pooling_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -17,7 +17,7 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
     using kernel_selector_t = kernel_selector::roll_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::roll_params, kernel_selector::roll_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::roll_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<roll_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -43,7 +43,7 @@ struct scatter_elements_update_impl : typed_primitive_impl_ocl<scatter_elements_
     using kernel_selector_t = kernel_selector::scatter_elements_update_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::scatter_elements_update_params, kernel_selector::scatter_elements_update_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::scatter_elements_update_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<scatter_elements_update_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
@@ -17,7 +17,7 @@ struct scatter_nd_update_impl : typed_primitive_impl_ocl<scatter_nd_update> {
     using kernel_selector_t = kernel_selector::scatter_nd_update_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::scatter_nd_update_params, kernel_selector::scatter_nd_update_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::scatter_nd_update_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<scatter_nd_update_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
@@ -42,7 +42,7 @@ struct scatter_update_impl : typed_primitive_impl_ocl<scatter_update> {
     using kernel_selector_t = kernel_selector::scatter_update_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::scatter_update_params, kernel_selector::scatter_update_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::scatter_update_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<scatter_update_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
@@ -17,7 +17,7 @@ struct select_impl : typed_primitive_impl_ocl<select> {
     using kernel_selector_t = kernel_selector::select_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::select_params, kernel_selector::select_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::select_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<select_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shape_of.cpp
@@ -17,7 +17,7 @@ struct shape_of_impl : typed_primitive_impl_ocl<shape_of> {
     using kernel_selector_t = kernel_selector::shape_of_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::shape_of_params, kernel_selector::shape_of_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::shape_of_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<shape_of_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
@@ -17,7 +17,7 @@ struct shuffle_channels_impl : typed_primitive_impl_ocl<shuffle_channels> {
     using kernel_selector_t = kernel_selector::shuffle_channels_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::shuffle_channels_params, kernel_selector::shuffle_channels_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::shuffle_channels_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<shuffle_channels_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -72,7 +72,7 @@ struct slice_impl : typed_primitive_impl_ocl<slice> {
         kInputsNum
     };
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::slice_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<slice_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -39,7 +39,7 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
     using kernel_selector_t = kernel_selector::softmax_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::softmax_params, kernel_selector::softmax_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::softmax_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<softmax_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
@@ -16,7 +16,7 @@ struct space_to_batch_impl : typed_primitive_impl_ocl<space_to_batch> {
     using kernel_selector_t = kernel_selector::space_to_batch_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::space_to_batch_params, kernel_selector::space_to_batch_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::space_to_batch_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<space_to_batch_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
@@ -16,7 +16,7 @@ struct space_to_depth_impl : typed_primitive_impl_ocl<space_to_depth> {
     using kernel_selector_t = kernel_selector::space_to_depth_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::space_to_depth_params, kernel_selector::space_to_depth_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::space_to_depth_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<space_to_depth_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -46,7 +46,7 @@ struct strided_slice_impl : typed_primitive_impl_ocl<strided_slice> {
     using kernel_selector_t = kernel_selector::strided_slice_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::strided_slice_params, kernel_selector::strided_slice_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::strided_slice_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<strided_slice_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -17,7 +17,7 @@ struct tile_impl : typed_primitive_impl_ocl<tile> {
     using kernel_selector_t = kernel_selector::tile_kernel_selector;
     using kernel_params_t = std::pair<kernel_selector::tile_params, kernel_selector::tile_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::tile_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<tile_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/unique.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/unique.cpp
@@ -17,7 +17,7 @@ struct unique_count_impl : typed_primitive_impl_ocl<unique_count> {
     using kernel_params_t =
         std::pair<kernel_selector::unique_count_params, kernel_selector::unique_count_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::unique_count_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<unique_count_impl>(*this);
@@ -88,7 +88,7 @@ struct unique_gather_impl : typed_primitive_impl_ocl<unique_gather> {
     using kernel_params_t =
         std::pair<kernel_selector::unique_gather_params, kernel_selector::unique_gather_optional_params>;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::unique_gather)
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<unique_gather_impl>(*this);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -21,7 +21,7 @@ struct concatenation_onednn : typed_primitive_onednn_impl<concatenation, dnnl::c
     using parent = typed_primitive_onednn_impl<concatenation, dnnl::concat::primitive_desc, dnnl::concat>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::concatenation_onednn)
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -26,7 +26,7 @@ struct convolution_onednn : typed_primitive_onednn_impl<convolution> {
     using parent = typed_primitive_onednn_impl<convolution>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::convolution_onednn)
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -22,7 +22,7 @@ struct deconvolution_onednn : typed_primitive_onednn_impl<deconvolution> {
     using parent = typed_primitive_onednn_impl<deconvolution>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::deconvolution_onednn)
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -19,7 +19,7 @@ struct fully_connected_onednn : typed_primitive_onednn_impl<fully_connected> {
     using parent = typed_primitive_onednn_impl<fully_connected>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::fully_connected_onednn)
 
 private:
     static std::vector<int64_t> reshape_to_2d(const ov::PartialShape& shape, int64_t feature) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -19,7 +19,7 @@ struct gemm_onednn : typed_primitive_onednn_impl<gemm> {
     using parent = typed_primitive_onednn_impl<gemm>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::gemm_onednn)
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
@@ -19,7 +19,7 @@ struct pooling_onednn : typed_primitive_onednn_impl<pooling> {
     using parent = typed_primitive_onednn_impl<pooling>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::pooling_onednn)
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
@@ -41,7 +41,7 @@ struct reduction_onednn : typed_primitive_onednn_impl<reduce> {
     using parent = typed_primitive_onednn_impl<reduce>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::reduction_onednn)
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
@@ -19,7 +19,7 @@ struct reorder_onednn : typed_primitive_onednn_impl<reorder, dnnl::reorder::prim
     using parent = typed_primitive_onednn_impl<reorder, dnnl::reorder::primitive_desc, dnnl::reorder>;
     using parent::parent;
 
-    DECLARE_OBJECT_TYPE_SERIALIZATION
+    DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::onednn::reorder_onednn)
 
 protected:
     std::unique_ptr<primitive_impl> clone() const override {

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -54,7 +54,7 @@ struct primitive_impl {
 
     virtual std::vector<layout> get_internal_buffer_layouts() const = 0;
     virtual void set_node_params(const program_node&) {}
-    virtual std::string get_type() const = 0;
+    virtual const std::string& get_type_info() const = 0;
     virtual void set_arguments(primitive_inst& instance) = 0;
     virtual void set_arguments(primitive_inst& instance, kernel_arguments_data& args) = 0;
     virtual kernel_arguments_data get_arguments(const primitive_inst& instance) const = 0;


### PR DESCRIPTION
### Details:
 - `type_for_serialization` could be initialized after `BinaryOutputBuffer<>` and save/load functions are registered with "" as a key instead of type identifier. Reproduced with clang-16
 -  `DECLARE_OBJECT_TYPE_SERIALIZATION ` is now called for all primitives within `CLDNN_DECLARE_PRIMITIVE` macro
 - Updated `DECLARE_OBJECT_TYPE_SERIALIZATION` call in primitive impls to pass impl name

### Tickets:
 - *119938*
