### PR TITLE
[CI] [GHA] Create directories for `conan` in ARM64 pipeline

### DIFF
--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -120,6 +120,10 @@ jobs:
 
       - name: Install conan and dependencies
         run: |
+          
+          # create build directories
+          mkdir -p ${{ env.BUILD_DIR }}/linux_arm64 ${{ env.BUILD_DIR }}/dependencies
+          
           python3 -m pip install conan
           # install build profile compilers
           sudo -E apt --assume-yes install gcc g++


### PR DESCRIPTION
### Details:
 - This PR introduces directories creation for `conan` build. It fixes [this failure](https://github.com/openvinotoolkit/openvino/actions/runs/6153126985/job/16696482886).
