### PR TITLE
Removed CMAKE_INSTALL_LIBDIR from oneDNN GPU configuration (#19716)

### DIFF
--- a/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
@@ -62,9 +62,6 @@ if(ENABLE_ONEDNN_FOR_GPU)
                 list(APPEND cmake_extra_args "-DCMAKE_CONFIGURATION_TYPES=${CMAKE_DEFAULT_BUILD_TYPE}")
                 list(APPEND cmake_extra_args "-DCMAKE_DEFAULT_BUILD_TYPE=${CMAKE_DEFAULT_BUILD_TYPE}")
             endif()
-            # sometimes $<CONFIG> is evaluated as real build type even for non-multi-config generators
-            # so, have to put under OV_GENERATOR_MULTI_CONFIG (example: docker pull conanio/gcc11-ubuntu16.04:latest)
-            list(APPEND cmake_config "$<CONFIG>")
         else()
             list(APPEND cmake_extra_args "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
         endif()
@@ -91,20 +88,14 @@ if(ENABLE_ONEDNN_FOR_GPU)
         endif()
 
         ExternalProject_Add(onednn_gpu_build
+            # Directory Options:
+            PREFIX "${ONEDNN_PREFIX_DIR}"
             SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu"
             BINARY_DIR "${ONEDNN_BUILD_DIR}"
             INSTALL_DIR "${ONEDNN_INSTALL_DIR}"
-            PREFIX "${ONEDNN_PREFIX_DIR}"
-            EXCLUDE_FROM_ALL ON
-            CMAKE_CACHE_ARGS
-                # The arguments below requires list to be passed as argument
-                # which doesn't work properly when passed to CMAKE_ARGS.
-                # Thus we pass it via CMAKE_CACHE_ARGS
-                "-DDNNL_ENABLE_PRIMITIVE:STRING=${ONEDNN_ENABLED_PRIMITIVES}"
-                "-DDNNL_ENABLE_PRIMITIVE_GPU_ISA:STRING=${ONEDNN_ENABLED_ISA}"
+            # Configure Step Options:
             CMAKE_ARGS
                 ${cmake_extra_args}
-                "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW"
                 "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
                 "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
                 "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}"
@@ -118,7 +109,6 @@ if(ENABLE_ONEDNN_FOR_GPU)
                 "-DDNNL_GPU_RUNTIME=OCL"
                 "-DDNNL_LIBRARY_NAME=openvino_onednn_gpu"
                 "-DCMAKE_INSTALL_PREFIX=${ONEDNN_INSTALL_DIR}"
-                "-DCMAKE_INSTALL_LIBDIR=lib/${cmake_config}"
                 "-DDNNL_ENABLE_CONCURRENT_EXEC=ON"
                 "-DDNNL_ENABLE_PRIMITIVE_CACHE=OFF"
                 "-DDNNL_ENABLE_WORKLOAD=INFERENCE"
@@ -133,10 +123,21 @@ if(ENABLE_ONEDNN_FOR_GPU)
                 # specifically for Conan, because it overrides CMAKE_PREFIX_PATH and oneDNN's FindOpenCL.cmake is ignored
                 # Conan's FindOpenCL.cmake module does not set OpenCL_INCLUDE_DIRS, so we need to set it manually
                 "-DOpenCL_INCLUDE_DIRS=$<TARGET_PROPERTY:OpenCL::OpenCL,INTERFACE_INCLUDE_DIRECTORIES>"
+                # Conan calls cmake with default value for CMP0091, so we have to bypass it to oneDNN build
+                # because we bypass conan_toolchain.cmake via CMAKE_TOOLCHAIN_FILE
+                "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW"
+            CMAKE_CACHE_ARGS
+                # The arguments below requires list to be passed as argument
+                # which doesn't work properly when passed to CMAKE_ARGS.
+                # Thus we pass it via CMAKE_CACHE_ARGS
+                "-DDNNL_ENABLE_PRIMITIVE:STRING=${ONEDNN_ENABLED_PRIMITIVES}"
+                "-DDNNL_ENABLE_PRIMITIVE_GPU_ISA:STRING=${ONEDNN_ENABLED_ISA}"
+            # Target Options:
+            EXCLUDE_FROM_ALL ON
         )
         add_library(onednn_gpu_tgt INTERFACE)
         set_target_properties(onednn_gpu_tgt PROPERTIES
-            INTERFACE_LINK_DIRECTORIES "${ONEDNN_INSTALL_DIR}/lib/${cmake_config}"
+            INTERFACE_LINK_DIRECTORIES "${ONEDNN_INSTALL_DIR}/lib"
             INTERFACE_LINK_LIBRARIES "openvino_onednn_gpu"
             INTERFACE_INCLUDE_DIRECTORIES "${ONEDNN_INSTALL_DIR}/include"
             INTERFACE_COMPILE_DEFINITIONS ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
### Details:
 - Ported https://github.com/openvinotoolkit/openvino/pull/19716
 - It finally fixes Conan build on all OSes with oneDNN for GPU
