### PR TITLE
[GPU] low accuracy problem in stable diffusion on igpu

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1381,6 +1381,11 @@ impl_types layout_optimizer::get_forced_impl_type_by_config(program_node& node) 
                     return impl_types::ocl;
                 else if (forced_impl_type == "concat:onednn")
                     return impl_types::onednn;
+            } else if (node.is_type<convolution>()) {
+                if (forced_impl_type == "conv:ocl")
+                    return impl_types::ocl;
+                else if (forced_impl_type == "conv:onednn")
+                    return impl_types::onednn;
             }
 
             // Forcing one layer

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_os_iyx_osv16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_os_iyx_osv16.cl
@@ -87,7 +87,7 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv16)(
     const uint feature_num = feature_idx; // feature index for fused operations
 #endif
     UNIT_TYPE in[IN_BLOCK_ARRAY_SIZE];
-    UNIT_TYPE out[OUTPUT_BLOCK_WIDTH * OUTPUT_BLOCK_HEIGHT];
+    ACCUMULATION_TYPE out[OUTPUT_BLOCK_WIDTH * OUTPUT_BLOCK_HEIGHT];
     UNIT_TYPE w[PREFETCH];
     uint in_addr;
     uint weight_addr = fmg * FILTER_IFM_NUM * FILTER_SIZE_X * FILTER_SIZE_Y * OSV_SIZE + lid;
@@ -97,7 +97,7 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv16)(
 #endif
 
     for(int i = 0; i < (OUTPUT_BLOCK_WIDTH * OUTPUT_BLOCK_HEIGHT); i++) {
-        out[i] = UNIT_VAL_ZERO;
+        out[i] = ACCUMULATION_VAL_ZERO;
     }
 
     uint in_split_offset = g * INPUT0_FEATURE_PITCH * FILTER_IFM_NUM;
@@ -180,7 +180,7 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv16)(
                         UNIT_TYPE val = _sub_group_shuffle( in[br * STRIDE_SIZE_Y + kr * DILATION_SIZE_Y], bc * STRIDE_SIZE_X + kc * DILATION_SIZE_X);
 #endif
 
-                        out[br * OUTPUT_BLOCK_WIDTH + bc] = mad(w[wi % PREFETCH], val, out[br * OUTPUT_BLOCK_WIDTH + bc]);
+                        out[br * OUTPUT_BLOCK_WIDTH + bc] += TO_ACCUMULATION_TYPE(w[wi % PREFETCH] * val);
                     }
                 }
                 w[wi % PREFETCH] = weights[weight_addr];

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_os_iyx_osv16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_os_iyx_osv16.cl
@@ -180,7 +180,7 @@ KERNEL(convolution_gpu_bfyx_os_iyx_osv16)(
                         UNIT_TYPE val = _sub_group_shuffle( in[br * STRIDE_SIZE_Y + kr * DILATION_SIZE_Y], bc * STRIDE_SIZE_X + kc * DILATION_SIZE_X);
 #endif
 
-                        out[br * OUTPUT_BLOCK_WIDTH + bc] += TO_ACCUMULATION_TYPE(w[wi % PREFETCH] * val);
+                        out[br * OUTPUT_BLOCK_WIDTH + bc] = mad(TO_ACCUMULATION_TYPE(w[wi % PREFETCH]), TO_ACCUMULATION_TYPE(val), out[br * OUTPUT_BLOCK_WIDTH + bc]);
                     }
                 }
                 w[wi % PREFETCH] = weights[weight_addr];

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_to_fs_byx_fsv32.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_to_fs_byx_fsv32.cl
@@ -172,7 +172,7 @@ KERNEL(convolution_gpu_bfyx_to_fs_byx_fsv32)(
 
 
                             const uint out_idx = out_y * OUTPUT_BLOCK_WIDTH * FSV_PER_THREAD + out_x * FSV_PER_THREAD + out_f;
-                            out[out_idx] += TO_ACCUMULATION_TYPE(in_val * w[out_f]);
+                            out[out_idx] = mad(TO_ACCUMULATION_TYPE(in_val), TO_ACCUMULATION_TYPE(w[out_f]), out[out_idx]);
                         }
                     }
                 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_fs_byx_fsv32.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_fs_byx_fsv32.cl
@@ -133,7 +133,7 @@ KERNEL(convolution_gpu_fs_byx_fsv32)(
                                 ifii % SUB_GROUP_SIZE);
 
                             const uint out_idx = out_x * FSV_PER_THREAD + out_f;
-                            out[out_idx] += TO_ACCUMULATION_TYPE(in_val * w[out_f]);
+                            out[out_idx] = mad(TO_ACCUMULATION_TYPE(in_val), TO_ACCUMULATION_TYPE(w[out_f]), out[out_idx]);
                         }
                     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_ref.cl
@@ -44,7 +44,7 @@ KERNEL(kernel_name)(
     const uint b = (uint)get_global_id(2) / OUTPUT_FEATURE_NUM;
 #endif
 
-    ACCUMULATOR_TYPE dotProd = (ACCUMULATOR_TYPE)0;
+    ACCUMULATION_TYPE dotProd = TO_ACCUMULATION_TYPE(0);
     const int input_x = x * STRIDE_SIZE_X - PADDING_SIZE_X;
     const int input_y = y * STRIDE_SIZE_Y - PADDING_SIZE_Y;
 #if  OUTPUT_DIMS > 4

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
@@ -462,4 +462,10 @@ Datatype ConvolutionKernelBase::GetAccumulatorType(const convolution_params& par
     return params.inputs[0].GetDType();
 }
 
+Datatype ConvolutionKernelBase::GetAccumulationType(const convolution_params& params) const {
+    auto accumulator_dt = GetAccumulatorType(params);
+    // WA: f16 accumulation occurs an accuracy problem.
+    return (accumulator_dt == Datatype::F16) ? Datatype::F32 : accumulator_dt;
+}
+
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.h
@@ -69,6 +69,7 @@ protected:
     Datatype GetPackedOutputType(const convolution_params& params) const;
     Datatype GetActivationType(const convolution_params& params) const;
     Datatype GetAccumulatorType(const convolution_params& params) const;
+    Datatype GetAccumulationType(const convolution_params& params) const;
 };
 
 bool ConvolutionCheckInput(const Params& p, const optional_params& o);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp
@@ -219,6 +219,7 @@ JitConstants ConvolutionKernel_bfyx_os_iyx_osv16::GetJitConstants(const convolut
     size_t leftovers = of_threads_per_batch - of_maps_per_group;
 
     auto jit = Parent::GetJitConstants(params, dispatchData);
+    jit.Merge(MakeTypeJitConstants(GetAccumulationType(params), "ACCUMULATION"));
 
     if (!params.fused_ops.empty()) {
         auto input_dt = GetUnitType(params);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_fs_byx_fsv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_fs_byx_fsv32.cpp
@@ -108,6 +108,7 @@ bool ConvolutionKernel_bfyx_to_fs_byx_fsv32::Validate(const Params& p, const opt
 JitConstants ConvolutionKernel_bfyx_to_fs_byx_fsv32::GetJitConstants(const convolution_params& params,
                                                                      const DispatchData& dispatchData) const {
     auto jit = ConvolutionKernelBase::GetJitConstants(params, dispatchData);
+    jit.Merge(MakeTypeJitConstants(GetAccumulationType(params), "ACCUMULATION"));
 
     jit.AddConstant(MakeJitConstant("OUTPUT_BLOCK_WIDTH", dispatchData.cldnnStyle.blockWidth));
     jit.AddConstant(MakeJitConstant("OUTPUT_BLOCK_HEIGHT", dispatchData.cldnnStyle.blockHeight));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_fs_byx_fsv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_fs_byx_fsv32.cpp
@@ -155,6 +155,7 @@ JitConstants ConvolutionKernel_fs_byx_fsv32::GetJitConstants(const convolution_p
     auto activation_type = GetAccumulatorType(params);
 
     jit.Merge(MakeTypeJitConstants(accumulator_type, "ACCUMULATOR"));
+    jit.Merge(MakeTypeJitConstants(GetAccumulationType(params), "ACCUMULATION"));
     jit.Merge(MakeTypeJitConstants(activation_type, "ACTIVATION"));
     jit.AddConstant(MakeJitConstant("INPUT_BLOCK_WIDTH", dispatchData.cldnnStyle.inputBlockWidth));
     jit.AddConstant(MakeJitConstant("OUTPUT_BLOCK_WIDTH", dispatchData.cldnnStyle.blockWidth));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.cpp
@@ -56,18 +56,13 @@ KernelsData ConvolutionKernel_Ref::GetKernelsData(const Params& params, const op
 JitConstants ConvolutionKernel_Ref::GetJitConstants(const convolution_params& params, const DispatchData& dispatchData) const {
     JitConstants jit = ConvolutionKernelBase::GetJitConstants(params, dispatchData);
 
-    Datatype accumulator_dt;
-    Datatype activation_dt;
-    if (params.quantization != QuantizationType::NONE) {
-        accumulator_dt = Datatype::INT32;
-        activation_dt = Datatype::F32;
-    } else {
-        accumulator_dt = GetAccumulatorType(params);
-        activation_dt = GetActivationType(params);
-    }
+    Datatype accumulation_dt = GetAccumulationType(params);
+    Datatype accumulator_dt = GetAccumulatorType(params);
+    Datatype activation_dt = GetActivationType(params);
 
     jit.Merge(MakeTypeJitConstants(activation_dt, "ACTIVATION"));
     jit.Merge(MakeTypeJitConstants(accumulator_dt, "ACCUMULATOR"));
+    jit.Merge(MakeTypeJitConstants(accumulation_dt, "ACCUMULATION"));
     jit.Merge(MakeActivationJitConstants(params.activations, activation_dt, "_TYPED"));
 
     if (!params.fused_ops.empty()) {


### PR DESCRIPTION
The f16 accumulation of ocl conv kernels has an accuracy problem.
For unet/f16/iGPU, 4 conv kernels are included.
- convolution_gpu_ref.cl
- convolution_gpu_bfyx_os_iyx_osv16.cl
- convolution_gpu_bfyx_to_fs_byx_fsv32.cl
- convolution_gpu_fs_byx_fsv32.cl

### Tickets:
 - 119157
