### PR TITLE
[CI] [GHA] Create only build directory for `conan` build

### DIFF
--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -4,24 +4,24 @@ on:
     # run daily at 00:00
     - cron: '0 0 * * *'
   workflow_dispatch:
-  pull_request:
-    paths-ignore:
-      - '**/docs/**'
-      - 'docs/**'
-      - '**/**.md'
-      - '**.md'
-      - '**/layer_tests_summary/**'
-      - '**/conformance/**'
-  push:
-    paths-ignore:
-      - '**/docs/**'
-      - 'docs/**'
-      - '**/**.md'
-      - '**.md'
-      - '**/layer_tests_summary/**'
-      - '**/conformance/**'
-    branches:
-      - master
+#  pull_request:
+#    paths-ignore:
+#      - '**/docs/**'
+#      - 'docs/**'
+#      - '**/**.md'
+#      - '**.md'
+#      - '**/layer_tests_summary/**'
+#      - '**/conformance/**'
+#  push:
+#    paths-ignore:
+#      - '**/docs/**'
+#      - 'docs/**'
+#      - '**/**.md'
+#      - '**.md'
+#      - '**/layer_tests_summary/**'
+#      - '**/conformance/**'
+#    branches:
+#      - master
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-linux-arm64

--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -4,24 +4,24 @@ on:
     # run daily at 00:00
     - cron: '0 0 * * *'
   workflow_dispatch:
-#  pull_request:
-#    paths-ignore:
-#      - '**/docs/**'
-#      - 'docs/**'
-#      - '**/**.md'
-#      - '**.md'
-#      - '**/layer_tests_summary/**'
-#      - '**/conformance/**'
-#  push:
-#    paths-ignore:
-#      - '**/docs/**'
-#      - 'docs/**'
-#      - '**/**.md'
-#      - '**.md'
-#      - '**/layer_tests_summary/**'
-#      - '**/conformance/**'
-#    branches:
-#      - master
+  pull_request:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
+  push:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-linux-arm64
@@ -121,8 +121,8 @@ jobs:
       - name: Install conan and dependencies
         run: |
           
-          # create build directories
-          mkdir -p ${{ env.BUILD_DIR }}/linux_arm64 ${{ env.BUILD_DIR }}/dependencies
+          # create build directory
+          mkdir -p ${{ env.BUILD_DIR }}
           
           python3 -m pip install conan
           # install build profile compilers


### PR DESCRIPTION
### Details:
 - This PR fixes [this failure](https://github.com/openvinotoolkit/openvino/actions/runs/6166196896/job/16735286398) by creating only a top-level build directory instead of a full path.
