### PR TITLE
[PyOV] Remove upper bound on `setuptools` and move wheel requirements under constraints

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -10,8 +10,9 @@ pytest-timeout==2.1.0
 # Python bindings
 py>=1.9.0
 pygments>=2.8.1
-setuptools>=53.0.0,<=68.1.2
+setuptools>=65.6.1
 wheel>=0.38.1
+patchelf<=0.17.2.1
 
 # Frontends
 docopt~=0.6.2

--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,4 @@
-setuptools>=65.6.1,<=68.1.2
-wheel>=0.38.1
-patchelf<=0.17.2.1; sys_platform == 'linux' and platform_machine == 'x86_64'
+-c ../constraints.txt
+setuptools
+wheel
+patchelf; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
### Details:
 - The setuptools bug which broke CI a few days a go has been fixed in the newest setuptools patch release: https://pypi.org/project/setuptools/68.2.2/

### Tickets:
 - N/A
