### PR TITLE
Refactor ConvolutionBackpropDataLayerTest, ConvolutionLayerTest, DeformableConvolutionLayerTest

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -5,15 +5,15 @@
 #include <vector>
 
 #include "common_test_utils/test_constants.hpp"
-#include "single_layer_tests/convolution.hpp"
+#include "single_op_tests/convolution.hpp"
 
-using namespace LayerTestsDefinitions;
 
 namespace {
+using ov::test::ConvolutionLayerTest;
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16,
-        InferenceEngine::Precision::I32};
+const std::vector<ov::element::Type> model_type = {
+        ov::element::f32, ov::element::f16,
+        ov::element::i32};
 
 /* ============= 1D Convolution ============= */
 const std::vector<std::vector<size_t>> kernels1D = {{3}, {5}};
@@ -27,35 +27,28 @@ const auto conv1DParams_ExplicitPadding = ::testing::Combine(
         ::testing::ValuesIn(kernels1D), ::testing::ValuesIn(strides1D),
         ::testing::ValuesIn(padBegins1D), ::testing::ValuesIn(padEnds1D),
         ::testing::ValuesIn(dilations1D), ::testing::ValuesIn(numOutChannels1D),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT));
+        ::testing::Values(ov::op::PadType::EXPLICIT));
 const auto conv1DParams_AutoPadValid = ::testing::Combine(
         ::testing::ValuesIn(kernels1D), ::testing::ValuesIn(strides1D),
         ::testing::Values(std::vector<ptrdiff_t>({0})),
         ::testing::Values(std::vector<ptrdiff_t>({0})),
         ::testing::ValuesIn(dilations1D), ::testing::ValuesIn(numOutChannels1D),
-        ::testing::Values(ngraph::op::PadType::VALID));
+        ::testing::Values(ov::op::PadType::VALID));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Convolution1D_ExplicitPadding, ConvolutionLayerTest,
         ::testing::Combine(
-                conv1DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(std::vector<size_t>({1, 3, 30})),
+                conv1DParams_ExplicitPadding,
+                ::testing::ValuesIn(model_type),
+                ::testing::Values(ov::test::static_shapes_to_test_representation({{1, 3, 30}})),
                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
         ConvolutionLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Convolution1D_AutoPadValid, ConvolutionLayerTest,
         ::testing::Combine(
-                conv1DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(std::vector<size_t>({1, 3, 30})),
+                conv1DParams_AutoPadValid, ::testing::ValuesIn(model_type),
+                ::testing::Values(ov::test::static_shapes_to_test_representation({{1, 3, 30}})),
                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
         ConvolutionLayerTest::getTestCaseName);
 
@@ -82,24 +75,16 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(
 INSTANTIATE_TEST_SUITE_P(
         smoke_Convolution2D_ExplicitPadding, ConvolutionLayerTest,
         ::testing::Combine(
-                conv2DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),
+                conv2DParams_ExplicitPadding, ::testing::ValuesIn(model_type),
+                ::testing::Values(ov::test::static_shapes_to_test_representation({{1, 3, 30, 30}})),
                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
         ConvolutionLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Convolution2D_AutoPadValid, ConvolutionLayerTest,
         ::testing::Combine(
-                conv2DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),
+                conv2DParams_AutoPadValid, ::testing::ValuesIn(model_type),
+                ::testing::Values(ov::test::static_shapes_to_test_representation({{1, 3, 30, 30}})),
                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
         ConvolutionLayerTest::getTestCaseName);
 
@@ -122,12 +107,8 @@ const auto conv2DParams_WeightLayout = ::testing::Combine(::testing::Values(kern
 
 INSTANTIATE_TEST_SUITE_P(smoke_Convolution2D_SpecificWeightLayout, ConvolutionLayerTest,
                          ::testing::Combine(conv2DParams_WeightLayout,
-                                            ::testing::ValuesIn(netPrecisions),
-                                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                            ::testing::Values(InferenceEngine::Layout::ANY),
-                                            ::testing::Values(InferenceEngine::Layout::ANY),
-                                            ::testing::Values(std::vector<size_t>({1, 1, 50, 75})),
+                                            ::testing::ValuesIn(model_type),
+                                            ::testing::Values(ov::test::static_shapes_to_test_representation({{1, 1, 50, 75}})),
                                             ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          ConvolutionLayerTest::getTestCaseName);
 } // namespace specificWeightLayout
@@ -154,24 +135,16 @@ const auto conv3DParams_AutoPadValid = ::testing::Combine(
 INSTANTIATE_TEST_SUITE_P(
         smoke_Convolution3D_ExplicitPadding, ConvolutionLayerTest,
         ::testing::Combine(
-                conv3DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),
+                conv3DParams_ExplicitPadding, ::testing::ValuesIn(model_type),
+                ::testing::Values(ov::test::static_shapes_to_test_representation({{1, 3, 10, 10, 10}})),
                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
         ConvolutionLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_Convolution3D_AutoPadValid, ConvolutionLayerTest,
         ::testing::Combine(
-                conv3DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(InferenceEngine::Layout::ANY),
-                ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),
+                conv3DParams_AutoPadValid, ::testing::ValuesIn(model_type),
+                ::testing::Values(ov::test::static_shapes_to_test_representation({{1, 3, 10, 10, 10}})),
                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
         ConvolutionLayerTest::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -4,31 +4,30 @@
 
 #include <vector>
 
-#include "single_layer_tests/convolution_backprop_data.hpp"
+#include "single_op_tests/convolution_backprop_data.hpp"
 #include "common_test_utils/test_constants.hpp"
 
-using namespace LayerTestsDefinitions;
-
 namespace {
+using ov::test::ConvolutionBackpropDataLayerTest;
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::FP16
+const std::vector<ov::element::Type> model_type = {
+        ov::element::f32,
+        ov::element::f16
 };
 
 const std::vector<size_t> numOutChannels = {1, 5, 16};
-const std::vector<std::vector<size_t >> emptyOutputShape = {{}};
-const std::vector<std::vector<ptrdiff_t >> emptyOutputPadding = {{}};
+const std::vector<ov::Shape> emptyOutputShape = {{}};
+const std::vector<std::vector<ptrdiff_t>> emptyOutputPadding = {{}};
 
 /* ============= 2D ConvolutionBackpropData ============= */
-const std::vector<std::vector<size_t >> inputShapes2D = {{1, 3, 30, 30},
-                                                         {1, 16, 10, 10},
-                                                         {1, 32, 10, 10}};
-const std::vector<std::vector<size_t >> kernels2D = {{1, 1}, {3, 3}, {3, 5}};
-const std::vector<std::vector<size_t >> strides2D = {{1, 1}, {1, 3}};
+const std::vector<std::vector<ov::Shape>> inputShapes2D_static = {{{1, 3, 30, 30}},
+                                                                  {{1, 16, 10, 10}},
+                                                                  {{1, 32, 10, 10}}};
+const std::vector<std::vector<size_t>> kernels2D = {/*{1, 1},*/ {3, 3}, {3, 5}};
+const std::vector<std::vector<size_t>> strides2D = {{1, 1}, {1, 3}};
 const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{0, 0}};
 const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{0, 0}, {1, 1}};
-const std::vector<std::vector<size_t >> dilations2D = {{1, 1}, {2, 2}};
+const std::vector<std::vector<size_t>> dilations2D = {{1, 1}, {2, 2}};
 
 const auto conv2DParams_ExplicitPadding = ::testing::Combine(
         ::testing::ValuesIn(kernels2D),
@@ -37,7 +36,7 @@ const auto conv2DParams_ExplicitPadding = ::testing::Combine(
         ::testing::ValuesIn(padEnds2D),
         ::testing::ValuesIn(dilations2D),
         ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
         ::testing::ValuesIn(emptyOutputPadding)
 );
 const auto conv2DParams_AutoPadValid = ::testing::Combine(
@@ -47,19 +46,15 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
         ::testing::ValuesIn(dilations2D),
         ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::VALID),
+        ::testing::Values(ov::op::PadType::VALID),
         ::testing::ValuesIn(emptyOutputPadding)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData2D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_ExplicitPadding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes2D),
+                                ::testing::ValuesIn(model_type),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes2D_static)),
                                 ::testing::ValuesIn(emptyOutputShape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
@@ -67,28 +62,20 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData2D_ExplicitPadding, Convol
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData2D_AutoPadValid, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes2D),
+                                ::testing::ValuesIn(model_type),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes2D_static)),
                                 ::testing::ValuesIn(emptyOutputShape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t >> inputShape2D = {{1, 3, 9, 12}};
-const std::vector<std::vector<size_t >> outputShapes2D = {{6, 6}, {4, 9}};
+const std::vector<ov::Shape> inputShape2D_static = {{1, 3, 9, 12}};
+const std::vector<ov::Shape> outputShapes2D = {{6, 6}, {4, 9}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData2D_OutputShapeDefined, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShape2D),
+                                ::testing::ValuesIn(model_type),
+                                ::testing::Values(ov::test::static_shapes_to_test_representation(inputShape2D_static)),
                                 ::testing::ValuesIn(outputShapes2D),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
@@ -103,7 +90,7 @@ const auto conv2DParams_ExplicitPadding_output_padding = ::testing::Combine(
         ::testing::ValuesIn(padEnds2D),
         ::testing::ValuesIn(dilations2D),
         ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
         ::testing::ValuesIn(outputPadding2D)
 );
 const auto conv2DParams_AutoPadValid_output_padding = ::testing::Combine(
@@ -113,19 +100,15 @@ const auto conv2DParams_AutoPadValid_output_padding = ::testing::Combine(
         ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
         ::testing::ValuesIn(dilations2D),
         ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::VALID),
+        ::testing::Values(ov::op::PadType::VALID),
         ::testing::ValuesIn(outputPadding2D)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData2D_ExplicitPadding_OutputPaddingDefined, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_AutoPadValid_output_padding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes2D),
+                                ::testing::ValuesIn(model_type),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes2D_static)),
                                 ::testing::ValuesIn(emptyOutputShape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
@@ -133,12 +116,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData2D_ExplicitPadding_OutputP
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData2D_AutoPadding_OutputPaddingDefined, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv2DParams_ExplicitPadding_output_padding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes2D),
+                                ::testing::ValuesIn(model_type),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes2D_static)),
                                 ::testing::ValuesIn(emptyOutputShape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
@@ -152,23 +131,19 @@ INSTANTIATE_TEST_CASE_P(smoke_ConvolutionBackpropData2D_RoundingOfPadding, Convo
                                         ::testing::Values(std::vector<ptrdiff_t>({15, 0})),
                                         ::testing::Values(std::vector<size_t>({1, 1})),
                                         ::testing::Values(size_t(4)),
-                                        ::testing::Values(ngraph::op::PadType::SAME_LOWER),
+                                        ::testing::Values(ov::op::PadType::SAME_LOWER),
                                         ::testing::Values(std::vector<ptrdiff_t>({0, 0}))),
-                                ::testing::Values(InferenceEngine::Precision::FP32),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(std::vector<size_t>({ 1, 512, 2, 1 })),
-                                ::testing::Values(std::vector<size_t>({ 16, 1 })),
+                                ::testing::Values(ov::element::f32),
+                                ::testing::Values(ov::test::static_shapes_to_test_representation({{1, 512, 2, 1}})),
+                                ::testing::Values(ov::Shape({ 16, 1 })),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
 /* ============= 3D ConvolutionBackpropData ============= */
-const std::vector<std::vector<size_t >> inputShapes3D = {{1, 3, 10, 10, 10},
-                                                         {1, 16, 5, 5, 5},
-                                                         {1, 32, 5, 5, 5}};
-const std::vector<std::vector<size_t >> kernels3D = {{1, 1, 1}, {3, 3, 3}};
+const std::vector<std::vector<ov::Shape>> inputShapes3D_static = {{{1, 3, 10, 10, 10}},
+                                                           {{1, 16, 5, 5, 5}},
+                                                           {{1, 32, 5, 5, 5}}};
+const std::vector<std::vector<size_t >> kernels3D = {/*{1, 1, 1},*/ {3, 3, 3}};
 const std::vector<std::vector<size_t >> strides3D = {{1, 1, 1}};
 const std::vector<std::vector<ptrdiff_t>> padBegins3D = {{0, 0, 0}};
 const std::vector<std::vector<ptrdiff_t>> padEnds3D = {{0, 0, 0}, {1, 1, 1}};
@@ -181,7 +156,7 @@ const auto conv3DParams_ExplicitPadding = ::testing::Combine(
         ::testing::ValuesIn(padEnds3D),
         ::testing::ValuesIn(dilations3D),
         ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
         ::testing::ValuesIn(emptyOutputPadding)
 );
 const auto conv3DParams_AutoPadValid = ::testing::Combine(
@@ -191,19 +166,15 @@ const auto conv3DParams_AutoPadValid = ::testing::Combine(
         ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
         ::testing::ValuesIn(dilations3D),
         ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::VALID),
+        ::testing::Values(ov::op::PadType::VALID),
         ::testing::ValuesIn(emptyOutputPadding)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv3DParams_ExplicitPadding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes3D),
+                                ::testing::ValuesIn(model_type),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes3D_static)),
                                 ::testing::ValuesIn(emptyOutputShape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
@@ -211,28 +182,20 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_ExplicitPadding, Convol
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_AutoPadValid, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv3DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes3D),
+                                ::testing::ValuesIn(model_type),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes3D_static)),
                                 ::testing::ValuesIn(emptyOutputShape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t >> inputShape3D = {{1, 3, 10, 10, 10}};
-const std::vector<std::vector<size_t >> outputShapes3D = {{8, 8, 8}, {10, 10, 10}};
+const std::vector<ov::Shape> inputShape3D_static = {{1, 3, 10, 10, 10}};
+const std::vector<ov::Shape> outputShapes3D = {{8, 8, 8}, {10, 10, 10}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_OutputShapeDefined, ConvolutionBackpropDataLayerTest,
                         ::testing::Combine(
                                 conv3DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShape3D),
+                                ::testing::ValuesIn(model_type),
+                                ::testing::Values(ov::test::static_shapes_to_test_representation(inputShape3D_static)),
                                 ::testing::ValuesIn(outputShapes3D),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
@@ -247,7 +210,7 @@ const auto conv3DParams_ExplicitPadding_output_padding = ::testing::Combine(
         ::testing::ValuesIn(padEnds3D),
         ::testing::ValuesIn(dilations3D),
         ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
         ::testing::ValuesIn(outputPadding3D)
 );
 const auto conv3DParams_AutoPadValid_output_padding = ::testing::Combine(
@@ -257,34 +220,26 @@ const auto conv3DParams_AutoPadValid_output_padding = ::testing::Combine(
         ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
         ::testing::ValuesIn(dilations3D),
         ::testing::ValuesIn(numOutChannels),
-        ::testing::Values(ngraph::op::PadType::VALID),
+        ::testing::Values(ov::op::PadType::VALID),
         ::testing::ValuesIn(outputPadding3D)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_ExplicitPadding_OutputPaddingDefined, ConvolutionBackpropDataLayerTest,
-                        ::testing::Combine(
-                                conv3DParams_AutoPadValid_output_padding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::ValuesIn(emptyOutputShape),
-                                ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+// INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_ExplicitPadding_OutputPaddingDefined, ConvolutionBackpropDataLayerTest,
+//                         ::testing::Combine(
+//                                 conv3DParams_AutoPadValid_output_padding,
+//                                 ::testing::ValuesIn(model_type),
+//                                 ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes3D_static)),
+//                                 ::testing::ValuesIn(emptyOutputShape),
+//                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
+//                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_AutoPadding_OutputPaddingDefined, ConvolutionBackpropDataLayerTest,
-                        ::testing::Combine(
-                                conv3DParams_ExplicitPadding_output_padding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::ValuesIn(emptyOutputShape),
-                                ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                        ConvolutionBackpropDataLayerTest::getTestCaseName);
+// INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_AutoPadding_OutputPaddingDefined, ConvolutionBackpropDataLayerTest,
+//                         ::testing::Combine(
+//                                 conv3DParams_ExplicitPadding_output_padding,
+//                                 ::testing::ValuesIn(model_type),
+//                                 ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes3D_static)),
+//                                 ::testing::ValuesIn(emptyOutputShape),
+//                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
+//                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
 }  // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/deformable_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/deformable_convolution.cpp
@@ -1,15 +1,15 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <vector>
 #include "common_test_utils/test_constants.hpp"
-#include "single_layer_tests/deformable_convolution.hpp"
-using namespace LayerTestsDefinitions;
-namespace {
+#include "single_op_tests/deformable_convolution.hpp"
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16,
-    InferenceEngine::Precision::I32, InferenceEngine::Precision::I16};
+namespace {
+using ov::test::DeformableConvolutionLayerTest;
+
+const std::vector<ov::element::Type> netPrecisions = {
+    ov::element::f32, ov::element::f16,
+    ov::element::i32, ov::element::i16};
 
 /* ============= 2D DeformableConvolution ============= */
 const std::vector<std::vector<size_t>> deformable_vals = {{1, 16, 2, 2}};
@@ -25,74 +25,117 @@ const std::vector<size_t> multiple_defor_groups = {4};
 const std::vector<std::vector<size_t>> deform_vals = {{1, 72, 64, 64}};
 const std::vector<std::vector<size_t>> kernel = {{16, 16, 3, 3}};
 
+const std::vector<ov::Shape> shapes_no_modulation {
+    {1, 2, 3, 3},
+    {1, 16, 2, 2}, //deformable_vals
+    {2, 2, 2, 2},  //kernels
+};
+
+const std::vector<ov::Shape> shapes_with_modulation {
+    {1, 2, 3, 3},
+    {1, 16, 2, 2}, //deformable_vals
+    {2, 2, 2, 2},  //kernels
+    {1, 8, 2, 2},  //modulation_shape
+};
+
 const std::vector<bool> with_bilinear_interpolation_pad = { false, true };
 const std::vector<bool> with_modulated_scalar = { false, true };
 
 const auto deformableConv2DParams_ExplicitPadding = ::testing::Combine(
-    ::testing::ValuesIn(deformable_vals),
-    ::testing::ValuesIn(kernels), ::testing::ValuesIn(strides),
+    ::testing::ValuesIn(strides),
     ::testing::ValuesIn(padBegins), ::testing::ValuesIn(padEnds),
     ::testing::ValuesIn(dilations), ::testing::ValuesIn(groups),
     ::testing::ValuesIn(defor_groups), ::testing::ValuesIn(numOutChannels),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT), ::testing::ValuesIn(with_bilinear_interpolation_pad),
-    ::testing::ValuesIn(with_modulated_scalar));
+    ::testing::Values(ov::op::PadType::EXPLICIT), ::testing::ValuesIn(with_bilinear_interpolation_pad));
 
 const auto deformableConv2DParams_AutoPadValid = ::testing::Combine(
-    ::testing::ValuesIn(deformable_vals),
-    ::testing::ValuesIn(kernels), ::testing::ValuesIn(strides),
+    ::testing::ValuesIn(strides),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
     ::testing::ValuesIn(dilations), ::testing::ValuesIn(groups),
     ::testing::ValuesIn(defor_groups), ::testing::ValuesIn(numOutChannels),
-    ::testing::Values(ngraph::op::PadType::VALID),
-    ::testing::ValuesIn(with_bilinear_interpolation_pad),
-    ::testing::ValuesIn(with_modulated_scalar));
+    ::testing::Values(ov::op::PadType::VALID),
+    ::testing::ValuesIn(with_bilinear_interpolation_pad));
 
 const auto deformableConv2DParams_DeformableGroups_AutoPadExplicit = ::testing::Combine(
-    ::testing::ValuesIn(deform_vals),
-    ::testing::ValuesIn(kernel), ::testing::ValuesIn(strides),
+    ::testing::ValuesIn(strides),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
     ::testing::ValuesIn(dilations), ::testing::ValuesIn(groups),
     ::testing::ValuesIn(multiple_defor_groups), ::testing::ValuesIn(numOutChannels),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(with_bilinear_interpolation_pad),
-    ::testing::ValuesIn(with_modulated_scalar));
+    ::testing::Values(ov::op::PadType::EXPLICIT),
+    ::testing::ValuesIn(with_bilinear_interpolation_pad));
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_DeformableConvolution2D_ExplicitPadding, DeformableConvolutionLayerTest,
+    smoke_DeformableConvolution2D_ExplicitPadding_NoModulation, DeformableConvolutionLayerTest,
     ::testing::Combine(
-        deformableConv2DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 2, 3, 3})),
+        deformableConv2DParams_ExplicitPadding,
+        ::testing::Values(false),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_no_modulation)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     DeformableConvolutionLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_DeformableConvolution2D_AutoPadValid, DeformableConvolutionLayerTest,
+    smoke_DeformableConvolution2D_ExplicitPadding_WithModulation, DeformableConvolutionLayerTest,
     ::testing::Combine(
-        deformableConv2DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 2, 3, 3})),
+        deformableConv2DParams_ExplicitPadding,
+        ::testing::Values(true),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_with_modulation)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     DeformableConvolutionLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_DeformableConvolution2D_DeformableGroups_ExplicitPadding, DeformableConvolutionLayerTest,
+    smoke_DeformableConvolution2D_AutoPadValid_NoModulation, DeformableConvolutionLayerTest,
+    ::testing::Combine(
+        deformableConv2DParams_AutoPadValid,
+        ::testing::Values(false),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_no_modulation)),
+        ::testing::Values(ov::test::utils::DEVICE_CPU)),
+    DeformableConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_DeformableConvolution2D_AutoPadValid_WithModulation, DeformableConvolutionLayerTest,
+    ::testing::Combine(
+        deformableConv2DParams_AutoPadValid,
+        ::testing::Values(true),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_with_modulation)),
+        ::testing::Values(ov::test::utils::DEVICE_CPU)),
+    DeformableConvolutionLayerTest::getTestCaseName);
+
+const std::vector<ov::Shape> shapes_2d_deformable_groups_no_modulation {
+    {1, 16, 66, 66},
+    {1, 72, 64, 64}, //deformable_vals
+    {16, 16, 3, 3},  //kernels
+};
+
+const std::vector<ov::Shape> shapes_2d_deformable_groups_with_modulation {
+    {1, 16, 66, 66},
+    {1, 72, 64, 64}, //deformable_vals
+    {16, 16, 3, 3},  //kernels
+    {1, 36, 64, 64},  //modulation_shape
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_DeformableConvolution2D_DeformableGroups_ExplicitPadding_NoModulation, DeformableConvolutionLayerTest,
     ::testing::Combine(
         deformableConv2DParams_DeformableGroups_AutoPadExplicit,
+        ::testing::Values(false),
         ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 16, 66, 66})),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_2d_deformable_groups_no_modulation)),
+        ::testing::Values(ov::test::utils::DEVICE_CPU)),
+    DeformableConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_DeformableConvolution2D_DeformableGroups_ExplicitPadding_WithModulation, DeformableConvolutionLayerTest,
+    ::testing::Combine(
+        deformableConv2DParams_DeformableGroups_AutoPadExplicit,
+        ::testing::Values(true),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_2d_deformable_groups_with_modulation)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     DeformableConvolutionLayerTest::getTestCaseName);
 
@@ -101,9 +144,21 @@ const std::vector<std::vector<size_t>> single_deform_vals = {{1, 54, 28, 28}};
 const std::vector<std::vector<size_t>> single_kernel = {{1, 3, 3, 3}};
 const std::vector<size_t> single_deform_groups = {3};
 
+const std::vector<ov::Shape> shapes_single_no_modulation {
+    {1, 3, 30, 30},
+    {1, 54, 28, 28}, //deformable_vals
+    {1, 3, 3, 3},  //kernels
+};
+
+const std::vector<ov::Shape> shapes_single_with_modulation {
+    {1, 3, 30, 30},
+    {1, 54, 28, 28}, //deformable_vals
+    {1, 3, 3, 3},  //kernels
+    {1, 27, 28, 28},  //modulation_shape
+};
+
+
 const auto deformableConv2DParams_SingleTestCase = ::testing::Combine(
-    ::testing::ValuesIn(single_deform_vals),
-    ::testing::ValuesIn(single_kernel),
     ::testing::ValuesIn(strides),
     ::testing::ValuesIn(padBegins),
     ::testing::ValuesIn(padEnds),
@@ -112,29 +167,47 @@ const auto deformableConv2DParams_SingleTestCase = ::testing::Combine(
     ::testing::ValuesIn(single_deform_groups),
     ::testing::ValuesIn(numOutChannels),
     ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(with_bilinear_interpolation_pad),
-    ::testing::ValuesIn(with_modulated_scalar)
-);
+    ::testing::ValuesIn(with_bilinear_interpolation_pad));
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_DeformableConvolution2D_SingleTestCase, DeformableConvolutionLayerTest,
+    smoke_DeformableConvolution2D_SingleTestCase_NoModulation, DeformableConvolutionLayerTest,
     ::testing::Combine(
         deformableConv2DParams_SingleTestCase,
+        ::testing::Values(false),
         ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_single_no_modulation)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     DeformableConvolutionLayerTest::getTestCaseName);
-/* ============= Multiple groups case ============= */
+
 INSTANTIATE_TEST_SUITE_P(
-        smoke_DeformableConvolution2D_MultipleGroups, DeformableConvolutionLayerTest,
+    smoke_DeformableConvolution2D_SingleTestCase_WithModulation, DeformableConvolutionLayerTest,
+    ::testing::Combine(
+        deformableConv2DParams_SingleTestCase,
+        ::testing::Values(true),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_single_with_modulation)),
+        ::testing::Values(ov::test::utils::DEVICE_CPU)),
+    DeformableConvolutionLayerTest::getTestCaseName);
+
+/* ============= Multiple groups case ============= */
+
+const std::vector<ov::Shape> shapes_multiple_groups_no_modulation {
+    {1, 4, 3, 3},
+    {1, 16, 2, 2}, //deformable_vals
+    {2, 2, 2, 2},  //kernels
+};
+
+const std::vector<ov::Shape> shapes_multiple_groups_with_modulation {
+    {1, 4, 3, 3},
+    {1, 16, 2, 2}, //deformable_vals
+    {2, 2, 2, 2},  //kernels
+    {1, 8, 2, 2},  //modulation_shape
+};
+
+INSTANTIATE_TEST_SUITE_P(
+        smoke_DeformableConvolution2D_MultipleGroups_NoModulation, DeformableConvolutionLayerTest,
         ::testing::Combine(
                 ::testing::Combine(
-                        ::testing::ValuesIn(std::vector<std::vector<size_t>> {{1, 16, 2, 2}}),  // offsets
-                        ::testing::ValuesIn(std::vector<std::vector<size_t>> {{2, 2, 2, 2}}),  // ker.
                         ::testing::ValuesIn(strides),
                         ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
                         ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
@@ -143,22 +216,49 @@ INSTANTIATE_TEST_SUITE_P(
                         ::testing::ValuesIn(std::vector<size_t> {2}),  // def. gr.
                         ::testing::ValuesIn(numOutChannels),
                         ::testing::Values(ngraph::op::PadType::EXPLICIT),
-                        ::testing::ValuesIn(with_bilinear_interpolation_pad),
-                        ::testing::ValuesIn(with_modulated_scalar)),
+                        ::testing::ValuesIn(with_bilinear_interpolation_pad)),
+                        ::testing::Values(false),
                         ::testing::ValuesIn(netPrecisions),
-                        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                        ::testing::Values(InferenceEngine::Layout::ANY),
-                        ::testing::Values(InferenceEngine::Layout::ANY),
-                        ::testing::Values(std::vector<size_t>({1, 4, 3, 3})),
+                        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_multiple_groups_no_modulation)),
                         ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         DeformableConvolutionLayerTest::getTestCaseName);
+
 INSTANTIATE_TEST_SUITE_P(
-        smoke_DeformableConvolution2D_MultipleGroups_2, DeformableConvolutionLayerTest,
+        smoke_DeformableConvolution2D_MultipleGroups_WithModulation, DeformableConvolutionLayerTest,
         ::testing::Combine(
                 ::testing::Combine(
-                        ::testing::ValuesIn(std::vector<std::vector<size_t>> {{1, 18, 66, 66}}),  // offsets
-                        ::testing::ValuesIn(std::vector<std::vector<size_t>> {{4, 2, 3, 3}}),  // ker.
+                        ::testing::ValuesIn(strides),
+                        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+                        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+                        ::testing::ValuesIn(dilations),
+                        ::testing::ValuesIn(std::vector<size_t> {2}),  // gr.
+                        ::testing::ValuesIn(std::vector<size_t> {2}),  // def. gr.
+                        ::testing::ValuesIn(numOutChannels),
+                        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+                        ::testing::ValuesIn(with_bilinear_interpolation_pad)),
+                        ::testing::Values(true),
+                        ::testing::ValuesIn(netPrecisions),
+                        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_multiple_groups_with_modulation)),
+                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                        DeformableConvolutionLayerTest::getTestCaseName);
+
+const std::vector<ov::Shape> shapes_multiple_groups_2_no_modulation {
+    {1, 8, 68, 68},
+    {1, 18, 66, 66}, //deformable_vals
+    {4, 2, 3, 3},  //kernels
+};
+
+const std::vector<ov::Shape> shapes_multiple_groups_2_with_modulation {
+    {1, 8, 68, 68},
+    {1, 18, 66, 66}, //deformable_vals
+    {4, 2, 3, 3},  //kernels
+    {1, 9, 66, 66},  //modulation_shape
+};
+
+INSTANTIATE_TEST_SUITE_P(
+        smoke_DeformableConvolution2D_MultipleGroups_2_NoModulation, DeformableConvolutionLayerTest,
+        ::testing::Combine(
+                ::testing::Combine(
                         ::testing::ValuesIn(strides),
                         ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
                         ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
@@ -167,14 +267,29 @@ INSTANTIATE_TEST_SUITE_P(
                         ::testing::ValuesIn(std::vector<size_t> {1}),  // def. gr.
                         ::testing::ValuesIn(numOutChannels),
                         ::testing::Values(ngraph::op::PadType::EXPLICIT),
-                        ::testing::ValuesIn(with_bilinear_interpolation_pad),
-                        ::testing::ValuesIn(with_modulated_scalar)),
+                        ::testing::ValuesIn(with_bilinear_interpolation_pad)),
+                        ::testing::Values(false),
                         ::testing::ValuesIn(netPrecisions),
-                        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                        ::testing::Values(InferenceEngine::Layout::ANY),
-                        ::testing::Values(InferenceEngine::Layout::ANY),
-                        ::testing::Values(std::vector<size_t>({1, 8, 68, 68})),
+                        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_multiple_groups_2_no_modulation)),
+                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                        DeformableConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+        smoke_DeformableConvolution2D_MultipleGroups_2_WithModulation, DeformableConvolutionLayerTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        ::testing::ValuesIn(strides),
+                        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+                        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+                        ::testing::ValuesIn(dilations),
+                        ::testing::ValuesIn(std::vector<size_t> {4}),  // gr.
+                        ::testing::ValuesIn(std::vector<size_t> {1}),  // def. gr.
+                        ::testing::ValuesIn(numOutChannels),
+                        ::testing::Values(ngraph::op::PadType::EXPLICIT),
+                        ::testing::ValuesIn(with_bilinear_interpolation_pad)),
+                        ::testing::Values(true),
+                        ::testing::ValuesIn(netPrecisions),
+                        ::testing::Values(ov::test::static_shapes_to_test_representation(shapes_multiple_groups_2_with_modulation)),
                         ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         DeformableConvolutionLayerTest::getTestCaseName);
 }  // namespace

--- a/src/tests/functional/plugin/shared/include/single_op_tests/convolution.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/convolution.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/convolution.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(ConvolutionLayerTest, Inference) {
+    run();
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/include/single_op_tests/convolution_backprop_data.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/convolution_backprop_data.hpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// DEPRECATED, can't be removed currently due to arm and kmb-plugin dependency (#55568)
+#pragma once
+
+#include "shared_test_classes/single_op/convolution_backprop_data.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(ConvolutionBackpropDataLayerTest, Inference) {
+    run();
+}
+} // namespace test
+} // namespace ov

--- a/src/tests/functional/plugin/shared/include/single_op_tests/deformable_convolution.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/deformable_convolution.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/deformable_convolution.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(DeformableConvolutionLayerTest, Inference) {
+    run();
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/convolution.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/convolution.hpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+// ! [test_convolution:definition]
+typedef std::tuple<
+        std::vector<size_t>,    // Kernel size
+        std::vector<size_t>,    // Strides
+        std::vector<ptrdiff_t>, // Pad begin
+        std::vector<ptrdiff_t>, // Pad end
+        std::vector<size_t>,    // Dilation
+        size_t,                 // Num out channels
+        ov::op::PadType         // Padding type
+> convSpecificParams;
+typedef std::tuple<
+        convSpecificParams,
+        ov::element::Type,        // Model type
+        std::vector<InputShape>,  // Input shapes
+        std::string               // Device name
+> convLayerTestParamsSet;
+
+class ConvolutionLayerTest : public testing::WithParamInterface<convLayerTestParamsSet>,
+                             virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<convLayerTestParamsSet>& obj);
+
+protected:
+    void SetUp() override;
+};
+// ! [test_convolution:definition]
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/convolution_backprop_data.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/convolution_backprop_data.hpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// DEPRECATED, can't be removed currently due to arm and kmb-plugin dependency (#55568)
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+typedef std::tuple<
+        std::vector<size_t>,            // Kernel size
+        std::vector<size_t>,            // Strides
+        std::vector<ptrdiff_t>,         // Pad begin
+        std::vector<ptrdiff_t>,         // Pad end
+        std::vector<size_t>,            // Dilation
+        size_t,                         // Num out channels
+        ov::op::PadType,                // Padding type
+        std::vector<ptrdiff_t>          // Output padding
+> convBackpropDataSpecificParams;
+typedef std::tuple<
+        convBackpropDataSpecificParams,
+        ov::element::Type,              // Net precision
+        std::vector<InputShape>,        // Input shapes
+        ov::Shape,                      // Output shapes
+        std::string                     // Device name
+> convBackpropDataLayerTestParamsSet;
+
+class ConvolutionBackpropDataLayerTest : public testing::WithParamInterface<convBackpropDataLayerTestParamsSet>,
+                                         virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<convBackpropDataLayerTestParamsSet>& obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/deformable_convolution.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/deformable_convolution.hpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+typedef std::tuple<
+        std::vector<size_t>,    // Strides
+        std::vector<ptrdiff_t>, // Pad begin
+        std::vector<ptrdiff_t>, // Pad end
+        std::vector<size_t>,    // Dilation
+        size_t,                 // Groups
+        size_t,                 // Deformable groups
+        size_t,                 // Num out channels
+        ov::op::PadType,        // Padding type
+        bool                   // Bilinear interpolation pad
+> deformableConvSpecificParams;
+typedef std::tuple<
+        deformableConvSpecificParams,
+        bool,                      // Modulation
+        ov::element::Type,         // Model type
+        std::vector<InputShape>,   // Input shapes
+        std::string                // Device name
+> deformableConvLayerTestParamsSet;
+
+class DeformableConvolutionLayerTest : public testing::WithParamInterface<deformableConvLayerTestParamsSet>,
+                                       virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<deformableConvLayerTestParamsSet>& obj);
+    void generate_inputs(const std::vector<ov::Shape>&) override;
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/deformable_convolution.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/deformable_convolution.hpp
@@ -35,8 +35,6 @@ class DeformableConvolutionLayerTest : public testing::WithParamInterface<deform
                                        virtual public ov::test::SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<deformableConvLayerTestParamsSet>& obj);
-    void generate_inputs(const std::vector<ov::Shape>&) override;
-
 protected:
     void SetUp() override;
 };

--- a/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
@@ -7,7 +7,7 @@
 #include "ov_ops/augru_cell.hpp"
 #include "ov_ops/augru_sequence.hpp"
 
-#include <common_test_utils/ov_tensor_utils.hpp>
+#include "common_test_utils/ov_tensor_utils.hpp"
 
 #include "shared_test_classes/single_layer/roi_align.hpp"
 #include "shared_test_classes/single_layer/psroi_pooling.hpp"
@@ -961,6 +961,19 @@ ov::runtime::Tensor generate(const
         OPENVINO_THROW("Unsupported element type: ", tensor.get_element_type());
     }
     return tensor;
+}
+
+ov::runtime::Tensor generate(const
+                             std::shared_ptr<ov::op::v8::DeformableConvolution>& node,
+                             size_t port,
+                             const ov::element::Type& elemType,
+                             const ov::Shape& targetShape) {
+    if (1 == port) {
+        return ov::test::utils::create_and_fill_tensor(elemType, targetShape, 2, 0, 10);
+    } else if (2 == port) {
+        return ov::test::utils::create_and_fill_tensor(elemType, targetShape, 1, 0, 20);
+    }
+    return generate(std::static_pointer_cast<ov::Node>(node), port, elemType, targetShape);
 }
 
 namespace comparison {

--- a/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
@@ -984,7 +984,6 @@ ov::runtime::Tensor generate(const
     }
     return ov::test::utils::create_and_fill_tensor(elemType, targetShape, in_gen_data.range,
                                                    in_gen_data.start_from, in_gen_data.resolution, in_gen_data.seed);
-
 }
 
 namespace comparison {

--- a/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
@@ -968,12 +968,23 @@ ov::runtime::Tensor generate(const
                              size_t port,
                              const ov::element::Type& elemType,
                              const ov::Shape& targetShape) {
-    if (1 == port) {
-        return ov::test::utils::create_and_fill_tensor(elemType, targetShape, 2, 0, 10);
-    } else if (2 == port) {
-        return ov::test::utils::create_and_fill_tensor(elemType, targetShape, 1, 0, 20);
+    InputGenerateData in_gen_data;
+    if (elemType.is_real()) {
+        set_real_number_generation_data(in_gen_data);
     }
-    return generate(std::static_pointer_cast<ov::Node>(node), port, elemType, targetShape);
+
+    if (1 == port) {
+        in_gen_data.range = 2;
+        in_gen_data.start_from = 0;
+        in_gen_data.resolution = 10;
+    } else if (2 == port) {
+        in_gen_data.range = 1;
+        in_gen_data.start_from = 0;
+        in_gen_data.resolution = 20;
+    }
+    return ov::test::utils::create_and_fill_tensor(elemType, targetShape, in_gen_data.range,
+                                                   in_gen_data.start_from, in_gen_data.resolution, in_gen_data.seed);
+
 }
 
 namespace comparison {

--- a/src/tests/functional/shared_test_classes/src/single_op/convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/convolution.cpp
@@ -1,0 +1,78 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/convolution.hpp"
+
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/convolution.hpp"
+#include "common_test_utils/data_utils.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
+
+namespace ov {
+namespace test {
+std::string ConvolutionLayerTest::getTestCaseName(const testing::TestParamInfo<convLayerTestParamsSet>& obj) {
+    convSpecificParams conv_params;
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    std::string targetDevice;
+    std::tie(conv_params, model_type, shapes, targetDevice) = obj.param;
+    ngraph::op::PadType pad_type;
+    InferenceEngine::SizeVector kernel, stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end;
+    size_t conv_out_channels;
+    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, pad_type) = conv_params;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (size_t i = 0lu; i < shapes.size(); i++) {
+        result << ov::test::utils::partialShape2str({shapes[i].first}) << (i < shapes.size() - 1lu ? "_" : "");
+    }
+    result << ")_TS=";
+    for (size_t i = 0lu; i < shapes.front().second.size(); i++) {
+        result << "{";
+        for (size_t j = 0lu; j < shapes.size(); j++) {
+            result << ov::test::utils::vec2str(shapes[j].second[i]) << (j < shapes.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+    }
+    result << "K" << ov::test::utils::vec2str(kernel) << "_";
+    result << "S" << ov::test::utils::vec2str(stride) << "_";
+    result << "PB" << ov::test::utils::vec2str(pad_begin) << "_";
+    result << "PE" << ov::test::utils::vec2str(pad_end) << "_";
+    result << "D=" << ov::test::utils::vec2str(dilation) << "_";
+    result << "O=" << conv_out_channels << "_";
+    result << "AP=" << pad_type << "_";
+    result << "netPRC=" << model_type.get_type_name() << "_";
+    result << "trgDev=" << targetDevice;
+    return result.str();
+}
+
+void ConvolutionLayerTest::SetUp() {
+    convSpecificParams conv_params;
+    std::vector<InputShape> shapes;
+    ov::element::Type model_type;
+    std::tie(conv_params, model_type, shapes, targetDevice) = this->GetParam();
+    init_input_shapes(shapes);
+
+    ov::op::PadType pad_type;
+    InferenceEngine::SizeVector kernel, stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end;
+    size_t conv_out_channels;
+    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, pad_type) = conv_params;
+
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
+
+    ov::Shape filterWeightsShape = {conv_out_channels, static_cast<size_t>(inputDynamicShapes.front()[1].get_length())};
+    filterWeightsShape.insert(filterWeightsShape.end(), kernel.begin(), kernel.end());
+
+    auto tensor = ov::test::utils::create_and_fill_tensor(model_type, filterWeightsShape);
+    auto filter_weights_node = std::make_shared<ov::op::v0::Constant>(tensor);
+    auto conv = std::make_shared<ov::op::v1::Convolution>(params[0], filter_weights_node, stride, pad_begin, pad_end, dilation, pad_type);
+
+    function = std::make_shared<ov::Model>(std::make_shared<ov::op::v0::Result>(conv), params, "convolution");
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/convolution_backprop_data.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// DEPRECATED, can't be removed currently due to arm and kmb-plugin dependency (#55568)
+
+#include "shared_test_classes/single_op/convolution_backprop_data.hpp"
+
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/convolution.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace ov {
+namespace test {
+std::string ConvolutionBackpropDataLayerTest::getTestCaseName(const testing::TestParamInfo<convBackpropDataLayerTestParamsSet>& obj) {
+    convBackpropDataSpecificParams convBackpropDataParams;
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    ov::Shape output_shapes;
+    std::string target_device;
+    std::tie(convBackpropDataParams, model_type, shapes, output_shapes, target_device) = obj.param;
+    ov::op::PadType pad_type;
+    InferenceEngine::SizeVector kernel, stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end, out_padding;
+    size_t convOutChannels;
+    std::tie(kernel, stride, pad_begin, pad_end, dilation, convOutChannels, pad_type, out_padding) = convBackpropDataParams;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (size_t i = 0lu; i < shapes.size(); i++) {
+        result << ov::test::utils::partialShape2str({shapes[i].first}) << (i < shapes.size() - 1lu ? "_" : "");
+    }
+    result << ")_TS=";
+    for (size_t i = 0lu; i < shapes.front().second.size(); i++) {
+        result << "{";
+        for (size_t j = 0lu; j < shapes.size(); j++) {
+            result << ov::test::utils::vec2str(shapes[j].second[i]) << (j < shapes.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+    }
+    result << "OS=" << ov::test::utils::vec2str(output_shapes) << "_";
+    result << "K" << ov::test::utils::vec2str(kernel) << "_";
+    result << "S" << ov::test::utils::vec2str(stride) << "_";
+    result << "PB" << ov::test::utils::vec2str(pad_begin) << "_";
+    result << "PE" << ov::test::utils::vec2str(pad_end) << "_";
+    result << "D=" << ov::test::utils::vec2str(dilation) << "_";
+    result << "OP=" << ov::test::utils::vec2str(out_padding) << "_";
+    result << "O=" << convOutChannels << "_";
+    result << "AP=" << pad_type << "_";
+    result << "netPRC=" << model_type.get_type_name() << "_";
+    result << "trgDev=" << target_device;
+    return result.str();
+}
+
+void ConvolutionBackpropDataLayerTest::SetUp() {
+    convBackpropDataSpecificParams convBackpropDataParams;
+    std::vector<InputShape> shapes;
+    ov::Shape output_shape;
+    ov::element::Type model_type;
+    std::tie(convBackpropDataParams, model_type, shapes, output_shape, targetDevice) = this->GetParam();
+    init_input_shapes(shapes);
+
+    ov::op::PadType pad_type;
+    InferenceEngine::SizeVector kernel, stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end, out_padding;
+    size_t convOutChannels;
+    std::tie(kernel, stride, pad_begin, pad_end, dilation, convOutChannels, pad_type, out_padding) = convBackpropDataParams;
+
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
+
+    std::shared_ptr<ov::op::v1::ConvolutionBackpropData> convBackpropData;
+    if (!output_shape.empty()) {
+        auto outShape = ov::op::v0::Constant::create(ov::element::i64, {output_shape.size()}, output_shape);
+        convBackpropData = std::dynamic_pointer_cast<ov::op::v1::ConvolutionBackpropData>(
+        ngraph::builder::makeConvolutionBackpropData(params[0]->output(0), outShape, model_type, kernel, stride, pad_begin,
+                                                     pad_end, dilation, pad_type, convOutChannels));
+    } else {
+        convBackpropData = std::dynamic_pointer_cast<ov::op::v1::ConvolutionBackpropData>(
+            ngraph::builder::makeConvolutionBackpropData(params[0]->output(0), model_type, kernel, stride, pad_begin,
+                                                         pad_end, dilation, pad_type, convOutChannels, false, out_padding));
+    }
+    function = std::make_shared<ov::Model>(std::make_shared<ov::op::v0::Result>(convBackpropData), params, "convolutionBackpropData");
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/deformable_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/deformable_convolution.cpp
@@ -1,0 +1,116 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "shared_test_classes/single_op/deformable_convolution.hpp"
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/deformable_convolution.hpp"
+
+
+namespace ov {
+namespace test {
+std::string DeformableConvolutionLayerTest::getTestCaseName(const testing::TestParamInfo<deformableConvLayerTestParamsSet>& obj) {
+    deformableConvSpecificParams convParams;
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    std::string target_device;
+    bool with_modulation;
+    std::tie(convParams, with_modulation, model_type, shapes, target_device) = obj.param;
+    ov::op::PadType padType;
+    std::vector<size_t> stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end;
+    size_t groups, deformable_groups, conv_out_channels;
+    bool with_bilinear_interpolation_pad;
+    std::tie(stride, pad_begin, pad_end, dilation, groups, deformable_groups, conv_out_channels, padType, with_bilinear_interpolation_pad) = convParams;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (size_t i = 0lu; i < shapes.size(); i++) {
+        result << ov::test::utils::partialShape2str({shapes[i].first}) << (i < shapes.size() - 1lu ? "_" : "");
+    }
+    result << ")_TS=";
+    for (size_t i = 0lu; i < shapes.front().second.size(); i++) {
+        result << "{";
+        for (size_t j = 0lu; j < shapes.size(); j++) {
+            result << ov::test::utils::vec2str(shapes[j].second[i]) << (j < shapes.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+    }
+    result << "S" << ov::test::utils::vec2str(stride) << "_";
+    result << "PB" << ov::test::utils::vec2str(pad_begin) << "_";
+    result << "PE" << ov::test::utils::vec2str(pad_end) << "_";
+    result << "D=" << ov::test::utils::vec2str(dilation) << "_";
+    result << "G=" << groups << "_";
+    result << "DG=" << deformable_groups << "_";
+    result << "O=" << conv_out_channels << "_";
+    result << "AP=" << padType << "_";
+    result << "BI_PAD=" << with_bilinear_interpolation_pad << "_";
+    result << "MODULATION=" << with_modulation << "_";
+    result << "netPRC=" << model_type.get_type_name() << "_";
+    result << "trgDev=" << target_device;
+    return result.str();
+}
+
+void DeformableConvolutionLayerTest::generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) {
+    SubgraphBaseTest::generate_inputs(target_input_static_shapes);
+
+    auto params = function->get_parameters();
+    OPENVINO_ASSERT(target_input_static_shapes.size() >= params.size());
+    for (int i = 0; i < params.size(); i++) {
+        auto name = params[i]->get_friendly_name();
+        if (name == "b_offset_vals") {
+            auto tensor = ov::test::utils::create_and_fill_tensor(params[i]->get_element_type(), target_input_static_shapes[i], 2, 0, 10);
+            inputs[params[i]] = tensor;
+        } else if (name == "c_modulation_scalars") {
+            auto tensor = ov::test::utils::create_and_fill_tensor(params[i]->get_element_type(), target_input_static_shapes[i], 1, 0, 20);
+            inputs[params[i]] = tensor;
+        }
+    }
+}
+void DeformableConvolutionLayerTest::SetUp() {
+    deformableConvSpecificParams convParams;
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    bool with_modulation;
+    std::tie(convParams, with_modulation, model_type, shapes, targetDevice) = this->GetParam();
+    init_input_shapes(shapes);
+
+    ov::op::PadType padType;
+    std::vector<size_t> stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end;
+    size_t groups, deformable_groups, conv_out_channels;
+    bool with_bilinear_interpolation_pad;
+    std::tie(stride, pad_begin, pad_end, dilation, groups, deformable_groups, conv_out_channels, padType, with_bilinear_interpolation_pad) = convParams;
+
+    auto data = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]);
+    data->set_friendly_name("a_data");
+    auto offset_vals = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[1]);//ov::Shape(offsets));
+    offset_vals->set_friendly_name("b_offset_vals");
+    auto filter_vals = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[2]);//ov::Shape(filter));
+    filter_vals->set_friendly_name("c_filter_vals");
+
+    ov::ParameterVector parameters{data, offset_vals, filter_vals};
+    std::shared_ptr<ov::Node> deformable_conv;
+    if (with_modulation) {
+        // auto modulation_shape = ov::Shape(offsets);
+        // modulation_shape[1] = offsets[1] / 2;
+        auto modulation_scalars = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[3]);// modulation_shape);
+        modulation_scalars->set_friendly_name("c_modulation_scalars");
+
+        deformable_conv = std::make_shared<ov::op::v8::DeformableConvolution>(data, offset_vals, filter_vals, modulation_scalars, stride, pad_begin,
+                                                                                  pad_end, dilation, padType, groups, deformable_groups,
+                                                                                  with_bilinear_interpolation_pad);
+        parameters.push_back(modulation_scalars);
+    } else {
+        deformable_conv = std::make_shared<ov::op::v8::DeformableConvolution>(data, offset_vals, filter_vals, stride, pad_begin, pad_end, dilation,
+                                                                                  padType, groups, deformable_groups, with_bilinear_interpolation_pad);
+    }
+
+    auto result = std::make_shared<ov::op::v0::Result>(deformable_conv);
+    function = std::make_shared<ov::Model>(result, parameters, "deformable_convolution");
+}
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Refactor ConvolutionBackpropDataLayerTest, ConvolutionLayerTest, DeformableConvolutionLayerTest
 - Update cpu plugin instantiation of these tests to use new implementation
 - Temporary disable some cases CVS-120413

### Tickets:
 - [CVS-111364](https://jira.devtools.intel.com/browse/CVS-111364)
