### PR TITLE
Clean up issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -100,7 +100,7 @@ body:
       label: Issue submission checklist
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/intel/intel-one-mono/blob/main/CODE_OF_CONDUCT.md)
       options:
-        - label: I report the issue. It's not a question.
+        - label: I'm reporting an issue. It's not a question.
           required: true
         - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found a solution.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,5 @@
-name: Bug Report
-description: Create a report to help us improve
+name: Bug report
+description: Help us improve OpenVINO.
 title: "[Bug]: "
 labels: ["bug", "support_request"]
 body:
@@ -53,7 +53,7 @@ body:
     id: framework
     attributes:
       label: Framework
-      description: Framework used in model optimization
+      description: Framework used for model optimization
       options:
         - TensorFlow 1
         - Keras (TensorFlow 2)
@@ -68,7 +68,7 @@ body:
     id: model_name
     attributes:
       label: Model used
-      description: Please provide us the link to your model in the description
+      description: Link to the model 
       placeholder: ResNet50 / YOLOv4
     validations:
       required: false
@@ -77,8 +77,7 @@ body:
     attributes:
       label: Issue description
       description: What issue are you having, and what did you expect to happen instead?
-      placeholder: Please provide a detailed description of what happened
-      value: "Error when performing model optimization on yolov4 model."
+      placeholder: "Error when performing model optimization on yolov4 model."
     validations:
       required: true
   - type: textarea
@@ -101,9 +100,9 @@ body:
       label: Issue submission checklist
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/intel/intel-one-mono/blob/main/CODE_OF_CONDUCT.md)
       options:
-        - label: I report the issue. It's not a question
+        - label: I report the issue. It's not a question.
           required: true
-        - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found the solution
+        - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found a solution.
           required: true
         - label: There is reproducer code and related data files such as images, videos, models, etc.
           required: true

--- a/.github/ISSUE_TEMPLATE/build.yml
+++ b/.github/ISSUE_TEMPLATE/build.yml
@@ -89,7 +89,7 @@ body:
       label: Issue submission checklist
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/intel/intel-one-mono/blob/main/CODE_OF_CONDUCT.md)
       options:
-        - label: I report the issue. It's not a question.
+        - label: I'm reporting an issue. It's not a question.
           required: true
         - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found a solution.
           required: true

--- a/.github/ISSUE_TEMPLATE/build.yml
+++ b/.github/ISSUE_TEMPLATE/build.yml
@@ -1,5 +1,5 @@
-name: Build Issue Report
-description: This report is for the build/installation issue
+name: Build Issue report
+description: Report a build or installation issue.
 title: "[Build]: "
 labels: ["build", "support_request"]
 body:
@@ -89,7 +89,7 @@ body:
       label: Issue submission checklist
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/intel/intel-one-mono/blob/main/CODE_OF_CONDUCT.md)
       options:
-        - label: I report the issue. It's not a question
+        - label: I report the issue. It's not a question.
           required: true
-        - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found the solution
+        - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found a solution.
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,5 +1,5 @@
-name: Documentation issue Report
-description: This report is related to the documentation 
+name: Documentation issue report
+description: Report an issue with Documentation. 
 title: "[Docs]: "
 labels: ["docs", "support_request"]
 body:
@@ -16,15 +16,17 @@ body:
     validations:
       required: true
   - type: textarea
-    id: build_description
+    id: description
     attributes:
-      label: Build issue description
-      description: What issue are you facing during the build/installation?
-      placeholder: Please provide a detailed description of what happened
+      label: Description
+      description: Provide a description of the issue you noticed.
     validations:
       required: true
+  - type: checkboxes
+    id: terms
+    attributes:
       label: Issue submission checklist
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/intel/intel-one-mono/blob/main/CODE_OF_CONDUCT.md)
       options:
-        - label: I report the documentation issue. It's not a question
+        - label: I report a documentation issue. It's not a question.
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -28,5 +28,5 @@ body:
       label: Issue submission checklist
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/intel/intel-one-mono/blob/main/CODE_OF_CONDUCT.md)
       options:
-        - label: I report a documentation issue. It's not a question.
+        - label: I'm reporting a documentation issue. It's not a question.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest a feature or improvement for the OpenVINO toolkit
+description: Suggest a feature or improvement for the OpenVINO toolkit.
 title: "[Feature Request]: "
 labels: ["enhancement", "feature"]
 assignees:
@@ -9,9 +9,8 @@ body:
     id: request_description
     attributes:
       label: Request Description
-      description: What is the request you would like us to improve on?
-      placeholder: Please provide a detailed description of your request
-      value: "To have OpenVINO support yolov8 model (with description)"
+      description: What would you like us to improve on?
+      placeholder: Please provide a detailed description of your request.
     validations:
       required: true
   - type: textarea
@@ -19,8 +18,7 @@ body:
     attributes:
       label: Feature Use Case
       description: What is the use case of the feature you are proposing?
-      placeholder: Please provide the use case where this will be useful
-      value: "Recent autonomous vehicles have been using the yolov8 model to perform object segmentation."
+      placeholder: What is the new feature use case? How will it be useful?
     validations:
       required: false
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -140,9 +140,9 @@ body:
       label: Issue submission checklist
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/intel/intel-one-mono/blob/main/CODE_OF_CONDUCT.md)
       options:
-        - label: I report the performance issue. It's not a question
+        - label: I report the performance issue. It's not a question.
           required: true
-        - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found the solution
+        - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found a solution.
           required: true
         - label: There is reproducer code and related data files such as images, videos, models, etc.
           required: true

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -140,7 +140,7 @@ body:
       label: Issue submission checklist
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/intel/intel-one-mono/blob/main/CODE_OF_CONDUCT.md)
       options:
-        - label: I report the performance issue. It's not a question.
+        - label: I'm reporting a performance issue. It's not a question.
           required: true
         - label: I checked the problem with the documentation, FAQ, open issues, Stack Overflow, etc., and have not found a solution.
           required: true

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -89,15 +89,15 @@ body:
     id: model_name
     attributes:
       label: Model used
-      description: Please provide us the link to your model in the description
+      description: Link to the model
       placeholder: ResNet50 / YOLOv4
     validations:
       required: true
   - type: dropdown
     id: model_quantized
     attributes:
-      label: Quantized model?
-      description: Is your model quantized with model optimized?
+      label: Model quantization
+      description: Is your model quantized?
       options:
         - 'Yes'
         - 'No'
@@ -119,11 +119,9 @@ body:
     attributes:
       label: Performance issue description
       description: What issue are you having, and what did you expect to happen instead?
-      placeholder: Please provide a detailed description of what happened
-      value: |
-          let us know the application you use for performance tests
-          e.g., hello_classification.py / benchmark_app / own test script
-          if you are using your own test script, could this reproduce using benchmark_app?
+      placeholder: |
+          Please provide a detailed description of what happened.
+          Can the issue be reproduced using benchmark_app?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/pre_release_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/pre_release_feedback.yml
@@ -16,16 +16,15 @@ body:
     attributes:
       label: Pre-release feedback
       description: What is the issue or feedback on the pre-release?
-      placeholder: Please describe the issue and/or feedback
-      value: "Inference performance drop in OpenVINO 2022.4."
+      placeholder: There is an inference performance drop in OpenVINO 2022.4.
     validations:
       required: true
   - type: textarea
     id: thoughts
     attributes:
-      label: New Feature Feedback?
+      label: New Feature Feedback
       description: Do you have any feedback on the new features released in the pre-release?
-      placeholder: Any thoughts on the new feature are welcome
+      placeholder: Any thoughts on the new features are welcome.
     validations:
       required: false
   - type: markdown


### PR DESCRIPTION
### Details:
 - There are some inconsistencies in our issue templates, such as placeholders about build issues in `documentation.yml`, typos or fields `value` which should rather be placeholders.
 - Issue templates are one of the first things people who come to the repository might see, so they should be well maintained and clean.

### Tickets:
 - N/A
