### PR TITLE
[template] Add faked hint property

### DIFF
--- a/src/plugins/template/src/config.cpp
+++ b/src/plugins/template/src/config.cpp
@@ -36,6 +36,18 @@ Configuration::Configuration(const ov::AnyMap& config, const Configuration& defa
         } else if (ov::hint::performance_mode == key) {
             std::stringstream strm{value.as<std::string>()};
             strm >> performance_mode;
+        } else if (ov::hint::inference_precision == key) {
+            inference_precision = value.as<ov::element::Type>();
+        } else if (ov::hint::execution_mode == key) {
+            execution_mode = value.as<ov::hint::ExecutionMode>();
+            if ((execution_mode != ov::hint::ExecutionMode::ACCURACY) &&
+                (execution_mode != ov::hint::ExecutionMode::PERFORMANCE)) {
+                OPENVINO_THROW("Unsupported execution mode, should be ACCURACY or PERFORMANCE, but was: ", value.as<std::string>());
+            }
+        } else if (ov::num_streams == key) {
+            streams_executor_config.set_property(key, value);
+        } else if (ov::hint::num_requests == key) {
+            num_requests = value.as<uint32_t>();
         } else if (throwOnUnsupported) {
             OPENVINO_THROW("Property was not found: ", key);
         }
@@ -66,6 +78,12 @@ ov::Any Configuration::Get(const std::string& name) const {
         return {std::to_string(streams_executor_config._threadsPerStream)};
     } else if (name == ov::hint::performance_mode) {
         return performance_mode;
+    } else if (name == ov::hint::inference_precision) {
+        return inference_precision;
+    } else if (name == ov::hint::execution_mode) {
+        return execution_mode;
+    } else if (name == ov::hint::num_requests) {
+        return num_requests;
     } else {
         OPENVINO_THROW("Property was not found: ", name);
     }

--- a/src/plugins/template/src/config.cpp
+++ b/src/plugins/template/src/config.cpp
@@ -42,12 +42,18 @@ Configuration::Configuration(const ov::AnyMap& config, const Configuration& defa
             execution_mode = value.as<ov::hint::ExecutionMode>();
             if ((execution_mode != ov::hint::ExecutionMode::ACCURACY) &&
                 (execution_mode != ov::hint::ExecutionMode::PERFORMANCE)) {
-                OPENVINO_THROW("Unsupported execution mode, should be ACCURACY or PERFORMANCE, but was: ", value.as<std::string>());
+                OPENVINO_THROW("Unsupported execution mode, should be ACCURACY or PERFORMANCE, but was: ",
+                               value.as<std::string>());
             }
         } else if (ov::num_streams == key) {
             streams_executor_config.set_property(key, value);
         } else if (ov::hint::num_requests == key) {
-            num_requests = value.as<uint32_t>();
+            auto tmp_val = value.as<std::string>();
+            int tmp_i = std::stoi(tmp_val);
+            if (tmp_i >= 0)
+                num_requests = tmp_i;
+            else
+                OPENVINO_THROW("Incorrect value, it should be unsigned integer: ", key);
         } else if (throwOnUnsupported) {
             OPENVINO_THROW("Property was not found: ", key);
         }

--- a/src/plugins/template/src/config.hpp
+++ b/src/plugins/template/src/config.hpp
@@ -31,11 +31,16 @@ struct Configuration {
     // Plugin configuration parameters
 
     int device_id = 0;
-    bool perf_count = true;
+    bool perf_count = false;
     ov::threading::IStreamsExecutor::Config streams_executor_config;
     ov::hint::PerformanceMode performance_mode = ov::hint::PerformanceMode::LATENCY;
+    uint32_t num_requests = 1;
     bool disable_transformations = false;
     bool exclusive_async_requests = false;
+
+    // unused
+    ov::element::Type inference_precision = ov::element::undefined;
+    ov::hint::ExecutionMode execution_mode = ov::hint::ExecutionMode::ACCURACY;
 };
 // ! [configuration:header]
 

--- a/src/plugins/template/src/plugin.cpp
+++ b/src/plugins/template/src/plugin.cpp
@@ -233,6 +233,10 @@ ov::Any ov::template_plugin::Plugin::get_property(const std::string& name, const
         std::vector<ov::PropertyName> rw_properties{ov::device::id,
                                                     ov::enable_profiling,
                                                     ov::hint::performance_mode,
+                                                    ov::hint::num_requests,
+                                                    ov::hint::inference_precision,
+                                                    ov::hint::execution_mode,
+                                                    ov::num_streams,
                                                     ov::template_plugin::disable_transformations};
         return rw_properties;
     };

--- a/src/plugins/template/tests/functional/shared_tests_instances/behavior/ov_executable_network/properties.cpp
+++ b/src/plugins/template/tests/functional/shared_tests_instances/behavior/ov_executable_network/properties.cpp
@@ -34,7 +34,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_AutoBatch_BehaviorTests,
                          OVClassCompiledModelPropertiesIncorrectTests::getTestCaseName);
 
 const std::vector<ov::AnyMap> default_properties = {
-    {ov::enable_profiling(true)},
+    {ov::enable_profiling(false)},
     {{ov::loaded_from_cache.name(), false}},
     {ov::device::id("0")},
 };

--- a/src/plugins/template/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/template/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -22,7 +22,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          OVPropertiesIncorrectTests::getTestCaseName);
 
 const std::vector<ov::AnyMap> default_properties = {
-    {ov::enable_profiling(true)},
+    {ov::enable_profiling(false)},
     {ov::device::id(0)},
 };
 

--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_executable_network/properties.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_executable_network/properties.cpp
@@ -78,7 +78,7 @@ const std::vector<ov::AnyMap> multiModelPriorityConfigs = {
 
 INSTANTIATE_TEST_SUITE_P(ov_compiled_model_mandatory,
                          OVClassCompiledModelGetPropertyTest_MODEL_PRIORITY,
-                         ::testing::Combine(::testing::Values(return_all_possible_device_combination()),
+                         ::testing::Combine(::testing::ValuesIn(return_all_possible_device_combination()),
                                             ::testing::ValuesIn(multiModelPriorityConfigs)));
 
 } // namespace

--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_executable_network/properties.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_executable_network/properties.cpp
@@ -70,4 +70,15 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(ov_plugin_mandatory, OVCompiledModelIncorrectDevice,
         ::testing::Values(targetDevice));
 
+const std::vector<ov::AnyMap> multiModelPriorityConfigs = {
+        {ov::hint::model_priority(ov::hint::Priority::HIGH)},
+        {ov::hint::model_priority(ov::hint::Priority::MEDIUM)},
+        {ov::hint::model_priority(ov::hint::Priority::LOW)},
+        {ov::hint::model_priority(ov::hint::Priority::DEFAULT)}};
+
+INSTANTIATE_TEST_SUITE_P(ov_compiled_model_mandatory,
+                         OVClassCompiledModelGetPropertyTest_MODEL_PRIORITY,
+                         ::testing::Combine(::testing::Values(return_all_possible_device_combination()),
+                                            ::testing::ValuesIn(multiModelPriorityConfigs)));
+
 } // namespace

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
@@ -254,13 +254,6 @@ std::vector<ov::AnyMap> OVPropertiesTestsWithCompileModelProps::getRWMandatoryPr
         }
     }
 
-    if (props.empty() || std::find(props.begin(), props.end(), ov::hint::model_priority.name()) != props.end()) {
-        ov::hint::Priority priorities[] = {ov::hint::Priority::LOW , ov::hint::Priority::MEDIUM, ov::hint::Priority::HIGH};
-        for (auto &priority : priorities) {
-            res.push_back({{ov::hint::model_priority(priority)}});
-        }
-    }
-
     if (props.empty() || std::find(props.begin(), props.end(), ov::hint::performance_mode.name()) != props.end()) {
         ov::hint::PerformanceMode performance_modes[] = {ov::hint::PerformanceMode::LATENCY,
                 ov::hint::PerformanceMode::THROUGHPUT, ov::hint::PerformanceMode::CUMULATIVE_THROUGHPUT};


### PR DESCRIPTION
### Details:
 - *added faked props `ov::hint::inference_precision` `ov::hint::execution_mode` `ov::hint::num_requests`*
 - *fixed default `perf_count` value, it is False now*
 - *fixed test for property ov::hint::model_priority in apiConformance. Property was tested by core->get_property in apiConformance , but it is implemented as compiled_model property, so this test is removed now . Another existing test, where getting property tested with compiled_model->get_property, added to apiConformance scope. Test with setting this property will be added after with task CVS-109419*

### Tickets:
 - *CVS-103948*
