### PR TITLE
[CPU] Transpose CF leftovers: correct transpose out memory descriptor

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -865,8 +865,6 @@ void GraphOptimizer::FuseFCAndTransposeOnWeights(Graph& graph) {
     for (auto parent : graphNodes) {
         if (isSuitablePattern(parent)) {
             CPU_GRAPH_OPTIMIZER_SCOPE(FuseFCAndTransposeOnWeights);
-            auto fcNode = std::dynamic_pointer_cast<FullyConnected>(parent->getChildEdgeAt(0)->getChild());
-            fcNode->keepWeightsNonTransposed(true);
             auto transposeNode = std::dynamic_pointer_cast<Transpose>(parent);
             transposeNode->setOptimized(true);
         }

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -473,11 +473,7 @@ void FullyConnected::prepareWeightsUsingDummyShape() {
     auto prim_desc = createPrimitiveDesc(key, getEngine());
     auto weights = DnnlExtensionUtils::makeDescriptor(prim_desc.weights_desc());
     // ignore the result since we just need to put the reordered weights into the cache
-    if (weightsNonTransposed) {
-        (void) prepareWeightMemory(weights, makeTransposedWeightDescriptor(weights));
-    } else {
-        (void) prepareWeightMemory(weights);
-    }
+    (void) prepareWeightMemory(weights);
 }
 #endif
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -56,9 +56,6 @@ public:
     void prepareParams() override;
     void executeDynamicImpl(dnnl::stream strm) override;
     bool canBeExecutedInInt8() const override;
-    void keepWeightsNonTransposed(bool weightsNonTransposed) {
-        this->weightsNonTransposed = weightsNonTransposed;
-    }
 
     void fuseDecompressionMultiply(const NodePtr& constData);
     const std::vector<float>& getDecompressionMultiply() const { return decompressionMultiply; }
@@ -123,10 +120,6 @@ private:
     bool useWeightsDecompressionImpl = false;
     std::vector<float> decompressionSubtract;
     std::vector<float> decompressionMultiply;
-
-    // FC with transposed weights
-    bool weightsNonTransposed = false;
-    DnnlMemoryDescPtr makeTransposedWeightDescriptor(DnnlMemoryDescPtr desc);
 };
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -119,7 +119,16 @@ void Transpose::initSupportedPrimitiveDescriptors() {
     } else {
         // general plain case
         config.inConfs[0].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, inputDataShape));
-        config.outConfs[0].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, outputDataShape));
+        std::shared_ptr<CpuBlockedMemoryDesc> outMemDescPtr;
+        if (isOptimized) {
+            VectorDims blockedDims = outputDataShape.getDims();
+            std::swap(blockedDims[0], blockedDims[1]);
+            outMemDescPtr = std::make_shared<CpuBlockedMemoryDesc>(CpuBlockedMemoryDesc(prec, outputDataShape, blockedDims, {1, 0}));
+        } else {
+            outMemDescPtr = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(prec, outputDataShape);
+        }
+        config.outConfs[0].setMemDesc(outMemDescPtr);
+
         supportedPrimitiveDescriptorsBuilder(config, transposeParams);
     }
 }


### PR DESCRIPTION
### Details:
- corrected tranpose out memory desctiptor
- removed unnecessary code for FC node

### Tickets:
[119453](https://jira.devtools.intel.com/browse/CVS-119453)