### PR TITLE
Disable clang-format for legacy C API

### DIFF
--- a/src/bindings/c/src/CMakeLists.txt
+++ b/src/bindings/c/src/CMakeLists.txt
@@ -8,11 +8,12 @@ set(TARGET_NAME openvino_c)
 ov_deprecated_no_errors()
 add_definitions(-DIN_OV_COMPONENT)
 
-file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
-file(GLOB_RECURSE HEADERS ${OpenVINO_C_API_SOURCE_DIR}/include/*.h)
+file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.h ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+file(GLOB_RECURSE LEGACY_HEADERS ${OpenVINO_C_API_SOURCE_DIR}/include/c_api/*.h)
+file(GLOB_RECURSE HEADERS ${OpenVINO_C_API_SOURCE_DIR}/include/openvino/*.h)
 
 # create library
-add_library(${TARGET_NAME} ${HEADERS} ${SOURCES})
+add_library(${TARGET_NAME} ${LEGACY_HEADERS} ${HEADERS} ${SOURCES})
 add_library(openvino::runtime::c ALIAS ${TARGET_NAME})
 
 target_link_libraries(${TARGET_NAME} PRIVATE openvino openvino::util)
@@ -24,7 +25,7 @@ if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(${TARGET_NAME} PUBLIC OPENVINO_STATIC_LIBRARY)
 endif()
 
-ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
+ov_add_clang_format_target(${TARGET_NAME}_clang FOR_SOURCES ${HEADERS} ${SOURCES})
 
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 

--- a/src/bindings/c/src/common.h
+++ b/src/bindings/c/src/common.h
@@ -17,7 +17,7 @@
 #define CATCH_IE_EXCEPTION(StatusCode, ExceptionType) \
     catch (const InferenceEngine::ExceptionType&) {   \
         return ov_status_e::StatusCode;               \
-    }                                                 \
+    }
 
 #define CATCH_OV_EXCEPTION(StatusCode, ExceptionType) \
     catch (const ov::ExceptionType&) {                \
@@ -42,7 +42,7 @@
     CATCH_IE_EXCEPTION(INFER_CANCELLED, InferCancelled)       \
     catch (...) {                                             \
         return ov_status_e::UNKNOW_EXCEPTION;                 \
-    }                                                         \
+    }
 
 #define GET_PROPERTY_FROM_ARGS_LIST                     \
     std::string property_key = va_arg(args_ptr, char*); \


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
