### PR TITLE
[CPU]Correct flags for clang compiler

### DIFF
--- a/cmake/developer_package/features.cmake
+++ b/cmake/developer_package/features.cmake
@@ -18,7 +18,7 @@ else()
     ie_option(USE_BUILD_TYPE_SUBFOLDER "Create dedicated sub-folder per build type for output binaries" ON)
 endif()
 
-if(DEFINED ENV{CI_BUILD_NUMBER} AND NOT (WIN32 OR CMAKE_CROSSCOMPILING))
+if(DEFINED ENV{CI_BUILD_NUMBER} AND NOT WIN32)
     set(CMAKE_COMPILE_WARNING_AS_ERROR_DEFAULT ON)
 else()
     set(CMAKE_COMPILE_WARNING_AS_ERROR_DEFAULT OFF)

--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # oneDNN arm64: unary minus operator applied to unsigned type, result still unsigned
     ov_add_compiler_flags(/wd4146)
 elseif(OV_COMPILER_IS_CLANG)
-    ov_add_compiler_flags(-Wno-delete-non-abstract-non-virtual-dtor)
+    ov_add_compiler_flags(-Wno-delete-non-virtual-dtor)
 endif()
 
 if(ARM)


### PR DESCRIPTION
### Details:
 - *Enable Warning as Error in Android Compilation*
 - *Change Unsupported clang flags from `-Wno-delete-non-abstract-non-virtual-dtor` to `-Wno-delete-non-virtual-dtor`*

### Tickets:
 - *CVS-120605*
