### PR TITLE
[CPU][ARM] Set f16 as default precision on ARM for non-convolution networks

### DIFF
--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -245,10 +245,16 @@ void Config::readProperties(const std::map<std::string, std::string> &prop, Mode
     // when both execution_mode and inference_precision are specified
     if (!inferencePrecisionSetExplicitly) {
         if (executionMode == ov::hint::ExecutionMode::PERFORMANCE) {
+            inferencePrecision = ov::element::f32;
+#if defined(OV_CPU_ARM_ENABLE_FP16)
+            //fp16 precision is used as default precision on ARM for non-convolution networks
+            //fp16 ACL convolution is slower than fp32
+            if (modelType != ModelType::CNN)
+                inferencePrecision = ov::element::f16;
+#else
             if (mayiuse(avx512_core_bf16))
                 inferencePrecision = ov::element::bf16;
-            else
-                inferencePrecision = ov::element::f32;
+#endif
         } else {
             inferencePrecision = ov::element::f32;
         }

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -249,7 +249,7 @@ void Config::readProperties(const std::map<std::string, std::string> &prop, Mode
 #if defined(OV_CPU_ARM_ENABLE_FP16)
             //fp16 precision is used as default precision on ARM for non-convolution networks
             //fp16 ACL convolution is slower than fp32
-            if (modelType != ModelType::CNN)
+            //if (modelType != ModelType::CNN)
                 inferencePrecision = ov::element::f16;
 #else
             if (mayiuse(avx512_core_bf16))


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
