### PR TITLE
[Snippets] Added Transpose support to SplitDimensionM

### DIFF
--- a/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
+++ b/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
@@ -65,6 +65,13 @@ private:
     VectorDims m_subtensor_shape{};
     /// \brief The corresponding abstract/physical register
     size_t m_reg = 0;
+
+    /// Notes: m_tensor_shape is dense shape which is controled by expression outputs.
+    ///        It means that the result of data writing of expression outputs should be read using this shape by the next expression inputs.
+    ///        Also if Port is input port of expression:
+    ///         - m_layout shows how the data should be read (by which strides) using m_tensor_shape.
+    ///        If Port is output port of expression:
+    ///         - m_layout shows how the data should be written (by which strides) to get m_tensor_shape.
 };
 
 class PortDescriptorUtils {

--- a/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
+++ b/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
@@ -66,7 +66,7 @@ private:
     /// \brief The corresponding abstract/physical register
     size_t m_reg = 0;
 
-    /// Notes: m_tensor_shape is dense shape which is controled by expression outputs.
+    /// Notes: m_tensor_shape is dense shape which is controlled by expression outputs.
     ///        It means that the result of data writing of expression outputs should be read using this shape by the next expression inputs.
     ///        Also if Port is input port of expression:
     ///         - m_layout shows how the data should be read (by which strides) using m_tensor_shape.

--- a/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
+++ b/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
@@ -66,12 +66,15 @@ private:
     /// \brief The corresponding abstract/physical register
     size_t m_reg = 0;
 
-    /// Notes: m_tensor_shape is dense shape which is controlled by expression outputs.
-    ///        It means that the result of data writing of expression outputs should be read using this shape by the next expression inputs.
-    ///        Also if Port is input port of expression:
-    ///         - m_layout shows how the data should be read (by which strides) using m_tensor_shape.
-    ///        If Port is output port of expression:
-    ///         - m_layout shows how the data should be written (by which strides) to get m_tensor_shape.
+    /// Notes:
+    ///   - `m_tensor_shape` is dense shape which is controlled by expression outputs.
+    ///     It means that the result of data writing of expression outputs should be read using this shape by the next expression inputs.
+    ///   - `m_layout` is the order of data reading or writing by MemoryAccess ops. Note that only MemoryAccess ops may have `m_layout`.
+    ///     For other expressions this order parameter is simply ignored for now.
+    ///     if it's input port of MemoryAccess expression:
+    ///      - `m_layout` shows how the data should be read (by which strides) using m_tensor_shape.
+    ///     If it's output port of MemoryAccess expression:
+    ///      - `m_layout` shows how the data should be written (by which strides) to get m_tensor_shape.
 };
 
 class PortDescriptorUtils {

--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -10,7 +10,7 @@
 #include <openvino/op/util/sub_graph_base.hpp>
 #include "openvino/op/op.hpp"
 #include "openvino/core/rt_info.hpp"
-#include "snippets/pass_manager.hpp"
+#include "snippets/pass/manager.hpp"
 #include "snippets/shape_inference/shape_inference.hpp"
 #include "snippets/lowered/pass/pass.hpp"
 

--- a/src/common/snippets/include/snippets/pass/common_optimizations.hpp
+++ b/src/common/snippets/include/snippets/pass/common_optimizations.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "openvino/pass/graph_rewrite.hpp"
-#include "snippets/op/subgraph.hpp"
 #include "snippets/pass/tokenization.hpp"
 
 namespace ov {
@@ -13,22 +12,15 @@ namespace snippets {
 namespace pass {
 
 class CommonOptimizations : public ov::pass::MatcherPass {
+    class SubgraphPass;
+    class SubgraphManager;
+    friend class ExtractConstants;
+    friend class ExtractUnsupportedTransposes;
+    friend class SplitDimensionM;
+
 public:
     OPENVINO_RTTI("CommonOptimizations", "0");
     CommonOptimizations(const SnippetsTokenization::Config& config = {});
-
-    // Returns True if parallelism work amount can be increased using SplitDimensionM optimization
-    static bool CanOptimizeParallelWA(const std::shared_ptr<const ov::Node>& node, size_t concurrency);
-
-private:
-    // Move up Constants which aren't scalars from body to Subgraph and replace them with Parameters inside body
-    void ExtractConstants(const std::shared_ptr<op::Subgraph>& subgraph);
-    // Move up unsupported Transposes on Parameter outputs from body
-    void ExtractUnsupportedTransposes(const std::shared_ptr<op::Subgraph>& subgraph);
-    // Insert Reshape nodes after and before Parameters and Results in Subgraphs with MatMul inside
-    // to split dimension M for MatMuls to increase work amount for parallelism
-    // Note: works only with 3D MHA patterns
-    void SplitDimensionM(const std::shared_ptr<op::Subgraph>& subgraph, size_t concurrency);
 };
 
 }  // namespace pass

--- a/src/common/snippets/include/snippets/pass/extract_constants.hpp
+++ b/src/common/snippets/include/snippets/pass/extract_constants.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "subgraph_pass.hpp"
+
+namespace ov {
+namespace snippets {
+namespace pass {
+
+/**
+ * @interface ExtractConstants
+ * @brief Moves up Constants which aren't scalars from body to Subgraph and replace them with Parameters inside body
+ * @ingroup snippets
+ */
+class ExtractConstants: public CommonOptimizations::SubgraphPass {
+public:
+    OPENVINO_RTTI("ExtractConstants", "0");
+    ExtractConstants() = default;
+
+    bool run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) override;
+};
+
+
+} // namespace pass
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/pass/extract_constants.hpp
+++ b/src/common/snippets/include/snippets/pass/extract_constants.hpp
@@ -12,7 +12,7 @@ namespace pass {
 
 /**
  * @interface ExtractConstants
- * @brief Moves up Constants which aren't scalars from body to Subgraph and replace them with Parameters inside body
+ * @brief Moves up Constants which aren't scalars from Subgraph body to Subgraph outside and replace them with Parameters inside body
  * @ingroup snippets
  */
 class ExtractConstants: public CommonOptimizations::SubgraphPass {

--- a/src/common/snippets/include/snippets/pass/extract_constants.hpp
+++ b/src/common/snippets/include/snippets/pass/extract_constants.hpp
@@ -12,7 +12,7 @@ namespace pass {
 
 /**
  * @interface ExtractConstants
- * @brief Moves up Constants which aren't scalars from Subgraph body to Subgraph outside and replace them with Parameters inside body
+ * @brief Moves up Constants which aren't scalars outside of the Subgraph's body and replaces them with Parameters inside body
  * @ingroup snippets
  */
 class ExtractConstants: public CommonOptimizations::SubgraphPass {

--- a/src/common/snippets/include/snippets/pass/extract_unsupported_transposes.hpp
+++ b/src/common/snippets/include/snippets/pass/extract_unsupported_transposes.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "subgraph_pass.hpp"
+
+namespace ov {
+namespace snippets {
+namespace pass {
+
+/**
+ * @interface ExtractUnsupportedTransposes
+ * @brief Moves up unsupported Transposes on Parameter outputs from body
+ * @ingroup snippets
+ */
+class ExtractUnsupportedTransposes: public CommonOptimizations::SubgraphPass {
+public:
+    OPENVINO_RTTI("ExtractUnsupportedTransposes", "0");
+    ExtractUnsupportedTransposes() = default;
+
+    bool run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) override;
+};
+
+
+} // namespace pass
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/pass/fuse_transpose_brgemm.hpp
+++ b/src/common/snippets/include/snippets/pass/fuse_transpose_brgemm.hpp
@@ -18,8 +18,8 @@ namespace pass {
 /**
  * @interface FuseTransposeBrgemm
  * @brief Fuses Transpose with Brgemm node, fusing on both Brgemm inputs and output is supported. Applicable to
- *        Transposes that don't change the position of the last dimension (since Brgemm supports strided rows i/o),
- *        but only 0213 Transpose is currently supported.
+ *        Transposes that don't change the position of the last dimension (since Brgemm supports strided rows i/o).
+ *        Supported any Transpose order where last index is equal to [rank - 1] - it means that last dimension isn't moved.
  * @ingroup snippets
  */
 class FuseTransposeBrgemm: public ov::pass::MatcherPass {

--- a/src/common/snippets/include/snippets/pass/fuse_transpose_brgemm.hpp
+++ b/src/common/snippets/include/snippets/pass/fuse_transpose_brgemm.hpp
@@ -26,10 +26,9 @@ class FuseTransposeBrgemm: public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("FuseTransposeBrgemm", "0");
     FuseTransposeBrgemm();
-    static const std::set<std::vector<int>> supported_cases;
 
-private:
-    static bool is_supported_transpose(const Output<Node>& transpose_port);
+    static bool is_supported_transpose(const Output<Node>& transpose_out);
+    static bool is_supported_transpose_order(const std::vector<int32_t>& order);
 };
 
 }  // namespace pass

--- a/src/common/snippets/include/snippets/pass/manager.hpp
+++ b/src/common/snippets/include/snippets/pass/manager.hpp
@@ -3,15 +3,18 @@
 //
 
 #pragma once
+
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/pass.hpp"
 #include "openvino/pass/validate.hpp"
+
 #include <typeinfo>
 
 
 namespace ov {
 namespace snippets {
 namespace pass {
+
 /**
  * @brief Manager is like ov::pass::Manager, but allows to insert new passes at arbitrary places in the pipeline
  * @ingroup snippets

--- a/src/common/snippets/include/snippets/pass/mha_tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/mha_tokenization.hpp
@@ -43,6 +43,9 @@ class TokenizeMHASnippets: public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("TokenizeMHASnippets", "0");
     TokenizeMHASnippets(const SnippetsTokenization::Config& config = {});
+
+    static std::vector<int32_t> get_fusion_transpose_order(size_t rank);
+    static std::vector<int32_t> get_decomposed_transpose_order(size_t rank);
     static bool is_matmul0_supported(const std::shared_ptr<ov::opset1::MatMul>& matmul);
 };
 

--- a/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
+++ b/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "subgraph_pass.hpp"
+
+namespace ov {
+namespace snippets {
+namespace pass {
+
+/**
+ * @interface SplitDimensionM
+ * @brief Inserts Reshape nodes after and before Parameters and Results in Subgraphs with MatMul inside
+ *        to split dimension M for MatMuls to increase work amount for parallelism
+ *        Note: works only with 3D MHA patterns
+ * @ingroup snippets
+ */
+class SplitDimensionM: public CommonOptimizations::SubgraphPass {
+public:
+    OPENVINO_RTTI("SplitDimensionM", "0");
+    SplitDimensionM(size_t concurrency) : m_concurrency(concurrency) {}
+
+    // Return True if the MatMul node is supported by this optimization
+    static bool isSupportedMatMul(const std::shared_ptr<const ov::Node>& node);
+
+    // Returns True if parallelism work amount (concurrency) can be increased by this optimization
+    static bool canBeOptimized(const std::shared_ptr<const ov::Node>& node, size_t concurrency);
+
+    bool run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) override;
+
+private:
+    size_t m_concurrency;
+};
+
+
+} // namespace pass
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
+++ b/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
@@ -12,9 +12,8 @@ namespace pass {
 
 /**
  * @interface SplitDimensionM
- * @brief Inserts Reshape nodes after and before Parameters and Results in Subgraphs with MatMul inside
- *        to split dimension M for MatMuls to increase work amount for parallelism
- *        Note: works only with 3D MHA patterns
+ * @brief Inserts Reshape nodes before inputs and after outputs of Subgraphs with MatMul inside
+ *        to split dimension M for MatMuls. It allows to increase work amount for parallelism
  * @ingroup snippets
  */
 class SplitDimensionM: public CommonOptimizations::SubgraphPass {

--- a/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
+++ b/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
@@ -22,15 +22,20 @@ public:
     OPENVINO_RTTI("SplitDimensionM", "0");
     SplitDimensionM(size_t concurrency) : m_concurrency(concurrency) {}
 
-    // Return True if the MatMul node is supported by this optimization
-    static bool isSupportedMatMul(const std::shared_ptr<const ov::Node>& node);
-
-    // Returns True if parallelism work amount (concurrency) can be increased by this optimization
-    static bool canBeOptimized(const std::shared_ptr<const ov::Node>& node, size_t concurrency);
-
     bool run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) override;
 
+    // Return True if the MatMul node is supported by this optimization
+    static bool is_supported_matmul(const std::shared_ptr<const ov::Node>& node);
+    // Returns True if parallelism work amount (concurrency) can be increased by this optimization
+    static bool can_be_optimized(const std::shared_ptr<const ov::Node>& node, size_t concurrency);
+
 private:
+    static std::shared_ptr<ov::op::v0::MatMul> get_matmul(const std::shared_ptr<op::Subgraph>& subgraph);
+    static std::pair<size_t, size_t> get_splited_dimensions(size_t batch_dim, size_t m_dim, size_t optimal_parallelism_work_amount);
+    static bool split(const ov::Shape& shape, size_t optimal_parallelism_work_amount, size_t& batch_m_dim, size_t& new_m_dim);
+
+    void reshape_subgraph(const std::shared_ptr<op::Subgraph>& subgraph, const ov::Shape& shape, size_t batch_m_dim, size_t new_m_dim);
+
     size_t m_concurrency;
 };
 

--- a/src/common/snippets/include/snippets/pass/subgraph_manager.hpp
+++ b/src/common/snippets/include/snippets/pass/subgraph_manager.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <typeinfo>
+#include <vector>
+
+#include "snippets/pass/common_optimizations.hpp"
+
+#include "snippets/pass/subgraph_pass.hpp"
+#include "snippets/op/subgraph.hpp"
+
+namespace ov {
+namespace snippets {
+namespace pass {
+/**
+ * @brief Manager class allows to manage transformation passes on Subgraph ops
+ *        It's light version of ov::Manager implementation
+ * @ingroup snippets
+ */
+class CommonOptimizations::SubgraphManager {
+public:
+    SubgraphManager() = default;
+
+    /// @brief Register given transformation class type to execution list
+    /// @return shared_ptr to the transformation instance
+    template <typename T, class... Args>
+    std::shared_ptr<T> register_pass(Args&&... args) {
+        static_assert(std::is_base_of<SubgraphPass, T>::value, "pass not derived from SubgraphPass base");
+        auto pass = std::make_shared<T>(std::forward<Args>(args)...);
+        m_pass_list.push_back(std::static_pointer_cast<SubgraphPass>(pass));
+        return pass;
+    }
+
+    /// @brief      Runs registered transformations on a given model
+    /// @param      model Input model
+    /// @return     Returns true if the model was changed by transformations, false otherwise.
+    bool run_passes(std::shared_ptr<ov::snippets::op::Subgraph> subgraph);
+
+protected:
+    std::vector<std::shared_ptr<SubgraphPass>> m_pass_list;
+};
+}  // namespace pass
+}  // namespace snippets
+}  // namespace ov

--- a/src/common/snippets/include/snippets/pass/subgraph_manager.hpp
+++ b/src/common/snippets/include/snippets/pass/subgraph_manager.hpp
@@ -17,8 +17,9 @@ namespace ov {
 namespace snippets {
 namespace pass {
 /**
- * @brief Manager class allows to manage transformation passes on Subgraph ops
- *        It's light version of ov::Manager implementation
+ * @brief Manager class allows to manage transformation passes (SubgraphPasses) on Subgraph ops.
+ *        See SubgraphPasses description for mode details.
+ *        It's light version of ov::Manager implementation the purpose of which is to change only Subgraph as separate node in model.
  * @ingroup snippets
  */
 class CommonOptimizations::SubgraphManager {
@@ -36,7 +37,7 @@ public:
     }
 
     /// @brief      Runs registered transformations on a given model
-    /// @param      model Input model
+    /// @param      subgraph Input model
     /// @return     Returns true if the model was changed by transformations, false otherwise.
     bool run_passes(std::shared_ptr<ov::snippets::op::Subgraph> subgraph);
 

--- a/src/common/snippets/include/snippets/pass/subgraph_manager.hpp
+++ b/src/common/snippets/include/snippets/pass/subgraph_manager.hpp
@@ -18,7 +18,7 @@ namespace snippets {
 namespace pass {
 /**
  * @brief Manager class allows to manage transformation passes (SubgraphPasses) on Subgraph ops.
- *        See SubgraphPasses description for mode details.
+ *        See SubgraphPasses description for more details.
  *        It's light version of ov::Manager implementation the purpose of which is to change only Subgraph as separate node in model.
  * @ingroup snippets
  */

--- a/src/common/snippets/include/snippets/pass/subgraph_pass.hpp
+++ b/src/common/snippets/include/snippets/pass/subgraph_pass.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <typeinfo>
+
+#include "snippets/pass/common_optimizations.hpp"
+
+
+namespace ov {
+namespace snippets {
+namespace pass {
+
+/**
+ * @brief Base class for Subgraph passes
+ * @ingroup snippets
+ */
+class CommonOptimizations::SubgraphPass {
+public:
+    SubgraphPass() = default;
+    virtual ~SubgraphPass() = default;
+
+    virtual bool run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) = 0;
+
+    void set_name(const std::string& name) { m_name = name; }
+    std::string get_name() const { return m_name; }
+
+    using type_info_t = DiscreteTypeInfo;
+    virtual const type_info_t& get_type_info() const = 0;
+
+private:
+    std::string m_name;
+};
+
+
+} // namespace pass
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/pass/subgraph_pass.hpp
+++ b/src/common/snippets/include/snippets/pass/subgraph_pass.hpp
@@ -14,7 +14,12 @@ namespace snippets {
 namespace pass {
 
 /**
- * @brief Base class for Subgraph passes
+ * @brief Base class for Subgraph passes.
+ *        The pass runs on `Subgraph` op that allows users to transform
+ *        `Subgraph` as node and `body` of this `Subgraph` as model at the same time.
+ *        These passes may change `Subgraph` as node, its `body` and other ops around `Subgraph` in model.
+ *        To avoid unsafe changes of other ops in model, SubgraphPass is not derived from ov::Pass to avoid
+ *        registration to ov::Model
  * @ingroup snippets
  */
 class CommonOptimizations::SubgraphPass {

--- a/src/common/snippets/include/snippets/pass/tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/tokenization.hpp
@@ -61,9 +61,9 @@ public:
      * @ingroup snippets
      */
     struct Config {
-        Config(size_t concurrency = 1, bool split_m_dimension = true, bool enable_transpose_on_output = true)
+        Config(size_t concurrency = 1, bool split_m_dimension = true, bool enable_transpose_on_output = true, std::set<size_t> transpose_ranks = {3, 4})
             : concurrency(concurrency), split_m_dimension(split_m_dimension),
-              mha_token_enable_transpose_on_output(enable_transpose_on_output) {}
+              mha_token_enable_transpose_on_output(enable_transpose_on_output), supported_transpose_ranks(std::move(transpose_ranks)) {}
 
         size_t concurrency = 1;
         // True if "SplitDimensionM" optimization is enabled. Otherwise, it's disabled.
@@ -72,6 +72,8 @@ public:
         // Otherwise, it may be fused into Subgraph if possible
         // TODO [111813]: Remove please when the ticket 111813 is implemented
         bool mha_token_enable_transpose_on_output = true;
+        // Set of supported Transpose shape ranks for tokenization in MHATokenization pass
+        std::set<size_t> supported_transpose_ranks = { 3, 4 };
     };
 
     OPENVINO_RTTI("SnippetsTokenization", "0");

--- a/src/common/snippets/include/snippets/pass/transpose_decomposition.hpp
+++ b/src/common/snippets/include/snippets/pass/transpose_decomposition.hpp
@@ -20,7 +20,9 @@ class TransposeDecomposition: public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("TransposeDecomposition", "0");
     TransposeDecomposition();
-    static const std::set<std::vector<int>> supported_cases;
+
+    static bool is_supported_transpose(const Output<Node>& transpose_out);
+    static bool is_supported_transpose_order(const std::vector<int32_t>& order);
 };
 
 }  // namespace pass

--- a/src/common/snippets/include/snippets/utils.hpp
+++ b/src/common/snippets/include/snippets/utils.hpp
@@ -25,12 +25,6 @@ inline auto is_scalar_constant(const std::shared_ptr<ov::Node>& source_output_no
     return ov::is_type<ov::opset1::Constant>(source_output_node) && ov::shape_size(source_output_node->get_shape()) == 1;
 }
 
-ov::PartialShape get_planar_pshape(const Input<Node>& out);
-ov::PartialShape get_planar_pshape(const Output<Node>& out);
-ov::PartialShape get_planar_pshape(const ov::PartialShape& shape, const std::vector<size_t>& layout);
-VectorDims pshape_to_vdims(const PartialShape&);
-ov::PartialShape vdims_to_pshape(const VectorDims&);
-
 inline auto normalize_rank(int32_t allocation_rank, const size_t shape_rank) -> int32_t {
     return allocation_rank < 0 ? allocation_rank + static_cast<int32_t>(shape_rank) + 1 : allocation_rank;
 }
@@ -60,10 +54,21 @@ inline T div_up(const T a, const U b) {
     return static_cast<T>((a + b - 1) / b);
 }
 
-VectorDims get_planar_vdims(const VectorDims& shape, const std::vector<size_t>& layout);
-VectorDims get_planar_vdims(const snippets::lowered::PortDescriptorPtr& port_desc);
+/* ----- Shape `getters` ----- */
+// Note:
+//   - If `is_forward` is True, `result shape` is ordered `shape` by `layout`
+//   - If `is_forward` is False, `result shape` is original shape to which the `layout` was applied
+ov::PartialShape get_planar_pshape(const ov::PartialShape& shape, const std::vector<size_t>& layout, bool is_forward = true);
+ov::PartialShape get_planar_pshape(const Input<Node>& out);
+ov::PartialShape get_planar_pshape(const Output<Node>& out);
+
+VectorDims get_planar_vdims(const VectorDims& shape, const std::vector<size_t>& layout, bool is_forward = true);
 VectorDims get_planar_vdims(const snippets::lowered::ExpressionPort& expr_port);
 bool is_dynamic_vdims(const VectorDims& shape);
+
+VectorDims pshape_to_vdims(const PartialShape&);
+ov::PartialShape vdims_to_pshape(const VectorDims&);
+/* --------------------------- */
 
 } // namespace utils
 } // namespace snippets

--- a/src/common/snippets/include/snippets/utils.hpp
+++ b/src/common/snippets/include/snippets/utils.hpp
@@ -55,15 +55,75 @@ inline T div_up(const T a, const U b) {
 }
 
 /* ----- Shape `getters` ----- */
-// Note:
-//   - If `is_forward` is True, `result shape` is ordered `shape` by `layout`
-//   - If `is_forward` is False, `result shape` is original shape to which the `layout` was applied
-ov::PartialShape get_planar_pshape(const ov::PartialShape& shape, const std::vector<size_t>& layout, bool is_forward = true);
-ov::PartialShape get_planar_pshape(const Input<Node>& out);
-ov::PartialShape get_planar_pshape(const Output<Node>& out);
-
-VectorDims get_planar_vdims(const VectorDims& shape, const std::vector<size_t>& layout, bool is_forward = true);
+/**
+ * @brief Returns a dense shape after applying the order.
+ *        It means that the shape dimensions will be reordered in accordance with order indices to produce planar shape
+ * @param shape preordered (original) partial shape
+ * @param order order
+ * @return reordered partial shape: `planar_shape[i]` = `shape[order[i]]`
+ *         Example, shape = [16, 2, 32, 64], order = [2, 0, 1, 3]
+ *                  planar_shape = [32, 16, 2, 64]
+ */
+ov::PartialShape get_planar_pshape(const ov::PartialShape& shape, const std::vector<size_t>& order);
+/**
+ * @brief Returns original shape before applying the order.
+ *        It means that the shape dimensions have been already reordered in accordance with order indices to produce planar shape
+ * @param shape planar (ordered) partial shape
+ * @param order order
+ * @return preordered partial shape: `shape[i]` = `planar_shape[order[i]]` where `shape` is shape before applying the order.
+ *         Example, shape = [16, 2, 32, 64], order = [2, 0, 1, 3]
+ *                  planar_shape = [2, 32, 16, 64]
+ */
+ov::PartialShape get_preordered_pshape(const ov::PartialShape& shape, const std::vector<size_t>& order);
+/**
+ * @brief Returns a dense shape of node input.
+ *        It means that the node input shape dimensions will be reordered in accordance with order indices to produce planar shape
+ * @param in input of node
+ * @return new reordered partial shape: `planar_shape[i]` = `shape[order[i]]`
+ */
+ov::PartialShape get_planar_pshape(const Input<Node>& in);
+/**
+ * @brief Returns original shape of node output before applying the order.
+ *        It means that the preordered output shape dimensions have been already reordered in accordance with order indices to produce planar shape
+ * @param out output of node
+ * @return preordered partial shape: `shape[i]` = `planar_shape[order[i]]` where `shape` is shape before applying the order.
+ */
+ov::PartialShape get_preordered_pshape(const Output<Node>& out);
+/**
+ * @brief Returns a dense shape after applying the order.
+ *        It means that the shape dimensions will be reordered in accordance with order indices to produce planar shape
+ * @param shape preordered (original) shape
+ * @param order order
+ * @return reordered partial shape: `planar_shape[i]` = `shape[order[i]]`
+ *         Example, shape = [16, 2, 32, 64], order = [2, 0, 1, 3]
+ *                  planar_shape = [32, 16, 2, 64]
+ */
+VectorDims get_planar_vdims(const VectorDims& shape, const std::vector<size_t>& order);
+/**
+ * @brief Returns original shape before applying the order.
+ *        It means that the preordered shape dimensions have been already reordered in accordance with order indices to produce planar shape
+ * @param shape planar (ordered) shape
+ * @param order order
+ * @return preordered shape: `shape[i]` = `planar_shape[order[i]]` where `shape` is shape before applying the order.
+ *         Example, shape = [16, 2, 32, 64], order = [2, 0, 1, 3]
+ *                  planar_shape = [2, 32, 16, 64]
+ */
+VectorDims get_preordered_vdims(const VectorDims& shape, const std::vector<size_t>& order);
+/**
+ * @brief Returns a dense shape of expression input port.
+ *        It means that the input shape dimensions will be reordered in accordance with order indices to produce planar shape
+ * @param expr_port input expression port
+ * @return new reordered partial shape: `planar_shape[i]` = `shape[order[i]]`
+ */
 VectorDims get_planar_vdims(const snippets::lowered::ExpressionPort& expr_port);
+/**
+ * @brief Returns original shape before applying the order of expression output port.
+ *        It means that the preordered output shape dimensions has been already reordered in accordance with order indices to produce planar shape
+ * @param out input of node
+ * @return preordered shape: `shape[i]` = `planar_shape[order[i]]` where `shape` is shape before applying the order.
+ */
+VectorDims get_preordered_vdims(const snippets::lowered::ExpressionPort& expr_port);
+
 bool is_dynamic_vdims(const VectorDims& shape);
 
 VectorDims pshape_to_vdims(const PartialShape&);

--- a/src/common/snippets/include/snippets/utils.hpp
+++ b/src/common/snippets/include/snippets/utils.hpp
@@ -55,6 +55,11 @@ constexpr inline bool implication(bool cause, bool cond) {
     return !cause || !!cond;
 }
 
+template <typename T, typename U>
+inline T div_up(const T a, const U b) {
+    return static_cast<T>((a + b - 1) / b);
+}
+
 VectorDims get_planar_vdims(const VectorDims& shape, const std::vector<size_t>& layout);
 VectorDims get_planar_vdims(const snippets::lowered::PortDescriptorPtr& port_desc);
 VectorDims get_planar_vdims(const snippets::lowered::ExpressionPort& expr_port);

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -365,10 +365,10 @@ VectorDims LinearIR::get_master_shape() const {
     }
     // Note: Snippets would benefit from a more generic master_shape calculation approach.
     //  It will be implemented in the scope of ROI propagation activity (ticket 120505)
-    const auto& result_parent = out_exprs[0]->get_input_port_connector(0)->get_source().get_expr();
+    const auto& source = out_exprs[0]->get_input_port_connector(0)->get_source();
     if (!m_config.m_enable_domain_optimization && out_exprs.size() == 1 &&
-        ov::is_type<snippets::op::Brgemm>(result_parent->get_node())) {
-        master_shape = utils::get_planar_vdims(out_exprs[0]->get_input_port_descriptor(0));
+        ov::is_type<snippets::op::Brgemm>(source.get_expr()->get_node())) {
+        master_shape = utils::get_planar_vdims(source);
     } else {
         for (const auto& oe : out_exprs) {
             const auto& port_desc = oe->get_input_port_descriptor(0);

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -368,7 +368,7 @@ VectorDims LinearIR::get_master_shape() const {
     const auto& source = out_exprs[0]->get_input_port_connector(0)->get_source();
     if (!m_config.m_enable_domain_optimization && out_exprs.size() == 1 &&
         ov::is_type<snippets::op::Brgemm>(source.get_expr()->get_node())) {
-        master_shape = utils::get_planar_vdims(source);
+        master_shape = utils::get_preordered_vdims(source);
     } else {
         for (const auto& oe : out_exprs) {
             const auto& port_desc = oe->get_input_port_descriptor(0);

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -181,9 +181,8 @@ void LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
     std::vector<size_t> loop_subtensor;
     std::vector<size_t> loop_tensor(loop_depth, 1);
     for (const auto& exit_point : loop_exit_points) {
-        const auto& desc = exit_point.get_descriptor_ptr();
-        const auto shape = utils::get_planar_vdims(exit_point);
-        auto subtensor = desc->get_subtensor();
+        const auto shape = utils::get_preordered_vdims(exit_point);
+        auto subtensor = exit_point.get_descriptor_ptr()->get_subtensor();
         if (subtensor.empty()) {
             subtensor.resize(loop_depth, 1);
             subtensor[subtensor.size() - 1] = vector_size;

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -182,7 +182,7 @@ void LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
     std::vector<size_t> loop_tensor(loop_depth, 1);
     for (const auto& exit_point : loop_exit_points) {
         const auto& desc = exit_point.get_descriptor_ptr();
-        const auto shape = utils::get_planar_vdims(desc);
+        const auto shape = utils::get_planar_vdims(exit_point);
         auto subtensor = desc->get_subtensor();
         if (subtensor.empty()) {
             subtensor.resize(loop_depth, 1);

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -16,7 +16,7 @@ namespace pass {
 using LoopPort = LinearIR::LoopManager::LoopPort;
 
 namespace {
-int64_t get_input_stride(size_t dim, const std::vector<size_t>& layout, const std::vector<size_t>& shape) {
+int64_t get_input_stride(size_t dim, const std::vector<size_t>& layout, const VectorDims& shape) {
     int64_t stride = 1;
     for (int i = static_cast<int>(layout.size()) - 1; i >= 0; i--) {
         if (layout[i] == dim) {
@@ -26,7 +26,7 @@ int64_t get_input_stride(size_t dim, const std::vector<size_t>& layout, const st
     }
     return stride;
 }
-int64_t get_output_stride(size_t dim, const std::vector<size_t>& shape) {
+int64_t get_output_stride(size_t dim, const VectorDims& shape) {
     int64_t stride = 1;
     for (size_t i = dim + 1; i < shape.size(); ++i) {
         stride *= static_cast<int64_t>(shape[i]);

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -16,13 +16,20 @@ namespace pass {
 using LoopPort = LinearIR::LoopManager::LoopPort;
 
 namespace {
-int64_t get_dim_stride(size_t dim, const std::vector<size_t>& layout, const std::vector<size_t>& shape) {
+int64_t get_input_stride(size_t dim, const std::vector<size_t>& layout, const std::vector<size_t>& shape) {
     int64_t stride = 1;
     for (int i = static_cast<int>(layout.size()) - 1; i >= 0; i--) {
         if (layout[i] == dim) {
             break;
         }
         stride *= static_cast<int64_t>(shape[layout[i]]);
+    }
+    return stride;
+}
+int64_t get_output_stride(size_t dim, const std::vector<size_t>& shape) {
+    int64_t stride = 1;
+    for (size_t i = dim + 1; i < shape.size(); ++i) {
+        stride *= static_cast<int64_t>(shape[i]);
     }
     return stride;
 }
@@ -42,7 +49,8 @@ void InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_inputs, std::vec
             const auto& dim = *(layout.rbegin() + dim_idx);
             // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
             if (!(shape[dim] == 1 && work_amount != 1)) {
-                loop_input.ptr_increment = get_dim_stride(dim, source.get_descriptor_ptr()->get_layout(), shape);
+                // Input layout shows how we should read data by which order and strides
+                loop_input.ptr_increment = get_input_stride(dim, source.get_descriptor_ptr()->get_layout(), shape);
             }
         }
     }
@@ -54,15 +62,12 @@ void InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_inputs, std::vec
             const auto loop_ids = port->get_expr()->get_loop_ids();
             const auto& layout = port->get_descriptor_ptr()->get_layout();
             const auto& shape = port->get_descriptor_ptr()->get_shape();
-            const auto& dim = *(layout.rbegin() + dim_idx);
-            // Ticket: 113106
-            // WA: the current logic doesn't support the case with transposed output shape for brgemm layer
-            // but for all existing cases planar layout can be used
-            std::vector<size_t> planar(layout.size());
-            std::iota(planar.begin(), planar.end(), 0);
+            const auto original_dim = layout.size() - 1 - dim_idx;
+            const auto& dim = std::distance(layout.cbegin(), std::find(layout.cbegin(), layout.cend(), original_dim));
             // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
             if (!(shape[dim] == 1 && work_amount != 1)) {
-                loop_output.ptr_increment = get_dim_stride(dim, planar, shape);
+                // Output layout shows how we already written data by which order and strides
+                loop_output.ptr_increment = get_output_stride(dim, shape);
             }
         }
     }

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -37,7 +37,7 @@ ov::Shape compute_allocation_shape(const LinearIR::LoopManagerPtr& loop_manager,
                                    const std::vector<size_t>& parent_loop_ids,
                                    const ExpressionPort& expr_port,
                                    const int allocation_rank) {
-    const auto& planar_shape = utils::get_planar_vdims(expr_port);
+    const auto planar_shape = utils::get_planar_vdims(expr_port);
 
     const size_t rank = allocation_rank >= 0 ? std::min(static_cast<size_t>(allocation_rank), planar_shape.size()) : planar_shape.size();
     ov::Shape allocation_shape(rank);

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -37,7 +37,7 @@ ov::Shape compute_allocation_shape(const LinearIR::LoopManagerPtr& loop_manager,
                                    const std::vector<size_t>& parent_loop_ids,
                                    const ExpressionPort& expr_port,
                                    const int allocation_rank) {
-    const auto planar_shape = utils::get_planar_vdims(expr_port);
+    const auto planar_shape = utils::get_preordered_vdims(expr_port);
 
     const size_t rank = allocation_rank >= 0 ? std::min(static_cast<size_t>(allocation_rank), planar_shape.size()) : planar_shape.size();
     ov::Shape allocation_shape(rank);

--- a/src/common/snippets/src/lowered/pass/optimize_domain.cpp
+++ b/src/common/snippets/src/lowered/pass/optimize_domain.cpp
@@ -98,7 +98,7 @@ bool OptimizeDomain::run(snippets::lowered::LinearIR& linear_ir) {
             const ExpressionPtr& shape_producing_expr = blocked_input_shapes ?
                                                         first_consumer :
                                                         io_expr;
-            const auto& shape = utils::get_planar_vdims(shape_producing_expr->get_output_port_descriptor(0));
+            const auto& shape = utils::get_preordered_vdims(shape_producing_expr->get_output_port(0));
             OPENVINO_ASSERT(std::none_of(shape.begin(), shape.end(),
                                         [](size_t d) {return d == snippets::IShapeInferSnippets::DYNAMIC_DIMENSION; }),
                             "OptimizeDomain pass does not support dynamic shapes");

--- a/src/common/snippets/src/op/brgemm.cpp
+++ b/src/common/snippets/src/op/brgemm.cpp
@@ -114,7 +114,7 @@ ov::element::Type Brgemm::get_output_type() const {
 
 std::vector<ov::PartialShape> Brgemm::get_planar_input_shapes(const std::vector<ov::Input<ov::Node>>& inputs) const {
     OPENVINO_ASSERT(inputs.size() == 2, "Brgemm::get_planar_input_shapes() expects 2 inputs");
-    return {utils::get_planar_pshape(inputs[0]), utils::get_planar_pshape(inputs[1]) };
+    return { utils::get_planar_pshape(inputs[0]), utils::get_planar_pshape(inputs[1]) };
 }
 
 ov::PartialShape Brgemm::get_planar_output_shape(const ov::PartialShape& output_shape) const {

--- a/src/common/snippets/src/op/load.cpp
+++ b/src/common/snippets/src/op/load.cpp
@@ -79,7 +79,6 @@ IShapeInferSnippets::Result LoadReshape::ShapeInfer::infer(const std::vector<Vec
     OPENVINO_ASSERT(input_shapes.size() == 1, "Got unexpected number of input shapes");
     return {{utils::get_planar_vdims(input_shapes[0], m_order)}, ShapeInferStatus::success};
 }
-
 }// namespace op
 }// namespace snippets
 }// namespace ov

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -329,7 +329,7 @@ VectorDims Subgraph::infer_master_shape() {
             const auto& res_input = res->input(0);
             OPENVINO_ASSERT(res_input.get_partial_shape().is_static(), "Result have dynamic shape in static pipeline");
             // We need to account to the shape's layout stored in Output<Node> rt_info
-            const auto& planar_shape = utils::get_planar_pshape(res_input.get_source_output());
+            const auto& planar_shape = utils::get_preordered_pshape(res_input.get_source_output());
             output_dims.emplace_back(planar_shape.get_shape());
         }
     }

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -46,7 +46,7 @@
 
 #include "transformations/utils/utils.hpp"
 
-#include "snippets/pass_manager.hpp"
+#include "snippets/pass/manager.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include <openvino/pass/serialize.hpp>

--- a/src/common/snippets/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/src/pass/collapse_subgraph.cpp
@@ -79,8 +79,8 @@ auto is_supported_op(const std::shared_ptr<const Node> &n) -> bool {
             const auto& order = as_type_ptr<const opset1::Constant>(n->get_input_node_shared_ptr(1));
             if (order) {
                 const auto order_value = order->cast_vector<int>();
-                return (TransposeDecomposition::supported_cases.count(order_value) != 0) ||
-                       (is_brgemm_case && FuseTransposeBrgemm::supported_cases.count(order_value) != 0);
+                return (TransposeDecomposition::is_supported_transpose_order(order_value)) ||
+                       (is_brgemm_case && FuseTransposeBrgemm::is_supported_transpose_order(order_value));
             }
         }
         return false;

--- a/src/common/snippets/src/pass/common_optimizations.cpp
+++ b/src/common/snippets/src/pass/common_optimizations.cpp
@@ -11,6 +11,10 @@
 #include "snippets/pass/fuse_transpose_brgemm.hpp"
 #include "snippets/pass/transform_convert.hpp"
 #include "snippets/pass/validate.hpp"
+#include "snippets/pass/split_dimension_m.hpp"
+#include "snippets/pass/extract_constants.hpp"
+#include "snippets/pass/extract_unsupported_transposes.hpp"
+#include "snippets/pass/subgraph_manager.hpp"
 #include "snippets/op/subgraph.hpp"
 #include "snippets/itt.hpp"
 
@@ -21,343 +25,9 @@ namespace ov {
 namespace snippets {
 namespace pass {
 
-namespace {
-size_t get_lcm(size_t a, size_t b) {
-    std::function<size_t(size_t, size_t)> get_gcd;
-    get_gcd = [&get_gcd](size_t a, size_t b) {
-        if (b == 0)
-            return a;
-        return get_gcd(b, a % b);
-    };
-    return a / get_gcd(a, b) * b;
-}
-
-bool is_supported_matmul_for_split_dim_m_optimization(const std::shared_ptr<const ov::Node>& node) {
-    const auto matmul = ov::as_type_ptr<const ov::op::v0::MatMul>(node);
-    return matmul && !matmul->get_transpose_a() && !matmul->is_dynamic() && node->get_shape().size() == 3; // It's needed only for 3D MHA patterns
-}
-}  // namespace
-
-bool CommonOptimizations::CanOptimizeParallelWA(const std::shared_ptr<const ov::Node>& node, size_t concurrency) {
-    if (!is_supported_matmul_for_split_dim_m_optimization(node))
-        return false;
-    const auto mm_shape = node->get_shape();
-    const auto current_parallel_work_amount =
-        std::accumulate(mm_shape.rbegin() + 2, mm_shape.rend(), size_t(1), std::multiplies<size_t>());
-    const auto dim_M = *(mm_shape.rbegin() + 1);
-    return (current_parallel_work_amount < concurrency) &&
-           (current_parallel_work_amount * dim_M >= concurrency);
-}
-
-void CommonOptimizations::SplitDimensionM(const std::shared_ptr<ov::snippets::op::Subgraph>& subgraph, size_t concurrency) {
-    // To increase parallelism work in 3D cases for MHA pattern,
-    // we split 1st dimension (starting from 0th) into 2 new dimensions to get 4D Shapes where
-    // - 0th and 1st dimensions are used in parallel scheduling,
-    // - 2nd and 3rd dimensions are used in kernel
-    // Note: 3D Patterns don't contain Transpose inside so the reshaping is valid
-
-    // It's needed only for MHA patterns. Need to add support for common patterns
-    if (!subgraph->has_domain_sensitive_ops())
-        return;
-
-    const auto& body = subgraph->body_ptr();
-    const auto& parameters = body->get_parameters();
-    // [107806]: If count of Parameters isn't equal to Subgraph inputs (it's possible case in general),
-    //           we cannot garantee correct extraction since we don't have correct connections between body I/O and Subgraph I/O.
-    OPENVINO_ASSERT(parameters.size() == subgraph->input_values().size(),
-                    "Failed to extract unsupported transposes: the count of Parameters isn't equal to Subgraph inputs");
-
-    // Need to find MatMul0 and check output shape
-    const auto& ops = body->get_ordered_ops();
-    const auto mm_it = std::find_if(ops.begin(), ops.end(),
-                                    [](const std::shared_ptr<ov::Node>& node){ return ov::is_type<ov::op::v0::MatMul>(node); });
-    if (mm_it == ops.end())
-        return;
-
-    const auto matmul0 = *mm_it;
-    if (!is_supported_matmul_for_split_dim_m_optimization(matmul0))
-        return;
-
-    auto get_dim_M = [](const ov::Shape& shape) {
-        return *(shape.rbegin() + 1);
-    };
-
-    const auto mm_shape = matmul0->get_shape();
-    const auto m_dim = get_dim_M(mm_shape);  // M
-    const auto batch_dim =
-        std::accumulate(mm_shape.rbegin() + 2, mm_shape.rend(), size_t(1), std::multiplies<size_t>());  // B (batch)
-
-    // We skip optimization if the current batch is optimal for concurrency
-    const auto optimal_parallelism_work_amount = concurrency;
-    if (batch_dim % optimal_parallelism_work_amount == 0)
-        return;
-
-    size_t batch_m_dim = 1;
-    size_t new_m_dim = m_dim;
-
-    auto is_optimized = [&](size_t batch_m_dim) {
-        return batch_m_dim > 1;
-    };
-
-    // [ First Step ]
-    // Need to find optimized dimension splitting: [b1..bk, m, n] -> [b1..bk, batch_m_dim, new_m_dim, n]
-    // The work amount for parallelism should be divided by max thread count in ideal case
-    // that all threads have the same full work amount (avoid of thread downtime)
-    // If it's impossible, we select such values so that as many threads as possible have work (see [ Second Step ])
-    // For example, there are 16 threads and shape [6, 512, 32]
-    //              LCM(6, 16) = 48 <- ideal work amount for parallelism
-    //              new_shape [6, 48 / 6, 512 / (48 / 6), 32 ] => [6, 8, 64, 32]
-    //              Each thread has parallelism_work_amount = 6 * 8 / nthrs = 3
-    const auto lcm = get_lcm(batch_dim, optimal_parallelism_work_amount);  // LCM(b, nthrs)
-    const auto batch_dim_multiplier = lcm / batch_dim;  // LCM(b, nthrs) / b
-    const auto needed_new_dim = m_dim / batch_dim_multiplier;  // m / (LCM(b, nthrs) / b) - needed factors of dimension m
-    if (batch_dim_multiplier * needed_new_dim == m_dim && is_optimized(batch_dim_multiplier)) {
-        batch_m_dim = batch_dim_multiplier;
-        new_m_dim = needed_new_dim;
-    } else {
-        // [ Second Step ]
-        // If we couldn't optimally split on the previous step, try the second step.
-        // The algorithm finds the more optimal parallelism work amount [batch_dim * batch_m_dim],
-        // where batch_m_dim is divisor of dimension M.
-        // The optimal parallelism work amount means the case when as many threads as possible have work
-        // For example, there are 8 threads and shape [5, 384, 32]
-        //              768 = [2 x 192] = [3 x 128] = [4 x 96] = [6 x 64]
-        //               - [5, 2, 192, 32] - WA = 10 = 8 + 2 (6 threads calculates once and 2 threads twice)
-        //               - [5, 3, 128, 32] - WA = 15 = 8 + 7 (all threads have 2 kernel except one thread) <- the most optimal case
-        //               - [5, 4,  96, 32] - WA = 20 = 8 x 2 + 4
-        //               - [5, 6,  64, 32] - WA = 30 = 8 x 3 + 6
-        // The most optimal and possible case is [5, 3, 128, 32] - almost all threads executes kernel twice
-        // Heuristic value for a quick exit from the algorithm.
-        // The value shows the number of threads in percentages that perform the most equal work
-        const auto optimal_thread_num_percent = 0.8;
-        size_t optimal_remainder = 1;
-        auto get_remainder = [batch_dim, optimal_parallelism_work_amount](const size_t potential_batch_dim) {
-            return (batch_dim * potential_batch_dim) % optimal_parallelism_work_amount;
-        };
-
-        auto update_optimal_params = [&](size_t divisor_0, size_t divisor_1) {
-            const auto remainder = batch_dim * divisor_0 % optimal_parallelism_work_amount;
-            if (remainder > optimal_remainder || remainder == 0) {
-                optimal_remainder = remainder;
-                batch_m_dim = divisor_0;
-                new_m_dim = divisor_1;
-            }
-        };
-
-        // Firstly we have shape [batch, 1, m_dim, smth].
-        // So at the beginning we have parallel_work_amount = batch x 1
-        optimal_remainder = get_remainder(1);
-        const auto root = std::sqrt(m_dim) + 1;
-        for (size_t divisor_0 = 2; divisor_0 < root; ++divisor_0) {
-            const size_t divisor_1 = m_dim / divisor_0;
-            if (divisor_0 * divisor_1 != m_dim)
-                continue;
-
-            update_optimal_params(divisor_0, divisor_1);
-            update_optimal_params(divisor_1, divisor_0);
-            if ((static_cast<float>(optimal_remainder) / static_cast<float>(optimal_parallelism_work_amount) > optimal_thread_num_percent) ||
-                (optimal_remainder == 0)) {
-                break;
-            }
-        }
-    }
-
-    OPENVINO_ASSERT(batch_m_dim * new_m_dim == m_dim, "Incorrect dimension M splitting!");
-    // nothing to split
-    if (!is_optimized(batch_m_dim))
-        return;
-
-    /***** Reshape insertion *****/
-
-    // There are two Parameter variants:
-    //  - Parameter on branches for Second input of MatMul - the shape should be only unsqueezed (add just 1)
-    //  - Other Parameters (on First input of MatMuls and between) - the shape should be splitted on M dimension
-
-    bool updated = false;
-    std::set<std::shared_ptr<ov::op::v0::Parameter>> reshaped_params;
-
-    auto insert_reshape = [&](const std::shared_ptr<ov::op::v0::Parameter>& param, const ov::Shape& new_shape) {
-        const auto index = std::distance(parameters.begin(), std::find(parameters.begin(), parameters.end(), param));
-        const auto shape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{new_shape.size()}, new_shape);
-        const auto reshape = std::make_shared<ov::op::v1::Reshape>(subgraph->input_value(index), shape_const, false);
-        subgraph->input(index).replace_source_output(reshape);
-        param->set_partial_shape(new_shape);
-        reshaped_params.insert(param);
-        updated = true;
-    };
-
-    auto get_updated_shape = [&](const ov::Shape& shape, bool split_m_dim) {
-        const auto current_m_dim = get_dim_M(shape);
-        OPENVINO_ASSERT(!split_m_dim || current_m_dim == 1 || current_m_dim == m_dim, "Incorrect shape for splitting!");
-        ov::Shape new_shape = shape;
-        if ((split_m_dim && current_m_dim == 1) || !split_m_dim) {
-            new_shape.insert((new_shape.rbegin() + 2).base(), 1);
-        } else {
-            new_shape.insert((new_shape.rbegin() + 2).base(), batch_m_dim);
-            *(new_shape.rbegin() + 1) = new_m_dim;
-        }
-        OPENVINO_ASSERT(ov::shape_size(new_shape) == ov::shape_size(shape), "Incorrect shape splitting!");
-        return new_shape;
-    };
-
-    auto reshape_parameter = [&](const std::shared_ptr<ov::Node>& node, bool split_m_dim = true) {
-        const auto param = ov::as_type_ptr<ov::op::v0::Parameter>(node);
-        if (!param || reshaped_params.count(param) > 0)
-            return;
-        insert_reshape(param, get_updated_shape(param->get_partial_shape().get_shape(), split_m_dim));
-    };
-
-    auto update_matmul_second_branch = [&](const std::shared_ptr<ov::Node>& node) {
-        auto parent = node->get_input_node_shared_ptr(1);
-        while (!ov::is_type<ov::op::v0::Parameter>(parent)) {
-            if (parent->get_input_size() > 1) {
-                for (const auto& input_source : parent->input_values()) {
-                    reshape_parameter(input_source.get_node_shared_ptr(), false);
-                }
-            }
-
-            // [107731]: It's covered my MHA tokenization
-            parent = parent->get_input_node_shared_ptr(0);
-        }
-        reshape_parameter(parent, false);
-    };
-
-    // Firstly, Unsqueeze parameters on second branches of MatMuls
-    for (const auto& op : ops) {
-        if (ov::is_type<ov::op::v0::MatMul>(op)) {
-            update_matmul_second_branch(op);
-        }
-    }
-
-    // Secondly, Update All M dimensions for remaining parameters
-    for (const auto& param : parameters) {
-        if (reshaped_params.count(param) == 0)
-            reshape_parameter(param, true);
-    }
-
-    // Return the previous shape on outputs
-    for (size_t i = 0; i < subgraph->get_output_size() && updated; ++i) {
-        const auto output_shape = subgraph->get_output_shape(i);
-        if (is_scalar(output_shape))
-            continue;
-
-        const auto& target_inputs = subgraph->get_output_target_inputs(i);
-        const auto shape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{output_shape.size()}, output_shape);
-        const auto reshape = std::make_shared<ov::op::v1::Reshape>(subgraph->output(i), shape_const, false);
-        // Save output name
-        const auto original_output = body->get_results()[i]->get_input_node_shared_ptr(0);
-        const auto original_name = original_output->get_friendly_name();
-        reshape->set_friendly_name(original_name);
-        original_output->set_friendly_name(original_name + "_original");
-
-        for (const auto& input : target_inputs) {
-            input.replace_source_output(reshape);
-            // Result input tensor name was changed, the name has to be restored
-            if (ov::is_type<ov::op::v0::Result>(input.get_node())) {
-                input.get_tensor_ptr()->add_names(subgraph->output(i).get_tensor_ptr()->get_names());
-            }
-        }
-        subgraph->output(i).get_tensor_ptr()->set_names({});
-        updated = true;
-    }
-    subgraph->set_friendly_name(subgraph->get_friendly_name() + "_original");
-
-    // Need to update inner Shapes and Softmax Axis
-    if (updated) {
-        for (const auto &op : ops) {
-            if (const auto softmax_v8 = ov::as_type_ptr<ov::op::v8::Softmax>(op)) {
-                softmax_v8->set_axis(-1);
-            } else if (const auto softmax_v1 = ov::as_type_ptr<ov::op::v1::Softmax>(op)) {
-                softmax_v1->set_axis(softmax_v1->get_output_partial_shape(0).size()); // since new_shape.size() = old_shape.size() + 1
-            } else if (const auto broadcast = ov::as_type_ptr<ov::op::v1::Broadcast>(op)) {
-                // Broadcast is tokenized only between MatMuls -> Split M dimension
-                const auto shape_const = ov::as_type_ptr<ov::op::v0::Constant>(broadcast->input_value(1).get_node_shared_ptr());
-                OPENVINO_ASSERT(shape_const, "SplitDimensionM expects Broadcast with Constant output shape");
-                const auto new_shape = get_updated_shape(shape_const->cast_vector<size_t>(), true);
-                broadcast->set_argument(1, std::make_shared<ov::op::v0::Constant>(shape_const->get_element_type(), ov::Shape{new_shape.size()}, new_shape));
-            }
-        }
-        subgraph->validate_and_infer_types();
-    }
-}
-
-void CommonOptimizations::ExtractConstants(const std::shared_ptr<ov::snippets::op::Subgraph>& subgraph) {
-    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ExtractConstants");
-    auto body = subgraph->body_ptr();
-
-    ParameterVector new_parameters;
-    OutputVector new_external_inputs = subgraph->input_values();
-
-    for (auto& op : body->get_ops()) {
-        auto constant = ov::as_type_ptr<ov::op::v0::Constant>(op);
-        if (!constant || ov::shape_size(constant->get_shape()) == 1ul)
-            continue;
-
-        const auto child = constant->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
-        if (op::Subgraph::constant_input_should_be_inside_body(child))
-            continue;
-
-        auto parameter = std::make_shared<ov::op::v0::Parameter>(constant->get_element_type(), constant->output(0).get_partial_shape());
-        parameter->set_friendly_name(constant->get_friendly_name());
-        ov::copy_runtime_info(constant, parameter);
-        constant->output(0).replace(parameter->output(0));
-
-        new_external_inputs.push_back(constant);
-        new_parameters.push_back(parameter);
-    }
-
-    if (new_parameters.size() != 0) {
-        body->add_parameters(new_parameters);
-        body->validate_nodes_and_infer_types();
-        subgraph->set_arguments(new_external_inputs);
-    }
-}
-
-void CommonOptimizations::ExtractUnsupportedTransposes(const std::shared_ptr<op::Subgraph>& subgraph) {
-    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ExtractUnsupportedTransposes");
-    const auto& body = subgraph->body_ptr();
-    const auto parameters = body->get_parameters();
-    // [107806]: If count of Parameters isn't equal to Subgraph inputs,
-    //           we cannot guarantee correct extraction since we don't have correct connections between body I/O and Subgraph I/O.
-    OPENVINO_ASSERT(parameters.size() == subgraph->input_values().size(),
-                    "Failed to extract unsupported transposes: the count of Parameters isn't equal to Subgraph inputs");
-
-    bool updated = false;
-    for (size_t i = 0; i < parameters.size(); ++i) {
-        const auto& parameter = parameters[i];
-        const auto& consumers = parameter->get_output_target_inputs(0);
-        if (consumers.size() != 1)
-            continue;
-
-        const auto transpose = ov::as_type_ptr<opset1::Transpose>(consumers.begin()->get_node()->shared_from_this());
-        if (!transpose)
-            continue;
-
-        const auto& order = ov::as_type_ptr<opset1::Constant>(transpose->get_input_node_shared_ptr(1));
-        if (!order)
-            continue;
-
-        const auto order_value = order->cast_vector<int>();
-        const auto transpose_child = *(transpose->get_output_target_inputs(0).begin());
-        const auto is_brgemm_case = ov::is_type<opset1::MatMul>(transpose_child.get_node()->shared_from_this());
-        // If Transpose is supported (can be decomposed or fused into Brgemm), skip
-        if ((is_brgemm_case && FuseTransposeBrgemm::supported_cases.count(order_value) != 0) ||
-            (TransposeDecomposition::supported_cases.count(order_value) != 0))
-            continue;
-
-        // If the transpose isn't supported - we have to extract it from Subgraph
-        transpose->set_argument(0, subgraph->input_value(i));
-        subgraph->set_argument(i, transpose);
-        transpose_child.replace_source_output(parameter);
-        // Update shape
-        parameter->set_partial_shape(transpose->get_output_partial_shape(0));
-        updated = true;
-    }
-
-    if (updated) {
-        subgraph->validate_and_infer_types();
-    }
-}
+#define REGISTER_SNIPPETS_PASS(manager, pass, enabled, ...) \
+    if (enabled) \
+        manager.register_pass<pass>(__VA_ARGS__);
 
 CommonOptimizations::CommonOptimizations(const SnippetsTokenization::Config& config) {
     MATCHER_SCOPE(CommonOptimizations);
@@ -371,29 +41,24 @@ CommonOptimizations::CommonOptimizations(const SnippetsTokenization::Config& con
 
         const auto& body = subgraph->body_ptr();
         const auto is_quantized = subgraph->is_quantized();
+        const auto is_domain_sensitive = subgraph->has_domain_sensitive_ops();
 
         // Firstly, we should transform all original Converts inside body to ConvertTruncation to save original behavior.
         // Then if Subgraph contains FakeQuantize we enable specific transformation for quantized subgraphs.
         ov::pass::Manager manager(get_pass_config());
-        manager.register_pass<ov::snippets::pass::TransformConvertToConvertTruncation>();
-        manager.register_pass<ov::snippets::pass::ExplicitTransposeMatMulInputs>();
-        if (is_quantized) {
-            manager.register_pass<ov::snippets::pass::CommonFakeQuantizeDecomposition>();
-        }
-        manager.register_pass<snippets::pass::SoftmaxReshapeElimination>();
+        REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::TransformConvertToConvertTruncation, true);
+        REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::ExplicitTransposeMatMulInputs, is_domain_sensitive);
+        REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::CommonFakeQuantizeDecomposition, is_quantized);
+        REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::SoftmaxReshapeElimination, is_domain_sensitive);
         manager.run_passes(body);
 
+        ov::snippets::pass::CommonOptimizations::SubgraphManager subgraph_manager;
         // At the moment only non-scalar Constants of FakeQuantize can be inside Subgraph
         // so we can enable ExtractConstants pass for quantized models
-        if (is_quantized) {
-            ExtractConstants(subgraph);
-        }
-        // Extract unsupported Transposes from body
-        if (subgraph->has_domain_sensitive_ops()) {
-            ExtractUnsupportedTransposes(subgraph);
-            if (config.split_m_dimension)
-                SplitDimensionM(subgraph, config.concurrency);
-        }
+        REGISTER_SNIPPETS_PASS(subgraph_manager, ov::snippets::pass::ExtractConstants, is_quantized);
+        REGISTER_SNIPPETS_PASS(subgraph_manager, ov::snippets::pass::ExtractUnsupportedTransposes, is_domain_sensitive);
+        REGISTER_SNIPPETS_PASS(subgraph_manager, ov::snippets::pass::SplitDimensionM, is_domain_sensitive && config.split_m_dimension, config.concurrency);
+        subgraph_manager.run_passes(subgraph);
 
         // Validate the body after all common optimizations
         ov::snippets::pass::Validate(get_pass_config()).run_on_model(body);

--- a/src/common/snippets/src/pass/extract_constants.cpp
+++ b/src/common/snippets/src/pass/extract_constants.cpp
@@ -24,10 +24,8 @@ bool ov::snippets::pass::ExtractConstants::run_on_subgraph(const std::shared_ptr
         if (ov::snippets::op::Subgraph::constant_input_should_be_inside_body(child))
             continue;
 
-        auto parameter = std::make_shared<ov::op::v0::Parameter>(constant->get_element_type(), constant->output(0).get_partial_shape());
-        parameter->set_friendly_name(constant->get_friendly_name());
-        ov::copy_runtime_info(constant, parameter);
-        constant->output(0).replace(parameter->output(0));
+        auto parameter = std::make_shared<ov::op::v0::Parameter>(constant->get_element_type(), constant->get_shape());
+        ov::replace_output_update_name(constant->output(0), parameter->output(0));
 
         new_external_inputs.push_back(constant);
         new_parameters.push_back(parameter);

--- a/src/common/snippets/src/pass/extract_constants.cpp
+++ b/src/common/snippets/src/pass/extract_constants.cpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/pass/extract_constants.hpp"
+
+#include "openvino/opsets/opset1.hpp"
+#include "snippets/itt.hpp"
+
+
+bool ov::snippets::pass::ExtractConstants::run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ExtractConstants");
+    auto body = subgraph->body_ptr();
+
+    ParameterVector new_parameters;
+    OutputVector new_external_inputs = subgraph->input_values();
+
+    for (auto& op : body->get_ops()) {
+        auto constant = ov::as_type_ptr<ov::op::v0::Constant>(op);
+        if (!constant || ov::shape_size(constant->get_shape()) == 1ul)
+            continue;
+
+        const auto child = constant->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
+        if (ov::snippets::op::Subgraph::constant_input_should_be_inside_body(child))
+            continue;
+
+        auto parameter = std::make_shared<ov::op::v0::Parameter>(constant->get_element_type(), constant->output(0).get_partial_shape());
+        parameter->set_friendly_name(constant->get_friendly_name());
+        ov::copy_runtime_info(constant, parameter);
+        constant->output(0).replace(parameter->output(0));
+
+        new_external_inputs.push_back(constant);
+        new_parameters.push_back(parameter);
+    }
+
+    if (new_parameters.size() != 0) {
+        body->add_parameters(new_parameters);
+        body->validate_nodes_and_infer_types();
+        subgraph->set_arguments(new_external_inputs);
+        return true;
+    }
+
+    return false;
+}

--- a/src/common/snippets/src/pass/extract_unsupported_transposes.cpp
+++ b/src/common/snippets/src/pass/extract_unsupported_transposes.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/pass/extract_unsupported_transposes.hpp"
+
+#include "openvino/opsets/opset1.hpp"
+#include "snippets/pass/transpose_decomposition.hpp"
+#include "snippets/pass/fuse_transpose_brgemm.hpp"
+#include "snippets/itt.hpp"
+
+
+bool ov::snippets::pass::ExtractUnsupportedTransposes::run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ExtractUnsupportedTransposes");
+    const auto& body = subgraph->body_ptr();
+    const auto parameters = body->get_parameters();
+    // [107806]: If count of Parameters isn't equal to Subgraph inputs,
+    //           we cannot guarantee correct extraction since we don't have correct connections between body I/O and Subgraph I/O.
+    OPENVINO_ASSERT(parameters.size() == subgraph->input_values().size(),
+                    "Failed to extract unsupported transposes: the count of Parameters isn't equal to Subgraph inputs");
+
+    bool updated = false;
+    for (size_t i = 0; i < parameters.size(); ++i) {
+        const auto& parameter = parameters[i];
+        const auto& consumers = parameter->get_output_target_inputs(0);
+        if (consumers.size() != 1)
+            continue;
+
+        const auto transpose = ov::as_type_ptr<opset1::Transpose>(consumers.begin()->get_node()->shared_from_this());
+        if (!transpose)
+            continue;
+
+        const auto& order = ov::as_type_ptr<opset1::Constant>(transpose->get_input_node_shared_ptr(1));
+        if (!order)
+            continue;
+
+        const auto order_value = order->cast_vector<int>();
+        const auto transpose_child = *(transpose->get_output_target_inputs(0).begin());
+        const auto is_brgemm_case = ov::is_type<opset1::MatMul>(transpose_child.get_node()->shared_from_this());
+        // If Transpose is supported (can be decomposed or fused into Brgemm), skip
+        if ((is_brgemm_case && FuseTransposeBrgemm::supported_cases.count(order_value) != 0) ||
+            (TransposeDecomposition::supported_cases.count(order_value) != 0))
+            continue;
+
+        // If the transpose isn't supported - we have to extract it from Subgraph
+        transpose->set_argument(0, subgraph->input_value(i));
+        subgraph->set_argument(i, transpose);
+        transpose_child.replace_source_output(parameter);
+        // Update shape
+        parameter->set_partial_shape(transpose->get_output_partial_shape(0));
+        updated = true;
+    }
+
+    if (updated) {
+        subgraph->validate_and_infer_types();
+    }
+
+    return updated;
+}

--- a/src/common/snippets/src/pass/extract_unsupported_transposes.cpp
+++ b/src/common/snippets/src/pass/extract_unsupported_transposes.cpp
@@ -30,8 +30,7 @@ bool ov::snippets::pass::ExtractUnsupportedTransposes::run_on_subgraph(const std
             continue;
 
         const auto& order = ov::as_type_ptr<opset1::Constant>(transpose->get_input_node_shared_ptr(1));
-        if (!order)
-            continue;
+        OPENVINO_ASSERT(order, "ExtractUnsupportedTransposes expects Transposes with constant order");
 
         const auto order_value = order->cast_vector<int>();
         const auto transpose_child = *(transpose->get_output_target_inputs(0).begin());
@@ -46,7 +45,6 @@ bool ov::snippets::pass::ExtractUnsupportedTransposes::run_on_subgraph(const std
         transpose->set_argument(0, subgraph->input_value(i));
         subgraph->set_argument(i, transpose);
         transpose_child.replace_source_output(parameter);
-        // Update shape
         parameter->set_partial_shape(transpose->get_output_partial_shape(0));
         updated = true;
     }

--- a/src/common/snippets/src/pass/extract_unsupported_transposes.cpp
+++ b/src/common/snippets/src/pass/extract_unsupported_transposes.cpp
@@ -5,8 +5,7 @@
 #include "snippets/pass/extract_unsupported_transposes.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "snippets/pass/transpose_decomposition.hpp"
-#include "snippets/pass/fuse_transpose_brgemm.hpp"
+#include "snippets/pass/mha_tokenization.hpp"
 #include "snippets/itt.hpp"
 
 
@@ -38,8 +37,9 @@ bool ov::snippets::pass::ExtractUnsupportedTransposes::run_on_subgraph(const std
         const auto transpose_child = *(transpose->get_output_target_inputs(0).begin());
         const auto is_brgemm_case = ov::is_type<opset1::MatMul>(transpose_child.get_node()->shared_from_this());
         // If Transpose is supported (can be decomposed or fused into Brgemm), skip
-        if ((is_brgemm_case && FuseTransposeBrgemm::supported_cases.count(order_value) != 0) ||
-            (TransposeDecomposition::supported_cases.count(order_value) != 0))
+        // [116568]: It should be covered by TransposeDecomposition::is_supported or FuseTransposeBrgemm::is_supported
+        if ((is_brgemm_case && TokenizeMHASnippets::get_fusion_transpose_order(order_value.size()) == order_value) ||
+            (TokenizeMHASnippets::get_decomposed_transpose_order(order_value.size()) == order_value))
             continue;
 
         // If the transpose isn't supported - we have to extract it from Subgraph

--- a/src/common/snippets/src/pass/manager.cpp
+++ b/src/common/snippets/src/pass/manager.cpp
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "snippets/pass_manager.hpp"
+#include "snippets/pass/manager.hpp"
+
 
 namespace ov {
 namespace snippets {
@@ -77,5 +78,5 @@ std::shared_ptr<Manager::PassBase> Manager::insert_pass_instance(const PassPosit
 }
 
 } // namespace pass
-}// namespace snippets
-}// namespace ov
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/src/pass/mha_tokenization.cpp
@@ -392,7 +392,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             // If Transpose has valid order for the Transpose fusing (ExplicitTransposeMatMulInputs pass call), tokenize him.
             // Otherwise, skip the Transpose.
             if (!is_input_transposed) {
-                if (is_valid_transpose(transpose, config.supported_transpose_ranks, order)) {
+                if (is_valid_transpose(transpose, config.mha_supported_transpose_ranks, order)) {
                     ordered_ops.insert(pos, transpose);
                 }
                 return;
@@ -402,7 +402,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             if (rank < 2)
                 return;
             std::swap(transposed_order[rank - 1], transposed_order[rank - 2]);
-            if (is_valid_transpose(transpose, config.supported_transpose_ranks, transposed_order)) {
+            if (is_valid_transpose(transpose, config.mha_supported_transpose_ranks, transposed_order)) {
                 ordered_ops.insert(pos, transpose);
             }
         };
@@ -446,7 +446,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
         //    Transpose3
         if (!are_ops_after_matmul1) {
             auto transpose3 = config.mha_token_enable_transpose_on_output ? ov::as_type_ptr<ov::opset1::Transpose>(child) : nullptr;
-            if (is_valid_transpose(transpose3, config.supported_transpose_ranks, get_fusion_transpose_order(pattern_rank)) &&
+            if (is_valid_transpose(transpose3, config.mha_supported_transpose_ranks, get_fusion_transpose_order(pattern_rank)) &&
                 transpose3->get_input_element_type(0) == matmul1_out_type) {  // To avoid Convert between MatMul1 and Transpose3
                 ordered_ops.push_back(transpose3);
             }

--- a/src/common/snippets/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/src/pass/mha_tokenization.cpp
@@ -180,7 +180,7 @@ std::vector<int32_t> rescale_order(std::vector<int32_t> default_order, size_t ra
     OPENVINO_ASSERT(rank > 2, "Incorrect rank for testing");
     auto order = std::vector<int32_t>(rank);
     std::iota(order.begin(), order.end(), 0);
-    const auto diff = rank - default_order.size();
+    const auto diff = static_cast<int32_t>(rank - default_order.size());
     for (size_t i = 0; i < default_order.size(); ++i) {
         order[diff + i] = default_order[i] + diff;
     }

--- a/src/common/snippets/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/src/pass/mha_tokenization.cpp
@@ -18,11 +18,11 @@
 
 
 namespace {
-auto is_supported_tensor(const ov::descriptor::Tensor& t) -> bool {
+bool is_supported_tensor(const ov::descriptor::Tensor& t) {
     return t.get_partial_shape().is_static() && ov::snippets::utils::one_of(t.get_shape().size(), 3lu, 4lu);
 }
 
-auto is_supported_intermediate_op(const std::shared_ptr<ov::Node>& node) -> bool {
+bool is_supported_intermediate_op(const std::shared_ptr<ov::Node>& node) {
     const auto is_intermediate_op = [](const std::shared_ptr<ov::Node>& node) {
         return ov::is_type<ov::op::util::UnaryElementwiseArithmetic>(node) ||
                ov::is_type<ov::op::util::BinaryElementwiseArithmetic>(node) ||
@@ -32,22 +32,23 @@ auto is_supported_intermediate_op(const std::shared_ptr<ov::Node>& node) -> bool
     return is_intermediate_op(node) && ov::snippets::pass::TokenizeSnippets::AppropriateForSubgraph(node);
 }
 
-auto is_valid_transpose(const std::shared_ptr<ov::opset1::Transpose>& node, std::vector<int64_t> expected_order) -> bool {
-    auto valid_transpose_order = [expected_order](const std::shared_ptr<ov::Node>& node) -> bool {
+bool is_valid_transpose(const std::shared_ptr<ov::opset1::Transpose>& node, const std::set<size_t>& supported_ranks, std::vector<int32_t> expected_order) {
+    auto is_valid_transpose_order = [expected_order, supported_ranks](const std::shared_ptr<ov::Node>& node) -> bool {
         const auto transpose_pattern = ov::as_type_ptr<ov::opset1::Constant>(node);
         if (!transpose_pattern)
             return false;
-        return transpose_pattern->cast_vector<int64_t>() == expected_order;
+        const auto existing_order = transpose_pattern->cast_vector<int32_t>();
+        return existing_order == expected_order && supported_ranks.count(existing_order.size()) != 0;
     };
     auto is_supported_transpose_tensor = [](const ov::descriptor::Tensor& t) {
         return is_supported_tensor(t) && ov::snippets::pass::TokenizeSnippets::get_supported_element_types().count(t.get_element_type()) != 0;
     };
 
-    return node && node->get_output_target_inputs(0).size() == 1 && node->get_shape().size() == 4 &&
-           valid_transpose_order(node->get_input_node_shared_ptr(1)) && is_supported_transpose_tensor(node->get_input_tensor(0));
+    return node && node->get_output_target_inputs(0).size() == 1 && is_valid_transpose_order(node->get_input_node_shared_ptr(1)) &&
+           is_supported_transpose_tensor(node->get_input_tensor(0));
 }
 
-auto tokenize_broadcast(const std::shared_ptr<ov::Node>& interm_op, ov::NodeVector& ordered_ops) -> void {
+void tokenize_broadcast(const std::shared_ptr<ov::Node>& interm_op, ov::NodeVector& ordered_ops) {
     // We can tokenize Broadcast op only when output shape of child doesn't depend on Broadcast shape without last dimension.
     // Snippets remove Broadcast op and insert BroadcastMove if last dimensions before and after Broadcast are different.
     // Otherwise, we can lose original shape.
@@ -95,9 +96,7 @@ auto tokenize_broadcast(const std::shared_ptr<ov::Node>& interm_op, ov::NodeVect
     }
 }
 
-auto tokenize_reshape_around_softmax(std::shared_ptr<ov::Node>& interm_op,
-                                     std::shared_ptr<ov::opset1::Reshape>& reshape,
-                                     ov::NodeVector& ordered_ops) -> bool {
+bool tokenize_reshape_around_softmax(std::shared_ptr<ov::Node>& interm_op, std::shared_ptr<ov::opset1::Reshape>& reshape, ov::NodeVector& ordered_ops) {
     reshape = ov::as_type_ptr<ov::opset1::Reshape>(interm_op);
     if (reshape) {
         const auto in_shape = reshape->get_input_shape(0);
@@ -110,7 +109,7 @@ auto tokenize_reshape_around_softmax(std::shared_ptr<ov::Node>& interm_op,
     return true;
 }
 
-auto get_potential_body_params(const std::shared_ptr<ov::Node>& op) -> size_t {
+size_t get_potential_body_params(const std::shared_ptr<ov::Node>& op) {
     size_t count = 0;
     for (size_t i = 1; i < op->get_input_size(); ++i) {
         const auto input = op->input_value(i);
@@ -125,8 +124,8 @@ auto get_potential_body_params(const std::shared_ptr<ov::Node>& op) -> size_t {
     return count;
 }
 
-auto update_intermediate_supported_ops(std::shared_ptr<ov::Node>& interm_op, ov::NodeVector& ordered_ops,
-                                       size_t& hidden_virtual_ports_count, size_t& potential_body_params_count) -> bool {
+bool update_intermediate_supported_ops(std::shared_ptr<ov::Node>& interm_op, ov::NodeVector& ordered_ops,
+                                       size_t& hidden_virtual_ports_count, size_t& potential_body_params_count) {
     while (is_supported_intermediate_op(interm_op)) {
         // All supported intermediate ops have only one output port
         if (interm_op->get_output_target_inputs(0).size() != 1)
@@ -176,7 +175,27 @@ auto update_intermediate_supported_ops(std::shared_ptr<ov::Node>& interm_op, ov:
     }
     return true;
 }
+
+std::vector<int32_t> rescale_order(std::vector<int32_t> default_order, size_t rank) {
+    OPENVINO_ASSERT(rank > 2, "Incorrect rank for testing");
+    auto order = std::vector<int32_t>(rank);
+    std::iota(order.begin(), order.end(), 0);
+    const auto diff = rank - default_order.size();
+    for (size_t i = 0; i < default_order.size(); ++i) {
+        order[diff + i] = default_order[i] + diff;
+    }
+    return order;
+}
 }  // namespace
+
+std::vector<int32_t> ov::snippets::pass::TokenizeMHASnippets::get_fusion_transpose_order(size_t rank) {
+    OPENVINO_ASSERT(rank > 2, "Incorrect rank for testing");
+    return rescale_order({1, 0, 2}, rank);
+}
+std::vector<int32_t> ov::snippets::pass::TokenizeMHASnippets::get_decomposed_transpose_order(size_t rank) {
+    OPENVINO_ASSERT(rank > 2, "Incorrect rank for testing");
+    return rescale_order({1, 2, 0}, rank);
+}
 
 bool ov::snippets::pass::TokenizeMHASnippets::is_matmul0_supported(const std::shared_ptr<ov::opset1::MatMul>& matmul) {
     if (!matmul || matmul->get_output_target_inputs(0).size() != 1 || matmul->get_transpose_a() ||
@@ -256,6 +275,8 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
         }
 
         ordered_ops.push_back(matmul0);
+
+        const auto pattern_rank = matmul0->get_output_partial_shape(0).size();
 
         auto interm_op = matmul0->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
         // Add supported operations which are between MatMul0 and Softmax to ordered_ops
@@ -368,12 +389,12 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
         }
 
         auto tokenize_transpose = [&](const std::shared_ptr<ov::opset1::Transpose>& transpose,
-                                      bool is_input_transposed, std::vector<int64_t> order,
+                                      bool is_input_transposed, std::vector<int32_t> order,
                                       const ov::NodeVector::const_iterator& pos) {
             // If Transpose has valid order for the Transpose fusing (ExplicitTransposeMatMulInputs pass call), tokenize him.
             // Otherwise, skip the Transpose.
             if (!is_input_transposed) {
-                if (is_valid_transpose(transpose, order)) {
+                if (is_valid_transpose(transpose, config.supported_transpose_ranks, order)) {
                     ordered_ops.insert(pos, transpose);
                 }
                 return;
@@ -383,7 +404,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             if (rank < 2)
                 return;
             std::swap(transposed_order[rank - 1], transposed_order[rank - 2]);
-            if (is_valid_transpose(transpose, transposed_order)) {
+            if (is_valid_transpose(transpose, config.supported_transpose_ranks, transposed_order)) {
                 ordered_ops.insert(pos, transpose);
             }
         };
@@ -391,9 +412,9 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
         const auto transpose1 = ov::as_type_ptr<ov::opset1::Transpose>(parent);
         const auto transpose0 = ov::as_type_ptr<ov::opset1::Transpose>(matmul0->get_input_node_shared_ptr(0));
         const auto transpose2 = ov::as_type_ptr<ov::opset1::Transpose>(matmul1->get_input_node_shared_ptr(1));
-        tokenize_transpose(transpose1, is_transposed_b_0, {0, 2, 3, 1}, ordered_ops.begin());
-        tokenize_transpose(transpose0, matmul0->get_transpose_a(), {0, 2, 1, 3}, ordered_ops.begin());
-        tokenize_transpose(transpose2, matmul1->get_transpose_b(), {0, 2, 1, 3}, ordered_ops.end());
+        tokenize_transpose(transpose1, is_transposed_b_0, get_decomposed_transpose_order(pattern_rank), ordered_ops.begin());
+        tokenize_transpose(transpose0, matmul0->get_transpose_a(), get_fusion_transpose_order(pattern_rank), ordered_ops.begin());
+        tokenize_transpose(transpose2, matmul1->get_transpose_b(), get_fusion_transpose_order(pattern_rank), ordered_ops.end());
         ordered_ops.push_back(matmul1);
 
         bool are_ops_after_matmul1 = false;
@@ -427,7 +448,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
         //    Transpose3
         if (!are_ops_after_matmul1) {
             auto transpose3 = config.mha_token_enable_transpose_on_output ? ov::as_type_ptr<ov::opset1::Transpose>(child) : nullptr;
-            if (is_valid_transpose(transpose3, {0, 2, 1, 3}) &&
+            if (is_valid_transpose(transpose3, config.supported_transpose_ranks, get_fusion_transpose_order(pattern_rank)) &&
                 transpose3->get_input_element_type(0) == matmul1_out_type) {  // To avoid Convert between MatMul1 and Transpose3
                 ordered_ops.push_back(transpose3);
             }
@@ -515,7 +536,7 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
         auto subgraph = std::make_shared<op::Subgraph>(subgraph_inputs, body);
         // Copy runtime info from last node to subgraph - to copy topological order
         copy_runtime_info(last_node, subgraph);
-        subgraph->set_friendly_name(last_node->get_friendly_name());
+        subgraph->set_friendly_name("MHA_" + last_node->get_friendly_name());
 
         for (size_t i = 0; i < subgraph->get_output_size(); ++i) {
             for (const auto& target_input : subgraph_result_inputs[i]) {

--- a/src/common/snippets/src/pass/split_dimension_m.cpp
+++ b/src/common/snippets/src/pass/split_dimension_m.cpp
@@ -1,0 +1,270 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/pass/split_dimension_m.hpp"
+
+#include "snippets/itt.hpp"
+
+namespace {
+size_t get_lcm(size_t a, size_t b) {
+    std::function<size_t(size_t, size_t)> get_gcd;
+    get_gcd = [&get_gcd](size_t a, size_t b) {
+        if (b == 0)
+            return a;
+        return get_gcd(b, a % b);
+    };
+    return a / get_gcd(a, b) * b;
+}
+}  // namespace
+
+bool ov::snippets::pass::SplitDimensionM::isSupportedMatMul(const std::shared_ptr<const ov::Node>& node) {
+    const auto matmul = ov::as_type_ptr<const ov::op::v0::MatMul>(node);
+    return matmul && !matmul->get_transpose_a() && !matmul->is_dynamic() && node->get_shape().size() == 3; // It's needed only for 3D MHA patterns
+}
+
+bool ov::snippets::pass::SplitDimensionM::canBeOptimized(const std::shared_ptr<const ov::Node>& node, size_t concurrency) {
+    if (!isSupportedMatMul(node))
+        return false;
+    const auto mm_shape = node->get_shape();
+    const auto current_parallel_work_amount =
+        std::accumulate(mm_shape.rbegin() + 2, mm_shape.rend(), size_t(1), std::multiplies<size_t>());
+    const auto dim_M = *(mm_shape.rbegin() + 1);
+    return (current_parallel_work_amount < concurrency) &&
+           (current_parallel_work_amount * dim_M >= concurrency);
+}
+
+bool ov::snippets::pass::SplitDimensionM::run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::SplitDimensionM");
+     // To increase parallelism work in 3D cases for MHA pattern,
+    // we split 1st dimension (starting from 0th) into 2 new dimensions to get 4D Shapes where
+    // - 0th and 1st dimensions are used in parallel scheduling,
+    // - 2nd and 3rd dimensions are used in kernel
+    // Note: 3D Patterns don't contain Transpose inside so the reshaping is valid
+
+    // It's needed only for MHA patterns. Need to add support for common patterns
+    if (!subgraph->has_domain_sensitive_ops())
+        return false;
+
+    const auto& body = subgraph->body_ptr();
+    const auto& parameters = body->get_parameters();
+    // [107806]: If count of Parameters isn't equal to Subgraph inputs (it's possible case in general),
+    //           we cannot garantee correct extraction since we don't have correct connections between body I/O and Subgraph I/O.
+    OPENVINO_ASSERT(parameters.size() == subgraph->input_values().size(),
+                    "Failed to extract unsupported transposes: the count of Parameters isn't equal to Subgraph inputs");
+
+    // Need to find MatMul0 and check output shape
+    const auto& ops = body->get_ordered_ops();
+    const auto mm_it = std::find_if(ops.begin(), ops.end(),
+                                    [](const std::shared_ptr<ov::Node>& node){ return ov::is_type<ov::op::v0::MatMul>(node); });
+    if (mm_it == ops.end())
+        return false;
+
+    const auto matmul0 = *mm_it;
+    if (!isSupportedMatMul(matmul0))
+        return false;
+
+    auto get_dim_M = [](const ov::Shape& shape) {
+        return *(shape.rbegin() + 1);
+    };
+
+    const auto mm_shape = matmul0->get_shape();
+    const auto m_dim = get_dim_M(mm_shape);  // M
+    const auto batch_dim =
+        std::accumulate(mm_shape.rbegin() + 2, mm_shape.rend(), size_t(1), std::multiplies<size_t>());  // B (batch)
+
+    // We skip optimization if the current batch is optimal for concurrency
+    const auto optimal_parallelism_work_amount = m_concurrency;
+    if (batch_dim % optimal_parallelism_work_amount == 0)
+        return false;
+
+    size_t batch_m_dim = 1;
+    size_t new_m_dim = m_dim;
+
+    auto is_optimized = [&](size_t batch_m_dim) {
+        return batch_m_dim > 1;
+    };
+
+    // [ First Step ]
+    // Need to find optimized dimension splitting: [b1..bk, m, n] -> [b1..bk, batch_m_dim, new_m_dim, n]
+    // The work amount for parallelism should be divided by max thread count in ideal case
+    // that all threads have the same full work amount (avoid of thread downtime)
+    // If it's impossible, we select such values so that as many threads as possible have work (see [ Second Step ])
+    // For example, there are 16 threads and shape [6, 512, 32]
+    //              LCM(6, 16) = 48 <- ideal work amount for parallelism
+    //              new_shape [6, 48 / 6, 512 / (48 / 6), 32 ] => [6, 8, 64, 32]
+    //              Each thread has parallelism_work_amount = 6 * 8 / nthrs = 3
+    const auto lcm = get_lcm(batch_dim, optimal_parallelism_work_amount);  // LCM(b, nthrs)
+    const auto batch_dim_multiplier = lcm / batch_dim;  // LCM(b, nthrs) / b
+    const auto needed_new_dim = m_dim / batch_dim_multiplier;  // m / (LCM(b, nthrs) / b) - needed factors of dimension m
+    if (batch_dim_multiplier * needed_new_dim == m_dim && is_optimized(batch_dim_multiplier)) {
+        batch_m_dim = batch_dim_multiplier;
+        new_m_dim = needed_new_dim;
+    } else {
+        // [ Second Step ]
+        // If we couldn't optimally split on the previous step, try the second step.
+        // The algorithm finds the more optimal parallelism work amount [batch_dim * batch_m_dim],
+        // where batch_m_dim is divisor of dimension M.
+        // The optimal parallelism work amount means the case when as many threads as possible have work
+        // For example, there are 8 threads and shape [5, 384, 32]
+        //              768 = [2 x 192] = [3 x 128] = [4 x 96] = [6 x 64]
+        //               - [5, 2, 192, 32] - WA = 10 = 8 + 2 (6 threads calculates once and 2 threads twice)
+        //               - [5, 3, 128, 32] - WA = 15 = 8 + 7 (all threads have 2 kernel except one thread) <- the most optimal case
+        //               - [5, 4,  96, 32] - WA = 20 = 8 x 2 + 4
+        //               - [5, 6,  64, 32] - WA = 30 = 8 x 3 + 6
+        // The most optimal and possible case is [5, 3, 128, 32] - almost all threads executes kernel twice
+        // Heuristic value for a quick exit from the algorithm.
+        // The value shows the number of threads in percentages that perform the most equal work
+        const auto optimal_thread_num_percent = 0.8;
+        size_t optimal_remainder = 1;
+        auto get_remainder = [batch_dim, optimal_parallelism_work_amount](const size_t potential_batch_dim) {
+            return (batch_dim * potential_batch_dim) % optimal_parallelism_work_amount;
+        };
+
+        auto update_optimal_params = [&](size_t divisor_0, size_t divisor_1) {
+            const auto remainder = batch_dim * divisor_0 % optimal_parallelism_work_amount;
+            if (remainder > optimal_remainder || remainder == 0) {
+                optimal_remainder = remainder;
+                batch_m_dim = divisor_0;
+                new_m_dim = divisor_1;
+            }
+        };
+
+        // Firstly we have shape [batch, 1, m_dim, smth].
+        // So at the beginning we have parallel_work_amount = batch x 1
+        optimal_remainder = get_remainder(1);
+        const auto root = std::sqrt(m_dim) + 1;
+        for (size_t divisor_0 = 2; divisor_0 < root; ++divisor_0) {
+            const size_t divisor_1 = m_dim / divisor_0;
+            if (divisor_0 * divisor_1 != m_dim)
+                continue;
+
+            update_optimal_params(divisor_0, divisor_1);
+            update_optimal_params(divisor_1, divisor_0);
+            if ((static_cast<float>(optimal_remainder) / static_cast<float>(optimal_parallelism_work_amount) > optimal_thread_num_percent) ||
+                (optimal_remainder == 0)) {
+                break;
+            }
+        }
+    }
+
+    OPENVINO_ASSERT(batch_m_dim * new_m_dim == m_dim, "Incorrect dimension M splitting!");
+    // nothing to split
+    if (!is_optimized(batch_m_dim))
+        return false;
+
+    /***** Reshape insertion *****/
+
+    // There are two Parameter variants:
+    //  - Parameter on branches for Second input of MatMul - the shape should be only unsqueezed (add just 1)
+    //  - Other Parameters (on First input of MatMuls and between) - the shape should be splitted on M dimension
+
+    bool updated = false;
+    std::set<std::shared_ptr<ov::op::v0::Parameter>> reshaped_params;
+
+    auto insert_reshape = [&](const std::shared_ptr<ov::op::v0::Parameter>& param, const ov::Shape& new_shape) {
+        const auto index = std::distance(parameters.begin(), std::find(parameters.begin(), parameters.end(), param));
+        const auto shape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{new_shape.size()}, new_shape);
+        const auto reshape = std::make_shared<ov::op::v1::Reshape>(subgraph->input_value(index), shape_const, false);
+        subgraph->input(index).replace_source_output(reshape);
+        param->set_partial_shape(new_shape);
+        reshaped_params.insert(param);
+        updated = true;
+    };
+
+    auto get_updated_shape = [&](const ov::Shape& shape, bool split_m_dim) {
+        const auto current_m_dim = get_dim_M(shape);
+        OPENVINO_ASSERT(!split_m_dim || current_m_dim == 1 || current_m_dim == m_dim, "Incorrect shape for splitting!");
+        ov::Shape new_shape = shape;
+        if ((split_m_dim && current_m_dim == 1) || !split_m_dim) {
+            new_shape.insert((new_shape.rbegin() + 2).base(), 1);
+        } else {
+            new_shape.insert((new_shape.rbegin() + 2).base(), batch_m_dim);
+            *(new_shape.rbegin() + 1) = new_m_dim;
+        }
+        OPENVINO_ASSERT(ov::shape_size(new_shape) == ov::shape_size(shape), "Incorrect shape splitting!");
+        return new_shape;
+    };
+
+    auto reshape_parameter = [&](const std::shared_ptr<ov::Node>& node, bool split_m_dim = true) {
+        const auto param = ov::as_type_ptr<ov::op::v0::Parameter>(node);
+        if (!param || reshaped_params.count(param) > 0)
+            return;
+        insert_reshape(param, get_updated_shape(param->get_partial_shape().get_shape(), split_m_dim));
+    };
+
+    auto update_matmul_second_branch = [&](const std::shared_ptr<ov::Node>& node) {
+        auto parent = node->get_input_node_shared_ptr(1);
+        while (!ov::is_type<ov::op::v0::Parameter>(parent)) {
+            if (parent->get_input_size() > 1) {
+                for (const auto& input_source : parent->input_values()) {
+                    reshape_parameter(input_source.get_node_shared_ptr(), false);
+                }
+            }
+
+            // [107731]: It's covered my MHA tokenization
+            parent = parent->get_input_node_shared_ptr(0);
+        }
+        reshape_parameter(parent, false);
+    };
+
+    // Firstly, Unsqueeze parameters on second branches of MatMuls
+    for (const auto& op : ops) {
+        if (ov::is_type<ov::op::v0::MatMul>(op)) {
+            update_matmul_second_branch(op);
+        }
+    }
+
+    // Secondly, Update All M dimensions for remaining parameters
+    for (const auto& param : parameters) {
+        if (reshaped_params.count(param) == 0)
+            reshape_parameter(param, true);
+    }
+
+    // Return the previous shape on outputs
+    for (size_t i = 0; i < subgraph->get_output_size() && updated; ++i) {
+        const auto output_shape = subgraph->get_output_shape(i);
+        if (is_scalar(output_shape))
+            continue;
+
+        const auto& target_inputs = subgraph->get_output_target_inputs(i);
+        const auto shape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{output_shape.size()}, output_shape);
+        const auto reshape = std::make_shared<ov::op::v1::Reshape>(subgraph->output(i), shape_const, false);
+        // Save output name
+        const auto original_output = body->get_results()[i]->get_input_node_shared_ptr(0);
+        const auto original_name = original_output->get_friendly_name();
+        reshape->set_friendly_name(original_name);
+        original_output->set_friendly_name(original_name + "_original");
+
+        for (const auto& input : target_inputs) {
+            input.replace_source_output(reshape);
+            // Result input tensor name was changed, the name has to be restored
+            if (ov::is_type<ov::op::v0::Result>(input.get_node())) {
+                input.get_tensor_ptr()->add_names(subgraph->output(i).get_tensor_ptr()->get_names());
+            }
+        }
+        subgraph->output(i).get_tensor_ptr()->set_names({});
+        updated = true;
+    }
+    subgraph->set_friendly_name(subgraph->get_friendly_name() + "_original");
+
+    // Need to update inner Shapes and Softmax Axis
+    if (updated) {
+        for (const auto &op : ops) {
+            if (const auto softmax_v8 = ov::as_type_ptr<ov::op::v8::Softmax>(op)) {
+                softmax_v8->set_axis(-1);
+            } else if (const auto softmax_v1 = ov::as_type_ptr<ov::op::v1::Softmax>(op)) {
+                softmax_v1->set_axis(softmax_v1->get_output_partial_shape(0).size()); // since new_shape.size() = old_shape.size() + 1
+            } else if (const auto broadcast = ov::as_type_ptr<ov::op::v1::Broadcast>(op)) {
+                // Broadcast is tokenized only between MatMuls -> Split M dimension
+                const auto shape_const = ov::as_type_ptr<ov::op::v0::Constant>(broadcast->input_value(1).get_node_shared_ptr());
+                OPENVINO_ASSERT(shape_const, "SplitDimensionM expects Broadcast with Constant output shape");
+                const auto new_shape = get_updated_shape(shape_const->cast_vector<size_t>(), true);
+                broadcast->set_argument(1, std::make_shared<ov::op::v0::Constant>(shape_const->get_element_type(), ov::Shape{new_shape.size()}, new_shape));
+            }
+        }
+        subgraph->validate_and_infer_types();
+    }
+
+    return updated;
+}

--- a/src/common/snippets/src/pass/subgraph_manager.cpp
+++ b/src/common/snippets/src/pass/subgraph_manager.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/pass/subgraph_manager.hpp"
+
+namespace ov {
+namespace snippets {
+namespace pass {
+
+bool CommonOptimizations::SubgraphManager::run_passes(std::shared_ptr<ov::snippets::op::Subgraph> subgraph) {
+    bool updated = false;
+    for (const auto& pass : m_pass_list) {
+        updated = pass->run_on_subgraph(subgraph) || updated;
+    }
+    return updated;
+}
+
+} // namespace pass
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/tests/include/lowering_utils.hpp
+++ b/src/common/snippets/tests/include/lowering_utils.hpp
@@ -6,7 +6,7 @@
 #include <common_test_utils/ov_test_utils.hpp>
 #include "snippets/op/subgraph.hpp"
 #include "snippets_helpers.hpp"
-#include "snippets/pass_manager.hpp"
+#include "snippets/pass/manager.hpp"
 #include "snippets/shape_inference/shape_inference.hpp"
 
 namespace ov {

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -28,7 +28,6 @@ void TokenizeMHASnippetsTests::run() {
     manager.register_pass<ov::snippets::pass::EnumerateNodes>();
     manager.register_pass<ov::snippets::pass::TokenizeMHASnippets>();
     manager.register_pass<ov::snippets::pass::CommonOptimizations>(config);
-    manager.register_pass<ov::pass::Serialize>("model.xml", "model.bin");
     disable_rt_info_check();
 }
 

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -28,12 +28,20 @@ void TokenizeMHASnippetsTests::run() {
     manager.register_pass<ov::snippets::pass::EnumerateNodes>();
     manager.register_pass<ov::snippets::pass::TokenizeMHASnippets>();
     manager.register_pass<ov::snippets::pass::CommonOptimizations>(config);
+    manager.register_pass<ov::pass::Serialize>("model.xml", "model.bin");
     disable_rt_info_check();
 }
 
-TEST_F(SKIP_TokenizeMHASnippetsTests /* CVS-114607 */, smoke_Snippets_MHA) {
-    GTEST_SKIP();
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 128, 12, 64}},
+                                std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}));
+    model = f.getOriginal();
+    model_ref = f.getReference();
+    run();
+}
+
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_3D) {
+    const auto &f = MHAFunction(std::vector<PartialShape>{{128, 12, 64}, {128, 12, 64}, {12, 128, 128}, {128, 12, 64}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}));
     model = f.getOriginal();
     model_ref = f.getReference();
@@ -80,10 +88,54 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Transpose_fusion) {
     run();
 }
 
-TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM) {
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA3D_SplitM) {
+    const auto& f = MHASplitMFunction(std::vector<PartialShape>{{128, 12, 64}, {128, 12, 64}, {12, 128, 128}, {128, 12, 64}},
+                                      std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
+                                      std::vector<Shape>{{2, 64, 12, 64}, {128, 12, 1, 64}, {12, 2, 64, 128}, {1, 128, 12, 64}, {128, 12, 64}},
+                                      false);
+    model = f.getOriginal();
+    model_ref = f.getReference();
+    config.concurrency = 24;
+    run();
+}
+
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA3D_SplitM_withMul) {
+    const auto& f = MHASplitMFunction(std::vector<PartialShape>{{128, 12, 64}, {128, 12, 64}, {12, 128, 128}, {128, 12, 64}},
+                                      std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
+                                      std::vector<Shape>{{2, 64, 12, 64}, {128, 12, 1, 64}, {12, 2, 64, 128}, {1, 128, 12, 64}, {128, 12, 64}},
+                                      true);
+    model = f.getOriginal();
+    model_ref = f.getReference();
+    config.concurrency = 16;
+    run();
+}
+
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA4D_SplitM) {
+    const auto& f = MHASplitMFunction(std::vector<PartialShape>{{1, 384, 16, 64}, {1, 384, 16, 64}, {1, 1, 1, 384}, {1, 384, 16, 64}},
+                                      std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
+                                      std::vector<Shape>{{1, 6, 64, 16, 64}, {1, 384, 16, 1, 64}, {1, 1, 1, 1, 384}, {1, 1, 384, 16, 64}, {1, 384, 16, 64}},
+                                      false);
+    model = f.getOriginal();
+    model_ref = f.getReference();
+    config.concurrency = 60;
+    run();
+}
+
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA4D_SplitM_withMul) {
+    const auto& f = MHASplitMFunction(std::vector<PartialShape>{{1, 384, 16, 64}, {1, 384, 16, 64}, {1, 1, 1, 384}, {1, 384, 16, 64}},
+                                      std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
+                                      std::vector<Shape>{{1, 6, 64, 16, 64}, {1, 384, 16, 1, 64}, {1, 1, 1, 1, 384}, {1, 1, 384, 16, 64}, {1, 384, 16, 64}},
+                                      true);
+    model = f.getOriginal();
+    model_ref = f.getReference();
+    config.concurrency = 60;
+    run();
+}
+
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHAWOTranspose_SplitM) {
     const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{10, 9216, 128}, {10, 128, 9216}, {10, 9216, 128}},
                                                  std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32}),
-                                                 std::vector<Shape>{{10, 9, 1024, 128}, {10, 1, 128, 9216}, {10, 1, 9216, 128}, {10, 9216, 128}});
+                                                 std::vector<Shape>{{10, 3, 3072, 128}, {10, 1, 128, 9216}, {10, 1, 9216, 128}, {10, 9216, 128}});
     model = f.getOriginal();
     model_ref = f.getReference();
     config.concurrency = 18;
@@ -93,7 +145,7 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM) {
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM_AlmostAllThreads) {
     const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{5, 30, 32}, {5, 32, 30}, {5, 30, 32}},
                                                  std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32}),
-                                                 std::vector<Shape>{{5, 6, 5, 32}, {5, 1, 32, 30}, {5, 1, 30, 32}, {5, 30, 32}});
+                                                 std::vector<Shape>{{5, 10, 3, 32}, {5, 1, 32, 30}, {5, 1, 30, 32}, {5, 30, 32}});
     model = f.getOriginal();
     model_ref = f.getReference();
     config.concurrency = 32;

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
@@ -367,8 +367,8 @@ public:
     static std::set<std::vector<element::Type>> get_supported_precisions(const std::shared_ptr<ngraph::Node>& node = nullptr);
     size_t aux_gprs_count() const override;
 
-    static size_t get_in_leading_dim(const ov::Shape& shape, const std::vector<size_t>& layout);
-    static size_t get_out_leading_dim(const ov::Shape& shape, const std::vector<size_t>& layout);
+    static size_t get_in_leading_dim(const VectorDims& shape, const std::vector<size_t>& layout);
+    static size_t get_out_leading_dim(const VectorDims& shape, const std::vector<size_t>& layout);
 
 private:
     void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_snippets_emitters.hpp
@@ -367,6 +367,9 @@ public:
     static std::set<std::vector<element::Type>> get_supported_precisions(const std::shared_ptr<ngraph::Node>& node = nullptr);
     size_t aux_gprs_count() const override;
 
+    static size_t get_in_leading_dim(const ov::Shape& shape, const std::vector<size_t>& layout);
+    static size_t get_out_leading_dim(const ov::Shape& shape, const std::vector<size_t>& layout);
+
 private:
     void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in,

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -495,6 +495,8 @@ static Config::SnippetsMode getSnippetsMode(const std::map<std::string, std::str
         return Config::SnippetsMode::IgnoreCallback;
     else if (val == PluginConfigInternalParams::DISABLE)
         return Config::SnippetsMode::Disable;
+    else if (val == PluginConfigInternalParams::ENABLE)
+        return Config::SnippetsMode::Enable;
     else
         IE_THROW() << "Wrong value for property key SNIPPETS_MODE. Expected values: ENABLE/DISABLE/IGNORE_CALLBACK";
 }
@@ -537,16 +539,16 @@ Engine::LoadExeNetworkImpl(const InferenceEngine::CNNNetwork &network, const std
 
     DEBUG_LOG(PrintableModel(*nGraphFunc, "org_"));
 
-    Transformations transformations(nGraphFunc, enableLPT, inferencePrecision, isLegacyAPI(), snippetsMode, engConfig);
+    // update the props after the perf mode translated to configs
+    // TODO: Clarify the behavior of SetConfig method. Skip eng_config or not?
+    Config conf = engConfig;
+
+    Transformations transformations(nGraphFunc, enableLPT, inferencePrecision, isLegacyAPI(), snippetsMode, conf);
     transformations.UpToLpt();
 
     if (!is_cpu_map_available()) {
         ApplyPerformanceHints(config, nGraphFunc);
     }
-
-    // update the props after the perf mode translated to configs
-    // TODO: Clarify the behavior of SetConfig method. Skip eng_config or not?
-    Config conf = engConfig;
 
     conf.readProperties(config, modelType);
     CalculateStreams(conf, nGraphFunc);

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.cpp
@@ -62,8 +62,8 @@ pass::BrgemmToBrgemmCPU::BrgemmToBrgemmCPU() {
         const auto& brgemm_in1_desc = PortDescriptorUtils::get_port_descriptor_ptr(brgemm->input(1));
         const auto& brgemm_out_desc = PortDescriptorUtils::get_port_descriptor_ptr(brgemm->output(0));
 
-        const auto dimsMatMulIn0 = snippets::utils::get_planar_pshape(brgemm->input_value(0)).get_shape();
-        const auto dimsMatMulIn1 = snippets::utils::get_planar_pshape(brgemm->input_value(1)).get_shape();
+        const auto dimsMatMulIn0 = snippets::utils::get_planar_pshape(brgemm->input(0)).get_shape();
+        const auto dimsMatMulIn1 = snippets::utils::get_planar_pshape(brgemm->input(1)).get_shape();
 
         const auto K = *dimsMatMulIn0.rbegin();
         const auto N = *dimsMatMulIn1.rbegin();

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/set_brgemm_cpu_blocking_params.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/set_brgemm_cpu_blocking_params.cpp
@@ -35,8 +35,8 @@ pass::SetBrgemmCPUBlockingParams::SetBrgemmCPUBlockingParams() {
             return false;
         }
 
-        const auto dimsMatMulIn0 = snippets::utils::get_planar_pshape(brgemm->input_value(0)).get_shape();
-        const auto dimsMatMulIn1 = snippets::utils::get_planar_pshape(brgemm->input_value(1)).get_shape();
+        const auto dimsMatMulIn0 = snippets::utils::get_planar_pshape(brgemm->input(0)).get_shape();
+        const auto dimsMatMulIn1 = snippets::utils::get_planar_pshape(brgemm->input(1)).get_shape();
         const auto K = *dimsMatMulIn0.rbegin();
         const auto N = *dimsMatMulIn1.rbegin();
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -112,6 +112,7 @@
 #include "snippets/pass/mha_tokenization.hpp"
 #include "snippets/pass/collapse_subgraph.hpp"
 #include "snippets/pass/common_optimizations.hpp"
+#include "snippets/pass/split_dimension_m.hpp"
 #include "snippets/pass/extract_reshapes_from_mha.hpp"
 
 // Misc
@@ -676,7 +677,7 @@ void Transformations::MainSnippets(void) {
             const auto is_unsupported_parallel_work_amount =
                 parallel_get_num_threads() / 2 > parallel_work_amount &&
                 static_cast<size_t>(parallel_work_amount) < needed_num_of_threads &&
-                !ov::snippets::pass::CommonOptimizations::CanOptimizeParallelWA(n, tokenization_config.concurrency);
+                !ov::snippets::pass::SplitDimensionM::canBeOptimized(n, tokenization_config.concurrency);
             return is_unsupported_parallel_work_amount;
         };
 #endif // OPENVINO_ARCH_X86_64

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -617,7 +617,7 @@ void Transformations::MainSnippets(void) {
     // To avoid uncontrolled behavior in tests, we disabled the optimization when there is Config::SnippetsMode::IgnoreCallback
     tokenization_config.split_m_dimension = snippetsMode != Config::SnippetsMode::IgnoreCallback;
     // [122706] Some 3D MHA Patterns have perf regressions when Transpose op is tokenized
-    tokenization_config.supported_transpose_ranks = { 4 };
+    tokenization_config.mha_supported_transpose_ranks = { 4 };
 
     ngraph::pass::Manager snippetsManager;
     snippetsManager.set_per_pass_validation(false);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -610,10 +610,14 @@ void Transformations::MainSnippets(void) {
     // To avoid sitations when Transpose is not alone node between MatMul and Result,
     // Plugin disables Transpose tokenization on output
     tokenization_config.mha_token_enable_transpose_on_output = (inferencePrecision == ov::element::f32);
-    tokenization_config.concurrency = parallel_get_num_threads();
+    tokenization_config.concurrency = config.streamExecutorConfig._threadsPerStream;
+    if (tokenization_config.concurrency == 0)
+        tokenization_config.concurrency = parallel_get_max_threads();
     // The optimization "SplitDimensionM" depends on target machine (thread count).
     // To avoid uncontrolled behavior in tests, we disabled the optimization when there is Config::SnippetsMode::IgnoreCallback
     tokenization_config.split_m_dimension = snippetsMode != Config::SnippetsMode::IgnoreCallback;
+    // [122706] Some 3D MHA Patterns have perf regressions when Transpose op is tokenized
+    tokenization_config.supported_transpose_ranks = { 4 };
 
     ngraph::pass::Manager snippetsManager;
     snippetsManager.set_per_pass_validation(false);
@@ -669,15 +673,10 @@ void Transformations::MainSnippets(void) {
             return true;
         };
         auto is_unsupported_parallel_work_amount = [&](const std::shared_ptr<const ov::Node>& n, const ov::Shape& shape) {
-            const auto parallel_work_amount = std::accumulate(shape.rbegin() + 2, shape.rend(), 1, std::multiplies<size_t>());
-            // Heuristic values:
-            //    parallelism work amount - not enough work amount for parallelism
-            // TODO: The heuristic will be removed after parallelism support on JIT level
-            const auto needed_num_of_threads = 12lu;
+            const size_t parallel_work_amount = std::accumulate(shape.rbegin() + 2, shape.rend(), 1, std::multiplies<size_t>());
             const auto is_unsupported_parallel_work_amount =
-                parallel_get_num_threads() / 2 > parallel_work_amount &&
-                static_cast<size_t>(parallel_work_amount) < needed_num_of_threads &&
-                !ov::snippets::pass::SplitDimensionM::canBeOptimized(n, tokenization_config.concurrency);
+                parallel_work_amount < tokenization_config.concurrency &&
+                !ov::snippets::pass::SplitDimensionM::can_be_optimized(n, tokenization_config.concurrency);
             return is_unsupported_parallel_work_amount;
         };
 #endif // OPENVINO_ARCH_X86_64

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -5,6 +5,7 @@
 #include "snippets/mha.hpp"
 #include "common_test_utils/test_constants.hpp"
 #include "test_utils/cpu_test_utils.hpp"
+#include "cpp_interfaces/interface/ie_internal_plugin_config.hpp"
 #include "ie_plugin_config.hpp"
 #include "ie_system_conf.h"
 
@@ -15,12 +16,17 @@ namespace snippets {
 
 namespace {
 
-const std::vector<std::vector<ov::PartialShape>> inputShapes = {
+const std::vector<std::vector<ov::PartialShape>> inputShapes_4D = {
         {{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 128, 12, 64}},
         {{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 16, 1, 1}, {1, 128, 16, 64}},
         {{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 1, 1, 128}, {1, 128, 16, 64}},
         {{2, 68, 6, 92}, {2, 68, 6, 92}, {1, 1, 68, 68}, {2, 68, 6, 92}},
         {{1, 58, 16, 34}, {1, 58, 16, 34}, {1, 1, 1, 58}, {1, 58, 16, 34}},
+};
+
+const std::vector<std::vector<ov::PartialShape>> inputShapes_3D = {
+        {{128, 12, 64}, {128, 12, 64}, {12, 128, 128}, {128, 12, 64}},
+        {{68, 6, 92}, {68, 6, 92}, {1, 68, 68}, { 68, 6, 92}},
 };
 
 static inline bool is_bf16_supported() {
@@ -40,24 +46,74 @@ static inline std::vector<std::vector<element::Type>> precision_bf16(size_t coun
     return prc;
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA, MHA,
+static std::map<std::string, std::string> enable_callback() {
+    return std::map<std::string, std::string>{
+        {
+          InferenceEngine::PluginConfigInternalParams::KEY_SNIPPETS_MODE,
+          InferenceEngine::PluginConfigInternalParams::ENABLE
+        },
+     };
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_4D, MHA,
                          ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapes),
+                                 ::testing::ValuesIn(inputShapes_4D),
                                  ::testing::ValuesIn(precision_f32(4)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({false, true}),
+                                 ::testing::Values(0),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
                                  ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig)),
                          MHA::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHABF16, MHA,
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_3D, MHA,
                          ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapes),
+                                 ::testing::ValuesIn(inputShapes_3D),
+                                 ::testing::ValuesIn(precision_f32(4)),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::ValuesIn({false, true}),
+                                 ::testing::Values(0),
+                                 ::testing::Values(5), // [122706]: Subgraph + 4 Transpose
+                                 ::testing::Values(2), // decomposed Transpose + MHA
+                                 ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                 ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig)),
+                         MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_4D_SplitDimensionM, MHA,
+                         ::testing::Combine(
+                                 ::testing::Values(std::vector<ov::PartialShape>{{1, 128, 2, 64}, {1, 128, 2, 64}, {1, 1, 1, 1}, {1, 128, 2, 64}}),
+                                 ::testing::ValuesIn(precision_f32(4)),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::Values(true),
+                                 ::testing::Values(4), // 4 Threads
+                                 ::testing::Values(6), // Subgraph + 4 Reshapes on inputs and 1 Reshape on output
+                                 ::testing::Values(1),
+                                 ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                 ::testing::Values(enable_callback())),
+                         MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_3D_SplitDimensionM, MHA,
+                         ::testing::Combine(
+                                 ::testing::Values(std::vector<ov::PartialShape>{{384, 2, 64}, {384, 2, 64}, {1, 384, 384}, {384, 2, 64}}),
+                                 ::testing::ValuesIn(precision_f32(4)),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::Values(true),
+                                 ::testing::Values(4), // 4 Threads
+                                 ::testing::Values(10), // Subgraph + 4 Reshapes on inputs and 1 Reshape on output + 4 Transposes
+                                 ::testing::Values(1), // MHA
+                                 ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                 ::testing::Values(enable_callback())),
+                         MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHABF16_4D, MHA,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(inputShapes_4D),
                                  ::testing::ValuesIn(precision_bf16(4)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({false, true}),
+                                 ::testing::Values(0),
                                  ::testing::Values(7), // MHA + 5 Converts + 1 Transpose on output
                                  ::testing::Values(6), // MHA + 5 Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -66,10 +122,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHABF16, MHA,
 
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAEnforceBF16, MHA,
                          ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapes),
+                                 ::testing::ValuesIn(inputShapes_4D),
                                  ::testing::ValuesIn(precision_f32(4)),
                                  ::testing::Values(ov::element::bf16),
                                  ::testing::ValuesIn({false}),
+                                 ::testing::Values(0),
                                  ::testing::Values(7),
                                  ::testing::Values(7),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -83,6 +140,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAMulAdd, MHAMulAdd,
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({false}),  // Need to support True for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -104,6 +162,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA, MHASelect,
                                  ::testing::ValuesIn(precision_f32(6)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false),  // Need to support True for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(2), // Less + MHA
                                  ::testing::Values(2),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -125,6 +184,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeOnInputs_4D, MHAWOTranspos
                                  ::testing::Values(std::vector<ov::element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(true),  // Need to support False for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -137,6 +197,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTranspose_4D, MHAWOTranspose,
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -149,6 +210,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTranspose_3D, MHAWOTranspose,
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -161,6 +223,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeBF16_4D, MHAWOTranspose,
                                  ::testing::ValuesIn(precision_bf16(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -173,6 +236,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeBF16_3D, MHAWOTranspose,
                                  ::testing::ValuesIn(precision_bf16(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -185,6 +249,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeEnforceBF16_4D, MHAWOTrans
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::bf16),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -197,6 +262,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeEnforceBF16_3D, MHAWOTrans
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::bf16),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -205,10 +271,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeEnforceBF16_3D, MHAWOTrans
 
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAINT8MatMul, MHAINT8MatMul,
                          ::testing::Combine(
-                                 ::testing::ValuesIn(std::vector<std::vector<ov::PartialShape>>(inputShapes.begin(), inputShapes.begin() + 2)),
+                                 ::testing::ValuesIn(std::vector<std::vector<ov::PartialShape>>(inputShapes_4D.begin(), inputShapes_4D.begin() + 2)),
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
+                                 ::testing::Values(0),
                                  ::testing::Values(6),     // FQx3 on inputs + MHA + Transpose on output + Deq Mul
                                  ::testing::Values(5),     // FQx3 on inputs + MHA + Deq Mul
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -221,18 +288,20 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAQuantMatMul0, MHAQuantMatMul0,
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
+                                 ::testing::Values(0),
                                  ::testing::Values(8),     // FQ on input + MHA + Transpose on output + 4 Reshapes + Deq Mul
                                  ::testing::Values(3),     // FQ on input + MHA + Deq Mul
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
                                  ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig)),
                          MHA::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAFQAfterMatMul, MHAFQAfterMatMul,
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAFQAfterMatMul_4D, MHAFQAfterMatMul,
                          ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapes),
+                                 ::testing::ValuesIn(inputShapes_4D),
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
+                                 ::testing::Values(0),
                                  ::testing::Values(3),     // MHA + Transpose on output + Deq Mul
                                  ::testing::Values(2),     // MHA + Deq Mul
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -245,6 +314,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAFQ, MHAFQ,
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
+                                 ::testing::Values(0),
                                  ::testing::Values(7),     // Transposex2 + Subgraphsx5
                                  ::testing::Values(5),     // MHA + Deq Mul on output + Deqs on inputs + 2 xFQ on inputs
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -261,6 +331,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHATransposedB, MHATransposedB,
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(2),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -282,6 +353,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWithExtractedReshape, MHAWithExtracte
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}), // False is not supported for graph builder in tests
+                                 ::testing::Values(0),
                                  ::testing::Values(3), // Extracted Add + Extracted Reshape + MHA
                                  ::testing::Values(2), // Extracted Add + MHA
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -61,7 +61,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_4D, MHA,
                                  ::testing::ValuesIn(precision_f32(4)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({false, true}),
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -74,7 +74,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_3D, MHA,
                                  ::testing::ValuesIn(precision_f32(4)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({false, true}),
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(5), // [122706]: Subgraph + 4 Transpose
                                  ::testing::Values(2), // decomposed Transpose + MHA
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -113,7 +113,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHABF16_4D, MHA,
                                  ::testing::ValuesIn(precision_bf16(4)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({false, true}),
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(7), // MHA + 5 Converts + 1 Transpose on output
                                  ::testing::Values(6), // MHA + 5 Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -126,7 +126,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAEnforceBF16, MHA,
                                  ::testing::ValuesIn(precision_f32(4)),
                                  ::testing::Values(ov::element::bf16),
                                  ::testing::ValuesIn({false}),
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(7),
                                  ::testing::Values(7),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -140,7 +140,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAMulAdd, MHAMulAdd,
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({false}),  // Need to support True for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -162,7 +162,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA, MHASelect,
                                  ::testing::ValuesIn(precision_f32(6)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false),  // Need to support True for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(2), // Less + MHA
                                  ::testing::Values(2),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -184,7 +184,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeOnInputs_4D, MHAWOTranspos
                                  ::testing::Values(std::vector<ov::element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(true),  // Need to support False for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -197,7 +197,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTranspose_4D, MHAWOTranspose,
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -210,7 +210,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTranspose_3D, MHAWOTranspose,
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -223,7 +223,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeBF16_4D, MHAWOTranspose,
                                  ::testing::ValuesIn(precision_bf16(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -236,7 +236,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeBF16_3D, MHAWOTranspose,
                                  ::testing::ValuesIn(precision_bf16(3)),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -249,7 +249,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeEnforceBF16_4D, MHAWOTrans
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::bf16),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -262,7 +262,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeEnforceBF16_3D, MHAWOTrans
                                  ::testing::ValuesIn(precision_f32(3)),
                                  ::testing::Values(ov::element::bf16),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(5), // MHA + 4 extra Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -275,7 +275,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAINT8MatMul, MHAINT8MatMul,
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(6),     // FQx3 on inputs + MHA + Transpose on output + Deq Mul
                                  ::testing::Values(5),     // FQx3 on inputs + MHA + Deq Mul
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -288,7 +288,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAQuantMatMul0, MHAQuantMatMul0,
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(8),     // FQ on input + MHA + Transpose on output + 4 Reshapes + Deq Mul
                                  ::testing::Values(3),     // FQ on input + MHA + Deq Mul
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -301,7 +301,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAFQAfterMatMul_4D, MHAFQAfterMatMul,
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(3),     // MHA + Transpose on output + Deq Mul
                                  ::testing::Values(2),     // MHA + Deq Mul
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -314,7 +314,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAFQ, MHAFQ,
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(7),     // Transposex2 + Subgraphsx5
                                  ::testing::Values(5),     // MHA + Deq Mul on output + Deqs on inputs + 2 xFQ on inputs
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -331,7 +331,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHATransposedB, MHATransposedB,
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(2),
                                  ::testing::Values(1),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
@@ -353,7 +353,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWithExtractedReshape, MHAWithExtracte
                                  ::testing::Values(std::vector<element::Type>{}),
                                  ::testing::Values(ov::element::f32),
                                  ::testing::ValuesIn({true}), // False is not supported for graph builder in tests
-                                 ::testing::Values(0),
+                                 ::testing::Values(MHA::default_thread_count),
                                  ::testing::Values(3), // Extracted Add + Extracted Reshape + MHA
                                  ::testing::Values(2), // Extracted Add + MHA
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/transpose.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/transpose.cpp
@@ -11,11 +11,24 @@ namespace snippets {
 
 
 namespace {
-std::vector<ov::PartialShape> input_shapes{{2, 3, 5, 13}, {2, 3, 2, 4}, {1, 7, 1, 4}};
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Transpose, Transpose,
+std::vector<ov::PartialShape> input_shapes_4D{{2, 3, 5, 13}, {2, 3, 2, 4}, {1, 7, 1, 4}};
+std::vector<ov::PartialShape> input_shapes_3D{{3, 5, 13}, {3, 2, 4}, {7, 1, 4}};
+
+std::vector<std::vector<int32_t>> orders_4D{{0, 2, 3, 1}};
+std::vector<std::vector<int32_t>> orders_3D{{1, 2, 0}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Transpose_3D, Transpose,
                      ::testing::Combine(
-                             ::testing::ValuesIn(input_shapes),
-                             ::testing::Values(std::vector<int> {0, 2,  3, 1}),
+                             ::testing::ValuesIn(input_shapes_3D),
+                             ::testing::ValuesIn(orders_3D),
+                             ::testing::Values(1), // Transpose
+                             ::testing::Values(1), // Tokenized Transpose
+                             ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                     Transpose::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Transpose_4D, Transpose,
+                     ::testing::Combine(
+                             ::testing::ValuesIn(input_shapes_4D),
+                             ::testing::ValuesIn(orders_4D),
                              ::testing::Values(1), // Transpose
                              ::testing::Values(1), // Tokenized Transpose
                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
@@ -25,7 +38,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_TransposeMul, TransposeMul,
                          ::testing::Combine(
                                  ::testing::Values(ov::PartialShape {2, 31, 3, 5}),
                                  ::testing::ValuesIn(std::vector<ov::PartialShape>{{2, 3, 5, 31}}),
-                                 ::testing::Values(std::vector<int> {0, 2,  3, 1}),
+                                 ::testing::Values(std::vector<int> {0, 2, 3, 1}),
                                  ::testing::Values(1), // Transpose
                                  ::testing::Values(1), // Tokenized Transpose
                                  ::testing::Values(ov::test::utils::DEVICE_CPU)),

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/mul_add_to_fma.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/mul_add_to_fma.cpp
@@ -10,7 +10,7 @@
 #include "snippets/op/scalar.hpp"
 #include "lowering_utils.hpp"
 #include "common_test_utils/common_utils.hpp"
-#include "snippets/pass_manager.hpp"
+#include "snippets/pass/manager.hpp"
 
 namespace ov {
 namespace test {

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -16,6 +16,7 @@ typedef std::tuple<
         std::vector<ov::element::Type>,    // Input Element types
         ov::element::Type,                 // Inference precision
         bool,                              // With Multiply
+        size_t,                            // Thread count
         size_t,                            // Expected num nodes
         size_t,                            // Expected num subgraphs
         std::string,                       // Target Device
@@ -30,10 +31,12 @@ public:
 protected:
     void SetUp() override;
 
+    void compile_model() override;
     void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override;
     virtual std::shared_ptr<SnippetsFunctionBase> get_subgraph();
 
     bool m_with_mul = false;
+    size_t m_thread_count;
     std::vector<ov::element::Type> m_input_types;
 };
 

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -28,6 +28,8 @@ class MHA : public testing::WithParamInterface<ov::test::snippets::MHAParams>,
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAParams> obj);
 
+    constexpr static size_t default_thread_count = 0;
+
 protected:
     void SetUp() override;
 

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -18,10 +18,11 @@ std::string MHA::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAP
     std::vector<ov::element::Type> elem_types;
     ov::element::Type prc;
     bool withMul;
+    size_t thread_count;
     std::string targetDevice;
     size_t num_nodes, num_subgraphs;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(inputShapes, elem_types, prc, withMul, num_nodes, num_subgraphs, targetDevice, additionalConfig) = obj.param;
+    std::tie(inputShapes, elem_types, prc, withMul, thread_count, num_nodes, num_subgraphs, targetDevice, additionalConfig) = obj.param;
 
     std::ostringstream result;
     for (size_t i = 0; i < inputShapes.size(); ++i)
@@ -29,6 +30,7 @@ std::string MHA::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAP
     for (size_t i = 0; i < elem_types.size(); i++)
         result << "T[" << i <<"]=" << elem_types[i] << "_";
     result << "Mul=" << withMul << "_";
+    result << "ThreadNum=" << thread_count << "_";
     result << "PRC=" << prc << "_";
     result << "#N=" << num_nodes << "_";
     result << "#S=" << num_subgraphs << "_";
@@ -48,7 +50,8 @@ void MHA::SetUp() {
     std::vector<ov::PartialShape> inputShapes;
     ov::element::Type prc;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(inputShapes, m_input_types, prc, m_with_mul, ref_num_nodes, ref_num_subgraphs, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(inputShapes, m_input_types, prc, m_with_mul, m_thread_count,
+             ref_num_nodes, ref_num_subgraphs, targetDevice, additionalConfig) = this->GetParam();
     init_input_shapes(static_partial_shapes_to_test_representation(inputShapes));
 
     const auto subgraph_model = get_subgraph();
@@ -64,6 +67,12 @@ void MHA::SetUp() {
     inType = outType = prc;
     if (prc == ov::element::bf16)
         rel_threshold = 0.05f;
+}
+
+void MHA::compile_model() {
+    if (m_thread_count > 0)
+        core->set_property(targetDevice, ov::inference_num_threads(m_thread_count));
+    SubgraphBaseTest::compile_model();
 }
 
 void MHA::generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) {

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -70,7 +70,7 @@ void MHA::SetUp() {
 }
 
 void MHA::compile_model() {
-    if (m_thread_count > 0)
+    if (m_thread_count != default_thread_count)
         core->set_property(targetDevice, ov::inference_num_threads(m_thread_count));
     SubgraphBaseTest::compile_model();
 }

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
@@ -45,7 +45,6 @@ class MHAFunction : public SnippetsFunctionBase {
 public:
     explicit MHAFunction(const std::vector<PartialShape>& inputShapes, const std::vector<ov::element::Type>& precisions, bool with_mul = true)
         : SnippetsFunctionBase(inputShapes), with_mul(with_mul), precisions(precisions) {
-        OPENVINO_ASSERT(input_shapes.size() == 4, "Got invalid number of input shapes");
         OPENVINO_ASSERT(precisions.size() == 4, "Got invalid number of input precisions");
     }
 protected:
@@ -54,6 +53,19 @@ protected:
 
     bool with_mul = true;
     std::vector<ov::element::Type> precisions;
+};
+
+class MHASplitMFunction : public MHAFunction {
+public:
+    explicit MHASplitMFunction(const std::vector<PartialShape>& inputShapes, const std::vector<ov::element::Type>& precisions,
+                                       const std::vector<Shape>& reshapes, bool with_mul = true)
+            : MHAFunction(inputShapes, precisions, with_mul), reshapes(reshapes) {
+        OPENVINO_ASSERT(reshapes.size() == 5, "Got invalid number of Reshape shapes");
+    }
+protected:
+    std::shared_ptr<ov::Model> initReference() const override;
+
+    std::vector<ov::Shape> reshapes;
 };
 
 /* Graph:

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
@@ -45,6 +45,7 @@ class MHAFunction : public SnippetsFunctionBase {
 public:
     explicit MHAFunction(const std::vector<PartialShape>& inputShapes, const std::vector<ov::element::Type>& precisions, bool with_mul = true)
         : SnippetsFunctionBase(inputShapes), with_mul(with_mul), precisions(precisions) {
+        OPENVINO_ASSERT(input_shapes.size() == 4, "Got invalid number of input shapes");
         OPENVINO_ASSERT(precisions.size() == 4, "Got invalid number of input precisions");
     }
 protected:

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
@@ -33,20 +33,20 @@ std::vector<int64_t> get_decomposed_order(size_t rank) {
     return rescale_order({1, 2, 0}, rank);
 }
 std::vector<int64_t> get_fusion_order_after_split_m(size_t rank, bool is_input) {
-    OPENVINO_ASSERT(rank == 4 || rank == 5, "Incorrect rank for testing");
     if (rank == 4) {
         return is_input ? std::vector<int64_t>{2, 0, 1, 3} : std::vector<int64_t>{1, 2, 0, 3};
     } else if (rank == 5) {
         return is_input ? std::vector<int64_t>{0, 3, 1, 2, 4} : std::vector<int64_t>{0, 2, 3, 1, 4};
     }
+    OPENVINO_THROW("Incorrect rank for testing");
 }
 std::vector<int64_t> get_decomposed_order_after_split_m(size_t rank) {
-    OPENVINO_ASSERT(rank == 4 || rank == 5, "Incorrect rank for testing");
     if (rank == 4) {
         return std::vector<int64_t>{1, 2, 3, 0};
     } else if (rank == 5) {
         return std::vector<int64_t>{0, 2, 3, 4, 1};
     }
+    OPENVINO_THROW("Incorrect rank for testing");
 }
 } // namespace
 

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace test {
 namespace snippets {
 namespace {
-std::vector<int64_t> rescale_order(std::vector<int64_t> default_order, size_t rank) {
+std::vector<int64_t> get_rank_equivalent_order(std::vector<int64_t> default_order, size_t rank) {
     OPENVINO_ASSERT(rank > 2, "Incorrect rank for testing");
     auto order = std::vector<int64_t>(rank);
     std::iota(order.begin(), order.end(), 0);
@@ -25,12 +25,10 @@ std::vector<int64_t> rescale_order(std::vector<int64_t> default_order, size_t ra
     return order;
 }
 std::vector<int64_t> get_fusion_order(size_t rank) {
-    OPENVINO_ASSERT(rank > 2, "Incorrect rank for testing");
-    return rescale_order({1, 0, 2}, rank);
+    return get_rank_equivalent_order({1, 0, 2}, rank);
 }
 std::vector<int64_t> get_decomposed_order(size_t rank) {
-    OPENVINO_ASSERT(rank > 2, "Incorrect rank for testing");
-    return rescale_order({1, 2, 0}, rank);
+    return get_rank_equivalent_order({1, 2, 0}, rank);
 }
 std::vector<int64_t> get_fusion_order_after_split_m(size_t rank, bool is_input) {
     if (rank == 4) {


### PR DESCRIPTION
### Details:
 - *Fixed all calculations related to output layouts of `PortDescriptors`*
 - *Added `Transpose` support to SplitDimensionM*
 - *Added `ND` pattern support to SplitDimensionM*
 - *Performance and accuracy validation reports are attached to the ticket 123067*

### Tickets:
 - *123067, 119022*

### Prerequisites:
- https://github.com/openvinotoolkit/openvino/pull/19951

