### PR TITLE
use etree to fix docs generated by doxygen

### DIFF
--- a/docs/scripts/prepare_xml.py
+++ b/docs/scripts/prepare_xml.py
@@ -4,7 +4,6 @@
 import re
 import logging
 import argparse
-import lxml.html
 from lxml import etree
 from pathlib import Path
 from xml.sax import saxutils
@@ -29,7 +28,7 @@ def prepare_xml(xml_dir: Path):
             # escape asterisks
             contents = contents.replace('*', '\\*')
             contents = str.encode(contents)
-            root = lxml.html.fromstring(contents)
+            root = etree.fromstring(contents)
 
             # unescape * in sphinxdirectives
             sphinxdirectives = root.xpath('//sphinxdirective')


### PR DESCRIPTION
### Details:
 - C++ API reference docs were not properly displayed (arguments missing or mixed with method/function name). This change resolves that issue.

### Tickets:
 - CVS-121041
