### PR TITLE
Refactor GrnLayerTest, GroupConvBackpropLayerTest, GroupConvolutionLayerTest, GRUCellTest

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/grn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/grn.cpp
@@ -4,31 +4,30 @@
 
 #include <vector>
 
-#include "single_layer_tests/grn.hpp"
+#include "single_op_tests/grn.hpp"
 #include "common_test_utils/test_constants.hpp"
 
-using namespace LayerTestsDefinitions;
-
 namespace {
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::BF16,
-        InferenceEngine::Precision::FP16,
-        InferenceEngine::Precision::FP32,
+using ov::test::GrnLayerTest;
+
+std::vector<ov::element::Type> model_types = {
+        ov::element::bf16,
+        ov::element::f16,
+        ov::element::f32,
 };
 
+std::vector<std::vector<ov::Shape>> input_shapes_static = {
+    {{16, 24}},
+    {{3, 16, 24}},
+    {{1, 3, 30, 30}},
+    {{2, 16, 15, 20}}};
+
+std::vector<float> bias = {1e-6f, 0.33f, 1.1f, 2.25f, 100.25f};
+
 const auto basicCases = ::testing::Combine(
-    ::testing::ValuesIn(netPrecisions),
-    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-    ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-    ::testing::Values(InferenceEngine::Layout::ANY),
-    ::testing::Values(InferenceEngine::Layout::ANY),
-     // input shapes
-    ::testing::Values(std::vector<size_t>{16, 24},
-                      std::vector<size_t>{3, 16, 24},
-                      std::vector<size_t>{1, 3, 30, 30},
-                      std::vector<size_t>{2, 16, 15, 20}),
-    // bias
-    ::testing::Values(1e-6f, 0.33f, 1.1f, 2.25f, 100.25f),
+    ::testing::ValuesIn(model_types),
+    ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
+    ::testing::ValuesIn(bias),
     ::testing::Values(ov::test::utils::DEVICE_CPU));
 
 INSTANTIATE_TEST_SUITE_P(smoke_GRN_Basic, GrnLayerTest,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/group_convolution.cpp
@@ -5,152 +5,155 @@
 #include <vector>
 
 #include "common_test_utils/test_constants.hpp"
-#include "single_layer_tests/group_convolution.hpp"
-
-using namespace LayerTestsDefinitions;
+#include "single_op_tests/group_convolution.hpp"
 
 namespace {
+using ov::test::GroupConvolutionLayerTest;
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16,
-    InferenceEngine::Precision::I32};
+const std::vector<ov::element::Type> model_types = {
+    ov::element::f32,
+    ov::element::f16,
+    ov::element::i32};
 
-/* ============= 1D GroupConvolution ============= */
-const std::vector<std::vector<size_t>> kernels1d = {{3}};
-const std::vector<std::vector<size_t>> strides1d = {{1}};
-const std::vector<std::vector<ptrdiff_t>> padBegins1d = {{0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds1d = {{0}};
-const std::vector<std::vector<size_t>> dilations1d = {{1}};
-const std::vector<size_t> numOutChannels1d = {8, 16};
-const std::vector<size_t> numGroups1d = {2, 8};
-const auto inputShapes1d = std::vector<size_t>({1, 16, 30});
+/* ============= _1d GroupConvolution ============= */
+const std::vector<ov::Shape> input_shapes_1d = {{1, 16, 30}};
 
-const auto groupConv1DParams_ExplicitPadding = ::testing::Combine(
-    ::testing::ValuesIn(kernels1d), ::testing::ValuesIn(strides1d),
-    ::testing::ValuesIn(padBegins1d), ::testing::ValuesIn(padEnds1d),
-    ::testing::ValuesIn(dilations1d), ::testing::ValuesIn(numOutChannels1d),
-    ::testing::ValuesIn(numGroups1d),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT));
-const auto groupConv1DParams_AutoPadValid = ::testing::Combine(
-    ::testing::ValuesIn(kernels1d), ::testing::ValuesIn(strides1d),
+const std::vector<std::vector<size_t>> kernels_1d = {{3}};
+const std::vector<std::vector<size_t>> strides_1d = {{1}};
+const std::vector<std::vector<ptrdiff_t>> pad_begins_1d = {{0}};
+const std::vector<std::vector<ptrdiff_t>> pad_ends_1d = {{0}};
+const std::vector<std::vector<size_t>> dilations_1d = {{1}};
+const std::vector<size_t> num_out_channels_1d = {8, 16};
+const std::vector<size_t> num_groups_1d = {2, 8};
+
+const auto group_conv_1d_params_explicit_padding = ::testing::Combine(
+    ::testing::ValuesIn(kernels_1d),
+    ::testing::ValuesIn(strides_1d),
+    ::testing::ValuesIn(pad_begins_1d),
+    ::testing::ValuesIn(pad_ends_1d),
+    ::testing::ValuesIn(dilations_1d),
+    ::testing::ValuesIn(num_out_channels_1d),
+    ::testing::ValuesIn(num_groups_1d),
+    ::testing::Values(ov::op::PadType::EXPLICIT));
+
+const auto group_conv_1d_params_auto_pad_valid = ::testing::Combine(
+    ::testing::ValuesIn(kernels_1d), ::testing::ValuesIn(strides_1d),
     ::testing::Values(std::vector<ptrdiff_t>({0})),
     ::testing::Values(std::vector<ptrdiff_t>({0})),
-    ::testing::ValuesIn(dilations1d), ::testing::ValuesIn(numOutChannels1d),
-    ::testing::ValuesIn(numGroups1d),
-    ::testing::Values(ngraph::op::PadType::VALID));
+    ::testing::ValuesIn(dilations_1d), ::testing::ValuesIn(num_out_channels_1d),
+    ::testing::ValuesIn(num_groups_1d),
+    ::testing::Values(ov::op::PadType::VALID));
 
 INSTANTIATE_TEST_SUITE_P(
     smoke_GroupConvolution1D_ExplicitPadding, GroupConvolutionLayerTest,
     ::testing::Combine(
-        groupConv1DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>(inputShapes1d)),
+        group_conv_1d_params_explicit_padding,
+        ::testing::ValuesIn(model_types),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(input_shapes_1d)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     GroupConvolutionLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
     smoke_GroupConvolution1D_AutoPadValid, GroupConvolutionLayerTest,
     ::testing::Combine(
-        groupConv1DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 16, 30})),
+        group_conv_1d_params_auto_pad_valid,
+        ::testing::ValuesIn(model_types),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(input_shapes_1d)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     GroupConvolutionLayerTest::getTestCaseName);
 
 /* ============= 2D GroupConvolution ============= */
-const std::vector<std::vector<size_t>> kernels = {{3, 3}};
-const std::vector<std::vector<size_t>> strides = {{1, 1}};
-const std::vector<std::vector<ptrdiff_t>> padBegins = {{0, 0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds = {{0, 0}};
-const std::vector<std::vector<size_t>> dilations = {{1, 1}};
-const std::vector<size_t> numOutChannels = {8, 16};
-const std::vector<size_t> numGroups = {2, 8};
-const auto inputShapes = std::vector<size_t>({1, 16, 30, 30});
+const std::vector<ov::Shape> input_shapes_2d = {{1, 16, 30, 30}};
 
-const auto groupConv2DParams_ExplicitPadding = ::testing::Combine(
-    ::testing::ValuesIn(kernels), ::testing::ValuesIn(strides),
-    ::testing::ValuesIn(padBegins), ::testing::ValuesIn(padEnds),
-    ::testing::ValuesIn(dilations), ::testing::ValuesIn(numOutChannels),
-    ::testing::ValuesIn(numGroups),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT));
-const auto groupConv2DParams_AutoPadValid = ::testing::Combine(
-    ::testing::ValuesIn(kernels), ::testing::ValuesIn(strides),
+const std::vector<std::vector<size_t>> kernels_2d = {{3, 3}};
+const std::vector<std::vector<size_t>> strides_2d = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> pad_begins_2d = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> pad_ends_2d = {{0, 0}};
+const std::vector<std::vector<size_t>> dilations_2d = {{1, 1}};
+const std::vector<size_t> num_out_channels_2d = {8, 16};
+const std::vector<size_t> num_groups_2d = {2, 8};
+
+const auto group_conv2DParams_explicit_padding = ::testing::Combine(
+    ::testing::ValuesIn(kernels_2d),
+    ::testing::ValuesIn(strides_2d),
+    ::testing::ValuesIn(pad_begins_2d),
+    ::testing::ValuesIn(pad_ends_2d),
+    ::testing::ValuesIn(dilations_2d),
+    ::testing::ValuesIn(num_out_channels_2d),
+    ::testing::ValuesIn(num_groups_2d),
+    ::testing::Values(ov::op::PadType::EXPLICIT));
+
+const auto group_conv2DParams_auto_pad_valid = ::testing::Combine(
+    ::testing::ValuesIn(kernels_2d),
+    ::testing::ValuesIn(strides_2d),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-    ::testing::ValuesIn(dilations), ::testing::ValuesIn(numOutChannels),
-    ::testing::ValuesIn(numGroups),
-    ::testing::Values(ngraph::op::PadType::VALID));
+    ::testing::ValuesIn(dilations_2d),
+    ::testing::ValuesIn(num_out_channels_2d),
+    ::testing::ValuesIn(num_groups_2d),
+    ::testing::Values(ov::op::PadType::VALID));
 
 INSTANTIATE_TEST_SUITE_P(
     smoke_GroupConvolution2D_ExplicitPadding, GroupConvolutionLayerTest,
     ::testing::Combine(
-        groupConv2DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>(inputShapes)),
+        group_conv2DParams_explicit_padding,
+        ::testing::ValuesIn(model_types),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(input_shapes_2d)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     GroupConvolutionLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
     smoke_GroupConvolution2D_AutoPadValid, GroupConvolutionLayerTest,
     ::testing::Combine(
-        groupConv2DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 16, 30, 30})),
+        group_conv2DParams_auto_pad_valid,
+        ::testing::ValuesIn(model_types),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(input_shapes_2d)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     GroupConvolutionLayerTest::getTestCaseName);
 
 /* ============= 3D GroupConvolution ============= */
-const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}};
-const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 0, 0}};
-const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}};
-const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}};
-const auto inputShapes3d = std::vector<size_t>({1, 4, 10, 10, 10});
+const std::vector<ov::Shape> input_shapes_3d = {{1, 4, 10, 10, 10}};
 
-const auto groupConv3DParams_ExplicitPadding = ::testing::Combine(
-    ::testing::ValuesIn(kernels3d), ::testing::ValuesIn(strides3d),
-    ::testing::ValuesIn(paddings3d), ::testing::ValuesIn(paddings3d),
-    ::testing::ValuesIn(dilations3d), ::testing::Values(4),
-    ::testing::Values(2), ::testing::Values(ngraph::op::PadType::EXPLICIT));
-const auto groupConv3DParams_AutoPadValid = ::testing::Combine(
-    ::testing::ValuesIn(kernels3d), ::testing::ValuesIn(strides3d),
+const std::vector<std::vector<size_t>> kernels_3d = {{3, 3, 3}};
+const std::vector<std::vector<ptrdiff_t>> paddings_3d = {{0, 0, 0}};
+const std::vector<std::vector<size_t>> strides_3d = {{1, 1, 1}};
+const std::vector<std::vector<size_t>> dilations_3d = {{1, 1, 1}};
+
+const auto group_conv3DParams_explicit_padding = ::testing::Combine(
+    ::testing::ValuesIn(kernels_3d),
+    ::testing::ValuesIn(strides_3d),
+    ::testing::ValuesIn(paddings_3d),
+    ::testing::ValuesIn(paddings_3d),
+    ::testing::ValuesIn(dilations_3d),
+    ::testing::Values(4),
+    ::testing::Values(2),
+    ::testing::Values(ov::op::PadType::EXPLICIT));
+
+const auto group_conv3DParams_auto_pad_valid = ::testing::Combine(
+    ::testing::ValuesIn(kernels_3d),
+    ::testing::ValuesIn(strides_3d),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
     ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
-    ::testing::ValuesIn(dilations3d), ::testing::Values(4),
-    ::testing::Values(2), ::testing::Values(ngraph::op::PadType::VALID));
+    ::testing::ValuesIn(dilations_3d),
+    ::testing::Values(4),
+    ::testing::Values(2),
+    ::testing::Values(ov::op::PadType::VALID));
 
 INSTANTIATE_TEST_SUITE_P(
     smoke_GroupConvolution3D_ExplicitPadding, GroupConvolutionLayerTest,
     ::testing::Combine(
-        groupConv3DParams_ExplicitPadding, ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>(inputShapes3d)),
+        group_conv3DParams_explicit_padding,
+        ::testing::ValuesIn(model_types),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(input_shapes_3d)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     GroupConvolutionLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
     smoke_GroupConvolution3D_AutoPadValid, GroupConvolutionLayerTest,
     ::testing::Combine(
-        groupConv3DParams_AutoPadValid, ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(InferenceEngine::Layout::ANY),
-        ::testing::Values(std::vector<size_t>({1, 4, 10, 10, 10})),
+        group_conv3DParams_auto_pad_valid,
+        ::testing::ValuesIn(model_types),
+        ::testing::Values(ov::test::static_shapes_to_test_representation(input_shapes_3d)),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     GroupConvolutionLayerTest::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/group_convolution_backprop_data.cpp
@@ -5,330 +5,281 @@
 #include <vector>
 
 #include "common_test_utils/test_constants.hpp"
-#include "single_layer_tests/group_convolution_backprop_data.hpp"
-
-using namespace LayerTestsDefinitions;
+#include "single_op_tests/group_convolution_backprop_data.hpp"
 
 namespace {
+using ov::test::GroupConvBackpropLayerTest;
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::FP16,
-        InferenceEngine::Precision::I32};
+const std::vector<ov::element::Type> model_types = {
+        ov::element::f32,
+        ov::element::f16,
+        ov::element::i32};
 
-const std::vector<size_t> numOutChannels = {16, 32};
-const std::vector<size_t> numGroups = {2, 8, 16};
-const std::vector<std::vector<size_t >> emptyOutputShape = {{}};
-const std::vector<std::vector<ptrdiff_t >> emptyOutputPadding = {{}};
+const std::vector<size_t> num_out_channels = {16, 32};
+const std::vector<size_t> num_groups = {2, 8, 16};
+const std::vector<ov::Shape> empty_output_shape = {{}};
+const std::vector<std::vector<ptrdiff_t >> empty_output_padding = {{}};
 
-/* ============= 1D GroupConvolution ============= */
-const std::vector<std::vector<size_t >> inputShapes1D = {{1, 16, 32}};
+/* ============= _1d GroupConvolution ============= */
+const std::vector<ov::Shape> input_shapes_1d = {{1, 16, 32}};
 
-const std::vector<std::vector<size_t >> kernels1D = {{1}, {3}};
-const std::vector<std::vector<size_t>> strides1D = {{1}};
-const std::vector<std::vector<ptrdiff_t>> padBegins1D = {{0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds1D = {{0}};
-const std::vector<std::vector<size_t>> dilations1D = {{1}};
+const std::vector<std::vector<size_t >> kernels_1d = {{1}, {3}};
+const std::vector<std::vector<size_t>> strides_1d = {{1}};
+const std::vector<std::vector<ptrdiff_t>> pad_begins_1d = {{0}};
+const std::vector<std::vector<ptrdiff_t>> pad_ends_1d = {{0}};
+const std::vector<std::vector<size_t>> dilations_1d = {{1}};
 
-const auto groupConvBackpropData1DParams_ExplicitPadding = ::testing::Combine(
-        ::testing::ValuesIn(kernels1D),
-        ::testing::ValuesIn(strides1D),
-        ::testing::ValuesIn(padBegins1D),
-        ::testing::ValuesIn(padEnds1D),
-        ::testing::ValuesIn(dilations1D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
+const auto groupConvBackpropData_1dParams_ExplicitPadding = ::testing::Combine(
+        ::testing::ValuesIn(kernels_1d),
+        ::testing::ValuesIn(strides_1d),
+        ::testing::ValuesIn(pad_begins_1d),
+        ::testing::ValuesIn(pad_ends_1d),
+        ::testing::ValuesIn(dilations_1d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(empty_output_padding)
 );
 
-const auto groupConvBackpropData1DParams_AutoPadValid = ::testing::Combine(
-        ::testing::ValuesIn(kernels1D),
-        ::testing::ValuesIn(strides1D),
-        ::testing::ValuesIn(padBegins1D),
-        ::testing::ValuesIn(padEnds1D),
-        ::testing::ValuesIn(dilations1D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::VALID),
-        ::testing::ValuesIn(emptyOutputPadding)
+const auto groupConvBackpropData_1dParams_AutoPadValid = ::testing::Combine(
+        ::testing::ValuesIn(kernels_1d),
+        ::testing::ValuesIn(strides_1d),
+        ::testing::ValuesIn(pad_begins_1d),
+        ::testing::ValuesIn(pad_ends_1d),
+        ::testing::ValuesIn(dilations_1d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::VALID),
+        ::testing::ValuesIn(empty_output_padding)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData1D_ExplicitPadding, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_1d_ExplicitPadding, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                groupConvBackpropData1DParams_ExplicitPadding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes1D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                groupConvBackpropData_1dParams_ExplicitPadding,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::Values(ov::test::static_shapes_to_test_representation(input_shapes_1d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData1D_AutoPadValid, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_1d_AutoPadValid, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                groupConvBackpropData1DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes1D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                groupConvBackpropData_1dParams_AutoPadValid,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::Values(ov::test::static_shapes_to_test_representation(input_shapes_1d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-/* ============= 2D GroupConvolution ============= */
-const std::vector<std::vector<size_t >> inputShapes2D = {{1, 16, 10, 10},
-                                                         {1, 32, 10, 10}};
-const std::vector<std::vector<size_t >> kernels2D = {{1, 1}, {3, 3}};
-const std::vector<std::vector<size_t >> strides2D = {{1, 1}};
-const std::vector<std::vector<ptrdiff_t>> padBegins2D = {{0, 0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds2D = {{0, 0}};
-const std::vector<std::vector<size_t >> dilations2D = {{1, 1}};
+/* ============= _2d GroupConvolution ============= */
+const std::vector<std::vector<ov::Shape>> input_shapes_2d = {{{1, 16, 10, 10}},
+                                                             {{1, 32, 10, 10}}};
+const std::vector<std::vector<size_t >> kernels_2d = {{1, 1}, {3, 3}};
+const std::vector<std::vector<size_t >> strides_2d = {{1, 1}};
+const std::vector<std::vector<ptrdiff_t>> pad_begins_2d = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> pad_ends_2d = {{0, 0}};
+const std::vector<std::vector<size_t >> dilations_2d = {{1, 1}};
 
-const auto groupConvBackpropData2DParams_ExplicitPadding = ::testing::Combine(
-        ::testing::ValuesIn(kernels2D),
-        ::testing::ValuesIn(strides2D),
-        ::testing::ValuesIn(padBegins2D),
-        ::testing::ValuesIn(padEnds2D),
-        ::testing::ValuesIn(dilations2D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
+const auto groupConvBackpropData_2dParams_ExplicitPadding = ::testing::Combine(
+        ::testing::ValuesIn(kernels_2d),
+        ::testing::ValuesIn(strides_2d),
+        ::testing::ValuesIn(pad_begins_2d),
+        ::testing::ValuesIn(pad_ends_2d),
+        ::testing::ValuesIn(dilations_2d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(empty_output_padding)
 );
-const auto groupConvBackpropData2DParams_AutoPadValid = ::testing::Combine(
-        ::testing::ValuesIn(kernels2D),
-        ::testing::ValuesIn(strides2D),
-        ::testing::ValuesIn(padBegins2D),
-        ::testing::ValuesIn(padEnds2D),
-        ::testing::ValuesIn(dilations2D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::VALID),
-        ::testing::ValuesIn(emptyOutputPadding)
+const auto groupConvBackpropData_2dParams_AutoPadValid = ::testing::Combine(
+        ::testing::ValuesIn(kernels_2d),
+        ::testing::ValuesIn(strides_2d),
+        ::testing::ValuesIn(pad_begins_2d),
+        ::testing::ValuesIn(pad_ends_2d),
+        ::testing::ValuesIn(dilations_2d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::VALID),
+        ::testing::ValuesIn(empty_output_padding)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData2D_ExplicitPadding, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_2d_ExplicitPadding, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                groupConvBackpropData2DParams_ExplicitPadding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes2D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                groupConvBackpropData_2dParams_ExplicitPadding,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_2d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData2D_AutoPadValid, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_2d_AutoPadValid, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                groupConvBackpropData2DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes2D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                groupConvBackpropData_2dParams_AutoPadValid,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_2d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t >> inputShape2D = {{1, 16, 9, 12}};
-const std::vector<std::vector<size_t >> outputShapes2D = {{6, 6}, {4, 9}};
+const std::vector<ov::Shape> input_shape_2d = {{1, 16, 9, 12}};
+const std::vector<ov::Shape> output_shapes_2d = {{6, 6}, {4, 9}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData2D_OutputShapeDefined, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_2d_OutputShapeDefined, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                groupConvBackpropData2DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShape2D),
-                                ::testing::ValuesIn(outputShapes2D),
+                                groupConvBackpropData_2dParams_AutoPadValid,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::Values(ov::test::static_shapes_to_test_representation(input_shape_2d)),
+                                ::testing::ValuesIn(output_shapes_2d),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-const std::vector<std::vector<ptrdiff_t>> outputPadding2D = {{1, 1}, {2, 2}};
-const std::vector<std::vector<size_t >> testStrides2D = {{3, 3}};
+const std::vector<std::vector<ptrdiff_t>> output_padding_2d = {{1, 1}, {2, 2}};
+const std::vector<std::vector<size_t >> test_strides_2d = {{3, 3}};
 
-const auto conv2DParams_ExplicitPadding_output_padding = ::testing::Combine(
-        ::testing::ValuesIn(kernels2D),
-        ::testing::ValuesIn(testStrides2D),
-        ::testing::ValuesIn(padBegins2D),
-        ::testing::ValuesIn(padEnds2D),
-        ::testing::ValuesIn(dilations2D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(outputPadding2D)
+const auto conv_2dParams_ExplicitPadding_output_padding = ::testing::Combine(
+        ::testing::ValuesIn(kernels_2d),
+        ::testing::ValuesIn(test_strides_2d),
+        ::testing::ValuesIn(pad_begins_2d),
+        ::testing::ValuesIn(pad_ends_2d),
+        ::testing::ValuesIn(dilations_2d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(output_padding_2d)
 );
-const auto conv2DParams_AutoPadValid_output_padding = ::testing::Combine(
-        ::testing::ValuesIn(kernels2D),
-        ::testing::ValuesIn(testStrides2D),
+const auto conv_2dParams_AutoPadValid_output_padding = ::testing::Combine(
+        ::testing::ValuesIn(kernels_2d),
+        ::testing::ValuesIn(test_strides_2d),
         ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
         ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-        ::testing::ValuesIn(dilations2D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::VALID),
-        ::testing::ValuesIn(outputPadding2D)
+        ::testing::ValuesIn(dilations_2d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::VALID),
+        ::testing::ValuesIn(output_padding_2d)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData2D_ExplicitPadding_OutputPaddingDefined, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_2d_ExplicitPadding_output_paddingDefined, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                conv2DParams_AutoPadValid_output_padding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes2D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                conv_2dParams_AutoPadValid_output_padding,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_2d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData2D_AutoPadding_OutputPaddingDefined, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_2d_AutoPadding_output_paddingDefined, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                conv2DParams_ExplicitPadding_output_padding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes2D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                conv_2dParams_ExplicitPadding_output_padding,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_2d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-/* ============= 3D GroupConvolution ============= */
-const std::vector<std::vector<size_t >> inputShapes3D = {{1, 16, 5, 5, 5},
-                                                         {1, 32, 5, 5, 5}};
-const std::vector<std::vector<size_t >> kernels3D = {{1, 1, 1}, {3, 3, 3}};
-const std::vector<std::vector<size_t >> strides3D = {{1, 1, 1}};
-const std::vector<std::vector<ptrdiff_t>> padBegins3D = {{0, 0, 0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds3D = {{0, 0, 0}};
-const std::vector<std::vector<size_t >> dilations3D = {{1, 1, 1}};
+/* ============= _3d GroupConvolution ============= */
+const std::vector<std::vector<ov::Shape>> input_shapes_3d = {{{1, 16, 5, 5, 5}},
+                                                             {{1, 32, 5, 5, 5}}};
+const std::vector<std::vector<size_t >> kernels_3d = {{1, 1, 1}, {3, 3, 3}};
+const std::vector<std::vector<size_t >> strides_3d = {{1, 1, 1}};
+const std::vector<std::vector<ptrdiff_t>> pad_begins_3d = {{0, 0, 0}};
+const std::vector<std::vector<ptrdiff_t>> pad_ends_3d = {{0, 0, 0}};
+const std::vector<std::vector<size_t >> dilations_3d = {{1, 1, 1}};
 
-const auto groupConvBackpropData3DParams_ExplicitPadding = ::testing::Combine(
-        ::testing::ValuesIn(kernels3D),
-        ::testing::ValuesIn(strides3D),
-        ::testing::ValuesIn(padBegins3D),
-        ::testing::ValuesIn(padEnds3D),
-        ::testing::ValuesIn(dilations3D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
+const auto groupConvBackpropData_3dParams_ExplicitPadding = ::testing::Combine(
+        ::testing::ValuesIn(kernels_3d),
+        ::testing::ValuesIn(strides_3d),
+        ::testing::ValuesIn(pad_begins_3d),
+        ::testing::ValuesIn(pad_ends_3d),
+        ::testing::ValuesIn(dilations_3d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(empty_output_padding)
 );
-const auto groupConvBackpropData3DParams_AutoPadValid = ::testing::Combine(
-        ::testing::ValuesIn(kernels3D),
-        ::testing::ValuesIn(strides3D),
-        ::testing::ValuesIn(padBegins3D),
-        ::testing::ValuesIn(padEnds3D),
-        ::testing::ValuesIn(dilations3D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::VALID),
-        ::testing::ValuesIn(emptyOutputPadding)
+const auto groupConvBackpropData_3dParams_AutoPadValid = ::testing::Combine(
+        ::testing::ValuesIn(kernels_3d),
+        ::testing::ValuesIn(strides_3d),
+        ::testing::ValuesIn(pad_begins_3d),
+        ::testing::ValuesIn(pad_ends_3d),
+        ::testing::ValuesIn(dilations_3d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::VALID),
+        ::testing::ValuesIn(empty_output_padding)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData3D_ExplicitPadding, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_3d_ExplicitPadding, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                groupConvBackpropData3DParams_ExplicitPadding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                groupConvBackpropData_3dParams_ExplicitPadding,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_3d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData3D_AutoPadValid, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_3d_AutoPadValid, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                groupConvBackpropData3DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                groupConvBackpropData_3dParams_AutoPadValid,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_3d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t >> inputShape3D = {{1, 16, 10, 10, 10}};
-const std::vector<std::vector<size_t >> outputShapes3D = {{8, 8, 8}, {10, 10, 10}};
+const std::vector<ov::Shape> input_shape_3d = {{1, 16, 10, 10, 10}};
+const std::vector<ov::Shape> output_shapes_3d = {{8, 8, 8}, {10, 10, 10}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData3D_OutputShapeDefined, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_3d_OutputShapeDefined, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                groupConvBackpropData3DParams_AutoPadValid,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShape3D),
-                                ::testing::ValuesIn(outputShapes3D),
+                                groupConvBackpropData_3dParams_AutoPadValid,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::Values(ov::test::static_shapes_to_test_representation(input_shape_3d)),
+                                ::testing::ValuesIn(output_shapes_3d),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-const std::vector<std::vector<ptrdiff_t>> outputPadding3D = {{1, 1, 1}, {2, 2, 2}};
-const std::vector<std::vector<size_t >> testStrides3D = {{3, 3, 3}};
+const std::vector<std::vector<ptrdiff_t>> output_padding_3d = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<size_t >> test_strides_3d = {{3, 3, 3}};
 
-const auto conv3DParams_ExplicitPadding_output_padding = ::testing::Combine(
-        ::testing::ValuesIn(kernels3D),
-        ::testing::ValuesIn(testStrides3D),
-        ::testing::ValuesIn(padBegins3D),
-        ::testing::ValuesIn(padEnds3D),
-        ::testing::ValuesIn(dilations3D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(outputPadding3D)
+const auto conv_3dParams_ExplicitPadding_output_padding = ::testing::Combine(
+        ::testing::ValuesIn(kernels_3d),
+        ::testing::ValuesIn(test_strides_3d),
+        ::testing::ValuesIn(pad_begins_3d),
+        ::testing::ValuesIn(pad_ends_3d),
+        ::testing::ValuesIn(dilations_3d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(output_padding_3d)
 );
-const auto conv3DParams_AutoPadValid_output_padding = ::testing::Combine(
-        ::testing::ValuesIn(kernels3D),
-        ::testing::ValuesIn(testStrides3D),
+const auto conv_3dParams_AutoPadValid_output_padding = ::testing::Combine(
+        ::testing::ValuesIn(kernels_3d),
+        ::testing::ValuesIn(test_strides_3d),
         ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
         ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),
-        ::testing::ValuesIn(dilations3D),
-        ::testing::ValuesIn(numOutChannels),
-        ::testing::ValuesIn(numGroups),
-        ::testing::Values(ngraph::op::PadType::VALID),
-        ::testing::ValuesIn(outputPadding3D)
+        ::testing::ValuesIn(dilations_3d),
+        ::testing::ValuesIn(num_out_channels),
+        ::testing::ValuesIn(num_groups),
+        ::testing::Values(ov::op::PadType::VALID),
+        ::testing::ValuesIn(output_padding_3d)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData3D_ExplicitPadding_OutputPaddingDefined, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_3d_ExplicitPadding_output_paddingDefined, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                conv3DParams_AutoPadValid_output_padding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                conv_3dParams_AutoPadValid_output_padding,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_3d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData3D_AutoPadding_OutputPaddingDefined, GroupConvBackpropLayerTest,
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConvBackpropData_3d_AutoPadding_output_paddingDefined, GroupConvBackpropLayerTest,
                         ::testing::Combine(
-                                conv3DParams_ExplicitPadding_output_padding,
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::Values(InferenceEngine::Layout::ANY),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::ValuesIn(emptyOutputShape),
+                                conv_3dParams_ExplicitPadding_output_padding,
+                                ::testing::ValuesIn(model_types),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_3d)),
+                                ::testing::ValuesIn(empty_output_shape),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         GroupConvBackpropLayerTest::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
@@ -4,12 +4,12 @@
 
 #include <vector>
 
-#include "single_layer_tests/gru_cell.hpp"
+#include "single_op_tests/gru_cell.hpp"
 #include "common_test_utils/test_constants.hpp"
 
-using namespace LayerTestsDefinitions;
-
 namespace {
+using ov::test::GRUCellTest;
+
     std::vector<bool> should_decompose{false, true};
     std::vector<size_t> batch{5};
     std::vector<size_t> hidden_size{1, 10};
@@ -18,12 +18,12 @@ namespace {
                                                          {"tanh", "relu"}};
     std::vector<float> clip = {0.0f, 0.7f};
     std::vector<bool> linear_before_reset = {true, false};
-    std::vector<ngraph::helpers::InputLayerType> layer_types = {
-        ngraph::helpers::InputLayerType::CONSTANT,
-        ngraph::helpers::InputLayerType::PARAMETER
+    std::vector<ov::test::utils::InputLayerType> layer_types = {
+        ov::test::utils::InputLayerType::CONSTANT,
+        ov::test::utils::InputLayerType::PARAMETER
     };
-    std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP32,
-                                                             InferenceEngine::Precision::FP16};
+    std::vector<ov::element::Type> model_types = {ov::element::f32,
+                                                  ov::element::f16};
 
     INSTANTIATE_TEST_SUITE_P(smoke_GRUCellCommon, GRUCellTest,
             ::testing::Combine(
@@ -37,7 +37,7 @@ namespace {
             ::testing::ValuesIn(layer_types),
             ::testing::ValuesIn(layer_types),
             ::testing::ValuesIn(layer_types),
-            ::testing::ValuesIn(netPrecisions),
+            ::testing::ValuesIn(model_types),
             ::testing::Values(ov::test::utils::DEVICE_CPU)),
             GRUCellTest::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -197,6 +197,9 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_TopK/TopKLayerTest.Inference.*_k=21_.*_sort=value_modelType=f16_trgDev=CPU.*)",
         // Issue: 121228
         R"(smoke_TestsDFT_(1|2|3|4)d/DFTLayerTest.Inference.*bf16.*)",
+        // Issue: 121313
+        R"(smoke_GroupConvBackpropData.*paddingDefined/GroupConvBackpropLayerTest.Inference.*f16.*)",
+        R"(smoke_GroupConvBackpropData.*paddingDefined/GroupConvBackpropLayerTest.Inference.*f32.*)",
     };
 #if defined(__APPLE__) && defined(OPENVINO_ARCH_ARM64)
     // Issue: 120950

--- a/src/tests/functional/plugin/shared/include/single_op_tests/grn.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/grn.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/grn.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(GrnLayerTest, Inference) {
+    run();
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/include/single_op_tests/group_convolution.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/group_convolution.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/group_convolution.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(GroupConvolutionLayerTest, Inference) {
+    run();
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/include/single_op_tests/group_convolution_backprop_data.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/group_convolution_backprop_data.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/group_convolution_backprop_data.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(GroupConvBackpropLayerTest, Inference) {
+    run();
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/include/single_op_tests/gru_cell.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/gru_cell.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/gru_cell.hpp"
+
+namespace ov {
+namespace test {
+TEST_P(GRUCellTest, Inference) {
+    run();
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/grn.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/grn.hpp
@@ -13,10 +13,11 @@
 namespace ov {
 namespace test {
 typedef std::tuple<
-    ov::element::Type,
-    std::vector<InputShape>,
-    float,
-    std::string> grnParams;
+    ov::element::Type,        // Model type
+    std::vector<InputShape>,  // Input shapes
+    float,                    // Bias
+    std::string               // Device name
+> grnParams;
 
 class GrnLayerTest : public testing::WithParamInterface<grnParams>,
                      virtual public ov::test::SubgraphBaseTest{

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/grn.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/grn.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+#include <tuple>
+#include <string>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+typedef std::tuple<
+    ov::element::Type,
+    std::vector<InputShape>,
+    float,
+    std::string> grnParams;
+
+class GrnLayerTest : public testing::WithParamInterface<grnParams>,
+                     virtual public ov::test::SubgraphBaseTest{
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<grnParams>& obj);
+protected:
+    void SetUp() override;
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/group_convolution.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/group_convolution.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+typedef std::tuple<
+        std::vector<size_t>,
+        std::vector<size_t>,
+        std::vector<ptrdiff_t>,
+        std::vector<ptrdiff_t>,
+        std::vector<size_t>,
+        size_t,
+        size_t,
+        ov::op::PadType> groupConvSpecificParams;
+typedef std::tuple<
+        groupConvSpecificParams,
+        ov::element::Type,
+        std::vector<InputShape>,
+        std::string> groupConvLayerTestParamsSet;
+
+class GroupConvolutionLayerTest : public testing::WithParamInterface<groupConvLayerTestParamsSet>,
+                                  virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<groupConvLayerTestParamsSet>& obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/group_convolution_backprop_data.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/group_convolution_backprop_data.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+using  groupConvBackpropSpecificParams = std::tuple<
+    std::vector<size_t>,        // kernels
+    std::vector<size_t>,        // strides
+    std::vector<ptrdiff_t>,     // pad begins
+    std::vector<ptrdiff_t>,     // pad ends
+    std::vector<size_t>,        // dilations
+    size_t,                     // num output channels
+    size_t,                     // num groups
+    ov::op::PadType,            // padding type
+    std::vector<ptrdiff_t>>;    // output padding
+
+using  groupConvBackpropLayerTestParamsSet = std::tuple<
+    groupConvBackpropSpecificParams,
+    ov::element::Type,        // Model type
+    std::vector<InputShape>,  // Input shape
+    ov::Shape,                // Output shapes
+    std::string>;             // Device name
+
+class GroupConvBackpropLayerTest : public testing::WithParamInterface<groupConvBackpropLayerTestParamsSet>,
+                                       virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<groupConvBackpropLayerTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/gru_cell.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/gru_cell.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "common_test_utils/test_enums.hpp"
+
+namespace ov {
+namespace test {
+using GRUCellParams = typename std::tuple<
+        bool,                              // using decompose to sub-ops transformation
+        size_t,                            // batch
+        size_t,                            // hidden size
+        size_t,                            // input size
+        std::vector<std::string>,          // activations
+        float,                             // clip
+        bool,                              // linear_before_reset
+        ov::test::utils::InputLayerType,   // W input type (Constant or Parameter)
+        ov::test::utils::InputLayerType,   // R input type (Constant or Parameter)
+        ov::test::utils::InputLayerType,   // B input type (Constant or Parameter)
+        ov::element::Type,                 // Network precision
+        std::string>;                      // Device name
+
+class GRUCellTest : public testing::WithParamInterface<GRUCellParams >,
+                     virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<GRUCellParams> &obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/gru_cell.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/gru_cell.hpp
@@ -24,7 +24,7 @@ using GRUCellParams = typename std::tuple<
         ov::test::utils::InputLayerType,   // W input type (Constant or Parameter)
         ov::test::utils::InputLayerType,   // R input type (Constant or Parameter)
         ov::test::utils::InputLayerType,   // B input type (Constant or Parameter)
-        ov::element::Type,                 // Network precision
+        ov::element::Type,                 // Model type
         std::string>;                      // Device name
 
 class GRUCellTest : public testing::WithParamInterface<GRUCellParams >,

--- a/src/tests/functional/shared_test_classes/src/single_op/grn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/grn.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/grn.hpp"
+
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/grn.hpp"
+
+namespace ov {
+namespace test {
+std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams>& obj) {
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    std::string target_device;
+    float bias;
+    std::tie(model_type, shapes, bias, target_device) = obj.param;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (size_t i = 0lu; i < shapes.size(); i++) {
+        result << ov::test::utils::partialShape2str({shapes[i].first}) << (i < shapes.size() - 1lu ? "_" : "");
+    }
+    result << ")_TS=";
+    for (size_t i = 0lu; i < shapes.front().second.size(); i++) {
+        result << "{";
+        for (size_t j = 0lu; j < shapes.size(); j++) {
+            result << ov::test::utils::vec2str(shapes[j].second[i]) << (j < shapes.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+    }
+    result << "netPRC=" << model_type.get_type_name() << '_';
+    result << "bias="   << bias << '_';
+    result << "trgDev=" << '_';
+    return result.str();
+}
+
+void GrnLayerTest::SetUp() {
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    float bias;
+    std::tie(model_type, shapes, bias, targetDevice) = GetParam();
+    init_input_shapes(shapes);
+
+    auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
+    auto grn = std::make_shared<ov::op::v0::GRN>(param, bias);
+    auto result = std::make_shared<ov::op::v0::Result>(grn);
+    function = std::make_shared<ov::Model>(result, ov::ParameterVector{param}, "Grn");
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/grn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/grn.cpp
@@ -30,7 +30,7 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
         }
         result << "}_";
     }
-    result << "netPRC=" << model_type.get_type_name() << '_';
+    result << "modelType=" << model_type.get_type_name() << '_';
     result << "bias="   << bias << '_';
     result << "trgDev=" << '_';
     return result.str();

--- a/src/tests/functional/shared_test_classes/src/single_op/group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/group_convolution.cpp
@@ -37,15 +37,15 @@ std::string GroupConvolutionLayerTest::getTestCaseName(const testing::TestParamI
         }
         result << "}_";
     }
-    result << "K" << ov::test::utils::vec2str(kernel) << "_";
-    result << "S" << ov::test::utils::vec2str(stride) << "_";
-    result << "PB" << ov::test::utils::vec2str(pad_begin) << "_";
-    result << "PE" << ov::test::utils::vec2str(pad_end) << "_";
+    result << "K=" << ov::test::utils::vec2str(kernel) << "_";
+    result << "S=" << ov::test::utils::vec2str(stride) << "_";
+    result << "PB=" << ov::test::utils::vec2str(pad_begin) << "_";
+    result << "PE=" << ov::test::utils::vec2str(pad_end) << "_";
     result << "D=" << ov::test::utils::vec2str(dilation) << "_";
     result << "O=" << conv_out_channels << "_";
     result << "G=" << num_groups << "_";
     result << "AP=" << pad_type << "_";
-    result << "netPRC=" << model_type.get_type_name() << "_";
+    result << "modelType=" << model_type.get_type_name() << "_";
     result << "trgDev=" << target_device;
     return result.str();
 }

--- a/src/tests/functional/shared_test_classes/src/single_op/group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/group_convolution.cpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/group_convolution.hpp"
+
+#include "ngraph_functions/builders.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/group_conv.hpp"
+
+namespace ov {
+namespace test {
+std::string GroupConvolutionLayerTest::getTestCaseName(const testing::TestParamInfo<groupConvLayerTestParamsSet>& obj) {
+    groupConvSpecificParams group_conv_params;
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    std::string target_device;
+    std::tie(group_conv_params, model_type, shapes, target_device) = obj.param;
+    ov::op::PadType pad_type;
+    std::vector<size_t> kernel, stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end;
+    size_t conv_out_channels, num_groups;
+    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type) = group_conv_params;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (size_t i = 0lu; i < shapes.size(); i++) {
+        result << ov::test::utils::partialShape2str({shapes[i].first}) << (i < shapes.size() - 1lu ? "_" : "");
+    }
+    result << ")_TS=";
+    for (size_t i = 0lu; i < shapes.front().second.size(); i++) {
+        result << "{";
+        for (size_t j = 0lu; j < shapes.size(); j++) {
+            result << ov::test::utils::vec2str(shapes[j].second[i]) << (j < shapes.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+    }
+    result << "K" << ov::test::utils::vec2str(kernel) << "_";
+    result << "S" << ov::test::utils::vec2str(stride) << "_";
+    result << "PB" << ov::test::utils::vec2str(pad_begin) << "_";
+    result << "PE" << ov::test::utils::vec2str(pad_end) << "_";
+    result << "D=" << ov::test::utils::vec2str(dilation) << "_";
+    result << "O=" << conv_out_channels << "_";
+    result << "G=" << num_groups << "_";
+    result << "AP=" << pad_type << "_";
+    result << "netPRC=" << model_type.get_type_name() << "_";
+    result << "trgDev=" << target_device;
+    return result.str();
+}
+
+void GroupConvolutionLayerTest::SetUp() {
+    groupConvSpecificParams group_conv_params;
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    std::tie(group_conv_params, model_type, shapes, targetDevice) = this->GetParam();
+    ov::op::PadType pad_type;
+    std::vector<size_t> kernel, stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end;
+    size_t conv_out_channels, num_groups;
+    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type) = group_conv_params;
+    init_input_shapes(shapes);
+
+    auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
+
+    auto group_conv = ngraph::builder::makeGroupConvolution(param, model_type, kernel, stride, pad_begin,
+                                             pad_end, dilation, pad_type, conv_out_channels, num_groups);
+
+    auto result = std::make_shared<ov::op::v0::Result>(group_conv);
+    function = std::make_shared<ov::Model>(result, ov::ParameterVector{param}, "groupConvolution");
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/group_convolution_backprop_data.cpp
@@ -1,0 +1,85 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/group_convolution_backprop_data.hpp"
+
+#include "ngraph_functions/builders.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/group_conv.hpp"
+
+namespace ov {
+namespace test {
+std::string GroupConvBackpropLayerTest::getTestCaseName(testing::TestParamInfo<groupConvBackpropLayerTestParamsSet> obj) {
+    groupConvBackpropSpecificParams group_conv_backprop_data_params;
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    ov::Shape output_shape;
+    std::string target_device;
+    std::tie(group_conv_backprop_data_params, model_type, shapes, output_shape, target_device) = obj.param;
+    ov::op::PadType pad_type;
+    std::vector<size_t> kernel, stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end, out_padding;
+    size_t conv_out_channels, num_groups;
+    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type, out_padding) = group_conv_backprop_data_params;
+
+    std::ostringstream result;
+    result << "IS=(";
+    for (size_t i = 0lu; i < shapes.size(); i++) {
+        result << ov::test::utils::partialShape2str({shapes[i].first}) << (i < shapes.size() - 1lu ? "_" : "");
+    }
+    result << ")_TS=";
+    for (size_t i = 0lu; i < shapes.front().second.size(); i++) {
+        result << "{";
+        for (size_t j = 0lu; j < shapes.size(); j++) {
+            result << ov::test::utils::vec2str(shapes[j].second[i]) << (j < shapes.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+    }
+    result << "OS=" << ov::test::utils::vec2str(output_shape) << "_";
+    result << "K" << ov::test::utils::vec2str(kernel) << "_";
+    result << "S" << ov::test::utils::vec2str(stride) << "_";
+    result << "PB" << ov::test::utils::vec2str(pad_begin) << "_";
+    result << "PE" << ov::test::utils::vec2str(pad_end) << "_";
+    result << "D=" << ov::test::utils::vec2str(dilation) << "_";
+    result << "OP=" << ov::test::utils::vec2str(out_padding) << "_";
+    result << "O=" << conv_out_channels << "_";
+    result << "G=" << num_groups << "_";
+    result << "AP=" << pad_type << "_";
+    result << "netPRC=" << model_type.get_type_name() << "_";
+    result << "trgDev=" << target_device;
+    return result.str();
+}
+
+void GroupConvBackpropLayerTest::SetUp() {
+    groupConvBackpropSpecificParams group_conv_backprop_data_params;
+    ov::element::Type model_type;
+    std::vector<InputShape> shapes;
+    ov::Shape output_shape;
+    std::tie(group_conv_backprop_data_params, model_type, shapes, output_shape, targetDevice) = this->GetParam();
+    ov::op::PadType pad_type;
+    std::vector<size_t> kernel, stride, dilation;
+    std::vector<ptrdiff_t> pad_begin, pad_end, out_padding;
+    size_t conv_out_channels, num_groups;
+    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type, out_padding) = group_conv_backprop_data_params;
+    init_input_shapes(shapes);
+
+    auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
+
+    std::shared_ptr<ov::Node> group_conv;
+    if (!output_shape.empty()) {
+        auto outShape = ov::op::v0::Constant::create(ov::element::i64, {output_shape.size()}, output_shape);
+        group_conv = ngraph::builder::makeGroupConvolutionBackpropData(param, outShape, model_type, kernel, stride, pad_begin,
+                                            pad_end, dilation, pad_type, conv_out_channels, num_groups, false, out_padding);
+    } else {
+        group_conv = ngraph::builder::makeGroupConvolutionBackpropData(param, model_type, kernel, stride, pad_begin,
+                                            pad_end, dilation, pad_type, conv_out_channels, num_groups, false, out_padding);
+    }
+
+    auto result = std::make_shared<ov::op::v0::Result>(group_conv);
+    function = std::make_shared<ov::Model>(result, ov::ParameterVector{param}, "GroupConvolutionBackpropData");
+}
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/single_op/gru_cell.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/gru_cell.cpp
@@ -84,17 +84,15 @@ void GRUCellTest::SetUp() {
     };
 
     std::vector<ov::Shape> param_shapes{input_shapes[0], input_shapes[1]};
-    if (WType == InputLayerType::PARAMETER) {
+    if (WType == InputLayerType::PARAMETER)
         param_shapes.push_back(input_shapes[2]);
-    };
 
-    if (RType == InputLayerType::PARAMETER) {
+    if (RType == InputLayerType::PARAMETER)
         param_shapes.push_back(input_shapes[3]);
-    };
 
-    if (BType == InputLayerType::PARAMETER) {
+    if (BType == InputLayerType::PARAMETER)
         param_shapes.push_back(input_shapes[4]);
-    };
+
     init_input_shapes(ov::test::static_shapes_to_test_representation(param_shapes));
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]),

--- a/src/tests/functional/shared_test_classes/src/single_op/gru_cell.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/gru_cell.cpp
@@ -1,0 +1,148 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/gru_cell.hpp"
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/gru_cell.hpp"
+#include "openvino/pass/manager.hpp"
+#include "transformations/op_conversions/gru_cell_decomposition.hpp"
+
+namespace ov {
+namespace test {
+using ov::test::utils::InputLayerType;
+
+std::string GRUCellTest::getTestCaseName(const testing::TestParamInfo<GRUCellParams> &obj) {
+    bool should_decompose;
+    size_t batch;
+    size_t hidden_size;
+    size_t input_size;
+    std::vector<std::string> activations;
+    std::vector<float> activations_alpha;
+    std::vector<float> activations_beta;
+    float clip;
+    bool linear_before_reset;
+    std::vector<std::vector<size_t>> input_shapes;
+    InputLayerType WType;
+    InputLayerType RType;
+    InputLayerType BType;
+    ov::element::Type model_type;
+    std::string targetDevice;
+    std::tie(should_decompose, batch, hidden_size, input_size, activations, clip,
+            linear_before_reset, WType, RType, BType, model_type, targetDevice) = obj.param;
+    input_shapes = {
+            {{batch, input_size},
+            {batch, hidden_size},
+            {3 * hidden_size, input_size},
+            {3 * hidden_size, hidden_size},
+            {(linear_before_reset? 4 : 3) * hidden_size}},
+    };
+    std::ostringstream result;
+    result << "decomposition" << should_decompose << "_";
+    result << "batch=" << batch << "_";
+    result << "hidden_size=" << hidden_size << "_";
+    result << "input_size=" << input_size << "_";
+    result << "IS=" << ov::test::utils::vec2str(input_shapes) << "_";
+    result << "activations=" << ov::test::utils::vec2str(activations) << "_";
+    result << "clip=" << clip << "_";
+    result << "linear_before_reset=" << linear_before_reset << "_";
+    result << "WType=" << WType << "_";
+    result << "RType=" << RType << "_";
+    result << "BType=" << BType << "_";
+    result << "netPRC=" << model_type.get_type_name() << "_";
+    result << "targetDevice=" << targetDevice << "_";
+    return result.str();
+}
+
+void GRUCellTest::SetUp() {
+    bool should_decompose;
+    size_t batch;
+    size_t hidden_size;
+    size_t input_size;
+    std::vector<std::string> activations;
+    std::vector<float> activations_alpha;
+    std::vector<float> activations_beta;
+    float clip;
+    bool linear_before_reset;
+    InputLayerType WType;
+    InputLayerType RType;
+    InputLayerType BType;
+    ov::element::Type model_type;
+    std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, linear_before_reset,
+            WType, RType, BType, model_type, targetDevice) = this->GetParam();
+
+    std::vector<std::vector<size_t>> input_shapes = {
+            {{batch, input_size},
+             {batch, hidden_size},
+             {3 * hidden_size, input_size},
+             {3 * hidden_size, hidden_size},
+             {(linear_before_reset? 4 : 3) * hidden_size}},
+    };
+
+    std::vector<ov::Shape> param_shapes{input_shapes[0], input_shapes[1]};
+    if (WType == InputLayerType::PARAMETER) {
+        param_shapes.push_back(input_shapes[2]);
+    };
+
+    if (RType == InputLayerType::PARAMETER) {
+        param_shapes.push_back(input_shapes[3]);
+    };
+
+    if (BType == InputLayerType::PARAMETER) {
+        param_shapes.push_back(input_shapes[4]);
+    };
+    init_input_shapes(ov::test::static_shapes_to_test_representation(param_shapes));
+
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]),
+                               std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[1])};
+
+    ov::NodeVector inputs{params[0], params[1]};
+    if (WType == InputLayerType::PARAMETER) {
+        auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[params.size()]);
+        params.push_back(param);
+        inputs.push_back(param);
+    } else {
+        auto tensor = ov::test::utils::create_and_fill_tensor(model_type, input_shapes[2]);
+        auto constant = std::make_shared<ov::op::v0::Constant>(tensor);
+        inputs.push_back(constant);
+    }
+
+    if (RType == InputLayerType::PARAMETER) {
+        auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[params.size()]);
+        params.push_back(param);
+        inputs.push_back(param);
+    } else {
+        auto tensor = ov::test::utils::create_and_fill_tensor(model_type, input_shapes[3]);
+        auto constant = std::make_shared<ov::op::v0::Constant>(tensor);
+        inputs.push_back(constant);
+    }
+
+    if (BType == InputLayerType::PARAMETER) {
+        auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[params.size()]);
+        params.push_back(param);
+        inputs.push_back(param);
+    } else {
+        auto tensor = ov::test::utils::create_and_fill_tensor(model_type, input_shapes[4]);
+        auto constant = std::make_shared<ov::op::v0::Constant>(tensor);
+        inputs.push_back(constant);
+    }
+
+    auto gru_cell = std::make_shared<ov::op::v3::GRUCell>(inputs[0], inputs[1], inputs[2], inputs[3], inputs[4],
+                                                          hidden_size, activations, activations_alpha, activations_beta,
+                                                          clip, linear_before_reset);
+
+    auto result = std::make_shared<ov::op::v0::Result>(gru_cell);
+
+    function = std::make_shared<ov::Model>(result, params, "gru_cell");
+    if (should_decompose) {
+        ov::pass::Manager m;
+        m.register_pass<ov::pass::GRUCellDecomposition>();
+        m.run_passes(function);
+    }
+}
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Refactor GrnLayerTest, GroupConvBackpropLayerTest, GroupConvolutionLayerTest, GRUCellTest
 - Update cpu plugin instantiation of these tests to use new implementation
 - f16 and f32 tests for GroupConvBackpropLayerTest tests with defined output padding are disabled until fixed CVS-121313

### Tickets:
 - [CVS-111364](https://jira.devtools.intel.com/browse/CVS-111364)
