### PR TITLE
[CONFORMANCE] Provide correct numbers for rel_passed && rel_all

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
@@ -214,6 +214,9 @@ uint64_t clip(uint64_t n, uint64_t lower, uint64_t upper) {
 }
 
 void ReadIRTest::SetUp() {
+    // todo: find the optimal way to find TEST_P instances
+    // inference + query_model + import_export
+    summary.setDowngradeCoefficient(3);
     std::pair<std::string, std::string> model_pair;
     std::tie(model_pair, targetDevice, configuration) = this->GetParam();
     std::tie(path_to_model, path_to_cache) = model_pair;

--- a/src/tests/test_utils/functional_test_utils/include/functional_test_utils/summary/op_summary.hpp
+++ b/src/tests/test_utils/functional_test_utils/include/functional_test_utils/summary/op_summary.hpp
@@ -30,16 +30,19 @@ private:
     static OpSummary* p_instance;
     static bool extractBody;
     std::map<ov::NodeTypeInfo, PassRate> opsStats = {};
+    unsigned short int downgrade_coefficient;
 
     std::string getOpVersion(const std::string& version);
 
 protected:
-    OpSummary();
+    OpSummary(unsigned short int downgrade_coefficient = 1);
+    static OpSummary& createInstance(unsigned short int downgrade_coefficient = 1);
     static OpSummaryDestroyer destroyer;
     friend class OpSummaryDestroyer;
 
 public:
     static OpSummary& getInstance();
+    static void setDowngradeCoefficient(unsigned short int downgrade_coefficient = 1);
 
     std::map<ov::NodeTypeInfo, PassRate> getOPsStats() {
         return opsStats;

--- a/src/tests/test_utils/functional_test_utils/include/functional_test_utils/summary/summary.hpp
+++ b/src/tests/test_utils/functional_test_utils/include/functional_test_utils/summary/summary.hpp
@@ -66,18 +66,6 @@ public:
 
     std::string getDeviceName() const;
 
-    // #define IE_TEST_DEBUG
-
-#ifdef IE_TEST_DEBUG
-    void saveDebugReport(const char* className,
-                         const char* opName,
-                         unsigned long passed,
-                         unsigned long failed,
-                         unsigned long skipped,
-                         unsigned long crashed,
-                         unsigned long hanged);
-#endif  // IE_TEST_DEBUG
-
     virtual void saveReport() {}
 
     void setReportFilename(const std::string& val);


### PR DESCRIPTION
### Details:
 - *Provide rel_all && rel_passed based on TEST_P cnt to avoid 300% passrate* 

CC @andrei-kochin 
