### PR TITLE
[GHA] concurrency fix

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,6 +24,7 @@ on:
       - master
 
 concurrency:
+  # github.run_id is not unique in post-commit
   group: ${{ github.ref_name == 'master' && github.run_id || github.ref }}-linux
   cancel-in-progress: true
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}-linux
+  group: ${{ github.ref_name == 'master' && github.run_id || github.ref }}-${{ runner.os }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ on:
       - master
 
 concurrency:
-  # github.run_id is not unique in post-commit
+  # github.ref is not unique in post-commit
   group: ${{ github.ref_name == 'master' && github.run_id || github.ref }}-linux
   cancel-in-progress: true
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.ref_name == 'master' && github.run_id || github.ref }}-${{ runner.os }}
+  group: ${{ github.ref_name == 'master' && github.run_id || github.ref }}-linux
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,10 +22,11 @@ on:
       - '**/conformance/**'
     branches:
       - master
+      - 'releases/**'
 
 concurrency:
   # github.ref is not unique in post-commit
-  group: ${{ github.ref_name == 'master' && github.run_id || github.ref }}-linux
+  group: ${{ github.event_name == 'push' && github.run_id || github.ref }}-linux
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Details:
 - fixed regression issue when job can be cancelled by another job in post-commits, because github.ref is not unique in the master

### Tickets:
 - *TBD*
