### PR TITLE
[GPU] Gather needs to keep the original input/output rank

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
@@ -21,6 +21,7 @@ struct gather : public primitive_base<gather> {
     /// @param dict Input dictionary primitive id.
     /// @param idx Input indexes primitive id.
     /// @param axis Gathering axis.
+    /// @param input_rank Input rank.
     /// @param output_shape Output shape.
     /// @param batch_dim Batch_dim
     /// @param support_neg_ind Support negative indexes
@@ -28,18 +29,22 @@ struct gather : public primitive_base<gather> {
            const input_info& dict,
            const input_info& idx,
            const int64_t axis,
+           const int64_t input_rank,
            const ov::Shape& output_shape,
            const int64_t batch_dim = 0,
            const bool support_neg_ind = false,
            const padding& output_padding = padding())
         : primitive_base(id, {dict, idx}, {output_padding})
         , axis(axis)
+        , input_rank(input_rank)
         , output_shape(output_shape)
         , batch_dim(batch_dim)
         , support_neg_ind(support_neg_ind) {}
 
     /// @brief Gathering axis
     int64_t axis = 0;
+    /// @brief Gather input rank
+    int64_t input_rank;
     /// @brief Gather output shape
     ov::Shape output_shape;
     /// @brief Gathering batch_dim
@@ -69,6 +74,7 @@ struct gather : public primitive_base<gather> {
     void save(BinaryOutputBuffer& ob) const override {
         primitive_base<gather>::save(ob);
         ob << axis;
+        ob << input_rank;
         ob << output_shape;
         ob << batch_dim;
         ob << support_neg_ind;
@@ -77,6 +83,7 @@ struct gather : public primitive_base<gather> {
     void load(BinaryInputBuffer& ib) override {
         primitive_base<gather>::load(ib);
         ib >> axis;
+        ib >> input_rank;
         ib >> output_shape;
         ib >> batch_dim;
         ib >> support_neg_ind;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -121,15 +121,10 @@ struct travel_direction_wrapper<direction_e::backwards> {
 static format get_target_output_format(layout_optimizer& lo, const std::map<program_node*, format::type>& fmt_map, program_node *node, program_node *next) {
     auto user_idx = node->get_user_index(*next);
 
-    bool allow_new_shape_infer = node->get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
     // 1. Check selected preferred_output_format
-    if (lo.get_optimization_attributes().use_onednn_impls || allow_new_shape_infer) {
-        // If onednn is not used, need to ignore get_preferred_output_fmt result as it is from onednn
-        auto ret = node->get_preferred_output_fmt(user_idx);
-
-        if (ret != format::any)
-            return ret;
-    }
+    auto ret = node->get_preferred_output_fmt(user_idx);
+    if (ret != format::any)
+        return ret;
 
     // 2. Check fmt
     if (fmt_map.count(node) > 0)
@@ -142,14 +137,10 @@ static format get_target_output_format(layout_optimizer& lo, const std::map<prog
 static format get_target_input_format(layout_optimizer& lo, const std::map<program_node*, format::type>& fmt_map, program_node *node, program_node *prev) {
     auto dep_idx = node->get_dependency_index(*prev);
 
-    bool allow_new_shape_infer = node->get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
     // 1. Check selected preferred_input_format
-    if (lo.get_optimization_attributes().use_onednn_impls || allow_new_shape_infer) {
-        // If onednn is not used, need to ignore get_preferred_input_fmt result as it is from onednn
-        auto ret = node->get_preferred_input_fmt(dep_idx);
-        if (ret != format::any)
-            return ret;
-    }
+    auto ret = node->get_preferred_input_fmt(dep_idx);
+    if (ret != format::any)
+        return ret;
 
     // 2. Check fmt
     if (fmt_map.count(node) > 0)

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
@@ -36,7 +36,7 @@ void select_preferred_formats::run(program& p) {
 
     engine.create_onednn_engine(p.get_config());
     for (auto n : p.get_processing_order()) {
-        if (n->is_input() || !_lo.are_data_types_suitable_for_onednn(*n)) {
+        if (n->is_input() || !layout_optimizer::is_node_suitable_for_onednn(*n)) {
             continue;
         }
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
@@ -40,11 +40,12 @@ void select_preferred_formats::run(program& p) {
             continue;
         }
 
-        for (auto& it : forcing_map) {
-            if (it.first == n->id() && it.second.second != impl_types::onednn) {
-                continue;
-            }
-        }
+        // skip to set preferred_formats if forcing_impl is not onednn.
+        if (std::find_if(forcing_map.begin(), forcing_map.end(),
+                [&n](std::map<primitive_id, std::pair<format::type, impl_types>>::value_type const& it) {
+                    return (it.first == n->id() && it.second.second != impl_types::onednn);
+                }) != forcing_map.end())
+            continue;
 
         // Onednn primitive descriptor creation may fail, for example, due to asymmetric weight.
         try {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
@@ -31,6 +31,9 @@ void select_preferred_formats::run(program& p) {
     if (!device_info.supports_immad)
         return;
 
+    if (!_lo.get_implementation_forcing().empty())
+        return;
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
     engine.create_onednn_engine(p.get_config());
     for (auto n : p.get_processing_order()) {

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -169,6 +169,7 @@ public:
     impl_types get_preferred_impl_type(program_node& node, format preferred_format);
 
     impl_types get_forced_impl_type_by_config(program_node& node);
+    static bool is_node_suitable_for_onednn(program_node& node);
     static bool are_data_types_suitable_for_onednn(program_node& node);
     bool are_layouts_suitable_for_onednn(program_node& node);
     static bool onednn_check_data_types_for_pooling(data_types in_dt, data_types out_dt);

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -188,6 +188,7 @@ public:
     optimization_attributes get_optimization_attributes() { return _optimization_attributes; }
 
     void set_implementation_forcing(const ov::intel_gpu::ImplForcingMap& map);
+    const std::map<primitive_id, std::pair<format::type, impl_types>> get_implementation_forcing() const;
 
     void update_formats_map(const convolution_node& node);
     bool is_format_optimized(const convolution_node& node, const format& format, bool use_weak_restrictions = false);

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -32,6 +32,7 @@
 #include "region_yolo_inst.h"
 #include "prior_box_inst.h"
 #include "scatter_nd_update_inst.h"
+#include "gather_inst.h"
 #include "to_string_utils.h"
 #include <vector>
 #include <memory>
@@ -1770,6 +1771,10 @@ format layout_optimizer::get_preferred_format(program_node& node) {
                 node.set_preferred_input_fmt(0, format::bfyx);
             }
         }
+    } else if (node.is_type<gather>()) {
+        // Gather needs the original input/output rank because
+        // the parameters as indices, batch_dims and axis depend on the rank.
+        node.set_preferred_input_fmt(0, format::get_default_format(node.as<gather>().get_primitive()->input_rank));
     }
 
     if (allow_new_shape_infer && node.get_preferred_input_fmt() != format::any) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -858,16 +858,7 @@ static bool is_node_for_onednn(convolution_node const& node) {
     if (input_layout.is_dynamic() || output_layout.is_dynamic())
         return false;
 
-    bool onednn_valid_dt = layout_optimizer::are_data_types_suitable_for_onednn((program_node&)node);
-
-    bool onednn_valid_params = onednn_valid_dt &&
-                               input_layout.feature() >= 16 &&
-                               prim->groups == 1 &&
-                               get_post_ops_count(node) <= 32;
-
-    auto spatial_dims_num = input_layout.get_spatial_rank();
-
-    return onednn_valid_dt && onednn_valid_params && spatial_dims_num <= 3;
+    return layout_optimizer::are_data_types_suitable_for_onednn((program_node&)node);
 }
 
 static bool is_node_for_onednn(deconvolution_node const& node) {
@@ -916,10 +907,7 @@ static bool is_node_for_onednn(fully_connected_node const& node) {
 }
 
 static bool is_node_for_onednn(gemm_node const& node) {
-    if (!layout_optimizer::are_data_types_suitable_for_onednn((program_node&)node))
-        return false;
-
-    return true;
+    return layout_optimizer::are_data_types_suitable_for_onednn((program_node&)node);
 }
 
 // This function is needed to avoid performance regressions for the convolutions with byxf layout

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -851,14 +851,15 @@ static bool is_node_for_onednn(reduce_node const& node, format preferred_format)
 }
 
 static bool is_node_for_onednn(convolution_node const& node) {
-    auto prim = node.get_primitive();
+    if (!layout_optimizer::are_data_types_suitable_for_onednn((program_node&)node))
+        return false;
+
     auto input_layout = node.get_input_layout(0);
     auto output_layout = node.get_output_layout(0);
-
     if (input_layout.is_dynamic() || output_layout.is_dynamic())
         return false;
 
-    return layout_optimizer::are_data_types_suitable_for_onednn((program_node&)node);
+    return true;
 }
 
 static bool is_node_for_onednn(deconvolution_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -2094,6 +2094,10 @@ void layout_optimizer::set_implementation_forcing(const ov::intel_gpu::ImplForci
     }
 }
 
+const std::map<primitive_id, std::pair<format::type, impl_types>> layout_optimizer::get_implementation_forcing() const {
+    return _forcing_map;
+}
+
 const std::vector<std::pair<format::type, bool>> layout_optimizer::optimized_formats = {
         {format::b_fs_yx_fsv16, true},
         {format::b_fs_yx_fsv16, false},

--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -188,6 +188,25 @@ void dump_graph_init(std::ofstream& graph,
 
         return out;
     };
+    const auto dump_mem_preferred_info = [](const program_node* ptr) {
+        std::string out = "";
+        auto input_fmts = ptr->get_preferred_input_fmts();
+        if (!input_fmts.empty()) {
+            out += "preferred_in_fmt";
+            for (auto& fmt : input_fmts) {
+                out += ":" + fmt_to_str(fmt);
+            }
+        }
+        auto output_fmts = ptr->get_preferred_output_fmts();
+        if (!output_fmts.empty()) {
+            out += "\npreferred_out_fmt";
+            for (auto& fmt : output_fmts) {
+                out += ":" + fmt_to_str(fmt);
+            }
+        }
+
+        return out;
+    };
 
     graph << "digraph cldnn_program {\n";
     for (auto& node : program.get_processing_order()) {
@@ -220,6 +239,7 @@ void dump_graph_init(std::ofstream& graph,
             }
         }
         graph << "\n" + dump_mem_info(node);
+        graph << "\n" + dump_mem_preferred_info(node);
         graph << "\"";
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -119,6 +119,7 @@ void CreateGatherOpBase(ProgramBuilder& p, const std::shared_ptr<T>& op, const i
                                         reordered_inputs[0],
                                         reordered_inputs[1],
                                         axis,
+                                        input_rank,
                                         out_shape,
                                         batch_dim,
                                         support_neg_ind);

--- a/src/plugins/intel_gpu/tests/unit/fusions/gather_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/gather_fusion_test.cpp
@@ -129,7 +129,7 @@ TEST_P(gather_quantize, basic) {
         data("in_hi", get_mem(get_per_channel_layout(p), 1, max_random)),
         data("out_lo", get_mem(get_single_element_layout(p), -127)),
         data("out_hi", get_mem(get_single_element_layout(p), 127)),
-        gather("gather_prim", input_info("input"), input_info("gather_indices"), p.axis, p.out_shape),
+        gather("gather_prim", input_info("input"), input_info("gather_indices"), p.axis, p.dictionary_shape.size(), p.out_shape),
         quantize("quantize", input_info("gather_prim"), input_info("in_lo"), input_info("in_hi"),
                  input_info("out_lo"), input_info("out_hi"), 255, data_types::i8),
         reorder("reorder_bfyx", input_info("quantize"), p.default_format, data_types::f32)
@@ -172,7 +172,7 @@ TEST_P(gather_eltwise_activation, basic) {
         input_layout("input", get_input_layout(p)),
         data("gather_indices", get_mem(get_indices_layout(p), 0, static_cast<int>(get_axis_dim(p) - 1))),
         data("eltwise_data", get_mem(get_per_channel_layout(p), -10, 10)),
-        gather("gather_prim", input_info("input"), input_info("gather_indices"), p.axis, p.out_shape),
+        gather("gather_prim", input_info("input"), input_info("gather_indices"), p.axis, p.dictionary_shape.size(), p.out_shape),
         activation("activation", input_info("gather_prim"), activation_func::abs),
         eltwise("eltwise", { input_info("activation"), input_info("eltwise_data") }, eltwise_mode::prod),
         reorder("reorder_bfyx", input_info("eltwise"), p.default_format, data_types::f32)
@@ -220,7 +220,7 @@ TEST_P(gather_eltwise_activation_dynamic, basic) {
         input_layout("input", get_input_layout(p, true)),
         input_layout("gather_indices", layout{ ov::PartialShape::dynamic(p.indices_shape.size()), p.data_type, format::bfyx }),
         input_layout("eltwise_data", get_per_channel_layout(p, true)),
-        gather("gather_prim", input_info("input"), input_info("gather_indices"), p.axis, p.out_shape),
+        gather("gather_prim", input_info("input"), input_info("gather_indices"), p.axis, p.dictionary_shape.size(), p.out_shape),
         activation("activation", input_info("gather_prim"), activation_func::abs),
         eltwise("eltwise", { input_info("activation"), input_info("eltwise_data") }, eltwise_mode::prod),
         reorder("reorder_bfyx", input_info("eltwise"), p.default_format, data_types::f32)

--- a/src/plugins/intel_gpu/tests/unit/module_tests/primitive_comparison_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/primitive_comparison_test.cpp
@@ -89,11 +89,11 @@ TEST(primitive_comparison, fully_connected) {
 }
 
 TEST(primitive_comparison, gather) {
-    auto gather_prim = gather("gather", input_info("input0"), input_info("input1"), 2, {1, 3, 224, 224}, 1, true);
-    auto gather_prim_eq = gather("gather_eq", input_info("input0_eq"), input_info("input1_eq"), 2, {1, 3, 224, 224}, 1, true);
-    auto gather_prim_axis = gather("gather", input_info("input0"), input_info("input1"), 3, {1, 3, 224, 224}, 1, true);
-    auto gather_prim_batch_dim = gather("gather", input_info("input0"), input_info("input1"), 2, {1, 3, 224, 224}, 2, true);
-    auto gather_prim_support_neg_ind = gather("gather", input_info("input0"), input_info("input1"), 2, {1, 3, 224, 224}, 1, false);
+    auto gather_prim = gather("gather", input_info("input0"), input_info("input1"), 2, {}, {1, 3, 224, 224}, 1, true);
+    auto gather_prim_eq = gather("gather_eq", input_info("input0_eq"), input_info("input1_eq"), 2, {}, {1, 3, 224, 224}, 1, true);
+    auto gather_prim_axis = gather("gather", input_info("input0"), input_info("input1"), 3, {}, {1, 3, 224, 224}, 1, true);
+    auto gather_prim_batch_dim = gather("gather", input_info("input0"), input_info("input1"), 2, {}, {1, 3, 224, 224}, 2, true);
+    auto gather_prim_support_neg_ind = gather("gather", input_info("input0"), input_info("input1"), 2, {}, {1, 3, 224, 224}, 1, false);
 
     ASSERT_EQ(gather_prim, gather_prim_eq);
     ASSERT_NE(gather_prim, gather_prim_axis);

--- a/src/plugins/intel_gpu/tests/unit/passes/add_required_reorders_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/add_required_reorders_test.cpp
@@ -41,11 +41,11 @@ TEST(add_required_reorders, input_reorder_inside_shape_of_subgraph) {
     topology.add(data("data_0", data_0));
     topology.add(data("data_1", data_1));
     topology.add(shape_of("shape_of", input_info("input"), 4, data_types::i32));
-    topology.add(gather("gather0", input_info("shape_of"), input_info("data_0"), 0, {}, 0, true));
+    topology.add(gather("gather0", input_info("shape_of"), input_info("data_0"), 0, {}, {}, 0, true));
     topology.add(eltwise("eltwise0", {input_info("gather0"), input_info("data_1")}, eltwise_mode::prod, data_types::f32));
     topology.add(reshape("reshape0", input_info("eltwise0"), false, {},
                          ov::PartialShape{1}, reshape::reshape_mode::unsqueeze));
-    topology.add(gather("gather1", input_info("shape_of"), input_info("data_0"), 0, {}, 0, true));
+    topology.add(gather("gather1", input_info("shape_of"), input_info("data_0"), 0, {}, {}, 0, true));
     topology.add(eltwise("eltwise1", {input_info("gather1"), input_info("data_1")}, eltwise_mode::prod, data_types::f32));
     topology.add(reshape("reshape1", input_info("eltwise1"), false, {},
                          ov::PartialShape{1}, reshape::reshape_mode::unsqueeze));

--- a/src/plugins/intel_gpu/tests/unit/passes/mark_shape_of_subgraphs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/mark_shape_of_subgraphs_test.cpp
@@ -62,7 +62,7 @@ TEST(mark_shape_of_subgraphs, simple_chain) {
     topology.add(data("data_0", data_0));
     topology.add(data("data_1", data_1));
     topology.add(shape_of("shape_of", input_info("input"), data_types::i64));
-    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {}));
+    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {}, {}));
     topology.add(eltwise("eltwise", input_info("gather"), input_info("data_1"), eltwise_mode::sum));
     topology.add(concatenation("concat", {input_info("eltwise"), input_info("data_1")}, 0));
     topology.add(broadcast("broadcast", input_info("input"), input_info("concat"), {}, ov::op::BroadcastType::BIDIRECTIONAL));
@@ -103,7 +103,7 @@ TEST(mark_shape_of_subgraphs, simple_chain_w_reshape_inside_subgraph) {
     topology.add(data("data_0", data_0));
     topology.add(data("data_1", data_1));
     topology.add(shape_of("shape_of", input_info("input"), data_types::i64));
-    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {1}));
+    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {1}, {1}));
     topology.add(reshape("reshape", input_info("gather"), input_info("data_1"), false, ov::PartialShape{2}));
     topology.add(broadcast("broadcast", input_info("input"), input_info("reshape"), {}, ov::op::BroadcastType::BIDIRECTIONAL));
 
@@ -129,8 +129,8 @@ TEST(mark_shape_of_subgraphs, parallel_shape_of_subgraphs) {
     topology.add(data("data_0", data_0));
     topology.add(shape_of("shape_of_0", input_info("input"), data_types::i64));
     topology.add(shape_of("shape_of_1", input_info("input"), data_types::i64));
-    topology.add(gather("gather_0", input_info("shape_of_0"), input_info("data_0"), 0, {}));
-    topology.add(gather("gather_1", input_info("shape_of_1"), input_info("data_0"), 0, {}));
+    topology.add(gather("gather_0", input_info("shape_of_0"), input_info("data_0"), 0, {}, {}));
+    topology.add(gather("gather_1", input_info("shape_of_1"), input_info("data_0"), 0, {}, {}));
     topology.add(eltwise("eltwise", input_info("gather_0"), input_info("gather_1"), eltwise_mode::sum));
     topology.add(reshape("reshape", input_info("input"), input_info("eltwise"), false, ov::PartialShape()));
 
@@ -160,9 +160,9 @@ TEST(mark_shape_of_subgraphs, parallel_shape_of_subgraphs_cascade) {
     topology.add(data("data_1", data_1));
     topology.add(data("data_2", data_2));
     topology.add(shape_of("shape_of_0", input_info("input"), data_types::i64));
-    topology.add(gather("gather_0", input_info("shape_of_0"), input_info("data_0"), 0, {1}));
+    topology.add(gather("gather_0", input_info("shape_of_0"), input_info("data_0"), 0, {1}, {1}));
     topology.add(shape_of("shape_of_1", input_info("input"), data_types::i64));
-    topology.add(gather("gather_1", input_info("shape_of_1"), input_info("data_0"), 0, {1}));
+    topology.add(gather("gather_1", input_info("shape_of_1"), input_info("data_0"), 0, {1}, {1}));
     topology.add(scatter_update("scatter_update_0", input_info("gather_0"), input_info("data_0"), input_info("data_0"), 0));
     topology.add(scatter_update("scatter_update_1", input_info("gather_1"), input_info("data_0"), input_info("data_0"), 0));
     topology.add(strided_slice("strided_slice_1",
@@ -171,7 +171,7 @@ TEST(mark_shape_of_subgraphs, parallel_shape_of_subgraphs_cascade) {
                                input_info("scatter_update_1"),
                                input_info("data_0"), {}, {}, {}, {}, {}, {}));
     topology.add(shape_of("shape_of_2", input_info("input"), data_types::i64));
-    topology.add(gather("gather_2", input_info("shape_of_2"), input_info("data_0"), 0, {}));
+    topology.add(gather("gather_2", input_info("shape_of_2"), input_info("data_0"), 0, {}, {}));
     topology.add(scatter_update("scatter_update_2", input_info("gather_2"), input_info("data_0"), input_info("data_0"), 0));
     topology.add(strided_slice("strided_slice_2",
                                input_info("data_1"),
@@ -207,7 +207,7 @@ TEST(mark_shape_of_subgraphs, simple_chain_w_inserted_reorder) {
     topology.add(input_layout("input", input_layout_dynamic));
     topology.add(data("data_0", data_0));
     topology.add(shape_of("shape_of", input_info("input"), data_types::i64));
-    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {1}));
+    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {1}, {1}));
     topology.add(reshape("reshape", input_info("gather"), true, {}, {}));
     topology.add(reorder("reorder", input_info("reshape"), format::bfyx, data_types::f16));
     topology.add(eltwise("eltwise", input_info("reorder"), input_info("data_0"), eltwise_mode::prod));
@@ -237,7 +237,7 @@ TEST(mark_shape_of_subgraphs, concat_with_empty_tensor_inputs) {
     topology.add(input_layout("input_empty", input_layout_empty));
     topology.add(data("data_0", data_0));
     topology.add(shape_of("shape_of_01", input_info("input"), data_types::i64));
-    topology.add(gather("gather01", input_info("shape_of_01"), input_info("data_0"), 0, {1}));
+    topology.add(gather("gather01", input_info("shape_of_01"), input_info("data_0"), 0, {1}, {1}));
     topology.add(shape_of("shape_of_02", input_info("input_empty"), data_types::i64));
     topology.add(shape_of("shape_of_03", input_info("input_empty"), data_types::i64));
     topology.add(concatenation("concat", {input_info("gather01"), input_info("shape_of_02"), input_info("shape_of_03")}, 0));

--- a/src/plugins/intel_gpu/tests/unit/passes/mark_shape_of_subgraphs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/mark_shape_of_subgraphs_test.cpp
@@ -62,7 +62,7 @@ TEST(mark_shape_of_subgraphs, simple_chain) {
     topology.add(data("data_0", data_0));
     topology.add(data("data_1", data_1));
     topology.add(shape_of("shape_of", input_info("input"), data_types::i64));
-    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {}, {}));
+    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, 0, {}));
     topology.add(eltwise("eltwise", input_info("gather"), input_info("data_1"), eltwise_mode::sum));
     topology.add(concatenation("concat", {input_info("eltwise"), input_info("data_1")}, 0));
     topology.add(broadcast("broadcast", input_info("input"), input_info("concat"), {}, ov::op::BroadcastType::BIDIRECTIONAL));
@@ -103,7 +103,7 @@ TEST(mark_shape_of_subgraphs, simple_chain_w_reshape_inside_subgraph) {
     topology.add(data("data_0", data_0));
     topology.add(data("data_1", data_1));
     topology.add(shape_of("shape_of", input_info("input"), data_types::i64));
-    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {1}, {1}));
+    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, 1, {1}));
     topology.add(reshape("reshape", input_info("gather"), input_info("data_1"), false, ov::PartialShape{2}));
     topology.add(broadcast("broadcast", input_info("input"), input_info("reshape"), {}, ov::op::BroadcastType::BIDIRECTIONAL));
 
@@ -129,8 +129,8 @@ TEST(mark_shape_of_subgraphs, parallel_shape_of_subgraphs) {
     topology.add(data("data_0", data_0));
     topology.add(shape_of("shape_of_0", input_info("input"), data_types::i64));
     topology.add(shape_of("shape_of_1", input_info("input"), data_types::i64));
-    topology.add(gather("gather_0", input_info("shape_of_0"), input_info("data_0"), 0, {}, {}));
-    topology.add(gather("gather_1", input_info("shape_of_1"), input_info("data_0"), 0, {}, {}));
+    topology.add(gather("gather_0", input_info("shape_of_0"), input_info("data_0"), 0, 0, {}));
+    topology.add(gather("gather_1", input_info("shape_of_1"), input_info("data_0"), 0, 0, {}));
     topology.add(eltwise("eltwise", input_info("gather_0"), input_info("gather_1"), eltwise_mode::sum));
     topology.add(reshape("reshape", input_info("input"), input_info("eltwise"), false, ov::PartialShape()));
 
@@ -160,9 +160,9 @@ TEST(mark_shape_of_subgraphs, parallel_shape_of_subgraphs_cascade) {
     topology.add(data("data_1", data_1));
     topology.add(data("data_2", data_2));
     topology.add(shape_of("shape_of_0", input_info("input"), data_types::i64));
-    topology.add(gather("gather_0", input_info("shape_of_0"), input_info("data_0"), 0, {1}, {1}));
+    topology.add(gather("gather_0", input_info("shape_of_0"), input_info("data_0"), 0, 1, {1}));
     topology.add(shape_of("shape_of_1", input_info("input"), data_types::i64));
-    topology.add(gather("gather_1", input_info("shape_of_1"), input_info("data_0"), 0, {1}, {1}));
+    topology.add(gather("gather_1", input_info("shape_of_1"), input_info("data_0"), 0, 1, {1}));
     topology.add(scatter_update("scatter_update_0", input_info("gather_0"), input_info("data_0"), input_info("data_0"), 0));
     topology.add(scatter_update("scatter_update_1", input_info("gather_1"), input_info("data_0"), input_info("data_0"), 0));
     topology.add(strided_slice("strided_slice_1",
@@ -171,7 +171,7 @@ TEST(mark_shape_of_subgraphs, parallel_shape_of_subgraphs_cascade) {
                                input_info("scatter_update_1"),
                                input_info("data_0"), {}, {}, {}, {}, {}, {}));
     topology.add(shape_of("shape_of_2", input_info("input"), data_types::i64));
-    topology.add(gather("gather_2", input_info("shape_of_2"), input_info("data_0"), 0, {}, {}));
+    topology.add(gather("gather_2", input_info("shape_of_2"), input_info("data_0"), 0, 0, {}));
     topology.add(scatter_update("scatter_update_2", input_info("gather_2"), input_info("data_0"), input_info("data_0"), 0));
     topology.add(strided_slice("strided_slice_2",
                                input_info("data_1"),
@@ -207,7 +207,7 @@ TEST(mark_shape_of_subgraphs, simple_chain_w_inserted_reorder) {
     topology.add(input_layout("input", input_layout_dynamic));
     topology.add(data("data_0", data_0));
     topology.add(shape_of("shape_of", input_info("input"), data_types::i64));
-    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, {1}, {1}));
+    topology.add(gather("gather", input_info("shape_of"), input_info("data_0"), 0, 1, {1}));
     topology.add(reshape("reshape", input_info("gather"), true, {}, {}));
     topology.add(reorder("reorder", input_info("reshape"), format::bfyx, data_types::f16));
     topology.add(eltwise("eltwise", input_info("reorder"), input_info("data_0"), eltwise_mode::prod));
@@ -237,7 +237,7 @@ TEST(mark_shape_of_subgraphs, concat_with_empty_tensor_inputs) {
     topology.add(input_layout("input_empty", input_layout_empty));
     topology.add(data("data_0", data_0));
     topology.add(shape_of("shape_of_01", input_info("input"), data_types::i64));
-    topology.add(gather("gather01", input_info("shape_of_01"), input_info("data_0"), 0, {1}, {1}));
+    topology.add(gather("gather01", input_info("shape_of_01"), input_info("data_0"), 0, 1, {1}));
     topology.add(shape_of("shape_of_02", input_info("input_empty"), data_types::i64));
     topology.add(shape_of("shape_of_03", input_info("input_empty"), data_types::i64));
     topology.add(concatenation("concat", {input_info("gather01"), input_info("shape_of_02"), input_info("shape_of_03")}, 0));

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -633,13 +633,13 @@ TEST(prepare_buffer_fusing, skip_in_place_concat_inside_shape_of_subgraph) {
     topology.add(data("data_1", data_1));
     topology.add(data("data_2", data_2));
     topology.add(shape_of("shape_of", input_info("input"), 4, data_types::i32));
-    topology.add(gather("gather0", input_info("shape_of"), input_info("data_0"), 0, {}, 0, true));
+    topology.add(gather("gather0", input_info("shape_of"), input_info("data_0"), 0, 0, {}, 0, true));
     topology.add(reorder("reorder0", input_info("gather0"), format::any, data_types::f32,
                          std::vector<float>(), reorder_mean_mode::subtract, padding(), true));
     topology.add(eltwise("eltwise0", input_info("reorder0"), input_info("data_1"), eltwise_mode::prod, broadcast_spec));
     topology.add(reshape("reshape0", input_info("eltwise0"), false, {},
                          ov::PartialShape{1}, reshape::reshape_mode::unsqueeze));
-    topology.add(gather("gather1", input_info("shape_of"), input_info("data_0"), 0, {}, 0, true));
+    topology.add(gather("gather1", input_info("shape_of"), input_info("data_0"), 0, 0, {}, 0, true));
     topology.add(reorder("reorder1", input_info("gather1"), format::any, data_types::f32,
                          std::vector<float>(), reorder_mean_mode::subtract, padding(), true));
     topology.add(eltwise("eltwise1", input_info("reorder1"), input_info("data_1"), eltwise_mode::prod, broadcast_spec));
@@ -693,7 +693,7 @@ TEST(prepare_buffer_fusing, test_implicit_crop_and_outerpadding) {
     topology.add(input_layout("Input", in_input->get_layout()));
     topology.add(input_layout("Input_idx_1", input_idx1->get_layout()));
     topology.add(reorder("reorder_input", input_info("Input"), format::bfzyx, data_types::f32));
-    topology.add(gather("gather1", input_info("reorder_input"), input_info("Input_idx_1"), axis, ov::Shape{1, 6, 2, 2, 2}));
+    topology.add(gather("gather1", input_info("reorder_input"), input_info("Input_idx_1"), axis, 5, ov::Shape{1, 6, 2, 2, 2}));
     topology.add(reorder("gather1_reorder", input_info("gather1"), reorder_layout));
     topology.add(reshape("reshape1", input_info("gather1_reorder"), tensor(6, 2, 2, 2)));
     topology.add(crop("crop", input_info("reorder_input"), tensor{1, 6, 2, 2, 2}, tensor(1, 0, 0, 0, 0)));

--- a/src/plugins/intel_gpu/tests/unit/passes/remove_redundant_reorders_tests.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/remove_redundant_reorders_tests.cpp
@@ -346,13 +346,13 @@ TEST(remove_redundant_reorders, not_to_fuse_concat_with_reorder_inside_shape_of_
     topology.add(data("data_1", data_1));
     topology.add(data("data_2", data_2));
     topology.add(shape_of("shape_of", input_info("input"), 4, data_types::i32));
-    topology.add(gather("gather0", input_info("shape_of"), input_info("data_0"), 0, {}, 0, true));
+    topology.add(gather("gather0", input_info("shape_of"), input_info("data_0"), 0, {}, {}, 0, true));
     topology.add(reorder("reorder0", input_info("gather0"), format::any, data_types::f32,
                          std::vector<float>(), reorder_mean_mode::subtract, padding(), true));
     topology.add(eltwise("eltwise0", input_info("reorder0"), input_info("data_1"), eltwise_mode::prod, broadcast_spec));
     topology.add(reshape("reshape0", input_info("eltwise0"), false, {},
                          ov::PartialShape{1}, reshape::reshape_mode::unsqueeze));
-    topology.add(gather("gather1", input_info("shape_of"), input_info("data_0"), 0, {}, 0, true));
+    topology.add(gather("gather1", input_info("shape_of"), input_info("data_0"), 0, {}, {}, 0, true));
     topology.add(reorder("reorder1", input_info("gather1"), format::any, data_types::f32,
                          std::vector<float>(), reorder_mean_mode::subtract, padding(), true));
     topology.add(eltwise("eltwise1", input_info("reorder1"), input_info("data_1"), eltwise_mode::prod, broadcast_spec));

--- a/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
@@ -136,8 +136,8 @@ TEST(reorder_inputs, mixed_ranks_gather) {
                              ov::CoordinateDiff{0, 0},
                              false));
     topology.add(border("pad", { input_info("conv") }, 0, ov::CoordinateDiff{0, 0, 1, 1}, ov::CoordinateDiff{0, 0, 1, 1}));
-    topology.add(gather("gather1", input_info("pad"), input_info("data1"), 2, { 1, 2, 3, 128, 57 }, 0, false));
-    topology.add(gather("gather2", input_info("gather1"), input_info("data2"), 4, { 1, 2, 3, 128, 3, 55 }, 0, false));
+    topology.add(gather("gather1", input_info("pad"), input_info("data1"), 2, 4, { 1, 2, 3, 128, 57 }, 0, false));
+    topology.add(gather("gather2", input_info("gather1"), input_info("data2"), 4, 5, { 1, 2, 3, 128, 3, 55 }, 0, false));
     topology.add(permute("permute", input_info("gather2"), {0, 1, 2, 4, 3, 5}));
 
     ExecutionConfig config = get_test_default_config(engine);
@@ -155,10 +155,10 @@ TEST(reorder_inputs, mixed_ranks_gather) {
     auto& gather1_node = prog_impl->get_node("gather1");
     auto& gather2_node = prog_impl->get_node("gather2");
 
-    ASSERT_EQ(gather1_node.get_input_layouts()[0].format, format::bfzyx);
+    ASSERT_EQ(gather1_node.get_input_layouts()[0].format, format::bfyx);
     ASSERT_EQ(gather1_node.get_output_layout().format, format::bfzyx);
 
-    ASSERT_EQ(gather2_node.get_input_layouts()[0].format, format::bfwzyx);
+    ASSERT_EQ(gather2_node.get_input_layouts()[0].format, format::bfzyx);
     ASSERT_EQ(gather2_node.get_output_layout().format, format::bfwzyx);
 }
 

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/gather_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/gather_si_test.cpp
@@ -37,7 +37,7 @@ TEST_P(gather_test, shape_infer) {
 
     auto input0_layout_prim = std::make_shared<input_layout>("input0", p.in0_layout);
     auto input1_layout_prim = std::make_shared<input_layout>("input1", p.in1_layout);
-    auto gather_prim = std::make_shared<gather>("output", input_info("input0"), input_info("input1"), p.axis, ov::Shape{}, p.batch_dim);
+    auto gather_prim = std::make_shared<gather>("output", input_info("input0"), input_info("input1"), p.axis, 0, ov::Shape{}, p.batch_dim);
 
     cldnn::program prog(engine);
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/canonicalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/canonicalization_gpu_test.cpp
@@ -220,7 +220,7 @@ TEST(canonicalization, gather) {
         topology.add(input_layout("data", data_layout));
         topology.add(input_layout("indices", indices_layout));
         topology.add(gather("gather", input_info("data"), input_info("indices"), params.second.axis,
-                            ov::Shape{}, params.second.batch_dim, params.second.support_neg_ind));
+                            0, ov::Shape{}, params.second.batch_dim, params.second.support_neg_ind));
 
         canonicalization_test(topology, "gather", std::get<1>(params.first), std::get<2>(params.first));
     }
@@ -254,9 +254,9 @@ TEST(canonicalization, fusing_gather_eltwise) {
         topology.add(input_layout("indices_second", indices_layout_second));
         topology.add(input_layout("data", input_mul_layout));
         topology.add(gather("gather_first", input_info("input"), input_info("indices_first"), shapes.second.axis,
-                            shapes.second.out_shape, shapes.second.batch_dim, shapes.second.support_neg_ind));
+                            shapes.second.data_shape.rank().get_length(), shapes.second.out_shape, shapes.second.batch_dim, shapes.second.support_neg_ind));
         topology.add(gather("gather_second", input_info("input"), input_info("indices_second"), shapes.second.axis,
-                            shapes.second.out_shape, shapes.second.batch_dim, shapes.second.support_neg_ind));
+                            shapes.second.data_shape.rank().get_length(), shapes.second.out_shape, shapes.second.batch_dim, shapes.second.support_neg_ind));
         topology.add(eltwise("mul", {input_info("gather_first"), input_info("data")}, eltwise_mode::prod));
         topology.add(eltwise("add", {input_info("gather_second"), input_info("mul")}, eltwise_mode::sum));
         topology.add(reorder("out_reorder", input_info("add"), format::bfyx, data_types::f32));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
@@ -2482,7 +2482,7 @@ TEST(eltwise_gpu_int, div_gather_fusing) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(input_layout("Input3", input3->get_layout()));
-    topology.add(gather("gather", input_info("InputDictionary"), input_info("InputText"), 0, ov::Shape{2, 2, 2, 2}));
+    topology.add(gather("gather", input_info("InputDictionary"), input_info("InputText"), 0, 4, ov::Shape{2, 2, 2, 2}));
     topology.add(reorder("gather_reorder", input_info("gather"), { data_types::i32, format::bfyx, { 2, 2, 2, 2 } }));
     topology.add(eltwise("eltwise",
                  { input_info("gather_reorder"), input_info("Input3") },

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gather_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gather_gpu_test.cpp
@@ -88,6 +88,7 @@ public:
                                 input_info("reorder0"),
                                 input_info("reorder1"),
                                 axis,
+                                shape_in[0].size(),
                                 ov::Shape(shape_out.begin(), shape_out.end()),
                                 batch_dim,
                                 true));
@@ -108,7 +109,7 @@ public:
         planar_topo.add(input_layout("input0", input0->get_layout()));
         planar_topo.add(input_layout("input1", input1->get_layout()));
         planar_topo.add(
-            gather("gather", input_info("input0"), input_info("input1"), axis, ov::Shape(shape_out.begin(), shape_out.end()), batch_dim, true));
+            gather("gather", input_info("input0"), input_info("input1"), axis, shape_in[0].size(), ov::Shape(shape_out.begin(), shape_out.end()), batch_dim, true));
         network planar_network(engine, planar_topo, get_test_default_config(engine));
         planar_network.set_input_data("input0", input0);
         planar_network.set_input_data("input1", input1);
@@ -408,7 +409,7 @@ TEST(gather8_gpu_fp16, d323_axisY_bdim_m1) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 3, 3, 2}, batch_dim, negative_indexes)
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 5, ov::Shape{3, 2, 3, 3, 2}, batch_dim, negative_indexes)
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -515,7 +516,7 @@ TEST(gather7_gpu_fp16, d222_axisX_bdim_m1) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2, 2, 2}, batch_dim)
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 6, ov::Shape{2, 2, 2, 2, 2, 2}, batch_dim)
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -626,7 +627,7 @@ TEST(gather7_gpu_fp16, d323_axisY_bdim_m1) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 3, 3, 2}, batch_dim)
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 5, ov::Shape{3, 2, 3, 3, 2}, batch_dim)
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -730,7 +731,7 @@ TEST(gather7_gpu_fp16, d44_axisY_bdim1) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{4, 3, 4, 1, 1, 1}, batch_dim)
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{4, 3, 4, 1, 1, 1}, batch_dim)
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -805,7 +806,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim_m1) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 1, 1}, batch_dim)
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{3, 2, 1, 1}, batch_dim)
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -868,7 +869,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim1) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 1, 1}, batch_dim)
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{3, 2, 1, 1}, batch_dim)
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -930,7 +931,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim0) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 3, 2, 1}, batch_dim)
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{3, 3, 2, 1}, batch_dim)
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -998,7 +999,7 @@ TEST(gather_gpu_fp16, d14_axisB) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{1, 4, 2, 1})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{1, 4, 2, 1})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1060,7 +1061,7 @@ TEST(gather_gpu_fp16, d222_axisB) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1121,7 +1122,7 @@ TEST(gather_gpu_fp16, d22_axisY) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1182,7 +1183,7 @@ TEST(gather_gpu_fp16, d22_axisF) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1240,7 +1241,7 @@ TEST(gather_gpu_fp32, d14_axisB) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{1, 4, 2, 1})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{1, 4, 2, 1})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1301,7 +1302,7 @@ TEST(gather_gpu_fp32, d222_axisB) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1362,7 +1363,7 @@ TEST(gather_gpu_fp32, d22_axisY) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1423,7 +1424,7 @@ TEST(gather_gpu_fp32, d22_axisF) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1484,7 +1485,7 @@ TEST(gather_gpu_int32, d22_axisF) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1542,7 +1543,7 @@ TEST(gather_gpu_int32, d14_axisB) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{1, 4, 2, 1})
+            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{1, 4, 2, 1})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1603,7 +1604,7 @@ TEST(gather_gpu_int32, d222_axisB) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1664,7 +1665,7 @@ TEST(gather_gpu_int32, d22_axisY) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
+            gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 2, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1728,7 +1729,7 @@ TEST(gather_gpu_fp32, d41_axisB) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{4, 1, 2, 3})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{4, 1, 2, 3})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1791,7 +1792,7 @@ TEST(gather_gpu_fp32, d41_axisF) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 4, 1, 2})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 4, 1, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1850,7 +1851,7 @@ TEST(gather_gpu_fp32, d2_axisX) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 1, 2})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{2, 2, 1, 2})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1900,7 +1901,7 @@ TEST(gather_gpu_fp32, 322_axisF) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 2, 1})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{3, 2, 2, 1})
     );
 
     network network(engine, topology, get_test_default_config(engine));
@@ -1940,7 +1941,7 @@ TEST(gather_gpu_fp32, dynamic_322_axisF) {
     topology topology;
     topology.add(input_layout("input1", in1_layout));
     topology.add(input_layout("input2", in2_layout));
-    topology.add(gather("gather", input_info("input1"), input_info("input2"), axis, ov::Shape{}));
+    topology.add(gather("gather", input_info("input1"), input_info("input2"), axis, 0, ov::Shape{}));
 
     ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
@@ -1983,7 +1984,7 @@ TEST(gather_gpu_fp32, indice_out_of_bound) {
     topology topology;
     topology.add(input_layout("input1", in1_layout));
     topology.add(input_layout("input2", in2_layout));
-    topology.add(gather("gather", input_info("input1"), input_info("input2"), axis, ov::Shape{}, 0, true));
+    topology.add(gather("gather", input_info("input1"), input_info("input2"), axis, 0, ov::Shape{}, 0, true));
 
     ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
@@ -2021,7 +2022,7 @@ TEST(gather_cpu_impl_fp32, dynamic_322_axisF) {
     topology topology;
     topology.add(input_layout("input1", in1_layout));
     topology.add(input_layout("input2", in2_layout));
-    topology.add(gather("gather", input_info("input1"), input_info("input2"), axis, ov::Shape{}));
+    topology.add(gather("gather", input_info("input1"), input_info("input2"), axis, 0, ov::Shape{}));
 
     auto config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
@@ -2071,7 +2072,7 @@ void test_gather_gpu_u8_322_axisF(bool is_caching_test) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 2, 1}));
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{3, 2, 2, 1}));
 
     cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
@@ -2121,7 +2122,7 @@ TEST(gather_single_axis, simple_Baxis) {
     topology.add(input_layout("InputDictionary", input1->get_layout()));
     topology.add(input_layout("InputText", input2->get_layout()));
     topology.add(
-        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{1, 2, 2, 1})
+        gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{1, 2, 2, 1})
     );
     topology.add(reorder("reorder", input_info("gather"), format::bfyx, data_types::i8));
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -94,7 +94,7 @@ public:
         topology.add(input_layout("InputDictionary", input1->get_layout()));
         topology.add(input_layout("InputText", input2->get_layout()));
         topology.add(
-            gather(key_prim_id, input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 3, 3, 2}, batch_dim, negative_indexes)
+            gather(key_prim_id, input_info("InputDictionary"), input_info("InputText"), axis, 5, ov::Shape{3, 2, 3, 3, 2}, batch_dim, negative_indexes)
         );
 
         cldnn::network::ptr net = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);


### PR DESCRIPTION
- because the parameters as indices, batch_dims and axis depend on the rank.
- add input_shape to gather primitive.
