### PR TITLE
[nGraph Transformations] Fix fused_names handling in CF for dynamic ShapeOf

### DIFF
--- a/src/common/transformations/include/transformations/rt_info/fused_names_attribute.hpp
+++ b/src/common/transformations/include/transformations/rt_info/fused_names_attribute.hpp
@@ -28,6 +28,7 @@ namespace ov {
  * all operation names that was fully or partially fused into node
  */
 class TRANSFORMATIONS_API FusedNames : public ov::RuntimeAttribute {
+protected:
     std::set<std::string> fused_names;
 
 public:
@@ -46,6 +47,13 @@ public:
         fused_names.insert(name);
     }
 
+    /**
+     * @brief      Constructs a new object consisting of multiple names    *
+     * @param[in]  names  The names
+     */
+    explicit FusedNames(const std::vector<std::string>& names) {
+        fused_names.insert(names.begin(), names.end());
+    }
     /**
      * @brief Unites current set of already fused names with another FusedNames object
      * @param[in] names Another object to fuse with

--- a/src/core/include/openvino/core/rt_info.hpp
+++ b/src/core/include/openvino/core/rt_info.hpp
@@ -12,7 +12,7 @@
 #include "openvino/pass/pass_config.hpp"
 
 namespace ov {
-using RTInfoConfig = typename pass::PassConfig;
+typedef class pass::PassConfig RTInfoConfig;
 
 OPENVINO_API
 void copy_runtime_info(const std::shared_ptr<ov::Node>& from,

--- a/src/core/include/openvino/core/rt_info.hpp
+++ b/src/core/include/openvino/core/rt_info.hpp
@@ -9,20 +9,33 @@
 #include "openvino/core/core_visibility.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type.hpp"
+#include "openvino/pass/pass_config.hpp"
 
 namespace ov {
-OPENVINO_API
-void copy_runtime_info(const std::shared_ptr<ov::Node>& from, const std::shared_ptr<ov::Node>& to);
+using RTInfoConfig = typename pass::PassConfig;
 
 OPENVINO_API
-void copy_runtime_info(const std::shared_ptr<ov::Node>& from, ov::NodeVector to);
+void copy_runtime_info(const std::shared_ptr<ov::Node>& from,
+                       const std::shared_ptr<ov::Node>& to,
+                       const std::shared_ptr<ov::RTInfoConfig> rt_config = nullptr);
 
 OPENVINO_API
-void copy_runtime_info(const ov::NodeVector& from, const std::shared_ptr<ov::Node>& to);
+void copy_runtime_info(const std::shared_ptr<ov::Node>& from,
+                       ov::NodeVector to,
+                       const std::shared_ptr<ov::RTInfoConfig> rt_config = nullptr);
 
 OPENVINO_API
-void copy_runtime_info(const ov::NodeVector& from, ov::NodeVector to);
+void copy_runtime_info(const ov::NodeVector& from,
+                       const std::shared_ptr<ov::Node>& to,
+                       const std::shared_ptr<ov::RTInfoConfig> rt_config = nullptr);
 
 OPENVINO_API
-void copy_output_runtime_info(const ov::OutputVector& from, ov::OutputVector to);
+void copy_runtime_info(const ov::NodeVector& from,
+                       ov::NodeVector to,
+                       const std::shared_ptr<ov::RTInfoConfig> rt_config = nullptr);
+
+OPENVINO_API
+void copy_output_runtime_info(const ov::OutputVector& from,
+                              ov::OutputVector to,
+                              const std::shared_ptr<ov::RTInfoConfig> rt_config = nullptr);
 }  // namespace ov

--- a/src/core/include/openvino/pass/constant_folding.hpp
+++ b/src/core/include/openvino/pass/constant_folding.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "openvino/core/rt_info.hpp"
 #include "openvino/core/runtime_attribute.hpp"
 #include "openvino/pass/pass.hpp"
 
@@ -22,7 +23,8 @@ public:
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 
 protected:
-    void copy_runtime_info_from_input_values(const std::shared_ptr<Node>& node);
+    void copy_runtime_info_from_input_values(const std::shared_ptr<Node>& node,
+                                             const std::shared_ptr<ov::RTInfoConfig> rt_config = nullptr);
     /// \brief Folds pre-calculated output tensor values to constants in case lower and
     /// upper estimations are equal. Traverses graph backwards starting from the results.
     bool pre_calculated_values_folding(const std::shared_ptr<ov::Model>& model);

--- a/src/core/src/pass/constant_folding.cpp
+++ b/src/core/src/pass/constant_folding.cpp
@@ -52,7 +52,16 @@ const auto friendly_name_from = [](const ov::Node& node, const size_t output_cou
 namespace {
 class PreFusedNames : public ov::FusedNames {
 public:
-    OPENVINO_RTTI("precalculated_fused_names");
+    static const ::ov::DiscreteTypeInfo& get_type_info_static() {
+        static const ::ov::DiscreteTypeInfo type_info_static{"precalculated_fused_names",
+                                                             "util",
+                                                             &ov::FusedNames::get_type_info_static()};
+        type_info_static.hash();
+        return type_info_static;
+    }
+    const ::ov::DiscreteTypeInfo& get_type_info() const override {
+        return get_type_info_static();
+    }
     PreFusedNames() = default;
     explicit PreFusedNames(const std::string& name) : FusedNames(name){};
     explicit PreFusedNames(const std::vector<std::string>& names) : FusedNames(names){};

--- a/src/core/src/pass/constant_folding.cpp
+++ b/src/core/src/pass/constant_folding.cpp
@@ -204,15 +204,16 @@ bool ov::pass::ConstantFolding::pre_calculated_values_folding(const std::shared_
         for (auto& output : curr_node->input_values()) {
             if (is_output_foldable(output) && output.get_tensor().has_and_set_bound()) {
                 auto input_node = output.get_node_shared_ptr();
-                auto& rt_info = input_node->get_rt_info();
-                // Set fused names to precalculated
-                if (rt_info.count(PreFusedNames::get_type_info_static()))
-                    rt_info[ov::FusedNames::get_type_info_static()] = ov::FusedNames(
-                        rt_info.at(PreFusedNames::get_type_info_static()).as<PreFusedNames>().getVectorNames());
                 const auto& lower = output.get_tensor().get_lower_value();
                 auto replacement =
                     std::make_shared<ov::op::v0::Constant>(lower.get_element_type(), lower.get_shape(), lower.data());
                 if (replacement && !ov::is_type<ov::op::v0::Constant>(input_node)) {
+                    auto& rt_info = input_node->get_rt_info();
+                    // Set fused names to precalculated
+                    if (rt_info.count(PreFusedNames::get_type_info_static()))
+                        rt_info[ov::FusedNames::get_type_info_static()] = ov::FusedNames(
+                            rt_info.at(PreFusedNames::get_type_info_static()).as<PreFusedNames>().getVectorNames());
+
                     replacement->set_friendly_name(
                         friendly_name_from(*input_node, input_node->get_output_size(), output.get_index()));
 

--- a/src/core/src/pass/constant_folding.cpp
+++ b/src/core/src/pass/constant_folding.cpp
@@ -129,7 +129,6 @@ bool ov::pass::ConstantFolding::run_on_model(const std::shared_ptr<ov::Model>& m
                 }
             }
         }
-        node->get_rt_info().erase(PreFusedNames::get_type_info_static());
     }
 
     return rewritten;
@@ -241,6 +240,8 @@ bool ov::pass::ConstantFolding::pre_calculated_values_folding(const std::shared_
             }
         }
     }
+    for (auto&& node : model->get_ordered_ops())
+        node->get_rt_info().erase(pre_fused_key);
     return rewritten;
 }
 

--- a/src/core/src/rt_info.cpp
+++ b/src/core/src/rt_info.cpp
@@ -8,14 +8,19 @@
 
 namespace {
 
-std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const ov::OutputVector& outputs,
-                                                                         const ov::Output<ov::Node>& to) {
+std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(
+    const ov::OutputVector& outputs,
+    const ov::Output<ov::Node>& to,
+    const std::shared_ptr<ov::RTInfoConfig>& rt_config) {
     std::unordered_map<std::string, std::vector<ov::Any>> attrs;
     for (const auto& output : outputs) {
         for (const auto& item : output.get_rt_info()) {
             bool copy = true;
             if (item.second.is<ov::RuntimeAttribute>()) {
-                copy = item.second.as<ov::RuntimeAttribute>().is_copyable(to.get_node_shared_ptr());
+                auto& rt_info = item.second.as<ov::RuntimeAttribute>();
+                copy = rt_info.is_copyable(to.get_node_shared_ptr()) &&
+                       (!rt_config || !rt_config->is_disabled(rt_info.get_type_info()) ||
+                        rt_config->is_enabled(rt_info.get_type_info()));
             }
             if (copy) {
                 attrs[item.first].push_back(item.second);
@@ -25,14 +30,19 @@ std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const o
     return attrs;
 }
 
-std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const ov::NodeVector& nodes,
-                                                                         const std::shared_ptr<ov::Node>& to) {
+std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(
+    const ov::NodeVector& nodes,
+    const std::shared_ptr<ov::Node>& to,
+    const std::shared_ptr<ov::RTInfoConfig>& rt_config) {
     std::unordered_map<std::string, std::vector<ov::Any>> attrs;
     for (const auto& node : nodes) {
         for (const auto& item : node->get_rt_info()) {
             bool copy = item.first != "opset";
             if (item.second.is<ov::RuntimeAttribute>()) {
-                copy = copy && item.second.as<ov::RuntimeAttribute>().is_copyable(to);
+                auto& rt_info = item.second.as<ov::RuntimeAttribute>();
+                copy = copy && rt_info.is_copyable(to) &&
+                       (!rt_config || !rt_config->is_disabled(rt_info.get_type_info()) ||
+                        rt_config->is_enabled(rt_info.get_type_info()));
             }
             if (copy) {
                 attrs[item.first].push_back(item.second);
@@ -43,8 +53,10 @@ std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const o
 }
 
 template <typename T>
-ov::Node::RTMap mergeRuntimeInfo(const std::vector<T>& items, const T& to) {
-    std::unordered_map<std::string, std::vector<ov::Any>> attrs = get_copyable_attrs(items, to);
+ov::Node::RTMap merge_runtime_info(const std::vector<T>& items,
+                                   const T& to,
+                                   const std::shared_ptr<ov::RTInfoConfig>& rt_config) {
+    std::unordered_map<std::string, std::vector<ov::Any>> attrs = get_copyable_attrs(items, to, rt_config);
 
     ov::Node::RTMap merged_attrs;
     for (auto& item : attrs) {
@@ -117,26 +129,36 @@ ov::OutputVector list_with_constants(const ov::OutputVector& to) {
 }
 }  // namespace
 
-void ov::copy_runtime_info(const std::shared_ptr<ov::Node>& from, const std::shared_ptr<ov::Node>& to) {
-    return copy_runtime_info(ov::NodeVector{from}, ov::NodeVector{to});
+void ov::copy_runtime_info(const std::shared_ptr<ov::Node>& from,
+                           const std::shared_ptr<ov::Node>& to,
+                           const std::shared_ptr<ov::RTInfoConfig> rt_config) {
+    return copy_runtime_info(ov::NodeVector{from}, ov::NodeVector{to}, rt_config);
 }
 
-void ov::copy_runtime_info(const std::shared_ptr<ov::Node>& from, ov::NodeVector to) {
-    return copy_runtime_info(ov::NodeVector{from}, to);
+void ov::copy_runtime_info(const std::shared_ptr<ov::Node>& from,
+                           ov::NodeVector to,
+                           const std::shared_ptr<ov::RTInfoConfig> rt_config) {
+    return copy_runtime_info(ov::NodeVector{from}, to, rt_config);
 }
 
-void ov::copy_runtime_info(const ov::NodeVector& from, const std::shared_ptr<ov::Node>& to) {
-    return copy_runtime_info(from, ov::NodeVector{to});
+void ov::copy_runtime_info(const ov::NodeVector& from,
+                           const std::shared_ptr<ov::Node>& to,
+                           const std::shared_ptr<ov::RTInfoConfig> rt_config) {
+    return copy_runtime_info(from, ov::NodeVector{to}, rt_config);
 }
 
-void ov::copy_runtime_info(const ov::NodeVector& from, ov::NodeVector to) {
+void ov::copy_runtime_info(const ov::NodeVector& from,
+                           ov::NodeVector to,
+                           const std::shared_ptr<ov::RTInfoConfig> rt_config) {
     for (auto& node : list_with_constants(to)) {
-        assign_runtime_info(mergeRuntimeInfo(from, node), node->get_rt_info());
+        assign_runtime_info(merge_runtime_info(from, node, rt_config), node->get_rt_info());
     }
 }
 
-void ov::copy_output_runtime_info(const ov::OutputVector& from, ov::OutputVector to) {
+void ov::copy_output_runtime_info(const ov::OutputVector& from,
+                                  ov::OutputVector to,
+                                  const std::shared_ptr<ov::RTInfoConfig> rt_config) {
     for (auto& node : list_with_constants(to)) {
-        assign_runtime_info(mergeRuntimeInfo(from, node), node.get_rt_info());
+        assign_runtime_info(merge_runtime_info(from, node, rt_config), node.get_rt_info());
     }
 }

--- a/src/core/tests/copy_runtime_info.cpp
+++ b/src/core/tests/copy_runtime_info.cpp
@@ -93,6 +93,24 @@ TEST(copy_runtime_info, node_to_node_1) {
     ASSERT_TRUE(TestAttributeNoCopyable::exists_in(b));
 }
 
+TEST(copy_runtime_info, node_to_node_1_disabled) {
+    auto a = make_shared<ov::op::v0::Parameter>(element::f32, Shape{1});
+    auto b = make_shared<ov::op::v0::Parameter>(element::f32, Shape{1});
+
+    TestAttributeCopyable::set(a);
+    TestAttributeNoCopyable::set(b);
+
+    auto rt_config = std::make_shared<ov::RTInfoConfig>();
+    rt_config->disable<TestAttributeCopyable>();
+
+    ov::copy_runtime_info(a, b, rt_config);
+
+    ASSERT_TRUE(TestAttributeCopyable::exists_in(a));
+    ASSERT_FALSE(TestAttributeCopyable::exists_in(b));
+
+    ASSERT_TRUE(TestAttributeNoCopyable::exists_in(b));
+}
+
 TEST(copy_runtime_info, node_to_node_2) {
     auto a = make_shared<op::v0::Parameter>(element::f32, Shape{1});
     auto b = make_shared<op::v0::Parameter>(element::f32, Shape{1});


### PR DESCRIPTION
### Details:
 - *Currently CF copies rt_info starting from ShapeOf operation (including [dynamic](https://github.com/openvinotoolkit/openvino/pull/16973/)) and propogates on futher operations during pre-calculation step even operation is not fused finally. This PR introduces internal PreFusedNames rt attribute which is used instead of ov::FusedNames for propogation and copied into ov::FusedNames on the last step. Also possibility to disable copying of specific runtime attribute types is added.*

### Tickets:
 - *121870*
