### PR TITLE
【PaddlePaddle Hackathon 5】add paddle tanh_shrink op

### DIFF
--- a/src/frontends/paddle/src/op/tanh_shrink.cpp
+++ b/src/frontends/paddle/src/op/tanh_shrink.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "default_opset.hpp"
+#include "openvino/frontend/paddle/node_context.hpp"
+
+namespace ov {
+namespace frontend {
+namespace paddle {
+namespace op {
+NamedOutputs tanh_shrink(const NodeContext& node) {
+    const auto x = node.get_input("X");
+
+    auto tanh_node = std::make_shared<default_opset::Tanh>(x);
+
+    return node.default_single_output_mapping({std::make_shared<default_opset::Subtract>(x, tanh_node)}, {"Out"});
+}
+
+}  // namespace op
+}  // namespace paddle
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/paddle/src/op_table.cpp
+++ b/src/frontends/paddle/src/op_table.cpp
@@ -113,6 +113,7 @@ OP_CONVERTER(stack);
 OP_CONVERTER(strided_slice);
 OP_CONVERTER(sum);
 OP_CONVERTER(swish);
+OP_CONVERTER(tanh_shrink);
 OP_CONVERTER(tanh);
 OP_CONVERTER(tensor_array_to_tensor);
 OP_CONVERTER(tile);
@@ -242,6 +243,7 @@ std::map<std::string, CreatorFunction> get_supported_ops() {
             {"sum", op::sum},
             {"swish", op::swish},
             {"sync_batch_norm", op::batch_norm},
+            {"tanh_shrink", op::tanh_shrink},
             {"tanh", op::tanh},
             {"tensor_array_to_tensor", op::tensor_array_to_tensor},
             {"tile", op::tile},

--- a/src/frontends/paddle/tests/op_fuzzy.cpp
+++ b/src/frontends/paddle/tests/op_fuzzy.cpp
@@ -6,9 +6,9 @@
 
 #include <fstream>
 
+#include "common_test_utils/test_control.hpp"
 #include "ngraph/ngraph.hpp"
 #include "paddle_utils.hpp"
-#include "common_test_utils/test_control.hpp"
 
 using namespace ngraph;
 using namespace InferenceEngine;
@@ -537,6 +537,7 @@ static const std::vector<std::string> models{
     std::string("sum_4"),
     std::string("swish_default_params"),
     std::string("swish_beta"),
+    std::string("tanh_shrink"),
     std::string("tanh"),
     std::string("tile_repeat_times_tensor"),
     std::string("tile_list_float32"),

--- a/src/frontends/paddle/tests/test_models/gen_scripts/generate_tanh_shrink.py
+++ b/src/frontends/paddle/tests/test_models/gen_scripts/generate_tanh_shrink.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# tanh_shrink paddle model generator
+#
+import numpy as np
+from save_model import saveModel
+import paddle
+import paddle.nn.functional as F
+import sys
+
+data_type = "float32"
+
+
+def tanh_shrink(name: str, x):
+    paddle.enable_static()
+
+    with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
+        data = paddle.static.data(name="x", shape=x.shape, dtype=data_type)
+        out = F.tanhshrink(data)
+
+        cpu = paddle.static.cpu_places(1)
+        exe = paddle.static.Executor(cpu[0])
+        # startup program will call initializer to initialize the parameters.
+        exe.run(paddle.static.default_startup_program())
+
+        outs = exe.run(feed={"x": x}, fetch_list=[out])
+
+        saveModel(
+            name,
+            exe,
+            feedkeys=["x"],
+            fetchlist=[out],
+            inputs=[x],
+            outputs=[outs[0]],
+            target_dir=sys.argv[1],
+        )
+
+    return outs[0]
+
+
+def main():
+    x = np.random.uniform(-1000, 1000, (8, 24, 32)).astype(data_type)
+
+    tanh_shrink("tanh_shrink", x)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Details:
 - add paddle tanh_shrink op convert support

### Tickets:


### reference:

- https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/nn/Tanhshrink_en.html
- https://github.com/PaddlePaddle/Paddle/blob/release/2.5/python/paddle/nn/functional/activation.py#L1404

![image](https://github.com/openvinotoolkit/openvino/assets/27223114/9823cce8-2be1-419f-93c0-0d10b096c342)

### Note:

only float32 would be supported; [The dtype that paddle support](https://github.com/PaddlePaddle/Paddle/blob/release/2.4/python/paddle/nn/functional/activation.py#L1484)