### PR TITLE
【PaddlePaddle Hackathon 5】add paddle partial_op

### DIFF
--- a/src/frontends/paddle/src/op/partial_concat.cpp
+++ b/src/frontends/paddle/src/op/partial_concat.cpp
@@ -24,20 +24,15 @@ NamedOutputs partial_concat(const NodeContext& node) {
 
     auto start_node = std::make_shared<Constant>(element::i32, Shape{1}, start_index);
     auto end_node = std::make_shared<Constant>(element::i32, Shape{1}, end_index);
-    auto step_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
-    auto axis_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
+    auto one_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
 
     NodeVector outputs;
     for (auto in : datas) {
-        auto out = std::make_shared<Slice>(in, start_node, end_node, step_node, axis_node);
-        auto casted = std::make_shared<Convert>(out, element::f32);
-        outputs.push_back(casted);
+        auto out = std::make_shared<Slice>(in, start_node, end_node, one_node, one_node);
+        outputs.push_back(out);
     }
 
-    Output<Node> output_node;
-    output_node = std::make_shared<Concat>(outputs, 1);
-
-    return node.default_single_output_mapping({std::make_shared<Convert>(output_node, element::f32)}, {"Out"});
+    return node.default_single_output_mapping({std::make_shared<Concat>(outputs, 1)}, {"Out"});
 }
 
 }  // namespace op

--- a/src/frontends/paddle/src/op/partial_concat.cpp
+++ b/src/frontends/paddle/src/op/partial_concat.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "default_opset.hpp"
+#include "openvino/frontend/paddle/node_context.hpp"
+
+namespace ov {
+namespace frontend {
+namespace paddle {
+namespace op {
+using namespace default_opset;
+NamedOutputs partial_concat(const NodeContext& node) {
+    auto datas = node.get_ng_inputs("X");
+    auto start_index = node.get_attribute<int>("start_index");
+    auto length = node.get_attribute<int>("length");
+
+    int end_index;
+    if (length < 0) {
+        end_index = datas[0].get_shape()[1];
+    } else {
+        end_index = start_index + length;
+    }
+
+    auto start_node = std::make_shared<Constant>(element::i32, Shape{1}, start_index);
+    auto end_node = std::make_shared<Constant>(element::i32, Shape{1}, end_index);
+    auto step_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
+    auto axis_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
+
+    NodeVector outputs;
+    for (auto in : datas) {
+        auto out = std::make_shared<Slice>(in, start_node, end_node, step_node, axis_node);
+        auto casted = std::make_shared<Convert>(out, element::f32);
+        outputs.push_back(casted);
+    }
+
+    Output<Node> output_node;
+    output_node = std::make_shared<Concat>(outputs, 1);
+
+    return node.default_single_output_mapping({std::make_shared<Convert>(output_node, element::f32)}, {"Out"});
+}
+
+}  // namespace op
+}  // namespace paddle
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/paddle/src/op/partial_concat.cpp
+++ b/src/frontends/paddle/src/op/partial_concat.cpp
@@ -15,7 +15,7 @@ NamedOutputs partial_concat(const NodeContext& node) {
     auto start_index = node.get_attribute<int>("start_index");
     auto length = node.get_attribute<int>("length");
 
-    int end_index;
+    size_t end_index;
     if (length < 0) {
         end_index = datas[0].get_shape()[1];
     } else {

--- a/src/frontends/paddle/src/op/partial_sum.cpp
+++ b/src/frontends/paddle/src/op/partial_sum.cpp
@@ -15,7 +15,7 @@ NamedOutputs partial_sum(const NodeContext& node) {
     auto start_index = node.get_attribute<int>("start_index");
     auto length = node.get_attribute<int>("length");
 
-    int end_index;
+    size_t end_index;
     if (length < 0) {
         end_index = datas[0].get_shape()[1];
     } else {

--- a/src/frontends/paddle/src/op/partial_sum.cpp
+++ b/src/frontends/paddle/src/op/partial_sum.cpp
@@ -24,20 +24,15 @@ NamedOutputs partial_sum(const NodeContext& node) {
 
     auto start_node = std::make_shared<Constant>(element::i32, Shape{1}, start_index);
     auto end_node = std::make_shared<Constant>(element::i32, Shape{1}, end_index);
-    auto step_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
-    auto axis_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
+    auto one_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
 
     NodeVector outputs;
     for (auto in : datas) {
-        auto out = std::make_shared<Slice>(in, start_node, end_node, step_node, axis_node);
-        auto casted = std::make_shared<Convert>(out, element::f32);
-        outputs.push_back(casted);
+        auto out = std::make_shared<Slice>(in, start_node, end_node, one_node, one_node);
+        outputs.push_back(out);
     }
 
-    Output<Node> output_node;
-    output_node = std::make_shared<Add>(outputs[0], outputs[1]);
-
-    return node.default_single_output_mapping({std::make_shared<Convert>(output_node, element::f32)}, {"Out"});
+    return node.default_single_output_mapping({std::make_shared<Add>(outputs[0], outputs[1])}, {"Out"});
 }
 
 }  // namespace op

--- a/src/frontends/paddle/src/op/partial_sum.cpp
+++ b/src/frontends/paddle/src/op/partial_sum.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "default_opset.hpp"
+#include "openvino/frontend/paddle/node_context.hpp"
+
+namespace ov {
+namespace frontend {
+namespace paddle {
+namespace op {
+using namespace default_opset;
+NamedOutputs partial_sum(const NodeContext& node) {
+    auto datas = node.get_ng_inputs("X");
+    auto start_index = node.get_attribute<int>("start_index");
+    auto length = node.get_attribute<int>("length");
+
+    int end_index;
+    if (length < 0) {
+        end_index = datas[0].get_shape()[1];
+    } else {
+        end_index = start_index + length;
+    }
+
+    auto start_node = std::make_shared<Constant>(element::i32, Shape{1}, start_index);
+    auto end_node = std::make_shared<Constant>(element::i32, Shape{1}, end_index);
+    auto step_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
+    auto axis_node = std::make_shared<Constant>(element::i32, Shape{1}, 1);
+
+    NodeVector outputs;
+    for (auto in : datas) {
+        auto out = std::make_shared<Slice>(in, start_node, end_node, step_node, axis_node);
+        auto casted = std::make_shared<Convert>(out, element::f32);
+        outputs.push_back(casted);
+    }
+
+    Output<Node> output_node;
+    output_node = std::make_shared<Add>(outputs[0], outputs[1]);
+
+    return node.default_single_output_mapping({std::make_shared<Convert>(output_node, element::f32)}, {"Out"});
+}
+
+}  // namespace op
+}  // namespace paddle
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/paddle/src/op_table.cpp
+++ b/src/frontends/paddle/src/op_table.cpp
@@ -77,6 +77,8 @@ OP_CONVERTER(nearest_interp_v2);
 OP_CONVERTER(one_hot_v2);
 OP_CONVERTER(p_norm);
 OP_CONVERTER(pad3d);
+OP_CONVERTER(partial_concat);
+OP_CONVERTER(partial_sum);
 OP_CONVERTER(pow);
 OP_CONVERTER(pool2d);
 OP_CONVERTER(prior_box);
@@ -205,6 +207,8 @@ std::map<std::string, CreatorFunction> get_supported_ops() {
             {"one_hot_v2", op::one_hot_v2},
             {"p_norm", op::p_norm},
             {"pad3d", op::pad3d},
+            {"partial_sum", op::partial_sum},
+            {"partial_concat", op::partial_concat},
             {"pow", op::pow},
             {"pool2d", op::pool2d},
             {"prior_box", op::prior_box},

--- a/src/frontends/paddle/tests/op_fuzzy.cpp
+++ b/src/frontends/paddle/tests/op_fuzzy.cpp
@@ -6,9 +6,9 @@
 
 #include <fstream>
 
+#include "common_test_utils/test_control.hpp"
 #include "ngraph/ngraph.hpp"
 #include "paddle_utils.hpp"
-#include "common_test_utils/test_control.hpp"
 
 using namespace ngraph;
 using namespace InferenceEngine;
@@ -396,6 +396,8 @@ static const std::vector<std::string> models{
     std::string("pad3d_test2"),
     std::string("pad3d_test3"),
     // pad3d_test4,
+    std::string("partial_concat"),
+    std::string("partial_sum"),
     std::string("pow_float32"),
     std::string("pow_int32"),
     std::string("pow_int64"),

--- a/src/frontends/paddle/tests/test_models/gen_scripts/generate_partial_concat.py
+++ b/src/frontends/paddle/tests/test_models/gen_scripts/generate_partial_concat.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# partial_concat paddle model generator
+#
+import numpy as np
+from save_model import saveModel
+import paddle
+import sys
+
+data_type = "float32"
+
+
+def partial_concat(name: str, x, y, start_index=0, length=-1):
+    paddle.enable_static()
+
+    with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
+        X = paddle.static.data(name="x", shape=x.shape, dtype=data_type)
+        Y = paddle.static.data(name="y", shape=x.shape, dtype=data_type)
+        sum_out = paddle.fluid.contrib.layers.partial_concat(
+            [X, Y], start_index=start_index, length=length
+        )
+
+        cpu = paddle.static.cpu_places(1)
+        exe = paddle.static.Executor(cpu[0])
+        # startup program will call initializer to initialize the parameters.
+        exe.run(paddle.static.default_startup_program())
+
+        outs = exe.run(feed={"x": x, "y": y}, fetch_list=[sum_out])
+
+        saveModel(
+            name,
+            exe,
+            feedkeys=["x", "y"],
+            fetchlist=[sum_out],
+            inputs=[x, y],
+            outputs=[outs[0]],
+            target_dir=sys.argv[1],
+        )
+
+    return outs[0]
+
+
+def main():
+    x = np.random.uniform(-100, 100, (2, 3)).astype(data_type)
+    y = np.random.uniform(-100, 100, (2, 3)).astype(data_type)
+    partial_concat("partial_concat", x, y)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/frontends/paddle/tests/test_models/gen_scripts/generate_partial_sum.py
+++ b/src/frontends/paddle/tests/test_models/gen_scripts/generate_partial_sum.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# partial_sum paddle model generator
+#
+import numpy as np
+from save_model import saveModel
+import paddle
+import sys
+
+data_type = "float32"
+
+
+def partial_sum(name: str, x, y, start_index=0, length=-1):
+    paddle.enable_static()
+
+    with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
+        X = paddle.static.data(name="x", shape=x.shape, dtype=data_type)
+        Y = paddle.static.data(name="y", shape=x.shape, dtype=data_type)
+        sum_out = paddle.fluid.contrib.layers.partial_sum(
+            [X, Y], start_index=start_index, length=length
+        )
+
+        cpu = paddle.static.cpu_places(1)
+        exe = paddle.static.Executor(cpu[0])
+        # startup program will call initializer to initialize the parameters.
+        exe.run(paddle.static.default_startup_program())
+
+        outs = exe.run(feed={"x": x, "y": y}, fetch_list=[sum_out])
+
+        saveModel(
+            name,
+            exe,
+            feedkeys=["x", "y"],
+            fetchlist=[sum_out],
+            inputs=[x, y],
+            outputs=[outs[0]],
+            target_dir=sys.argv[1],
+        )
+
+    return outs[0]
+
+
+def main():
+    x = np.random.uniform(-100, 100, (2, 3)).astype(data_type)
+    y = np.random.uniform(-100, 100, (2, 3)).astype(data_type)
+    partial_sum("partial_sum", x, y)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Details:
 - add paddle partial_sum/partial_concat op convert support

### Tickets:


### reference:

- https://github.com/PaddlePaddle/Paddle/blob/2.4.1/python/paddle/fluid/contrib/layers/nn.py#L951
- https://github.com/PaddlePaddle/Paddle/blob/2.4.1/python/paddle/fluid/contrib/layers/nn.py#L1013C50-L1014

![image](https://github.com/openvinotoolkit/openvino/assets/27223114/2e8eee2d-96a1-4953-a064-8d29845b7f8e)
