### PR TITLE
[GPU] Add handling of unsupported simd8 for PVC

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.cpp
@@ -213,6 +213,9 @@ bool ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::ValidateAutoTuneParams(const c
                                                                          const AutoTuneParams& tparams) const {
     bool valid_tune_params = true;
 
+    if (!IsSIMDSizeSupported(params.engineInfo, tparams.simd))
+        return false;
+
     auto total_lws = tparams.simd * tparams.lws0 * tparams.lws1;
     valid_tune_params &= total_lws <= params.engineInfo.maxWorkGroupSize;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8.cpp
@@ -183,6 +183,10 @@ bool GemmKernelMMADint8::Validate(const Params& params, const optional_params& o
         (input1_type != Datatype::UINT8 && input1_type != Datatype::INT8))
         return false;
 
+    GemmTuningData tuning_data = SetTuningParams(gmm_params);
+    if (!IsSIMDSizeSupported(params.engineInfo, tuning_data.simd_size))
+        return false;
+
     return true;
 }
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8_slm.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8_slm.cpp
@@ -161,6 +161,9 @@ bool GemmKernelMMADslmInt8::Validate(const Params& params, const optional_params
     if (HasLeftovers(tuning_data))
         return false;
 
+    if (!IsSIMDSizeSupported(params.engineInfo, tuning_data.simd_size))
+        return false;
+
     if ((input0_type != Datatype::UINT8 && input0_type != Datatype::INT8) ||
         (input1_type != Datatype::UINT8 && input1_type != Datatype::INT8))
         return false;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -83,7 +83,7 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
 
         bool leftovers = m_size % tuning_data.tile_m_size || k_size % tuning_data.tile_k_size || n_size % tuning_data.tile_n_size;
 
-        if (leftovers || total_batches > 1 || params.transpose_input0 || params.transpose_input1) {
+        if (leftovers || total_batches > 1 || params.transpose_input0 || params.transpose_input1 || !IsSIMDSizeSupported(params.engineInfo, 8)) {
             tuning_data.simd_size = 16;
             tuning_data.tile_n_size = tuning_data.simd_size;
             tuning_data.tile_k_size = tuning_data.simd_size;


### PR DESCRIPTION
### Details:
 - Add handling of unsupported simd8 for PVC (the issue originally happened with gemm_kernel_tiled_opt kernel)

### Tickets:
 - *ticket-id*
