### PR TITLE
Add optional Core instance injection in benchmark tools

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
@@ -26,10 +26,15 @@ def check_positive(value):
     return ivalue
 
 class print_help(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        self.core = kwargs.pop('core', None)
+        super(print_help, self).__init__(option_strings, dest, nargs, **kwargs)
+
     def __call__(self, parser, namespace, values, option_string=None):
         parser.print_help()
-        show_available_devices()
+        show_available_devices(self.core)
         sys.exit()
+
 class HelpFormatterWithLines(argparse.HelpFormatter):
     def _split_lines(self, text, width):
         lines = super()._split_lines(text, width)
@@ -39,11 +44,11 @@ class HelpFormatterWithLines(argparse.HelpFormatter):
         lines = text.split('\n')
         return lines
 
-def parse_args():
+def parse_args(core=None):
     parser = argparse.ArgumentParser(add_help=False, formatter_class=HelpFormatterWithLines)
     args = parser.add_argument_group('Options')
     args.add_argument('-h', '--help', action=print_help, nargs='?', default=argparse.SUPPRESS,
-                      help='Show this help message and exit.')
+                      help='Show this help message and exit.', core=core)
     args.add_argument('-i', '--paths_to_input', action='append', nargs='+', type=str, required=False,
                       help='Optional. '
                            'Path to a folder with images and/or binaries or to specific image or binary file.'

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
@@ -752,8 +752,11 @@ def get_network_batch_size(inputs_info):
     return batch_size
 
 
-def show_available_devices():
-    print("\nAvailable target devices:  ", ("  ".join(Core().available_devices)))
+def show_available_devices(core):
+    if core is None:
+        core = Core()
+
+    print("\nAvailable target devices:  ", ("  ".join(core.available_devices)))
 
 
 def device_properties_to_string(config):


### PR DESCRIPTION
### Details:
 - Enables the ability to print out all devices in the benchmark tool utilities by optionally injecting an instance of `Core` if using a custom device plugin XML.

Current usage:
```py
from openvino.tools.benchmark.parameters import parse_args
...
args, parser = parse_args()
...
```
```sh
> python script.py -h
...
Available target devices:    CPU  GNA
```

Example usage after change:
```py
from openvino.tools.benchmark.parameters import parse_args
...
args, parser = parse_args(Core(path_to_plugins_xml_file))
...
```
```sh
> python script.py -h
...
Available target devices:    CPU  GNA  FPGA
```

### Tickets:
 - N/A
