### PR TITLE
[GPU] Fix os_is_yx_osv16_isv4 weights format matching

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -896,7 +896,7 @@ cldnn::format::type from_weights_layout(kernel_selector::weights_layout l) {
         case kernel_selector::weights_layout::g_os_is_zyx_isv16_osv16:
             return cldnn::format::g_os_is_zyx_isv16_osv16;
         case kernel_selector::weights_layout::os_is_yx_osv16_isv4:
-            return cldnn::format::g_os_is_yx_osv16_isv4;
+            return cldnn::format::os_is_yx_osv16_isv4;
         case kernel_selector::weights_layout::os_is_zyx_osv16_isv16:
             return cldnn::format::os_is_zyx_osv16_isv16;
         case kernel_selector::weights_layout::g_os_is_zyx_osv16_isv16:


### PR DESCRIPTION
### Details:
 - This PR fixes fully_connected_gpu_imad (and all other kernels which use this format) accuracy issue caused by incorrect formats matching

### Tickets:
 - 121175
