### PR TITLE
[apiConformance] Move creation core in each test to one core

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -208,10 +208,9 @@ INSTANTIATE_TEST_SUITE_P(smoke_OVClassSetDevicePriorityConfigPropsTest,
 //
 using OVGetMetricPropsTest_GPU_DEVICE_TOTAL_MEM_SIZE = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_DEVICE_TOTAL_MEM_SIZE, GetMetricAndPrintNoThrow) {
-    ov::Core ie;
     ov::Any p;
 
-    ASSERT_NO_THROW(p = ie.get_property(target_device, GPU_METRIC_KEY(DEVICE_TOTAL_MEM_SIZE)));
+    ASSERT_NO_THROW(p = core->get_property(target_device, GPU_METRIC_KEY(DEVICE_TOTAL_MEM_SIZE)));
     auto t = p.as<uint64_t>();
 
     std::cout << "GPU device total memory size: " << t << std::endl;
@@ -225,10 +224,9 @@ INSTANTIATE_TEST_SUITE_P(nightly_OVGetMetricPropsTest,
 
 using OVGetMetricPropsTest_GPU_UARCH_VERSION = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_UARCH_VERSION, GetMetricAndPrintNoThrow) {
-    ov::Core ie;
     ov::Any p;
 
-    ASSERT_NO_THROW(p = ie.get_property(target_device, GPU_METRIC_KEY(UARCH_VERSION)));
+    ASSERT_NO_THROW(p = core->get_property(target_device, GPU_METRIC_KEY(UARCH_VERSION)));
     auto t = p.as<std::string>();
 
     std::cout << "GPU device uarch: " << t << std::endl;
@@ -241,10 +239,9 @@ INSTANTIATE_TEST_SUITE_P(nightly_OVGetMetricPropsTest,
 
 using OVGetMetricPropsTest_GPU_EXECUTION_UNITS_COUNT = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_EXECUTION_UNITS_COUNT, GetMetricAndPrintNoThrow) {
-    ov::Core ie;
     ov::Any p;
 
-    ASSERT_NO_THROW(p = ie.get_property(target_device, GPU_METRIC_KEY(EXECUTION_UNITS_COUNT)));
+    ASSERT_NO_THROW(p = core->get_property(target_device, GPU_METRIC_KEY(EXECUTION_UNITS_COUNT)));
     auto t = p.as<int>();
 
     std::cout << "GPU EUs count: " << t << std::endl;
@@ -258,10 +255,8 @@ INSTANTIATE_TEST_SUITE_P(nightly_OVGetMetricPropsTest,
 
 using OVClassGetPropertyTest_GPU = OVClassBaseTestP;
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricAvailableDevicesAndPrintNoThrow) {
-    ov::Core ie;
-
     std::vector<std::string> properties;
-    ASSERT_NO_THROW(properties = ie.get_property(target_device, ov::available_devices));
+    ASSERT_NO_THROW(properties = core->get_property(target_device, ov::available_devices));
 
     std::cout << "AVAILABLE_DEVICES: ";
     for (const auto& prop : properties) {
@@ -273,10 +268,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricAvailableDevicesAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricRangeForAsyncInferRequestsAndPrintNoThrow) {
-    ov::Core ie;
-
     std::tuple<unsigned int, unsigned int, unsigned int> property;
-    ASSERT_NO_THROW(property = ie.get_property(target_device, ov::range_for_async_infer_requests));
+    ASSERT_NO_THROW(property = core->get_property(target_device, ov::range_for_async_infer_requests));
 
     std::cout << "RANGE_FOR_ASYNC_INFER_REQUESTS: " << std::get<0>(property) << " " << std::get<1>(property) << " "
               << std::get<2>(property) << std::endl;
@@ -285,10 +278,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricRangeForAsyncInferRequestsAndPrintNo
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricRangeForStreamsAndPrintNoThrow) {
-    ov::Core ie;
-
     std::tuple<unsigned int, unsigned int> property;
-    ASSERT_NO_THROW(property = ie.get_property(target_device, ov::range_for_streams));
+    ASSERT_NO_THROW(property = core->get_property(target_device, ov::range_for_streams));
 
     std::cout << "RANGE_FOR_STREAMS: " << std::get<0>(property) << " " << std::get<1>(property) << std::endl;
 
@@ -296,10 +287,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricRangeForStreamsAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricOptimalBatchSizeAndPrintNoThrow) {
-    ov::Core ie;
-
     unsigned int property = 0;
-    ASSERT_NO_THROW(property = ie.get_property(target_device, ov::optimal_batch_size));
+    ASSERT_NO_THROW(property = core->get_property(target_device, ov::optimal_batch_size));
 
     std::cout << "OPTIMAL_BATCH_SIZE: " << property << std::endl;
 
@@ -307,10 +296,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricOptimalBatchSizeAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricFullNameAndPrintNoThrow) {
-    ov::Core ie;
-
     std::string property;
-    ASSERT_NO_THROW(property = ie.get_property(target_device, ov::device::full_name));
+    ASSERT_NO_THROW(property = core->get_property(target_device, ov::device::full_name));
 
     std::cout << "FULL_DEVICE_NAME: " << property << std::endl;
 
@@ -318,10 +305,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricFullNameAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricTypeAndPrintNoThrow) {
-    ov::Core ie;
-
     ov::device::Type property = ov::device::Type::INTEGRATED;
-    ASSERT_NO_THROW(property = ie.get_property(target_device, ov::device::type));
+    ASSERT_NO_THROW(property = core->get_property(target_device, ov::device::type));
 
     std::cout << "DEVICE_TYPE: " << property << std::endl;
 
@@ -329,10 +314,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricTypeAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricGopsAndPrintNoThrow) {
-    ov::Core ie;
-
     std::map<ov::element::Type, float> properties;
-    ASSERT_NO_THROW(properties = ie.get_property(target_device, ov::device::gops));
+    ASSERT_NO_THROW(properties = core->get_property(target_device, ov::device::gops));
 
     std::cout << "DEVICE_GOPS: " << std::endl;
     for (const auto& prop : properties) {
@@ -343,10 +326,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricGopsAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricCapabilitiesAndPrintNoThrow) {
-    ov::Core ie;
-
     std::vector<std::string> properties;
-    ASSERT_NO_THROW(properties = ie.get_property(target_device, ov::device::capabilities));
+    ASSERT_NO_THROW(properties = core->get_property(target_device, ov::device::capabilities));
 
     std::cout << "OPTIMIZATION_CAPABILITIES: " << std::endl;
     for (const auto& prop : properties) {
@@ -357,10 +338,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricCapabilitiesAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricDeviceTotalMemSizeAndPrintNoThrow) {
-    ov::Core ie;
-
     uint64_t property = 0;
-    ASSERT_NO_THROW(property = ie.get_property(target_device, ov::intel_gpu::device_total_mem_size));
+    ASSERT_NO_THROW(property = core->get_property(target_device, ov::intel_gpu::device_total_mem_size));
 
     std::cout << "GPU_DEVICE_TOTAL_MEM_SIZE: " << property << std::endl;
 
@@ -368,10 +347,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricDeviceTotalMemSizeAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricUarchVersionAndPrintNoThrow) {
-    ov::Core ie;
-
     std::string property;
-    ASSERT_NO_THROW(property = ie.get_property(target_device, ov::intel_gpu::uarch_version));
+    ASSERT_NO_THROW(property = core->get_property(target_device, ov::intel_gpu::uarch_version));
 
     std::cout << "GPU_UARCH_VERSION: " << property << std::endl;
 
@@ -379,10 +356,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricUarchVersionAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricExecutionUnitsCountAndPrintNoThrow) {
-    ov::Core ie;
-
     int32_t property = 0;
-    ASSERT_NO_THROW(property = ie.get_property(target_device, ov::intel_gpu::execution_units_count));
+    ASSERT_NO_THROW(property = core->get_property(target_device, ov::intel_gpu::execution_units_count));
 
     std::cout << "GPU_EXECUTION_UNITS_COUNT: " << property << std::endl;
 
@@ -390,10 +365,8 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricExecutionUnitsCountAndPrintNoThrow) 
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetMetricMemoryStatisticsAndPrintNoThrow) {
-    ov::Core ie;
-
     std::map<std::string, uint64_t> properties;
-    ASSERT_NO_THROW(properties = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+    ASSERT_NO_THROW(properties = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
     std::cout << "GPU_MEMORY_STATISTICS: " << std::endl;
     for (const auto& prop : properties) {
@@ -404,137 +377,124 @@ TEST_P(OVClassGetPropertyTest_GPU, GetMetricMemoryStatisticsAndPrintNoThrow) {
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetAndSetPerformanceModeNoThrow) {
-    ov::Core ie;
-
     ov::hint::PerformanceMode defaultMode{};
-    ASSERT_NO_THROW(defaultMode = ie.get_property(target_device, ov::hint::performance_mode));
+    ASSERT_NO_THROW(defaultMode = core->get_property(target_device, ov::hint::performance_mode));
 
     std::cout << "Default PERFORMANCE_HINT: \"" << defaultMode << "\"" << std::endl;
 
-    ie.set_property(target_device, ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY));
-    ASSERT_EQ(ov::hint::PerformanceMode::LATENCY, ie.get_property(target_device, ov::hint::performance_mode));
-    ie.set_property(target_device, ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT));
-    ASSERT_EQ(ov::hint::PerformanceMode::THROUGHPUT, ie.get_property(target_device, ov::hint::performance_mode));
+    core->set_property(target_device, ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY));
+    ASSERT_EQ(ov::hint::PerformanceMode::LATENCY, core->get_property(target_device, ov::hint::performance_mode));
+    core->set_property(target_device, ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT));
+    ASSERT_EQ(ov::hint::PerformanceMode::THROUGHPUT, core->get_property(target_device, ov::hint::performance_mode));
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::hint::performance_mode);
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetAndSetEnableProfilingNoThrow) {
-    ov::Core ie;
-
     bool defaultValue = false;
-    ASSERT_NO_THROW(defaultValue = ie.get_property(target_device, ov::enable_profiling));
+    ASSERT_NO_THROW(defaultValue = core->get_property(target_device, ov::enable_profiling));
 
     std::cout << "Default PERF_COUNT: " << defaultValue << std::endl;
 
-    ie.set_property(target_device, ov::enable_profiling(true));
-    ASSERT_EQ(true, ie.get_property(target_device, ov::enable_profiling));
+    core->set_property(target_device, ov::enable_profiling(true));
+    ASSERT_EQ(true, core->get_property(target_device, ov::enable_profiling));
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::enable_profiling);
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetAndSetInferencePrecisionNoThrow) {
-    ov::Core ie;
     auto value = ov::element::undefined;
     const auto expected_default_precision = ov::element::f16;
 
-    OV_ASSERT_NO_THROW(value = ie.get_property(target_device, ov::hint::inference_precision));
+    OV_ASSERT_NO_THROW(value = core->get_property(target_device, ov::hint::inference_precision));
     ASSERT_EQ(expected_default_precision, value);
 
     const auto forced_precision = ov::element::f32;
 
-    OV_ASSERT_NO_THROW(ie.set_property(target_device, ov::hint::inference_precision(forced_precision)));
-    OV_ASSERT_NO_THROW(value = ie.get_property(target_device, ov::hint::inference_precision));
+    OV_ASSERT_NO_THROW(core->set_property(target_device, ov::hint::inference_precision(forced_precision)));
+    OV_ASSERT_NO_THROW(value = core->get_property(target_device, ov::hint::inference_precision));
     ASSERT_EQ(value, forced_precision);
 
     OPENVINO_SUPPRESS_DEPRECATED_START
     const auto forced_precision_deprecated = ov::element::f16;
-    OV_ASSERT_NO_THROW(ie.set_property(target_device, ov::hint::inference_precision(forced_precision_deprecated)));
-    OV_ASSERT_NO_THROW(value = ie.get_property(target_device, ov::hint::inference_precision));
+    OV_ASSERT_NO_THROW(core->set_property(target_device, ov::hint::inference_precision(forced_precision_deprecated)));
+    OV_ASSERT_NO_THROW(value = core->get_property(target_device, ov::hint::inference_precision));
     ASSERT_EQ(value, forced_precision_deprecated);
     OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetAndSetModelPriorityNoThrow) {
-    ov::Core ie;
-
     ov::hint::Priority defaultValue{};
-    ASSERT_NO_THROW(defaultValue = ie.get_property(target_device, ov::hint::model_priority));
+    ASSERT_NO_THROW(defaultValue = core->get_property(target_device, ov::hint::model_priority));
 
     std::cout << "Default model_priority: " << defaultValue << std::endl;
 
-    ie.set_property(target_device, ov::hint::model_priority(ov::hint::Priority::HIGH));
-    ASSERT_EQ(ov::hint::Priority::HIGH, ie.get_property(target_device, ov::hint::model_priority));
-    ASSERT_EQ(ov::hint::Priority::MEDIUM, ie.get_property(target_device, ov::intel_gpu::hint::queue_priority));
-    ie.set_property(target_device, ov::hint::model_priority(ov::hint::Priority::LOW));
-    ASSERT_EQ(ov::hint::Priority::LOW, ie.get_property(target_device, ov::hint::model_priority));
-    ASSERT_EQ(ov::hint::Priority::MEDIUM, ie.get_property(target_device, ov::intel_gpu::hint::queue_priority));
-    ie.set_property(target_device, ov::hint::model_priority(ov::hint::Priority::MEDIUM));
-    ASSERT_EQ(ov::hint::Priority::MEDIUM, ie.get_property(target_device, ov::hint::model_priority));
-    ASSERT_EQ(ov::hint::Priority::MEDIUM, ie.get_property(target_device, ov::intel_gpu::hint::queue_priority));
-    ie.set_property(target_device, ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH));
-    ASSERT_EQ(ov::hint::Priority::HIGH, ie.get_property(target_device, ov::intel_gpu::hint::queue_priority));
+    core->set_property(target_device, ov::hint::model_priority(ov::hint::Priority::HIGH));
+    ASSERT_EQ(ov::hint::Priority::HIGH, core->get_property(target_device, ov::hint::model_priority));
+    ASSERT_EQ(ov::hint::Priority::MEDIUM, core->get_property(target_device, ov::intel_gpu::hint::queue_priority));
+    core->set_property(target_device, ov::hint::model_priority(ov::hint::Priority::LOW));
+    ASSERT_EQ(ov::hint::Priority::LOW, core->get_property(target_device, ov::hint::model_priority));
+    ASSERT_EQ(ov::hint::Priority::MEDIUM, core->get_property(target_device, ov::intel_gpu::hint::queue_priority));
+    core->set_property(target_device, ov::hint::model_priority(ov::hint::Priority::MEDIUM));
+    ASSERT_EQ(ov::hint::Priority::MEDIUM, core->get_property(target_device, ov::hint::model_priority));
+    ASSERT_EQ(ov::hint::Priority::MEDIUM, core->get_property(target_device, ov::intel_gpu::hint::queue_priority));
+    core->set_property(target_device, ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH));
+    ASSERT_EQ(ov::hint::Priority::HIGH, core->get_property(target_device, ov::intel_gpu::hint::queue_priority));
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::hint::model_priority);
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetAndSetQueuePriorityNoThrow) {
-    ov::Core ie;
-
     ov::hint::Priority defaultValue{};
-    ASSERT_NO_THROW(defaultValue = ie.get_property(target_device, ov::intel_gpu::hint::queue_priority));
+    ASSERT_NO_THROW(defaultValue = core->get_property(target_device, ov::intel_gpu::hint::queue_priority));
 
     std::cout << "Default GPU_QUEUE_PRIORITY: " << defaultValue << std::endl;
 
-    ie.set_property(target_device, ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH));
-    ASSERT_EQ(ov::hint::Priority::HIGH, ie.get_property(target_device, ov::intel_gpu::hint::queue_priority));
-    ie.set_property(target_device, ov::intel_gpu::hint::queue_priority(ov::hint::Priority::LOW));
-    ASSERT_EQ(ov::hint::Priority::LOW, ie.get_property(target_device, ov::intel_gpu::hint::queue_priority));
-    ie.set_property(target_device, ov::intel_gpu::hint::queue_priority(ov::hint::Priority::MEDIUM));
-    ASSERT_EQ(ov::hint::Priority::MEDIUM, ie.get_property(target_device, ov::intel_gpu::hint::queue_priority));
+    core->set_property(target_device, ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH));
+    ASSERT_EQ(ov::hint::Priority::HIGH, core->get_property(target_device, ov::intel_gpu::hint::queue_priority));
+    core->set_property(target_device, ov::intel_gpu::hint::queue_priority(ov::hint::Priority::LOW));
+    ASSERT_EQ(ov::hint::Priority::LOW, core->get_property(target_device, ov::intel_gpu::hint::queue_priority));
+    core->set_property(target_device, ov::intel_gpu::hint::queue_priority(ov::hint::Priority::MEDIUM));
+    ASSERT_EQ(ov::hint::Priority::MEDIUM, core->get_property(target_device, ov::intel_gpu::hint::queue_priority));
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::intel_gpu::hint::queue_priority);
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, GetAndSetThrottleLevelNoThrow) {
-    ov::Core ie;
-
     ov::intel_gpu::hint::ThrottleLevel defaultValue{};
-    ASSERT_NO_THROW(defaultValue = ie.get_property(target_device, ov::intel_gpu::hint::queue_throttle));
+    ASSERT_NO_THROW(defaultValue = core->get_property(target_device, ov::intel_gpu::hint::queue_throttle));
 
     std::cout << "Default GPU_QUEUE_THROTTLE: " << defaultValue << std::endl;
 
-    ie.set_property(target_device, ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::HIGH));
+    core->set_property(target_device, ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::HIGH));
     ASSERT_EQ(ov::intel_gpu::hint::ThrottleLevel::HIGH,
-              ie.get_property(target_device, ov::intel_gpu::hint::queue_throttle));
-    ie.set_property(target_device, ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW));
+              core->get_property(target_device, ov::intel_gpu::hint::queue_throttle));
+    core->set_property(target_device, ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW));
     ASSERT_EQ(ov::intel_gpu::hint::ThrottleLevel::LOW,
-              ie.get_property(target_device, ov::intel_gpu::hint::queue_throttle));
-    ie.set_property(target_device, ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::MEDIUM));
+              core->get_property(target_device, ov::intel_gpu::hint::queue_throttle));
+    core->set_property(target_device, ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::MEDIUM));
     ASSERT_EQ(ov::intel_gpu::hint::ThrottleLevel::MEDIUM,
-              ie.get_property(target_device, ov::intel_gpu::hint::queue_throttle));
+              core->get_property(target_device, ov::intel_gpu::hint::queue_throttle));
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::intel_gpu::hint::queue_throttle);
 }
 
 TEST_P(OVClassGetPropertyTest_GPU, CanSetDefaultValueBackToPluginNewAPI) {
-    ov::Core ie;
-
     std::vector<ov::PropertyName> properties;
-    ASSERT_NO_THROW(properties = ie.get_property(target_device, ov::supported_properties));
+    ASSERT_NO_THROW(properties = core->get_property(target_device, ov::supported_properties));
 
     std::cout << "SUPPORTED_PROPERTIES:" << std::endl;
     for (const auto& property : properties) {
         ov::Any prop;
         if (property.is_mutable()) {
             std::cout << "RW: " << property << " ";
-            ASSERT_NO_THROW(prop = ie.get_property(target_device, property));
+            ASSERT_NO_THROW(prop = core->get_property(target_device, property));
             prop.print(std::cout);
             std::cout << std::endl;
-            ASSERT_NO_THROW(ie.set_property(target_device, {{property, prop}}));
+            ASSERT_NO_THROW(core->set_property(target_device, {{property, prop}}));
         } else {
             std::cout << "RO: " << property << " ";
-            ASSERT_NO_THROW(prop = ie.get_property(target_device, property));
+            ASSERT_NO_THROW(prop = core->get_property(target_device, property));
             prop.print(std::cout);
             std::cout << std::endl;
         }
@@ -548,11 +508,10 @@ INSTANTIATE_TEST_SUITE_P(nightly_OVGetMetricPropsTest, OVClassGetPropertyTest_GP
 using OVGetMetricPropsTest_GPU_OPTIMAL_BATCH_SIZE = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_OPTIMAL_BATCH_SIZE, GetMetricAndPrintNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    ov::Core ie;
     unsigned int p = 0;
 
     ov::AnyMap _options = {ov::hint::model(simpleNetwork)};
-    ASSERT_NO_THROW(p = ie.get_property(target_device, ov::optimal_batch_size.name(), _options).as<unsigned int>());
+    ASSERT_NO_THROW(p = core->get_property(target_device, ov::optimal_batch_size.name(), _options).as<unsigned int>());
 
     std::cout << "GPU device optimal batch size: " << p << std::endl;
 
@@ -566,11 +525,10 @@ INSTANTIATE_TEST_SUITE_P(nightly_OVClassCompiledModelGetPropertyTest,
 using OVGetMetricPropsTest_GPU_MAX_BATCH_SIZE_DEFAULT = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_MAX_BATCH_SIZE_DEFAULT, GetMetricAndPrintNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    ov::Core ie;
     unsigned int p = 0;
 
     ov::AnyMap _options = {ov::hint::model(simpleNetwork)};
-    ASSERT_NO_THROW(p = ie.get_property(target_device, ov::max_batch_size.name(), _options).as<unsigned int>());
+    ASSERT_NO_THROW(p = core->get_property(target_device, ov::max_batch_size.name(), _options).as<unsigned int>());
 
     std::cout << "GPU device max available batch size: " << p << std::endl;
 
@@ -584,9 +542,8 @@ INSTANTIATE_TEST_SUITE_P(nightly_IEClassExecutableNetworkGetMetricTest,
 using OVGetMetricPropsTest_GPU_MAX_BATCH_SIZE_STREAM_DEVICE_MEM = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_MAX_BATCH_SIZE_STREAM_DEVICE_MEM, GetMetricAndPrintNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    ov::Core ie;
     unsigned int p = 0;
-    auto exec_net1 = ie.compile_model(simpleNetwork, target_device);
+    auto exec_net1 = core->compile_model(simpleNetwork, target_device);
 
     uint32_t n_streams = 2;
     int64_t available_device_mem_size = 1073741824;
@@ -594,7 +551,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MAX_BATCH_SIZE_STREAM_DEVICE_MEM, GetMetricAndPr
                            ov::num_streams(n_streams),
                            ov::intel_gpu::hint::available_device_mem(available_device_mem_size)};
 
-    ASSERT_NO_THROW(p = ie.get_property(target_device, ov::max_batch_size.name(), _options).as<unsigned int>());
+    ASSERT_NO_THROW(p = core->get_property(target_device, ov::max_batch_size.name(), _options).as<unsigned int>());
 
     std::cout << "GPU device max available batch size: " << p << std::endl;
 
@@ -608,12 +565,11 @@ INSTANTIATE_TEST_SUITE_P(nightly_IEClassExecutableNetworkGetMetricTest,
 using OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_DEFAULT = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_DEFAULT, GetMetricAndPrintNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    ov::Core ie;
     std::map<std::string, uint64_t> p;
 
-    auto exec_net = ie.compile_model(simpleNetwork, target_device);
+    auto exec_net = core->compile_model(simpleNetwork, target_device);
 
-    ASSERT_NO_THROW(p = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+    ASSERT_NO_THROW(p = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
     ASSERT_FALSE(p.empty());
     std::cout << "Memory Statistics: " << std::endl;
@@ -632,22 +588,21 @@ INSTANTIATE_TEST_SUITE_P(nightly_IEClassGetMetricTest,
 using OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTIPLE_NETWORKS = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTIPLE_NETWORKS, GetMetricAndPrintNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    ov::Core ie;
     std::map<std::string, uint64_t> t1;
     std::map<std::string, uint64_t> t2;
 
-    auto exec_net1 = ie.compile_model(simpleNetwork, target_device);
+    auto exec_net1 = core->compile_model(simpleNetwork, target_device);
 
-    ASSERT_NO_THROW(t1 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+    ASSERT_NO_THROW(t1 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
     ASSERT_FALSE(t1.empty());
     for (auto&& kv : t1) {
         ASSERT_NE(kv.second, 0);
     }
 
-    auto exec_net2 = ie.compile_model(simpleNetwork, target_device);
+    auto exec_net2 = core->compile_model(simpleNetwork, target_device);
 
-    ASSERT_NO_THROW(t2 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+    ASSERT_NO_THROW(t2 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
     ASSERT_FALSE(t2.empty());
     for (auto&& kv : t2) {
@@ -667,28 +622,27 @@ INSTANTIATE_TEST_SUITE_P(nightly_IEClassGetMetricTest,
 
 using OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrintNoThrow) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    ov::Core ie;
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     std::map<std::string, uint64_t> t1;
 
-    ASSERT_NO_THROW(t1 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+    ASSERT_NO_THROW(t1 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
     ASSERT_TRUE(t1.empty());
 
     {
-        auto exec_net1 = ie.compile_model(simpleNetwork, target_device);
+        auto exec_net1 = core->compile_model(simpleNetwork, target_device);
 
         std::map<std::string, uint64_t> t2;
-        ASSERT_NO_THROW(t2 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+        ASSERT_NO_THROW(t2 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
         ASSERT_FALSE(t2.empty());
         for (auto&& kv : t2) {
             ASSERT_NE(kv.second, 0);
         }
         {
-            auto exec_net2 = ie.compile_model(actualNetwork, target_device);
+            auto exec_net2 = core->compile_model(actualNetwork, target_device);
 
             std::map<std::string, uint64_t> t3;
-            ASSERT_NO_THROW(t3 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+            ASSERT_NO_THROW(t3 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
             ASSERT_FALSE(t3.empty());
             for (auto&& kv : t3) {
@@ -696,7 +650,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrin
             }
         }
         std::map<std::string, uint64_t> t4;
-        ASSERT_NO_THROW(t4 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+        ASSERT_NO_THROW(t4 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
         ASSERT_FALSE(t4.empty());
         for (auto&& kv : t4) {
@@ -710,7 +664,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrin
         }
     }
     std::map<std::string, uint64_t> t5;
-    ASSERT_NO_THROW(t5 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+    ASSERT_NO_THROW(t5 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
     ASSERT_FALSE(t5.empty());
     for (auto&& kv : t5) {
@@ -729,7 +683,6 @@ INSTANTIATE_TEST_SUITE_P(nightly_IEClassGetMetricTest,
 using OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTI_THREADS = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTI_THREADS, GetMetricAndPrintNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    ov::Core ie;
     std::map<std::string, uint64_t> t1;
     std::map<std::string, uint64_t> t2;
 
@@ -741,9 +694,9 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTI_THREADS, GetMetricAndPri
     networks.emplace_back(simpleNetwork);
     networks.emplace_back(simpleNetwork);
 
-    auto exec_net1 = ie.compile_model(simpleNetwork, target_device);
+    auto exec_net1 = core->compile_model(simpleNetwork, target_device);
 
-    ASSERT_NO_THROW(t1 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+    ASSERT_NO_THROW(t1 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
     ASSERT_FALSE(t1.empty());
     for (auto&& kv : t1) {
@@ -753,7 +706,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTI_THREADS, GetMetricAndPri
     for (auto& thread : threads) {
         thread = std::thread([&]() {
             auto value = counter++;
-            exec_net_map[value] = ie.compile_model(networks[value], target_device);
+            exec_net_map[value] = core->compile_model(networks[value], target_device);
         });
     }
 
@@ -763,7 +716,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTI_THREADS, GetMetricAndPri
         }
     }
 
-    ASSERT_NO_THROW(t2 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
+    ASSERT_NO_THROW(t2 = core->get_property(target_device, ov::intel_gpu::memory_statistics));
 
     ASSERT_FALSE(t2.empty());
     for (auto&& kv : t2) {
@@ -783,7 +736,6 @@ INSTANTIATE_TEST_SUITE_P(nightly_IEClassGetMetricTest,
 
 using OVGetMetricPropsTest_CACHING_PROPERTIES = OVClassBaseTestP;
 TEST_P(OVGetMetricPropsTest_CACHING_PROPERTIES, GetMetricAndPrintNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
     std::vector<ov::PropertyName> caching_properties = {};
     const std::vector<ov::PropertyName> expected_properties = {
         ov::device::architecture.name(),
@@ -793,7 +745,7 @@ TEST_P(OVGetMetricPropsTest_CACHING_PROPERTIES, GetMetricAndPrintNoThrow) {
         ov::hint::execution_mode.name(),
     };
 
-    ASSERT_NO_THROW(caching_properties = ie.get_property(target_device, ov::internal::caching_properties));
+    ASSERT_NO_THROW(caching_properties = core->get_property(target_device, ov::internal::caching_properties));
 
     std::cout << "GPU Caching properties: " << std::endl;
     for (auto& prop : caching_properties) {

--- a/src/tests/functional/plugin/shared/include/base/ov_behavior_test_utils.hpp
+++ b/src/tests/functional/plugin/shared/include/base/ov_behavior_test_utils.hpp
@@ -205,6 +205,8 @@ public:
 class OVClassBaseTestP : public OVClassNetworkTest,
                          public ::testing::WithParamInterface<std::string>,
                          public OVPluginTestBase {
+protected:
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
 public:
     void SetUp() override {
         target_device = GetParam();
@@ -219,6 +221,8 @@ using OVClassModelOptionalTestP = OVClassBaseTestP;
 class OVCompiledModelClassBaseTestP : public OVClassNetworkTest,
                                       public ::testing::WithParamInterface<std::string>,
                                       public OVCompiledNetworkTestBase {
+protected:
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
 public:
     void SetUp() override {
         target_device = GetParam();
@@ -234,6 +238,7 @@ protected:
     std::string deviceName;
     ov::AnyMap configuration;
     std::shared_ptr<ngraph::Function> actualNetwork;
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
 
 public:
     void SetUp() override {

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/import_export.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/import_export.hpp
@@ -510,12 +510,11 @@ TEST_P(OVCompiledGraphImportExportTest, ovImportExportedFunction) {
 using OVClassCompiledModelImportExportTestP = OVCompiledModelClassBaseTestP;
 
 TEST_P(OVClassCompiledModelImportExportTestP, smoke_ImportNetworkNoThrowWithDeviceName) {
-    ov::Core ie = createCoreWithTemplate();
     std::stringstream strm;
     ov::CompiledModel executableNetwork;
-    OV_ASSERT_NO_THROW(executableNetwork = ie.compile_model(actualNetwork, target_device));
+    OV_ASSERT_NO_THROW(executableNetwork = core->compile_model(actualNetwork, target_device));
     OV_ASSERT_NO_THROW(executableNetwork.export_model(strm));
-    OV_ASSERT_NO_THROW(executableNetwork = ie.import_model(strm, target_device));
+    OV_ASSERT_NO_THROW(executableNetwork = core->import_model(strm, target_device));
     OV_ASSERT_NO_THROW(executableNetwork.create_infer_request());
 }
 

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/properties.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/properties.hpp
@@ -29,6 +29,11 @@ public:
     std::shared_ptr<Core> core = utils::PluginCache::get().core();
     std::shared_ptr<Model> model;
     AnyMap properties;
+
+    void TearDown() override {
+        utils::PluginCache::get().reset();
+        APIBaseTest::TearDown();
+    }
 };
 
 class OVClassCompiledModelEmptyPropertiesTests : public testing::WithParamInterface<std::string>,
@@ -63,6 +68,7 @@ class OVClassCompiledModelSetCorrectConfigTest :
         public ::testing::WithParamInterface<std::tuple<std::string, std::pair<std::string, std::string>>>,
         public OVCompiledNetworkTestBase {
 protected:
+    std::shared_ptr<Core> core = utils::PluginCache::get().core();
     std::string configKey;
     ov::Any configValue;
 
@@ -98,6 +104,11 @@ public:
     AnyMap compileModelProperties;
 
     std::string expectedDeviceName;
+
+    void TearDown() override {
+        utils::PluginCache::get().reset();
+        APIBaseTest::TearDown();
+    }
 };
 
 using OVClassCompiledModelGetPropertyTest_EXEC_DEVICES = OVCompileModelGetExecutionDeviceTests;
@@ -109,6 +120,7 @@ using PriorityParams = std::tuple<
 class OVClassCompiledModelGetPropertyTest_Priority : public ::testing::WithParamInterface<PriorityParams>,
                                                        public OVCompiledNetworkTestBase {
 protected:
+    std::shared_ptr<Core> core = utils::PluginCache::get().core();
     ov::AnyMap configuration;
     std::shared_ptr<ngraph::Function> simpleNetwork;
 
@@ -119,6 +131,11 @@ public:
         SKIP_IF_CURRENT_TEST_IS_DISABLED();
         APIBaseTest::SetUp();
         simpleNetwork = ngraph::builder::subgraph::makeSingleConv();
+    }
+
+    void TearDown() override {
+        utils::PluginCache::get().reset();
+        APIBaseTest::TearDown();
     }
 };
 

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/properties_hetero.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/properties_hetero.hpp
@@ -25,9 +25,9 @@ class OVClassHeteroCompiledModelGetMetricTest :
         public ::testing::WithParamInterface<std::string>,
         public OVCompiledNetworkTestBase {
 protected:
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
     std::string heteroDeviceName;
     void SetCpuAffinity(ov::Core& core, std::vector<std::string>& expectedTargets);
-
 public:
     void SetUp() override {
         target_device = GetParam();

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/get_metric.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/get_metric.hpp
@@ -34,6 +34,7 @@ using PriorityParams = std::tuple<
 class OVClassExecutableNetworkGetMetricTest_Priority : public ::testing::WithParamInterface<PriorityParams>,
                                                        public OVCompiledNetworkTestBase {
 protected:
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
     ov::AnyMap configuration;
     std::shared_ptr<ngraph::Function> simpleNetwork;
 
@@ -65,6 +66,7 @@ class OVClassExecutableNetworkGetMetricTestForSpecificConfig :
         public ::testing::WithParamInterface<std::tuple<std::string, std::pair<std::string, std::string>>>,
         public OVCompiledNetworkTestBase {
 protected:
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
     std::string configKey;
     ov::Any configValue;
 
@@ -89,6 +91,7 @@ class OVClassHeteroExecutableNetworkGetMetricTest :
         public ::testing::WithParamInterface<std::string>,
         public OVCompiledNetworkTestBase {
 protected:
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
     std::string heteroDeviceName;
     void SetCpuAffinity(ov::Core& core, std::vector<std::string>& expectedTargets);
 

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/properties.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/properties.hpp
@@ -21,6 +21,11 @@ public:
     std::shared_ptr<Core> core = utils::PluginCache::get().core();
     std::shared_ptr<Model> model;
     AnyMap properties;
+
+    void TearDown() override {
+        utils::PluginCache::get().reset();
+        APIBaseTest::TearDown();
+    }
 };
 
 class OVCompiledModelEmptyPropertiesTests : public testing::WithParamInterface<std::string>,

--- a/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/infer_request_dynamic.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/infer_request_dynamic.hpp
@@ -51,7 +51,7 @@ protected:
     void SetUp() override;
     bool checkOutput(const ov::runtime::Tensor& in, const ov::runtime::Tensor& actual);
 
-    std::shared_ptr<ov::Core> ie = utils::PluginCache::get().core();
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
     std::shared_ptr<Model> function;
     ov::AnyMap configuration;
     std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>> inOutShapes;

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/core_integration_sw.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/core_integration_sw.hpp
@@ -13,6 +13,8 @@ namespace behavior {
 class OVClassSeveralDevicesTests : public OVPluginTestBase,
                                    public OVClassNetworkTest,
                                    public ::testing::WithParamInterface<std::vector<std::string>> {
+protected:
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
 public:
     std::vector<std::string> target_devices;
 
@@ -31,19 +33,16 @@ using OVClassCompileModelWithCondidateDeviceListContainedMetaPluginTest = OVClas
 
 TEST_P(OVClassCompileModelWithCondidateDeviceListContainedMetaPluginTest,
        CompileModelRepeatedlyWithMetaPluginTestThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    ASSERT_THROW(ie.compile_model(actualNetwork, target_device, configuration), ov::Exception);
+    ASSERT_THROW(core->compile_model(actualNetwork, target_device, configuration), ov::Exception);
 }
 
 TEST_P(OVClassSeveralDevicesTestCompileModel, CompileModelActualSeveralDevicesNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
     std::string clear_target_device;
     auto pos = target_devices.begin()->find('.');
     if (pos != std::string::npos) {
         clear_target_device = target_devices.begin()->substr(0, pos);
     }
-    auto deviceIDs = ie.get_property(clear_target_device, ov::available_devices);
+    auto deviceIDs = core->get_property(clear_target_device, ov::available_devices);
     if (deviceIDs.size() < target_devices.size())
         GTEST_FAIL() << "Incorrect DeviceID" << std::endl;
 
@@ -54,30 +53,26 @@ TEST_P(OVClassSeveralDevicesTestCompileModel, CompileModelActualSeveralDevicesNo
             multitarget_device += ",";
         }
     }
-    OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork, multitarget_device));
+    OV_ASSERT_NO_THROW(core->compile_model(actualNetwork, multitarget_device));
 }
 
 TEST_P(OVClassModelOptionalTestP, CompileModelActualHeteroDeviceUsingDevicePropertiesNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork,
+    OV_ASSERT_NO_THROW(core->compile_model(actualNetwork,
                                         ov::test::utils::DEVICE_HETERO,
                                         ov::device::priorities(target_device),
                                         ov::device::properties(target_device, ov::enable_profiling(true))));
 }
 
 TEST_P(OVClassModelOptionalTestP, CompileModelActualHeteroDeviceNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork, ov::test::utils::DEVICE_HETERO + std::string(":") + target_device));
+    OV_ASSERT_NO_THROW(core->compile_model(actualNetwork, ov::test::utils::DEVICE_HETERO + std::string(":") + target_device));
 }
 
 TEST_P(OVClassModelOptionalTestP, CompileModelActualHeteroDevice2NoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork, ov::test::utils::DEVICE_HETERO, ov::device::priorities(target_device)));
+    OV_ASSERT_NO_THROW(core->compile_model(actualNetwork, ov::test::utils::DEVICE_HETERO, ov::device::priorities(target_device)));
 }
 
 TEST_P(OVClassModelOptionalTestP, CompileModelCreateDefaultExecGraphResult) {
-    auto ie = createCoreWithTemplate();
-    auto net = ie.compile_model(actualNetwork, target_device);
+    auto net = core->compile_model(actualNetwork, target_device);
     auto runtime_function = net.get_runtime_model();
     ASSERT_NE(nullptr, runtime_function);
     auto actual_parameters = runtime_function->get_parameters();
@@ -105,14 +100,12 @@ TEST_P(OVClassModelOptionalTestP, CompileModelCreateDefaultExecGraphResult) {
 }
 
 TEST_P(OVClassSeveralDevicesTestQueryModel, QueryModelActualSeveralDevicesNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
     std::string clear_target_device;
     auto pos = target_devices.begin()->find('.');
     if (pos != std::string::npos) {
         clear_target_device = target_devices.begin()->substr(0, pos);
     }
-    auto deviceIDs = ie.get_property(clear_target_device, ov::available_devices);
+    auto deviceIDs = core->get_property(clear_target_device, ov::available_devices);
     ASSERT_LT(deviceIDs.size(), target_devices.size());
 
     std::string multi_target_device = ov::test::utils::DEVICE_MULTI + std::string(":");
@@ -122,7 +115,7 @@ TEST_P(OVClassSeveralDevicesTestQueryModel, QueryModelActualSeveralDevicesNoThro
             multi_target_device += ",";
         }
     }
-    OV_ASSERT_NO_THROW(ie.query_model(actualNetwork, multi_target_device));
+    OV_ASSERT_NO_THROW(core->query_model(actualNetwork, multi_target_device));
 }
 
 TEST(OVClassBasicPropsTest, smoke_SetConfigHeteroThrows) {
@@ -178,8 +171,7 @@ TEST(OVClassBasicPropsTest, smoke_GetMetricSupportedMetricsHeteroNoThrow) {
 }
 
 TEST_P(OVClassModelOptionalTestP, getVersionsNonEmpty) {
-    ov::Core core = createCoreWithTemplate();
-    ASSERT_EQ(2, core.get_versions(ov::test::utils::DEVICE_HETERO + std::string(":") + target_device).size());
+    ASSERT_EQ(2, core->get_versions(ov::test::utils::DEVICE_HETERO + std::string(":") + target_device).size());
 }
 
 }  // namespace behavior

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/properties_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/properties_tests.hpp
@@ -17,7 +17,7 @@ namespace behavior {
 
 #define OV_ASSERT_PROPERTY_SUPPORTED(property_key)                                  \
     {                                                                               \
-        auto properties = ie.get_property(target_device, ov::supported_properties); \
+        auto properties = core->get_property(target_device, ov::supported_properties); \
         auto it = std::find(properties.begin(), properties.end(), property_key);    \
         ASSERT_NE(properties.end(), it);                                            \
     }
@@ -27,6 +27,11 @@ public:
     std::shared_ptr<Core> core = utils::PluginCache::get().core();
     std::shared_ptr<Model> model;
     AnyMap properties;
+
+    void TearDown() override {
+        utils::PluginCache::get().reset();
+        APIBaseTest::TearDown();
+    }
 };
 
 using PropertiesParams = std::tuple<std::string, AnyMap>;
@@ -86,6 +91,7 @@ using OVCheckMetricsPropsTests_ModelDependceProps = OVPropertiesTestsWithCompile
 class OVClassSetDefaultDeviceIDPropTest : public OVPluginTestBase,
                                           public ::testing::WithParamInterface<std::pair<std::string, std::string>> {
 protected:
+    std::shared_ptr<Core> core = utils::PluginCache::get().core();
     std::string deviceName;
     std::string deviceID;
 
@@ -116,6 +122,7 @@ using OVSpecificDeviceTestSetConfig = OVClassBaseTestP;
 class OVBasicPropertiesTestsP : public OVPluginTestBase,
                                public ::testing::WithParamInterface<std::pair<std::string, std::string>> {
 protected:
+    std::shared_ptr<Core> core = utils::PluginCache::get().core();
     std::string deviceName;
     std::string pluginName;
 public:
@@ -127,6 +134,11 @@ public:
         if (pluginName == (std::string("openvino_template_plugin") + IE_BUILD_POSTFIX)) {
             pluginName = ov::util::make_plugin_library_name(ov::test::utils::getExecutableDirectory(), pluginName);
         }
+    }
+
+    void TearDown() override {
+        utils::PluginCache::get().reset();
+        APIBaseTest::TearDown();
     }
 };
 

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/query_model.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/query_model.hpp
@@ -23,14 +23,11 @@ namespace behavior {
 using OVClassQueryModelTest = OVClassBaseTestP;
 
 TEST_P(OVClassModelTestP, QueryModelActualNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    ie.query_model(actualNetwork, target_device);
+    core->query_model(actualNetwork, target_device);
 }
 
 TEST_P(OVClassModelTestP, QueryModelWithKSO) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto rl_map = ie.query_model(ksoNetwork, target_device);
+    auto rl_map = core->query_model(ksoNetwork, target_device);
     auto func = ksoNetwork;
     for (const auto& op : func->get_ops()) {
         if (!rl_map.count(op->get_friendly_name())) {
@@ -40,8 +37,6 @@ TEST_P(OVClassModelTestP, QueryModelWithKSO) {
 }
 
 TEST_P(OVClassQueryModelTest, QueryModelWithMatMul) {
-    ov::Core ie = createCoreWithTemplate();
-
     std::shared_ptr<ov::Model> func;
     {
         ov::PartialShape shape({1, 84});
@@ -67,7 +62,7 @@ TEST_P(OVClassQueryModelTest, QueryModelWithMatMul) {
         func = std::make_shared<ov::Model>(results, params);
     }
 
-    auto rl_map = ie.query_model(func, target_device);
+    auto rl_map = core->query_model(func, target_device);
     for (const auto& op : func->get_ops()) {
         if (!rl_map.count(op->get_friendly_name())) {
             FAIL() << "Op " << op->get_friendly_name() << " is not supported by " << target_device;
@@ -76,24 +71,20 @@ TEST_P(OVClassQueryModelTest, QueryModelWithMatMul) {
 }
 
 TEST_P(OVClassQueryModelTest, QueryModelHETEROWithDeviceIDNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto deviceIDs = ie.get_property(target_device, ov::available_devices);
+    auto deviceIDs = core->get_property(target_device, ov::available_devices);
     if (deviceIDs.empty())
         GTEST_FAIL();
-    OV_ASSERT_NO_THROW(ie.query_model(actualNetwork,
+    OV_ASSERT_NO_THROW(core->query_model(actualNetwork,
                                       ov::test::utils::DEVICE_HETERO,
                                       ov::device::priorities(target_device + "." + deviceIDs[0], target_device)));
 }
 
 TEST_P(OVClassQueryModelTest, QueryModelWithBigDeviceIDThrows) {
-    ov::Core ie = createCoreWithTemplate();
-    ASSERT_THROW(ie.query_model(actualNetwork, target_device + ".110"), ov::Exception);
+    ASSERT_THROW(core->query_model(actualNetwork, target_device + ".110"), ov::Exception);
 }
 
 TEST_P(OVClassQueryModelTest, QueryModelWithInvalidDeviceIDThrows) {
-    ov::Core ie = createCoreWithTemplate();
-    ASSERT_THROW(ie.query_model(actualNetwork, target_device + ".l0"), ov::Exception);
+    ASSERT_THROW(core->query_model(actualNetwork, target_device + ".l0"), ov::Exception);
 }
 
 }  // namespace behavior

--- a/src/tests/functional/plugin/shared/src/behavior/compiled_model/properties.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/compiled_model/properties.cpp
@@ -115,8 +115,7 @@ TEST_P(OVClassCompiledModelPropertiesIncorrectTests, CanNotCompileModelWithIncor
 }
 
 TEST_P(OVCompiledModelIncorrectDevice, CanNotCompileModelWithIncorrectDeviceID) {
-    ov::Core ie = createCoreWithTemplate();
-    ASSERT_THROW(ie.compile_model(actualNetwork, target_device + ".10"), ov::Exception);
+    ASSERT_THROW(core->compile_model(actualNetwork, target_device + ".10"), ov::Exception);
 }
 
 TEST_P(OVCompiledModelPropertiesDefaultSupportedTests, CanCompileWithDefaultValueFromPlugin) {
@@ -171,9 +170,7 @@ std::string OVClassCompiledModelGetPropertyTest_Priority::getTestCaseName(testin
 
 // get property
 TEST_P(OVClassCompiledModelGetConfigTest, GetConfigNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::vector<ov::PropertyName> property_names;
     OV_ASSERT_NO_THROW(property_names = compiled_model.get_property(ov::supported_properties));
@@ -186,12 +183,10 @@ TEST_P(OVClassCompiledModelGetConfigTest, GetConfigNoThrow) {
 }
 
 TEST_P(OVClassCompiledModelGetConfigTest, GetConfigFromCoreAndFromCompiledModel) {
-    ov::Core ie = createCoreWithTemplate();
-
     std::vector<ov::PropertyName> dev_property_names;
-    OV_ASSERT_NO_THROW(dev_property_names = ie.get_property(target_device, ov::supported_properties));
+    OV_ASSERT_NO_THROW(dev_property_names = core->get_property(target_device, ov::supported_properties));
 
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::vector<ov::PropertyName> model_property_names;
     OV_ASSERT_NO_THROW(model_property_names = compiled_model.get_property(ov::supported_properties));
@@ -199,9 +194,7 @@ TEST_P(OVClassCompiledModelGetConfigTest, GetConfigFromCoreAndFromCompiledModel)
 
 // readonly
 TEST_P(OVClassCompiledModelGetPropertyTest, GetMetricNoThrow_SUPPORTED_CONFIG_KEYS) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::vector<ov::PropertyName> supported_properties;
     OV_ASSERT_NO_THROW(supported_properties = compiled_model.get_property(ov::supported_properties));
@@ -230,9 +223,7 @@ TEST_P(OVClassCompiledModelGetPropertyTest, GetMetricNoThrow_SUPPORTED_CONFIG_KE
 }
 
 TEST_P(OVClassCompiledModelGetPropertyTest, GetMetricNoThrow_NETWORK_NAME) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::string model_name;
     OV_ASSERT_NO_THROW(model_name = compiled_model.get_property(ov::model_name));
@@ -243,9 +234,7 @@ TEST_P(OVClassCompiledModelGetPropertyTest, GetMetricNoThrow_NETWORK_NAME) {
 }
 
 TEST_P(OVClassCompiledModelGetPropertyTest, GetMetricNoThrow_OPTIMAL_NUMBER_OF_INFER_REQUESTS) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     unsigned int value = 0;
     OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::optimal_number_of_infer_requests));
@@ -256,17 +245,14 @@ TEST_P(OVClassCompiledModelGetPropertyTest, GetMetricNoThrow_OPTIMAL_NUMBER_OF_I
 }
 
 TEST_P(OVClassCompiledModelGetIncorrectPropertyTest, GetConfigThrows) {
-    ov::Core ie = createCoreWithTemplate();
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
     ASSERT_THROW(compiled_model.get_property("unsupported_property"), ov::Exception);
 }
 
 // set property
 TEST_P(OVClassCompiledModelSetCorrectConfigTest, canSetConfig) {
-    ov::Core ie = createCoreWithTemplate();
     ov::Any param;
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
     OV_ASSERT_NO_THROW(compiled_model.set_property({{configKey, configValue}}));
     OV_ASSERT_NO_THROW(param = compiled_model.get_property(configKey));
     EXPECT_FALSE(param.empty());
@@ -274,9 +260,7 @@ TEST_P(OVClassCompiledModelSetCorrectConfigTest, canSetConfig) {
 }
 
 TEST_P(OVClassCompiledModelSetIncorrectConfigTest, canNotSetConfigToCompiledModelWithIncorrectConfig) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
     std::map<std::string, std::string> incorrectConfig = {{"abc", "def"}};
     std::map<std::string, ov::Any> config;
     for (const auto& confItem : incorrectConfig) {
@@ -287,8 +271,7 @@ TEST_P(OVClassCompiledModelSetIncorrectConfigTest, canNotSetConfigToCompiledMode
 
 // writeble
 TEST_P(OVClassCompiledModelGetPropertyTest_MODEL_PRIORITY, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device, configuration);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device, configuration);
 
     ov::hint::Priority value;
     OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::hint::model_priority));
@@ -296,8 +279,7 @@ TEST_P(OVClassCompiledModelGetPropertyTest_MODEL_PRIORITY, GetMetricNoThrow) {
 }
 
 TEST_P(OVClassCompiledModelGetPropertyTest_DEVICE_PRIORITY, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device, configuration);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device, configuration);
 
     std::string value;
     OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::device::priorities));
@@ -305,9 +287,8 @@ TEST_P(OVClassCompiledModelGetPropertyTest_DEVICE_PRIORITY, GetMetricNoThrow) {
 }
 
 TEST_P(OVClassCompiledModelGetPropertyTest_EXEC_DEVICES, CanGetExecutionDeviceInfo) {
-    ov::Core ie = createCoreWithTemplate();
     std::vector<std::string> expectedTargets = {expectedDeviceName};
-    auto compiled_model = ie.compile_model(model, target_device, compileModelProperties);
+    auto compiled_model = core->compile_model(model, target_device, compileModelProperties);
 
     std::vector<std::string> exeTargets;
     OV_ASSERT_NO_THROW(exeTargets = compiled_model.get_property(ov::execution_devices));

--- a/src/tests/functional/plugin/shared/src/behavior/compiled_model/properties_hetero.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/compiled_model/properties_hetero.cpp
@@ -25,10 +25,8 @@ void OVClassHeteroCompiledModelGetMetricTest::SetCpuAffinity(ov::Core& core, std
 }
 
 TEST_P(OVClassHeteroCompiledModelGetMetricTest_SUPPORTED_CONFIG_KEYS, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto heteroExeNetwork = ie.compile_model(actualNetwork, heteroDeviceName);
-    auto deviceExeNetwork = ie.compile_model(actualNetwork, target_device);
+    auto heteroExeNetwork = core->compile_model(actualNetwork, heteroDeviceName);
+    auto deviceExeNetwork = core->compile_model(actualNetwork, target_device);
 
     std::vector<ov::PropertyName> heteroConfigValues, deviceConfigValues;
     OV_ASSERT_NO_THROW(heteroConfigValues = heteroExeNetwork.get_property(ov::supported_properties));
@@ -61,11 +59,9 @@ TEST_P(OVClassHeteroCompiledModelGetMetricTest_SUPPORTED_CONFIG_KEYS, GetMetricN
 }
 
 TEST_P(OVClassHeteroCompiledModelGetMetricTest_TARGET_FALLBACK, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
     setHeteroNetworkAffinity(target_device);
 
-    auto compiled_model = ie.compile_model(actualNetwork, heteroDeviceName);
+    auto compiled_model = core->compile_model(actualNetwork, heteroDeviceName);
 
     std::string targets;
     OV_ASSERT_NO_THROW(targets = compiled_model.get_property(ov::device::priorities));
@@ -76,12 +72,11 @@ TEST_P(OVClassHeteroCompiledModelGetMetricTest_TARGET_FALLBACK, GetMetricNoThrow
 }
 
 TEST_P(OVClassHeteroCompiledModelGetMetricTest_EXEC_DEVICES, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
     std::vector<std::string> expectedTargets = {target_device};
 
-    SetCpuAffinity(ie, expectedTargets);
+    SetCpuAffinity(*core, expectedTargets);
 
-    auto compiled_model = ie.compile_model(actualNetwork, heteroDeviceName);
+    auto compiled_model = core->compile_model(actualNetwork, heteroDeviceName);
 
     std::vector<std::string> exeTargets;
     OV_ASSERT_NO_THROW(exeTargets = compiled_model.get_property(ov::execution_devices));

--- a/src/tests/functional/plugin/shared/src/behavior/ov_executable_network/get_metric.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_executable_network/get_metric.cpp
@@ -43,12 +43,11 @@ void OVClassHeteroExecutableNetworkGetMetricTest::SetCpuAffinity(ov::Core& core,
 //
 
 TEST_P(OVClassExecutableNetworkImportExportTestP, smoke_ImportNetworkNoThrowWithDeviceName) {
-    ov::Core ie = createCoreWithTemplate();
     std::stringstream strm;
     ov::CompiledModel executableNetwork;
-    OV_ASSERT_NO_THROW(executableNetwork = ie.compile_model(actualNetwork, target_device));
+    OV_ASSERT_NO_THROW(executableNetwork = core->compile_model(actualNetwork, target_device));
     OV_ASSERT_NO_THROW(executableNetwork.export_model(strm));
-    OV_ASSERT_NO_THROW(executableNetwork = ie.import_model(strm, target_device));
+    OV_ASSERT_NO_THROW(executableNetwork = core->import_model(strm, target_device));
     OV_ASSERT_NO_THROW(executableNetwork.create_infer_request());
 }
 
@@ -56,9 +55,7 @@ TEST_P(OVClassExecutableNetworkImportExportTestP, smoke_ImportNetworkNoThrowWith
 // ExecutableNetwork GetMetric / GetConfig
 //
 TEST_P(OVClassExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::vector<ov::PropertyName> supported_properties;
     OV_ASSERT_NO_THROW(supported_properties = compiled_model.get_property(ov::supported_properties));
@@ -73,9 +70,7 @@ TEST_P(OVClassExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS, GetMetricNoT
 }
 
 TEST_P(OVClassExecutableNetworkGetMetricTest_SUPPORTED_METRICS, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::vector<ov::PropertyName> supported_properties;
     OV_ASSERT_NO_THROW(supported_properties = compiled_model.get_property(ov::supported_properties));
@@ -90,9 +85,7 @@ TEST_P(OVClassExecutableNetworkGetMetricTest_SUPPORTED_METRICS, GetMetricNoThrow
 }
 
 TEST_P(OVClassExecutableNetworkGetMetricTest_NETWORK_NAME, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::string model_name;
     OV_ASSERT_NO_THROW(model_name = compiled_model.get_property(ov::model_name));
@@ -103,9 +96,7 @@ TEST_P(OVClassExecutableNetworkGetMetricTest_NETWORK_NAME, GetMetricNoThrow) {
 }
 
 TEST_P(OVClassExecutableNetworkGetMetricTest_OPTIMAL_NUMBER_OF_INFER_REQUESTS, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     unsigned int value = 0;
     OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::optimal_number_of_infer_requests));
@@ -115,8 +106,7 @@ TEST_P(OVClassExecutableNetworkGetMetricTest_OPTIMAL_NUMBER_OF_INFER_REQUESTS, G
     ASSERT_EXEC_METRIC_SUPPORTED(ov::optimal_number_of_infer_requests);
 }
 TEST_P(OVClassExecutableNetworkGetMetricTest_MODEL_PRIORITY, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device, configuration);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device, configuration);
 
     ov::hint::Priority value;
     OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::hint::model_priority));
@@ -124,8 +114,7 @@ TEST_P(OVClassExecutableNetworkGetMetricTest_MODEL_PRIORITY, GetMetricNoThrow) {
 }
 
 TEST_P(OVClassExecutableNetworkGetMetricTest_DEVICE_PRIORITY, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device, configuration);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device, configuration);
 
     std::string value;
     OV_ASSERT_NO_THROW(value = compiled_model.get_property(ov::device::priorities));
@@ -133,17 +122,13 @@ TEST_P(OVClassExecutableNetworkGetMetricTest_DEVICE_PRIORITY, GetMetricNoThrow) 
 }
 
 TEST_P(OVClassExecutableNetworkGetMetricTest_ThrowsUnsupported, GetMetricThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     ASSERT_THROW(compiled_model.get_property("unsupported_property"), ov::Exception);
 }
 
 TEST_P(OVClassExecutableNetworkGetConfigTest, GetConfigNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::vector<ov::PropertyName> property_names;
     OV_ASSERT_NO_THROW(property_names = compiled_model.get_property(ov::supported_properties));
@@ -156,26 +141,18 @@ TEST_P(OVClassExecutableNetworkGetConfigTest, GetConfigNoThrow) {
 }
 
 TEST_P(OVClassExecutableNetworkGetConfigTest, GetConfigThrows) {
-    ov::Core ie = createCoreWithTemplate();
     ov::Any p;
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
-
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
     ASSERT_THROW(compiled_model.get_property("unsupported_property"), ov::Exception);
 }
 
 TEST_P(OVClassExecutableNetworkSetConfigTest, SetConfigThrows) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
-
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
     ASSERT_THROW(compiled_model.set_property({{"unsupported_config", "some_value"}}), ov::Exception);
 }
 
 TEST_P(OVClassExecutableNetworkSetConfigTest, canNotSetConfigToCompiledModelWithIncorrectConfig) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
     std::map<std::string, std::string> incorrectConfig = {{"abc", "def"}};
     std::map<std::string, ov::Any> config;
     for (const auto& confItem : incorrectConfig) {
@@ -185,28 +162,24 @@ TEST_P(OVClassExecutableNetworkSetConfigTest, canNotSetConfigToCompiledModelWith
 }
 
 TEST_P(OVClassExecutableNetworkSupportedConfigTest, SupportedConfigWorks) {
-    ov::Core ie = createCoreWithTemplate();
     ov::Any p;
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
     OV_ASSERT_NO_THROW(compiled_model.set_property({{configKey, configValue}}));
     OV_ASSERT_NO_THROW(p = compiled_model.get_property(configKey));
     ASSERT_EQ(p, configValue);
 }
 
 TEST_P(OVClassExecutableNetworkGetMetricTestForSpecificConfig, canSetConfigToCompiledModel) {
-    ov::Core ie = createCoreWithTemplate();
     std::shared_ptr<ov::Model> function = ov::test::behavior::getDefaultNGraphFunctionForTheDevice();
-    auto execNet = ie.compile_model(function, target_device);
+    auto execNet = core->compile_model(function, target_device);
     std::map<std::string, ov::Any> config;
     config.emplace(configKey, configValue);
     EXPECT_NO_THROW(execNet.set_property(config));
 }
 
 TEST_P(OVClassExecutableNetworkGetMetricTestForSpecificConfig, canSetConfigToCompiledModelGetConfigAndCheck) {
-    ov::Core ie = createCoreWithTemplate();
     std::shared_ptr<ov::Model> function = ov::test::behavior::getDefaultNGraphFunctionForTheDevice();
-    auto execNet = ie.compile_model(simpleNetwork, target_device);
+    auto execNet = core->compile_model(simpleNetwork, target_device);
     std::map<std::string, ov::Any> config;
     config.emplace(configKey, configValue);
     execNet.set_property(config);
@@ -217,30 +190,23 @@ TEST_P(OVClassExecutableNetworkGetMetricTestForSpecificConfig, canSetConfigToCom
 }
 
 TEST_P(OVClassExecutableNetworkUnsupportedConfigTest, UnsupportedConfigThrows) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
-
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
     ASSERT_THROW(compiled_model.set_property({{configKey, configValue}}), ov::Exception);
 }
 
 TEST_P(OVClassExecutableNetworkGetConfigTest, GetConfigNoEmptyNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
     std::vector<ov::PropertyName> dev_property_names;
-    OV_ASSERT_NO_THROW(dev_property_names = ie.get_property(target_device, ov::supported_properties));
+    OV_ASSERT_NO_THROW(dev_property_names = core->get_property(target_device, ov::supported_properties));
 
-    auto compiled_model = ie.compile_model(simpleNetwork, target_device);
+    auto compiled_model = core->compile_model(simpleNetwork, target_device);
 
     std::vector<ov::PropertyName> model_property_names;
     OV_ASSERT_NO_THROW(model_property_names = compiled_model.get_property(ov::supported_properties));
 }
 
 TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto heteroExeNetwork = ie.compile_model(actualNetwork, heteroDeviceName);
-    auto deviceExeNetwork = ie.compile_model(actualNetwork, target_device);
+    auto heteroExeNetwork = core->compile_model(actualNetwork, heteroDeviceName);
+    auto deviceExeNetwork = core->compile_model(actualNetwork, target_device);
 
     std::vector<ov::PropertyName> heteroConfigValues, deviceConfigValues;
     OV_ASSERT_NO_THROW(heteroConfigValues = heteroExeNetwork.get_property(ov::supported_properties));
@@ -273,10 +239,8 @@ TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS, GetMet
 }
 
 TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_METRICS, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto heteroExeNetwork = ie.compile_model(actualNetwork, heteroDeviceName);
-    auto deviceExeNetwork = ie.compile_model(actualNetwork, target_device);
+    auto heteroExeNetwork = core->compile_model(actualNetwork, heteroDeviceName);
+    auto deviceExeNetwork = core->compile_model(actualNetwork, target_device);
 
     std::vector<ov::PropertyName> heteroConfigValues, deviceConfigValues;
     OV_ASSERT_NO_THROW(heteroConfigValues = heteroExeNetwork.get_property(ov::supported_properties));
@@ -309,9 +273,7 @@ TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_METRICS, GetMetricN
 }
 
 TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_NETWORK_NAME, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
-    auto compiled_model = ie.compile_model(actualNetwork, heteroDeviceName);
+    auto compiled_model = core->compile_model(actualNetwork, heteroDeviceName);
 
     std::string model_name;
     OV_ASSERT_NO_THROW(model_name = compiled_model.get_property(ov::model_name));
@@ -320,11 +282,9 @@ TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_NETWORK_NAME, GetMetricNoThro
 }
 
 TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_TARGET_FALLBACK, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-
     setHeteroNetworkAffinity(target_device);
 
-    auto compiled_model = ie.compile_model(actualNetwork, heteroDeviceName);
+    auto compiled_model = core->compile_model(actualNetwork, heteroDeviceName);
 
     std::string targets;
     OV_ASSERT_NO_THROW(targets = compiled_model.get_property(ov::device::priorities));
@@ -335,12 +295,11 @@ TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_TARGET_FALLBACK, GetMetricNoT
 }
 
 TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_EXEC_DEVICES, GetMetricNoThrow) {
-    ov::Core ie = createCoreWithTemplate();
     std::vector<std::string> expectedTargets = {target_device};
 
-    SetCpuAffinity(ie, expectedTargets);
+    SetCpuAffinity(*core, expectedTargets);
 
-    auto compiled_model = ie.compile_model(actualNetwork, heteroDeviceName);
+    auto compiled_model = core->compile_model(actualNetwork, heteroDeviceName);
 
     std::vector<std::string> exeTargets;
     OV_ASSERT_NO_THROW(exeTargets = compiled_model.get_property(ov::execution_devices));

--- a/src/tests/functional/plugin/shared/src/behavior/ov_executable_network/properties.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_executable_network/properties.cpp
@@ -93,8 +93,7 @@ TEST_P(OVCompiledModelPropertiesIncorrectTests, CanNotCompileModelWithIncorrectP
 }
 
 TEST_P(OVClassCompileModelTest, LoadNetworkWithBigDeviceIDThrows) {
-    ov::Core ie = createCoreWithTemplate();
-    ASSERT_THROW(ie.compile_model(actualNetwork, target_device + ".10"), ov::Exception);
+    ASSERT_THROW(core->compile_model(actualNetwork, target_device + ".10"), ov::Exception);
 }
 
 TEST_P(OVCompiledModelPropertiesDefaultTests, CanCompileWithDefaultValueFromPlugin) {

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/infer_request_dynamic.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/infer_request_dynamic.cpp
@@ -67,7 +67,7 @@ void OVInferRequestDynamicTests::SetUp() {
 
 bool OVInferRequestDynamicTests::checkOutput(const ov::runtime::Tensor& in, const ov::runtime::Tensor& actual) {
     bool result = true;
-    auto net = ie->compile_model(function, ov::test::utils::DEVICE_TEMPLATE);
+    auto net = core->compile_model(function, ov::test::utils::DEVICE_TEMPLATE);
     ov::InferRequest req;
     req = net.create_infer_request();
     auto tensor = req.get_tensor(function->inputs().back().get_any_name());
@@ -101,7 +101,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetwork) {
     };
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     const std::string outputname = function->outputs().back().get_any_name();
@@ -122,7 +122,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkSetUnexpectedOutputTensorB
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::runtime::Tensor tensor, otensor;
@@ -147,7 +147,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkSetOutputTensorPreAllocate
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::runtime::Tensor tensor;
@@ -172,7 +172,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkSetOutputShapeBeforeInfer)
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::runtime::Tensor tensor, otensor;
@@ -196,7 +196,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkGetOutputThenSetOutputTens
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::runtime::Tensor tensor;
@@ -224,7 +224,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkWithoutSetShape) {
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor;
@@ -238,7 +238,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkBoundWithoutSetShape) {
     shapes[tensor_name] = {ov::Dimension(0, 5), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor;
@@ -255,7 +255,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkWithGetTensor) {
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor, otensor;
@@ -285,7 +285,7 @@ TEST_P(OVInferRequestDynamicTests, InferUpperBoundNetworkWithGetTensor) {
     shapes[tensor_name] = {ov::Dimension(0, 19), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor, otensor;
@@ -311,7 +311,7 @@ TEST_P(OVInferRequestDynamicTests, InferUpperBoundNetworkAfterIOTensorsReshaping
     shapes[tensor_name] = {ov::Dimension(0, 19), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor, otensor;
@@ -339,7 +339,7 @@ TEST_P(OVInferRequestDynamicTests, InferFullyDynamicNetworkWithGetTensor) {
     shapes[tensor_name] = ov::PartialShape::dynamic();
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor, otensor;
@@ -368,7 +368,7 @@ TEST_P(OVInferRequestDynamicTests, InferOutOfRangeShapeNetworkWithGetTensorLower
     shapes[tensor_name] = {ov::Dimension(2, 3), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor;
@@ -387,7 +387,7 @@ TEST_P(OVInferRequestDynamicTests, InferOutOfRangeShapeNetworkWithGetTensorUpper
     shapes[tensor_name] = {ov::Dimension(1, 2), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor;
@@ -408,7 +408,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkWithGetTensor2times) {
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor;
@@ -443,7 +443,7 @@ TEST_P(OVInferRequestDynamicTests, GetSameTensor2times) {
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor;
@@ -463,7 +463,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkWithSetTensor) {
     shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor(ov::element::f32, refShape);
@@ -487,7 +487,7 @@ TEST_P(OVInferRequestDynamicTests, InferFullyDynamicNetworkWithSetTensor) {
     shapes[tensor_name] = ov::PartialShape::dynamic();
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor(ov::element::f32, refShape), otensor;
@@ -520,7 +520,7 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkWithSetTensor2times) {
     OV_ASSERT_NO_THROW(function->reshape(shapes));
     const std::string outputName = function->outputs().back().get_any_name();
     // Load ov::Model to target plugins
-    auto execNet = ie->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(function, target_device, configuration);
     // Create InferRequest
     ov::InferRequest req;
     ov::Tensor tensor(ov::element::f32, refShape);
@@ -549,13 +549,13 @@ TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkWithSetTensor2times) {
 TEST_P(OVInferRequestDynamicTests, InferDynamicNetworkWithLocalCore) {
     ov::CompiledModel compiled_model;
     {
-        ov::Core local_core = createCoreWithTemplate();
+        std::shared_ptr<Core> local_core = utils::PluginCache::get().core();
         const std::string tensor_name = "input_tensor";
         std::map<std::string, ov::PartialShape> shapes;
         shapes[tensor_name] = {ov::Dimension::dynamic(), 4, 20, 20};
         OV_ASSERT_NO_THROW(function->reshape(shapes));
         // Load ov::Model to target plugins
-        compiled_model = local_core.compile_model(function, target_device, configuration);
+        compiled_model = local_core->compile_model(function, target_device, configuration);
     }
     // Create InferRequest
     OV_ASSERT_NO_THROW(compiled_model.create_infer_request());
@@ -573,7 +573,7 @@ TEST_P(OVNotSupportRequestDynamicTests, InferDynamicNotSupported) {
     const std::string outputName = function->outputs().back().get_any_name();
     // Load ov::Function to target plugins
     ov::CompiledModel execNet;
-    ASSERT_THROW((execNet = ie->compile_model(function, target_device, configuration)), ov::Exception);
+    ASSERT_THROW((execNet = core->compile_model(function, target_device, configuration)), ov::Exception);
 }
 }  // namespace behavior
 }  // namespace test

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/life_time.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/life_time.cpp
@@ -40,8 +40,8 @@ static void release_order_test(std::vector<std::size_t> order, const std::string
                                std::shared_ptr<ngraph::Function> function) {
     ov::AnyVector objects;
     {
-        ov::Core core = createCoreWithTemplate();
-        auto compiled_model = core.compile_model(function, deviceName);
+        std::shared_ptr<Core> core = utils::PluginCache::get().core();
+        auto compiled_model = core->compile_model(function, deviceName);
         auto request = compiled_model.create_infer_request();
 
         objects = {core, compiled_model, request};


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
