### PR TITLE
Improve Commit slider's handling of non-decodable characters

### DIFF
--- a/src/plugins/intel_cpu/tools/commit_slider/utils/helpers.py
+++ b/src/plugins/intel_cpu/tools/commit_slider/utils/helpers.py
@@ -191,14 +191,10 @@ def runCommandList(commit, cfgData, enforceClean=False):
         )
         proc = subprocess.Popen(
             formattedCmd, cwd=cwd, stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT
+            stderr=subprocess.STDOUT,
+            encoding="utf-8", errors="replace"
         )
         for line in proc.stdout:
-            # decode if line is byte-type
-            try:
-                line = line.decode("utf-8")
-            except (UnicodeDecodeError, AttributeError):
-                pass
             sys.stdout.write(line)
             commitLogger.info(line)
             if "catchMsg" in cmd:


### PR DESCRIPTION
### Details:
 - *Commit slider could have troubles writing to stdout non-unicode characters that it failed to decode. This patch fixes this behavior, so the non-decodable characters will be replaced with "?" now.*

### Tickets:
 - *-*
