### PR TITLE
[CI win/lin] Fix tanh namespace conflict

### DIFF
--- a/src/core/src/op/util/activation_functions.cpp
+++ b/src/core/src/op/util/activation_functions.cpp
@@ -15,6 +15,7 @@
 #include "openvino/op/sigmoid.hpp"
 #include "openvino/op/tanh.hpp"
 
+namespace builder {
 static std::shared_ptr<ov::Node> sigmoid(const std::shared_ptr<ov::Node>& arg, float /* alpha */, float /* beta */) {
     return std::make_shared<ov::op::v0::Sigmoid>(arg);
 }
@@ -33,6 +34,7 @@ static std::shared_ptr<ov::Node> hardsigmoid(const std::shared_ptr<ov::Node>& ar
 
     return std::make_shared<ov::op::v0::HardSigmoid>(arg, alpha_node, beta_node);
 }
+}  // namespace builder
 
 ov::op::util::ActivationFunction::ActivationFunction(ActivationFunctionType f, float alpha, float beta)
     : m_function{f},
@@ -53,10 +55,10 @@ ov::op::util::ActivationFunction ov::op::util::get_activation_func_by_name(const
     using ActivationFunctionMap = std::unordered_map<std::string, op::util::ActivationFunction>;
 
     static ActivationFunctionMap func_map{
-        {"sigmoid", op::util::ActivationFunction{sigmoid}},
-        {"tanh", op::util::ActivationFunction{tanh}},
-        {"relu", op::util::ActivationFunction{relu}},
-        {"hardsigmoid", op::util::ActivationFunction{hardsigmoid, 0.2f, 0.5f}},
+        {"sigmoid", op::util::ActivationFunction{builder::sigmoid}},
+        {"tanh", op::util::ActivationFunction{builder::tanh}},
+        {"relu", op::util::ActivationFunction{builder::relu}},
+        {"hardsigmoid", op::util::ActivationFunction{builder::hardsigmoid, 0.2f, 0.5f}},
     };
 
     auto func_it = func_map.find(func_name);


### PR DESCRIPTION
### Details:
 - Fix proposal for failing CI checks with:
  ".../op/util/activation_functions.cpp:57:47: error: unexpected namespace name 'tanh': expected expression
        {"tanh", op::util::ActivationFunction{tanh}},"
   ".../op/util/activation_functions.cpp(57): error C2882: 'tanh': illegal use of namespace identifier in expression"

 Example log:
 win: https://dev.azure.com/openvinoci/dldt/_build/results?buildId=654108&view=logs&j=b5f22b75-a995-5545-eb44-87d86e78d173&t=3d35312a-1a39-5de2-24e6-ca2238503408&l=1514
 linux: https://dev.azure.com/openvinoci/dldt/_build/results?buildId=654140&view=logs&j=982848f2-7f8d-5e57-730a-8df1e5f991ba&t=e34f4ac2-e568-502a-2d74-a30ae92fdad2&l=1670

### Tickets:
 - N/A
