### PR TITLE
[CI] [GHA] Transfer Linux ONNX Runtime to AKS runners

### DIFF
--- a/.github/workflows/linux_onnxruntime.yml
+++ b/.github/workflows/linux_onnxruntime.yml
@@ -1,75 +1,73 @@
 name: Linux ONNX Runtime (Ubuntu 20.04, Python 3.11)
 on:
   workflow_dispatch:
-  schedule:
-    # run daily at 00:00
-    - cron: '0 0 * * *'
-#  pull_request:
-#    paths-ignore:
-#      - '**/docs/**'
-#      - 'docs/**'
-#      - '**/**.md'
-#      - '**.md'
-#      - '**/layer_tests_summary/**'
-#      - '**/conformance/**'
-#  push:
-#    paths-ignore:
-#      - '**/docs/**'
-#      - 'docs/**'
-#      - '**/**.md'
-#      - '**.md'
-#      - '**/layer_tests_summary/**'
-#      - '**/conformance/**'
-#    branches:
-#      - master
+  pull_request:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
+  push:
+    paths-ignore:
+      - '**/docs/**'
+      - 'docs/**'
+      - '**/**.md'
+      - '**.md'
+      - '**/layer_tests_summary/**'
+      - '**/conformance/**'
+    branches:
+      - master
+      - 'releases/**'
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}-linux-onnx-runtime
+  # github.ref is not unique in post-commit
+  group: ${{ github.event_name == 'push' && github.run_id || github.ref }}-linux-onnxruntime
   cancel-in-progress: true
 
 jobs:
   Build:
-    # TODO: remove. Temporary measure to prevent the workflow from scheduling on forks.
-    if: ${{ github.repository_owner == 'openvinotoolkit' }}
     defaults:
       run:
         shell: bash
-    runs-on: ubuntu-20.04-8-cores
+    runs-on: aks-linux-16-cores
+    container:
+      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04
+      volumes:
+        - /mount/caches:/mount/caches
     env:
+      DEBIAN_FRONTEND: noninteractive # to prevent apt-get from waiting user input
       CMAKE_BUILD_TYPE: 'Release'
-      CMAKE_GENERATOR: 'Ninja'
+      CMAKE_GENERATOR: 'Ninja Multi-Config'
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
       CMAKE_C_COMPILER_LAUNCHER: ccache
-      CMAKE_CXX_LINKER_LAUNCHER: ccache
-      CMAKE_C_LINKER_LAUNCHER: ccache
-      BUILD_TYPE: Release
-      OPENVINO_REPO: ${{ github.workspace }}/openvino
-      ONNX_RUNTIME_REPO: ${{ github.workspace }}/onnxruntime
-      ONNX_RUNTIME_UTILS: ${{ github.workspace }}/openvino/.ci/azure/ci_utils/onnxruntime
-      ONNX_RUNTIME_BUILD_DIR: ${{ github.workspace }}/onnxruntime/build
-      BUILD_DIR: ${{ github.workspace }}/build
-      INSTALL_DIR: ${{ github.workspace }}/install/openvino
+      OPENVINO_REPO: /__w/openvino/openvino/openvino
+      INSTALL_DIR: /__w/openvino/openvino/openvino_install
+      BUILD_DIR: /__w/openvino/openvino/openvino_build
+      CCACHE_DIR: /mount/caches/ccache/ubuntu20_x86_64_Release
+      CCACHE_TEMPDIR: /__w/openvino/openvino/ccache_temp
+      CCACHE_MAXSIZE: 50G
+      ONNX_RUNTIME_REPO: /__w/openvino/openvino/onnxruntime
+      ONNX_RUNTIME_UTILS: /__w/openvino/openvino/openvino/.ci/azure/ci_utils/onnxruntime
+      ONNX_RUNTIME_BUILD_DIR: /__w/openvino/openvino/onnxruntime/build
     steps:
+
+      - name: Install git
+        run: |
+          apt-get update
+          apt-get install --assume-yes --no-install-recommends git ca-certificates
+
       - name: Clone OpenVINO
         uses: actions/checkout@v4
         with:
-          path: 'openvino'
+          path: ${{ env.OPENVINO_REPO }}
           submodules: 'true'
 
       - name: Clone ONNX Runtime
         run: |
-          branch=`tr -s '\n ' < ${{ env.ONNX_RUNTIME_UTILS }}/version`
-          git clone --branch $branch --single-branch --recursive https://github.com/microsoft/onnxruntime.git ${{ env.ONNX_RUNTIME_REPO }}
-
-      - name: Create Directories
-        run: |
-          mkdir -p ${{ env.BUILD_DIR }}
-          mkdir -p ${{ env.INSTALL_DIR }}
-
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
+          branch=`tr -s '\n ' < ${ONNX_RUNTIME_UTILS}/version`
+          git clone --branch $branch --single-branch --recursive https://github.com/microsoft/onnxruntime.git ${ONNX_RUNTIME_REPO}
 
       #
       # Dependencies
@@ -77,33 +75,17 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo -E ${{ env.OPENVINO_REPO }}/install_build_dependencies.sh
-
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          max-size: "2000M"
-          # Should save cache only if run in the master branch of the base repo
-          # github.ref_name is 'ref/PR_#' in case of the PR, and 'branch_name' when executed on push
-          save: ${{ github.ref_name == 'master' && 'true' || 'false'  }}
-          verbose: 2
-          key: ${{ github.job }}-linux-onnx-runtime
-          restore-keys: |
-            ${{ github.job }}-linux-onnx-runtime
+          bash ${OPENVINO_REPO}/install_build_dependencies.sh
 
       #
       # Build
       #
 
-      - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v2
-        id: cpu-cores
-
       - name: CMake configure
         run: |
           cmake \
-            -GNinja \
-            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -G "${{ env.CMAKE_GENERATOR }}" \
+            -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF \
             -DENABLE_INTEL_GNA=OFF \
             -DENABLE_INTEL_GPU=OFF \
@@ -114,69 +96,66 @@ jobs:
             -DENABLE_OV_TF_LITE=OFF \
             -DENABLE_OV_PADDLE_FRONTEND=OFF \
             -DENABLE_OV_PYTORCH_FRONTEND=OFF \
-            -S ${{ env.OPENVINO_REPO }} \
-            -B ${{ env.BUILD_DIR }}
-
-      - name: Clean ccache stats
-        run: ccache --zero-stats --show-config
+            -S ${OPENVINO_REPO} \
+            -B ${BUILD_DIR}
 
       - name: Build
-        run: cmake --build ${{ env.BUILD_DIR }} --parallel ${{ steps.cpu-cores.outputs.count }} --config ${{ env.BUILD_TYPE }}
+        run: cmake --build ${BUILD_DIR} --parallel --config ${{ env.CMAKE_BUILD_TYPE }}
 
       - name: Show ccache stats
         run: ccache --show-stats
 
       - name: Install OpenVINO
-        run: cmake -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -P ${{ env.BUILD_DIR }}/cmake_install.cmake
+        run: cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -P ${BUILD_DIR}/cmake_install.cmake
 
       - name: Build Lin ONNX Runtime
         run: |
-          source ${{ env.INSTALL_DIR }}/setupvars.sh
+          source ${INSTALL_DIR}/setupvars.sh
           
-          ${{ env.ONNX_RUNTIME_REPO }}/build.sh \
+          ${ONNX_RUNTIME_REPO}/build.sh \
             --config RelWithDebInfo \
             --use_openvino CPU_FP32 \
             --build_shared_lib \
             --parallel \
             --skip_tests \
             --compile_no_warning_as_error \
-            --build_dir ${{ env.ONNX_RUNTIME_BUILD_DIR }}
+            --build_dir ${ONNX_RUNTIME_BUILD_DIR}
         env:
           CXXFLAGS: "-Wno-error=deprecated-declarations"
 
       - name: Run onnxruntime_test_all
         run: |
-          source ${{ env.INSTALL_DIR }}/setupvars.sh
-          skip_tests=$(tr -s '\n ' ':' < ${{ env.ONNX_RUNTIME_UTILS }}/skip_tests)
+          source ${INSTALL_DIR}/setupvars.sh
+          skip_tests=$(tr -s '\n ' ':' < ${ONNX_RUNTIME_UTILS}/skip_tests)
           ./onnxruntime_test_all --gtest_filter=-$skip_tests
         working-directory: ${{ env.ONNX_RUNTIME_BUILD_DIR }}/RelWithDebInfo
 
       - name: Run onnxruntime_shared_lib_test
         run: |
-          source ${{ env.INSTALL_DIR }}/setupvars.sh
+          source ${INSTALL_DIR}/setupvars.sh
           ./onnxruntime_shared_lib_test --gtest_filter=-CApiTest.test_custom_op_openvino_wrapper_library
         working-directory: ${{ env.ONNX_RUNTIME_BUILD_DIR }}/RelWithDebInfo
 
       - name: Run onnxruntime_global_thread_pools_test
         run: |
-          source ${{ env.INSTALL_DIR }}/setupvars.sh
+          source ${INSTALL_DIR}/setupvars.sh
           ./onnxruntime_global_thread_pools_test
         working-directory: ${{ env.ONNX_RUNTIME_BUILD_DIR }}/RelWithDebInfo
 
       - name: Run onnxruntime_api_tests_without_env
         run: |
-          source ${{ env.INSTALL_DIR }}/setupvars.sh
+          source ${INSTALL_DIR}/setupvars.sh
           ./onnxruntime_api_tests_without_env
         working-directory: ${{ env.ONNX_RUNTIME_BUILD_DIR }}/RelWithDebInfo
 
       - name: Run pytorch-converted tests
         run: |
-          source ${{ env.INSTALL_DIR }}/setupvars.sh
-          ./onnx_test_runner "${{ env.ONNX_RUNTIME_REPO }}/cmake/external/onnx/onnx/backend/test/data/pytorch-converted"
+          source ${INSTALL_DIR}/setupvars.sh
+          ./onnx_test_runner "${ONNX_RUNTIME_REPO}/cmake/external/onnx/onnx/backend/test/data/pytorch-converted"
         working-directory: ${{ env.ONNX_RUNTIME_BUILD_DIR }}/RelWithDebInfo
 
       - name: Run pytorch-operator tests
         run: |
-          source ${{ env.INSTALL_DIR }}/setupvars.sh
-          ./onnx_test_runner "${{ env.ONNX_RUNTIME_REPO }}/cmake/external/onnx/onnx/backend/test/data/pytorch-operator"
+          source ${INSTALL_DIR}/setupvars.sh
+          ./onnx_test_runner "${ONNX_RUNTIME_REPO}/cmake/external/onnx/onnx/backend/test/data/pytorch-operator"
         working-directory: ${{ env.ONNX_RUNTIME_BUILD_DIR }}/RelWithDebInfo


### PR DESCRIPTION
### Details:
This PR transfers the Linux ONNX Runtime pipeline to the AKS runners and enables it in precommit.

### Tickets:
 - *121798*
