### PR TITLE
Segmentation fault when running test_get_runtime_model test

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_compiled_model.py
+++ b/src/bindings/python/tests/test_runtime/test_compiled_model.py
@@ -25,6 +25,11 @@ def test_get_property(device):
 
 def test_get_runtime_model(device):
     compiled_model = generate_relu_compiled_model(device)
+    
+    core = Core()
+    user_stream = compiled_model.export_model()
+    core.import_model(user_stream, device)
+
     runtime_model = compiled_model.get_runtime_model()
     assert isinstance(runtime_model, Model)
 

--- a/src/bindings/python/tests/test_runtime/test_compiled_model.py
+++ b/src/bindings/python/tests/test_runtime/test_compiled_model.py
@@ -25,7 +25,7 @@ def test_get_property(device):
 
 def test_get_runtime_model(device):
     compiled_model = generate_relu_compiled_model(device)
-    
+
     core = Core()
     user_stream = compiled_model.export_model()
     core.import_model(user_stream, device)


### PR DESCRIPTION
### Details:
 - fixes segfault as produced in issue
 - python `3.8.10`

### Tickets:
 - #18388

It appears that the segfault is fixed when `core.import_model()` is called before `get_runtime_model()` 