### PR TITLE
[build_samples_msvc] Exit properly on error

### DIFF
--- a/samples/cpp/build_samples_msvc.bat
+++ b/samples/cpp/build_samples_msvc.bat
@@ -72,3 +72,4 @@ exit /b
 
 :errorHandling
 echo Error
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
### Details:
At least in some environments build_samples_msvc.bat may exit with a zero exit code even in case of an error. This PR fixes that behavior by setting an exit code explicitly if error occurs

### Tickets:
 - 121769
