### PR TITLE
Keep precision of inputs/outputs in SubgraphBaseTest::calculate_refs

### DIFF
--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -287,7 +287,7 @@ std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
     auto functionToProcess = functionRefs->clone();
     precisions_map convert_precisions = get_ref_precisions_convert_map();
     pass::Manager manager;
-    manager.register_pass<ov::pass::ConvertPrecision>(convert_precisions);
+    manager.register_pass<ov::pass::ConvertPrecision>(convert_precisions, type_to_fuse_map{}, false, false);
     manager.run_passes(functionToProcess);
     functionToProcess->validate_nodes_and_infer_types();
 


### PR DESCRIPTION
### Details:
 - *Keep precision of inputs/outputs in SubgraphBaseTest::calculate_refs otherwise it leads to precision mismatch for f16*
 
### Tickets:
 - *ticket-id*
