### PR TITLE
[EISW-89683] Switch `DEVICE_KEEMBAY` to `DEVICE_NPU`

### DIFF
--- a/src/plugins/auto/tests/unit/compile_model_metric_test.cpp
+++ b/src/plugins/auto/tests/unit/compile_model_metric_test.cpp
@@ -172,7 +172,7 @@ TEST_P(ExecNetworkget_propertyOptimalNumInferReq, OPTIMAL_NUMBER_OF_INFER_REQUES
             .WillByDefault(RETURN_MOCK_VALUE(actualOptimalNum));
         ON_CALL(
             *core,
-            get_property(StrEq(ov::test::utils::DEVICE_KEEMBAY), StrEq(ov::optimal_number_of_infer_requests.name()), _))
+            get_property(StrEq(ov::test::utils::DEVICE_NPU), StrEq(ov::optimal_number_of_infer_requests.name()), _))
             .WillByDefault(RETURN_MOCK_VALUE(actualOptimalNum));
     }
     if (isSupportNumRequests)
@@ -196,7 +196,7 @@ TEST_P(ExecNetworkget_propertyOptimalNumInferReq, OPTIMAL_NUMBER_OF_INFER_REQUES
         std::tuple<unsigned int, unsigned int> rangeOfStreams = std::make_tuple<unsigned int, unsigned int>(1, 3);
         ON_CALL(*core, get_property(StrEq(ov::test::utils::DEVICE_GPU), StrEq(ov::optimal_batch_size.name()), _))
             .WillByDefault(RETURN_MOCK_VALUE(gpuOptimalBatchNum));
-        ON_CALL(*core, get_property(StrEq(ov::test::utils::DEVICE_KEEMBAY), StrEq(ov::optimal_batch_size.name()), _))
+        ON_CALL(*core, get_property(StrEq(ov::test::utils::DEVICE_NPU), StrEq(ov::optimal_batch_size.name()), _))
             .WillByDefault(RETURN_MOCK_VALUE(npuOptimalBatchNum));
         ON_CALL(*core, get_property(_, StrEq(ov::range_for_streams.name()), _))
             .WillByDefault(RETURN_MOCK_VALUE(rangeOfStreams));
@@ -330,28 +330,28 @@ const std::vector<ConfigParams> testConfigs = {
     ConfigParams{false, 3, 5, false, 0, 5, true, ov::test::utils::DEVICE_GPU, 1, 6, true, true},
     ConfigParams{true, 3, 5, false, 6, 5, true, ov::test::utils::DEVICE_GPU, 6, 6, true, true},
     ConfigParams{false, 3, 5, false, 6, 5, true, ov::test::utils::DEVICE_GPU, 6, 6, true, true},
-    ConfigParams{false, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 1, 0, false, true},
-    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 8, 0, false, true},
-    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 8, 0, false, false},
-    ConfigParams{true, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_KEEMBAY, 8, 0, true, false},
-    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 2, 0, true, false},
-    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 2, 1, true, false},
-    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 6, 6, false, false},
-    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 8, 10, false, false},
-    ConfigParams{true, 3, -1, false, 4, -1, true, ov::test::utils::DEVICE_KEEMBAY, 4, 6, true, true},
-    ConfigParams{true, 3, -1, false, 4, -1, true, ov::test::utils::DEVICE_KEEMBAY, 2, 2, true, true},
-    ConfigParams{true, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_KEEMBAY, 8, 10, true, true},
-    ConfigParams{true, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_KEEMBAY, 6, 6, true, true},
-    ConfigParams{false, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_KEEMBAY, 1, 0, true, true},
-    ConfigParams{true, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_KEEMBAY, 8, 0, true, true},
-    ConfigParams{false, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 2, 0, true, true},
-    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_KEEMBAY, 2, 0, true, true},
-    ConfigParams{false, 3, -1, true, 2, -1, false, ov::test::utils::DEVICE_KEEMBAY, 2, 0, false, true},
-    ConfigParams{true, 3, -1, true, 2, -1, false, ov::test::utils::DEVICE_KEEMBAY, 2, 0, false, true},
-    ConfigParams{false, 3, 5, false, 2, 5, true, ov::test::utils::DEVICE_KEEMBAY, 1, 0, false, true},
-    ConfigParams{true, 3, 5, false, 2, 5, true, ov::test::utils::DEVICE_KEEMBAY, 8, 0, false, true},
-    ConfigParams{false, 3, 5, true, 2, 5, false, ov::test::utils::DEVICE_KEEMBAY, 2, 0, false, true},
-    ConfigParams{true, 3, 5, true, 2, 5, false, ov::test::utils::DEVICE_KEEMBAY, 2, 0, false, true},
+    ConfigParams{false, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 1, 0, false, true},
+    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 8, 0, false, true},
+    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 8, 0, false, false},
+    ConfigParams{true, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_NPU, 8, 0, true, false},
+    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 2, 0, true, false},
+    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 2, 1, true, false},
+    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 6, 6, false, false},
+    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 8, 10, false, false},
+    ConfigParams{true, 3, -1, false, 4, -1, true, ov::test::utils::DEVICE_NPU, 4, 6, true, true},
+    ConfigParams{true, 3, -1, false, 4, -1, true, ov::test::utils::DEVICE_NPU, 2, 2, true, true},
+    ConfigParams{true, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_NPU, 8, 10, true, true},
+    ConfigParams{true, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_NPU, 6, 6, true, true},
+    ConfigParams{false, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_NPU, 1, 0, true, true},
+    ConfigParams{true, 3, -1, false, 0, -1, true, ov::test::utils::DEVICE_NPU, 8, 0, true, true},
+    ConfigParams{false, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 2, 0, true, true},
+    ConfigParams{true, 3, -1, false, 2, -1, true, ov::test::utils::DEVICE_NPU, 2, 0, true, true},
+    ConfigParams{false, 3, -1, true, 2, -1, false, ov::test::utils::DEVICE_NPU, 2, 0, false, true},
+    ConfigParams{true, 3, -1, true, 2, -1, false, ov::test::utils::DEVICE_NPU, 2, 0, false, true},
+    ConfigParams{false, 3, 5, false, 2, 5, true, ov::test::utils::DEVICE_NPU, 1, 0, false, true},
+    ConfigParams{true, 3, 5, false, 2, 5, true, ov::test::utils::DEVICE_NPU, 8, 0, false, true},
+    ConfigParams{false, 3, 5, true, 2, 5, false, ov::test::utils::DEVICE_NPU, 2, 0, false, true},
+    ConfigParams{true, 3, 5, true, 2, 5, false, ov::test::utils::DEVICE_NPU, 2, 0, false, true},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests,

--- a/src/plugins/intel_npu/tests/functional/common/utils.cpp
+++ b/src/plugins/intel_npu/tests/functional/common/utils.cpp
@@ -7,20 +7,6 @@
 #include "npu_private_properties.hpp"
 #include "utils.hpp"
 
-namespace ov {
-
-namespace test {
-
-namespace utils {
-
-const char* DEVICE_NPU = "NPU";
-
-}  // namespace utils
-
-}  // namespace test
-
-}  // namespace ov
-
 std::string getBackendName(const ov::Core& core) {
     return core.get_property("NPU", ov::intel_npu::backend_name.name()).as<std::string>();
 }

--- a/src/plugins/intel_npu/tests/functional/common/utils.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/utils.hpp
@@ -8,20 +8,6 @@
 #include <openvino/runtime/core.hpp>
 #include "common_test_utils/unicode_utils.hpp"
 
-namespace ov {
-
-namespace test {
-
-namespace utils {
-
-extern const char* DEVICE_NPU;
-
-}  // namespace utils
-
-}  // namespace test
-
-}  // namespace ov
-
 std::string getBackendName(const ov::Core& core);
 
 std::vector<std::string> getAvailableDevices(const ov::Core& core);

--- a/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/properties_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/properties_tests.hpp
@@ -121,7 +121,7 @@ TEST_P(InferRequestPropertiesTest, ReusableCPUStreamsExecutor) {
         // Load CNNNetwork to target plugins
         execNet = core->compile_model(function, target_device, config);
         auto req = execNet.create_infer_request();
-        if (target_device == ov::test::utils::DEVICE_KEEMBAY) {
+        if (target_device == ov::test::utils::DEVICE_NPU) {
             ASSERT_EQ(1u, ov::threading::executor_manager()->get_executors_number());
             ASSERT_EQ(0u, ov::threading::executor_manager()->get_idle_cpu_streams_executors_number());
         } else if ((target_device == ov::test::utils::DEVICE_AUTO) ||

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/test_constants.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/test_constants.hpp
@@ -11,8 +11,8 @@ namespace utils {
 extern const char* DEVICE_AUTO;
 extern const char* DEVICE_CPU;
 extern const char* DEVICE_GPU;
+extern const char* DEVICE_NPU;
 extern const char* DEVICE_BATCH;
-extern const char* DEVICE_KEEMBAY;
 extern const char* DEVICE_MULTI;
 extern const char* DEVICE_TEMPLATE;
 extern const char* DEVICE_HETERO;

--- a/src/tests/test_utils/common_test_utils/src/test_constants.cpp
+++ b/src/tests/test_utils/common_test_utils/src/test_constants.cpp
@@ -11,7 +11,7 @@ namespace utils {
 const char* DEVICE_AUTO = "AUTO";
 const char* DEVICE_CPU = "CPU";
 const char* DEVICE_GPU = "GPU";
-const char* DEVICE_KEEMBAY = "NPU";
+const char* DEVICE_NPU = "NPU";
 const char* DEVICE_BATCH = "BATCH";
 const char* DEVICE_MULTI = "MULTI";
 const char* DEVICE_TEMPLATE = "TEMPLATE";


### PR DESCRIPTION
### Details:
 - *Align OV with latest renaming in `vpux-plugin`*
 - After [PR #5738](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/5738) in `vpux-plugin` was merged, we are ready to update `ov::test::utils::DEVICE_KEEMBAY` to `ov::test::utils::DEVICE_NPU` on openvino side.

### Tickets:
 - *[EISW-89683](https://jira.devtools.intel.com/browse/EISW-89683)*
