### PR TITLE
[Snippets] Deep copy interface

### DIFF
--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -26,7 +26,6 @@ class Expression : public std::enable_shared_from_this<Expression> {
 
 public:
     Expression() = default;
-    Expression(const Expression& other);
     virtual ~Expression() = default;
 
     std::shared_ptr<Node> get_node() const;
@@ -62,12 +61,11 @@ public:
     ExpressionPtr clone_with_new_inputs(const ExressionMap& expr_map, const std::shared_ptr<Node>& new_node) const;
 
 protected:
+    Expression(const Expression& other);
     // Note: The constructor initialization is private since an expression can be created only by Linear IR.
     //       The method must be used only by Linear IR builder of expressions!
     Expression(const std::shared_ptr<Node>& n, const std::shared_ptr<IShapeInferSnippetsFactory>& factory);
-    static void update_node_and_connectors(const ExpressionPtr& expr,
-                                           const std::vector<PortConnectorPtr>& new_inputs,
-                                           const std::shared_ptr<Node>& new_node);
+    void update_node_and_connectors(const std::vector<PortConnectorPtr>& new_inputs, const std::shared_ptr<Node>& new_node);
 
     void replace_input(size_t port, PortConnectorPtr to);
 
@@ -88,7 +86,6 @@ class IOExpression : public Expression {
 
 public:
     enum class io_type {INPUT, OUTPUT, UNDEFINED};
-    IOExpression(const IOExpression& other) = default;
     ExpressionPtr clone_with_new_inputs(const std::vector<PortConnectorPtr>& new_inputs,
                                         const std::shared_ptr<Node>& new_node) const override;
     int64_t get_index() const  { return m_index; }
@@ -96,6 +93,7 @@ public:
     // Result needs shapeInfer to copy shape from Parent's output to this expr input
     bool needShapeInfer() const override {return m_type == io_type::OUTPUT; }
 private:
+    IOExpression(const IOExpression& other) = default;
     explicit IOExpression(const std::shared_ptr<ov::opset1::Parameter>& n, int64_t index, const std::shared_ptr<IShapeInferSnippetsFactory>& factory);
     explicit IOExpression(const std::shared_ptr<ov::opset1::Result>& n, int64_t index, const std::shared_ptr<IShapeInferSnippetsFactory>& factory);
 

--- a/src/common/snippets/include/snippets/lowered/expression_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_port.hpp
@@ -25,6 +25,11 @@ public:
 
     ExpressionPort() = default;
     explicit ExpressionPort(const std::shared_ptr<Expression>& expr, Type type, size_t port);
+    /**
+    * @interface clone
+    * @brief Creates similar Expression port, but for new expression
+     */
+    std::shared_ptr<ExpressionPort> clone_for_new_expr(const std::shared_ptr<Expression>& new_expr) const;
 
     std::shared_ptr<Expression> get_expr() const;
     Type get_type() const { return m_type; }

--- a/src/common/snippets/include/snippets/lowered/expression_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_port.hpp
@@ -26,10 +26,10 @@ public:
     ExpressionPort() = default;
     explicit ExpressionPort(const std::shared_ptr<Expression>& expr, Type type, size_t port);
     /**
-    * @interface clone
+    * @interface clone_with_new_expr
     * @brief Creates similar Expression port, but for new expression
      */
-    std::shared_ptr<ExpressionPort> clone_for_new_expr(const std::shared_ptr<Expression>& new_expr) const;
+    std::shared_ptr<ExpressionPort> clone_with_new_expr(const std::shared_ptr<Expression>& new_expr) const;
 
     std::shared_ptr<Expression> get_expr() const;
     Type get_type() const { return m_type; }

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -49,7 +49,10 @@ public:
 
     ExpressionPtr create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& inputs);
 
-    static LinearIR::container deep_copy_range(LinearIR::container::const_iterator begin, LinearIR::container::const_iterator end);
+    std::shared_ptr<LinearIR> clone() const;
+    static LinearIR::container deep_copy_range(LinearIR::container::const_iterator begin,
+                                               LinearIR::container::const_iterator end,
+                                               ExressionMap& expression_map);
 
     const container& get_ops() const {return m_expressions; }
     const io_container& get_IO_ops() const {return m_io_expressions; }
@@ -116,7 +119,6 @@ public:
     IShapeInferSnippets::Result shape_infer(const std::vector<VectorDimsRef>& input_shapes);
     const std::shared_ptr<ShapeInferSnippetsNode>& get_shape_infer_instance() const {return m_shape_infer; }
     VectorDims get_master_shape() const;
-    LinearIR deep_copy() const;
 
 private:
     std::shared_ptr<ShapeInferSnippetsNode> m_shape_infer = nullptr;

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -24,6 +24,8 @@ public:
         LoopPort(const ExpressionPort& port, bool is_scheduled = true)
             : expr_port(std::make_shared<ExpressionPort>(port)), is_incremented(is_scheduled) {}
 
+        std::shared_ptr<LoopPort> clone_for_new_expr(const ExpressionPtr& new_expr) const;
+
         friend bool operator==(const LoopPort& lhs, const LoopPort& rhs);
         friend bool operator!=(const LoopPort& lhs, const LoopPort& rhs);
         friend bool operator<(const LoopPort& lhs, const LoopPort& rhs);
@@ -49,6 +51,8 @@ public:
                  const std::vector<ExpressionPort>& entries,
                  const std::vector<ExpressionPort>& exits);
 
+        std::shared_ptr<LoopInfo> clone_for_new_expr(const ExressionMap& expr_map) const;
+
         size_t work_amount = 0;
         size_t increment = 0;
         size_t dim_idx = 0;  // The numeration begins from the end (dim_idx = 0 -> is the most inner dimension)
@@ -63,6 +67,7 @@ public:
     };
     using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 
+    std::shared_ptr<LoopManager> clone_for_new_expr(const ExressionMap& expr_map) const;
     size_t add_loop_info(const LoopInfoPtr& loop);
     void remove_loop_info(size_t index);
     LoopInfoPtr get_loop_info(size_t index) const;

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -24,7 +24,7 @@ public:
         LoopPort(const ExpressionPort& port, bool is_scheduled = true)
             : expr_port(std::make_shared<ExpressionPort>(port)), is_incremented(is_scheduled) {}
 
-        std::shared_ptr<LoopPort> clone_for_new_expr(const ExpressionPtr& new_expr) const;
+        std::shared_ptr<LoopPort> clone_with_new_expr(const ExpressionPtr& new_expr) const;
 
         friend bool operator==(const LoopPort& lhs, const LoopPort& rhs);
         friend bool operator!=(const LoopPort& lhs, const LoopPort& rhs);
@@ -51,7 +51,7 @@ public:
                  const std::vector<ExpressionPort>& entries,
                  const std::vector<ExpressionPort>& exits);
 
-        std::shared_ptr<LoopInfo> clone_for_new_expr(const ExressionMap& expr_map) const;
+        std::shared_ptr<LoopInfo> clone_with_new_expr(const ExressionMap& expr_map) const;
 
         size_t work_amount = 0;
         size_t increment = 0;
@@ -67,7 +67,7 @@ public:
     };
     using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 
-    std::shared_ptr<LoopManager> clone_for_new_expr(const ExressionMap& expr_map) const;
+    std::shared_ptr<LoopManager> clone_with_new_expr(const ExressionMap& expr_map) const;
     size_t add_loop_info(const LoopInfoPtr& loop);
     void remove_loop_info(size_t index);
     LoopInfoPtr get_loop_info(size_t index) const;

--- a/src/common/snippets/src/lowered/expression_factory.cpp
+++ b/src/common/snippets/src/lowered/expression_factory.cpp
@@ -91,7 +91,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::Loop
                                                   const std::vector<PortConnectorPtr>& inputs,
                                                   const LinearIR& linear_ir) {
     OPENVINO_ASSERT(inputs.empty(), "LoopBegin cannot have inputs");
-    auto expr = std::make_shared<Expression>(Expression(n, linear_ir.m_shape_infer_factory));
+    auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory));
     init_expression_inputs(expr, inputs);
     create_expression_outputs(expr);
     expr->validate();

--- a/src/common/snippets/src/lowered/expression_port.cpp
+++ b/src/common/snippets/src/lowered/expression_port.cpp
@@ -14,6 +14,10 @@ namespace lowered {
 ExpressionPort::ExpressionPort(const std::shared_ptr<Expression>& expr, Type type, size_t port)
         : m_expr(expr), m_type(type), m_port_index(port) {}
 
+std::shared_ptr<ExpressionPort> ExpressionPort::clone_for_new_expr(const std::shared_ptr<Expression>& new_expr) const {
+    return std::make_shared<ExpressionPort>(new_expr, m_type, m_port_index);
+}
+
 std::shared_ptr<Expression> ExpressionPort::get_expr() const {
     const auto expr_ptr = m_expr.lock();
     OPENVINO_ASSERT(expr_ptr != nullptr, "ExpressionPort has invalid expression pointer");

--- a/src/common/snippets/src/lowered/expression_port.cpp
+++ b/src/common/snippets/src/lowered/expression_port.cpp
@@ -14,7 +14,7 @@ namespace lowered {
 ExpressionPort::ExpressionPort(const std::shared_ptr<Expression>& expr, Type type, size_t port)
         : m_expr(expr), m_type(type), m_port_index(port) {}
 
-std::shared_ptr<ExpressionPort> ExpressionPort::clone_for_new_expr(const std::shared_ptr<Expression>& new_expr) const {
+std::shared_ptr<ExpressionPort> ExpressionPort::clone_with_new_expr(const std::shared_ptr<Expression>& new_expr) const {
     return std::make_shared<ExpressionPort>(new_expr, m_type, m_port_index);
 }
 

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -47,16 +47,6 @@ LinearIR::LinearIR(const std::shared_ptr<ov::Model>& model, const std::shared_pt
 std::shared_ptr<LinearIR> LinearIR::clone() const {
     auto cloned = std::make_shared<LinearIR>();
     cloned->m_config = m_config;
-    // Clone underlying ngraph nodes
-    NodeVector original_nodes;
-    original_nodes.reserve(m_expressions.size());
-    for (const auto& expr : m_expressions)
-        original_nodes.push_back(expr->get_node());
-    // node_map and expr_map map original node pointer (expression) to a new pointer (expression)
-    ngraph::NodeMap node_map;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    ngraph::clone_nodes(original_nodes, node_map);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
     ExressionMap expression_map;
     cloned->m_expressions = deep_copy_range(m_expressions.cbegin(), m_expressions.cend(), expression_map);

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -44,6 +44,35 @@ LinearIR::LinearIR(const std::shared_ptr<ov::Model>& model, const std::shared_pt
     m_shape_infer = std::make_shared<LIRShapeInfer>(m_expressions, m_io_expressions);
 }
 
+std::shared_ptr<LinearIR> LinearIR::clone() const {
+    auto cloned = std::make_shared<LinearIR>();
+    cloned->m_config = m_config;
+    // Clone underlying ngraph nodes
+    NodeVector original_nodes;
+    original_nodes.reserve(m_expressions.size());
+    for (const auto& expr : m_expressions)
+        original_nodes.push_back(expr->get_node());
+    // node_map and expr_map map original node pointer (expression) to a new pointer (expression)
+    ngraph::NodeMap node_map;
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    ngraph::clone_nodes(original_nodes,  node_map);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+
+    ExressionMap expression_map;
+    cloned->m_expressions = deep_copy_range(m_expressions.cbegin(), m_expressions.cend(), expression_map);
+    for (const auto& expr : cloned->m_expressions) {
+        cloned->m_node2expression_map[expr->get_node()] = expr;
+        if (const auto& io = std::dynamic_pointer_cast<IOExpression>(expr))
+            cloned->m_io_expressions.push_back(io);
+    }
+
+    cloned->m_loop_manager = m_loop_manager->clone_for_new_expr(expression_map);
+    // It's Ok to share shapeInfer factory ptr, since the factory doesn't depend on LIR in any way
+    cloned->m_shape_infer_factory = m_shape_infer_factory;
+    cloned->m_shape_infer = std::make_shared<LIRShapeInfer>(cloned->m_expressions, cloned->m_io_expressions);
+    return cloned;
+}
+
 ExpressionPtr LinearIR::create_expression(const std::shared_ptr<Node>& n, const std::shared_ptr<ov::Model>& model) {
     return ExpressionFactory::build(n, *this, model);
 }
@@ -99,80 +128,28 @@ void LinearIR::serialize(const std::string& xml, const std::string& bin) const {
     ov::pass::Serialize(xml, bin).run_on_model(tmp_model);
 }
 
-LinearIR::container LinearIR::deep_copy_range(LinearIR::container::const_iterator begin, LinearIR::container::const_iterator end) {
-    auto deep_clone_ports = [](std::vector<PortDescriptorPtr>& ports) {
-        for (auto& port : ports) { port = port->clone(); }
-    };
+LinearIR::container LinearIR::deep_copy_range(LinearIR::container::const_iterator begin,
+                                              LinearIR::container::const_iterator end,
+                                              ExressionMap& expression_map) {
+    OPENVINO_ASSERT(expression_map.empty(), "deep_copy_range expects empty expression_map as an input");
     LinearIR::container result;
     NodeVector original_nodes;
     for (auto it = begin; it != end; it++)
         original_nodes.push_back((*it)->get_node());
-    ngraph::NodeMap node_map;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    ngraph::clone_nodes(original_nodes,  node_map);
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    for (auto it = begin; it != end; it++) {
-        // copy by value, so result shared_pointer point to new objects
-        Expression new_expr = **it;
-        new_expr.m_source_node = node_map[(*it)->get_node().get()];
-        deep_clone_ports(new_expr.m_input_port_descriptors);
-        deep_clone_ports(new_expr.m_output_port_descriptors);
-        result.emplace_back(std::make_shared<Expression>(new_expr));
-    }
-    return result;
-}
 
-LinearIR LinearIR::deep_copy() const {
-    // todo: implement the same functionality using standard copy constructor
-    auto clone_ports_descriptors = [](std::vector<PortDescriptorPtr>& ports) {
-        std::for_each(ports.begin(), ports.end(), [](PortDescriptorPtr& pd) { pd = pd->clone(); });
-    };
-    const auto& original_lir = *this;
-    LinearIR new_lir;
-    new_lir.m_config = original_lir.m_config;
-    new_lir.m_shape_infer = original_lir.m_shape_infer;
-    NodeVector original_nodes;
-    original_nodes.reserve(original_lir.m_expressions.size());
-    std::unordered_map<PortConnectorPtr, PortConnectorPtr> connectors_map;
-    for (const auto& orig_expr : original_lir) {
-        original_nodes.push_back(orig_expr->get_node());
-        const auto& copy_expr = ExpressionFactory::shallow_copy(orig_expr);
-        clone_ports_descriptors(copy_expr->m_input_port_descriptors);
-        clone_ports_descriptors(copy_expr->m_output_port_descriptors);
-
-        for (auto& orig_con : copy_expr->m_output_port_connectors) {
-            const auto& copy_source = copy_expr->get_output_port(orig_con->get_source().get_index());
-            const auto& copy_con = std::make_shared<PortConnector>(copy_source);
-            connectors_map[orig_con] = copy_con;
-            orig_con = copy_con;
-        }
-        for (size_t i = 0; i < copy_expr->get_input_count(); i++) {
-            const auto& copy_connector = connectors_map[copy_expr->get_input_port_connector(i)];
-            const auto& copy_consumer = copy_expr->get_input_port(i);
-            copy_connector->add_consumer(copy_consumer);
-            copy_expr->replace_input(i, copy_connector);
-        }
-
-        if (auto io_expr = std::dynamic_pointer_cast<IOExpression>(copy_expr))
-            new_lir.m_io_expressions.push_back(io_expr);
-        new_lir.m_expressions.push_back(copy_expr);
-    }
     // node_map and expr_map map original node pointer (expression) to a new pointer (expression)
     ngraph::NodeMap node_map;
     OPENVINO_SUPPRESS_DEPRECATED_START
     ngraph::clone_nodes(original_nodes,  node_map);
     OPENVINO_SUPPRESS_DEPRECATED_END
-    new_lir.m_node2expression_map.clear();
-    for (const auto& copy_expr : new_lir.m_expressions) {
-        copy_expr->m_source_node = node_map[copy_expr->m_source_node.get()];
-        new_lir.m_node2expression_map[copy_expr->m_source_node] = copy_expr;
+
+    for (auto it = begin; it != end; it++) {
+        const auto& expr = *it;
+        const auto& new_expr = expr->clone_with_new_inputs(expression_map, node_map[expr->get_node().get()]);
+        result.push_back(new_expr);
+        expression_map[expr.get()] = new_expr;
     }
-    new_lir.m_loop_manager = std::make_shared<LoopManager>();
-    // It's Ok to share shapeInfer factory, since LIR doesn't change it
-    new_lir.m_shape_infer_factory = m_shape_infer_factory;
-    // Note: shapeInfer stores expression pointers. we re-create it, so shape inference is performed on cloned exprs.
-    new_lir.m_shape_infer = std::make_shared<LIRShapeInfer>(new_lir.m_expressions, new_lir.m_io_expressions);
-    return new_lir;
+    return result;
 }
 
 void LinearIR::debug_print(bool tds_as_pointers) const {

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<LinearIR> LinearIR::clone() const {
     // node_map and expr_map map original node pointer (expression) to a new pointer (expression)
     ngraph::NodeMap node_map;
     OPENVINO_SUPPRESS_DEPRECATED_START
-    ngraph::clone_nodes(original_nodes,  node_map);
+    ngraph::clone_nodes(original_nodes, node_map);
     OPENVINO_SUPPRESS_DEPRECATED_END
 
     ExressionMap expression_map;
@@ -66,7 +66,7 @@ std::shared_ptr<LinearIR> LinearIR::clone() const {
             cloned->m_io_expressions.push_back(io);
     }
 
-    cloned->m_loop_manager = m_loop_manager->clone_for_new_expr(expression_map);
+    cloned->m_loop_manager = m_loop_manager->clone_with_new_expr(expression_map);
     // It's Ok to share shapeInfer factory ptr, since the factory doesn't depend on LIR in any way
     cloned->m_shape_infer_factory = m_shape_infer_factory;
     cloned->m_shape_infer = std::make_shared<LIRShapeInfer>(cloned->m_expressions, cloned->m_io_expressions);

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<LoopPort> LoopPort::clone_with_new_expr(const ExpressionPtr& new
 }
 
 LoopInfo::LoopInfo(size_t work_amount, size_t increment, size_t dim_idx,
-                                          const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits)
+                   const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits)
     : work_amount(work_amount), increment(increment), dim_idx(dim_idx), outer_splited_loop(false) {
     entry_points.reserve(entries.size());
     exit_points.reserve(exits.size());

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -356,11 +356,13 @@ void LinearIR::LoopManager::update_loop_port(size_t loop_id, const ExpressionPor
         return;
 
     // to save other parameters except expression port
-    std::vector<LoopPort> target_loop_ports;
-    target_loop_ports.reserve(target_ports.size());
-    for (const auto& p : target_ports)
-        target_loop_ports.push_back(*port_it->clone_with_new_expr(p.get_expr()));
-
+    std::vector<LoopPort> target_loop_ports(target_ports.size(), *port_it);
+    std::transform(target_loop_ports.begin(), target_loop_ports.end(), target_ports.begin(), target_loop_ports.begin(),
+                   [](LoopPort loop_port, const ExpressionPort& expr_port) {
+                       LoopPort copy = std::move(loop_port);  // to save loop port parameters
+                       copy.expr_port = std::make_shared<ExpressionPort>(expr_port);
+                       return copy;
+                   });
     port_it = ports.erase(port_it);
     ports.insert(port_it, target_ports.cbegin(), target_ports.cend());
 }

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -28,7 +28,8 @@ std::shared_ptr<op::LoopEnd> InsertTailLoop::create_tail_loop(LinearIR& linear_i
     // tail loop is fake loop because for tail we should calculate only
     // finalization offsets which are supported by LoopEnd.
     if (need_vector_loop) {
-        auto vector_loop_deep_copy = LinearIR::deep_copy_range(vector_begin, vector_end);
+        ExressionMap expression_map;
+        auto vector_loop_deep_copy = LinearIR::deep_copy_range(vector_begin, vector_end, expression_map);
         tail_begin = linear_ir.insert(vector_end, vector_loop_deep_copy.begin(), vector_loop_deep_copy.end());
         tail_end = vector_end;
     } else {

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -376,7 +376,7 @@ std::shared_ptr<Subgraph> Subgraph::clone() const {
     result->set_friendly_name(get_friendly_name());
     if (m_linear_ir)
         result->m_linear_ir = m_linear_ir->clone();
-    // Note: we don't update shapeInfer here, since it's initialized ihn the constructor
+    // Note: we don't update shapeInfer here, since it's initialized in the constructor
     if (m_generator)
         result->m_generator = m_generator->clone();
     return result;

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -375,8 +375,8 @@ std::shared_ptr<Subgraph> Subgraph::clone() const {
     ov::copy_runtime_info(const_pointer_cast<Node>(shared_from_this()), result);
     result->set_friendly_name(get_friendly_name());
     if (m_linear_ir)
-        result->m_linear_ir = std::make_shared<lowered::LinearIR>(m_linear_ir->deep_copy());
-    // Note: we don't update shapeInfer here, since it's initialized in the constructor
+        result->m_linear_ir = m_linear_ir->clone();
+    // Note: we don't update shapeInfer here, since it's initialized ihn the constructor
     if (m_generator)
         result->m_generator = m_generator->clone();
     return result;
@@ -492,7 +492,7 @@ snippets::Schedule Subgraph::generate_from_linear_ir(const lowered::pass::PassPi
     // Note: some transformations performed in the generator, e.g. tail insertion, can break shape propagation
     //  until we fix this behavior, we have to make a copy of LIR before giving it to the generator.
     OPENVINO_ASSERT(m_linear_ir, "Attempt to call generate, when linear IR was not initialized");
-    auto linear_ir = m_linear_ir->deep_copy();
+    auto linear_ir {*m_linear_ir->clone()};
     LoweringResult lowering_result;
     control_flow_transformations(linear_ir, lowering_result, backend_passes_pre_common, backend_passes_post_common);
     m_generator->generate(linear_ir, lowering_result, compile_params);


### PR DESCRIPTION
### Details:
 - *During review of PR18563 it was established that it is hard to perform correct deep copy of LIR, because it owns a range of pointers that in turn needs to be deep copied. In this PR we introduce a convenient and safe way to copy LIR or deep_copy a range of expressions*

### Tickets:
 - *-*
 
### Prerequisites:
- [x] Snippets dynamic pipeline reorganization [18563](https://github.com/openvinotoolkit/openvino/pull/18563)

PR between branches for review: https://github.com/IvanNovoselov/openvino/pull/14
