### PR TITLE
[GPU] Minor debug fixes

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -208,7 +208,8 @@ std::unique_ptr<json_composite> program_node::desc_to_json() const {
 #endif
         impls.push_back(selected_impl->get_kernel_name());
 
-        if (get_preferred_impl_type() == impl_types::ocl) {
+        auto preferred_impl_type = get_preferred_impl_type();
+        if (preferred_impl_type != impl_types::onednn && preferred_impl_type != impl_types::cpu) {
             json_composite cl_dump_info;
             cl_dump_info.add("batch_hash", selected_impl->get_kernels_dump_info().first);
             cl_dump_info.add("kernel_entry", selected_impl->get_kernels_dump_info().second);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
@@ -80,6 +80,10 @@ std::string KernelBaseOpenCL::GetEntryPoint(const std::string& templateName,
     // UniqueID = program_id + processing_index + additional weight/reorder tag
     kernelID += "_" + params.uniqueID + "_" + std::to_string(partID);
 
+    // Add "__sa" suffix for shape agnostic kernels
+    if (params.is_shape_agnostic)
+        kernelID += "__sa";
+
     return kernelID;
 }
 


### PR DESCRIPTION
### Details:
 - Added additional suffix `__sa` for shape agnostic kernels names for better clarity in profiling software:
```
/* Previous */
    reorder_data_14821491574453208146_0,      1,      12700052,    0.15%,      12700052,      12700052,      12700052
    reorder_data_16385396756226318839_0,     64,        193201,    0.00%,          3018,          1822,         12031

/* Now */
    reorder_data_14821491574453208146_0,      1,      12700052,    0.15%,      12700052,      12700052,      12700052
reorder_data_16385396756226318839_0__sa,     64,        193201,    0.00%,          3018,          1822,         12031
```
- Added dump of `cl dump_ info` for `impl_types::any`, since `impl_types::any` implementation type may be associated with cldnn kernels as well

### Tickets:
 - *ticket-id*
