### PR TITLE
[Snippets][CPU] Disabled MHA tokenization with infer precision f16

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -591,7 +591,7 @@ void Transformations::MainSnippets(void) {
 
     // - MHA has BRGEMM that is supported only on AVX512 platforms
     // - CPU Plugin Subgraph supports only f32, bf16 (and quantized) BRGEMM
-    //   TODO[122494]: Need to add support of f16
+    // TODO[122494]: Need to add support of f16
     const bool isMHASupported =
             dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) &&
             one_of(inferencePrecision, ov::element::bf16, ov::element::f32);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -589,8 +589,12 @@ void Transformations::MainSnippets(void) {
         CPU_REGISTER_PASS_X64(snippetsManager, SnippetsMarkSkipped, inferencePrecision != ov::element::f32);
     CPU_REGISTER_PASS_X64(snippetsManager, snippets::pass::SnippetsTokenization, tokenization_config);
 
+    // - MHA has BRGEMM that is supported only on AVX512 platforms
+    // - CPU Plugin Subgraph supports only f32, bf16 (and quantized) BRGEMM
+    //   TODO[122494]: Need to add support of f16
     const bool isMHASupported =
-            dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core);  // MHA has BRGEMM that is supported only on AVX512 platforms
+            dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) &&
+            one_of(inferencePrecision, ov::element::bf16, ov::element::f32);
     if (!isMHASupported) {
         CPU_DISABLE_PASS_X64(snippetsManager, snippets::pass::TokenizeMHASnippets);
         CPU_DISABLE_PASS_X64(snippetsManager, snippets::pass::ExtractReshapesFromMHA);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -591,7 +591,7 @@ void Transformations::MainSnippets(void) {
 
     // - MHA has BRGEMM that is supported only on AVX512 platforms
     // - CPU Plugin Subgraph supports only f32, bf16 (and quantized) BRGEMM
-    // TODO[122494]: Need to add support of f16
+    //   [122494] Need to add support of f16
     const bool isMHASupported =
             dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) &&
             one_of(inferencePrecision, ov::element::bf16, ov::element::f32);


### PR DESCRIPTION
### Details:
 - *CPU Plugin Subgraph supports BRGEMM only with precisions `f32`, `bf16`, `i8`. If precision is `f16`, MHA should be executed with this precision as separate node set on plugin side. Thus, the PR enabled MHA tokenization only with infer precision `f32`, `bf16`*

### Tickets:
 - *N/A*
