### PR TITLE
[DOCS] Direct Github link to a specific notebook for 23.1

### DIFF
--- a/docs/nbdoc/consts.py
+++ b/docs/nbdoc/consts.py
@@ -6,6 +6,8 @@ repo_owner = "openvinotoolkit"
 
 repo_name = "openvino_notebooks"
 
+repo_branch = "tree/main"
+
 artifacts_link = "http://repository.toolbox.iotg.sclab.intel.com/projects/ov-notebook/0.1.0-latest/20230815220807/dist/rst_files/"
 
 blacklisted_extensions = ['.xml', '.bin']
@@ -29,7 +31,7 @@ To run without installing anything, click the "launch binder" button.
 
 .. |github_link| raw:: html
 
-   <a href="https://github.com/{{ owner }}/{{ repo }}" target="_blank"><img src="https://badgen.net/badge/icon/github?icon=github&label" alt="Github"></a>
+   <a href="https://github.com/{{ owner }}/{{ repo }}/{{ branch }}/{{ folder }}/{{ notebook }}" target="_blank"><img src="https://badgen.net/badge/icon/github?icon=github&label" alt="Github"></a>
 
 \n
 """
@@ -50,7 +52,7 @@ To run without installing anything, click the "Open in Colab" button.
 
 .. |github_link| raw:: html
 
-   <a href="https://github.com/{{ owner }}/{{ repo }}" target="_blank"><img src="https://badgen.net/badge/icon/github?icon=github&label" alt="Github"></a>
+   <a href="https://github.com/{{ owner }}/{{ repo }}/{{ branch }}/{{ folder }}/{{ notebook }}" target="_blank"><img src="https://badgen.net/badge/icon/github?icon=github&label" alt="Github"></a>
 
 \n
 """
@@ -75,7 +77,7 @@ To run without installing anything, click the "launch binder" or "Open in Colab"
 
 .. |github_link| raw:: html
 
-   <a href="https://github.com/{{ owner }}/{{ repo }}" target="_blank"><img src="https://badgen.net/badge/icon/github?icon=github&label" alt="Github"></a>
+   <a href="https://github.com/{{ owner }}/{{ repo }}/{{ branch }}/{{ folder }}/{{ notebook }}" target="_blank"><img src="https://badgen.net/badge/icon/github?icon=github&label" alt="Github"></a>
 
 \n
 """
@@ -91,7 +93,7 @@ See the |installation_link| for instructions to run this tutorial locally on Win
 
 .. |github_link| raw:: html
 
-   <a href="https://github.com/{{ owner }}/{{ repo }}" target="_blank"><img src="https://badgen.net/badge/icon/github?icon=github&label" alt="Github"></a>
+   <a href="https://github.com/{{ owner }}/{{ repo }}/{{ branch }}/{{ folder }}/{{ notebook }}" target="_blank"><img src="https://badgen.net/badge/icon/github?icon=github&label" alt="Github"></a>
 
 \n
 """

--- a/docs/nbdoc/nbdoc.py
+++ b/docs/nbdoc/nbdoc.py
@@ -16,6 +16,7 @@ from consts import (
     no_binder_template,
     repo_directory,
     repo_name,
+    repo_branch,
     repo_owner,
 )
 from notebook import Notebook
@@ -79,6 +80,7 @@ class NbProcessor:
             "owner": repo_owner,
             "repo": repo_name,
             "folder": repo_directory,
+            "branch": repo_branch,
         }
         self.colab_data = {
             "owner": repo_owner,


### PR DESCRIPTION
Creating a direct link to a specific notebook in the `openvino_notebooks` Github repository.
This PR addresses Jira ticket: 121735

Porting:
https://github.com/openvinotoolkit/openvino/pull/20248
