### PR TITLE
[PyOV] Add torch lower bound to solve sporadic CI fail

### DIFF
--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -22,4 +22,4 @@ pytest-html==3.2.0
 pytest-timeout==2.1.0
 jax<=0.4.14
 jaxlib<=0.4.14
-torch<2.1.0
+torch<2.1.0,>=1.13


### PR DESCRIPTION
### Details:
 - CI sometimes installs `torch==1.12`, which doesn't have `force` attribute for `torch.Tensor`
 - we're using that attribute at https://github.com/openvinotoolkit/openvino/blob/master/src/bindings/python/src/openvino/frontend/pytorch/utils.py#L67
 - it causes sporadic CI errors
 - the `force` attribute has been added in `torch==1.13`
 - having a lower bound on torch for tests should resolve the sporadic error issue

### Tickets:
 - 121645
