### PR TITLE
fix Output and Input comparison to use instance id instead of addresses

### DIFF
--- a/src/core/src/node_input.cpp
+++ b/src/core/src/node_input.cpp
@@ -61,11 +61,13 @@ bool Input<Node>::operator!=(const Input& other) const {
     return !(*this == other);
 }
 bool Input<Node>::operator<(const Input& other) const {
-    return m_node < other.m_node || (m_node == other.m_node && m_index < other.m_index);
+    return m_node->get_instance_id() < other.m_node->get_instance_id() ||
+           (m_node == other.m_node && m_index < other.m_index);
 }
 
 bool Input<Node>::operator>(const Input& other) const {
-    return m_node > other.m_node || (m_node == other.m_node && m_index > other.m_index);
+    return m_node->get_instance_id() > other.m_node->get_instance_id() ||
+           (m_node == other.m_node && m_index > other.m_index);
 }
 
 bool Input<Node>::operator<=(const Input& other) const {

--- a/src/core/src/node_output.cpp
+++ b/src/core/src/node_output.cpp
@@ -137,10 +137,12 @@ bool Output<Node>::operator!=(const Output& other) const {
     return !(*this == other);
 }
 bool Output<Node>::operator<(const Output& other) const {
-    return m_node < other.m_node || (m_node == other.m_node && m_index < other.m_index);
+    return m_node->get_instance_id() < other.m_node->get_instance_id() ||
+           (m_node == other.m_node && m_index < other.m_index);
 }
 bool Output<Node>::operator>(const Output& other) const {
-    return m_node > other.m_node || (m_node == other.m_node && m_index > other.m_index);
+    return m_node->get_instance_id() > other.m_node->get_instance_id() ||
+           (m_node == other.m_node && m_index > other.m_index);
 }
 bool Output<Node>::operator<=(const Output& other) const {
     return !(*this > other);


### PR DESCRIPTION
### Details:
 - fix Output and Input comparison operators
 - addresses differ on each run instead of instance id

### Tickets:
 - 118730
