### PR TITLE
[TF FE] Support TF 2.14 and add OnesLike translator

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -17,7 +17,7 @@ patchelf<=0.17.2.1
 # Frontends
 docopt~=0.6.2
 paddlepaddle==2.5.1
-tensorflow>=1.15.5,<2.14.0
+tensorflow>=1.15.5,<2.15.0
 six~=1.16.0
 protobuf>=3.18.1,<4.0.0
 onnx==1.14.1

--- a/src/frontends/tensorflow/src/op_table.cpp
+++ b/src/frontends/tensorflow/src/op_table.cpp
@@ -211,6 +211,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"NoOp", CreatorFunction(translate_no_op)},  // do nothing
         {"OneHot", CreatorFunction(translate_one_hot_op)},
         {"OneShotIterator", CreatorFunction(translate_iterator_op)},
+        {"OnesLike", CreatorFunction(translate_ones_like_op)},
         {"Pack", CreatorFunction(translate_pack_op)},
         {"Pad", CreatorFunction(translate_pad_op)},
         {"PadV2", CreatorFunction(translate_padv2_op)},

--- a/src/frontends/tensorflow_common/include/common_op_table.hpp
+++ b/src/frontends/tensorflow_common/include/common_op_table.hpp
@@ -97,6 +97,7 @@ OP_CONVERTER(translate_placeholder_op);
 OP_CONVERTER(translate_placeholder_with_default_op);
 OP_CONVERTER(translate_no_op);
 OP_CONVERTER(translate_one_hot_op);
+OP_CONVERTER(translate_ones_like_op);
 OP_CONVERTER(translate_pack_op);
 OP_CONVERTER(translate_pad_op);
 OP_CONVERTER(translate_padv2_op);

--- a/src/frontends/tensorflow_common/src/op/ones_like.cpp
+++ b/src/frontends/tensorflow_common/src/op/ones_like.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_op_table.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "utils.hpp"
+
+using namespace std;
+using namespace ov::op;
+
+namespace ov {
+namespace frontend {
+namespace tensorflow {
+namespace op {
+
+OutputVector translate_ones_like_op(const NodeContext& node) {
+    default_op_checks(node, 1, {"OnesLike"});
+    auto x = node.get_input(0);
+    Output<Node> shape_of = make_shared<v3::ShapeOf>(x, element::i32);
+    auto one_const = create_same_type_const_scalar<int32_t>(x, 1);
+
+    // in case of x to be scalar, we need handle it more specifically
+    // since Broadcast supports only broadcasting to rank greater 0
+    // we have to introduce extra dimension for input scalar case
+    auto one_dim = make_shared<v0::Constant>(element::i32, Shape{1}, 1);
+    shape_of = make_shared<v0::Concat>(OutputVector{one_dim, shape_of}, 0);
+
+    // create a tensor of zeros of shape with extra dimension
+    Output<Node> ones_like = make_shared<v3::Broadcast>(one_const, shape_of);
+    // remove extra dimension by squeezing
+    auto zero_dim_ind = make_shared<v0::Constant>(element::i32, Shape{1}, 0);
+    ones_like = make_shared<v0::Squeeze>(ones_like, zero_dim_ind);
+
+    set_node_name(node.get_name(), ones_like.get_node_shared_ptr());
+    return {ones_like};
+}
+
+}  // namespace op
+}  // namespace tensorflow
+}  // namespace frontend
+}  // namespace ov

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -11,7 +11,7 @@ scipy>=1.11.1; python_version >= "3.9"
 wheel>=0.38.1
 defusedxml>=0.7.1
 fastjsonschema~=2.17.1
-tensorflow>=2.5,<2.14.0
+tensorflow>=2.5,<2.15.0
 test-generator==0.1.2
 requests>=2.25.1
 opencv-python>=4.5

--- a/tests/layer_tests/common/tflite_layer_test_class.py
+++ b/tests/layer_tests/common/tflite_layer_test_class.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 import os
+
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 import tensorflow as tf
 from tensorflow.lite.tools import flatbuffer_utils as utils
@@ -62,7 +63,15 @@ class TFLiteLayerTest(CommonLayerTest):
             else:
                 op_names.append(builtin_operators[op.builtinCode])
         op_names = sorted(op_names)
-        assert op_names == self.allowed_ops, "TFLite model is not as you expect it to be: " + ", ".join(op_names)
+        if isinstance(self.allowed_ops, tuple):
+            passed = False
+            for allowed_ops_var in self.allowed_ops:
+                if op_names == allowed_ops_var:
+                    passed = True
+                    break
+            assert passed, "TFLite model is not as you expect it to be: " + ", ".join(op_names)
+        else:
+            assert op_names == self.allowed_ops, "TFLite model is not as you expect it to be: " + ", ".join(op_names)
 
     def _test(self, ie_device, precision, temp_dir, params):
         model = self.make_model(params)

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_FullyConnected.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_FullyConnected.py
@@ -13,7 +13,7 @@ test_params = [
 class TestTFLiteFullyConnectedLayerTest(TFLiteLayerTest):
     inputs = ["Input_x", "Input_y"]
     outputs = ["FullyConnected"]
-    allowed_ops = ['BATCH_MATMUL'] # changed since TF 2.14
+    allowed_ops = (['FULLY_CONNECTED'], ['BATCH_MATMUL'])
 
     def make_model(self, params):
         assert len(set(params.keys()).intersection({'shape_x', 'shape_y'})) == 2, \

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_FullyConnected.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_FullyConnected.py
@@ -13,7 +13,7 @@ test_params = [
 class TestTFLiteFullyConnectedLayerTest(TFLiteLayerTest):
     inputs = ["Input_x", "Input_y"]
     outputs = ["FullyConnected"]
-    allowed_ops = ['FULLY_CONNECTED']
+    allowed_ops = ['BATCH_MATMUL'] # changed since TF 2.14
 
     def make_model(self, params):
         assert len(set(params.keys()).intersection({'shape_x', 'shape_y'})) == 2, \

--- a/tests/layer_tests/tensorflow_tests/test_tf_OnesLike.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_OnesLike.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from common.tf_layer_test_class import CommonTFLayerTest
+
+
+class TestOnesLike(CommonTFLayerTest):
+    def _prepare_input(self, inputs_info):
+        assert 'x' in inputs_info
+        x_shape = inputs_info['x']
+        inputs_data = {}
+        rng = np.random.default_rng()
+        inputs_data['x'] = rng.integers(-10, 10, x_shape).astype(self.x_type)
+        return inputs_data
+
+    def create_ones_like_net(self, x_shape, x_type):
+        self.x_type = x_type
+        tf.compat.v1.reset_default_graph()
+        # Create the graph and model
+        with tf.compat.v1.Session() as sess:
+            x = tf.compat.v1.placeholder(tf.dtypes.as_dtype(x_type), x_shape, 'x')
+            tf.raw_ops.OnesLike(x=x)
+            tf.compat.v1.global_variables_initializer()
+            tf_net = sess.graph_def
+
+        return tf_net, None
+
+    test_data_basic = [
+        dict(x_shape=[], x_type=np.float32),
+        dict(x_shape=[2], x_type=np.int32),
+        dict(x_shape=[2, 3, 4], x_type=np.float32),
+        dict(x_shape=[1, 4, 3, 1], x_type=np.int32),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_basic)
+    @pytest.mark.precommit_tf_fe
+    @pytest.mark.nightly
+    def test_ones_like(self, params, ie_device, precision, ir_version, temp_dir,
+                       use_new_frontend, use_old_api):
+        self._test(*self.create_ones_like_net(**params),
+                   ie_device, precision, ir_version, temp_dir=temp_dir,
+                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,5 +1,5 @@
 -c ../constraints.txt
-tensorflow>=1.15.5,<2.14.0
+tensorflow>=1.15.5,<2.15.0
 numpy>=1.16.6,<1.26
 networkx
 defusedxml

--- a/tools/mo/requirements_tf2.txt
+++ b/tools/mo/requirements_tf2.txt
@@ -1,5 +1,5 @@
 -c ../constraints.txt
-tensorflow>=2.5,<2.14.0
+tensorflow>=2.5,<2.15.0
 numpy>=1.16.6,<1.26
 networkx
 defusedxml


### PR DESCRIPTION
**Details:** Support TF 2.14 and add OnesLike translator. TF 2.14 requires OnesLike since RNN ops use this operation in the decomposition

**Ticket:** TBD

