### PR TITLE
[TESTS] Fix random generator for custom signed types

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/normalize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/normalize.cpp
@@ -80,6 +80,10 @@ protected:
         }
         auto normalize = builder::makeNormalizeL2(params[0], axes, eps, epsMode);
         function = makeNgraphFunction(inType, params, normalize, "Normalize");
+
+        if (inType == ov::element::bf16) {
+            abs_threshold = 1e-1f;
+        }
     }
 
     void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override {

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
 #include <random>
 #include <utility>
 
@@ -223,7 +224,7 @@ void inline fill_data_random(T* pointer,
     const uint32_t k_range = k * range;  // range with respect to k
     random.Generate(k_range);
 
-    if (start_from < 0 && !std::is_signed<T>::value) {
+    if (start_from < 0 && !std::numeric_limits<T>::is_signed) {
         start_from = 0;
     }
     for (std::size_t i = 0; i < size; i++) {


### PR DESCRIPTION
### Details:
 - Currently used `std::is_signed` always returns false for custom type (such as `ov::float16`) so we always have positive range generated for fp16 tensors which could increase representation error due to larger absolute values in accumulators/out tensors.
 - cpp spec says `The behavior of a program that adds specializations for std::is_signed or std::is_signed_v is undefined.` while specializations for numeric_limits are allowed and we already have specializations for `float16` and `bfloat16`, so this PR switches to numeric_limits usage
