### PR TITLE
Small fix for GPU memory allocation documentation

### DIFF
--- a/src/plugins/intel_gpu/docs/memory_allocation_gpu_plugin.md
+++ b/src/plugins/intel_gpu/docs/memory_allocation_gpu_plugin.md
@@ -20,7 +20,7 @@ calls the corresponding memory object wrapper for each allocation type: [gpu_buf
 
 ## Dump memory allocation history
 
-The memory allocation history is being managed by the `engine`, which can be dumped by setting the environment variable `OV_GPU_Verbose=1` if OpenVino is built with the cmake configuration `ENABLE_DEBUG_CAPS=ON`.
+The memory allocation history is being managed by the `engine`, which can be dumped by setting the environment variable `OV_GPU_Verbose=2` if OpenVINO is built with the cmake configuration `ENABLE_DEBUG_CAPS=ON`.
 ```cpp
 ...
 GPU_Debug: Allocate 58982400 bytes of usm_host allocation type (current=117969612; max=117969612)


### PR DESCRIPTION
OV_GPU_Verbose should be 2 instead of 1 to dump memory info. 