### PR TITLE
Revert "[CI] [GHA] Skip `test_div_uint8_cpu` on macOS only; unskip `test_onnx/test_backend.py` in GHA workflows"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -896,7 +896,8 @@ jobs:
         run: |
           python3 -m pytest -s ${INSTALL_TEST_DIR}/pyngraph \
             --junitxml=${INSTALL_TEST_DIR}/TEST-Pyngraph.xml \
-            --ignore=${INSTALL_TEST_DIR}/pyngraph/tests_compatibility/test_onnx/test_zoo_models.py
+            --ignore=${INSTALL_TEST_DIR}/pyngraph/tests_compatibility/test_onnx/test_zoo_models.py \
+            --ignore=${INSTALL_TEST_DIR}/pyngraph/tests_compatibility/test_onnx/test_backend.py
 
       - name: Python API 2.0 Tests
         run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -485,11 +485,12 @@ jobs:
             python3 -m pip install $ov_dev_wheel_name[mxnet,caffe,kaldi,onnx,tensorflow2]
           popd
 
-      - name: Python API 1.0 Tests
+      - name: nGraph and IE Python Bindings Tests
         run: |
           python3 -m pytest -s ${{ env.INSTALL_TEST_DIR }}/pyngraph \
             --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-Pyngraph.xml \
-            --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests/test_onnx/test_zoo_models.py
+            --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests/test_onnx/test_zoo_models.py \
+            --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests/test_onnx/test_backend.py
 
       - name: Python API 2.0 Tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -309,7 +309,7 @@ jobs:
         shell: cmd
         run: |
           set PYTHONPATH=${{ env.OPENVINO_REPO }}\tools\mo;${{ env.LAYER_TESTS_INSTALL_DIR }};%PYTHONPATH%
-          call "${{ env.INSTALL_DIR }}\\setupvars.bat" && python3 -m pytest -s ${{ env.INSTALL_TEST_DIR }}/pyngraph ${{ env.PYTHON_STATIC_ARGS }} --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-Pyngraph.xml --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests_compatibility/test_onnx/test_zoo_models.py
+          call "${{ env.INSTALL_DIR }}\\setupvars.bat" && python3 -m pytest -s ${{ env.INSTALL_TEST_DIR }}/pyngraph ${{ env.PYTHON_STATIC_ARGS }} --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-Pyngraph.xml --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests_compatibility/test_onnx/test_zoo_models.py --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests_compatibility/test_onnx/test_backend.py
 
       - name: Python API 2.0 Tests
         shell: cmd

--- a/src/bindings/python/tests_compatibility/test_onnx/test_backend.py
+++ b/src/bindings/python/tests_compatibility/test_onnx/test_backend.py
@@ -3,8 +3,6 @@
 
 import logging
 
-from sys import platform
-
 import onnx.backend.test
 from tests_compatibility import (
     BACKEND_NAME,
@@ -34,7 +32,6 @@ from tests_compatibility import (
     xfail_issue_48052,
     xfail_issue_52463,
     xfail_issue_58033,
-    xfail_issue_58676,
     xfail_issue_63033,
     xfail_issue_63036,
     xfail_issue_63043,
@@ -811,12 +808,6 @@ tests_expected_to_fail = [
         "OnnxBackendNodeModelTest.test_roialign_mode_max_cpu",
     ),
 ]
-
-if platform == 'darwin':
-    tests_expected_to_fail.append((
-        xfail_issue_58676,
-        "OnnxBackendNodeModelTest.test_div_uint8_cpu"
-    ))
 
 for test_group in tests_expected_to_fail:
     for test_case in test_group[1:]:

--- a/src/frontends/onnx/tests/tests_python/test_backend.py
+++ b/src/frontends/onnx/tests/tests_python/test_backend.py
@@ -4,8 +4,6 @@
 
 import logging
 
-from sys import platform
-
 import onnx.backend.test
 from tests import (
     BACKEND_NAME,
@@ -34,7 +32,6 @@ from tests import (
     xfail_issue_48052,
     xfail_issue_52463,
     xfail_issue_58033,
-    xfail_issue_58676,
     xfail_issue_63033,
     xfail_issue_63036,
     xfail_issue_63043,
@@ -685,12 +682,6 @@ tests_expected_to_fail = [
         "OnnxBackendNodeModelTest.test_roialign_mode_max_cpu",
     ),
 ]
-
-if platform == 'darwin':
-    tests_expected_to_fail.append((
-        xfail_issue_58676,
-        "OnnxBackendNodeModelTest.test_div_uint8_cpu"
-    ))
 
 for test_group in tests_expected_to_fail:
     for test_case in test_group[1:]:


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#20367