### PR TITLE
[CPU] Enabled custom MHA fusion for BF16 and INT8+FP32 cases

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -70,8 +70,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAEnforceBF16, MHA,
                                  ::testing::ValuesIn(precision_f32(4)),
                                  ::testing::Values(ov::element::bf16),
                                  ::testing::ValuesIn({false}),
-                                 ::testing::Values(7),
-                                 ::testing::Values(7),
+                                 ::testing::Values(7), // MHA + 5 Converts + 1 Transpose on output
+                                 ::testing::Values(6), // MHA + 5 Converts on inputs and output
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
                                  ::testing::Values(CPUTestUtils::cpuBF16PluginConfig)),
                          MHA::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
@@ -296,9 +296,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MHA_BF16, MHATest,
                                  ::testing::Values(std::vector<ElementType>{ ElementType::bf16, ElementType::bf16, ElementType::bf16, ElementType::bf16 }),
                                  ::testing::ValuesIn(matMulIn0Precisions),
                                  ::testing::ValuesIn(patternTypes),
-                                 ::testing::Values(ExpectedNodes{{"Subgraph", 1},
-                                                                 {"Transpose", 1}}),  // Plugin disables tokenization of Transpose on output
-                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                 ::testing::Values(ExpectedNodes{{"MHA", 1}}),     // If Snippets: Subgraph[1] + Transpose[1]
+                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),  // (tokenization of Transpose on out is disabled by Plugin)
                          MHATest::getTestCaseName);
 
 } // namespace
@@ -590,9 +589,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant_Pattern0, MHAQuantTest,
                                 ::testing::ValuesIn(inputPrecisionsQuant),
                                 ::testing::ValuesIn(matMulIn0PrecisionsQuant),
                                 ::testing::Values(0),
-                                ::testing::Values(ExpectedNodes{{"Subgraph", 5},  // FQs on inputs x 3 + MHA + Deq Mul
-                                                                {"Transpose", 1}}),  // Transpose between MHA and Deq Mul
-                                ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                ::testing::Values(ExpectedNodes{{"MHA", 1}}),    // If Snippets: Subgraph[5] + Transpose[1]
+                                ::testing::Values(ov::test::utils::DEVICE_CPU)), // (FQs on inputs x 3 + MHA + Deq Mul and Transpose between MHA and Deq Mul)
                         MHAQuantTest::getTestCaseName);
 
 
@@ -602,9 +600,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant_Pattern1, MHAQuantTest,
                                 ::testing::ValuesIn(inputPrecisionsQuant),
                                 ::testing::ValuesIn(matMulIn0PrecisionsQuant),
                                 ::testing::Values(1),
-                                ::testing::Values(ExpectedNodes{{"Subgraph", 3},  // FQ on input + MHA + Deq Mul
-                                                                {"Transpose", 1}}),  // Transpose between MHA and Deq Mul
-                                ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                ::testing::Values(ExpectedNodes{{"MHA", 1}}),    // If Snippets: Subgraph[3] + Transpose[1]
+                                ::testing::Values(ov::test::utils::DEVICE_CPU)), // (FQ on input + MHA + Deq Mul and Transpose between MHA and Deq Mul)
                         MHAQuantTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant_Pattern2, MHAQuantTest,


### PR DESCRIPTION
### Details:
 - *Some MHA patterns were fused into custom MHA node but after Snippets MHA tokenization enabling for BF16, INT8 models these subgraphs aren't tokenized into single node because of heuristic conditions: if there are big shapes, Snippets don't guarantee performance because of BRGEMM blocking for BF16 and INT8 is not implemented . The PR returns custom MHA fusion for these subgraphs only for BF16 and INT8+FP32 cases: FP32 case is faster on Snippets (due to blocking support) and INT8+BF16 case is supported only by Snippets(Custom MHA supports only INT8+FP32 that slower). Seems like custom MHA is matched only on models with small shapes that we don't have performance regressions*

### Tickets:
 - *N/A*
