### PR TITLE
[CONFORMANCE][PRECOMMIT] Add one sporadically interapted test to expected failures

### DIFF
--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/skip_configs/CPU/expected_failures_OP.csv
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/skip_configs/CPU/expected_failures_OP.csv
@@ -1129,3 +1129,4 @@ conformance_PriorBox/ReadIRTest.ImportExport/Op=PriorBox.1_Type=f32_IR=PriorBox-
 conformance_PRelu/ReadIRTest.ImportExport/Op=PRelu.1_Type=f32_IR=20e7e74f55eb5fb78014cce7e0665d6925bbefd708dd9ccff12dbfbea2a330dd_Device=CPU_Shape=static_Config=(),5.69266e-06
 conformance_RegionYolo/ReadIRTest.ImportExport/Op=RegionYolo.1_Type=f32_IR=RegionYolo-1_750_Device=CPU_Shape=static_Config=(),5.06332e-06
 conformance_Add/ReadIRTest.ImportExport/Op=Add.1_Type=i32_IR=28f23780d4ca0d40671caf79d5cd9223ad8f6dc2fa5ade2521f3d99586eeeb7f_Device=CPU_Shape=static_Config=(),9.72615e-07
+conformance_Convolution/ReadIRTest.Inference/Op=Convolution.1_Type=f32_IR=c301804445f273eef62f41f02204711d9d6e571da28c76ab447d7d90983b0032_Device=CPU_Shape=dynamic_Config=(),0.000113281


### PR DESCRIPTION
### Details:
 - *is sporadically killed by timeout:*
 ```
[ RUN      ] conformance_Convolution/ReadIRTest.Inference/Op=Convolution.1_Type=f32_IR=c301804445f273eef62f41f02204711d9d6e571da28c76ab447d7d90983b0032_Device=CPU_Shape=dynamic_Config=()

MEM_USAGE=53196KB
[ CONFORMANCE ] Influence coefficient: 0.000113281
[ PLUGIN      ] `SubgraphBaseTest::compile_model()` is started
[ PLUGIN      ] `SubgraphBaseTest::compile_model()` is finished successfully. Duration is 0.0524182s
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is started
[ REFERENCE   ] Calculate reference in runtime
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is started
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is finished successfully. Duration is 0.0512713s
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is 1.15993s
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is started
[ COMPARATION ] rel_threshold: 1.79769e+308
[ COMPARATION ] abs_threshold: 116.571
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is finished successfully. Duration is 0.640411s
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is started
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is started
[ REFERENCE   ] Calculate reference in runtime
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is finished successfully. Duration is 0.428756s
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is 13.0844s
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is started
[ COMPARATION ] rel_threshold: 1.79769e+308
[ COMPARATION ] abs_threshold: 116.571
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is finished successfully. Duration is 6.34024s
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is started
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is started
[ REFERENCE   ] Calculate reference in runtime
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is finished successfully. Duration is 4.70287s

```

### Tickets:
 - *ticket-id*
