### PR TITLE
[core]Migrate LogicalOr to new API

### DIFF
--- a/src/core/include/openvino/op/logical_or.hpp
+++ b/src/core/include/openvino/op/logical_or.hpp
@@ -34,9 +34,7 @@ public:
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v1

--- a/src/core/reference/include/openvino/reference/or.hpp
+++ b/src/core/reference/include/openvino/reference/or.hpp
@@ -4,31 +4,38 @@
 
 #pragma once
 
-#include <cstddef>
+#include <algorithm>
+#include <functional>
 
 #include "openvino/core/shape.hpp"
-#include "openvino/op/util/attr_types.hpp"
 #include "openvino/reference/autobroadcast_binop.hpp"
 
 namespace ov {
 namespace reference {
-template <typename T>
-void logical_or(const T* arg0, const T* arg1, T* out, size_t count) {
-    for (size_t i = 0; i < count; i++) {
-        out[i] = static_cast<T>(arg0[i] || arg1[i]);
-    }
+
+template <class T>
+void logical_or(const T* arg0, const T* arg1, T* out, const size_t count) {
+    std::transform(arg0, std::next(arg0, count), arg1, out, std::logical_or<T>());
 }
 
-template <typename T>
+/**
+ * @brief Reference implementation of binary elementwise LogicalOr operator.
+ *
+ * @param arg0            Pointer to input 0 data.
+ * @param arg1            Pointer to input 1 data.
+ * @param out             Pointer to output data.
+ * @param arg_shape0      Input 0 shape.
+ * @param arg_shape1      Input 1 shape.
+ * @param broadcast_spec  Broadcast specification mode.
+ */
+template <class T>
 void logical_or(const T* arg0,
                 const T* arg1,
                 T* out,
                 const Shape& arg0_shape,
                 const Shape& arg1_shape,
                 const op::AutoBroadcastSpec& broadcast_spec) {
-    autobroadcast_binop(arg0, arg1, out, arg0_shape, arg1_shape, broadcast_spec, [](T x, T y) -> T {
-        return static_cast<T>(x || y);
-    });
+    autobroadcast_binop(arg0, arg1, out, arg0_shape, arg1_shape, broadcast_spec, std::logical_or<T>());
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/src/op/logical_or.cpp
+++ b/src/core/src/op/logical_or.cpp
@@ -4,9 +4,7 @@
 
 #include "openvino/op/logical_or.hpp"
 
-#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/validation_util.hpp"
 #include "openvino/reference/or.hpp"
 #include "utils.hpp"
 

--- a/src/core/src/op/logical_or.cpp
+++ b/src/core/src/op/logical_or.cpp
@@ -2,77 +2,56 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/op/logical_or.hpp"
+
+#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/op/or.hpp"
-#include "ngraph/runtime/host_tensor.hpp"
 #include "ngraph/validation_util.hpp"
 #include "openvino/reference/or.hpp"
+#include "utils.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace v1 {
 
-op::v1::LogicalOr::LogicalOr(const Output<Node>& arg0,
-                             const Output<Node>& arg1,
-                             const AutoBroadcastSpec& auto_broadcast)
+LogicalOr::LogicalOr(const Output<Node>& arg0, const Output<Node>& arg1, const AutoBroadcastSpec& auto_broadcast)
     : BinaryElementwiseLogical(arg0, arg1, auto_broadcast) {
     constructor_validate_and_infer_types();
 }
 
-shared_ptr<Node> op::v1::LogicalOr::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> LogicalOr::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v1_LogicalOr_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<v1::LogicalOr>(new_args.at(0), new_args.at(1), this->get_autob());
+    return std::make_shared<LogicalOr>(new_args.at(0), new_args.at(1), get_autob());
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace logor {
-namespace {
-template <element::Type_t ET>
-bool evaluate(const HostTensorPtr& arg0,
-              const HostTensorPtr& arg1,
-              const HostTensorPtr& out,
-              const op::AutoBroadcastSpec& broadcast_spec) {
-    ov::reference::logical_or(arg0->get_data_ptr<ET>(),
-                              arg1->get_data_ptr<ET>(),
-                              out->get_data_ptr<ET>(),
-                              arg0->get_shape(),
-                              arg1->get_shape(),
-                              broadcast_spec);
-    return true;
-}
-
-bool evaluate_logor(const HostTensorPtr& arg0,
-                    const HostTensorPtr& arg1,
-                    const HostTensorPtr& out,
-                    const op::AutoBroadcastSpec& broadcast_spec) {
-    bool rc = true;
-    out->set_broadcast(broadcast_spec, arg0, arg1);
-    switch (arg0->get_element_type()) {
-        OPENVINO_TYPE_CASE(evaluate_logor, boolean, arg0, arg1, out, broadcast_spec);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace logor
-
-bool op::v1::LogicalOr::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool LogicalOr::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v1_LogicalOr_evaluate);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    OPENVINO_ASSERT(validate_host_tensor_vector(outputs, 1) && validate_host_tensor_vector(inputs, 2));
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    return logor::evaluate_logor(inputs[0], inputs[1], outputs[0], get_autob());
+    OPENVINO_ASSERT(outputs.size() == 1);
+    OPENVINO_ASSERT(inputs.size() == 2);
+
+    const auto& shape_0 = inputs[0].get_shape();
+    const auto& shape_1 = inputs[1].get_shape();
+    outputs[0].set_shape(infer_broadcast_shape(this, shape_0, shape_1));
+
+    if (inputs[0].get_element_type() == element::boolean) {
+        using T = fundamental_type_for<element::boolean>;
+        reference::logical_or(inputs[0].data<const T>(),
+                              inputs[1].data<const T>(),
+                              outputs[0].data<T>(),
+                              shape_0,
+                              shape_1,
+                              get_autob());
+        return true;
+    } else {
+        return false;
+    }
 }
 
-bool op::v1::LogicalOr::has_evaluate() const {
+bool LogicalOr::has_evaluate() const {
     OV_OP_SCOPE(v1_LogicalOr_has_evaluate);
-    switch (get_input_element_type(0)) {
-    case ngraph::element::boolean:
-        return true;
-    default:
-        break;
-    }
-    return false;
+    return get_input_element_type(0) == element::boolean;
 }
+}  // namespace v1
+}  // namespace op
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Migrate `LogicalOr` to new API, remove old classes, namespaces, functions.
 - Minor refactor of operator and reference implementation to reduce binary size.

### Tickets:
 - [CVS-118620](https://jira.devtools.intel.com/browse/CVS-118620)
