### PR TITLE
Removed check for openvino::runtime::c in samples

### DIFF
--- a/samples/cpp/CMakeLists.txt
+++ b/samples/cpp/CMakeLists.txt
@@ -214,9 +214,7 @@ macro(ov_add_sample)
     find_package(Threads REQUIRED)
 
     find_package(OpenVINO REQUIRED COMPONENTS Runtime)
-
-    # Conan does not generate openvino::runtime::c target
-    if(c_sample AND TARGET openvino::runtime::c)
+    if(c_sample)
         set(ov_link_libraries openvino::runtime::c)
     else()
         set(ov_link_libraries openvino::runtime)


### PR DESCRIPTION
### Details:
 - Once this PR is merged, we don't need a check anymore https://github.com/conan-io/conan-center-index/pull/20420
