### PR TITLE
[CPU] Weights compression: f16 decompression support

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -233,12 +233,18 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
                 return false;
             }
             // TODO: Uncomment when group decompression is supported
-            // else if (ov::is_type<ov::opset1::Reshape>(consumer)) {
+            // if (ov::is_type<ov::opset1::Reshape>(consumer)) {
             //     consumer = get_single_consumer(consumer);
             //     if (consumer != nullptr && ov::is_type<ov::opset1::MatMul>(consumer)) {
             //         return false;
             //     }
             // }
+            if (ov::is_type<ov::opset1::Convert>(consumer)) {
+                consumer = get_single_consumer(consumer);
+                if (consumer != nullptr && ov::is_type<ov::opset1::MatMul>(consumer)) {
+                    return false;
+                }
+            }
             return true;
         }, ov::pass::MarkDequantizationSubgraph);
     }


### PR DESCRIPTION
### Details
In this PR, f16 decompression support is provided through f16->f32 decompression constants conversion. Support without additional conversion will be provided in next PR

### Tickets:
 - *CVS-119180*
