### PR TITLE
Revert "Revert "[CI] [GHA] Skip `test_div_uint8_cpu` on macOS only; u…

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -896,8 +896,7 @@ jobs:
         run: |
           python3 -m pytest -s ${INSTALL_TEST_DIR}/pyngraph \
             --junitxml=${INSTALL_TEST_DIR}/TEST-Pyngraph.xml \
-            --ignore=${INSTALL_TEST_DIR}/pyngraph/tests_compatibility/test_onnx/test_zoo_models.py \
-            --ignore=${INSTALL_TEST_DIR}/pyngraph/tests_compatibility/test_onnx/test_backend.py
+            --ignore=${INSTALL_TEST_DIR}/pyngraph/tests_compatibility/test_onnx/test_zoo_models.py
 
       - name: Python API 2.0 Tests
         run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -485,7 +485,7 @@ jobs:
             python3 -m pip install $ov_dev_wheel_name[mxnet,caffe,kaldi,onnx,tensorflow2,pytorch]
           popd
 
-      - name: nGraph and IE Python Bindings Tests
+      - name: Python API 1.0 Tests
         run: |
           python3 -m pytest -s ${{ env.INSTALL_TEST_DIR }}/pyngraph \
             --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-Pyngraph.xml \
@@ -501,9 +501,7 @@ jobs:
 
           python3 -m pytest -sv ${{ env.INSTALL_TEST_DIR }}/pyopenvino \
             --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-Pyngraph.xml \
-            --ignore=${{ env.INSTALL_TEST_DIR }}/pyopenvino/tests/test_utils/test_utils.py \
-            --ignore=${{ env.INSTALL_TEST_DIR }}/pyopenvino/tests/test_onnx/test_zoo_models.py \
-            --ignore=${{ env.INSTALL_TEST_DIR }}/pyopenvino/tests/test_onnx/test_backend.py
+            --ignore=${{ env.INSTALL_TEST_DIR }}/pyopenvino/tests/test_utils/test_utils.py
 
       - name: MO Python API Tests
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -309,7 +309,7 @@ jobs:
         shell: cmd
         run: |
           set PYTHONPATH=${{ env.OPENVINO_REPO }}\tools\mo;${{ env.LAYER_TESTS_INSTALL_DIR }};%PYTHONPATH%
-          call "${{ env.INSTALL_DIR }}\\setupvars.bat" && python3 -m pytest -s ${{ env.INSTALL_TEST_DIR }}/pyngraph ${{ env.PYTHON_STATIC_ARGS }} --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-Pyngraph.xml --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests_compatibility/test_onnx/test_zoo_models.py --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests_compatibility/test_onnx/test_backend.py
+          call "${{ env.INSTALL_DIR }}\\setupvars.bat" && python3 -m pytest -s ${{ env.INSTALL_TEST_DIR }}/pyngraph ${{ env.PYTHON_STATIC_ARGS }} --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-Pyngraph.xml --ignore=${{ env.INSTALL_TEST_DIR }}/pyngraph/tests_compatibility/test_onnx/test_zoo_models.py
 
       - name: Python API 2.0 Tests
         shell: cmd

--- a/src/bindings/python/tests_compatibility/test_onnx/test_backend.py
+++ b/src/bindings/python/tests_compatibility/test_onnx/test_backend.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from sys import platform
+
 import onnx.backend.test
 from tests_compatibility import (
     BACKEND_NAME,
@@ -32,6 +34,7 @@ from tests_compatibility import (
     xfail_issue_48052,
     xfail_issue_52463,
     xfail_issue_58033,
+    xfail_issue_58676,
     xfail_issue_63033,
     xfail_issue_63036,
     xfail_issue_63043,
@@ -808,6 +811,12 @@ tests_expected_to_fail = [
         "OnnxBackendNodeModelTest.test_roialign_mode_max_cpu",
     ),
 ]
+
+if platform == 'darwin':
+    tests_expected_to_fail.append((
+        xfail_issue_58676,
+        "OnnxBackendNodeModelTest.test_div_uint8_cpu"
+    ))
 
 for test_group in tests_expected_to_fail:
     for test_case in test_group[1:]:

--- a/src/frontends/onnx/tests/tests_python/test_backend.py
+++ b/src/frontends/onnx/tests/tests_python/test_backend.py
@@ -4,6 +4,8 @@
 
 import logging
 
+from sys import platform
+
 import onnx.backend.test
 from tests import (
     BACKEND_NAME,
@@ -32,6 +34,7 @@ from tests import (
     xfail_issue_48052,
     xfail_issue_52463,
     xfail_issue_58033,
+    xfail_issue_58676,
     xfail_issue_63033,
     xfail_issue_63036,
     xfail_issue_63043,
@@ -682,6 +685,12 @@ tests_expected_to_fail = [
         "OnnxBackendNodeModelTest.test_roialign_mode_max_cpu",
     ),
 ]
+
+if platform == 'darwin':
+    tests_expected_to_fail.append((
+        xfail_issue_58676,
+        "OnnxBackendNodeModelTest.test_div_uint8_cpu"
+    ))
 
 for test_group in tests_expected_to_fail:
     for test_case in test_group[1:]:


### PR DESCRIPTION
…nskip `test_onnx/test_backend.py` in GHA workflows (#20367)" (#20402)"

This reverts commit d41e7fcc30dbfb56650903f74987f99d41ce0675.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
