### PR TITLE
[GPU] Fix scatter_nd_update output paddings handling

### DIFF
--- a/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
@@ -69,8 +69,9 @@ scatter_nd_update_inst::typed_primitive_inst(network& network, scatter_nd_update
 void scatter_nd_update_inst::on_execute() {
     auto input1_shape = _impl_params->input_layouts[1].get_partial_shape();
     auto input2_shape = _impl_params->input_layouts[2].get_partial_shape();
+    auto same_layouts = _impl_params->input_layouts[0] == _impl_params->output_layouts[0];
 
-    if ((ov::shape_size(input1_shape.to_shape()) == 0) || (ov::shape_size(input2_shape.to_shape()) == 0))
+    if (same_layouts && ((ov::shape_size(input1_shape.to_shape()) == 0) || (ov::shape_size(input2_shape.to_shape()) == 0)))
         reuse_input();
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_nd_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_nd_update_ref.cl
@@ -36,8 +36,10 @@
 
 KERNEL(scatter_nd_update_ref)(OPTIONAL_SHAPE_INFO_ARG
                    const __global INPUT0_TYPE* data,
+#ifdef IS_SECOND_ITER
                    const __global INPUT1_TYPE* indices,
                    const __global INPUT2_TYPE* updates,
+#endif
                    __global OUTPUT_TYPE* output
 #if HAS_FUSED_OPS_DECLS
                    , FUSED_OPS_DECLS
@@ -56,8 +58,9 @@ KERNEL(scatter_nd_update_ref)(OPTIONAL_SHAPE_INFO_ARG
     const uint f = dim2 % OUTPUT_FEATURE_NUM;
     const uint b = dim2 / OUTPUT_FEATURE_NUM;
 
+    const uint input_idx = GET_UPDATES_INDEX(INPUT0, ORDER);
     const uint output_idx = GET_OUTPUT_INDEX(ORDER);
-    INPUT0_TYPE val = data[output_idx];
+    INPUT0_TYPE val = data[input_idx];
     #if HAS_FUSED_OPS
         FUSED_OPS_FIRST_KERNEL;
         output[output_idx] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT_FIRST_KERNEL);

--- a/src/plugins/intel_gpu/src/kernel_selector/tensor_type.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/tensor_type.h
@@ -621,6 +621,10 @@ public:
         return same;
     }
 
+    bool operator!=(const TensorBaseT& t) const {
+        return !(*this == t);
+    }
+
     bool SameDims(const TensorBaseT& t) const {
         bool same = dtype == t.dtype && layout == t.layout && dims.size() == t.dims.size();
         if (same) {


### PR DESCRIPTION
### Details:
 - Fix input index calculation in scatter_nd_update kernel (for padded case input and output indexes are not the same)
 - Allow to run only first stage of scatter_nd_update (copy stage) if `indices` or `updates` inputs are emtpy, but data modification is needed

### Tickets:
 - 118222
