### PR TITLE
Remove TREAT_WARNING option from the doc

### DIFF
--- a/docs/dev/cmake_options_for_custom_compilation.md
+++ b/docs/dev/cmake_options_for_custom_compilation.md
@@ -157,8 +157,6 @@ In this case OpenVINO CMake scripts take `TBBROOT` environment variable into acc
 * `ENABLE_CLANG_FORMAT` enables [Clang format] code style check:
     * `ON` is default.
     * Used only for ngraph component.
-* `TREAT_WARNING_AS_ERROR` treats all warnings as an error:
-    * `OFF` is default.
 * `ENABLE_FASTER_BUILD` enables [precompiled headers] and [unity build] using CMake:
     * `OFF` is default.
 * `ENABLE_INTEGRITYCHECK` builds DLLs with [/INTEGRITYCHECK] flag:


### PR DESCRIPTION
### Details:
 - Removed legacy cmake option
