### PR TITLE
[GPU] Deferred events deallocation and tuning for FC bf_tiled kernel

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -283,6 +283,8 @@ private:
     size_t _weights_cache_capacity = 1;
 
     std::unordered_map<primitive_id, event::ptr> _events;
+    // This map is used to temporarily hold events that will be deallocated later
+    std::unordered_map<primitive_id, event::ptr> _old_events;
     output_chains_map _output_chains;
 
     std::unique_ptr<ShapePredictor> _shape_predictor;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -241,6 +241,9 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
                     .Case(tune_params(8,  std::min(max_tile_ofm, 2u), 1, 1, 1,  1, EXE_MODE_AGE_BASED));
         }
 
+        if (params.compressed && batch == 1)
+            selector.Case(tune_params(1,  std::min(max_tile_ofm, 2u), 4, 2, 1, 1, EXE_MODE_AGE_BASED));
+
         selector.Case([&](const fully_connected_params&) -> tune_params {
             tune_params result(8, std::min(max_tile_ofm, 2u), 1, 2, 1, 1, EXE_MODE_DEFAULT);
 


### PR DESCRIPTION
### Details:
 - Add temporarily `_old_events` map for events deallocation optimization
 - Tune FC kernel for compressed weights

### Tickets:
 - *ticket-id*
