### PR TITLE
[GPU] Fixed surfaces shape in create_tensor_nv12 helpers

### DIFF
--- a/src/inference/include/openvino/runtime/intel_gpu/ocl/dx.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/ocl/dx.hpp
@@ -161,10 +161,10 @@ public:
         AnyMap tensor_params = {{ov::intel_gpu::shared_mem_type.name(), ov::intel_gpu::SharedMemType::VA_SURFACE},
                                   {ov::intel_gpu::dev_object_handle.name(), static_cast<gpu_handle_param>(nv12_surf)},
                                   {ov::intel_gpu::va_plane.name(), uint32_t(0)}};
-        auto y_tensor = create_tensor(element::u8, {1, 1, height, width}, tensor_params);
+        auto y_tensor = create_tensor(element::u8, {1, height, width, 1}, tensor_params);
         tensor_params[ov::intel_gpu::mem_handle.name()] = static_cast<gpu_handle_param>(nv12_surf);
         tensor_params[ov::intel_gpu::va_plane.name()] = uint32_t(1);
-        auto uv_tensor = create_tensor(element::u8, {1, 2, height / 2, width / 2}, tensor_params);
+        auto uv_tensor = create_tensor(element::u8, {1, height / 2, width / 2, 2}, tensor_params);
         return std::make_pair(y_tensor.as<D3DSurface2DTensor>(), uv_tensor.as<D3DSurface2DTensor>());
     }
 

--- a/src/inference/include/openvino/runtime/intel_gpu/ocl/ocl.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/ocl/ocl.hpp
@@ -264,9 +264,9 @@ public:
         AnyMap tensor_params = {
             {ov::intel_gpu::shared_mem_type.name(), ov::intel_gpu::SharedMemType::OCL_IMAGE2D},
             {ov::intel_gpu::mem_handle.name(), static_cast<gpu_handle_param>(nv12_image_plane_y.get())}};
-        auto y_tensor = create_tensor(element::u8, {1, 1, height, width}, tensor_params);
+        auto y_tensor = create_tensor(element::u8, {1, height, width, 1}, tensor_params);
         tensor_params[ov::intel_gpu::mem_handle.name()] = static_cast<gpu_handle_param>(nv12_image_plane_uv.get());
-        auto uv_tensor = create_tensor(element::u8, {1, 2, height / 2, width / 2}, tensor_params);
+        auto uv_tensor = create_tensor(element::u8, {1, height / 2, width / 2, 2}, tensor_params);
         return std::make_pair(y_tensor.as<ClImage2DTensor>(), uv_tensor.as<ClImage2DTensor>());
     }
 

--- a/src/inference/include/openvino/runtime/intel_gpu/ocl/va.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/ocl/va.hpp
@@ -125,9 +125,9 @@ public:
         AnyMap tensor_params = {{ov::intel_gpu::shared_mem_type.name(), ov::intel_gpu::SharedMemType::VA_SURFACE},
                                 {ov::intel_gpu::dev_object_handle.name(), nv12_surf},
                                 {ov::intel_gpu::va_plane.name(), uint32_t(0)}};
-        auto y_tensor = create_tensor(element::u8, {1, 1, height, width}, tensor_params);
+        auto y_tensor = create_tensor(element::u8, {1, height, width, 1}, tensor_params);
         tensor_params[ov::intel_gpu::va_plane.name()] = uint32_t(1);
-        auto uv_tensor = create_tensor(element::u8, {1, 2, height / 2, width / 2}, tensor_params);
+        auto uv_tensor = create_tensor(element::u8, {1, height / 2, width / 2, 2}, tensor_params);
         return std::make_pair(y_tensor.as<VASurfaceTensor>(), uv_tensor.as<VASurfaceTensor>());
     }
 

--- a/src/plugins/intel_gpu/tests/functional/remote_blob_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_blob_tests/gpu_remote_tensor_tests.cpp
@@ -1040,8 +1040,10 @@ TEST_F(OVRemoteTensor_Test, NV12toBGR_image_ConvertTranspose) {
     cl::Image2D img_y = cl::Image2D(nv12_image_plane_y);
     cl::Image2D img_uv = cl::Image2D(nv12_image_plane_uv);
 
-    auto tensor_remote_y = cldnn_context.create_tensor(param_input_y->get_element_type(), fake_image_data_y.get_shape(), img_y);
-    auto tensor_remote_uv = cldnn_context.create_tensor(param_input_uv->get_element_type(), fake_image_data_uv.get_shape(), img_uv);
+    auto nv12 = cldnn_context.create_tensor_nv12(img_y, img_uv);
+
+    auto tensor_remote_y = nv12.first;
+    auto tensor_remote_uv = nv12.second;
 
     inf_req_remote.set_tensor(*param_input_y->output(0).get_tensor().get_names().begin(), tensor_remote_y);
     inf_req_remote.set_tensor(*param_input_uv->output(0).get_tensor().get_names().begin(), tensor_remote_uv);


### PR DESCRIPTION
### Details:
 - `create_tensor_nv12` helpers didn't work after plugin API 2.0 impl due to new shape compatibility checks added. This PR fixes surface shape to match expected dims order.

### Tickets:
 - *123049*
