### PR TITLE
Enabled FrontendLibCloseTest FE test suite

### DIFF
--- a/src/frontends/onnx/tests/skip_tests_config.cpp
+++ b/src/frontends/onnx/tests/skip_tests_config.cpp
@@ -9,9 +9,11 @@
 
 std::vector<std::string> disabledTestPatterns() {
     return {
-#ifndef BUILD_SHARED_LIBS
+#ifdef OPENVINO_STATIC_LIBRARY
         // Disable tests for static libraries
-        ".*FrontendLibCloseTest.*"
+        ".*FrontendLibCloseTest.*",
 #endif
+        // CVS-123201
+        ".*testUnloadLibBeforeDeletingDependentObject.*",
     };
 }

--- a/src/frontends/paddle/tests/skip_tests_config.cpp
+++ b/src/frontends/paddle/tests/skip_tests_config.cpp
@@ -9,7 +9,7 @@
 
 std::vector<std::string> disabledTestPatterns() {
     return {
-#ifndef BUILD_SHARED_LIBS
+#ifdef OPENVINO_STATIC_LIBRARY
         // Disable tests for static libraries
         ".*FrontendLibCloseTest.*"
 #endif


### PR DESCRIPTION
### Details:
 - `BUILD_SHARED_LIBS` is not correct check in C++ files.
