### PR TITLE
[GPU] fixed to create Graphs with different stream_ids

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -169,7 +169,7 @@ CompiledModel::CompiledModel(cldnn::BinaryInputBuffer ib,
     auto pos = ib.tellg();
     for (uint16_t n = 0; n < m_config.get_property(ov::num_streams); n++) {
         ib.seekg(pos);
-        auto graph = std::make_shared<Graph>(ib, context, m_config, 0);
+        auto graph = std::make_shared<Graph>(ib, context, m_config, n);
         m_graphs.push_back(graph);
     }
 }

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/plugin/configuration_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/plugin/configuration_tests.cpp
@@ -68,6 +68,8 @@ namespace {
             {{CONFIG_KEY(AUTO_BATCH_DEVICE_CONFIG), ov::test::utils::DEVICE_GPU}},
             {{CONFIG_KEY(AUTO_BATCH_DEVICE_CONFIG), ov::test::utils::DEVICE_GPU},
              {CONFIG_KEY(AUTO_BATCH_TIMEOUT), "1"}},
+            {{CONFIG_KEY(AUTO_BATCH_DEVICE_CONFIG), ov::test::utils::DEVICE_GPU},
+             {ov::num_streams.name(), "AUTO"}},
         };
     };
 


### PR DESCRIPTION
### Details:
 - This PR fixes to create `Graph`s with different `stream_id`s when deserializing them for multiple streams.

### Tickets:
 - 123287
