### PR TITLE
[DRAFT][GPU][CONFORMANCE] Possible solution for ov_plugin_mandatory GPU issues

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -363,6 +363,9 @@ ov::Any Plugin::get_property(const std::string& name, const ov::AnyMap& options)
         return decltype(ov::available_devices)::value_type {available_devices};
     } else if (name == ov::internal::caching_properties) {
         return decltype(ov::internal::caching_properties)::value_type(get_caching_properties());
+    } else if (name == ov::execution_devices) {
+        const std::string dev_name = get_device_name();
+        return decltype(ov::execution_devices)::value_type{dev_name};
     }
 
     OPENVINO_SUPPRESS_DEPRECATED_START
@@ -595,6 +598,8 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::hint::inference_precision.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::enable_cpu_pinning.name(), PropertyMutability::RW},
         ov::PropertyName{ov::device::id.name(), PropertyMutability::RW},
+
+        ov::PropertyName{ov::execution_devices.name(), PropertyMutability::RO}
     };
 
     return supported_properties;

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -598,8 +598,8 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::hint::inference_precision.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::enable_cpu_pinning.name(), PropertyMutability::RW},
         ov::PropertyName{ov::device::id.name(), PropertyMutability::RW},
-
-        ov::PropertyName{ov::execution_devices.name(), PropertyMutability::RO}
+        ov::PropertyName{ov::execution_devices.name(), PropertyMutability::RO},
+        ov::PropertyName{ov::log::level.name(), PropertyMutability::RW}
     };
 
     return supported_properties;

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -49,6 +49,7 @@ void ExecutionConfig::set_default() {
         std::make_tuple(ov::hint::execution_mode, ov::hint::ExecutionMode::PERFORMANCE),
         std::make_tuple(ov::hint::num_requests, 0),
         std::make_tuple(ov::hint::enable_cpu_pinning, false),
+        std::make_tuple(ov::log::level, ov::log::Level::NO),
 
         std::make_tuple(ov::intel_gpu::hint::host_task_priority, ov::hint::Priority::MEDIUM),
         std::make_tuple(ov::intel_gpu::hint::queue_throttle, ov::intel_gpu::hint::ThrottleLevel::MEDIUM),

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
@@ -403,13 +403,20 @@ TEST_P(OVCheckChangePropComplieModleGetPropTests_InferencePrecision, ChangeCorre
     OV_ASSERT_NO_THROW(default_property = core->get_property(target_device, ov::hint::inference_precision));
     ASSERT_FALSE(default_property.empty());
 
-    const std::vector<ov::element::Type> ovElemTypes = {
-        ov::element::f64, ov::element::f32, ov::element::f16, ov::element::bf16,
-        ov::element::i64, ov::element::i32, ov::element::i16, ov::element::i8, ov::element::i4,
-        ov::element::u64, ov::element::u32, ov::element::u16, ov::element::u8, ov::element::u4,  ov::element::u1,
-        ov::element::boolean, ov::element::undefined, ov::element::dynamic
+    const std::vector<ov::element::Type> defaultPrecisionTypes{
+             ov::element::f64, ov::element::f32, ov::element::f16, ov::element::bf16,
+             ov::element::i64, ov::element::i32, ov::element::i16, ov::element::i8, ov::element::i4,
+             ov::element::u64, ov::element::u32, ov::element::u16, ov::element::u8, ov::element::u4,  ov::element::u1,
+             ov::element::boolean, ov::element::undefined, ov::element::dynamic
     };
 
+    const std::map<std::string, const std::vector<ov::element::Type>> inferencePrecisionTypes = {
+        {"GPU", std::vector<ov::element::Type>{ov::element::f16, ov::element::f32}},
+        {"CPU", std::vector<ov::element::Type>{ov::element::bf16, ov::element::f16, ov::element::f32}}
+    };
+
+    const auto found = inferencePrecisionTypes.find(target_device);
+    const auto& ovElemTypes = found == inferencePrecisionTypes.cend() ? defaultPrecisionTypes : found->second;
     bool any_supported = false;
     for (ov::element::Type type : ovElemTypes) {
         try {


### PR DESCRIPTION
- Use only inference types supported by plugins
- Support EXECUTION_DEVICES property in GPU plugin

Ticket https://jira.devtools.intel.com/browse/CVS-119084 