### PR TITLE
`setupvars.sh`: ignore `cd` output

### DIFF
--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -6,7 +6,7 @@
 abs_path () {
     script_path=$(eval echo "$1")
     directory=$(dirname "$script_path")
-    echo "$(cd "$directory" || exit; pwd -P)";
+    echo "$(cd "$directory" >/dev/null || exit; pwd -P)";
 }
 
 SCRIPT_DIR="$(abs_path "${BASH_SOURCE[0]}")" >/dev/null 2>&1


### PR DESCRIPTION
Having `function cd() { builtin cd "$@" && l; }` defined in bash breaks `setupvars.sh`