### PR TITLE
don't fold ShapeOf in TransposeSinking

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/disable_shapeof_constant_folding.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/disable_shapeof_constant_folding.hpp
@@ -20,5 +20,5 @@ class TRANSFORMATIONS_API DisableShapeOfConstantFolding;
 class ov::pass::DisableShapeOfConstantFolding : public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("DisableShapeOfConstantFolding", "0");
-    explicit DisableShapeOfConstantFolding(bool check_shape = true);
+    DisableShapeOfConstantFolding();
 };

--- a/src/common/transformations/include/transformations/common_optimizations/enable_shapeof_constant_folding.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/enable_shapeof_constant_folding.hpp
@@ -18,7 +18,7 @@ namespace pass {
 class TRANSFORMATIONS_API EnableShapeOfConstantFolding : public MatcherPass {
 public:
     OPENVINO_RTTI("EnableShapeOfConstantFolding", "0");
-    explicit EnableShapeOfConstantFolding(bool check_shape = true);
+    EnableShapeOfConstantFolding();
 };
 
 }  // namespace pass

--- a/src/common/transformations/src/transformations/common_optimizations/disable_shapeof_constant_folding.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/disable_shapeof_constant_folding.cpp
@@ -10,11 +10,9 @@
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/disable_constant_folding.hpp"
 
-ov::pass::DisableShapeOfConstantFolding::DisableShapeOfConstantFolding(bool check_shape) {
+ov::pass::DisableShapeOfConstantFolding::DisableShapeOfConstantFolding() {
     auto shape_of = pattern::wrap_type<ov::op::v0::ShapeOf, ov::op::v3::ShapeOf>([=](const Output<Node>& output) {
         const auto& shape = output.get_partial_shape();
-        if (!check_shape)
-            return true;
         return shape.is_dynamic() || shape_size(shape.get_shape()) != 1;
     });
 

--- a/src/common/transformations/src/transformations/common_optimizations/enable_shapeof_constant_folding.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/enable_shapeof_constant_folding.cpp
@@ -8,11 +8,9 @@
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/disable_constant_folding.hpp"
 
-ov::pass::EnableShapeOfConstantFolding::EnableShapeOfConstantFolding(bool check_shape) {
+ov::pass::EnableShapeOfConstantFolding::EnableShapeOfConstantFolding() {
     auto shape_of = pattern::wrap_type<op::util::ShapeOfBase>([=](const Output<Node>& output) {
         const auto& shape = output.get_partial_shape();
-        if (!check_shape)
-            return true;
         return shape.is_dynamic() || shape_size(shape.get_shape()) != 1;
     });
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_general.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_general.cpp
@@ -73,19 +73,14 @@ bool TSGeneral::run_on_model(const std::shared_ptr<ov::Model>& f) {
     RUN_ON_FUNCTION_SCOPE(TSGeneral);
     {
         Manager manager(get_pass_config());
-        manager.register_pass<DisableShapeOfConstantFolding>(/* check_shape */ false);
         manager.register_pass<TSGeneralForward>();
-        manager.register_pass<ConstantFolding>();
         manager.run_passes(f);
     }
 
     {
         Manager manager(get_pass_config());
-        manager.register_pass<DisableShapeOfConstantFolding>(/* check_shape */ false);
         manager.register_pass<TSGeneralBackward>();
-        manager.register_pass<ConstantFolding>();
         manager.register_pass<TSResetNoSinkingAttribute>();
-        manager.register_pass<EnableShapeOfConstantFolding>(/* check_shape */ false);
         manager.run_passes(f);
     }
 

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -119,9 +119,16 @@ TEST_F(FrontEndConversionWithReferenceTestsF, SavedModelBroadcastIssue) {
     { model = convert_model("saved_model_broadcast_issue"); }
     {
         // create a reference graph
-        auto x = make_shared<Constant>(element::i64, Shape{2, 2}, vector<int64_t>{1, 2, -1, -1});
+        auto const1 = make_shared<Constant>(element::i32, Shape{}, vector<float>{-1});
+        const1->output(0).set_names({"Cast/x"});
+        auto convert = make_shared<Convert>(const1, element::i64);
+        auto broadcast_const = make_shared<Constant>(element::i32, Shape{2}, vector<int32_t>{1, 2});
+        auto broadcast = make_shared<Broadcast>(convert, broadcast_const);
+        auto const2 = make_shared<Constant>(element::i64, Shape{1, 2}, vector<int64_t>{1, 2});
+        auto concat = make_shared<Concat>(OutputVector{const2, broadcast}, 0);
+        auto result = make_shared<Result>(concat);
 
-        model_ref = make_shared<Model>(OutputVector{x}, ParameterVector{});
+        model_ref = make_shared<Model>(OutputVector{result}, ParameterVector{});
     }
 }
 

--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -761,9 +761,12 @@ TEST_F(FrontEndConversionWithReferenceTestsF, ConvolutionWithDynamicInputChannel
         auto transpose_order = make_shared<Constant>(i64, Shape{4}, vector<int32_t>{0, 3, 1, 2});
         auto transpose = make_shared<Transpose>(input, transpose_order);
 
-        auto filter = make_shared<Constant>(element::f32, Shape{6, 6, 3, 3}, vector<float>(6 * 6 * 3 * 3, 0.0f));
+        auto filter = make_shared<Constant>(element::f32, Shape{3, 3, 6, 6}, vector<float>(6 * 6 * 3 * 3, 0.0f));
+        auto filer_transpose_order = make_shared<Constant>(i64, Shape{4}, vector<int32_t>{3, 2, 0, 1});
+        auto filter_transpose = make_shared<Transpose>(filter, filer_transpose_order);
+
         auto conv = make_shared<Convolution>(transpose,
-                                             filter,
+                                             filter_transpose,
                                              Strides{1, 1},
                                              CoordinateDiff{0, 0},
                                              CoordinateDiff{0, 0},

--- a/src/plugins/intel_gna/src/gna_transformations_pipeline.cpp
+++ b/src/plugins/intel_gna/src/gna_transformations_pipeline.cpp
@@ -141,7 +141,8 @@ void TransformationsPipeline::apply(const std::shared_ptr<ov::Model>& model,
         manager.register_pass<ov::intel_gna::pass::ReplaceGnaNHWCLayers>();
         manager.register_pass<ov::intel_gna::pass::InsertConvolutionTransposeHW>();
         manager.register_pass<ov::intel_gna::pass::GatherSinkingTranspose>();
-        manager.register_pass<ov::pass::TransposeSinkingGeneral>();
+        manager.register_pass<ov::pass::transpose_sinking::TSGeneral>();
+        manager.register_pass<ov::pass::ConstantFolding>();
         manager.register_pass<ov::intel_gna::pass::TransposeCompress>();
         manager.register_pass<ov::intel_gna::pass::TSConcatForward>();
         manager.register_pass<ov::intel_gna::pass::TSSplitBackward>();


### PR DESCRIPTION
### Details:
**This fix is a workaround for this Release only, we will investigate side effects of deleting  `shape_size(shape.get_shape()) != 1` condition from the pattern in the next Release.**

 - TransposeSinking prevents folding ShapeOf using DisableShapeOfConstantFolding transformation. But this transformation doesn't set disable_folding rt_info flag if shape_size(shape.get_shape()) != 1. Ticket describes the case of reshapability when we need to prevent doing folding ShapeOf node with shape [1,1,1].


 - add flag that leads to disable ShapeOf folding anyway
 - add unit test

### Tickets:
 - CVS-123305
