### PR TITLE
Fix stride issue for ZeroDims

### DIFF
--- a/src/core/src/runtime/itensor.cpp
+++ b/src/core/src/runtime/itensor.cpp
@@ -25,9 +25,10 @@ size_t ITensor::get_byte_size() const {
 }
 
 bool ITensor::is_continuous() const {
-    if (get_element_type().bitwidth() < 8)
+    if ((get_element_type().bitwidth() < 8) || get_size() == 0) {
         // OpenVINO doesn't support strides for lp types
         return true;
+    }
     const auto& shape = get_shape();
     const auto& type = get_element_type();
     std::vector<size_t> strides(shape.size());

--- a/src/core/tests/tensor.cpp
+++ b/src/core/tests/tensor.cpp
@@ -52,3 +52,12 @@ TEST(tensor, wrap_tensor_with_unspecified_type_from_host_tensor) {
     // !tensor means that the tensor is not initialized
     EXPECT_EQ(!tensor, true);
 }
+
+TEST(tensor, create_tensor_with_zero_dims_check_stride) {
+    ov::Shape shape = {0, 0, 0, 0};
+    auto tensor = ov::Tensor(element::f32, shape);
+    EXPECT_EQ(!!tensor, true);
+    auto stride = tensor.get_strides();
+    EXPECT_EQ(stride.size(), shape.size());
+    EXPECT_EQ(stride.back(), 0);
+}

--- a/src/core/tests/tensor.cpp
+++ b/src/core/tests/tensor.cpp
@@ -60,4 +60,5 @@ TEST(tensor, create_tensor_with_zero_dims_check_stride) {
     auto stride = tensor.get_strides();
     EXPECT_EQ(stride.size(), shape.size());
     EXPECT_EQ(stride.back(), 0);
+    EXPECT_EQ(tensor.is_continuous(), true);
 }

--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -77,7 +77,7 @@ protected:
         auto& shape = get_shape();
         if (m_strides.empty() && !shape.empty()) {
             m_strides.resize(shape.size());
-            m_strides.back() = m_element_type.size();
+            m_strides.back() = shape.back() == 0 ? 0 : m_element_type.size();
             std::transform(shape.crbegin(),
                            shape.crend() - 1,
                            m_strides.rbegin(),

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -63,7 +63,7 @@ void RemoteTensorImpl::update_strides() {
     m_strides.clear();
     if (!shape.empty()) {
         m_strides.resize(shape.size());
-        m_strides.back() = m_element_type.size();
+        m_strides.back() = shape.back() == 0 ? 0 : m_element_type.size();
         std::copy(shape.rbegin(), shape.rend() - 1, m_strides.rbegin() + 1);
         std::partial_sum(m_strides.rbegin(), m_strides.rend(), m_strides.rbegin(), std::multiplies<size_t>());
     }

--- a/src/plugins/template/src/remote_context.cpp
+++ b/src/plugins/template/src/remote_context.cpp
@@ -26,7 +26,7 @@ class VectorTensorImpl : public ov::IRemoteTensor {
         m_strides.clear();
         if (!shape.empty()) {
             m_strides.resize(shape.size());
-            m_strides.back() = m_element_type.size();
+            m_strides.back() = shape.back() == 0 ? 0 : m_element_type.size();
             std::copy(shape.rbegin(), shape.rend() - 1, m_strides.rbegin() + 1);
             std::partial_sum(m_strides.rbegin(), m_strides.rend(), m_strides.rbegin(), std::multiplies<size_t>());
         }


### PR DESCRIPTION
### Details:
   Fixed issue: tensor shape={0,0,0,0} will get strides={0,0,0,4} or {0,0,0,8}, actually it should be {0,0,0,0} 

### Tickets:
 - *ticket-id*
