### PR TITLE
[PyOV] fix set_node_friendly_name

### DIFF
--- a/src/bindings/python/src/openvino/runtime/utils/decorators.py
+++ b/src/bindings/python/src/openvino/runtime/utils/decorators.py
@@ -9,7 +9,7 @@ from openvino.runtime import Node, Output
 from openvino.runtime.utils.types import NodeInput, as_node, as_nodes
 
 
-def _set_node_friendly_name(node: Node, **kwargs: Any) -> Node:
+def _set_node_friendly_name(node: Node, /, **kwargs: Any) -> Node:
     if "name" in kwargs:
         node.friendly_name = kwargs["name"]
     return node

--- a/src/bindings/python/tests/test_graph/test_reduction.py
+++ b/src/bindings/python/tests/test_graph/test_reduction.py
@@ -154,3 +154,9 @@ def test_normalize_l2():
     assert node.get_output_size() == 1
     assert node.get_type_name() == "NormalizeL2"
     assert list(node.get_output_shape(0)) == input_shape
+
+
+def test_reduce_with_keywork():
+    const = ov.constant([-1], np.int64)
+    min_op = ov.reduce_min(node=const, reduction_axes=0)
+    assert min_op.get_output_size() == 1


### PR DESCRIPTION
### Details:
 - allow to use `node` as keyword argument
### Tickets:
 - CVS-105065
