### PR TITLE
support int4 as int8 in MemBandwidthPressureTolerance

### DIFF
--- a/src/inference/dev_api/performance_heuristics.hpp
+++ b/src/inference/dev_api/performance_heuristics.hpp
@@ -34,7 +34,8 @@ static MemBandwidthPressure MemBandwidthPressureTolerance(
         return (cache_size / (size_data_moved * datatype_size));
     };
     auto isLowPrecision = [&](ov::element::Type type) -> bool {
-        return (type == ov::element::i8) || (type == ov::element::u8);
+        return (type == ov::element::i8) || (type == ov::element::u8) || (type == ov::element::i4) ||
+               (type == ov::element::u4) || (type == ov::element::nf4);
     };
     auto isHalfPrecision = [&](ov::element::Type type) -> bool {
         return (type == ov::element::bf16) || (type == ov::element::f16);


### PR DESCRIPTION
### Details:
 - *support int4 as int8 in MemBandwidthPressureTolerance*


### Tickets:
 - *ticket-id*
