### PR TITLE
[Snippets] Fixed Convert elimination in AlignElementType

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -71,7 +71,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAEnforceBF16, MHA,
                                  ::testing::Values(ov::element::bf16),
                                  ::testing::ValuesIn({false}),
                                  ::testing::Values(7),
-                                 ::testing::Values(7),
+                                 ::testing::Values(6),
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
                                  ::testing::Values(CPUTestUtils::cpuBF16PluginConfig)),
                          MHA::getTestCaseName);


### PR DESCRIPTION
### Details:
 - *Note that the Snippets have limitation: `Transpose` ops must be only after `Parameter` or before `Result`. Moreover, `Transpose` is supported only via `FuseTransposeToBrgemm` or `TransposeDecomposition`. To fuse `Transpose` into `Brgemm` there shouldn't be ops between `Transpose` and `Brgemm`*
 - *When CPU Plugin enforce bf16 precision for f32 body,  `AlignElementTypes` insert `Convert[bf16->f32]` ops after `Parameter` to align input precisions of bodies (If there is `Transpose`, the pass inserts after `Parameter->Transpose`). Then the pass `EnforcePrecisions` inserts `Convert[f32->bf16]` before `Brgemms` to allow `Brgemm` be executed in `bf16`. These `Converts` are eliminated in the pass `EnforcePrecision` since they're redundant. However, the order of pases `AlignElementTypes` and `EnforcePrecisions` was changed in the https://github.com/openvinotoolkit/openvino/pull/18563. And after `AlignElementTypes` we have `Convert[bf16->f32] -> Convert[f32->bf16]` now. The current PR adds support of redudant `Convert` elimination to `AlignElementTypes` if it's possible.*
![image](https://github.com/openvinotoolkit/openvino/assets/43129309/7c8d521f-63f9-4781-88a8-42efeb1c3fb9)


### Tickets:
 - *123656*
