### PR TITLE
[CI] [GHA] Increase timeout for RISC-V workflow

### DIFF
--- a/.github/workflows/linux_riscv.yml
+++ b/.github/workflows/linux_riscv.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   Build:
-    timeout-minutes: 15
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Details:
 - Example of canceled pipeline with over 15 minutes in length on a PR: https://github.com/openvinotoolkit/openvino/actions/runs/6651036317/job/18072259304
