### PR TITLE
DOCS Update optimization docs with ov.save_model() instead of ov.serialize()

### DIFF
--- a/docs/optimization_guide/nncf/ptq/code/ptq_aa_openvino.py
+++ b/docs/optimization_guide/nncf/ptq/code/ptq_aa_openvino.py
@@ -58,6 +58,9 @@ model_int8 = ov.compile_model(quantized_model)
 input_fp32 = ... # FP32 model input
 res = model_int8(input_fp32)
 
-# save the model
-ov.serialize(quantized_model, "quantized_model.xml")
+# save the model with compress_to_fp16=False to avoid an accuracy drop from compression
+# of unquantized weights to FP16. This is necessary because
+# nncf.quantize_with_accuracy_control(...) keeps the most impactful operations within
+# the model in the original precision to achieve the specified model accuracy
+ov.save_model(quantized_model, "quantized_model.xml", compress_to_fp16=False)
 #! [inference]

--- a/docs/optimization_guide/nncf/ptq/code/ptq_onnx.py
+++ b/docs/optimization_guide/nncf/ptq/code/ptq_onnx.py
@@ -36,5 +36,5 @@ input_fp32 = ... # FP32 model input
 res = model_int8(input_fp32)
 
 # save the model
-ov.serialize(ov_quantized_model, "quantized_model.xml")
+ov.save_model(ov_quantized_model, "quantized_model.xml")
 #! [inference]

--- a/docs/optimization_guide/nncf/ptq/code/ptq_openvino.py
+++ b/docs/optimization_guide/nncf/ptq/code/ptq_openvino.py
@@ -29,5 +29,5 @@ input_fp32 = ... # FP32 model input
 res = model_int8(input_fp32)
 
 # save the model
-ov.serialize(quantized_model, "quantized_model.xml")
+ov.save_model(quantized_model, "quantized_model.xml")
 #! [inference]

--- a/docs/optimization_guide/nncf/ptq/code/ptq_tensorflow.py
+++ b/docs/optimization_guide/nncf/ptq/code/ptq_tensorflow.py
@@ -35,5 +35,5 @@ input_fp32 = ... # FP32 model input
 res = model_int8(input_fp32)
 
 # save the model
-ov.serialize(ov_quantized_model, "quantized_model.xml")
+ov.save_model(ov_quantized_model, "quantized_model.xml")
 #! [inference]

--- a/docs/optimization_guide/nncf/ptq/code/ptq_torch.py
+++ b/docs/optimization_guide/nncf/ptq/code/ptq_torch.py
@@ -40,5 +40,5 @@ model_int8 = ov.compile_model(ov_quantized_model)
 res = model_int8(input_fp32)
 
 # save the model
-ov.serialize(ov_quantized_model, "quantized_model.xml")
+ov.save_model(ov_quantized_model, "quantized_model.xml")
 #! [inference]


### PR DESCRIPTION
### Details:
 - Update OV documentation with ov.save_model() instead of ov.serialize()

### Tickets:
 - 121310
