### PR TITLE
Fixed compilation with C++23

### DIFF
--- a/src/bindings/c/src/CMakeLists.txt
+++ b/src/bindings/c/src/CMakeLists.txt
@@ -5,7 +5,8 @@
 set(TARGET_NAME openvino_c)
 
 # Suppress warnings due to catch macro with legacy exception types
-ov_deprecated_no_errors()
+ov_disable_deprecated_warnings()
+
 add_definitions(-DIN_OV_COMPONENT)
 
 file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.h ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)

--- a/src/common/preprocessing/tests/CMakeLists.txt
+++ b/src/common/preprocessing/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 set(TARGET fluid_preproc_tests)
 
-ov_deprecated_no_errors()
+ov_disable_deprecated_warnings()
 
 find_package(OpenCV QUIET COMPONENTS gapi core imgproc)
 if(NOT OpenCV_FOUND OR NOT OpenCV_VERSION VERSION_GREATER_EQUAL 4)

--- a/src/core/src/type.cpp
+++ b/src/core/src/type.cpp
@@ -37,7 +37,7 @@ std::string DiscreteTypeInfo::get_version() const {
     if (version_id) {
         return std::string(version_id);
     }
-    return nullptr;
+    return {};
 }
 
 DiscreteTypeInfo::operator std::string() const {

--- a/src/frontends/onnx/frontend/src/ops_bridge.hpp
+++ b/src/frontends/onnx/frontend/src/ops_bridge.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <iterator>
 #include <map>
 #include <mutex>
 #include <string>

--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -397,7 +397,7 @@ public:
     }
 
     void allocate() noexcept override {
-        if (InferenceEngine::TBlob<T>::buffer() != tensor->data()) {
+        if ((void*)InferenceEngine::TBlob<T>::buffer() != tensor->data()) {
             InferenceEngine::TBlob<T>::_allocator =
                 InferenceEngine::details::make_pre_allocator(static_cast<T*>(tensor->data()), tensor->get_byte_size());
             InferenceEngine::TBlob<T>::allocate();


### PR DESCRIPTION
### Details:
 - Fixed compilation with C++23 for core components
 - Replaced `ov_deprecated_no_errors` with `ov_disable_deprecated_warnings` for deprecated components, because we don't plan to fix them