### PR TITLE
[Snippets][CPU] Disabled SplitDimensionM CPU Func tests

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -195,6 +195,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_RNNSequenceCommonZeroClip/RNNSequenceTest.Inference.*hidden_size=10.*relu.*)",
         // Issue: 123427
         R"(.*RDFTLayerTest.*SignalSize=().*)",
+        // Issue: 123815 (Tests are sensintive to available thread count on testing machines)
+        R"(.*smoke_Snippets_MHA_.?D_SplitDimensionM.*)",
     };
 
 #if defined(OPENVINO_ARCH_X86)


### PR DESCRIPTION
### Details:
 - *Disabled SplitDimensionM CPU Func tests that are sporadic failed because of there is not enough thread count on testing machine*
- *[Example](https://github.com/openvinotoolkit/openvino/actions/runs/6667202715/job/18120713755) of failed tests*