### PR TITLE
[DOCS] Fixing instructions for archive windows installation

### DIFF
--- a/docs/install_guides/installing-openvino-from-archive-windows.md
+++ b/docs/install_guides/installing-openvino-from-archive-windows.md
@@ -98,7 +98,7 @@ Step 1: Download and Install OpenVINO Core Components
    .. code-block:: sh
 
       tar -xf openvino_2023.1.0.zip
-      ren w_openvino_toolkit_windows_2023.1.0.10926.b4452d56304_x86_64 openvino_2023.1.0
+      ren w_openvino_toolkit_windows_2023.1.0.12185.47b736f63ed_x86_64 openvino_2023.1.0
       move openvino_2023.1.0 "C:\Program Files (x86)\Intel"
 
 


### PR DESCRIPTION
Fixing instructions in the `Install OpenVINO™ Runtime on Windows from an Archive File` article.
Porting:
https://github.com/openvinotoolkit/openvino/pull/20752