### PR TITLE
Increase timeout for hub tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1187,7 +1187,7 @@ jobs:
       run:
         shell: bash
     runs-on: ${{ github.event_name == 'schedule' && 'ubuntu-20.04-16-cores' || 'ubuntu-20.04-8-cores'}}
-    timeout-minutes: ${{ github.event_name == 'schedule' && 300 || 5 }}
+    timeout-minutes: ${{ github.event_name == 'schedule' && 400 || 5 }}
     # TODO: Switch back to self-hosted runners
     # container:
     #   image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04
@@ -1264,7 +1264,7 @@ jobs:
   PyTorch_Models_Tests:
     name: PyTorch Models tests
     needs: Build
-    timeout-minutes: ${{ github.event_name == 'schedule' && 300 || 30 }}
+    timeout-minutes: ${{ github.event_name == 'schedule' && 400 || 30 }}
     defaults:
       run:
         shell: bash

--- a/tests/model_hub_tests/torch_tests/test_hf_transformers.py
+++ b/tests/model_hub_tests/torch_tests/test_hf_transformers.py
@@ -53,7 +53,7 @@ class TestTransformersModel(TestConvertModel):
         from PIL import Image
         import requests
 
-        self.infer_timeout = 1200
+        self.infer_timeout = 800
 
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         self.image = Image.open(requests.get(url, stream=True).raw)


### PR DESCRIPTION
### Details:
 - *300 minutes is 5 hours, tests run slightly more, increase timeout to 400 which is higher then 6 hours internal timeout in GHA*

### Tickets:
 - *ticket-id*
