### PR TITLE
[core]Migrate Sigmoid operator to new API

### DIFF
--- a/src/core/include/openvino/op/sigmoid.hpp
+++ b/src/core/include/openvino/op/sigmoid.hpp
@@ -18,9 +18,7 @@ public:
     Sigmoid(const Output<Node>& arg);
     Sigmoid() = default;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v0

--- a/src/core/reference/include/openvino/reference/sigmoid.hpp
+++ b/src/core/reference/include/openvino/reference/sigmoid.hpp
@@ -8,24 +8,26 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "openvino/reference/utils/type_util.hpp"
+
 namespace ov {
 namespace reference {
-template <typename T, typename std::enable_if<std::is_integral<T>::value, bool>::type = true>
-void sigmoid(const T* arg, T* out, size_t count) {
-    T exp_value;
-    for (size_t i = 0; i < count; i++) {
-        exp_value = static_cast<T>(std::exp(-static_cast<typename std::make_signed<T>::type>(arg[i])));
-        out[i] = static_cast<T>(1 / (1 + exp_value));
-    }
+namespace func {
+template <class T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+T sigmoid(const T value) {
+    const auto exp_value = static_cast<T>(std::exp(-static_cast<typename std::make_signed<T>::type>(value)));
+    return 1 / (1 + exp_value);
 }
 
-template <typename T, typename std::enable_if<!std::is_integral<T>::value, bool>::type = true>
-void sigmoid(const T* arg, T* out, size_t count) {
-    T exp_value;
-    for (size_t i = 0; i < count; i++) {
-        exp_value = static_cast<T>(std::exp(-arg[i]));
-        out[i] = static_cast<T>(1 / (1 + exp_value));
-    }
+template <class T, typename std::enable_if<ov::is_floating_point<T>()>::type* = nullptr>
+T sigmoid(const T value) {
+    return 1 / (1 + std::exp(-value));
+}
+}  // namespace func
+
+template <class T>
+void sigmoid(const T* arg, T* out, const size_t count) {
+    std::transform(arg, arg + count, out, func::sigmoid<T>);
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/reference/include/openvino/reference/sigmoid.hpp
+++ b/src/core/reference/include/openvino/reference/sigmoid.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <type_traits>
 
 #include "openvino/reference/utils/type_util.hpp"
 

--- a/src/core/src/op/sigmoid.cpp
+++ b/src/core/src/op/sigmoid.cpp
@@ -2,80 +2,68 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/sigmoid.hpp"
+#include "openvino/op/sigmoid.hpp"
 
-#include <ngraph/validation_util.hpp>
-
+#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/log.hpp"
-#include "ngraph/runtime/host_tensor.hpp"
-#include "ngraph/util.hpp"
 #include "openvino/reference/sigmoid.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace sigmoid {
 
-shared_ptr<Node> ov::op::v0::Sigmoid::clone_with_new_inputs(const OutputVector& new_args) const {
+struct Evaluate : element::NoAction<bool> {
+    using element::NoAction<bool>::visit;
+
+    template <element::Type_t ET, class T = fundamental_type_for<ET>>
+    static result_type visit(const Tensor& arg0, Tensor& out, const size_t count) {
+        reference::sigmoid(arg0.data<const T>(), out.data<T>(), count);
+        return true;
+    }
+};
+}  // namespace sigmoid
+
+namespace v0 {
+
+std::shared_ptr<Node> Sigmoid::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v0_Sigmoid_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<Sigmoid>(new_args.at(0));
+    return std::make_shared<Sigmoid>(new_args.at(0));
 }
 
-ov::op::v0::Sigmoid::Sigmoid(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
+Sigmoid::Sigmoid(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
     constructor_validate_and_infer_types();
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace sigmoid {
-namespace {
-template <element::Type_t ET>
-inline bool evaluate(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    using T = typename element_type_traits<ET>::value_type;
-    ov::reference::sigmoid<T>(arg0->get_data_ptr<ET>(), out->get_data_ptr<ET>(), count);
-    return true;
-}
-
-bool evaluate_sigmoid(const HostTensorPtr& arg0, const HostTensorPtr& out) {
-    bool rc = true;
-    size_t count = shape_size(arg0->get_shape());
-    out->set_unary(arg0);
-
-    switch (arg0->get_element_type()) {
-        OPENVINO_TYPE_CASE(evaluate_sigmoid, i32, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sigmoid, i64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sigmoid, u32, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sigmoid, u64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sigmoid, f16, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sigmoid, f32, arg0, out, count);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace sigmoid
-
-bool ov::op::v0::Sigmoid::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool Sigmoid::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v0_Sigmoid_evaluate);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    OPENVINO_ASSERT(validate_host_tensor_vector(outputs, 1) && validate_host_tensor_vector(inputs, 1));
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    return sigmoid::evaluate_sigmoid(inputs[0], outputs[0]);
+    OPENVINO_ASSERT(outputs.size() == 1);
+    OPENVINO_ASSERT(inputs.size() == 1);
+
+    const auto& in_shape = inputs[0].get_shape();
+    outputs[0].set_shape(in_shape);
+
+    using namespace ov::element;
+    return IfTypeOf<f16, f32, i32, i64, u32, u64>::apply<sigmoid::Evaluate>(inputs[0].get_element_type(),
+                                                                            inputs[0],
+                                                                            outputs[0],
+                                                                            shape_size(in_shape));
 }
 
-bool ov::op::v0::Sigmoid::has_evaluate() const {
+bool Sigmoid::has_evaluate() const {
     OV_OP_SCOPE(v0_Sigmoid_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::i32:
-    case ngraph::element::i64:
-    case ngraph::element::u32:
-    case ngraph::element::u64:
-    case ngraph::element::f16:
-    case ngraph::element::f32:
+    case element::f16:
+    case element::f32:
+    case element::i32:
+    case element::i64:
+    case element::u32:
+    case element::u64:
         return true;
     default:
-        break;
+        return false;
     }
-    return false;
 }
+}  // namespace v0
+}  // namespace op
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Migrate Sigmoid operator to new API, remove legacy classes, namespaces, includes.
 - Refactor reference to reduce binary size.

### Tickets:
 - [CVS-118654](https://jira.devtools.intel.com/browse/CVS-118654)
