### PR TITLE
Handle Reshape's special zero in SimplifySecondInputOfReshape

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -284,7 +284,7 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
         new_concat->set_friendly_name(concat->get_friendly_name());
         copy_runtime_info(concat, new_concat);
 
-        const auto new_reshape = std::make_shared<v1::Reshape>(reshape->get_input_node_shared_ptr(0), new_concat, true);
+        const auto new_reshape = std::make_shared<v1::Reshape>(reshape->input_value(0), new_concat, true);
         new_reshape->set_friendly_name(reshape->get_friendly_name());
 
         copy_runtime_info(reshape, new_reshape);


### PR DESCRIPTION
SimplifySecondInputOfReshape detects ShapeOf->Gather->Concat subgraphs on Reshape's second input and replaces ShapeOf->Gather with a Constant with zero(s). Currently it works only with Reshapes that have special_zero set to true, but it can work for Reshapes with `special_zero == false` if non-Gather inputs to Concat are Constants and don't contain any zero.

![image](https://github.com/openvinotoolkit/openvino/assets/21181928/2eadd6f3-1809-4a59-912c-cf0d97193f88)

Now for  `special_zero == false` case,  the transformation checks that all inputs Constants to Concat don't contain 0 values and sets `special_zero = true` flag to Reshape operation.

Ticket: CVS-123434