### PR TITLE
Remove WA with double loading of FE in OVC.

### DIFF
--- a/tools/ovc/openvino/tools/ovc/convert_impl.py
+++ b/tools/ovc/openvino/tools/ovc/convert_impl.py
@@ -132,15 +132,12 @@ def get_moc_frontends(argv: argparse.Namespace):
 
     available_moc_front_ends = get_available_front_ends(fem)
     if argv.framework:
-        moc_front_end = fem.load_by_framework(argv.framework) # WA to prevent process hanging. Need to remove when 115994 fixed.
         moc_front_end = fem.load_by_framework(argv.framework)
         return moc_front_end, available_moc_front_ends
     if argv.input_model:
         if isinstance(argv.input_model, (tuple, list)) and len(argv.input_model) == 2:
-            moc_front_end = fem.load_by_model([argv.input_model[0], argv.input_model[1]]) # WA to prevent process hanging. Need to remove when 115994 fixed.
             moc_front_end = fem.load_by_model([argv.input_model[0], argv.input_model[1]])  # TODO: Pass all input model parts
         else:
-            moc_front_end = fem.load_by_model(argv.input_model) # WA to prevent process hanging. Need to remove when 115994 fixed.
             moc_front_end = fem.load_by_model(argv.input_model)
         if not moc_front_end:
             return None, available_moc_front_ends


### PR DESCRIPTION
Description: 
Removed WA with double loading of FE in OVC, as the problem from 115994 does not reproduce anymore.

Ticket: 116177

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A