### PR TITLE
[nGraph Transformations] NMS convert precisions - change sequence of checks

### DIFF
--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -606,6 +606,19 @@ bool fuse_type_to_nms5(const std::shared_ptr<ov::Node>& node, const precisions_m
     }
 
     bool res = false;
+    auto type_relaxed = std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(node);
+    if (type_relaxed) {
+        for (size_t i = 0; i < node->get_output_size(); i++) {
+            auto it = precisions.find(node->get_output_element_type(i));
+            if (it == precisions.end()) {
+                continue;
+            }
+            const auto& to = it->second;
+            type_relaxed->set_overridden_output_type(to, i);
+            res = true;
+        }
+        return res;
+    }
     auto it = precisions.find(node->get_output_element_type(0));
     if (it != precisions.end()) {
         const auto& to = it->second;
@@ -618,7 +631,6 @@ bool fuse_type_to_nms5(const std::shared_ptr<ov::Node>& node, const precisions_m
         }
     }
 
-    auto type_relaxed = std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(node);
     ov::element::TypeVector output_types;
     for (size_t i = 0; i < node->get_output_size(); i++) {
         it = precisions.find(node->get_output_element_type(i));
@@ -627,22 +639,13 @@ bool fuse_type_to_nms5(const std::shared_ptr<ov::Node>& node, const precisions_m
             continue;
         }
         const auto& to = it->second;
-        if (type_relaxed) {
-            type_relaxed->set_overridden_output_type(to, i);
-            res = true;
-        }
         output_types.push_back(to);
     }
 
-    if (!type_relaxed) {
-        auto relaxed_op = std::make_shared<ov::op::TypeRelaxed<opset5::NonMaxSuppression>>(*nms,
-                                                                                           ov::element::TypeVector{},
-                                                                                           output_types);
-        replace_node(node, relaxed_op);
-        res = true;
-    }
-
-    return res;
+    auto relaxed_op =
+        std::make_shared<ov::op::TypeRelaxed<opset5::NonMaxSuppression>>(*nms, ov::element::TypeVector{}, output_types);
+    replace_node(node, relaxed_op);
+    return true;
 }
 
 bool fuse_type_to_nms9(const std::shared_ptr<ov::Node>& node, const precisions_map& precisions) {

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -688,9 +688,8 @@ bool fuse_type_to_nms9(const std::shared_ptr<ov::Node>& node, const precisions_m
         output_types.push_back(to);
     }
 
-    auto relaxed_op = std::make_shared<ov::op::TypeRelaxed<opset9::NonMaxSuppression>>(*nms,
-                                                                                       ov::element::TypeVector{},
-                                                                                       output_types);
+    auto relaxed_op =
+        std::make_shared<ov::op::TypeRelaxed<opset9::NonMaxSuppression>>(*nms, ov::element::TypeVector{}, output_types);
     replace_node(node, relaxed_op);
     return true;
 }

--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -19,6 +19,7 @@
 #include "openvino/opsets/opset4.hpp"
 #include "openvino/opsets/opset5.hpp"
 #include "openvino/opsets/opset8.hpp"
+#include "openvino/opsets/opset9.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/visualize_tree.hpp"
 #include "ov_ops/type_relaxed.hpp"
@@ -134,6 +135,40 @@ TEST(TransformationTests, ConvertPrecision_NMS5) {
     static const precisions_map precisions = {{element::i64, element::i32}, {element::f32, element::f16}};
     manager.register_pass<pass::InitNodeInfo>();
     manager.register_pass<pass::ConvertPrecision>(precisions);
+    manager.run_passes(f);
+    ASSERT_NO_THROW(check_rt_info(f));
+    ASSERT_FALSE(has_type<element::Type_t::i64>(f));
+    ASSERT_FALSE(has_type<element::Type_t::f32>(f));
+}
+
+TEST(TransformationTests, DoubleConvertPrecision_NMS9) {
+    std::shared_ptr<Model> f;
+    {
+        auto boxes = std::make_shared<opset9::Parameter>(element::f32, Shape{1, 1000, 4});
+        auto scores = std::make_shared<opset9::Parameter>(element::f32, Shape{1, 1, 1000});
+        auto max_output_boxes_per_class = opset9::Constant::create(element::i64, Shape{}, {10});
+        auto iou_threshold = opset9::Constant::create(element::f32, Shape{}, {0.75});
+        auto score_threshold = opset9::Constant::create(element::f32, Shape{}, {0.7});
+        auto nms = std::make_shared<opset9::NonMaxSuppression>(boxes,
+                                                               scores,
+                                                               max_output_boxes_per_class,
+                                                               iou_threshold,
+                                                               score_threshold,
+                                                               opset9::NonMaxSuppression::BoxEncodingType::CORNER,
+                                                               true);
+
+        auto result1 = std::make_shared<opset9::Result>(nms->output(0));
+        auto result2 = std::make_shared<opset9::Result>(nms->output(1));
+        auto result3 = std::make_shared<opset9::Result>(nms->output(2));
+        f = std::make_shared<Model>(ResultVector{result1, result2, result3}, ParameterVector{boxes, scores});
+    }
+
+    pass::Manager manager;
+    static const precisions_map precisions1 = {{element::f32, element::f16}};
+    static const precisions_map precisions2 = {{element::i64, element::i32}};
+    manager.register_pass<pass::InitNodeInfo>();
+    manager.register_pass<pass::ConvertPrecision>(precisions1);
+    manager.register_pass<pass::ConvertPrecision>(precisions2);
     manager.run_passes(f);
     ASSERT_NO_THROW(check_rt_info(f));
     ASSERT_FALSE(has_type<element::Type_t::i64>(f));


### PR DESCRIPTION
### Details:
If model contains NMS node and being executed on ARM CPU with f16 inference precision then output precision issues may occur: `The plugin does not support I64` or `While validating node ABC type of then_body output i32 is not equal type of else_body output i64`
The issue happens because NMS node wrapped by `TypeRelaxed` is not overridden output types while i32/i64 conversion.
The suggested fix is to change the order of checks: `TypeRelaxed` check initially, i32/i64 check then and `TypeRelaxed` creation at the end.

### Tickets:
 - 123909
 - 123910
