### PR TITLE
Fixed issue with cat in fx backend

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
@@ -82,6 +82,8 @@ class OperatorSupport(OperatorSupport):
             "torch.ops.aten.mul.Scalar": None,
             "torch.ops.aten.mul.Tensor": None,
             "torch.ops.aten.native_batch_norm.default": None,
+            "torch.ops.aten._native_batch_norm_legit.default": None,
+            "torch.ops.aten._native_batch_norm_legit_no_training.default": None,
             "torch.ops.aten.native_group_norm.default": None,
             "torch.ops.aten.native_layer_norm.default": None,
             "torch.ops.aten.neg.default": None,

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -213,7 +213,8 @@ OP_CONVERTER(translate_quantized_linear);
 OP_CONVERTER(translate_xor);
 // Torch FX Translations
 OP_CONVERTER(translate_arange_fx);
-OP_CONVERTER(translate_batch_norm_fx);
+OP_CONVERTER(translate_batch_norm_legit_fx);
+OP_CONVERTER(translate_batch_norm_legit_no_training_fx);
 OP_CONVERTER(translate_cat_fx);
 OP_CONVERTER(translate_chunk_fx);
 OP_CONVERTER(translate_expand_fx);
@@ -612,7 +613,9 @@ const std::map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.mm.default", op::translate_1to1_match_2_inputs<opset10::MatMul>},
         {"aten.mul.Tensor", op::translate_1to1_match_2_inputs_align_types<opset10::Multiply>},
         {"aten.mul.Scalar", op::translate_1to1_match_2_inputs_align_types<opset10::Multiply>},
-        {"aten.native_batch_norm.default", op::translate_batch_norm_fx},
+        {"aten.native_batch_norm.default", op::translate_batch_norm_legit_fx},
+        {"aten._native_batch_norm_legit.default", op::translate_batch_norm_legit_fx},
+        {"aten._native_batch_norm_legit_no_training.default", op::translate_batch_norm_legit_no_training_fx},
         {"aten.native_group_norm.default", op::translate_group_norm_fx},
         {"aten.native_layer_norm.default", op::translate_layer_norm_fx},
         {"aten.neg.default", op::translate_neg},


### PR DESCRIPTION
Fixed issue with cat in fx backend that was causing perf degradation

Added new op batch_norm_legit_no_training which was introduced in Pytorch 2.1.0 which is just batch_norm op with no training argument

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-124095
