### PR TITLE
Extend throughput benchmark with device CLI parameter

### DIFF
--- a/docs/articles_en/learn_openvino/openvino_samples/cpp_sample_throughput_benchmark.md
+++ b/docs/articles_en/learn_openvino/openvino_samples/cpp_sample_throughput_benchmark.md
@@ -75,7 +75,7 @@ Running
 
 .. code-block:: sh
 
-   throughput_benchmark <path_to_model>
+   throughput_benchmark <path_to_model> <device_name>(default: CPU)
 
 
 To run the sample, you need to specify a model:

--- a/docs/articles_en/learn_openvino/openvino_samples/python_sample_throughput_benchmark.md
+++ b/docs/articles_en/learn_openvino/openvino_samples/python_sample_throughput_benchmark.md
@@ -72,7 +72,7 @@ Running
 
 .. code-block:: sh
 
-   python throughput_benchmark.py <path_to_model>
+   python throughput_benchmark.py <path_to_model> <device_name>(default: CPU)
 
 
 To run the sample, you need to specify a model:

--- a/samples/cpp/benchmark/throughput_benchmark/main.cpp
+++ b/samples/cpp/benchmark/throughput_benchmark/main.cpp
@@ -22,8 +22,12 @@ int main(int argc, char* argv[]) {
     try {
         slog::info << "OpenVINO:" << slog::endl;
         slog::info << ov::get_openvino_version();
-        if (argc != 2) {
-            slog::info << "Usage : " << argv[0] << " <path_to_model>" << slog::endl;
+
+        std::string device_name = "CPU";
+        if (argc == 3) {
+            device_name = TSTRING2STRING(argv[2]);
+        } else if (argc != 2) {
+            slog::info << "Usage : " << argv[0] << " <path_to_model> <device_name>(default: CPU)" << slog::endl;
             return EXIT_FAILURE;
         }
         // Optimize for throughput. Best throughput can be reached by
@@ -34,7 +38,7 @@ int main(int argc, char* argv[]) {
         // Pick a device by replacing CPU, for example MULTI:CPU(4),GPU(8).
         // It is possible to set CUMULATIVE_THROUGHPUT as ov::hint::PerformanceMode for AUTO device
         ov::Core core;
-        ov::CompiledModel compiled_model = core.compile_model(argv[1], "CPU", tput);
+        ov::CompiledModel compiled_model = core.compile_model(argv[1], device_name, tput);
         // Create optimal number of ov::InferRequest instances
         uint32_t nireq = compiled_model.get_property(ov::optimal_number_of_infer_requests);
         std::vector<ov::InferRequest> ireqs(nireq);

--- a/samples/cpp/benchmark/throughput_benchmark/main.cpp
+++ b/samples/cpp/benchmark/throughput_benchmark/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
         ov::AnyMap tput{{ov::hint::performance_mode.name(), ov::hint::PerformanceMode::THROUGHPUT}};
 
         // Create ov::Core and use it to compile a model.
-        // Pick a device by replacing CPU, for example MULTI:CPU(4),GPU(8).
+        // Select the device by providing the name as the second parameter to CLI.
         // It is possible to set CUMULATIVE_THROUGHPUT as ov::hint::PerformanceMode for AUTO device
         ov::Core core;
         ov::CompiledModel compiled_model = core.compile_model(argv[1], device_name, tput);

--- a/samples/cpp/benchmark/throughput_benchmark/main.cpp
+++ b/samples/cpp/benchmark/throughput_benchmark/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
 
         std::string device_name = "CPU";
         if (argc == 3) {
-            device_name = TSTRING2STRING(argv[2]);
+            device_name = argv[2];
         } else if (argc != 2) {
             slog::info << "Usage : " << argv[0] << " <path_to_model> <device_name>(default: CPU)" << slog::endl;
             return EXIT_FAILURE;

--- a/samples/python/benchmark/throughput_benchmark/throughput_benchmark.py
+++ b/samples/python/benchmark/throughput_benchmark/throughput_benchmark.py
@@ -38,10 +38,10 @@ def main():
     tput = {'PERFORMANCE_HINT': 'THROUGHPUT'}
 
     # Create Core and use it to compile a model.
-    # Pick a device by replacing CPU, for example MULTI:CPU(4),GPU(8).
     # It is possible to set CUMULATIVE_THROUGHPUT as PERFORMANCE_HINT for AUTO device
     core = ov.Core()
-    compiled_model = core.compile_model(sys.argv[1], 'CPU', tput)
+    device_name = 'CPU' if len(sys.argv) == 2 else sys.argv[2]
+    compiled_model = core.compile_model(sys.argv[1], device_name, tput)
     # AsyncInferQueue creates optimal number of InferRequest instances
     ireqs = ov.AsyncInferQueue(compiled_model)
     # Fill input data for ireqs

--- a/samples/python/benchmark/throughput_benchmark/throughput_benchmark.py
+++ b/samples/python/benchmark/throughput_benchmark/throughput_benchmark.py
@@ -30,7 +30,7 @@ def main():
     log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.INFO, stream=sys.stdout)
     log.info('OpenVINO:')
     log.info(f"{'Build ':.<39} {get_version()}")
-    device_name = "CPU"
+    device_name = 'CPU'
     if len(sys.argv) == 3:
         device_name = sys.argv[2]
     elif len(sys.argv) != 2:

--- a/samples/python/benchmark/throughput_benchmark/throughput_benchmark.py
+++ b/samples/python/benchmark/throughput_benchmark/throughput_benchmark.py
@@ -30,17 +30,20 @@ def main():
     log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.INFO, stream=sys.stdout)
     log.info('OpenVINO:')
     log.info(f"{'Build ':.<39} {get_version()}")
-    if len(sys.argv) != 2:
-        log.info(f'Usage: {sys.argv[0]} <path_to_model>')
+    device_name = "CPU"
+    if len(sys.argv) == 3:
+        device_name = sys.argv[2]
+    elif len(sys.argv) != 2:
+        log.info(f'Usage: {sys.argv[0]} <path_to_model> <device_name>(default: CPU)')
         return 1
     # Optimize for throughput. Best throughput can be reached by
     # running multiple openvino.runtime.InferRequest instances asyncronously
     tput = {'PERFORMANCE_HINT': 'THROUGHPUT'}
 
     # Create Core and use it to compile a model.
+    # Select the device by providing the name as the second parameter to CLI.
     # It is possible to set CUMULATIVE_THROUGHPUT as PERFORMANCE_HINT for AUTO device
     core = ov.Core()
-    device_name = 'CPU' if len(sys.argv) == 2 else sys.argv[2]
     compiled_model = core.compile_model(sys.argv[1], device_name, tput)
     # AsyncInferQueue creates optimal number of InferRequest instances
     ireqs = ov.AsyncInferQueue(compiled_model)


### PR DESCRIPTION
Added device name as the second CLI parameter with default CPU value for throughput benchmark sample
