### PR TITLE
[core]Migrate FloorMod operator to new API

### DIFF
--- a/src/core/include/openvino/op/floor_mod.hpp
+++ b/src/core/include/openvino/op/floor_mod.hpp
@@ -35,9 +35,7 @@ public:
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
     bool visit_attributes(AttributeVisitor& visitor) override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v1

--- a/src/core/include/openvino/op/floor_mod.hpp
+++ b/src/core/include/openvino/op/floor_mod.hpp
@@ -34,7 +34,6 @@ public:
              const AutoBroadcastSpec& auto_broadcast = AutoBroadcastType::NUMPY);
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-    bool visit_attributes(AttributeVisitor& visitor) override;
     bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };

--- a/src/core/reference/include/openvino/reference/floor_mod.hpp
+++ b/src/core/reference/include/openvino/reference/floor_mod.hpp
@@ -8,9 +8,31 @@
 #include <cstddef>
 
 #include "openvino/reference/autobroadcast_binop.hpp"
+#include "openvino/reference/mod.hpp"
 
 namespace ov {
 namespace reference {
+namespace func {
+
+template <class T, typename std::enable_if<std::is_unsigned<T>::value>::type* = nullptr>
+constexpr T floor_mod(const T x, const T y) {
+    return mod(x, y);
+}
+
+template <class T, typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value>::type* = nullptr>
+T floor_mod(const T x, const T y) {
+    // Cast to double is needed for integer input,
+    // otherwise std::floor will act like std::trunc
+    const auto floor_div = static_cast<T>(std::floor(x / static_cast<double>(y)));
+    return x - (floor_div * y);
+}
+
+template <class T, typename std::enable_if<ov::is_floating_point<T>()>::type* = nullptr>
+T floor_mod(const T x, const T y) {
+    return x - (std::floor(x / y) * y);
+}
+}  // namespace func
+
 template <typename T>
 void floor_mod(const T* arg0,
                const T* arg1,
@@ -18,12 +40,7 @@ void floor_mod(const T* arg0,
                const Shape& arg0_shape,
                const Shape& arg1_shape,
                const op::AutoBroadcastSpec& broadcast_spec) {
-    autobroadcast_binop(arg0, arg1, out, arg0_shape, arg1_shape, broadcast_spec, [](T x, T y) -> T {
-        // Cast to double is needed for integer input,
-        // otherwise std::floor will act like std::trunc
-        const double divisor = static_cast<double>(y);
-        return static_cast<T>(x - y * std::floor(x / divisor));
-    });
+    autobroadcast_binop(arg0, arg1, out, arg0_shape, arg1_shape, broadcast_spec, func::floor_mod<T>);
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/reference/include/openvino/reference/floor_mod.hpp
+++ b/src/core/reference/include/openvino/reference/floor_mod.hpp
@@ -19,17 +19,12 @@ constexpr T floor_mod(const T x, const T y) {
     return mod(x, y);
 }
 
-template <class T, typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value>::type* = nullptr>
+template <class T, typename std::enable_if<ov::is_floating_point<T>() || std::is_signed<T>::value>::type* = nullptr>
 T floor_mod(const T x, const T y) {
-    // Cast to double is needed for integer input,
+    // Cast to double is needed for integer input (signed),
     // otherwise std::floor will act like std::trunc
-    const auto floor_div = static_cast<T>(std::floor(x / static_cast<double>(y)));
-    return x - (floor_div * y);
-}
-
-template <class T, typename std::enable_if<ov::is_floating_point<T>()>::type* = nullptr>
-T floor_mod(const T x, const T y) {
-    return x - (std::floor(x / y) * y);
+    const double divisor = static_cast<double>(y);
+    return static_cast<T>(x - y * std::floor(x / divisor));
 }
 }  // namespace func
 

--- a/src/core/src/op/floor_mod.cpp
+++ b/src/core/src/op/floor_mod.cpp
@@ -75,12 +75,6 @@ bool FloorMod::has_evaluate() const {
         return false;
     }
 }
-
-bool FloorMod::visit_attributes(AttributeVisitor& visitor) {
-    OV_OP_SCOPE(v1_FloorMod_visit_attributes);
-    BinaryElementwiseArithmetic::visit_attributes(visitor);
-    return true;
-}
 }  // namespace v1
 }  // namespace op
 }  // namespace ov

--- a/src/core/src/op/floor_mod.cpp
+++ b/src/core/src/op/floor_mod.cpp
@@ -2,94 +2,85 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/floor_mod.hpp"
+#include "openvino/op/floor_mod.hpp"
 
+#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/runtime/host_tensor.hpp"
 #include "openvino/reference/floor_mod.hpp"
+#include "utils.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace floor_mod {
 
-op::v1::FloorMod::FloorMod(const Output<Node>& arg0, const Output<Node>& arg1, const AutoBroadcastSpec& auto_broadcast)
+struct Evaluate : element::NoAction<bool> {
+    using element::NoAction<bool>::visit;
+
+    template <element::Type_t ET, class T = fundamental_type_for<ET>>
+    static result_type visit(const Tensor& arg0,
+                             const Tensor& arg1,
+                             Tensor& out,
+                             const Shape& shape0,
+                             const Shape& shape1,
+                             const AutoBroadcastSpec& broadcast_spec) {
+        reference::floor_mod(arg0.data<const T>(), arg1.data<const T>(), out.data<T>(), shape0, shape1, broadcast_spec);
+        return true;
+    }
+};
+}  // namespace floor_mod
+
+namespace v1 {
+FloorMod::FloorMod(const Output<Node>& arg0, const Output<Node>& arg1, const AutoBroadcastSpec& auto_broadcast)
     : BinaryElementwiseArithmetic(arg0, arg1, auto_broadcast) {
     constructor_validate_and_infer_types();
 }
 
-shared_ptr<Node> op::v1::FloorMod::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> FloorMod::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v1_FloorMod_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<FloorMod>(new_args.at(0), new_args.at(1), this->get_autob());
+    return std::make_shared<FloorMod>(new_args.at(0), new_args.at(1), get_autob());
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace floor_mod {
-namespace {
-template <element::Type_t ET>
-bool evaluate(const HostTensorPtr& arg0,
-              const HostTensorPtr& arg1,
-              const HostTensorPtr& out,
-              const op::AutoBroadcastSpec& broadcast_spec) {
-    ov::reference::floor_mod(arg0->get_data_ptr<ET>(),
-                             arg1->get_data_ptr<ET>(),
-                             out->get_data_ptr<ET>(),
-                             arg0->get_shape(),
-                             arg1->get_shape(),
-                             broadcast_spec);
-    return true;
-}
-
-bool evaluate_floor_mod(const HostTensorPtr& arg0,
-                        const HostTensorPtr& arg1,
-                        const HostTensorPtr& out,
-                        const op::AutoBroadcastSpec& broadcast_spec) {
-    bool rc = true;
-    out->set_broadcast(broadcast_spec, arg0, arg1);
-    switch (arg0->get_element_type()) {
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, i8, arg0, arg1, out, broadcast_spec);
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, i32, arg0, arg1, out, broadcast_spec);
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, i64, arg0, arg1, out, broadcast_spec);
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, u8, arg0, arg1, out, broadcast_spec);
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, u32, arg0, arg1, out, broadcast_spec);
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, u64, arg0, arg1, out, broadcast_spec);
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, bf16, arg0, arg1, out, broadcast_spec);
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, f16, arg0, arg1, out, broadcast_spec);
-        OPENVINO_TYPE_CASE(evaluate_floor_mod, f32, arg0, arg1, out, broadcast_spec);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace floor_mod
-
-bool op::v1::FloorMod::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool FloorMod::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v1_FloorMod_evaluate);
-    return floor_mod::evaluate_floor_mod(inputs[0], inputs[1], outputs[0], get_autob());
+    OPENVINO_ASSERT(outputs.size() == 1);
+
+    outputs[0].set_shape(infer_broadcast_shape(this, inputs));
+
+    using namespace ov::element;
+    return IfTypeOf<bf16, f16, f32, i8, i32, i64, u8, u32, u64>::apply<floor_mod::Evaluate>(
+        inputs[0].get_element_type(),
+        inputs[0],
+        inputs[1],
+        outputs[0],
+        inputs[0].get_shape(),
+        inputs[1].get_shape(),
+        get_autob());
 }
 
-bool op::v1::FloorMod::has_evaluate() const {
+bool FloorMod::has_evaluate() const {
     OV_OP_SCOPE(v1_FloorMod_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::i8:
-    case ngraph::element::i32:
-    case ngraph::element::i64:
-    case ngraph::element::u8:
-    case ngraph::element::u32:
-    case ngraph::element::u64:
-    case ngraph::element::bf16:
-    case ngraph::element::f16:
-    case ngraph::element::f32:
+    case element::bf16:
+    case element::f16:
+    case element::f32:
+    case element::i8:
+    case element::i32:
+    case element::i64:
+    case element::u8:
+    case element::u32:
+    case element::u64:
         return true;
     default:
-        break;
+        return false;
     }
-    return false;
 }
 
-bool op::v1::FloorMod::visit_attributes(AttributeVisitor& visitor) {
+bool FloorMod::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(v1_FloorMod_visit_attributes);
     BinaryElementwiseArithmetic::visit_attributes(visitor);
     return true;
 }
+}  // namespace v1
+}  // namespace op
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Migrate `FloorMod` operator to new API, remove old headers, classes namespaces
 - Refactor reference implementation to reduce binary size
 - Remove `visit_attributes` member function as implementation is same as base class.
 - 

### Tickets:
 - [CVS-118583](https://jira.devtools.intel.com/browse/CVS-118583)
