### PR TITLE
[core]Migrate Floor operator to new API

### DIFF
--- a/src/core/include/openvino/op/floor.hpp
+++ b/src/core/include/openvino/op/floor.hpp
@@ -21,7 +21,6 @@ public:
     /// \param arg Node that produces the input tensor.
     Floor(const Output<Node>& arg);
 
-    bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
     bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;

--- a/src/core/include/openvino/op/floor.hpp
+++ b/src/core/include/openvino/op/floor.hpp
@@ -23,9 +23,7 @@ public:
 
     bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v0

--- a/src/core/reference/include/openvino/reference/floor.hpp
+++ b/src/core/reference/include/openvino/reference/floor.hpp
@@ -7,13 +7,36 @@
 #include <cmath>
 #include <cstddef>
 
+#include "openvino/reference/copy.hpp"
+#include "openvino/reference/utils/type_util.hpp"
+
 namespace ov {
 namespace reference {
-template <typename T>
-void floor(const T* arg, T* out, size_t count) {
-    for (size_t i = 0; i < count; i++) {
-        out[i] = std::floor(arg[i]);
-    }
+
+/**
+ * @brief Reference implementation of Floor operator (integral types).
+ *
+ * @param arg    Input pointer to data.
+ * @param out    Output pointer to results.
+ * @param count  Number of elements in input buffer.
+ */
+template <class T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+void floor(const T* arg, T* out, const size_t count) {
+    reference::copy(arg, out, count);
+}
+
+/**
+ * @brief Reference implementation of Floor operator (floating point types).
+ *
+ * @param arg    Input pointer to data.
+ * @param out    Output pointer to results.
+ * @param count  Number of elements in input buffer.
+ */
+template <class T, typename std::enable_if<ov::is_floating_point<T>()>::type* = nullptr>
+void floor(const T* arg, T* out, const size_t count) {
+    std::transform(arg, arg + count, out, [](const T v) {
+        return std::floor(v);
+    });
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/src/op/floor.cpp
+++ b/src/core/src/op/floor.cpp
@@ -2,95 +2,79 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/floor.hpp"
+#include "openvino/op/floor.hpp"
 
+#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/op/util/eval_copy.hpp"
-#include "ngraph/runtime/host_tensor.hpp"
 #include "openvino/reference/copy.hpp"
 #include "openvino/reference/floor.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace floor {
 
-op::Floor::Floor(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
+struct Evaluate : element::NoAction<bool> {
+    using element::NoAction<bool>::visit;
+
+    template <element::Type_t ET, class T = fundamental_type_for<ET>>
+    static result_type visit(const Tensor& arg, Tensor& out, const size_t count) {
+        reference::floor(arg.data<const T>(), out.data<T>(), count);
+        return true;
+    }
+};
+}  // namespace floor
+
+namespace v0 {
+
+Floor::Floor(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
     constructor_validate_and_infer_types();
 }
 
-bool ngraph::op::v0::Floor::visit_attributes(AttributeVisitor& visitor) {
+bool Floor::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(v0_Floor_visit_attributes);
     return true;
 }
 
-shared_ptr<Node> op::Floor::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> Floor::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v0_Floor_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<Floor>(new_args.at(0));
+    return std::make_shared<Floor>(new_args.at(0));
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace floorop {
-namespace {
-// function used by TYPE_CASE
-template <element::Type_t ET>
-inline bool evaluate(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    using T = typename element_type_traits<ET>::value_type;
-    ov::reference::floor<T>(arg0->get_data_ptr<ET>(), out->get_data_ptr<ET>(), count);
-    return true;
-}
-
-// function used by COPY_TENSOR
-template <element::Type_t ET>
-inline bool copy_tensor(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    ov::reference::copy(arg0->get_data_ptr<ET>(), out->get_data_ptr<ET>(), count);
-    return true;
-}
-
-bool evaluate_floor(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    bool rc = true;
-    out->set_unary(arg0);
-
-    switch (arg0->get_element_type()) {
-        OPENVINO_COPY_TENSOR(evaluate_floor, i8, arg0, out, count);
-        OPENVINO_COPY_TENSOR(evaluate_floor, i16, arg0, out, count);
-        OPENVINO_COPY_TENSOR(evaluate_floor, i32, arg0, out, count);
-        OPENVINO_COPY_TENSOR(evaluate_floor, i64, arg0, out, count);
-        OPENVINO_COPY_TENSOR(evaluate_floor, u8, arg0, out, count);
-        OPENVINO_COPY_TENSOR(evaluate_floor, u16, arg0, out, count);
-        OPENVINO_COPY_TENSOR(evaluate_floor, u32, arg0, out, count);
-        OPENVINO_COPY_TENSOR(evaluate_floor, u64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_floor, f16, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_floor, f32, arg0, out, count);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace floorop
-
-bool op::Floor::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool Floor::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v0_Floor_evaluate);
-    return floorop::evaluate_floor(inputs[0], outputs[0], shape_size(inputs[0]->get_shape()));
+    OPENVINO_ASSERT(outputs.size() == 1);
+    OPENVINO_ASSERT(inputs.size() == 1);
+
+    const auto& in_shape = inputs[0].get_shape();
+    outputs[0].set_shape(in_shape);
+
+    using namespace ov::element;
+    return IfTypeOf<f16, f32, i8, i16, i32, i64, u8, u16, u32, u64>::apply<floor::Evaluate>(
+        inputs[0].get_element_type(),
+        inputs[0],
+        outputs[0],
+        shape_size(in_shape));
 }
 
-bool op::Floor::has_evaluate() const {
+bool Floor::has_evaluate() const {
     OV_OP_SCOPE(v0_Floor_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::i8:
-    case ngraph::element::i16:
-    case ngraph::element::i32:
-    case ngraph::element::i64:
-    case ngraph::element::u8:
-    case ngraph::element::u16:
-    case ngraph::element::u32:
-    case ngraph::element::u64:
-    case ngraph::element::f16:
-    case ngraph::element::f32:
+    case element::f16:
+    case element::f32:
+    case element::i8:
+    case element::i16:
+    case element::i32:
+    case element::i64:
+    case element::u8:
+    case element::u16:
+    case element::u32:
+    case element::u64:
         return true;
     default:
-        break;
+        return false;
     }
-    return false;
 }
+}  // namespace v0
+}  // namespace op
+}  // namespace ov

--- a/src/core/src/op/floor.cpp
+++ b/src/core/src/op/floor.cpp
@@ -6,7 +6,6 @@
 
 #include "element_visitor.hpp"
 #include "itt.hpp"
-#include "openvino/reference/copy.hpp"
 #include "openvino/reference/floor.hpp"
 
 namespace ov {
@@ -28,11 +27,6 @@ namespace v0 {
 
 Floor::Floor(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
     constructor_validate_and_infer_types();
-}
-
-bool Floor::visit_attributes(AttributeVisitor& visitor) {
-    OV_OP_SCOPE(v0_Floor_visit_attributes);
-    return true;
 }
 
 std::shared_ptr<Node> Floor::clone_with_new_inputs(const OutputVector& new_args) const {


### PR DESCRIPTION
### Details:
 - Migrate `Floor` operator to new API, remove legacy headers, classes namespace.
 - Move reference logic selection into Floor reference implementation.
 - Remove `visit_attributes` as is same as base class implementation.

### Tickets:
 - [CVS-118584](https://jira.devtools.intel.com/browse/CVS-118584)
