### PR TITLE
[GPU] Fix cum_sum_partial_sum implementation for dimensions >=16

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/cum_sum_partial_sum.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/cum_sum_partial_sum.cl
@@ -119,12 +119,17 @@ inline uint FUNC(get_block_num)(int axis)
 #endif
 }
 
-inline uint FUNC(get_current_index)(int i)
+// This function works incorrect for the last block when there are leftovers (i.e. SUM_ITEMS_NUM % BLOCKSIZE != 0)
+// and REVERSE == false. But it is expected, since it will never be called for the last block when calculating 
+// sum of the previous blocks (see loop in cum_sum_final), thus, no need to make it correct 
+// at cost of complexity and performance.
+inline uint FUNC(get_last_index_in_block)(int block)
 {
+    const int num_items_in_blocks_before = (block + 1) * BLOCK_SIZE;
 #ifdef REVERSE
-    return SUM_ITEMS_NUM - i*BLOCK_SIZE - BLOCK_SIZE;
+    return SUM_ITEMS_NUM - num_items_in_blocks_before;
 #else
-    return i*BLOCK_SIZE + BLOCK_SIZE - 1;
+    return num_items_in_blocks_before - 1;
 #endif
 }
 
@@ -148,17 +153,15 @@ KERNEL(cum_sum_final)(
     PARTIAL_TYPE res = partial[ind];
 
     PARTIAL_TYPE sum = 0;
-    uint block_num = FUNC_CALL(get_block_num)(axes[AXIS]);
-    int n = 4;
-    for (int i = 0; i < block_num / n; ++i) {
-        unroll_for (int j = 0; j < n; ++j) {
-            axes[AXIS] = FUNC_CALL(get_current_index)(i*n + j);
-            ind = FUNC_CALL(get_input_index)(axes[0], axes[1], axes[2], axes[3], axes[4], axes[5]);
-            sum += partial[ind];
-        }
+    const uint current_block = FUNC_CALL(get_block_num)(axes[AXIS]);
+
+    for (int block = 0; block < current_block; ++block) {
+        axes[AXIS] = FUNC_CALL(get_last_index_in_block)(block);
+        ind = FUNC_CALL(get_input_index)(axes[0], axes[1], axes[2], axes[3], axes[4], axes[5]);
+        sum += partial[ind];
     }
 
-    uint out_ind = FUNC_CALL(get_output_index)(batch, features, w, z, y, x);
+    const uint out_ind = FUNC_CALL(get_output_index)(batch, features, w, z, y, x);
     output[out_ind] = ACTIVATION(TO_OUTPUT_TYPE(res + sum), ACTIVATION_PARAMS);
 }
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/cum_sum/cum_sum_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/cum_sum/cum_sum_kernel_ref.cpp
@@ -68,6 +68,6 @@ KernelsData CumSumKernelRef::GetKernelsData(const Params& params, const optional
 }
 
 KernelsPriority CumSumKernelRef::GetKernelsPriority(const Params& /*params*/, const optional_params& /*options*/) const {
-    return DONT_USE_IF_HAVE_SOMETHING_ELSE;
+    return FORCE_PRIORITY_9;
 }
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/cum_sum.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/cum_sum.cpp
@@ -44,4 +44,20 @@ INSTANTIATE_TEST_SUITE_P(smoke_CumSum, CumSumLayerTest,
                                 ::testing::ValuesIn(reverse),
                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         CumSumLayerTest::getTestCaseName);
+
+const std::vector<std::vector<ov::Shape>> inShapesWithBigDims = {
+        {{64, 64}},
+        {{73, 73, 73}},
+        {{49, 49, 49, 49}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_CumSumBigDims, CumSumLayerTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapesWithBigDims)),
+                                ::testing::Values(ov::element::f32),
+                                ::testing::ValuesIn(axes),
+                                ::testing::ValuesIn(exclusive),
+                                ::testing::ValuesIn(reverse),
+                                ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                        CumSumLayerTest::getTestCaseName);
 }  // namespace

--- a/src/plugins/intel_gpu/tests/unit/test_cases/cum_sum_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/cum_sum_gpu_test.cpp
@@ -348,3 +348,118 @@ TEST(cum_sum_gpu_fp32, dynamic) {
         ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
+
+TEST(cum_sum_partial, big_shapes) {
+    auto& engine = get_test_engine();
+
+    const std::vector<size_t> input_sizes = {16, 17, 34, 65, 256, 300};
+
+    for (const auto num_items : input_sizes) {
+        std::vector<float> input_data;
+        input_data.resize(num_items);
+        std::iota(input_data.begin(), input_data.end(), 1);
+
+        const auto shape_num_items = static_cast<int>(num_items);
+        const tensor shape{shape_num_items, 1, 1, 1};
+        const layout in_layout{data_types::f32, format::bfyx, shape};
+        const auto input = engine.allocate_memory(in_layout);
+
+        set_values(input, input_data);
+
+        topology topology;
+        topology.add(input_layout("input", in_layout));
+        topology.add(cum_sum("cum_sum", input_info("input")));
+
+        auto config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::force_implementations(
+                ov::intel_gpu::ImplForcingMap{ {"cum_sum", {format::bfyx, "cum_sum_partial_sum"}} }));
+        network network(engine, topology, config);
+        network.set_input_data("input", input);
+
+        const auto inst = network.get_primitive("cum_sum");
+        const auto outputs = network.execute();
+        ASSERT_EQ(outputs.begin()->first, "cum_sum");
+
+        const auto output = outputs.at("cum_sum").get_memory();
+        const cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+        const auto expected = cumsum(input_data, format::bfyx, {shape_num_items, 1, 1, 1, 1, 1 });
+
+        ASSERT_EQ(expected.size(), num_items);
+        ASSERT_EQ(output->count(), num_items);
+        for (size_t i = 0; i < num_items; ++i) {
+            ASSERT_TRUE(are_equal(expected[i], output_ptr[i])) << "num_items=" << num_items << ", i=" << i;
+        }
+    }
+}
+
+TEST(cum_sum_partial, DISABLED_perf_test) {
+    auto& engine = get_test_engine();
+
+    const std::vector<size_t> input_sizes = {1, 2, 4, 8, 16, 17, 34, 48, 65, 256, 300, 515, 1025};
+
+    for (const auto num_items : input_sizes) {
+        std::vector<float> input_data;
+        input_data.resize(num_items);
+        std::iota(input_data.begin(), input_data.end(), 1);
+
+        const auto shape_num_items = static_cast<int>(num_items);
+        const tensor shape{shape_num_items, 1, 1, 1};
+        const layout in_layout{data_types::f32, format::bfyx, shape};
+
+
+        const auto input_ref = engine.allocate_memory(in_layout);
+        set_values(input_ref, input_data);
+        topology topology_ref;
+        topology_ref.add(input_layout("input", in_layout));
+        topology_ref.add(cum_sum("cum_sum", input_info("input")));
+        ExecutionConfig config_ref(ov::enable_profiling(true));
+        config_ref.set_property(ov::intel_gpu::force_implementations(
+                ov::intel_gpu::ImplForcingMap{ {"cum_sum", {format::bfyx, "cum_sum_ref"}} }));
+        network network_ref(engine, topology_ref, config_ref);
+        network_ref.set_input_data("input", input_ref);
+
+
+        const auto input_partial = engine.allocate_memory(in_layout);
+        set_values(input_partial, input_data);
+        topology topology_partial;
+        topology_partial.add(input_layout("input", in_layout));
+        topology_partial.add(cum_sum("cum_sum", input_info("input")));
+        ExecutionConfig config_partial(ov::enable_profiling(true));
+        config_partial.set_property(ov::intel_gpu::force_implementations(
+                ov::intel_gpu::ImplForcingMap{ {"cum_sum", {format::bfyx, "cum_sum_partial_sum"}} }));
+        network network_partial(engine, topology_partial, config_partial);
+        network_partial.set_input_data("input", input_partial);
+
+
+        std::map<primitive_id, network_output> output_ref;
+        std::map<primitive_id, network_output> output_partial;
+
+        constexpr int WARMUP_ROUNDS = 10;
+        for (int i = 0; i < WARMUP_ROUNDS; ++i) {
+            output_ref = network_ref.execute();
+            output_partial = network_partial.execute();
+        }
+
+        constexpr int PERFTEST_ROUNDS = 100;
+        double exectime_ref = 0.f;
+        double exectime_partial = 0.f;
+        for (int i = 0; i < PERFTEST_ROUNDS; ++i) {
+            output_ref = network_ref.execute();
+            const auto t_ref = get_profiling_exectime(output_ref, "cum_sum");
+            exectime_ref += t_ref;
+
+            output_partial = network_partial.execute();
+            const auto t_partial = get_profiling_exectime(output_partial, "cum_sum");
+            exectime_partial += t_partial;
+        }
+        exectime_ref /= PERFTEST_ROUNDS;
+        exectime_partial /= PERFTEST_ROUNDS;
+
+        std::cout << std::endl;
+        std::cout << "Execution time for num_items=" << num_items << " "
+                  << "cum_sum_ref" << " " << exectime_ref << std::endl;
+        std::cout << "Execution time for num_items=" << num_items << " "
+                  << "cum_sum_partial_sum" << " " << exectime_partial << std::endl;
+    }
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -2273,46 +2273,6 @@ TEST_P(permute_f_y_axes_tile, combined) {
 
 struct TiledPerformancePermuteTest : TiledPermuteTest
 {
-    static double get_exectime(const std::map<cldnn::primitive_id, cldnn::network_output>& outputs,
-                                const std::string& primitive_id)
-    {
-        using namespace std::chrono;
-        std::shared_ptr<event> e = outputs.at(primitive_id).get_event();
-        e->wait(); // should ensure execution completion, if not segfault will occur
-        double avg_time = 0.0;
-        auto intervals = e->get_profiling_info();
-        for (const auto& q : intervals)
-        {
-            if (q.stage != instrumentation::profiling_stage::executing) {
-                continue;
-            }
-            avg_time = duration_cast<duration<double, microseconds::period>>(q.value->value()).count();
-            break;
-        }
-        return avg_time;
-    }
-
-    static void print_all_perf(std::map<primitive_id, network_output> outputs)
-    {
-        std::cout << "Print last run time" << std::endl;
-        using namespace std::chrono;
-        for( const auto &n : outputs ) {
-            std::shared_ptr<event> e = n.second.get_event();
-            auto intervals = e->get_profiling_info();
-            double time = 0.0;
-            for (const auto& q : intervals)
-            {
-                if (q.stage == instrumentation::profiling_stage::executing) {
-                    continue;
-                }
-                time = duration_cast<duration<double, microseconds::period>>(q.value->value()).count();
-                break;
-            }
-            std::cout << n.first << ":" << time << std::endl;
-        }
-        std::cout << std::endl;
-    }
-
     template<data_types Data_Type>
     void execute_perf_test(const std::vector<cldnn::tensor::value_type>& sizes, cldnn::format format_fsv,
                             const std::string & kernel_name, std::vector<uint16_t> permute_order)
@@ -2382,11 +2342,11 @@ struct TiledPerformancePermuteTest : TiledPermuteTest
         double exectime_opt = 0.f;
         for (int i = 0; i < r; ++i) {
             output_permute_opt = network_tile.execute();
-            auto t_opt = get_exectime(output_permute_opt, "output");
+            auto t_opt = get_profiling_exectime(output_permute_opt, "output");
             exectime_opt += t_opt;
 
             output_permute_ref = network_ref.execute();
-            auto t_ref = get_exectime(output_permute_ref, "output");
+            auto t_ref = get_profiling_exectime(output_permute_ref, "output");
             exectime_ref += t_ref;
         }
         exectime_ref /= r;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/resample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/resample_gpu_test.cpp
@@ -2099,46 +2099,6 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
 
 struct resample_opt_random_test_ext : resample_opt_random_test
 {
-    static double get_exectime(const std::map<cldnn::primitive_id, cldnn::network_output>& outputs,
-                                const std::string& primitive_id)
-    {
-        using namespace std::chrono;
-        std::shared_ptr<event> e = outputs.at(primitive_id).get_event();
-        e->wait(); // should ensure execution completion, if not segfault will occur
-        double avg_time = 0.0;
-        auto intervals = e->get_profiling_info();
-        for (const auto& q : intervals)
-        {
-            if (q.stage == instrumentation::profiling_stage::executing) {
-                continue;
-            }
-            avg_time = duration_cast<duration<double, microseconds::period>>(q.value->value()).count();
-            break;
-        }
-        return avg_time;
-    }
-
-    static void print_all_perf(std::map<primitive_id, network_output> outputs)
-    {
-        std::cout << "Print last run time" << std::endl;
-        using namespace std::chrono;
-        for( const auto &n : outputs ) {
-            std::shared_ptr<event> e = n.second.get_event();
-            auto intervals = e->get_profiling_info();
-            double time = 0.0;
-            for (const auto& q : intervals)
-            {
-                if (q.stage == instrumentation::profiling_stage::executing) {
-                    continue;
-                }
-                time = duration_cast<duration<double, microseconds::period>>(q.value->value()).count();
-                break;
-            }
-            std::cout << n.first << ":" << time << std::endl;
-        }
-        std::cout << std::endl;
-    }
-
     void execute_perf_test(const resample_opt_random_test_params& params, const std::string& kernel, const bool do_planar = false) {
         auto& engine = get_test_engine();
 
@@ -2174,7 +2134,7 @@ struct resample_opt_random_test_ext : resample_opt_random_test
         double exectime = 0.f;
         for (int i = 0; i < r; ++i) {
             result_opt = net_opt.execute();
-            exectime += get_exectime(result_opt, "resample_opt");
+            exectime += get_profiling_exectime(result_opt, "resample_opt");
         }
         exectime /= r;
         std::string frm_str = format(working_format).to_string();
@@ -2197,7 +2157,7 @@ struct resample_opt_random_test_ext : resample_opt_random_test
                   << frm_str << " " << input_type << " " << exectime << std::endl;
 
         // Uncomment line below if you like to see the latencies of all operations from last iteration
-        //print_all_perf(result_opt);
+        //print_profiling_all_exectimes(result_opt);
     }
 };
 

--- a/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.h
+++ b/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.h
@@ -730,4 +730,8 @@ inline cldnn::network::ptr get_network(cldnn::engine& engine,
     return network;
 }
 
+double get_profiling_exectime(const std::map<cldnn::primitive_id, cldnn::network_output>& outputs,
+                    const std::string& primitive_id);
+void print_profiling_all_exectimes(const std::map<cldnn::primitive_id, cldnn::network_output>& outputs);
+
 } // namespace tests


### PR DESCRIPTION
 
- fix cum_sum_partial_sum kernel;
- add unit test and func test for big dimensions;
- add test to compare Partial vs Ref performance;
- change kernels' priorities according to performance measurements;
- move common profiling helpers to test_utils.

Tickets: 
CVS-123590

