### PR TITLE
[core]Migrate MatMul operator to new API

### DIFF
--- a/src/core/include/openvino/op/matmul.hpp
+++ b/src/core/include/openvino/op/matmul.hpp
@@ -31,9 +31,7 @@ public:
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 
     bool get_transpose_a() const {

--- a/src/core/src/op/matmul.cpp
+++ b/src/core/src/op/matmul.cpp
@@ -106,7 +106,8 @@ void MatMul::validate_and_infer_types() {
                           get_input_element_type(1),
                           ").");
 
-    const auto &A_shape = get_input_partial_shape(0), &B_shape = get_input_partial_shape(1);
+    const auto& A_shape = get_input_partial_shape(0);
+    const auto& B_shape = get_input_partial_shape(1);
     const auto output_shapes = shape_infer(this, std::vector<ov::PartialShape>{A_shape, B_shape});
     set_output_type(0, result_et, output_shapes[0]);
 }

--- a/src/core/src/op/matmul.cpp
+++ b/src/core/src/op/matmul.cpp
@@ -2,110 +2,99 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/matmul.hpp"
+#include "openvino/op/matmul.hpp"
 
-#include <memory>
-
+#include "element_visitor.hpp"
 #include "itt.hpp"
 #include "matmul_shape_inference.hpp"
-#include "ngraph/attribute_visitor.hpp"
 #include "openvino/reference/matmul.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace matmul {
 
-op::MatMul::MatMul(const Output<Node>& A, const Output<Node>& B, const bool& transpose_a, const bool& transpose_b)
+struct Evaluate : element::NoAction<bool> {
+    using element::NoAction<bool>::visit;
+
+    template <element::Type_t ET, class T = fundamental_type_for<ET>>
+    static result_type visit(const Tensor& arg0,
+                             const Tensor& arg1,
+                             Tensor& out,
+                             const Shape& shape0,
+                             const Shape& shape1,
+                             const Shape& out_shape,
+                             const bool transpose_a,
+                             const bool transpose_b) {
+        reference::matmul(arg0.data<const T>(),
+                          arg1.data<const T>(),
+                          out.data<T>(),
+                          shape0,
+                          shape1,
+                          out_shape,
+                          transpose_a,
+                          transpose_b);
+        return true;
+    }
+};
+}  // namespace matmul
+
+namespace v0 {
+
+MatMul::MatMul(const Output<Node>& A, const Output<Node>& B, const bool& transpose_a, const bool& transpose_b)
     : Op(OutputVector{A, B}),
       m_transpose_a{transpose_a},
       m_transpose_b{transpose_b} {
     constructor_validate_and_infer_types();
 }
 
-bool ngraph::op::v0::MatMul::visit_attributes(AttributeVisitor& visitor) {
+bool MatMul::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(v0_MatMul_visit_attributes);
     visitor.on_attribute("transpose_a", m_transpose_a);
     visitor.on_attribute("transpose_b", m_transpose_b);
     return true;
 }
 
-shared_ptr<Node> op::MatMul::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> MatMul::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v0_MatMul_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<MatMul>(new_args.at(0), new_args.at(1), m_transpose_a, m_transpose_b);
+    return std::make_shared<MatMul>(new_args.at(0), new_args.at(1), m_transpose_a, m_transpose_b);
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace matmul {
-namespace {
-template <element::Type_t ET>
-bool evaluate(const op::MatMul* op, const HostTensorPtr& arg0, const HostTensorPtr& arg1, const HostTensorPtr& output) {
-    using T = typename element_type_traits<ET>::value_type;
-
-    ov::Shape arg0_shape = arg0->get_shape();
-    ov::Shape arg1_shape = arg1->get_shape();
-
-    std::vector<ov::PartialShape> input_shapes = {arg0_shape, arg1_shape};
-    std::vector<ov::PartialShape> output_shapes = shape_infer(op, input_shapes);
-
-    ov::Shape output_shape = output_shapes[0].to_shape();
-    output->set_element_type(arg0->get_element_type());
-    output->set_shape(output_shape);
-
-    ov::reference::matmul<T>(arg0->get_data_ptr<ET>(),
-                             arg1->get_data_ptr<ET>(),
-                             output->get_data_ptr<ET>(),
-                             arg0_shape,
-                             arg1_shape,
-                             output_shape,
-                             op->get_transpose_a(),
-                             op->get_transpose_b());
-    return true;
-}
-
-bool evaluate_matmul(const op::MatMul* op,
-                     const HostTensorPtr& arg0,
-                     const HostTensorPtr& arg1,
-                     const HostTensorPtr& output) {
-    bool rc = true;
-
-    switch (arg0->get_element_type()) {
-        OPENVINO_TYPE_CASE(evaluate_matmul, i32, op, arg0, arg1, output);
-        OPENVINO_TYPE_CASE(evaluate_matmul, i64, op, arg0, arg1, output);
-        OPENVINO_TYPE_CASE(evaluate_matmul, u32, op, arg0, arg1, output);
-        OPENVINO_TYPE_CASE(evaluate_matmul, u64, op, arg0, arg1, output);
-        OPENVINO_TYPE_CASE(evaluate_matmul, f16, op, arg0, arg1, output);
-        OPENVINO_TYPE_CASE(evaluate_matmul, f32, op, arg0, arg1, output);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace matmul
-
-bool op::MatMul::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool MatMul::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v0_MatMul_evaluate);
-    return matmul::evaluate_matmul(this, inputs[0], inputs[1], outputs[0]);
+    OPENVINO_ASSERT(outputs.size() == 1);
+
+    const auto out_shape = shape_infer(this, ov::util::get_tensors_partial_shapes(inputs)).front().to_shape();
+    outputs[0].set_shape(out_shape);
+
+    using namespace ov::element;
+    return IfTypeOf<f16, f32, i32, i64, u32, u64>::apply<matmul::Evaluate>(inputs[0].get_element_type(),
+                                                                           inputs[0],
+                                                                           inputs[1],
+                                                                           outputs[0],
+                                                                           inputs[0].get_shape(),
+                                                                           inputs[1].get_shape(),
+                                                                           out_shape,
+                                                                           m_transpose_a,
+                                                                           m_transpose_b);
 }
 
-bool op::MatMul::has_evaluate() const {
+bool MatMul::has_evaluate() const {
     OV_OP_SCOPE(v0_MatMul_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::i32:
-    case ngraph::element::i64:
-    case ngraph::element::u32:
-    case ngraph::element::u64:
-    case ngraph::element::f16:
-    case ngraph::element::f32:
+    case element::f16:
+    case element::f32:
+    case element::i32:
+    case element::i64:
+    case element::u32:
+    case element::u64:
         return true;
     default:
-        break;
+        return false;
     }
-    return false;
 }
 
-void ngraph::op::v0::MatMul::validate_and_infer_types() {
+void MatMul::validate_and_infer_types() {
     OV_OP_SCOPE(v0_MatMul_validate_and_infer_types);
     element::Type result_et;
 
@@ -117,8 +106,10 @@ void ngraph::op::v0::MatMul::validate_and_infer_types() {
                           get_input_element_type(1),
                           ").");
 
-    const auto &A_shape = get_input_partial_shape(0), B_shape = get_input_partial_shape(1);
-    std::vector<ov::PartialShape> input_shapes = {A_shape, B_shape};
-    std::vector<ov::PartialShape> output_shapes = shape_infer(this, input_shapes);
+    const auto &A_shape = get_input_partial_shape(0), &B_shape = get_input_partial_shape(1);
+    const auto output_shapes = shape_infer(this, std::vector<ov::PartialShape>{A_shape, B_shape});
     set_output_type(0, result_et, output_shapes[0]);
 }
+}  // namespace v0
+}  // namespace op
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Migrate `MatMul` operator to new API.
 - Minor refactor operator to reduce binary size.

### Tickets:
 - [CVS-118624](https://jira.devtools.intel.com/browse/CVS-118624)
