### PR TITLE
[nGraph Transformations]Move FakeQuantize up through data movement operations 

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_eltwise_up_data_movement.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_eltwise_up_data_movement.cpp
@@ -101,12 +101,16 @@ ov::intel_cpu::MoveEltwiseUpThroughDataMov::MoveEltwiseUpThroughDataMov() {
         }
 
         // eltwise constant shape should match new input shape
-        if (is_binary_op && current->get_output_partial_shape(0).rank().get_length() != eltwise->get_input_partial_shape(1).rank().get_length()) {
-            auto old_eltwise_const = std::dynamic_pointer_cast<ov::opset8::Constant>(eltwise->get_input_node_shared_ptr(1));
-            auto new_constant = std::make_shared<ov::opset8::Constant>(*old_eltwise_const.get(), ov::Shape{});
+        if (is_binary_op || fq) {
+            for (size_t i = 1; i < eltwise->get_input_size(); i++) {
+                if (current->get_output_partial_shape(0).rank().get_length() != eltwise->get_input_partial_shape(i).rank().get_length()) {
+                    auto old_eltwise_const = std::dynamic_pointer_cast<ov::opset8::Constant>(eltwise->get_input_node_shared_ptr(i));
+                    auto new_constant = std::make_shared<ov::opset8::Constant>(*old_eltwise_const.get(), ov::Shape{});
 
-            ov::copy_runtime_info(old_eltwise_const, new_constant);
-            ov::replace_node(old_eltwise_const, new_constant);
+                    ov::copy_runtime_info(old_eltwise_const, new_constant);
+                    ov::replace_node(old_eltwise_const, new_constant);
+                }
+            }
         }
         ov::replace_output_update_name(eltwise->output(0), eltwise->input_value(0));
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -640,7 +640,7 @@ void Transformations::PostLpt() {
     CPU_SET_CALLBACK_COMMON(postLPTPassManager,
         [](const std::shared_ptr<const ov::Node>& node) -> bool {
             if (node->get_input_size() >= 2) {
-                return node->get_input_element_type(1) == ov::element::i8 || node->get_input_element_type(1) == ov::element::u8;
+                return node->get_input_element_type(1) == ov::element::i8 || node->get_input_element_type(1) == ov::element::u8 || (ov::is_type<const ov::op::v0::FakeQuantize>(node) && !ov::is_type<const ov::op::v1::Transpose>(node->get_input_node_shared_ptr(0)));
             }
             return false;
         },

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -640,7 +640,9 @@ void Transformations::PostLpt() {
     CPU_SET_CALLBACK_COMMON(postLPTPassManager,
         [](const std::shared_ptr<const ov::Node>& node) -> bool {
             if (node->get_input_size() >= 2) {
-                return node->get_input_element_type(1) == ov::element::i8 || node->get_input_element_type(1) == ov::element::u8 || (ov::is_type<const ov::op::v0::FakeQuantize>(node) && !ov::is_type<const ov::op::v1::Transpose>(node->get_input_node_shared_ptr(0)));
+                return node->get_input_element_type(1) == ov::element::i8 ||
+                       node->get_input_element_type(1) == ov::element::u8 ||
+                       (ov::is_type<const ov::op::v0::FakeQuantize>(node) && !ov::is_type<const ov::op::v1::Transpose>(node->get_input_node_shared_ptr(0)));
             }
             return false;
         },

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -647,6 +647,7 @@ void Transformations::PostLpt() {
             return false;
         },
         MoveEltwiseUpThroughDataMov);
+    CPU_REGISTER_PASS_COMMON(postLPTPassManager, ov::pass::Validate);
 
     CPU_REGISTER_PASS_COMMON(postLPTPassManager, ov::pass::ConstantFolding);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -283,8 +283,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAQuantMatMul0, MHAQuantMatMul0,
                                  ::testing::Values(ov::element::f32),
                                  ::testing::Values(false), // The graph doesn't contain Multiply
                                  ::testing::Values(MHA::default_thread_count),
-                                 ::testing::Values(8),     // FQ on input + MHA + Transpose on output + 4 Reshapes + Deq Mul
-                                 ::testing::Values(3),     // FQ on input + MHA + Deq Mul
+                                 ::testing::Values(9),     // FQx2 on inputs + MHA + Transpose on output + 4 Reshapes + Deq Mul
+                                 ::testing::Values(4),     // FQx2 on inputs + MHA + Deq Mul
                                  ::testing::Values(ov::test::utils::DEVICE_CPU),
                                  ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig)),
                          MHA::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
@@ -686,7 +686,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant_Pattern1,
                                             ::testing::ValuesIn(matMulIn0PrecisionsQuant),
                                             ::testing::Values(1),
                                             ::testing::Values(ExpectedNodes{
-                                                {"Subgraph", 3},     // FQ on input + MHA + Deq Mul
+                                                {"Subgraph", 4},     // FQ on input x 2 + MHA + Deq Mul
                                                 {"Transpose", 1}}),  // Transpose between MHA and Deq Mul
                                             ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          MHAQuantTest::getTestCaseName);
@@ -697,7 +697,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MHAQuant_Pattern2,
                                             ::testing::ValuesIn(inputPrecisionsQuant),
                                             ::testing::ValuesIn(matMulIn0PrecisionsQuant),
                                             ::testing::Values(2),
-                                            ::testing::Values(ExpectedNodes{{"Subgraph", 2},     // MHA + Deq Mul
+                                            ::testing::Values(ExpectedNodes{{"Subgraph", 3},     // FQ on inputs x 2 + MHA
                                                                             {"Transpose", 0}}),  // Transpose is fused
                                             ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          MHAQuantTest::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/unit/transformations/move_eltwise_up_data_movement_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/move_eltwise_up_data_movement_test.cpp
@@ -306,7 +306,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantize) {
     }
 }
 
-TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantizeNotPerTenser) {
+TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantizePerChannel) {
     const ov::Shape shape{1, 3, 12, 64};
     const std::vector<int64_t> input_order = {0, 2, 1, 3};
     {
@@ -324,5 +324,20 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantizeNotPerTenser) {
 
         model = std::make_shared<ov::Model>(ov::NodeVector{fakequantize}, ov::ParameterVector{input});
         manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, shape);
+
+        auto transpose_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
+        auto transpose = std::make_shared<ov::opset8::Transpose>(input, transpose_const);
+
+        auto fakequantize = std::make_shared<ov::opset8::FakeQuantize>(input,
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 3, 1, 1}, {-8.5, -7.5, -10.}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 3, 1, 1}, {8.5, 7.5, 10.}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {-128}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {127}),
+                                                          255);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fakequantize}, ov::ParameterVector{input});
     }
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/move_eltwise_up_data_movement_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/move_eltwise_up_data_movement_test.cpp
@@ -307,7 +307,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantize) {
 }
 
 TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantizePerChannel) {
-    const ov::Shape shape{1, 3, 12, 64};
+    const ov::Shape shape{1, 12, 3, 64};
     const std::vector<int64_t> input_order = {0, 2, 1, 3};
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, shape);
@@ -315,7 +315,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantizePerChannel) {
         auto transpose_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ov::opset8::Transpose>(input, transpose_const);
 
-        auto fakequantize = std::make_shared<ov::opset8::FakeQuantize>(input,
+        auto fakequantize = std::make_shared<ov::opset8::FakeQuantize>(transpose,
                                                           ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 3, 1, 1}, {-8.5, -7.5, -10.}),
                                                           ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 3, 1, 1}, {8.5, 7.5, 10.}),
                                                           ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {-128}),
@@ -324,20 +324,5 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantizePerChannel) {
 
         model = std::make_shared<ov::Model>(ov::NodeVector{fakequantize}, ov::ParameterVector{input});
         manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
-    }
-    {
-        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, shape);
-
-        auto transpose_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
-        auto transpose = std::make_shared<ov::opset8::Transpose>(input, transpose_const);
-
-        auto fakequantize = std::make_shared<ov::opset8::FakeQuantize>(input,
-                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 3, 1, 1}, {-8.5, -7.5, -10.}),
-                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 3, 1, 1}, {8.5, 7.5, 10.}),
-                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {-128}),
-                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {127}),
-                                                          255);
-
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fakequantize}, ov::ParameterVector{input});
     }
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/move_eltwise_up_data_movement_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/move_eltwise_up_data_movement_test.cpp
@@ -271,3 +271,58 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicRank) {
     model = std::make_shared<ov::Model>(ov::NodeVector{sigmoid}, ov::ParameterVector{input});
     manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
 }
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantize) {
+    const ov::Shape shape{1, 128, 12, 64};
+    const std::vector<int64_t> input_order = {0, 2, 1, 3};
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, shape);
+
+        auto transpose_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
+        auto transpose = std::make_shared<ov::opset8::Transpose>(input, transpose_const);
+        auto fakequantize = std::make_shared<ov::opset8::FakeQuantize>(transpose,
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {-8.5}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {8.5}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {-128}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {127}),
+                                                          255);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{fakequantize}, ov::ParameterVector{input});
+        manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, shape);
+
+        auto fakequantize = std::make_shared<ov::opset8::FakeQuantize>(input,
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {-8.5}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {8.5}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {-128}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {127}),
+                                                          255);
+        auto transpose_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
+        auto transpose = std::make_shared<ov::opset8::Transpose>(fakequantize, transpose_const);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{transpose}, ov::ParameterVector{input});
+    }
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantizeNotPerTenser) {
+    const ov::Shape shape{1, 3, 12, 64};
+    const std::vector<int64_t> input_order = {0, 2, 1, 3};
+    {
+        auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, shape);
+
+        auto transpose_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
+        auto transpose = std::make_shared<ov::opset8::Transpose>(input, transpose_const);
+
+        auto fakequantize = std::make_shared<ov::opset8::FakeQuantize>(input,
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 3, 1, 1}, {-8.5, -7.5, -10.}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{1, 3, 1, 1}, {8.5, 7.5, 10.}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {-128}),
+                                                          ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {127}),
+                                                          255);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{fakequantize}, ov::ParameterVector{input});
+        manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
+    }
+}


### PR DESCRIPTION

### Details:
 - *Move FakeQuantize up through data movement operations to make data movement operations executed in int8 precision. For example, modify "transpose-->FakeQuantize" to "FakeQuantize-->transpose" *


### Tickets:
 - *CVS-124005*
