### PR TITLE
[TF FE] Removed logic of building example input by user shape in TF decoder.

### DIFF
--- a/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
@@ -118,33 +118,6 @@ def get_input_spec_from_model(model):
     return input_spec
 
 
-def create_example_input_by_user_shapes(input_shapes, input_types):
-    import tensorflow as tf
-    if input_shapes is None:
-        return None
-    if isinstance(input_shapes, dict):
-        res = {}
-        for name, shape in input_shapes.items():
-            shape = get_static_shape(shape, 1)
-            args = {}
-            if name in input_types:
-                args["dtype"] = input_types[name]
-            tensor = tf.zeros(shape=shape, **args)
-            res[name] = tensor
-        return res
-    elif isinstance(input_shapes, list):
-        res = []
-        for idx, shape in enumerate(input_shapes):
-            shape = get_static_shape(shape, 1)
-            args = {}
-            if idx < len(input_types):
-                args["dtype"] = input_types[idx]
-            tensor = tf.zeros(shape=shape, **args)
-            res.append(tensor)
-        return res
-    raise Exception("Could not create example input by provided shape {}".format(input_shapes))
-
-
 def get_concrete_func(tf_function, example_input, input_needs_packing, error_message, use_example_input=True):
     """
     Runs tracing of TF function and returns a concrete function.
@@ -280,10 +253,6 @@ def trace_tf_model(model, input_shapes, input_types, example_input):
 
     if example_input is not None:
         concrete_func = get_concrete_func(tf_function, example_input, input_needs_packing,
-                                          "Could not trace the TF model with the following error: {}")
-    elif are_shapes_defined(input_shapes):
-        inp = create_example_input_by_user_shapes(input_shapes, input_types)
-        concrete_func = get_concrete_func(tf_function, inp, input_needs_packing,
                                           "Could not trace the TF model with the following error: {}")
     else:
         if isinstance(tf_function, tf.types.experimental.GenericFunction) and \

--- a/tests/layer_tests/mo_python_api_tests/test_mo_convert_tf.py
+++ b/tests/layer_tests/mo_python_api_tests/test_mo_convert_tf.py
@@ -139,7 +139,8 @@ def create_tf_module(tmp_dir):
     model_ref = Model([sigm], parameter_list, "test")
 
     net = Net()
-    return net, model_ref, {'input': [PartialShape([1, 2, 3]), PartialShape([1, 2, 3])]}
+    return net, model_ref, {'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                               np.random.rand(1, 2, 3).astype(np.float32))}
 
 
 def create_tf_module_layout_list(tmp_dir):
@@ -166,7 +167,8 @@ def create_tf_module_layout_list(tmp_dir):
     model_ref.inputs[1].node.layout = Layout('NHC')
 
     net = Net()
-    return net, model_ref, {'input_shape': [PartialShape([1, 2, 3]), PartialShape([1, 2, 3])], 'layout': ["NCH", "NHC"],
+    return net, model_ref, {'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                               np.random.rand(1, 2, 3).astype(np.float32)), 'layout': ["NCH", "NHC"],
                             'use_convert_model_from_mo': True}
 
 
@@ -193,7 +195,10 @@ def create_tf_module_dynamic(tmp_dir):
     model_ref = Model([sigm], parameter_list, "test")
 
     net = Net()
-    return net, model_ref, {'input': input_shapes}
+    return net, model_ref, {'input': input_shapes,
+                            'example_input': (np.random.rand(1, 2, 3).astype(np.float32),
+                                              np.random.rand(1, 2, 3).astype(np.float32))
+                            }
 
 
 def create_keras_layer(tmp_dir):
@@ -217,7 +222,9 @@ def create_keras_layer(tmp_dir):
     model_ref = Model([sigm], parameter_list, "test")
 
     net = LayerModel()
-    return net, model_ref, {'input': [PartialShape([1, 2, 3]), PartialShape([1, 2, 3])]}
+    return net, model_ref, {'example_input': (np.random.rand(1, 2, 3).astype(np.float32),
+                                              np.random.rand(1, 2, 3).astype(np.float32))
+                            }
 
 
 def create_keras_layer_dynamic(tmp_dir):
@@ -243,7 +250,10 @@ def create_keras_layer_dynamic(tmp_dir):
     model_ref = Model([sigm], parameter_list, "test")
 
     net = LayerModel()
-    return net, model_ref, {'input': input_shapes}
+    return net, model_ref, {'input': input_shapes,
+                            'example_input': (np.random.rand(1, 2, 3).astype(np.float32),
+                                              np.random.rand(1, 2, 3).astype(np.float32))
+                            }
 
 
 def create_tf_checkpoint(tmp_dir):
@@ -531,17 +541,19 @@ def create_keras_layer_with_example_input_2(tmp_dir):
 
 def create_keras_layer_with_input_shapes_case1(tmp_dir):
     model, model_ref = create_keras_layer_input_list()
-    return model, model_ref, {'input': [[1, 2, 3], [1, 2, 3]]}
+    return model, model_ref, {'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                                 np.random.rand(1, 2, 3).astype(np.float32))}
 
 
 def create_keras_layer_with_input_shapes_case2(tmp_dir):
     model, model_ref = create_keras_layer_input_list()
-    return model, model_ref, {'input': [([1, 2, 3], np.float32), ([1, 2, 3], np.float32)]}
+    return model, model_ref, {'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                                 np.random.rand(1, 2, 3).astype(np.float32))}
 
 
 def create_keras_layer_with_input_shapes_case3(tmp_dir):
     model, model_ref = create_keras_layer_input_dict_one_inp()
-    return model, model_ref, {'input': [('args', [1, 2, 3])]}
+    return model, model_ref, {'example_input':  {"args": np.random.rand(1, 2, 3).astype(np.float32)}}
 
 
 def create_keras_layer_with_input_shapes_case4(tmp_dir):

--- a/tests/layer_tests/ovc_python_api_tests/test_tf.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_tf.py
@@ -131,7 +131,8 @@ def create_tf_module(tmp_dir):
     model_ref = Model([sigm], parameter_list, "test")
 
     net = Net()
-    return net, model_ref, {'input': [PartialShape([1, 2, 3]), PartialShape([1, 2, 3])]}
+    return net, model_ref, {'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                               np.random.rand(1, 2, 3).astype(np.float32))}
 
 
 def create_tf_module_dynamic(tmp_dir):
@@ -155,7 +156,9 @@ def create_tf_module_dynamic(tmp_dir):
     model_ref = Model([sigm], parameter_list, "test")
 
     net = Net()
-    return net, model_ref, {'input': input_shapes}
+    return net, model_ref, {'input': input_shapes,
+                            'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                               np.random.rand(1, 2, 3).astype(np.float32))}
 
 
 def create_keras_layer(tmp_dir):
@@ -178,7 +181,8 @@ def create_keras_layer(tmp_dir):
     model_ref = Model([sigm], parameter_list, "test")
 
     net = LayerModel()
-    return net, model_ref, {'input': [PartialShape([1, 2, 3]), PartialShape([1, 2, 3])]}
+    return net, model_ref, {'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                               np.random.rand(1, 2, 3).astype(np.float32))}
 
 
 def create_keras_layer_dynamic(tmp_dir):
@@ -203,7 +207,10 @@ def create_keras_layer_dynamic(tmp_dir):
     model_ref = Model([sigm], parameter_list, "test")
 
     net = LayerModel()
-    return net, model_ref, {'input': input_shapes}
+    return net, model_ref, {'input': input_shapes,
+                            'example_input': (np.random.rand(1, 2, 3).astype(np.float32),
+                                              np.random.rand(1, 2, 3).astype(np.float32))
+                            }
 
 
 def create_tf_checkpoint(tmp_dir):
@@ -478,17 +485,19 @@ def create_keras_layer_with_example_input_2(tmp_dir):
 
 def create_keras_layer_with_input_shapes_case1(tmp_dir):
     model, model_ref = create_keras_layer_input_list()
-    return model, model_ref, {'input': [[1, 2, 3], [1, 2, 3]]}
+    return model, model_ref, {'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                                 np.random.rand(1, 2, 3).astype(np.float32))}
 
 
 def create_keras_layer_with_input_shapes_case2(tmp_dir):
     model, model_ref = create_keras_layer_input_list()
-    return model, model_ref, {'input': [([1, 2, 3], np.float32), ([1, 2, 3], np.float32)]}
+    return model, model_ref, {'example_input':  (np.random.rand(1, 2, 3).astype(np.float32),
+                                                 np.random.rand(1, 2, 3).astype(np.float32))}
 
 
 def create_keras_layer_with_input_shapes_case3(tmp_dir):
     model, model_ref = create_keras_layer_input_dict_one_inp()
-    return model, model_ref, {'input': [('args', [1, 2, 3])]}
+    return model, model_ref, {'example_input':  {'args': np.random.rand(1, 2, 3).astype(np.float32)}}
 
 
 def create_keras_layer_with_input_shapes_case4(tmp_dir):


### PR DESCRIPTION
Root cause analysis: 
Auto-generating of example inputs by user shapes leads to issues like inability to generate dynamically-shaped inputs. 

Solution: 
Provide example_input every time when it is required and remove logic of auto-generating of example inputs.

Ticket: 119701


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update