### PR TITLE
[core]Migrate ReLU operator to new API

### DIFF
--- a/src/core/include/openvino/op/relu.hpp
+++ b/src/core/include/openvino/op/relu.hpp
@@ -25,11 +25,8 @@ public:
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
-    bool visit_attributes(AttributeVisitor& visitor) override;
 };
 }  // namespace v0
 }  // namespace op

--- a/src/core/reference/include/openvino/reference/relu.hpp
+++ b/src/core/reference/include/openvino/reference/relu.hpp
@@ -27,9 +27,9 @@ void relu(const T* arg, T* out, const size_t count) {
         arg + count,
         out,
         [](const T v) {
-            return v < 0;
+            return v < T{0};
         },
-        0);
+        T{0});
 }
 
 /**

--- a/src/core/reference/include/openvino/reference/relu.hpp
+++ b/src/core/reference/include/openvino/reference/relu.hpp
@@ -4,16 +4,44 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
+
+#include "openvino/reference/copy.hpp"
+#include "openvino/reference/utils/type_util.hpp"
 
 namespace ov {
 namespace reference {
-template <typename T>
-void relu(const T* arg, T* out, size_t count) {
-    T zero = 0;
-    for (size_t i = 0; i < count; i++) {
-        out[i] = arg[i] > zero ? arg[i] : zero;
-    }
+
+/**
+ * @brief Reference implementation of ReLU operator (signed values).
+ *
+ * @param arg    Pointer to input data.
+ * @param out    Pointer to output data.
+ * @param count  Number of elements in input buffer.
+ */
+template <class T, typename std::enable_if<ov::is_floating_point<T>() || std::is_signed<T>::value>::type* = nullptr>
+void relu(const T* arg, T* out, const size_t count) {
+    std::replace_copy_if(
+        arg,
+        arg + count,
+        out,
+        [](const T v) {
+            return v < 0;
+        },
+        0);
+}
+
+/**
+ * @brief Reference implementation of ReLU operator (unsigned).
+ *
+ * @param arg    Pointer to input data.
+ * @param out    Pointer to output data.
+ * @param count  Number of elements in input buffer.
+ */
+template <class T, typename std::enable_if<std::is_unsigned<T>::value>::type* = nullptr>
+void relu(const T* arg, T* out, const size_t count) {
+    copy(arg, out, count);
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/src/op/relu.cpp
+++ b/src/core/src/op/relu.cpp
@@ -2,84 +2,66 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/relu.hpp"
+#include "openvino/op/relu.hpp"
 
-#include <ngraph/validation_util.hpp>
-
+#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/op/multiply.hpp"
-#include "ngraph/runtime/host_tensor.hpp"
 #include "openvino/reference/relu.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace relu {
+struct Evaluate : element::NoAction<bool> {
+    using element::NoAction<bool>::visit;
 
-op::Relu::Relu(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
+    template <element::Type_t ET, class T = fundamental_type_for<ET>>
+    static result_type visit(const Tensor& arg, Tensor& out, const size_t count) {
+        reference::relu(arg.data<const T>(), out.data<T>(), count);
+        return true;
+    }
+};
+}  // namespace relu
+namespace v0 {
+
+Relu::Relu(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
     constructor_validate_and_infer_types();
 }
 
-shared_ptr<Node> op::Relu::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> Relu::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v0_Relu_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<Relu>(new_args.at(0));
+    return std::make_shared<Relu>(new_args.at(0));
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace relu {
-namespace {
-template <element::Type_t ET>
-inline bool evaluate(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    using T = typename element_type_traits<ET>::value_type;
-    ov::reference::relu<T>(arg0->get_data_ptr<ET>(), out->get_data_ptr<ET>(), count);
-    return true;
-}
-
-bool evaluate_relu(const HostTensorPtr& arg0, const HostTensorPtr& out) {
-    bool rc = true;
-    size_t count = shape_size(arg0->get_shape());
-    out->set_unary(arg0);
-
-    switch (arg0->get_element_type()) {
-        OPENVINO_TYPE_CASE(evaluate_relu, i32, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_relu, i64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_relu, u32, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_relu, u64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_relu, f16, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_relu, f32, arg0, out, count);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace relu
-
-bool op::Relu::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool Relu::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v0_Relu_evaluate);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    OPENVINO_ASSERT(validate_host_tensor_vector(outputs, 1) && validate_host_tensor_vector(inputs, 1));
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    return relu::evaluate_relu(inputs[0], outputs[0]);
+    OPENVINO_ASSERT(outputs.size() == 1);
+    OPENVINO_ASSERT(inputs.size() == 1);
+
+    const auto& in_shape = inputs[0].get_shape();
+    outputs[0].set_shape(in_shape);
+
+    using namespace ov::element;
+    return IfTypeOf<f16, f32, i32, i64, u32, u64>::apply<relu::Evaluate>(inputs[0].get_element_type(),
+                                                                         inputs[0],
+                                                                         outputs[0],
+                                                                         shape_size(in_shape));
 }
 
-bool op::Relu::has_evaluate() const {
+bool Relu::has_evaluate() const {
     OV_OP_SCOPE(v0_Relu_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::i32:
-    case ngraph::element::i64:
-    case ngraph::element::u32:
-    case ngraph::element::u64:
-    case ngraph::element::f16:
-    case ngraph::element::f32:
+    case element::f16:
+    case element::f32:
+    case element::i32:
+    case element::i64:
+    case element::u32:
+    case element::u64:
         return true;
     default:
-        break;
+        return false;
     }
-    return false;
 }
-
-bool op::Relu::visit_attributes(AttributeVisitor& visitor) {
-    OV_OP_SCOPE(v0_Relu_visit_attributes);
-    return true;
-}
+}  // namespace v0
+}  // namespace op
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Migrate `ReLU` operator to new API.
 - Refactor operator and reference implementation for size reduction.
 - Remove `visit_attributes` as is same as base class implementation.

### Tickets:
 - [CVS-118643](https://jira.devtools.intel.com/browse/CVS-118643)
