### PR TITLE
[core]Migrate Sign operator to new API

### DIFF
--- a/src/core/include/openvino/op/sign.hpp
+++ b/src/core/include/openvino/op/sign.hpp
@@ -22,11 +22,8 @@ public:
     /// \param arg Node that produces the input tensor.
     Sign(const Output<Node>& arg);
 
-    bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v0

--- a/src/core/reference/include/openvino/reference/sign.hpp
+++ b/src/core/reference/include/openvino/reference/sign.hpp
@@ -4,15 +4,35 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
+
+#include "openvino/reference/utils/type_util.hpp"
 
 namespace ov {
 namespace reference {
+namespace func {
+template <class T, typename std::enable_if<std::is_unsigned<T>::value>::type* = nullptr>
+constexpr T sign(const T v) {
+    return static_cast<T>(static_cast<bool>(v));
+}
+
+template <class T, typename std::enable_if<ov::is_floating_point<T>() || std::is_signed<T>::value>::type* = nullptr>
+constexpr T sign(const T v) {
+    return static_cast<T>((T{0} < v) - (v < T{0}));
+}
+}  // namespace func
+
+/**
+ * @brief Reference implementation of Sign operator.
+ *
+ * @param arg    Pointer to input data.
+ * @param out    Pointer to output data.
+ * @param count  Number of elements in input buffer.
+ */
 template <typename T>
 void sign(const T* arg, T* out, size_t count) {
-    for (size_t i = 0; i < count; i++) {
-        out[i] = (arg[i] < T(0) ? T(-1) : (arg[i] > T(0) ? T(1) : T(0)));
-    }
+    std::transform(arg, arg + count, out, func::sign<T>);
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/src/op/sign.cpp
+++ b/src/core/src/op/sign.cpp
@@ -2,81 +2,66 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/sign.hpp"
-
+#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/runtime/host_tensor.hpp"
-#include "ngraph/validation_util.hpp"
+#include "openvino/op/sign.hpp"
 #include "openvino/reference/sign.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
 
-op::Sign::Sign(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
+namespace sign {
+struct Evaluate : element::NoAction<bool> {
+    using element::NoAction<bool>::visit;
+
+    template <element::Type_t ET, class T = fundamental_type_for<ET>>
+    static result_type visit(const Tensor& arg, Tensor& out, const size_t count) {
+        reference::sign(arg.data<const T>(), out.data<T>(), count);
+        return true;
+    }
+};
+}  // namespace sign
+namespace v0 {
+
+Sign::Sign(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
     constructor_validate_and_infer_types();
 }
 
-bool ngraph::op::v0::Sign::visit_attributes(AttributeVisitor& visitor) {
-    OV_OP_SCOPE(v0_Sign_visit_attributes);
-    return true;
-}
-
-shared_ptr<Node> op::Sign::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> Sign::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v0_Sign_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<Sign>(new_args.at(0));
+    return std::make_shared<Sign>(new_args.at(0));
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace signop {
-namespace {
-template <element::Type_t ET>
-inline bool evaluate(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    using T = typename element_type_traits<ET>::value_type;
-    ov::reference::sign<T>(arg0->get_data_ptr<ET>(), out->get_data_ptr<ET>(), count);
-    return true;
-}
-
-bool evaluate_sign(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    bool rc = true;
-    out->set_unary(arg0);
-
-    switch (arg0->get_element_type()) {
-        OPENVINO_TYPE_CASE(evaluate_sign, i32, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sign, i64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sign, u32, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sign, u64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sign, f16, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_sign, f32, arg0, out, count);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace signop
-
-bool op::Sign::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool Sign::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v0_Sign_evaluate);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    OPENVINO_ASSERT(validate_host_tensor_vector(outputs, 1) && validate_host_tensor_vector(inputs, 1));
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    return signop::evaluate_sign(inputs[0], outputs[0], shape_size(inputs[0]->get_shape()));
+    OPENVINO_ASSERT(outputs.size() == 1);
+    OPENVINO_ASSERT(inputs.size() == 1);
+
+    const auto& in_shape = inputs[0].get_shape();
+    outputs[0].set_shape(in_shape);
+
+    using namespace ov::element;
+    return IfTypeOf<f16, f32, i32, i64, u32, u64>::apply<sign::Evaluate>(inputs[0].get_element_type(),
+                                                                         inputs[0],
+                                                                         outputs[0],
+                                                                         shape_size(in_shape));
 }
 
-bool op::Sign::has_evaluate() const {
+bool Sign::has_evaluate() const {
     OV_OP_SCOPE(v0_Sign_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::i32:
-    case ngraph::element::i64:
-    case ngraph::element::u32:
-    case ngraph::element::u64:
-    case ngraph::element::f16:
-    case ngraph::element::f32:
+    case element::f16:
+    case element::f32:
+    case element::i32:
+    case element::i64:
+    case element::u32:
+    case element::u64:
         return true;
     default:
-        break;
+        return false;
     }
-    return false;
 }
+}  // namespace v0
+}  // namespace op
+}  // namespace ov

--- a/src/core/src/op/sign.cpp
+++ b/src/core/src/op/sign.cpp
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/op/sign.hpp"
+
 #include "element_visitor.hpp"
 #include "itt.hpp"
-#include "openvino/op/sign.hpp"
 #include "openvino/reference/sign.hpp"
 
 namespace ov {


### PR DESCRIPTION
### Details:
 - Migrate `Sign` operator to new API
 - Remove `visit_attributes` as is same as base class implementation.
 - Refactor operator and reference implementation for size reduction.

### Tickets:
 - [CVS-118655](https://jira.devtools.intel.com/browse/CVS-118655)
