### PR TITLE
[core]Migrate Mish operator to new API

### DIFF
--- a/src/core/include/openvino/op/mish.hpp
+++ b/src/core/include/openvino/op/mish.hpp
@@ -22,7 +22,6 @@ public:
     ///
     /// \param data Input tensor
     Mish(const Output<Node>& arg);
-    bool visit_attributes(AttributeVisitor& visitor) override;
     void validate_and_infer_types() override;
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/src/core/include/openvino/op/mish.hpp
+++ b/src/core/include/openvino/op/mish.hpp
@@ -26,10 +26,7 @@ public:
     void validate_and_infer_types() override;
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v4

--- a/src/core/reference/include/openvino/reference/mish.hpp
+++ b/src/core/reference/include/openvino/reference/mish.hpp
@@ -20,7 +20,7 @@ namespace reference {
 template <typename T>
 void mish(const T* arg, T* out, const size_t count) {
     std::transform(arg, arg + count, out, [](const T v) {
-        return v * std::tanh(std::log(std::exp(v) + T{1}));
+        return static_cast<T>(v * std::tanh(std::log(std::exp(v) + T{1})));
     });
 }
 }  // namespace reference

--- a/src/core/reference/include/openvino/reference/mish.hpp
+++ b/src/core/reference/include/openvino/reference/mish.hpp
@@ -9,11 +9,19 @@
 
 namespace ov {
 namespace reference {
+
+/**
+ * @brief Reference implementation of Mish operator.
+ *
+ * @param arg    Pointer to input data.
+ * @param out    Pointer to output data.
+ * @param count  Number of elements in input buffer.
+ */
 template <typename T>
-void mish(const T* arg, T* out, size_t count) {
-    for (size_t i = 0; i < count; i++) {
-        out[i] = static_cast<T>(arg[i] * std::tanh(std::log((std::exp(arg[i]) + 1.0))));
-    }
+void mish(const T* arg, T* out, const size_t count) {
+    std::transform(arg, arg + count, out, [](const T v) {
+        return v * std::tanh(std::log(std::exp(v) + T{1}));
+    });
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/src/op/mish.cpp
+++ b/src/core/src/op/mish.cpp
@@ -2,90 +2,83 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/mish.hpp"
+#include "openvino/op/mish.hpp"
 
-#include <ngraph/validation_util.hpp>
-
+#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/attribute_visitor.hpp"
-#include "ngraph/runtime/host_tensor.hpp"
 #include "openvino/reference/mish.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace mish {
 
-op::v4::Mish::Mish(const Output<Node>& arg) : util::UnaryElementwiseArithmetic(arg) {
+struct Evaluate : element::NoAction<bool> {
+    using element::NoAction<bool>::visit;
+
+    template <element::Type_t ET, class T = fundamental_type_for<ET>>
+    static result_type visit(const Tensor& arg, Tensor& out, const size_t count) {
+        reference::mish(arg.data<const T>(), out.data<T>(), count);
+        return true;
+    }
+};
+}  // namespace mish
+
+namespace v4 {
+
+Mish::Mish(const Output<Node>& arg) : util::UnaryElementwiseArithmetic(arg) {
     constructor_validate_and_infer_types();
 }
 
-bool op::v4::Mish::visit_attributes(AttributeVisitor& visitor) {
+bool Mish::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(v4_Mish_visit_attributes);
     return true;
 }
 
-void op::v4::Mish::validate_and_infer_types() {
+void Mish::validate_and_infer_types() {
     OV_OP_SCOPE(v4_Mish_validate_and_infer_types);
 
     NODE_VALIDATION_CHECK(this, get_input_size() == 1, "Only accepts one argument. Got: ", get_input_size());
 
-    element::Type data_batch_et = get_input_element_type(0);
+    const auto& data_batch_et = get_input_element_type(0);
     NODE_VALIDATION_CHECK(this,
                           data_batch_et.is_real(),
                           "Element must be of floating point type, Got: ",
                           data_batch_et);
 
-    set_output_type(0, get_input_element_type(0), get_input_partial_shape(0));
+    set_output_type(0, data_batch_et, get_input_partial_shape(0));
 }
 
-shared_ptr<Node> op::v4::Mish::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> Mish::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v4_Mish_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<Mish>(new_args.at(0));
+    return std::make_shared<Mish>(new_args.at(0));
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace mish {
-namespace {
-template <element::Type_t ET>
-inline bool evaluate(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    using T = typename element_type_traits<ET>::value_type;
-    ov::reference::mish<T>(arg0->get_data_ptr<ET>(), out->get_data_ptr<ET>(), count);
-    return true;
-}
-
-bool evaluate_mish(const HostTensorPtr& arg0, const HostTensorPtr& out) {
-    bool rc = true;
-    size_t count = shape_size(arg0->get_shape());
-    out->set_unary(arg0);
-
-    switch (arg0->get_element_type()) {
-        OPENVINO_TYPE_CASE(evaluate_mish, f16, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_mish, f32, arg0, out, count);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace mish
-
-bool op::v4::Mish::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool Mish::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v4_Mish_evaluate);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    OPENVINO_ASSERT(validate_host_tensor_vector(outputs, 1) && validate_host_tensor_vector(inputs, 1));
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    return mish::evaluate_mish(inputs[0], outputs[0]);
+    OPENVINO_ASSERT(outputs.size() == 1);
+    OPENVINO_ASSERT(inputs.size() == 1);
+
+    const auto& in_shape = inputs[0].get_shape();
+    outputs[0].set_shape(in_shape);
+
+    using namespace ov::element;
+    return IfTypeOf<f16, f32>::apply<mish::Evaluate>(inputs[0].get_element_type(),
+                                                     inputs[0],
+                                                     outputs[0],
+                                                     shape_size(in_shape));
 }
 
-bool op::v4::Mish::has_evaluate() const {
+bool Mish::has_evaluate() const {
     OV_OP_SCOPE(v4_Mish_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::f16:
-    case ngraph::element::f32:
+    case element::f16:
+    case element::f32:
         return true;
     default:
-        break;
+        return false;
     }
-    return false;
 }
+}  // namespace v4
+}  // namespace op
+}  // namespace ov

--- a/src/core/src/op/mish.cpp
+++ b/src/core/src/op/mish.cpp
@@ -29,11 +29,6 @@ Mish::Mish(const Output<Node>& arg) : util::UnaryElementwiseArithmetic(arg) {
     constructor_validate_and_infer_types();
 }
 
-bool Mish::visit_attributes(AttributeVisitor& visitor) {
-    OV_OP_SCOPE(v4_Mish_visit_attributes);
-    return true;
-}
-
 void Mish::validate_and_infer_types() {
     OV_OP_SCOPE(v4_Mish_validate_and_infer_types);
 


### PR DESCRIPTION
### Details:
 - Migrate `Mish` operator to new API.
 - Remove `visit_attributes` as is same as base class implementation.
 - Refactor operator and its reference implementation for size reduction.

### Tickets:
 - [CVS-118630](https://jira.devtools.intel.com/browse/CVS-118630)
