### PR TITLE
[core]Migrate Exp operator to new API

### DIFF
--- a/src/core/include/openvino/op/exp.hpp
+++ b/src/core/include/openvino/op/exp.hpp
@@ -22,12 +22,9 @@ public:
     /// \param arg Node that produces the input tensor.
     Exp(const Output<Node>& arg);
 
-    bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v0

--- a/src/core/reference/include/openvino/reference/exp.hpp
+++ b/src/core/reference/include/openvino/reference/exp.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 

--- a/src/core/reference/include/openvino/reference/exp.hpp
+++ b/src/core/reference/include/openvino/reference/exp.hpp
@@ -9,11 +9,19 @@
 
 namespace ov {
 namespace reference {
-template <typename T>
+
+/**
+ * @brief Reference implementation of Exp operator.
+ *
+ * @param arg    Pointer to input data.
+ * @param out    Pointer to output data.
+ * @param count  Number of elements in input buffer.
+ */
+template <class T>
 void exp(const T* arg, T* out, size_t count) {
-    for (size_t i = 0; i < count; i++) {
-        out[i] = static_cast<T>(std::exp(arg[i]));
-    }
+    std::transform(arg, arg + count, out, [](const T v) {
+        return static_cast<T>(std::exp(v));
+    });
 }
 }  // namespace reference
 }  // namespace ov

--- a/src/core/src/op/exp.cpp
+++ b/src/core/src/op/exp.cpp
@@ -2,83 +2,68 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/exp.hpp"
+#include "openvino/op/exp.hpp"
 
-#include <ngraph/validation_util.hpp>
-
+#include "element_visitor.hpp"
 #include "itt.hpp"
-#include "ngraph/runtime/host_tensor.hpp"
 #include "openvino/reference/exp.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace exp {
 
-op::Exp::Exp(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
+struct Evaluate : element::NoAction<bool> {
+    using element::NoAction<bool>::visit;
+
+    template <element::Type_t ET, class T = fundamental_type_for<ET>>
+    static result_type visit(const Tensor& arg, Tensor& out, const size_t count) {
+        reference::exp(arg.data<const T>(), out.data<T>(), count);
+        return true;
+    }
+};
+}  // namespace exp
+
+namespace v0 {
+
+Exp::Exp(const Output<Node>& arg) : UnaryElementwiseArithmetic(arg) {
     constructor_validate_and_infer_types();
 }
 
-bool ngraph::op::v0::Exp::visit_attributes(AttributeVisitor& visitor) {
-    OV_OP_SCOPE(v0_Exp_visit_attributes);
-    return true;
-}
-
-shared_ptr<Node> op::Exp::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> Exp::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v0_Exp_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<Exp>(new_args.at(0));
+    return std::make_shared<Exp>(new_args.at(0));
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-namespace expop {
-namespace {
-template <element::Type_t ET>
-inline bool evaluate(const HostTensorPtr& arg0, const HostTensorPtr& out, const size_t count) {
-    using T = typename element_type_traits<ET>::value_type;
-    ov::reference::exp<T>(arg0->get_data_ptr<ET>(), out->get_data_ptr<ET>(), count);
-    return true;
-}
-
-bool evaluate_exp(const HostTensorPtr& arg0, const HostTensorPtr& out) {
-    bool rc = true;
-    size_t count = shape_size(arg0->get_shape());
-    out->set_unary(arg0);
-
-    switch (arg0->get_element_type()) {
-        OPENVINO_TYPE_CASE(evaluate_exp, i32, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_exp, i64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_exp, u32, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_exp, u64, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_exp, f16, arg0, out, count);
-        OPENVINO_TYPE_CASE(evaluate_exp, f32, arg0, out, count);
-    default:
-        rc = false;
-        break;
-    }
-    return rc;
-}
-}  // namespace
-}  // namespace expop
-
-bool op::Exp::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
+bool Exp::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v0_Exp_evaluate);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    OPENVINO_ASSERT(validate_host_tensor_vector(outputs, 1) && validate_host_tensor_vector(inputs, 1));
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    return expop::evaluate_exp(inputs[0], outputs[0]);
+    OPENVINO_ASSERT(outputs.size() == 1);
+    OPENVINO_ASSERT(inputs.size() == 1);
+
+    const auto& in_shape = inputs[0].get_shape();
+    outputs[0].set_shape(in_shape);
+
+    using namespace ov::element;
+    return IfTypeOf<f16, f32, i32, i64, u32, u64>::apply<exp::Evaluate>(inputs[0].get_element_type(),
+                                                                        inputs[0],
+                                                                        outputs[0],
+                                                                        shape_size(in_shape));
 }
 
-bool op::Exp::has_evaluate() const {
+bool Exp::has_evaluate() const {
     OV_OP_SCOPE(v0_Exp_has_evaluate);
     switch (get_input_element_type(0)) {
-    case ngraph::element::i32:
-    case ngraph::element::i64:
-    case ngraph::element::u32:
-    case ngraph::element::u64:
-    case ngraph::element::f16:
-    case ngraph::element::f32:
+    case element::f16:
+    case element::f32:
+    case element::i32:
+    case element::i64:
+    case element::u32:
+    case element::u64:
         return true;
     default:
-        break;
+        return false;
     }
-    return false;
 }
+}  // namespace v0
+}  // namespace op
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Migrate `Exp` operator to new API.
 - Remove `visit_attributes` as is same as base class implementation.
 - Minor refactor to reduce binary size.

### Tickets:
 - [CVS-118561](https://jira.devtools.intel.com/browse/CVS-118561)
