### PR TITLE
[TF FE] Fix conversion of TF1 OD models out-of-the-box

### DIFF
--- a/src/frontends/tensorflow_common/src/helper_transforms/const_to_result_remover.cpp
+++ b/src/frontends/tensorflow_common/src/helper_transforms/const_to_result_remover.cpp
@@ -16,6 +16,8 @@ namespace tensorflow {
 namespace pass {
 
 bool ConstToResultRemover::run_on_model(const std::shared_ptr<ov::Model>& m) {
+    // Note: need to perform this transformation only on the main ov::Model graph
+    // no need to apply it for sub-graphs!
     ResultVector results_to_remove;
     // look for isolated UnsupportedConst->Result sub-graphs to remove
     // also, find isolated Constant->Result sub-graphs to remove


### PR DESCRIPTION
**Details:** Fix conversion of TF1 OD models out-of-the-box. The fix provides recursive run of SwitchMergeResolver. Since this is a model pass we need to provide recursive run on our own.

**Tickets:** 62837

This fixes following GitHub issues:
- https://github.com/openvinotoolkit/openvino/issues/15870
- https://github.com/openvinotoolkit/openvino/issues/16389
