### PR TITLE
[DOCS] Fixing link in Get Started article for 23.2

### DIFF
--- a/docs/articles_en/get_started.md
+++ b/docs/articles_en/get_started.md
@@ -22,7 +22,7 @@
    <link rel="stylesheet" type="text/css" href="_static/css/getstarted_style.css">
 
    <p id="GSG_introtext">Welcome to OpenVINO! This guide introduces installation and learning materials for Intel® Distribution of OpenVINO™ toolkit. The guide walks through the following steps:<br />
-     <a href="https://mybinder.org/v2/gh/openvinotoolkit/openvino_notebooks/HEAD?filepath=notebooks%2F201-vision-monodepth%2F201-vision-monodepth.ipynb" >Quick Start Example</a>
+     <a href="notebooks/201-vision-monodepth-with-output.html" >Quick Start Example</a>
      <a href="openvino_docs_install_guides_overview.html" >Install OpenVINO</a>
      <a href="#learn-openvino" >Learn OpenVINO</a>
    </p>
@@ -36,7 +36,7 @@
 .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
    :width: 400
 
-Try out OpenVINO's capabilities with this quick start example that estimates depth in a scene using an OpenVINO monodepth model. `Run the example in a Jupyter Notebook inside your web browser <https://mybinder.org/v2/gh/openvinotoolkit/openvino_notebooks/HEAD?filepath=notebooks%2F201-vision-monodepth%2F201-vision-monodepth.ipynb>`__ to quickly see how to load a model, prepare an image, inference the image, and display the result.
+Try out OpenVINO's capabilities with this `quick start example <notebooks/201-vision-monodepth-with-output.html>`__ that estimates depth in a scene using an OpenVINO monodepth model to quickly see how to load a model, prepare an image, inference the image, and display the result.
 
 .. _install-openvino-gsg:
 


### PR DESCRIPTION
Porting https://github.com/openvinotoolkit/openvino/pull/20881

Addressing JIRA ticket: 124289

Replacing the binder link with a direct link to the `Monodepth Estimation with OpenVINO` notebook.

