### PR TITLE
Add separate label for docs snippets

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,8 +55,12 @@
         '!thirdparty/**/CMakeLists.txt']
 
 'category: docs':
-- 'docs/**/*'
 - '**/*.md'
+- any: ['docs/**/*',
+        '!docs/snippets/**/*']
+
+'category: docs_snippets':
+- 'docs/snippets/**/*'
 
 'category: extensions':
 - 'src/core/include/openvino/core/extension.hpp'


### PR DESCRIPTION
This is to be able to skip pipelines for any changes in docs except snippets via Smart CI