### PR TITLE
[GPU] Decompose test combination to reduce test time

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -48,22 +48,25 @@ const std::vector<ov::element::Type> netPrecisions = {
     ov::element::f32
 };
 
-const auto extractImagePatchesParamsSet = ::testing::Combine(
-        ::testing::ValuesIn(inDataShape),
-        ::testing::ValuesIn(kernels),
-        ::testing::ValuesIn(strides),
-        ::testing::ValuesIn(rates),
-        ::testing::ValuesIn(autoPads)
-);
+INSTANTIATE_TEST_SUITE_P(smoke_layers_GPU1, ExtractImagePatchesTest,
+        ::testing::Combine(
+            ::testing::Values(ov::test::static_shapes_to_test_representation(inDataShape)[0]),
+            ::testing::Values(kernels[0]),
+            ::testing::Values(strides[0]),
+            ::testing::ValuesIn(rates),
+            ::testing::ValuesIn(autoPads),
+            ::testing::ValuesIn(netPrecisions),
+            ::testing::Values(ov::test::utils::DEVICE_GPU)),
+        ExtractImagePatchesTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_layers_GPU, ExtractImagePatchesTest,
+INSTANTIATE_TEST_SUITE_P(smoke_layers_GPU2, ExtractImagePatchesTest,
         ::testing::Combine(
             ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inDataShape)),
             ::testing::ValuesIn(kernels),
             ::testing::ValuesIn(strides),
-            ::testing::ValuesIn(rates),
-            ::testing::ValuesIn(autoPads),
-            ::testing::ValuesIn(netPrecisions),
+            ::testing::Values(rates[0]),
+            ::testing::Values(autoPads[0]),
+            ::testing::Values(netPrecisions[0]),
             ::testing::Values(ov::test::utils::DEVICE_GPU)),
         ExtractImagePatchesTest::getTestCaseName);
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
@@ -23,13 +23,28 @@ namespace {
     std::vector<ov::element::Type> model_types = {ov::element::f32,
                                                   ov::element::f16};
 
-    INSTANTIATE_TEST_SUITE_P(smoke_RNNCellCommon, RNNCellTest,
+    INSTANTIATE_TEST_SUITE_P(smoke_RNNCellCommon1, RNNCellTest,
             ::testing::Combine(
             ::testing::ValuesIn(should_decompose),
             ::testing::ValuesIn(batch),
             ::testing::ValuesIn(hidden_size),
             ::testing::ValuesIn(input_size),
             ::testing::ValuesIn(activations),
+            ::testing::Values(clip[0]),
+            ::testing::Values(layer_types[0]),
+            ::testing::Values(layer_types[0]),
+            ::testing::Values(layer_types[0]),
+            ::testing::Values(model_types[0]),
+            ::testing::Values(ov::test::utils::DEVICE_GPU)),
+            RNNCellTest::getTestCaseName);
+
+    INSTANTIATE_TEST_SUITE_P(smoke_RNNCellCommon2, RNNCellTest,
+            ::testing::Combine(
+            ::testing::Values(should_decompose[0]),
+            ::testing::Values(batch[0]),
+            ::testing::Values(hidden_size[0]),
+            ::testing::Values(input_size[0]),
+            ::testing::Values(activations[0]),
             ::testing::ValuesIn(clip),
             ::testing::ValuesIn(layer_types),
             ::testing::ValuesIn(layer_types),

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/detection_output.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/detection_output.cpp
@@ -273,7 +273,7 @@ const std::vector<bool> decreaseLabelId = {true, false};
 const float objectnessScore = 0.4f;
 const std::vector<size_t> numberBatch = {1, 2};
 
-const auto commonAttributes = ::testing::Combine(
+const auto commonAttributes1 = ::testing::Combine(
     ::testing::Values(numClasses[0]),
     ::testing::Values(backgroundLabelId),
     ::testing::ValuesIn(topK),
@@ -285,7 +285,18 @@ const auto commonAttributes = ::testing::Combine(
     ::testing::ValuesIn(clipBeforeNms),
     ::testing::ValuesIn(decreaseLabelId)
 );
-
+const auto commonAttributes2 = ::testing::Combine(
+    ::testing::Values(numClasses[0]),
+    ::testing::Values(backgroundLabelId),
+    ::testing::Values(topK[0]),
+    ::testing::Values(keepTopK[0]),
+    ::testing::Values(codeType[0]),
+    ::testing::Values(nmsThreshold),
+    ::testing::Values(confidenceThreshold),
+    ::testing::Values(clipAfterNms[0]),
+    ::testing::Values(clipBeforeNms[0]),
+    ::testing::Values(decreaseLabelId[0])
+);
 const auto commonAttributes_v8 = ::testing::Combine(
     ::testing::Values(numClasses[1]),
     ::testing::Values(backgroundLabelId),
@@ -383,8 +394,17 @@ const std::vector<ParamsWhichSizeDependsDynamic> specificParams3InDynamic = {
     },
 };
 
-const auto params3InputsDynamic = ::testing::Combine(
-        commonAttributes,
+const auto params3InputsDynamic1 = ::testing::Combine(
+        commonAttributes1,
+        ::testing::Values(specificParams3InDynamic[0]),
+        ::testing::ValuesIn(numberBatch),
+        ::testing::Values(objectnessScore),
+        ::testing::Values(false, true),
+        ::testing::Values(ov::test::utils::DEVICE_GPU)
+);
+
+const auto params3InputsDynamic2 = ::testing::Combine(
+        commonAttributes2,
         ::testing::ValuesIn(specificParams3InDynamic),
         ::testing::ValuesIn(numberBatch),
         ::testing::Values(objectnessScore),
@@ -401,8 +421,12 @@ const auto params3InputsDynamic_v8 = ::testing::Combine(
         ::testing::Values(ov::test::utils::DEVICE_GPU)
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_GPUDetectionOutputDynamic3In, DetectionOutputLayerGPUTest,
-                         params3InputsDynamic,
+INSTANTIATE_TEST_SUITE_P(smoke_GPUDetectionOutputDynamic3In1, DetectionOutputLayerGPUTest,
+                         params3InputsDynamic1,
+                         DetectionOutputLayerGPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_GPUDetectionOutputDynamic3In2, DetectionOutputLayerGPUTest,
+                         params3InputsDynamic2,
                          DetectionOutputLayerGPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_GPUDetectionOutputV8Dynamic3In, DetectionOutputLayerGPUTest,


### PR DESCRIPTION
### Details:
- Func test was using combination too much and generates tons of cases

### Tickets:
 - 124669
