### PR TITLE
[GPU] Prevent fusing for eltwise which is not broadcastable from input to fused output

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -131,6 +131,14 @@ void prepare_primitive_fusing_through::run(program& p) {
         auto new_prev = fuse_through_order[fuse_through_order.size() - 1];
         auto new_next = fuse_through_order[fuse_through_order.size() - 2];
 
+        // Check broadcastable for fused eltwise's output
+        if (node->is_type<eltwise>()) {
+            auto out_shape = new_prev->get_output_layout().get_partial_shape();  // new_prev's layout became node's new layout after fusing
+            auto in_shape = node->get_dependency(1).get_output_layout().get_partial_shape();
+            if (!broadcastable(in_shape, out_shape, true, true))
+                continue;
+        }
+
         if (new_prev->is_type<input_layout>() ||
             new_prev->is_type<mutable_data>() ||
             new_prev->is_type<quantize>())

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
@@ -236,17 +236,24 @@ inline ov::PartialShape extend_shape_to_rank_from_begin(ov::PartialShape pshape,
     return extended_pshape;
 }
 
-inline bool broadcastable(const ov::PartialShape& first_pshape, const ov::PartialShape& second_pshape, bool use_new_shape_infer) {
+inline bool broadcastable(const ov::PartialShape& first_pshape, const ov::PartialShape& second_pshape, bool use_new_shape_infer,
+                          bool first_to_second_only = false) {
     if (first_pshape.is_dynamic() || second_pshape.is_dynamic()) {
         return false;
     }
-    if (first_pshape.size() != second_pshape.size() && use_new_shape_infer) {
-        return false;
+    if (first_to_second_only) {
+        if (first_pshape.size() > second_pshape.size()) {
+            return false;
+        }
+    } else {
+        if (first_pshape.size() != second_pshape.size() && use_new_shape_infer) {
+            return false;
+        }
     }
     size_t min_size = std::min(first_pshape.size(), second_pshape.size());
 
     for (size_t i = 0; i < min_size; ++i) {
-        if (!(first_pshape[i] == 1 || second_pshape[i] == 1 || first_pshape[i] == second_pshape[i])) {
+        if (!(first_pshape[i] == 1 || (!first_to_second_only && second_pshape[i] == 1) || first_pshape[i] == second_pshape[i])) {
             return false;
         }
     }


### PR DESCRIPTION
### Details:
 - *Prevent fusing for eltwise which is not broadcastable from input to fused output. If it doesn't prevent, the fused eltwise would have an assertion during MakeIndexJitConstants() to get idx_order with input1*


### Tickets:
 - *https://github.com/openvinotoolkit/openvino/issues/20871*
