### PR TITLE
[Func Test] remove ngraph::helpers::QuantizationGranularity

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/quantized_group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/quantized_group_convolution.cpp
@@ -8,7 +8,6 @@
 #include "common_test_utils/test_constants.hpp"
 
 using namespace SubgraphTestsDefinitions;
-using namespace ngraph::helpers;
 
 namespace {
 
@@ -20,8 +19,10 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 const std::vector<size_t> numOutChannels = {3, 24, 48};
 const std::vector<size_t> numGroups = {3};
 
-const std::vector<size_t > levels = {256};
-const std::vector<QuantizationGranularity> granularity = {QuantizationGranularity::Pertensor, QuantizationGranularity::Perchannel};
+const std::vector<size_t> levels = {256};
+const std::vector<ov::test::utils::QuantizationGranularity> granularity = {
+    ov::test::utils::QuantizationGranularity::Pertensor,
+    ov::test::utils::QuantizationGranularity::Perchannel};
 const std::vector<bool> quantizeWeights = {false, true};
 
 /* ============= 2D GroupConvolution ============= */

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/quantized_group_convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/quantized_group_convolution_backprop_data.cpp
@@ -8,7 +8,6 @@
 #include "common_test_utils/test_constants.hpp"
 
 using namespace SubgraphTestsDefinitions;
-using namespace ngraph::helpers;
 
 namespace {
 
@@ -19,8 +18,10 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 const std::vector<size_t> numOutChannels = {16, 32};
 const std::vector<size_t> numGroups = {2, 8, 16};
 
-const std::vector<size_t > levels = {256};
-const std::vector<QuantizationGranularity > granularity = {QuantizationGranularity::Pertensor, QuantizationGranularity::Perchannel};
+const std::vector<size_t> levels = {256};
+const std::vector<ov::test::utils::QuantizationGranularity> granularity = {
+    ov::test::utils::QuantizationGranularity::Pertensor,
+    ov::test::utils::QuantizationGranularity::Perchannel};
 
 /* ============= 2D GroupConvolutionBackpropData ============= */
 const std::vector<std::vector<size_t >> inputShapes2D = {{1, 16, 10, 10}, {1, 32, 10, 10}};

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/quantized_convolution_backprop_data.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/quantized_convolution_backprop_data.hpp
@@ -24,7 +24,7 @@ typedef std::tuple<
         size_t,
         ngraph::op::PadType,
         size_t,
-        ngraph::helpers::QuantizationGranularity> quantConvBackpropDataSpecificParams;
+        ov::test::utils::QuantizationGranularity> quantConvBackpropDataSpecificParams;
 typedef std::tuple<
         quantConvBackpropDataSpecificParams,
         InferenceEngine::Precision,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/quantized_group_convolution.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/quantized_group_convolution.hpp
@@ -24,7 +24,7 @@ typedef std::tuple<
         size_t,
         size_t,
         size_t,
-        ngraph::helpers::QuantizationGranularity,
+        ov::test::utils::QuantizationGranularity,
         bool> quantGroupConvSpecificParams;
 typedef std::tuple<
         quantGroupConvSpecificParams,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/quantized_group_convolution_backprop_data.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/quantized_group_convolution_backprop_data.hpp
@@ -25,7 +25,7 @@ typedef std::tuple<
         size_t,
         ngraph::op::PadType,
         size_t,
-        ngraph::helpers::QuantizationGranularity> quantGroupConvBackpropDataSpecificParams;
+        ov::test::utils::QuantizationGranularity> quantGroupConvBackpropDataSpecificParams;
 typedef std::tuple<
         quantGroupConvBackpropDataSpecificParams,
         InferenceEngine::Precision,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/quantized_mat_mul.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/quantized_mat_mul.hpp
@@ -20,7 +20,7 @@ typedef std::tuple<
         uint64_t,
         QuantRange,
         QuantRange,
-        ngraph::helpers::QuantizationGranularity,
+        ov::test::utils::QuantizationGranularity,
         InferenceEngine::Precision> QuantParams;
 
 typedef std::tuple<

--- a/src/tests/functional/shared_test_classes/src/subgraph/quantized_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/quantized_convolution_backprop_data.cpp
@@ -5,7 +5,6 @@
 #include "shared_test_classes/subgraph/quantized_convolution_backprop_data.hpp"
 
 namespace SubgraphTestsDefinitions {
-using ngraph::helpers::QuantizationGranularity;
 
 std::string QuantConvBackpropDataLayerTest::getTestCaseName(const testing::TestParamInfo<quantConvBackpropDataLayerTestParamsSet>& obj) {
     quantConvBackpropDataSpecificParams groupConvBackpropDataParams;
@@ -18,7 +17,7 @@ std::string QuantConvBackpropDataLayerTest::getTestCaseName(const testing::TestP
     std::vector<ptrdiff_t> padBegin, padEnd;
     size_t convOutChannels;
     size_t quantLevels;
-    QuantizationGranularity quantGranularity;
+    ov::test::utils::QuantizationGranularity quantGranularity;
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, quantLevels, quantGranularity) = groupConvBackpropDataParams;
 
     std::ostringstream result;
@@ -49,13 +48,13 @@ void QuantConvBackpropDataLayerTest::SetUp() {
     std::vector<ptrdiff_t> padBegin, padEnd;
     size_t convOutChannels;
     size_t quantLevels;
-    QuantizationGranularity quantGranularity;
+    ov::test::utils::QuantizationGranularity quantGranularity;
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, quantLevels, quantGranularity) = groupConvBackpropDataParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
 
     std::vector<size_t> dataFqConstShapes(inputShape.size(), 1);
-    if (quantGranularity == QuantizationGranularity::Perchannel)
+    if (quantGranularity == ov::test::utils::QuantizationGranularity::Perchannel)
         dataFqConstShapes[1] = inputShape[1];
     auto dataFq = ngraph::builder::makeFakeQuantize(params[0], ngPrc, quantLevels, dataFqConstShapes);
 
@@ -66,7 +65,7 @@ void QuantConvBackpropDataLayerTest::SetUp() {
     auto weightsNode = ngraph::builder::makeConstant(ngPrc, weightsShapes, weightsData, weightsData.empty());
 
     std::vector<size_t> weightsFqConstShapes(weightsShapes.size(), 1);
-    if (quantGranularity == QuantizationGranularity::Perchannel)
+    if (quantGranularity == ov::test::utils::QuantizationGranularity::Perchannel)
         weightsFqConstShapes[0] = weightsShapes[0];
 
     auto weightsFq = ngraph::builder::makeFakeQuantize(weightsNode, ngPrc, quantLevels, weightsFqConstShapes);

--- a/src/tests/functional/shared_test_classes/src/subgraph/quantized_group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/quantized_group_convolution.cpp
@@ -4,8 +4,6 @@
 
 #include "shared_test_classes/subgraph/quantized_group_convolution.hpp"
 
-using ngraph::helpers::QuantizationGranularity;
-
 namespace SubgraphTestsDefinitions {
 
 std::string QuantGroupConvLayerTest::getTestCaseName(const testing::TestParamInfo<quantGroupConvLayerTestParamsSet>& obj) {
@@ -19,7 +17,7 @@ std::string QuantGroupConvLayerTest::getTestCaseName(const testing::TestParamInf
     std::vector<ptrdiff_t> padBegin, padEnd;
     size_t convOutChannels, numGroups;
     size_t quantLevels;
-    QuantizationGranularity quantGranularity;
+    ov::test::utils::QuantizationGranularity quantGranularity;
     bool quantizeWeights;
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, quantLevels, quantGranularity, quantizeWeights) = groupConvParams;
 
@@ -53,14 +51,14 @@ void QuantGroupConvLayerTest::SetUp() {
     std::vector<ptrdiff_t> padBegin, padEnd;
     size_t convOutChannels, numGroups;
     size_t quantLevels;
-    size_t quantGranularity;
+    ov::test::utils::QuantizationGranularity quantGranularity;
     bool quantizeWeights;
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, quantLevels, quantGranularity, quantizeWeights) = groupConvParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
 
     std::vector<size_t> dataFqConstShapes(inputShape.size(), 1);
-    if (quantGranularity == QuantizationGranularity::Perchannel)
+    if (quantGranularity == ov::test::utils::QuantizationGranularity::Perchannel)
         dataFqConstShapes[1] = inputShape[1];
     auto dataFq = ngraph::builder::makeFakeQuantize(params[0], ngPrc, quantLevels, dataFqConstShapes);
 
@@ -76,7 +74,7 @@ void QuantGroupConvLayerTest::SetUp() {
     auto weightsNode = ngraph::builder::makeConstant(ngPrc, weightsShapes, weightsData, weightsData.empty());
 
     std::vector<size_t> weightsFqConstShapes(weightsShapes.size(), 1);
-    if (quantGranularity == QuantizationGranularity::Perchannel)
+    if (quantGranularity == ov::test::utils::QuantizationGranularity::Perchannel)
         weightsFqConstShapes[0] = weightsShapes[0];
 
     std::shared_ptr<ngraph::Node> weights;

--- a/src/tests/functional/shared_test_classes/src/subgraph/quantized_group_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/quantized_group_convolution_backprop_data.cpp
@@ -5,7 +5,6 @@
 #include "shared_test_classes/subgraph/quantized_group_convolution_backprop_data.hpp"
 
 namespace SubgraphTestsDefinitions {
-using ngraph::helpers::QuantizationGranularity;
 
 std::string QuantGroupConvBackpropDataLayerTest::getTestCaseName(const testing::TestParamInfo<quantGroupConvBackpropDataLayerTestParamsSet>& obj) {
     quantGroupConvBackpropDataSpecificParams groupConvBackpropDataParams;
@@ -18,7 +17,7 @@ std::string QuantGroupConvBackpropDataLayerTest::getTestCaseName(const testing::
     std::vector<ptrdiff_t> padBegin, padEnd;
     size_t convOutChannels, numGroups;
     size_t quantLevels;
-    QuantizationGranularity quantGranularity;
+    ov::test::utils::QuantizationGranularity quantGranularity;
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType, quantLevels, quantGranularity) = groupConvBackpropDataParams;
 
     std::ostringstream result;
@@ -50,13 +49,13 @@ void QuantGroupConvBackpropDataLayerTest::SetUp() {
     std::vector<ptrdiff_t> padBegin, padEnd;
     size_t convOutChannels, numGroups;
     size_t quantLevels;
-    QuantizationGranularity quantGranularity;
+    ov::test::utils::QuantizationGranularity quantGranularity;
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType, quantLevels, quantGranularity) = groupConvBackpropDataParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
 
     std::vector<size_t> dataFqConstShapes(inputShape.size(), 1);
-    if (quantGranularity == QuantizationGranularity::Perchannel)
+    if (quantGranularity == ov::test::utils::QuantizationGranularity::Perchannel)
         dataFqConstShapes[1] = inputShape[1];
     auto dataFq = ngraph::builder::makeFakeQuantize(params[0], ngPrc, quantLevels, dataFqConstShapes);
 
@@ -72,7 +71,7 @@ void QuantGroupConvBackpropDataLayerTest::SetUp() {
     auto weightsNode = ngraph::builder::makeConstant(ngPrc, weightsShapes, weightsData, weightsData.empty());
 
     std::vector<size_t> weightsFqConstShapes(weightsShapes.size(), 1);
-    if (quantGranularity == QuantizationGranularity::Perchannel)
+    if (quantGranularity == ov::test::utils::QuantizationGranularity::Perchannel)
         weightsFqConstShapes[0] = weightsShapes[0];
 
     auto weightsFq = ngraph::builder::makeFakeQuantize(weightsNode, ngPrc, quantLevels, weightsFqConstShapes);

--- a/src/tests/functional/shared_test_classes/src/subgraph/quantized_mat_mul.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/quantized_mat_mul.cpp
@@ -7,8 +7,6 @@
 
 namespace SubgraphTestsDefinitions {
 
-using ngraph::helpers::QuantizationGranularity;
-
 std::string QuantMatMulTest::getTestCaseName(const testing::TestParamInfo<QuantMatMulLayerTestParamsSet> &obj) {
     QuantParams quantParams0;
     QuantParams quantParams1;
@@ -24,8 +22,8 @@ std::string QuantMatMulTest::getTestCaseName(const testing::TestParamInfo<QuantM
 
     size_t quantLevels0;
     size_t quantLevels1;
-    QuantizationGranularity quantGranularity0;
-    QuantizationGranularity quantGranularity1;
+    ov::test::utils::QuantizationGranularity quantGranularity0;
+    ov::test::utils::QuantizationGranularity quantGranularity1;
     InferenceEngine::Precision fqPrec0;
     InferenceEngine::Precision fqPrec1;
     std::tie(quantLevels0, inputRange0, outputRange0, quantGranularity0, fqPrec0) = quantParams0;
@@ -63,8 +61,8 @@ void QuantMatMulTest::SetUp() {
     QuantRange inputRange1;
     QuantRange outputRange0;
     QuantRange outputRange1;
-    QuantizationGranularity quantGranularity0;
-    QuantizationGranularity quantGranularity1;
+    ov::test::utils::QuantizationGranularity quantGranularity0;
+    ov::test::utils::QuantizationGranularity quantGranularity1;
     InferenceEngine::Precision fqPrec0;
     InferenceEngine::Precision fqPrec1;
     std::tie(quantLevels0, inputRange0, outputRange0, quantGranularity0, fqPrec0) = quantParams0;
@@ -75,10 +73,10 @@ void QuantMatMulTest::SetUp() {
                                 std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape1))};
 
     auto makeFakeQuantizeNode = [ngPrc](size_t quantLevels, QuantRange inputRange, QuantRange outputRange,
-            QuantizationGranularity quantGranularity, const ngraph::Output<ngraph::Node> &in, std::vector<size_t> inputShape,
+            ov::test::utils::QuantizationGranularity quantGranularity, const ngraph::Output<ngraph::Node> &in, std::vector<size_t> inputShape,
             InferenceEngine::Precision prec) -> std::shared_ptr<ngraph::Node> {
         std::vector<size_t> dataFqConstShapes(inputShape.size(), 1);
-        if (quantGranularity == QuantizationGranularity::Perchannel)
+        if (quantGranularity == ov::test::utils::QuantizationGranularity::Perchannel)
             dataFqConstShapes[1] = inputShape[1];
         size_t constDataSize = ngraph::shape_size(dataFqConstShapes);
         std::vector<float> inputLowData(constDataSize), inputHighData(constDataSize), outputLowData(constDataSize), outputHighData(constDataSize);

--- a/src/tests/ov_helpers/ov_models/include/ov_models/utils/ov_helpers.hpp
+++ b/src/tests/ov_helpers/ov_models/include/ov_models/utils/ov_helpers.hpp
@@ -80,11 +80,6 @@ using ov::test::utils::LogicalTypes;
 using ov::test::utils::SqueezeOpType;
 using ov::test::utils::MinMaxOpType;
 
-enum QuantizationGranularity {
-    Pertensor,
-    Perchannel
-};
-
 using ov::test::utils::TensorIteratorBody;
 using ov::test::utils::ReductionType;
 using ov::test::utils::DFTOpType;
@@ -92,26 +87,10 @@ using ov::test::utils::InputLayerType;
 using ov::test::utils::PadMode;
 using ov::test::utils::SequenceTestsMode;
 using ov::test::utils::MemoryTransformation;
+using ov::test::utils::QuantizationGranularity;
 // clang-format on
 
 bool is_tensor_iterator_exist(const std::shared_ptr<ngraph::Function>& func);
-
-inline std::string quantizationGranularityToString(const QuantizationGranularity& granularity) {
-    static std::map<QuantizationGranularity, std::string> names = {
-        {Pertensor, "Pertensor"},
-        {Perchannel, "Perchannel"},
-    };
-
-    auto i = names.find(granularity);
-    if (i != names.end())
-        return i->second;
-    else
-        throw std::runtime_error("Unsupported QuantizationGranularity type");
-}
-
-inline std::ostream& operator<<(std::ostream& out, const QuantizationGranularity& granularity) {
-    return out << quantizationGranularityToString(granularity);
-}
 
 ngraph::OutputVector convert2OutputVector(const std::vector<std::shared_ptr<ngraph::Node>>& nodes);
 

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/test_enums.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/test_enums.hpp
@@ -206,6 +206,8 @@ std::ostream& operator<<(std::ostream& os, ov::op::v8::MatrixNms::DecayFunction 
 
 std::ostream& operator<<(std::ostream& os, TensorIteratorBody type);
 
+std::ostream& operator<<(std::ostream& os, QuantizationGranularity type);
+
 std::ostream& operator<<(std::ostream& os, MemoryTransformation type);
 
 }  // namespace utils


### PR DESCRIPTION
### Details:
 - for easy code review, split from this PR https://github.com/openvinotoolkit/openvino/pull/20901
 - remove ngraph::helpers::QuantizationGranularity, replaced with ov::test::utils::QuantizationGranularity

### Tickets:
 - *CVS-124431*
