### PR TITLE
[CI]Fix compile warning regarding ABI changes in GNA plugin transormations

### DIFF
--- a/src/plugins/intel_gna/src/transformations/pwl_approximation.hpp
+++ b/src/plugins/intel_gna/src/transformations/pwl_approximation.hpp
@@ -261,21 +261,21 @@ double lower_bound() {
 }
 
 template <typename T>
-double lower_bound(std::true_type, double exponent) {
+double lower_bound(double exponent, std::true_type) {
     return Function<ngraph::opset8::Power>::lower_bound(exponent);
 }
 
 template <typename T>
-double lower_bound(std::false_type, double exponent) {
+double lower_bound(double exponent, std::false_type) {
     throw std::runtime_error("Not supported");
 }
 
 template <typename T>
 double lower_bound(double exponent) {
     return lower_bound<T>(
+        exponent,
         std::integral_constant < bool,
-        std::is_same<T, ngraph::opset8::Power>::value || std::is_same<T, ngraph::op::PowerIE>::value > (),
-        exponent);
+        std::is_same<T, ngraph::opset8::Power>::value || std::is_same<T, ngraph::op::PowerIE>::value > ());
 }
 
 template <typename T>


### PR DESCRIPTION
### Details:
 - Fix using `std::true_type` and `std::false_type` as function parameter to remove compiler warning in GNA transformations.

### Tickets:
 - [CVS-124762](https://jira.devtools.intel.com/browse/CVS-124762)
