### PR TITLE
[Inference] Return state ptr by value

### DIFF
--- a/src/inference/dev_api/openvino/runtime/ivariable_state.hpp
+++ b/src/inference/dev_api/openvino/runtime/ivariable_state.hpp
@@ -49,7 +49,7 @@ public:
      * @brief Returns the value of the variable state.
      * @return The value of the variable state
      */
-    virtual const ov::SoPtr<ov::ITensor>& get_state() const;
+    virtual ov::SoPtr<ov::ITensor> get_state() const;
 
 protected:
     /**

--- a/src/inference/src/dev/converter_utils.cpp
+++ b/src/inference/src/dev/converter_utils.cpp
@@ -651,7 +651,6 @@ namespace InferenceEngine {
 class IVariableStateWrapper : public ov::IVariableState {
 private:
     std::shared_ptr<InferenceEngine::IVariableStateInternal> m_state;
-    mutable ov::SoPtr<ov::ITensor> m_converted_state;
 
 public:
     explicit IVariableStateWrapper(const std::shared_ptr<InferenceEngine::IVariableStateInternal>& state)
@@ -666,10 +665,8 @@ public:
         m_state->SetState(ov::tensor_to_blob(state));
     }
 
-    const ov::SoPtr<ov::ITensor>& get_state() const override {
-        m_converted_state = ov::make_tensor(std::const_pointer_cast<InferenceEngine::Blob>(m_state->GetState()));
-
-        return m_converted_state;
+    ov::SoPtr<ov::ITensor> get_state() const override {
+        return ov::make_tensor(std::const_pointer_cast<InferenceEngine::Blob>(m_state->GetState()));
     }
 };
 

--- a/src/inference/src/dev/ivariable_state.cpp
+++ b/src/inference/src/dev/ivariable_state.cpp
@@ -22,6 +22,6 @@ void ov::IVariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
     m_state = state;
 }
 
-const ov::SoPtr<ov::ITensor>& ov::IVariableState::get_state() const {
+ov::SoPtr<ov::ITensor> ov::IVariableState::get_state() const {
     return m_state;
 }

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/variable_state.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/variable_state.hpp
@@ -16,7 +16,7 @@ public:
 
     void reset() override;
     void set_state(const ov::SoPtr<ov::ITensor>& state) override;
-    const ov::SoPtr<ov::ITensor>& get_state() const override;
+    ov::SoPtr<ov::ITensor> get_state() const override;
 
 private:
     cldnn::network::VariableState::Ptr m_variable_state;

--- a/src/plugins/intel_gpu/src/plugin/variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/variable_state.cpp
@@ -40,7 +40,7 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
     m_variable_state->is_set = true;
 }
 
-const ov::SoPtr<ov::ITensor>& VariableState::get_state() const {
+ov::SoPtr<ov::ITensor> VariableState::get_state() const {
     auto internal_memory = m_variable_state->memory;
     const bool blocking = true;
     internal_memory->copy_to(m_engine.get_service_stream(), m_state->data(), blocking);

--- a/src/tests/test_utils/unit_test_utils/mocks/openvino/runtime/mock_ivariable_state.hpp
+++ b/src/tests/test_utils/unit_test_utils/mocks/openvino/runtime/mock_ivariable_state.hpp
@@ -19,7 +19,7 @@ public:
     MOCK_METHOD(const std::string&, get_name, (), (const));
     MOCK_METHOD(void, reset, ());
     MOCK_METHOD(void, set_state, (const ov::SoPtr<ov::ITensor>&));
-    MOCK_METHOD(const ov::SoPtr<ov::ITensor>&, get_state, (), (const));
+    MOCK_METHOD(ov::SoPtr<ov::ITensor>, get_state, (), (const));
 };
 
 }  // namespace ov


### PR DESCRIPTION
### Details:
This PR changes `ov::IVaraibleState` interface allowing return the internal state pointer by value rather than by a const reference. That gives more flexibility for the implementations for instancing the state tensor on the fly when `get_state()` is called in exchange to an almost negligible performance impact.

### Tickets:
 - *ticket-id*
