### PR TITLE
[GPU] Cleanup buffer reuse code

### DIFF
--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -240,21 +240,11 @@ crop_inst::typed_primitive_inst(network& network, crop_node const& node) : paren
 
     if (node.can_be_optimized()) {
         build_deps();
-        reuse_input();
+        update_output_memory();
     }
 }
 
 void crop_inst::on_execute() {
-    if (!can_be_optimized())
-        return;
-
-    if (_outputs[0] && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
-        return;
-
-    reuse_input();
-}
-
-void crop_inst::reuse_input() {
     update_output_memory();
 }
 

--- a/src/plugins/intel_gpu/src/graph/include/crop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/crop_inst.h
@@ -58,8 +58,6 @@ public:
 
 private:
     void on_execute() override;
-
-    void reuse_input();
 };
 
 using crop_inst = typed_primitive_inst<crop>;

--- a/src/plugins/intel_gpu/src/graph/include/permute_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/permute_inst.h
@@ -71,7 +71,6 @@ public:
 
 private:
     void on_execute() override;
-    void reuse_input();
 };
 
 using permute_inst = typed_primitive_inst<permute>;

--- a/src/plugins/intel_gpu/src/graph/include/reorder_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reorder_inst.h
@@ -108,7 +108,6 @@ public:
 
 private:
     void on_execute() override;
-    void reuse_input();
 
     bool _req_reinterpr = false;
 };

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -111,8 +111,6 @@ public:
 
 private:
     void on_execute() override;
-
-    void reuse_input();
 };
 
 using reshape_inst = typed_primitive_inst<reshape>;

--- a/src/plugins/intel_gpu/src/graph/include/scatter_elements_update_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scatter_elements_update_inst.h
@@ -26,7 +26,6 @@ public:
 
 private:
     void on_execute() override;
-    void reuse_input();
 };
 
 using scatter_elements_update_inst = typed_primitive_inst<scatter_elements_update>;

--- a/src/plugins/intel_gpu/src/graph/include/scatter_nd_update_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scatter_nd_update_inst.h
@@ -28,7 +28,6 @@ public:
 
 private:
     void on_execute() override;
-    void reuse_input();
 };
 
 using scatter_nd_update_inst = typed_primitive_inst<scatter_nd_update>;

--- a/src/plugins/intel_gpu/src/graph/include/scatter_update_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scatter_update_inst.h
@@ -41,7 +41,6 @@ public:
 
 private:
     void on_execute() override;
-    void reuse_input();
 };
 
 using scatter_update_inst = typed_primitive_inst<scatter_update>;

--- a/src/plugins/intel_gpu/src/graph/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/permute.cpp
@@ -118,19 +118,13 @@ permute_inst::typed_primitive_inst(network& network, permute_node const& node) :
             CLDNN_ERROR_MESSAGE(node.id(), "Permute order does not contain all of required values.");
     }
 
-    if (node.can_be_optimized()) {
-        reuse_input();
-    }
+    update_output_memory();
 }
 
 void permute_inst::on_execute() {
-    if (can_be_optimized())
-        reuse_input();
-}
-
-void permute_inst::reuse_input() {
     update_output_memory();
 }
+
 
 void permute_inst::update_output_memory() {
     if (!can_be_optimized())

--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -219,8 +219,7 @@ reorder_inst::typed_primitive_inst(network& network, reorder_node const& node) :
         parent(network, node, !node.can_be_optimized()
                               && (node.get_output_layout().is_static() || node.get_output_layout().has_upper_bound()))
         , _req_reinterpr(node.requires_reinterpret()) {
-    if (node.can_be_optimized())
-        reuse_input();
+    update_output_memory();
 
     if (is_dynamic())
         return;
@@ -256,11 +255,6 @@ reorder_inst::typed_primitive_inst(network& network, reorder_node const& node) :
 }
 
 void reorder_inst::on_execute() {
-    if (can_be_optimized())
-        reuse_input();
-}
-
-void reorder_inst::reuse_input() {
     update_output_memory();
 }
 

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -182,25 +182,15 @@ reshape_inst::typed_primitive_inst(network& network, reshape_node const& node) :
             _outputs = allocate_outputs();
             _mem_allocated = true;
         } else {
-            reuse_input();
+            update_output_memory();
         }
     } else {
         if (_exec_deps.size() > 0 && input_memory_ptr())
-            reuse_input();
+            update_output_memory();
     }
 }
 
 void reshape_inst::on_execute() {
-    if (!can_be_optimized())
-        return;
-
-    if (_outputs[0] && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
-        return;
-
-    reuse_input();
-}
-
-void reshape_inst::reuse_input() {
     update_output_memory();
 }
 

--- a/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
@@ -59,11 +59,7 @@ void scatter_elements_update_inst::on_execute() {
     auto input2_shape = _impl_params->input_layouts[2].get_partial_shape();
 
     if ((ov::shape_size(input1_shape.to_shape()) == 0) || (ov::shape_size(input2_shape.to_shape()) == 0))
-        reuse_input();
-}
-
-void scatter_elements_update_inst::reuse_input() {
-    update_output_memory();
+        update_output_memory();
 }
 
 void scatter_elements_update_inst::update_output_memory() {

--- a/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
@@ -72,11 +72,7 @@ void scatter_nd_update_inst::on_execute() {
     auto same_layouts = _impl_params->input_layouts[0] == _impl_params->output_layouts[0];
 
     if (same_layouts && ((ov::shape_size(input1_shape.to_shape()) == 0) || (ov::shape_size(input2_shape.to_shape()) == 0)))
-        reuse_input();
-}
-
-void scatter_nd_update_inst::reuse_input() {
-    update_output_memory();
+        update_output_memory();
 }
 
 void scatter_nd_update_inst::update_output_memory() {

--- a/src/plugins/intel_gpu/src/graph/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_update.cpp
@@ -51,11 +51,7 @@ void scatter_update_inst::on_execute() {
     auto input2_shape = _impl_params->input_layouts[2].get_partial_shape();
 
     if ((ov::shape_size(input1_shape.to_shape()) == 0) || (ov::shape_size(input2_shape.to_shape()) == 0))
-        reuse_input();
-}
-
-void scatter_update_inst::reuse_input() {
-    update_output_memory();
+        update_output_memory();
 }
 
 void scatter_update_inst::update_output_memory() {


### PR DESCRIPTION
### Details:
 - Removed `reuse_input()` method of some primitives as it always calls `update_output_memory()`
 - Simplified `on_execute()` impls in some cases to avoid duplicated conditions with `update_output_memory()`
