### PR TITLE
Remove `castOps2Nodes` and `convert2OutputVector`

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_cell.cpp
@@ -94,12 +94,14 @@ protected:
         }
 
         ov::ParameterVector params;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
+            auto param = std::make_shared<ov::op::v0::Parameter>(netPrecision, shape);
+            params.push_back(param);
+            paramsOuts.push_back(param);
         }
         std::vector<ngraph::Shape> WRB = {{3 * hiddenSize, inputSize}, {3 * hiddenSize, hiddenSize}, {(linearBeforeReset ? 4 : 3) * hiddenSize}};
-        auto augruCellOp = ngraph::builder::makeAUGRU(
-            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)), WRB, hiddenSize/*, activations, {}, {}, clip, linearBeforeReset*/);
+        auto augruCellOp = ngraph::builder::makeAUGRU(paramsOuts, WRB, hiddenSize/*, activations, {}, {}, clip, linearBeforeReset*/);
 
         function = makeNgraphFunction(netPrecision, params, augruCellOp, "AUGRUCell");
     }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_sequence.cpp
@@ -130,10 +130,13 @@ protected:
                 params[3]->set_element_type(ElementType::i64);
             }
         }
+        ov::OutputVector paramsOuts;
+        for (const auto& param : params)
+            paramsOuts.push_back(param);
 
         std::vector<ov::Shape> WRB = {{numDirections, 3 * hiddenSize, inputSize}, {numDirections, 3 * hiddenSize, hiddenSize},
                 {numDirections, (linearBeforeReset ? 4 : 3) * hiddenSize}, {batchSize}};
-        auto augruSequenceOp = ngraph::builder::makeAUGRU(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
+        auto augruSequenceOp = ngraph::builder::makeAUGRU(paramsOuts,
                                                      WRB,
                                                      hiddenSize,
                                                      true,

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/concat.cpp
@@ -79,12 +79,13 @@ protected:
         init_input_shapes(inputShape);
 
         ov::ParameterVector params;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
+            auto param = std::make_shared<ov::op::v0::Parameter>(netPrecision, shape);
+            params.push_back(param);
+            paramsOuts.push_back(param);
         }
-        auto paramOuts = ngraph::helpers::convert2OutputVector(
-                ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-        auto concat = std::make_shared<ngraph::opset1::Concat>(paramOuts, axis);
+        auto concat = std::make_shared<ngraph::opset1::Concat>(paramsOuts, axis);
 
         function = makeNgraphFunction(netPrecision, params, concat, "ConcatCPU");
     }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/custom_op_internal_dyn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/custom_op_internal_dyn.cpp
@@ -86,12 +86,13 @@ protected:
 
         init_input_shapes({inputShapes});
         ov::ParameterVector inputParams;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, shape));
+            auto param = std::make_shared<ov::op::v0::Parameter>(ngraph::element::f32, shape);
+            inputParams.push_back(param);
+            paramsOuts.push_back(param);
         }
-
-        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
-        auto customOp = std::make_shared<CustomOp>(paramOuts);
+        auto customOp = std::make_shared<CustomOp>(paramsOuts);
         auto shapeOf = std::make_shared<ov::opset10::ShapeOf>(customOp->output(1));
 
         ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(customOp->output(0)),

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/detection_output.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/detection_output.cpp
@@ -198,11 +198,13 @@ public:
         init_input_shapes({ inShapes });
 
         ov::ParameterVector params;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            params.push_back(std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape));
+            auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+            params.push_back(param);
+            paramsOuts.push_back(param);
         }
-        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(params));
-        auto detOut = ngraph::builder::makeDetectionOutput(paramOuts, attrs);
+        auto detOut = ngraph::builder::makeDetectionOutput(paramsOuts, attrs);
         ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(detOut)};
         function = std::make_shared<ngraph::Function>(results, params, "DetectionOutputDynamic");
     }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_cell.cpp
@@ -94,12 +94,14 @@ protected:
         }
 
         ov::ParameterVector params;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
+          auto param = std::make_shared<ov::op::v0::Parameter>(netPrecision, shape);
+            params.push_back(param);
+            paramsOuts.push_back(param);
         }
         std::vector<ngraph::Shape> WRB = {{3 * hiddenSize, inputSize}, {3 * hiddenSize, hiddenSize}, {(linearBeforeReset ? 4 : 3) * hiddenSize}};
-        auto gruCellOp = ngraph::builder::makeGRU(
-            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)), WRB, hiddenSize, activations, {}, {}, clip, linearBeforeReset);
+        auto gruCellOp = ngraph::builder::makeGRU(paramsOuts, WRB, hiddenSize, activations, {}, {}, clip, linearBeforeReset);
 
         function = makeNgraphFunction(netPrecision, params, gruCellOp, "GRUCell");
     }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_sequence.cpp
@@ -122,9 +122,13 @@ protected:
             }
         }
 
+        ov::OutputVector paramsOuts;
+        for (const auto& param : params)
+          paramsOuts.push_back(param);
+
         std::vector<ov::Shape> WRB = {{numDirections, 3 * hiddenSize, inputSize}, {numDirections, 3 * hiddenSize, hiddenSize},
                 {numDirections, (linearBeforeReset ? 4 : 3) * hiddenSize}, {batchSize}};
-        auto gruSequenceOp = ngraph::builder::makeGRU(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
+        auto gruSequenceOp = ngraph::builder::makeGRU(paramsOuts,
                                                      WRB,
                                                      hiddenSize,
                                                      activations,

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_cell.cpp
@@ -93,10 +93,13 @@ protected:
         }
 
         ov::ParameterVector params;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
+            auto param = std::make_shared<ov::op::v0::Parameter>(netPrecision, shape);
+            params.push_back(param);
+            paramsOuts.push_back(param);
         }
-        auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
+
         std::vector<ngraph::Shape> WRB = {{4 * hiddenSize, inputSize}, {4 * hiddenSize, hiddenSize}, {4 * hiddenSize}};
         auto lstmCellOp = ngraph::builder::makeLSTM(paramsOuts, WRB, hiddenSize, activations, {}, {}, clip);
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_sequence.cpp
@@ -130,9 +130,13 @@ protected:
             }
         }
 
+        ov::OutputVector paramsOuts;
+        for (const auto& param : params)
+          paramsOuts.push_back(param);
+
         std::vector<ov::Shape> WRB = {{numDirections, 4 * hiddenSize, inputSize}, {numDirections, 4 * hiddenSize, hiddenSize},
                 {numDirections, 4 * hiddenSize}, {batchSize}};
-        auto lstmSequenceOp = ngraph::builder::makeLSTM(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
+        auto lstmSequenceOp = ngraph::builder::makeLSTM(paramsOuts,
                                                         WRB,
                                                         hiddenSize,
                                                         activations,

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_cell.cpp
@@ -89,10 +89,12 @@ protected:
         }
 
         ov::ParameterVector params;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
+            auto param = std::make_shared<ov::op::v0::Parameter>(netPrecision, shape);
+            params.push_back(param);
+            paramsOuts.push_back(param);
         }
-        auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
         std::vector<ov::Shape> WRB = {{hiddenSize, inputSize}, {hiddenSize, hiddenSize}, {hiddenSize}};
         auto rnnCellOp = ngraph::builder::makeRNN(paramsOuts, WRB, hiddenSize, activations, {}, {}, clip);
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_sequence.cpp
@@ -106,10 +106,10 @@ protected:
             rel_threshold = 1e-4;
         }
 
-            ov::ParameterVector params;
-            for (auto&& shape : inputDynamicShapes) {
-                params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
-            }
+        ov::ParameterVector params;
+        for (auto&& shape : inputDynamicShapes) {
+            params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
+        }
         const size_t batchSize = inputDynamicShapes[0][0].is_static() ? inputDynamicShapes[0][0].get_length() :
             inputDynamicShapes[1][0].is_static() ? inputDynamicShapes[1][0].get_length() :
             inputDynamicShapes.size() > 2 && inputDynamicShapes[2][0].is_static() ? inputDynamicShapes[2][0].get_length() :
@@ -124,9 +124,13 @@ protected:
             }
         }
 
+        ov::OutputVector paramsOuts;
+        for (const auto& param : params)
+          paramsOuts.push_back(param);
+
         std::vector<ov::Shape> WRB = {{numDirections, hiddenSize, inputSize}, {numDirections, hiddenSize, hiddenSize}, {numDirections, hiddenSize},
                                         {batchSize}};
-        auto rnn_sequence = ngraph::builder::makeRNN(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
+        auto rnn_sequence = ngraph::builder::makeRNN(paramsOuts,
                                                      WRB,
                                                      hiddenSize,
                                                      activations,

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/custom_op_insert_convert_i64.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/custom_op_insert_convert_i64.cpp
@@ -101,11 +101,13 @@ protected:
 
         init_input_shapes({inputShape});
         ov::ParameterVector inputParams;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(inType, shape));
+            auto param = std::make_shared<ov::op::v0::Parameter>(inType, shape);
+            inputParams.push_back(param);
+            paramsOuts.push_back(param);
         }
-        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(inputParams));
-        auto customOp = std::make_shared<CustomOpI64>(paramOuts);
+        auto customOp = std::make_shared<CustomOpI64>(paramsOuts);
 
         ov::ResultVector results{std::make_shared<ov::op::v0::Result>(customOp)};
         function = std::make_shared<ov::Model>(results, inputParams, "customOpTest");

--- a/src/plugins/intel_gna/tests/functional/preprocess_tests/precision_convert.cpp
+++ b/src/plugins/intel_gna/tests/functional/preprocess_tests/precision_convert.cpp
@@ -55,12 +55,13 @@ protected:
         init_input_shapes({input_shapes});
 
         ov::ParameterVector params;
+        ov::OutputVector paramsOuts;
         for (auto&& shape : inputDynamicShapes) {
-            params.push_back(std::make_shared<ov::op::v0::Parameter>(net_type, shape));
+            auto param = std::make_shared<ov::op::v0::Parameter>(net_type, shape);
+            params.push_back(param);
+            paramsOuts.push_back(param);
         }
-        auto paramOuts =
-            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-        auto concat = std::make_shared<ngraph::opset8::Concat>(paramOuts, 1);
+        auto concat = std::make_shared<ngraph::opset8::Concat>(paramsOuts, 1);
         ngraph::ResultVector results{std::make_shared<ngraph::opset8::Result>(concat)};
         function = std::make_shared<ngraph::Function>(results, params, "concat");
     }

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/detection_output.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/detection_output.cpp
@@ -212,8 +212,11 @@ protected:
             ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(detOut)};
             function = std::make_shared<ngraph::Function>(results, params, "DetectionOutputDynamic");
         } else {
-            auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(params));
-            auto detOut = ngraph::builder::makeDetectionOutput(paramOuts, attrs);
+            ov::OutputVector paramsOuts;
+            for (auto&& param : params) {
+                paramsOuts.push_back(param);
+            }
+            auto detOut = ngraph::builder::makeDetectionOutput(paramsOuts, attrs);
             ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(detOut)};
             function = std::make_shared<ngraph::Function>(results, params, "DetectionOutputDynamic");
         }

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/group_normalization.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/group_normalization.hpp
@@ -59,16 +59,13 @@ protected:
         InputShape biasInputShape = ExtractBiasShape(shapes);
         init_input_shapes({shapes, biasInputShape, biasInputShape});
         ov::ParameterVector params;
-        for (auto&& shape : inputDynamicShapes) {
+        for (auto&& shape : inputDynamicShapes)
             params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, shape));
-        }
-        const auto paramOuts =
-            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
         const auto groupNormalization = std::make_shared<ov::op::v12::GroupNormalization>(
-            paramOuts.at(0),
-            paramOuts.at(1),
-            paramOuts.at(2),
+            params.at(0),
+            params.at(1),
+            params.at(2),
             num_groups,
             epsilon);
         const ngraph::ResultVector results{std::make_shared<ngraph::opset8::Result>(groupNormalization)};

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/softmax.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/softmax.hpp
@@ -65,13 +65,10 @@ protected:
         init_input_shapes({shapes});
 
         ov::ParameterVector params;
-        for (auto&& shape : inputDynamicShapes) {
+        for (auto&& shape : inputDynamicShapes)
             params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, shape));
-        }
-        const auto paramOuts =
-            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
 
-        const auto softMax = std::make_shared<SoftmaxOpType>(paramOuts.at(0), axis);
+        const auto softMax = std::make_shared<SoftmaxOpType>(params.at(0), axis);
         const ngraph::ResultVector results{std::make_shared<ov::op::v0::Result>(softMax)};
 
         // TODO: This workaround is needed as there is no full support for f16 type in the reference implementation

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
@@ -38,10 +38,8 @@ void BatchNormLayerTest::SetUp() {
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
 
-    auto batchNorm = ngraph::builder::makeBatchNormInference(paramOuts[0], epsilon);
+    auto batchNorm = ngraph::builder::makeBatchNormInference(params[0], epsilon);
     ngraph::ResultVector results{std::make_shared<ov::op::v0::Result>(batchNorm)};
     function = std::make_shared<ngraph::Function>(results, params, "BatchNormInference");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
@@ -36,9 +36,7 @@ void BatchToSpaceLayerTest::SetUp() {
     std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto b2s = ngraph::builder::makeBatchToSpace(paramOuts[0], ngPrc, blockShape, cropsBegin, cropsEnd);
+    auto b2s = ngraph::builder::makeBatchToSpace(params[0], ngPrc, blockShape, cropsBegin, cropsEnd);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(b2s)};
     function = std::make_shared<ngraph::Function>(results, params, "BatchToSpace");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
@@ -33,12 +33,13 @@ void ConcatLayerTest::SetUp() {
     std::tie(axis, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params;
+    ov::OutputVector paramsOuts;
     for (auto&& shape : inputShape) {
-        params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shape)));
+        auto param = std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shape));
+        params.push_back(param);
+        paramsOuts.push_back(param);
     }
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto concat = std::make_shared<ngraph::opset1::Concat>(paramOuts, axis);
+    auto concat = std::make_shared<ngraph::opset1::Concat>(paramsOuts, axis);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(concat)};
     function = std::make_shared<ngraph::Function>(results, params, "concat");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
@@ -52,8 +52,6 @@ void ConvolutionLayerTest::SetUp() {
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     std::vector<float> filter_weights;
     if (targetDevice == ov::test::utils::DEVICE_GNA) {
         auto filter_size = std::accumulate(std::begin(kernel), std::end(kernel), 1, std::multiplies<size_t>());
@@ -61,7 +59,7 @@ void ConvolutionLayerTest::SetUp() {
                                                                  -0.1f, 0.1f);
     }
     auto conv = std::dynamic_pointer_cast<ngraph::opset1::Convolution>(
-            ngraph::builder::makeConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
+            ngraph::builder::makeConvolution(params[0], ngPrc, kernel, stride, padBegin,
                                              padEnd, dilation, padType, convOutChannels, false, filter_weights));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(conv)};
     function = std::make_shared<ngraph::Function>(results, params, "convolution");

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
@@ -54,15 +54,13 @@ void ConvolutionBackpropLayerTest::SetUp() {
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = convBackpropDataParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto convBackpropData = std::dynamic_pointer_cast<ngraph::opset1::ConvolutionBackpropData>(
-            ngraph::builder::makeConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
+            ngraph::builder::makeConvolutionBackpropData(params[0], ngPrc, kernel, stride, padBegin,
                                                         padEnd, dilation, padType, convOutChannels, false, outPadding));
     if (!outputShape.empty()) {
         auto outShape = ngraph::opset3::Constant::create(ngraph::element::i64, {outputShape.size()}, outputShape);
         convBackpropData = std::dynamic_pointer_cast<ngraph::opset1::ConvolutionBackpropData>(
-        ngraph::builder::makeConvolutionBackpropData(paramOuts[0], outShape, ngPrc, kernel, stride, padBegin,
+        ngraph::builder::makeConvolutionBackpropData(params[0], outShape, ngPrc, kernel, stride, padBegin,
                                                         padEnd, dilation, padType, convOutChannels));
     }
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(convBackpropData)};

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
@@ -56,15 +56,13 @@ void ConvolutionBackpropDataLayerTest::SetUp() {
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = convBackpropDataParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto convBackpropData = std::dynamic_pointer_cast<ngraph::opset1::ConvolutionBackpropData>(
-            ngraph::builder::makeConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
+            ngraph::builder::makeConvolutionBackpropData(params[0], ngPrc, kernel, stride, padBegin,
                                                         padEnd, dilation, padType, convOutChannels, false, outPadding));
     if (!outputShape.empty()) {
         auto outShape = ngraph::opset3::Constant::create(ngraph::element::i64, {outputShape.size()}, outputShape);
         convBackpropData = std::dynamic_pointer_cast<ngraph::opset1::ConvolutionBackpropData>(
-        ngraph::builder::makeConvolutionBackpropData(paramOuts[0], outShape, ngPrc, kernel, stride, padBegin,
+        ngraph::builder::makeConvolutionBackpropData(params[0], outShape, ngPrc, kernel, stride, padBegin,
                                                         padEnd, dilation, padType, convOutChannels));
     }
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(convBackpropData)};

--- a/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder.cpp
@@ -45,11 +45,9 @@ void CTCGreedyDecoderLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector paramsIn {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-        ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
 
     auto ctcGreedyDecoder = std::dynamic_pointer_cast<ngraph::opset1::CTCGreedyDecoder>(
-            ngraph::builder::makeCTCGreedyDecoder(paramOuts[0], mergeRepeated));
+            ngraph::builder::makeCTCGreedyDecoder(paramsIn[0], mergeRepeated));
 
     ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(ctcGreedyDecoder) };
     function = std::make_shared<ngraph::Function>(results, paramsIn, "CTCGreedyDecoder");

--- a/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder_seq_len.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder_seq_len.cpp
@@ -56,8 +56,6 @@ void CTCGreedyDecoderSeqLenLayerTest::SetUp() {
     auto ngDataPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(dataPrecision);
     auto ngIdxPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(indicesPrecision);
     ov::ParameterVector paramsIn {std::make_shared<ov::op::v0::Parameter>(ngDataPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-        ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
 
     const auto sequenceLenNode = [&] {
         const size_t B = inputShape[0];
@@ -83,7 +81,7 @@ void CTCGreedyDecoderSeqLenLayerTest::SetUp() {
     blankIndex = std::min(blankIndex, C - 1);
 
     auto ctcGreedyDecoderSeqLen = std::dynamic_pointer_cast<ngraph::op::v6::CTCGreedyDecoderSeqLen>(
-            ngraph::builder::makeCTCGreedyDecoderSeqLen(paramOuts[0], sequenceLenNode,
+            ngraph::builder::makeCTCGreedyDecoderSeqLen(paramsIn[0], sequenceLenNode,
                                                         blankIndex, mergeRepeated, ngIdxPrc));
 
     ngraph::ResultVector results;

--- a/src/tests/functional/shared_test_classes/src/single_layer/ctc_loss.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/ctc_loss.cpp
@@ -51,10 +51,8 @@ void CTCLossLayerTest::SetUp() {
     auto ngIntPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(intPrecision);
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngFpPrc, ov::Shape(logitsShapes))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto ctcLoss = std::dynamic_pointer_cast<ngraph::opset4::CTCLoss>(
-            ngraph::builder::makeCTCLoss(paramOuts[0], logitsLength, labels, labelsLength, blankIndex,
+            ngraph::builder::makeCTCLoss(params[0], logitsLength, labels, labelsLength, blankIndex,
                 ngFpPrc, ngIntPrc, preprocessCollapseRepeated, ctcMergeRepeated, unique));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(ctcLoss)};
     function = std::make_shared<ngraph::Function>(results, params, "CTCLoss");

--- a/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
@@ -76,8 +76,6 @@ void DeformableConvolutionLayerTest::SetUp() {
     for (auto&& shape : {inputShape, offsets, filter}) {
         params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shape)));
     }
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto data = std::make_shared<ngraph::op::Parameter>(ngPrc, ngraph::Shape(inputShape));
     data->set_friendly_name("a_data");
     auto offset_vals = std::make_shared<ngraph::op::Parameter>(ngPrc, ngraph::Shape(offsets));

--- a/src/tests/functional/shared_test_classes/src/single_layer/deformable_psroi_pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/deformable_psroi_pooling.cpp
@@ -97,10 +97,8 @@ namespace LayerTestsDefinitions {
         if (offsetsShape.empty()) { // Test without optional third input (offsets)
             params = ov::ParameterVector{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(dataShape)),
                                          std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(roisShape))};
-            inputs = ngraph::helpers::convert2OutputVector(
-                    ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-            defomablePSROIPooling = std::make_shared<ngraph::op::v1::DeformablePSROIPooling>(inputs[0],
-                                                                                                inputs[1],
+            defomablePSROIPooling = std::make_shared<ngraph::op::v1::DeformablePSROIPooling>(params[0],
+                                                                                                params[1],
                                                                                                 outputDim,
                                                                                                 spatialScale_,
                                                                                                 groupSize,
@@ -113,11 +111,9 @@ namespace LayerTestsDefinitions {
             params = ov::ParameterVector{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(dataShape)),
                                          std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(roisShape)),
                                          std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(offsetsShape))};
-            inputs = ngraph::helpers::convert2OutputVector(
-                    ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-            defomablePSROIPooling = std::make_shared<ngraph::op::v1::DeformablePSROIPooling>(inputs[0],
-                                                                                                inputs[1],
-                                                                                                inputs[2],
+            defomablePSROIPooling = std::make_shared<ngraph::op::v1::DeformablePSROIPooling>(params[0],
+                                                                                                params[1],
+                                                                                                params[2],
                                                                                                 outputDim,
                                                                                                 spatialScale_,
                                                                                                 groupSize,

--- a/src/tests/functional/shared_test_classes/src/single_layer/detection_output.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/detection_output.cpp
@@ -152,11 +152,13 @@ void DetectionOutputLayerTest::SetUp() {
     }
 
     ov::ParameterVector params;
+    ov::OutputVector paramsOuts;
     for (auto&& shape : inShapes) {
-        params.push_back(std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape(shape)));
+        auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape(shape));
+        params.push_back(param);
+        paramsOuts.push_back(param);
     }
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(params));
-    auto detOut = ngraph::builder::makeDetectionOutput(paramOuts, attrs);
+    auto detOut = ngraph::builder::makeDetectionOutput(paramsOuts, attrs);
     ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(detOut)};
     function = std::make_shared<ngraph::Function>(results, params, "DetectionOutput");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/dft.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/dft.cpp
@@ -37,8 +37,7 @@ void DFTLayerTest::SetUp() {
     auto paramData = std::make_shared<ngraph::opset1::Parameter>(inType, ngraph::Shape(inputShapes));
     paramVector.push_back(paramData);
 
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramVector));
-    auto dft = ngraph::builder::makeDFT(paramOuts[0], axes, signalSize, opType);
+    auto dft = ngraph::builder::makeDFT(paramVector[0], axes, signalSize, opType);
 
 
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(dft)};

--- a/src/tests/functional/shared_test_classes/src/single_layer/einsum.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/einsum.cpp
@@ -34,12 +34,14 @@ void EinsumLayerTest::SetUp() {
 
     const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(precision);
     ov::ParameterVector params;
+    ov::OutputVector paramsOuts;
     for (auto&& shape : inputShapes) {
-        params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shape)));
+        auto param = std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shape));
+        params.push_back(param);
+        paramsOuts.push_back(param);
     }
-    const auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
-    const std::shared_ptr<ngraph::Node> einsum = ngraph::builder::makeEinsum(paramOuts, equation);
+    const std::shared_ptr<ngraph::Node> einsum = ngraph::builder::makeEinsum(paramsOuts, equation);
     const ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(einsum)};
     function = std::make_shared<ngraph::Function>(results, params, "einsum");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_detection_output.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_detection_output.cpp
@@ -87,10 +87,9 @@ void ExperimentalDetectronDetectionOutputLayerTest::SetUp() {
     init_input_shapes(inputShapes);
 
     ov::ParameterVector params;
-    for (auto&& shape : inputDynamicShapes) {
+    for (auto&& shape : inputDynamicShapes)
         params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
-    }
-    auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
     auto experimentalDetectron = std::make_shared<ngraph::opset6::ExperimentalDetectronDetectionOutput>(
         params[0], // input_rois
         params[1], // input_deltas

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_generate_proposals_single_image.cpp
@@ -76,10 +76,9 @@ void ExperimentalDetectronGenerateProposalsSingleImageLayerTest::SetUp() {
     init_input_shapes(inputShapes);
 
     ov::ParameterVector params;
-    for (auto&& shape : inputDynamicShapes) {
+    for (auto&& shape : inputDynamicShapes)
         params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
-    }
-    auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
     auto experimentalDetectron = std::make_shared<ov::op::v6::ExperimentalDetectronGenerateProposalsSingleImage>(
         params[0], // im_info
         params[1], // anchors

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_prior_grid_generator.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_prior_grid_generator.cpp
@@ -59,10 +59,9 @@ void ExperimentalDetectronPriorGridGeneratorLayerTest::SetUp() {
     init_input_shapes(param.inputShapes);
 
     ov::ParameterVector params;
-    for (auto&& shape : inputDynamicShapes) {
+    for (auto&& shape : inputDynamicShapes)
         params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
-    }
-    auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
     auto experimentalDetectron = std::make_shared<op::v6::ExperimentalDetectronPriorGridGenerator>(
         params[0], // priors
         params[1], // feature_map

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_roifeatureextractor.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_roifeatureextractor.cpp
@@ -67,10 +67,12 @@ void ExperimentalDetectronROIFeatureExtractorLayerTest::SetUp() {
     attrs.pyramid_scales = pyramidScales;
 
     ov::ParameterVector params;
+    ov::OutputVector paramsOuts;
     for (auto&& shape : inputDynamicShapes) {
-        params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
+        auto param = std::make_shared<ov::op::v0::Parameter>(netPrecision, shape);
+        params.push_back(param);
+        paramsOuts.push_back(param);
     }
-    auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto experimentalDetectronROIFeatureExtractor = std::make_shared<ExperimentalROI>(paramsOuts, attrs);
     function = std::make_shared<ov::Model>(ov::OutputVector{experimentalDetectronROIFeatureExtractor->output(0),
                                                                experimentalDetectronROIFeatureExtractor->output(1)},

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_topkrois.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_topkrois.cpp
@@ -51,11 +51,10 @@ void ExperimentalDetectronTopKROIsLayerTest::SetUp() {
     init_input_shapes(inputShapes);
 
     ov::ParameterVector params;
-    for (auto&& shape : inputDynamicShapes) {
+    for (auto&& shape : inputDynamicShapes)
         params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
-    }
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto experimentalDetectronTopKROIs = std::make_shared<ov::op::v6::ExperimentalDetectronTopKROIs>(paramOuts[0], paramOuts[1], maxRois);
+
+    auto experimentalDetectronTopKROIs = std::make_shared<ov::op::v6::ExperimentalDetectronTopKROIs>(params[0], params[1], maxRois);
     function = std::make_shared<ov::Model>(ov::OutputVector {experimentalDetectronTopKROIs->output(0)}, "ExperimentalDetectronTopKROIs");
 }
 } // namespace subgraph

--- a/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
@@ -69,7 +69,6 @@ void FakeQuantizeLayerTest::SetUp() {
     }
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
     UpdateSeed();
 
@@ -81,10 +80,10 @@ void FakeQuantizeLayerTest::SetUp() {
         }
         std::cout << "\033[0;32m" << "[          ] " << "\033[0;0m"
                   << "ngraphSeed = " << ngraphSeed << std::endl;
-        fakeQNode = ngraph::builder::makeFakeQuantize(paramOuts[0], ngPrc, levels, constShape, ngraphSeed);
+        fakeQNode = ngraph::builder::makeFakeQuantize(params[0], ngPrc, levels, constShape, ngraphSeed);
     } else {
         fakeQNode = ngraph::builder::makeFakeQuantize(
-            paramOuts[0],
+            params[0],
             ngPrc,
             levels,
             constShape,

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
@@ -16,10 +16,9 @@ void GatherLayerTestBase::SetUp(const gatherParamsTuple& params) {
     ASSERT_EQ(ngraph::shape_size(indicesShape), indices.size()) << "Indices vector size and provided indices shape doesn't fit each other";
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector functionParams {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(functionParams));
     auto indicesNode = ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape(indicesShape), indices);
     auto axisNode = ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape({}), {axis});
-    auto gather = std::make_shared<ngraph::opset3::Gather>(paramOuts[0], indicesNode, axisNode);
+    auto gather = std::make_shared<ngraph::opset3::Gather>(functionParams[0], indicesNode, axisNode);
     ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(gather)};
     function = std::make_shared<ngraph::Function>(results, functionParams, "gather");
 }
@@ -84,11 +83,10 @@ void Gather7LayerTest::SetUp() {
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector functionParams {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(functionParams));
     auto indicesNode = ngraph::builder::makeConstant<int>(ngraph::element::i64, indicesShape, {}, true,
                                                           inputShape[axis < 0 ? axis + inputShape.size() : axis] - 1, 0);
     auto axisNode = ngraph::opset7::Constant::create(ngraph::element::i64, ngraph::Shape({}), { axis });
-    auto gather = std::make_shared<ngraph::opset7::Gather>(paramOuts[0], indicesNode, axisNode, batchIdx);
+    auto gather = std::make_shared<ngraph::opset7::Gather>(functionParams[0], indicesNode, axisNode, batchIdx);
     ngraph::ResultVector results{ std::make_shared<ngraph::opset7::Result>(gather) };
     function = std::make_shared<ngraph::Function>(results, functionParams, "gather");
 }
@@ -126,12 +124,11 @@ void Gather8LayerTest::SetUp() {
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector functionParams {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(functionParams));
     auto indicesNode = ngraph::builder::makeConstant<int>(ngraph::element::i64, indicesShape, {}, true,
                                                           inputShape[axis < 0 ? axis + inputShape.size() : axis] - 1,
                                                           -static_cast<int>(inputShape[axis < 0 ? axis + inputShape.size() : axis]));
     auto axisNode = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape({}), { axis });
-    auto gather = std::make_shared<ngraph::opset8::Gather>(paramOuts[0], indicesNode, axisNode, batchIdx);
+    auto gather = std::make_shared<ngraph::opset8::Gather>(functionParams[0], indicesNode, axisNode, batchIdx);
     ngraph::ResultVector results{ std::make_shared<ngraph::opset8::Result>(gather) };
     function = std::make_shared<ngraph::Function>(results, functionParams, "gather");
 }
@@ -169,11 +166,10 @@ void Gather8IndiceScalarLayerTest::SetUp() {
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector functionParams {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(functionParams));
     auto indicesNode = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{}, {inputShape[axis] - 1})->output(0);
 
     auto axisNode = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape({}), { axis });
-    auto gather = std::make_shared<ngraph::opset8::Gather>(paramOuts[0], indicesNode, axisNode, batchIdx);
+    auto gather = std::make_shared<ngraph::opset8::Gather>(functionParams[0], indicesNode, axisNode, batchIdx);
     ngraph::ResultVector results{ std::make_shared<ngraph::opset8::Result>(gather) };
     function = std::make_shared<ngraph::Function>(results, functionParams, "gather");
 }
@@ -222,10 +218,9 @@ void Gather8withIndicesDataLayerTest::SetUp() {
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector functionParams {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(functionParams));
     auto indicesNode = ngraph::builder::makeConstant<int>(ngraph::element::i64, indicesShape, indicesData);
     auto axisNode = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape({}), { axis });
-    auto gather = std::make_shared<ngraph::opset8::Gather>(paramOuts[0], indicesNode, axisNode, batchIdx);
+    auto gather = std::make_shared<ngraph::opset8::Gather>(functionParams[0], indicesNode, axisNode, batchIdx);
     ngraph::ResultVector results{ std::make_shared<ngraph::opset8::Result>(gather) };
     function = std::make_shared<ngraph::Function>(results, functionParams, "gather");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather_elements.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather_elements.cpp
@@ -41,10 +41,8 @@ void GatherElementsLayerTest::SetUp() {
     auto ngIPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(iPrecision);
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngDPrc, ov::Shape(dataShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto gather = std::dynamic_pointer_cast<ngraph::op::v6::GatherElements>(
-            ngraph::builder::makeGatherElements(paramOuts[0], indicesShape, ngIPrc, axis));
+            ngraph::builder::makeGatherElements(params[0], indicesShape, ngIPrc, axis));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(gather)};
     function = std::make_shared<ngraph::Function>(results, params, "gatherEl");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather_nd.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather_nd.cpp
@@ -45,9 +45,7 @@ void GatherNDLayerTest::SetUp() {
     auto ngIPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(iPrecision);
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngDPrc, ov::Shape(dataShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto dataNode = paramOuts[0];
+    auto dataNode = params[0];
     auto gather = std::dynamic_pointer_cast<ngraph::opset5::GatherND>(
             ngraph::builder::makeGatherND(dataNode, indicesShape, ngIPrc, batchDims));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(gather)};
@@ -71,9 +69,7 @@ void GatherND8LayerTest::SetUp() {
     auto ngIPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(iPrecision);
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngDPrc, ov::Shape(dataShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-        ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto dataNode = paramOuts[0];
+    auto dataNode = params[0];
     auto gather = std::dynamic_pointer_cast<ngraph::opset8::GatherND>(
         ngraph::builder::makeGatherND8(dataNode, indicesShape, ngIPrc, batchDims));
     ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(gather) };

--- a/src/tests/functional/shared_test_classes/src/single_layer/generate_proposals.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/generate_proposals.cpp
@@ -93,10 +93,9 @@ void GenerateProposalsLayerTest::SetUp() {
     init_input_shapes(inputShapes);
 
     ov::ParameterVector params;
-    for (auto&& shape : inputDynamicShapes) {
+    for (auto&& shape : inputDynamicShapes)
         params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
-    }
-    auto paramsOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
     auto generateProposals = std::make_shared<ov::op::v9::GenerateProposals>(
         params[0], // im_info
         params[1], // anchors

--- a/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
@@ -37,9 +37,7 @@ void GrnLayerTest::SetUp() {
     std::tie(netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, bias, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector paramsIn {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes))};
-    auto paramsOut = ngraph::helpers::convert2OutputVector(
-        ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
-    auto grn = std::make_shared<ngraph::opset1::GRN>(paramsOut[0], bias);
+    auto grn = std::make_shared<ngraph::opset1::GRN>(paramsIn[0], bias);
     ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(grn) };
     function = std::make_shared<ngraph::Function>(results, paramsIn, "Grn");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
@@ -51,10 +51,8 @@ void GroupConvolutionLayerTest::SetUp() {
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto groupConv = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolution>(
-            ngraph::builder::makeGroupConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
+            ngraph::builder::makeGroupConvolution(params[0], ngPrc, kernel, stride, padBegin,
                                              padEnd, dilation, padType, convOutChannels, numGroups));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(groupConv)};
     function = std::make_shared<ngraph::Function>(results, params, "groupConvolution");

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
@@ -53,10 +53,8 @@ void GroupConvBackpropDataLayerTest::SetUp() {
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvBackpropDataParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto groupConvBackpropData = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolutionBackpropData>(
-            ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
+            ngraph::builder::makeGroupConvolutionBackpropData(params[0], ngPrc, kernel, stride, padBegin,
                                              padEnd, dilation, padType, convOutChannels, numGroups));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(groupConvBackpropData)};
     function = std::make_shared<ngraph::Function>(results, params, "GroupConvolutionBackpropData");
@@ -109,17 +107,15 @@ void GroupConvBackpropLayerTest::SetUp() {
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType, outPadding) = groupConvBackpropDataParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     std::shared_ptr<ngraph::op::v1::GroupConvolutionBackpropData> groupConvBackpropData;
     if (!outputShape.empty()) {
         auto outShape = ngraph::opset3::Constant::create(ngraph::element::i64, {outputShape.size()}, outputShape);
         groupConvBackpropData = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolutionBackpropData>(
-        ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], outShape, ngPrc, kernel, stride, padBegin,
+        ngraph::builder::makeGroupConvolutionBackpropData(params[0], outShape, ngPrc, kernel, stride, padBegin,
                                                         padEnd, dilation, padType, convOutChannels, numGroups, false, outPadding));
     } else {
         groupConvBackpropData = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolutionBackpropData>(
-        ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
+        ngraph::builder::makeGroupConvolutionBackpropData(params[0], ngPrc, kernel, stride, padBegin,
                                              padEnd, dilation, padType, convOutChannels, numGroups, false, outPadding));
     }
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(groupConvBackpropData)};

--- a/src/tests/functional/shared_test_classes/src/single_layer/is_inf.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/is_inf.cpp
@@ -62,10 +62,9 @@ void IsInfLayerTest::SetUp() {
         parameters.push_back(std::make_shared<ov::op::v0::Parameter>(dataPrc, shape));
     }
     parameters[0]->set_friendly_name("Data");
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(parameters));
 
     ov::op::v10::IsInf::Attributes attributes {detectNegative, detectPositive};
-    auto isInf = std::make_shared<ov::op::v10::IsInf>(paramOuts[0], attributes);
+    auto isInf = std::make_shared<ov::op::v10::IsInf>(parameters[0], attributes);
     ov::ResultVector results;
     for (int i = 0; i < isInf->get_output_size(); i++) {
         results.push_back(std::make_shared<ov::op::v0::Result>(isInf->output(i)));

--- a/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
@@ -41,10 +41,7 @@ void LogSoftmaxLayerTest::SetUp() {
 
     const ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
 
-    const auto paramOuts =
-        ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-
-    const auto logSoftmax = std::make_shared<ngraph::op::v5::LogSoftmax>(paramOuts.at(0), axis);
+    const auto logSoftmax = std::make_shared<ngraph::op::v5::LogSoftmax>(params.at(0), axis);
 
     const ngraph::ResultVector results {std::make_shared<ngraph::opset1::Result>(logSoftmax)};
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/lrn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/lrn.cpp
@@ -42,11 +42,9 @@ void LrnLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes))};
-    auto paramIn =
-        ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
     auto axes_node = std::make_shared<ngraph::op::Constant>(ngraph::element::i64, ngraph::Shape{axes.size()}, axes.data());
-    auto lrn = std::make_shared<ngraph::opset3::LRN>(paramIn[0], axes_node, alpha, beta, bias, size);
+    auto lrn = std::make_shared<ngraph::opset3::LRN>(params[0], axes_node, alpha, beta, bias, size);
     ngraph::ResultVector results {std::make_shared<ngraph::opset3::Result>(lrn)};
     function = std::make_shared<ngraph::Function>(results, params, "lrn");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/lstm_cell_basic.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/lstm_cell_basic.cpp
@@ -64,10 +64,12 @@ void LSTMCellBasicTest::SetUp() {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes[0])),
                                std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes[1])),
                                std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes[2]))};
+    ov::OutputVector paramsOuts;
+    for (auto&& param : params)
+        paramsOuts.push_back(param);
 
     std::vector<ngraph::Shape> WRB = {inputShapes[3], inputShapes[4], inputShapes[5]};
-    auto lstm_cell = ngraph::builder::makeLSTM(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
-            WRB, hidden_size, activations, {}, {}, clip);
+    auto lstm_cell = ngraph::builder::makeLSTM(paramsOuts, WRB, hidden_size, activations, {}, {}, clip);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(lstm_cell->output(0)),
                                  std::make_shared<ngraph::opset1::Result>(lstm_cell->output(1))};
     function = std::make_shared<ngraph::Function>(results, params, "lstm_cell");

--- a/src/tests/functional/shared_test_classes/src/single_layer/mat_mul.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/mat_mul.cpp
@@ -67,10 +67,8 @@ void MatMulTest::SetUp() {
     if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
         params.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(secondaryInput));
     }
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto MatMul = std::dynamic_pointer_cast<ngraph::opset3::MatMul>(
-            ngraph::builder::makeMatMul(paramOuts[0], secondaryInput, shapeRelatedParams.input1.second, shapeRelatedParams.input2.second));
+            ngraph::builder::makeMatMul(params[0], secondaryInput, shapeRelatedParams.input1.second, shapeRelatedParams.input2.second));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(MatMul)};
     function = std::make_shared<ngraph::Function>(results, params, "MatMul");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/matrix_nms.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/matrix_nms.cpp
@@ -319,9 +319,7 @@ void MatrixNmsLayerTest::SetUp() {
     for (auto&& shape : inputDynamicShapes) {
         params.push_back(std::make_shared<ov::op::v0::Parameter>(paramsPrec, shape));
     }
-    const auto paramOuts =
-            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto nms = std::make_shared<opset8::MatrixNms>(paramOuts[0], paramOuts[1], m_attrs);
+    auto nms = std::make_shared<opset8::MatrixNms>(params[0], params[1], m_attrs);
 
     function = std::make_shared<Function>(nms, params, "MatrixNMS");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/multiclass_nms.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/multiclass_nms.cpp
@@ -378,8 +378,6 @@ void MulticlassNmsLayerTest::SetUp() {
             params.push_back(std::make_shared<ov::op::v0::Parameter>(paramsPrec, shape));
         }
     }
-    const auto paramOuts =
-            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
     m_attrs.iou_threshold = iouThr;
     m_attrs.score_threshold = scoreThr;
@@ -392,7 +390,12 @@ void MulticlassNmsLayerTest::SetUp() {
     m_attrs.background_class = backgroundClass;
     m_attrs.normalized = normalized;
 
-    const auto nms = CreateNmsOp(paramOuts);
+    std::shared_ptr<ov::Node> nms;
+    if (params.size() > 2) {
+        nms = std::make_shared<ov::op::v9::MulticlassNms>(params[0], params[1], params[2], m_attrs);
+    } else {
+        nms = std::make_shared<ov::op::v9::MulticlassNms>(params[0], params[1], m_attrs);
+    }
 
     function = std::make_shared<Function>(nms, params, "MulticlassNMS");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/mvn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/mvn.cpp
@@ -38,10 +38,9 @@ void Mvn1LayerTest::SetUp() {
     std::tie(inputShapes, inputPrecision, axes, acrossChanels, normalizeVariance, eps, targetDevice) = this->GetParam();
     auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
     ov::ParameterVector param {std::make_shared<ov::op::v0::Parameter>(inType, ov::Shape(inputShapes))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(param));
-    auto mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(paramOuts[0], acrossChanels, normalizeVariance, eps));
+    auto mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(param[0], acrossChanels, normalizeVariance, eps));
     if (!axes.empty()) {
-        mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(paramOuts[0], axes, normalizeVariance, eps));
+        mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(param[0], axes, normalizeVariance, eps));
     }
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(mvn)};
     function = std::make_shared<ngraph::Function>(results, param, "MVN1");
@@ -82,9 +81,8 @@ void Mvn6LayerTest::SetUp() {
     auto axesType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(axesPrecision);
 
     ov::ParameterVector param {std::make_shared<ov::op::v0::Parameter>(dataType, ov::Shape(inputShapes))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(param));
     auto axesNode = ngraph::builder::makeConstant(axesType, ngraph::Shape{axes.size()}, axes);
-    auto mvn = ngraph::builder::makeMVN6(paramOuts[0], axesNode, normalizeVariance, eps, epsMode);
+    auto mvn = ngraph::builder::makeMVN6(param[0], axesNode, normalizeVariance, eps, epsMode);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(mvn)};
     function = std::make_shared<ngraph::Function>(results, param, "MVN6");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/one_hot.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/one_hot.cpp
@@ -42,10 +42,8 @@ void OneHotLayerTest::SetUp() {
     this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(params));
 
-    auto onehot = ngraph::builder::makeOneHot(paramOuts[0], depth_type, depth_val, set_type, on_val, off_val, axis);
+    auto onehot = ngraph::builder::makeOneHot(params[0], depth_type, depth_val, set_type, on_val, off_val, axis);
     ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(onehot)};
     function = std::make_shared<ngraph::Function>(results, params, "OneHot");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/pad.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pad.cpp
@@ -44,9 +44,7 @@ void PadLayerTest::SetUp() {
     this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(params));
-    auto pad = CreatePadOp(paramOuts[0], padsBegin, padsEnd, argPadValue, padMode);
+    auto pad = CreatePadOp(params[0], padsBegin, padsEnd, argPadValue, padMode);
     ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(pad)};
     function = std::make_shared<ngraph::Function>(results, params, "pad");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
@@ -145,10 +145,8 @@ void PoolingLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
-    std::shared_ptr<ngraph::Node> pooling = ngraph::builder::makePooling(paramOuts[0],
+    std::shared_ptr<ngraph::Node> pooling = ngraph::builder::makePooling(params[0],
                                                                          stride,
                                                                          padBegin,
                                                                          padEnd,
@@ -179,10 +177,8 @@ void GlobalPoolingLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
-    std::shared_ptr<ngraph::Node> pooling = ngraph::builder::makePooling(paramOuts[0],
+    std::shared_ptr<ngraph::Node> pooling = ngraph::builder::makePooling(params[0],
                                                                          stride,
                                                                          padBegin,
                                                                          padEnd,
@@ -211,10 +207,8 @@ void MaxPoolingV8LayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
-    std::shared_ptr<ngraph::Node> maxPool = ngraph::builder::makeMaxPoolingV8(paramOuts[0], stride, dilation, padBegin, padEnd,
+    std::shared_ptr<ngraph::Node> maxPool = ngraph::builder::makeMaxPoolingV8(params[0], stride, dilation, padBegin, padEnd,
                                                                               kernel, roundingType, padType,
                                                                               indexElementType, axis);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/proposal.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/proposal.cpp
@@ -151,10 +151,9 @@ void ProposalLayerTest::SetUp() {
                                std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(boxesShape))};
     params[0]->set_friendly_name("a_scores");
     params[1]->set_friendly_name("b_boxes");
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
     auto proposal = std::dynamic_pointer_cast<ngraph::opset4::Proposal>(
-             ngraph::builder::makeProposal(paramOuts[0], paramOuts[1], img_info, ngPrc,
+             ngraph::builder::makeProposal(params[0], params[1], img_info, ngPrc,
                                            base_size,
                                            pre_nms_topn,
                                            post_nms_topn,

--- a/src/tests/functional/shared_test_classes/src/single_layer/psroi_pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/psroi_pooling.cpp
@@ -109,10 +109,8 @@ void PSROIPoolingLayerTest::SetUp() {
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape)),
                                 std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(coordsShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    std::shared_ptr<ngraph::Node> psroiPooling = std::make_shared<ngraph::op::v0::PSROIPooling>(paramOuts[0],
-                                                                                                paramOuts[1],
+    std::shared_ptr<ngraph::Node> psroiPooling = std::make_shared<ngraph::op::v0::PSROIPooling>(params[0],
+                                                                                                params[1],
                                                                                                 outputDim,
                                                                                                 groupSize_,
                                                                                                 spatialScale_,

--- a/src/tests/functional/shared_test_classes/src/single_layer/rdft.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/rdft.cpp
@@ -37,9 +37,7 @@ void RDFTLayerTest::SetUp() {
     auto paramData = std::make_shared<ngraph::opset1::Parameter>(inType, ngraph::Shape(inputShapes));
     paramVector.push_back(paramData);
 
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramVector));
-    auto rdft = ngraph::builder::makeRDFT(paramOuts[0], axes, signalSize, opType);
-
+    auto rdft = ngraph::builder::makeRDFT(paramVector[0], axes, signalSize, opType);
 
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(rdft)};
     function = std::make_shared<ngraph::Function>(results, paramVector, "RDFT");

--- a/src/tests/functional/shared_test_classes/src/single_layer/reduce_ops.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reduce_ops.cpp
@@ -42,8 +42,6 @@ void ReduceOpsLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
     std::vector<size_t> shapeAxes;
     switch (opType) {
@@ -62,7 +60,7 @@ void ReduceOpsLayerTest::SetUp() {
     auto reductionAxesNode = std::dynamic_pointer_cast<ngraph::Node>(
                              std::make_shared<ngraph::opset3::Constant>(ngraph::element::Type_t::i64, ngraph::Shape(shapeAxes), axes));
 
-    const auto reduce = ngraph::builder::makeReduce(paramOuts[0], reductionAxesNode, keepDims, reductionType);
+    const auto reduce = ngraph::builder::makeReduce(params[0], reductionAxesNode, keepDims, reductionType);
     const ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(reduce)};
     function = std::make_shared<ngraph::Function>(results, params, "Reduce");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
@@ -37,12 +37,10 @@ void ReshapeLayerTest::SetUp() {
         this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector paramsIn {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes))};
-    auto paramIn = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
     auto constNode = std::make_shared<ngraph::opset1::Constant>(
             ngraph::element::Type_t::i64, ngraph::Shape{outFormShapes.size()}, outFormShapes);
     auto reshape = std::dynamic_pointer_cast<ngraph::opset1::Reshape>(
-            std::make_shared<ngraph::opset1::Reshape>(paramIn[0], constNode, specialZero));
+            std::make_shared<ngraph::opset1::Reshape>(paramsIn[0], constNode, specialZero));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(reshape)};
     function = std::make_shared<ngraph::Function>(results, paramsIn, "Reshape");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/roi_align.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/roi_align.cpp
@@ -92,8 +92,6 @@ void ROIAlignLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts =
-        ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     std::vector<float> proposalVector;
     std::vector<int> roiIdxVector;
     proposalVector.resize(coordsShape[0] * 4);
@@ -106,7 +104,7 @@ void ROIAlignLayerTest::SetUp() {
     auto coords = std::make_shared<ngraph::opset1::Constant>(ngPrc, coordsShape, proposalVector.data());
     auto roisIdx = std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, idxShape, roiIdxVector.data());
 
-    std::shared_ptr<ngraph::Node> roiAlign = std::make_shared<ngraph::opset3::ROIAlign>(paramOuts[0],
+    std::shared_ptr<ngraph::Node> roiAlign = std::make_shared<ngraph::opset3::ROIAlign>(params[0],
                                                                                         coords,
                                                                                         roisIdx,
                                                                                         pooledH,
@@ -173,8 +171,6 @@ void ROIAlignV9LayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts =
-        ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     std::vector<float> proposalVector;
     std::vector<int> roiIdxVector;
     proposalVector.resize(coordsShape[0] * 4);
@@ -194,7 +190,7 @@ void ROIAlignV9LayerTest::SetUp() {
     auto roisIdx = std::make_shared<ngraph::opset1::Constant>(ngraph::element::i32, idxShape, roiIdxVector.data());
 
     std::shared_ptr<ngraph::Node> roiAlign = std::make_shared<ngraph::opset9::ROIAlign>(
-            paramOuts[0],
+            params[0],
             coords,
             roisIdx,
             pooledH,

--- a/src/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
@@ -74,10 +74,8 @@ namespace LayerTestsDefinitions {
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape)),
                                     std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(coordsShape))};
-        auto paramOuts = ngraph::helpers::convert2OutputVector(
-                ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-        std::shared_ptr<ngraph::Node> roi_pooling = ngraph::builder::makeROIPooling(paramOuts[0],
-                                                                                    paramOuts[1],
+        std::shared_ptr<ngraph::Node> roi_pooling = ngraph::builder::makeROIPooling(params[0],
+                                                                                    params[1],
                                                                                     poolShape,
                                                                                     spatial_scale,
                                                                                     pool_method);

--- a/src/tests/functional/shared_test_classes/src/single_layer/scatter_ND_update.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/scatter_ND_update.cpp
@@ -66,8 +66,7 @@ void ScatterNDUpdateLayerTest::SetUp() {
     paramVector.push_back(inputParams);
     auto updateParams = std::make_shared<ngraph::opset1::Parameter>(inPrc, ngraph::Shape(updateShape));
     paramVector.push_back(updateParams);
-    auto paramVectorOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramVector));
-    auto s2d = ngraph::builder::makeScatterNDUpdate(paramVectorOuts[0], idxPrc, indicesShape, indicesValue, paramVectorOuts[1]);
+    auto s2d = ngraph::builder::makeScatterNDUpdate(paramVector[0], idxPrc, indicesShape, indicesValue, paramVector[1]);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2d)};
     function = std::make_shared<ngraph::Function>(results, paramVector, "ScatterNDUpdate");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/scatter_elements_update.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/scatter_elements_update.cpp
@@ -57,8 +57,7 @@ void ScatterElementsUpdateLayerTest::SetUp() {
     paramVector.push_back(inputParams);
     auto updateParams = std::make_shared<ngraph::opset1::Parameter>(inPrc, ngraph::Shape(indicesShape));
     paramVector.push_back(updateParams);
-    auto paramVectorOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramVector));
-    auto s2d = ngraph::builder::makeScatterElementsUpdate(paramVectorOuts[0], idxPrc, indicesShape, indicesValue, paramVectorOuts[1], axis);
+    auto s2d = ngraph::builder::makeScatterElementsUpdate(paramVector[0], idxPrc, indicesShape, indicesValue, paramVector[1], axis);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2d)};
     function = std::make_shared<ngraph::Function>(results, paramVector, "ScatterElementsUpdate");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/scatter_update.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/scatter_update.cpp
@@ -76,8 +76,7 @@ void ScatterUpdateLayerTest::SetUp() {
     paramVector.push_back(inputParams);
     auto updateParams = std::make_shared<ngraph::opset1::Parameter>(inPrc, ngraph::Shape(updateShape));
     paramVector.push_back(updateParams);
-    auto paramVectorOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramVector));
-    auto s2d = ngraph::builder::makeScatterUpdate(paramVectorOuts[0], idxPrc, indicesShape, indicesValue, paramVectorOuts[1], axis);
+    auto s2d = ngraph::builder::makeScatterUpdate(paramVector[0], idxPrc, indicesShape, indicesValue, paramVector[1], axis);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2d)};
     function = std::make_shared<ngraph::Function>(results, paramVector, "ScatterUpdate");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/shape_of.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/shape_of.cpp
@@ -27,8 +27,7 @@ namespace LayerTestsDefinitions {
         auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
         auto outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
         ov::ParameterVector param {std::make_shared<ov::op::v0::Parameter>(inType, ov::Shape(inputShapes))};
-        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(param));
-        auto shapeOf = std::make_shared<ngraph::opset3::ShapeOf>(paramOuts[0], outType);
+        auto shapeOf = std::make_shared<ngraph::opset3::ShapeOf>(param[0], outType);
         ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(shapeOf)};
         function = std::make_shared<ngraph::Function>(results, param, "shapeOf");
     }

--- a/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
@@ -40,10 +40,8 @@ void ShuffleChannelsLayerTest::SetUp() {
     std::tie(axis, group) = shuffleChannelsParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto shuffleChannels = std::dynamic_pointer_cast<ngraph::opset3::ShuffleChannels>(
-            ngraph::builder::makeShuffleChannels(paramOuts[0], axis, group));
+            ngraph::builder::makeShuffleChannels(params[0], axis, group));
     ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(shuffleChannels)};
     function = std::make_shared<ngraph::Function>(results, params, "shuffleChannels");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
@@ -37,9 +37,7 @@ void SpaceToBatchLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto s2b = ngraph::builder::makeSpaceToBatch(paramOuts[0], ngPrc, blockShape, padsBegin, padsEnd);
+    auto s2b = ngraph::builder::makeSpaceToBatch(params[0], ngPrc, blockShape, padsBegin, padsEnd);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2b)};
     function = std::make_shared<ngraph::Function>(results, params, "SpaceToBatch");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/space_to_depth.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/space_to_depth.cpp
@@ -46,8 +46,7 @@ void SpaceToDepthLayerTest::SetUp() {
     std::tie(inShape, inputPrecision, mode, blockSize, targetDevice) = this->GetParam();
     auto inPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(inPrc, ov::Shape(inShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto s2d = ngraph::builder::makeSpaceToDepth(paramOuts[0], mode, blockSize);
+    auto s2d = ngraph::builder::makeSpaceToDepth(params[0], mode, blockSize);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2d)};
     function = std::make_shared<ngraph::Function>(results, params, "SpaceToDepth");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
@@ -44,9 +44,7 @@ void SplitLayerTest::SetUp() {
     }
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto split = std::dynamic_pointer_cast<ngraph::opset5::Split>(ngraph::builder::makeSplit(paramOuts[0],
+    auto split = std::dynamic_pointer_cast<ngraph::opset5::Split>(ngraph::builder::makeSplit(params[0],
                                                                                              ngPrc, numSplits, axis));
     ngraph::ResultVector results;
     for (int i = 0; i < outIndices.size(); i++) {

--- a/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
@@ -44,9 +44,7 @@ void StridedSliceLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(ssParams.inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto ss = ngraph::builder::makeStridedSlice(paramOuts[0], ssParams.begin, ssParams.end, ssParams.strides, ngPrc, ssParams.beginMask,
+    auto ss = ngraph::builder::makeStridedSlice(params[0], ssParams.begin, ssParams.end, ssParams.strides, ngPrc, ssParams.beginMask,
                                                 ssParams.endMask, ssParams.newAxisMask, ssParams.shrinkAxisMask, ssParams.ellipsisAxisMask);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(ss)};
     function = std::make_shared<ngraph::Function>(results, params, "StridedSlice");

--- a/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
@@ -34,9 +34,7 @@ void TileLayerTest::SetUp() {
     std::tie(tileParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto tile = ngraph::builder::makeTile(paramOuts[0], tileParams);
+    auto tile = ngraph::builder::makeTile(params[0], tileParams);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(tile)};
     function = std::make_shared<ngraph::Function>(results, params, "tile");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/topk.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/topk.cpp
@@ -39,12 +39,10 @@ void TopKLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramIn = ngraph::helpers::convert2OutputVector(
-                        ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
     auto k = std::make_shared<ngraph::opset3::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{}, &keepK);
     auto topk = std::dynamic_pointer_cast<ngraph::opset4::TopK>(
-            std::make_shared<ngraph::opset4::TopK>(paramIn[0], k, axis, mode, sort));
+            std::make_shared<ngraph::opset4::TopK>(params[0], k, axis, mode, sort));
 
     ngraph::ResultVector results;
     for (size_t i = 0; i < topk->get_output_size(); i++) {

--- a/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
@@ -32,14 +32,12 @@ void TransposeLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto paramOuts = ngraph::helpers::convert2OutputVector(
-            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
 
     const auto inOrderShape = inputOrder.empty() ? ngraph::Shape({0}) : ngraph::Shape({inputShape.size()});
     const auto inputOrderOp = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64,
                                                                          inOrderShape,
                                                                          inputOrder);
-    const auto transpose = std::make_shared<ngraph::opset3::Transpose>(paramOuts.at(0), inputOrderOp);
+    const auto transpose = std::make_shared<ngraph::opset3::Transpose>(params.at(0), inputOrderOp);
     const ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(transpose)};
     function = std::make_shared<ngraph::Function>(results, params, "Transpose");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
@@ -36,8 +36,6 @@ namespace LayerTestsDefinitions {
         std::tie(numSplits, axis, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-        auto paramOuts = ngraph::helpers::convert2OutputVector(
-                ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(params));
         auto VariadicSplit = std::dynamic_pointer_cast<ngraph::opset3::VariadicSplit>(ngraph::builder::makeVariadicSplit(params[0], numSplits,
                 axis));
         ngraph::ResultVector results;


### PR DESCRIPTION
### Tickets:
 - [CVS-117139](https://jira.devtools.intel.com/browse/CVS-117139)
