### PR TITLE
FuseU4WeightsAndZeroPoint tests compilation fix

### DIFF
--- a/src/common/transformations/tests/common_optimizations/convert_u4_weights_zero_point_to_scalar.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_u4_weights_zero_point_to_scalar.cpp
@@ -113,7 +113,7 @@ TEST_F(TransformationTestsF, FuseU4WeightsAndZeroPointNotScalarLikeZP) {
     ov::Shape decompression_shape{32, 1, 64};
     auto weights = ov::op::v0::Constant::create(weights_precision, weights_shape, {4});
     auto convert = std::make_shared<ov::op::v0::Convert>(weights, decompression_precision);
-    std::vector<std::int8_t> zero_point_values(ov::shape_size(decompression_shape), 8);
+    std::vector<int> zero_point_values(ov::shape_size(decompression_shape), 8);
     zero_point_values.back() = 6;
     auto zero_point = ov::op::v0::Constant::create(weights_precision, decompression_shape, zero_point_values);
     auto zero_point_convert = std::make_shared<ov::op::v0::Convert>(zero_point, decompression_precision);


### PR DESCRIPTION
### Details:
-Werror=stringop-overflow= warning occurs in some new GCC versions (e.g. 11.4.0) because of the std::vector<std::int8_t> usage in the test code.
Since this is not necessary to use int8 vector in FuseU4WeightsAndZeroPoint tests, it is replaced with std::vector<int>.
PR to master branch: #20918 

### Tickets:
 - *CVS-124460*