### PR TITLE
[HETERO] Fix split subgraphs with parameter of different affinity

### DIFF
--- a/src/plugins/hetero/src/subgraph_collector.cpp
+++ b/src/plugins/hetero/src/subgraph_collector.cpp
@@ -212,7 +212,7 @@ void ov::hetero::SubgraphCollector::split_subgraphs_by_parameter_results() {
     for (const auto& input : ordered_subgraph_inputs) {
         if (!is_graph_input_node(input.get_node())) {
             auto input_source_output = input.get_source_output();
-            if (!is_graph_input_node(input_source_output.get_node())) {
+            if (!ov::op::util::is_constant(input_source_output.get_node())) {
                 ordered_subgraph_outputs.push_back(input_source_output);
             }
         }

--- a/src/plugins/hetero/tests/unit/subgraph_collector.cpp
+++ b/src/plugins/hetero/tests/unit/subgraph_collector.cpp
@@ -479,3 +479,16 @@ TEST_F(SubgraphCollectorTest2, submodel_replacement_both_devices) {
     ASSERT_EQ(exptected_mapping_info._submodels_input_to_prev_output,
               actual_mapping_info._submodels_input_to_prev_output);
 }
+
+TEST_F(SubgraphCollectorTest, submodel_with_different_affinity_parameter) {
+    const std::map<std::string, std::string> supported_ops_with_affinity = {
+        {"input", "MOCK.0"},
+        {"const_val", "MOCK.0"},
+        {"add", "MOCK.1"},
+        {"reshape_val", "MOCK.0"},
+        {"reshape", "MOCK.0"},
+        {"res", "MOCK.0"},
+    };
+    auto supported_ops = supported_ops_with_affinity;
+    ASSERT_NO_THROW(ov::hetero::mask_model_subgraphs_by_ops(m_model, supported_ops, false, "TEST"));
+}


### PR DESCRIPTION
### Details:
 - This issue was discovered when splitting the execution of LLama v2 7b on multiple GPUs
 - The subgraphs can not be generated because some ops has parameter with different affinity

### Tickets:
 - CVS-124326
