### PR TITLE
Refactor ngraph builders 2

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/mvn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/mvn.cpp
@@ -103,11 +103,11 @@ void MvnLayerCPUTest::SetUp() {
     for (auto&& shape : inputDynamicShapes)
         params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
 
-    std::shared_ptr<ov::Node> mvn;
+    std::shared_ptr<ov::op::v0::MVN> mvn;
     if (!axes.empty()) {
         mvn = std::make_shared<ov::op::v0::MVN>(params[0], axes, normalizeVariance, eps);
     } else {
-        auto mvnNode = std::make_shared<ov::op::v0::MVN>(params[0], acrossChanels, normalizeVariance, eps);
+        mvn = std::make_shared<ov::op::v0::MVN>(params[0], acrossChanels, normalizeVariance, eps);
 
         // OpenVINO MVN implementation implicitly adds 0th dimension to reduction axes set which is not valid behavior
         ov::AxisSet axes;
@@ -115,7 +115,7 @@ void MvnLayerCPUTest::SetUp() {
         const size_t numOfDims = params[0]->output(0).get_partial_shape().size();
         for (size_t i = startAxis; i < numOfDims; i++)
             axes.insert(i);
-        mvnNode->set_reduction_axes(axes);
+        mvn->set_reduction_axes(axes);
     }
 
     rel_threshold = 0.015f;

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/loop.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/loop.cpp
@@ -278,8 +278,13 @@ protected:
         }
 
         // Body
-        const auto axis = 1;
-        auto s = ngraph::builder::makeSlice(body_params[0], {0}, {1}, {1}, {axis}, inType);
+        ov::Shape constShape = {1};
+        auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{0});
+        auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{1});
+        auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{1});
+        auto axesNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{1});
+        auto s = std::make_shared<ov::op::v8::Slice>(body_params[0], beginNode, endNode, strideNode, axesNode);
+
         auto constant = ngraph::builder::makeConstant(inType, std::vector<size_t>{1}, std::vector<float>{0.5});
         auto eltwise = std::make_shared<ov::op::v1::Add>(body_params[0], constant);
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/slice.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/slice.cpp
@@ -116,14 +116,25 @@ protected:
                 // With axes parameter
                 auto axesNode = std::make_shared<ngraph::opset1::Parameter>(ov::element::i64, ov::Shape{sliceParams.axes.size()});
                 params.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(axesNode));
-                sliceNode = ngraph::builder::makeSlice(params[0], startNode, stopdNode, stepNode, axesNode);
+                sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], startNode, stopdNode, stepNode, axesNode);
             } else {
                 //without axes parameter
-                sliceNode = ngraph::builder::makeSlice(params[0], startNode, stopdNode, stepNode);
+                sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], startNode, stopdNode, stepNode);
             }
         } else if (secondaryInputType == ngraph::helpers::InputLayerType::CONSTANT) {
             // Slice start, stop, step, axes are const.
-            sliceNode = ngraph::builder::makeSlice(params[0], sliceParams.start, sliceParams.stop, sliceParams.step, sliceParams.axes, netPrecision);;
+            ov::Shape constShape = {sliceParams.start.size()};
+            auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.start.data());
+            auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.stop.data());
+            auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.step.data());
+            if (!sliceParams.axes.empty()) {
+                // With axes parameter
+                auto axesNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.axes.data());
+                sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], beginNode, endNode, strideNode, axesNode);
+            } else {
+                //without axes parameter
+                sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], beginNode, endNode, strideNode);
+            }
         } else {
             // Not supported others.
             IE_THROW() << "Slice8LayerCPUTest: Unsupported ngraph::helpers::InputLayerType , value: " << secondaryInputType;

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/remove_convert.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/remove_convert.cpp
@@ -47,16 +47,15 @@ public:
         auto begin = builder::makeConstant(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 0, 0, 0});
         auto end = builder::makeConstant(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 0, 16, 0});
         auto stride = builder::makeConstant(element::i64, ov::Shape{4}, std::vector<int64_t>{1, 1, 1, 1});
-        auto slice = builder::makeStridedSlice(convert,
-                                               begin,
-                                               end,
-                                               stride,
-                                               element::f32,
-                                               {0, 0, 0, 0},
-                                               {1, 1, 0, 1},
-                                               {},
-                                               {},
-                                               {});
+        auto slice = std::make_shared<ov::op::v1::StridedSlice>(convert,
+                                                                begin,
+                                                                end,
+                                                                stride,
+                                                                std::vector<int64_t>{0, 0, 0, 0},
+                                                                std::vector<int64_t>{1, 1, 0, 1},
+                                                                std::vector<int64_t>{},
+                                                                std::vector<int64_t>{},
+                                                                std::vector<int64_t>{});
         auto convert2 = std::make_shared<ov::op::v0::Convert>(slice, inType);
         function = std::make_shared<ov::Model>(convert2, ov::ParameterVector{input_params}, "remove_convert");
     };

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/strided_slice_zero_dims.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/strided_slice_zero_dims.cpp
@@ -46,7 +46,15 @@ public:
         auto axes = builder::makeConstant(element::i64, {1}, std::vector<int64_t>{0});
         auto shapeOf = std::make_shared<opset9::ShapeOf>(inputParams[1]);
         auto gather = std::make_shared<opset9::Gather>(shapeOf, indices, axes);
-        auto strided_slice = builder::makeStridedSlice(inputParams.front(), gather, end, stride, element::f32, {0}, {0});
+        auto strided_slice = std::make_shared<ov::op::v1::StridedSlice>(inputParams.front(),
+                                                                        gather,
+                                                                        end,
+                                                                        stride,
+                                                                        std::vector<int64_t>{0},
+                                                                        std::vector<int64_t>{0},
+                                                                        std::vector<int64_t>{},
+                                                                        std::vector<int64_t>{},
+                                                                        std::vector<int64_t>{});
         NodeVector results{strided_slice};
         function = std::make_shared<Function>(results, inputParams, "StridedSliceStaticShape");
     }

--- a/src/plugins/intel_gna/tests/functional/pass_tests/convolution_crop_axis_h.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/convolution_crop_axis_h.cpp
@@ -87,7 +87,9 @@ protected:
         const std::vector<int64_t> crop_end{20};
         const std::vector<int64_t> crop_stride{1};
         const std::vector<int64_t> axes{h_index_in_nchw};
+        OPENVINO_SUPPRESS_DEPRECATED_START
         auto split_node = ngraph::builder::makeSlice(convolution_node, crop_begin, crop_end, crop_stride, axes, ngPrc);
+        OPENVINO_SUPPRESS_DEPRECATED_END
 
         auto convolution_node2 = ngraph::builder::makeConvolution(split_node,
                                                                   ngPrc,

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/mvn.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/mvn.cpp
@@ -76,7 +76,10 @@ protected:
             params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
 
        auto axesNode = ngraph::builder::makeConstant(axesType, ngraph::Shape{axes.size()}, axes);
-       auto mvn = ngraph::builder::makeMVN6(params[0], axesNode, normalizeVariance, eps, eps_mode);
+       ov::op::MVNEpsMode nEpsMode = ov::op::MVNEpsMode::INSIDE_SQRT;
+       if (eps_mode == "outside_sqrt")
+           nEpsMode = ov::op::MVNEpsMode::OUTSIDE_SQRT;
+       auto mvn = std::make_shared<ov::op::v6::MVN>(params[0], axesNode, normalizeVariance, eps, nEpsMode);
 
        rel_threshold = 0.015f;
 

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/prior_box.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/prior_box.cpp
@@ -90,22 +90,36 @@ protected:
         inType = ov::element::Type(netPrecision);
         outType = ElementType::f32;
 
-        auto beginInput = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
-        auto endInput = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {4});
-        auto strideInput = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {1});
+        auto beginInput = ov::op::v0::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto endInput = ov::op::v0::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {4});
+        auto strideInput = ov::op::v0::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {1});
 
         ov::ParameterVector functionParams;
         for (auto&& shape : inputDynamicShapes)
             functionParams.push_back(std::make_shared<ov::op::v0::Parameter>(inType, shape));
 
-        auto shapeOfOp1 = std::make_shared<opset3::ShapeOf>(functionParams[0], element::i32);
-        auto shapeOfOp2 = std::make_shared<opset3::ShapeOf>(functionParams[1], element::i32);
+        auto shapeOfOp1 = std::make_shared<ov::op::v3::ShapeOf>(functionParams[0], element::i32);
+        auto shapeOfOp2 = std::make_shared<ov::op::v3::ShapeOf>(functionParams[1], element::i32);
 
+        auto stridedSliceOp1 = std::make_shared<ov::op::v1::StridedSlice>(shapeOfOp1,
+                                                                          beginInput,
+                                                                          endInput,
+                                                                          strideInput,
+                                                                          std::vector<int64_t>{0},
+                                                                          std::vector<int64_t>{1},
+                                                                          std::vector<int64_t>{0},
+                                                                          std::vector<int64_t>{0},
+                                                                          std::vector<int64_t>{0});
 
-        auto stridedSliceOp1 = ngraph::builder::makeStridedSlice(shapeOfOp1, beginInput, endInput, strideInput, element::i32,
-                                                                {0}, {1}, {0}, {0}, {0});
-        auto stridedSliceOp2 = ngraph::builder::makeStridedSlice(shapeOfOp2, beginInput, endInput, strideInput, element::i32,
-                                                                {0}, {1}, {0}, {0}, {0});
+        auto stridedSliceOp2 = std::make_shared<ov::op::v1::StridedSlice>(shapeOfOp2,
+                                                                          beginInput,
+                                                                          endInput,
+                                                                          strideInput,
+                                                                          std::vector<int64_t>{0},
+                                                                          std::vector<int64_t>{1},
+                                                                          std::vector<int64_t>{0},
+                                                                          std::vector<int64_t>{0},
+                                                                          std::vector<int64_t>{0});
 
         switch (priorboxType) {
             case priorbox_type::Clustered: {

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
@@ -36,7 +36,9 @@ void BatchToSpaceLayerTest::SetUp() {
     std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
+    OPENVINO_SUPPRESS_DEPRECATED_START
     auto b2s = ngraph::builder::makeBatchToSpace(params[0], ngPrc, blockShape, cropsBegin, cropsEnd);
+    OPENVINO_SUPPRESS_DEPRECATED_END
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(b2s)};
     function = std::make_shared<ngraph::Function>(results, params, "BatchToSpace");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/mvn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/mvn.cpp
@@ -38,10 +38,12 @@ void Mvn1LayerTest::SetUp() {
     std::tie(inputShapes, inputPrecision, axes, acrossChanels, normalizeVariance, eps, targetDevice) = this->GetParam();
     auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
     ov::ParameterVector param {std::make_shared<ov::op::v0::Parameter>(inType, ov::Shape(inputShapes))};
+    OPENVINO_SUPPRESS_DEPRECATED_START
     auto mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(param[0], acrossChanels, normalizeVariance, eps));
     if (!axes.empty()) {
         mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(param[0], axes, normalizeVariance, eps));
     }
+    OPENVINO_SUPPRESS_DEPRECATED_END
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(mvn)};
     function = std::make_shared<ngraph::Function>(results, param, "MVN1");
 }
@@ -82,7 +84,9 @@ void Mvn6LayerTest::SetUp() {
 
     ov::ParameterVector param {std::make_shared<ov::op::v0::Parameter>(dataType, ov::Shape(inputShapes))};
     auto axesNode = ngraph::builder::makeConstant(axesType, ngraph::Shape{axes.size()}, axes);
+    OPENVINO_SUPPRESS_DEPRECATED_START
     auto mvn = ngraph::builder::makeMVN6(param[0], axesNode, normalizeVariance, eps, epsMode);
+    OPENVINO_SUPPRESS_DEPRECATED_END
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(mvn)};
     function = std::make_shared<ngraph::Function>(results, param, "MVN6");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/slice.cpp
@@ -52,7 +52,9 @@ void Slice8LayerTest::SetUp() {
     for (auto&& shape : inputDynamicShapes) {
         params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
     }
+    OPENVINO_SUPPRESS_DEPRECATED_START
     auto sliceOp = ngraph::builder::makeSlice(params[0], sliceParams.start, sliceParams.stop, sliceParams.step, sliceParams.axes, netPrecision);
+    OPENVINO_SUPPRESS_DEPRECATED_END
 
     ov::ResultVector results;
     for (int i = 0; i < sliceOp->get_output_size(); i++)

--- a/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
@@ -37,7 +37,9 @@ void SpaceToBatchLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
+    OPENVINO_SUPPRESS_DEPRECATED_START
     auto s2b = ngraph::builder::makeSpaceToBatch(params[0], ngPrc, blockShape, padsBegin, padsEnd);
+    OPENVINO_SUPPRESS_DEPRECATED_END
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2b)};
     function = std::make_shared<ngraph::Function>(results, params, "SpaceToBatch");
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
@@ -44,8 +44,21 @@ void StridedSliceLayerTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(ssParams.inputShape))};
-    auto ss = ngraph::builder::makeStridedSlice(params[0], ssParams.begin, ssParams.end, ssParams.strides, ngPrc, ssParams.beginMask,
-                                                ssParams.endMask, ssParams.newAxisMask, ssParams.shrinkAxisMask, ssParams.ellipsisAxisMask);
+
+    ov::Shape constShape = {ssParams.begin.size()};
+    auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.begin.data());
+    auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.end.data());
+    auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.strides.data());
+    auto ss = std::make_shared<ov::op::v1::StridedSlice>(params[0],
+                                                             beginNode,
+                                                             endNode,
+                                                             strideNode,
+                                                             ssParams.beginMask,
+                                                             ssParams.endMask,
+                                                             ssParams.newAxisMask,
+                                                             ssParams.shrinkAxisMask,
+                                                             ssParams.ellipsisAxisMask);
+
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(ss)};
     function = std::make_shared<ngraph::Function>(results, params, "StridedSlice");
 }

--- a/src/tests/functional/shared_test_classes/src/subgraph/const_strided_slice_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/const_strided_slice_concat.cpp
@@ -46,8 +46,20 @@ namespace {
 template <class A, class B, class C>
 void appendSlices(A&& destVector, B&& src, const int64_t chunkSize, const int64_t totalSize, C precission) {
     for (int64_t start = 0; start < totalSize; start += chunkSize) {
-        using ngraph::builder::makeStridedSlice;
-        destVector.push_back(makeStridedSlice(src, { 0, start }, { 0, start + chunkSize }, { 1, 1 }, precission, { 1, 0 }, { 1, 0 }));
+        ov::Shape constShape = {2};
+        auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{ 0, start });
+        auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{ 0, start + chunkSize });
+        auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{ 1, 1 });
+        auto ssNode = std::make_shared<ov::op::v1::StridedSlice>(src,
+                                                                beginNode,
+                                                                endNode,
+                                                                strideNode,
+                                                                std::vector<int64_t>{ 1, 0 },
+                                                                std::vector<int64_t>{ 1, 0 },
+                                                                std::vector<int64_t>{},
+                                                                std::vector<int64_t>{},
+                                                                std::vector<int64_t>{});
+        destVector.push_back(ssNode);
     }
 }
 } // namespace

--- a/src/tests/functional/shared_test_classes/src/subgraph/multi_crops_to_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/multi_crops_to_concat.cpp
@@ -40,25 +40,53 @@ void MultiCropsToConcatTest::SetUp() {
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
 
-    auto crop1 = ngraph::builder::makeStridedSlice(params[0], std::vector<int64_t>{0, offsets[0].first}, std::vector<int64_t>{1, offsets[0].second},
-                                                std::vector<int64_t>{1, 1}, ngPrc, std::vector<int64_t>{1, 0},
-                                                std::vector<int64_t>{1, 0}, std::vector<int64_t>{0, 0},
-                                                std::vector<int64_t>{0, 0}, std::vector<int64_t>{0, 0});
+    ov::Shape const_shape_crop1 = {2};
+    auto begin_node_crop1 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop1, std::vector<int64_t>{ 0, offsets[0].first });
+    auto end_node_crop1 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop1, std::vector<int64_t>{ 1, offsets[0].second });
+    auto strideN_node_crop1 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop1, std::vector<int64_t>{ 1, 1 });
+    auto crop1 = std::make_shared<ov::op::v1::StridedSlice>(params[0],
+                                                            begin_node_crop1,
+                                                            end_node_crop1,
+                                                            strideN_node_crop1,
+                                                            std::vector<int64_t>{ 1, 0 },
+                                                            std::vector<int64_t>{ 1, 0 },
+                                                            std::vector<int64_t>{ 0, 0 },
+                                                            std::vector<int64_t>{ 0, 0 },
+                                                            std::vector<int64_t>{ 0, 0 });
 
-    auto crop2 = ngraph::builder::makeStridedSlice(params[0], std::vector<int64_t>{0, offsets[1].first}, std::vector<int64_t>{1, offsets[1].second},
-                                                std::vector<int64_t>{1, 1}, ngPrc, std::vector<int64_t>{1, 0},
-                                                std::vector<int64_t>{1, 0}, std::vector<int64_t>{0, 0},
-                                                std::vector<int64_t>{0, 0}, std::vector<int64_t>{0, 0});
+    ov::Shape const_shape_crop2 = {2};
+    auto begin_node_crop2 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop2, std::vector<int64_t>{ 0, offsets[1].first });
+    auto end_node_crop2 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop2, std::vector<int64_t>{ 1, offsets[1].second });
+    auto strideN_node_crop2 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop2, std::vector<int64_t>{ 1, 1 });
+    auto crop2 = std::make_shared<ov::op::v1::StridedSlice>(params[0],
+                                                            begin_node_crop2,
+                                                            end_node_crop2,
+                                                            strideN_node_crop2,
+                                                            std::vector<int64_t>{ 1, 0 },
+                                                            std::vector<int64_t>{ 1, 0 },
+                                                            std::vector<int64_t>{ 0, 0 },
+                                                            std::vector<int64_t>{ 0, 0 },
+                                                            std::vector<int64_t>{ 0, 0 });
 
     auto concat1 = std::make_shared<ngraph::opset8::Concat>(ngraph::OutputVector{crop1, crop2}, 1);
     std::shared_ptr<ov::op::v0::Result> result;
 
     // Case with 3 crops
     if (offsets.size() == 3) {
-        auto crop3 = ngraph::builder::makeStridedSlice(params[0], std::vector<int64_t>{0, offsets[2].first}, std::vector<int64_t>{1, offsets[2].second},
-                                                std::vector<int64_t>{1, 1}, ngPrc, std::vector<int64_t>{1, 0},
-                                                std::vector<int64_t>{1, 0}, std::vector<int64_t>{0, 0},
-                                                std::vector<int64_t>{0, 0}, std::vector<int64_t>{0, 0});
+        ov::Shape const_shape_crop3 = {2};
+        auto begin_node_crop3 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop3, std::vector<int64_t>{ 0, offsets[2].first });
+        auto end_node_crop3 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop3, std::vector<int64_t>{ 1, offsets[2].second });
+        auto strideN_node_crop3 = std::make_shared<ov::op::v0::Constant>(ov::element::i64, const_shape_crop3, std::vector<int64_t>{ 1, 1 });
+        auto crop3 = std::make_shared<ov::op::v1::StridedSlice>(params[0],
+                                                                begin_node_crop3,
+                                                                end_node_crop3,
+                                                                strideN_node_crop3,
+                                                                std::vector<int64_t>{ 1, 0 },
+                                                                std::vector<int64_t>{ 1, 0 },
+                                                                std::vector<int64_t>{ 0, 0 },
+                                                                std::vector<int64_t>{ 0, 0 },
+                                                                std::vector<int64_t>{ 0, 0 });
+
         auto concat2 = std::make_shared<ngraph::opset8::Concat>(ngraph::OutputVector{crop1, crop2}, 1);
         result = std::make_shared<ngraph::opset8::Result>(concat2);
     } else {

--- a/src/tests/functional/shared_test_classes/src/subgraph/mvn_multiply_add.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/mvn_multiply_add.cpp
@@ -47,7 +47,11 @@ void MVNMultiplyAdd::SetUp() {
 
     ov::ParameterVector param{std::make_shared<ov::op::v0::Parameter>(dataType, ov::Shape(inputShapes))};
     auto axesNode = ngraph::builder::makeConstant(axesType, ov::Shape{axes.size()}, axes);
-    auto mvn = ngraph::builder::makeMVN6(param[0], axesNode, normalizeVariance, eps, epsMode);
+    ov::op::MVNEpsMode nEpsMode = ov::op::MVNEpsMode::INSIDE_SQRT;
+    if (epsMode == "outside_sqrt")
+        nEpsMode = ov::op::MVNEpsMode::OUTSIDE_SQRT;
+    auto mvn = std::make_shared<ov::op::v6::MVN>(param[0], axesNode, normalizeVariance, eps, nEpsMode);
+
     auto gamma = ngraph::builder::makeConstant<float>(dataType, constantShapes, {}, true);
     auto mul = std::make_shared<ov::op::v1::Multiply>(mvn, gamma);
     auto beta = ngraph::builder::makeConstant<float>(dataType, constantShapes, {}, true);

--- a/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
@@ -48,8 +48,22 @@ void StridedSliceTest::SetUp() {
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(ssParams.inputShape))};
     auto relu = std::make_shared<ngraph::opset1::Relu>(params[0]);
-    auto ss = ngraph::builder::makeStridedSlice(relu, ssParams.begin, ssParams.end, ssParams.strides, ngPrc, ssParams.beginMask,
-                                                ssParams.endMask, ssParams.newAxisMask, ssParams.shrinkAxisMask, ssParams.ellipsisAxisMask);
+
+    ov::Shape constShape = {ssParams.begin.size()};
+    auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.begin.data());
+    auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.end.data());
+    auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.strides.data());
+
+    auto ss = std::make_shared<ov::op::v1::StridedSlice>(relu,
+                                                        beginNode,
+                                                        endNode,
+                                                        strideNode,
+                                                        ssParams.beginMask,
+                                                        ssParams.endMask,
+                                                        ssParams.newAxisMask,
+                                                        ssParams.shrinkAxisMask,
+                                                        ssParams.ellipsisAxisMask);
+
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(ss)};
     function = std::make_shared<ngraph::Function>(results, params, "strided_slice");
 }

--- a/src/tests/functional/shared_test_classes/src/subgraph/stridedslice_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/stridedslice_concat.cpp
@@ -50,10 +50,20 @@ void SliceConcatTest::SetUp() {
             ngraph::builder::makeConstant(ngraph::element::i64, ngraph::Shape{inputShape.size()}, inputShape), false);
     }
 
-    auto ss = ngraph::builder::makeStridedSlice(input, begin, end, strides, ngPrc, beginMask, endMask,
-                                                std::vector<int64_t>(inputShape.size(), 0),
-                                                std::vector<int64_t>(inputShape.size(), 0),
-                                                std::vector<int64_t>(inputShape.size(), 0));
+    ov::Shape constShape = {begin.size()};
+    auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, begin.data());
+    auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, end.data());
+    auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, strides.data());
+
+    auto ss = std::make_shared<ov::op::v1::StridedSlice>(input,
+                                                        beginNode,
+                                                        endNode,
+                                                        strideNode,
+                                                        beginMask,
+                                                        endMask,
+                                                        std::vector<int64_t>(inputShape.size(), 0),
+                                                        std::vector<int64_t>(inputShape.size(), 0),
+                                                        std::vector<int64_t>(inputShape.size(), 0));
 
     ngraph::Shape const_shape(inputShape.size(), 1);
     const_shape.back() = 32;

--- a/src/tests/functional/shared_test_classes/src/subgraph/stridedslice_conv.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/stridedslice_conv.cpp
@@ -59,10 +59,20 @@ void SliceConvTest::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
-    auto ss = ngraph::builder::makeStridedSlice(params[0], std::vector<int64_t>{0, 0, 0, 64}, std::vector<int64_t>{1, 1, 1, 128},
-                                                std::vector<int64_t>{1, 1, 1, 1}, ngPrc, std::vector<int64_t>{1, 1, 1, 0},
-                                                std::vector<int64_t>{1, 1, 1, 0}, std::vector<int64_t>{0, 0, 0, 0},
-                                                std::vector<int64_t>{0, 0, 0, 0}, std::vector<int64_t>{0, 0, 0, 0});
+
+    ov::Shape constShape = {4};
+    auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{0, 0, 0, 64});
+    auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{1, 1, 1, 128});
+    auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, std::vector<int64_t>{1, 1, 1, 1});
+    auto ss = std::make_shared<ov::op::v1::StridedSlice>(params[0],
+                                                        beginNode,
+                                                        endNode,
+                                                        strideNode,
+                                                        std::vector<int64_t>{1, 1, 1, 0},
+                                                        std::vector<int64_t>{1, 1, 1, 0},
+                                                        std::vector<int64_t>{0, 0, 0, 0},
+                                                        std::vector<int64_t>{0, 0, 0, 0},
+                                                        std::vector<int64_t>{0, 0, 0, 0});
 
     auto filterWeights = ov::test::utils::generate_float_numbers(outputChannels * inputShape[1] * kernelShape[0] * kernelShape[1],
                                                                  -0.2f, 0.2f);

--- a/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
+++ b/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
@@ -290,6 +290,7 @@ std::shared_ptr<ov::Node> makeBatchToSpace(const ov::Output<Node>& in,
                                            const std::vector<int64_t>& cropsBegin,
                                            const std::vector<int64_t>& cropsEnd);
 
+OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
 std::shared_ptr<ov::Node> makeSpaceToBatch(const ov::Output<Node>& in,
                                            const element::Type& type,
                                            const std::vector<int64_t>& blockShape,

--- a/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
+++ b/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
@@ -297,6 +297,7 @@ std::shared_ptr<ov::Node> makeSpaceToBatch(const ov::Output<Node>& in,
                                            const std::vector<int64_t>& padsBegin,
                                            const std::vector<int64_t>& padsEnd);
 
+OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
 std::shared_ptr<ov::Node> makeSlice(const ov::Output<Node>& in,
                                     const std::vector<int64_t>& begin,
                                     const std::vector<int64_t>& end,
@@ -304,12 +305,14 @@ std::shared_ptr<ov::Node> makeSlice(const ov::Output<Node>& in,
                                     const std::vector<int64_t>& axes,
                                     const element::Type& type);
 
+OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
 std::shared_ptr<ov::Node> makeSlice(const ov::Output<Node>& in,
                                     const ov::Output<Node>& begin,
                                     const ov::Output<Node>& end,
                                     const ov::Output<Node>& stride,
                                     const ov::Output<Node>& axes);
 
+OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
 std::shared_ptr<ov::Node> makeSlice(const ov::Output<Node>& in,
                                     const ov::Output<Node>& begin,
                                     const ov::Output<Node>& end,

--- a/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
+++ b/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
@@ -318,8 +318,10 @@ std::shared_ptr<ov::Node> makeSlice(const ov::Output<Node>& in,
                                     const ov::Output<Node>& end,
                                     const ov::Output<Node>& stride);
 
+OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
 std::shared_ptr<ov::Node> makeMVN(const ov::Output<Node>& in, bool acrossChannels, bool normalizeVariance, double eps);
 
+OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
 std::shared_ptr<ov::Node> makeMVN(const ov::Output<Node>& in,
                                   const ov::AxisSet& axes,
                                   bool normalizeVariance,

--- a/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
+++ b/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
@@ -297,28 +297,6 @@ std::shared_ptr<ov::Node> makeSpaceToBatch(const ov::Output<Node>& in,
                                            const std::vector<int64_t>& padsBegin,
                                            const std::vector<int64_t>& padsEnd);
 
-std::shared_ptr<ov::Node> makeStridedSlice(const ov::Output<Node>& in,
-                                           const std::vector<int64_t>& begin,
-                                           const std::vector<int64_t>& end,
-                                           const std::vector<int64_t>& stride,
-                                           const element::Type& type,
-                                           const std::vector<int64_t>& begin_mask,
-                                           const std::vector<int64_t>& end_mask,
-                                           const std::vector<int64_t>& new_axis_mask = std::vector<int64_t>{},
-                                           const std::vector<int64_t>& shrink_mask = std::vector<int64_t>{},
-                                           const std::vector<int64_t>& ellipsis_mask = std::vector<int64_t>{});
-
-std::shared_ptr<ov::Node> makeStridedSlice(const ov::Output<Node>& in,
-                                           const ov::Output<Node>& beginNode,
-                                           const ov::Output<Node>& endNode,
-                                           const ov::Output<Node>& strideNode,
-                                           const element::Type& type,
-                                           const std::vector<int64_t>& begin_mask,
-                                           const std::vector<int64_t>& end_mask,
-                                           const std::vector<int64_t>& new_axis_mask = std::vector<int64_t>{},
-                                           const std::vector<int64_t>& shrink_mask = std::vector<int64_t>{},
-                                           const std::vector<int64_t>& ellipsis_mask = std::vector<int64_t>{});
-
 std::shared_ptr<ov::Node> makeSlice(const ov::Output<Node>& in,
                                     const std::vector<int64_t>& begin,
                                     const std::vector<int64_t>& end,

--- a/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
+++ b/src/tests/ov_helpers/ov_models/include/ov_models/builders.hpp
@@ -283,6 +283,7 @@ std::shared_ptr<ov::Node> makeEltwise(const ov::Output<Node>& in0,
                                       const ov::Output<Node>& in1,
                                       ov::test::utils::EltwiseTypes eltwiseType);
 
+OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
 std::shared_ptr<ov::Node> makeBatchToSpace(const ov::Output<Node>& in,
                                            const element::Type& type,
                                            const std::vector<int64_t>& blockShape,

--- a/src/tests/ov_helpers/ov_models/src/strided_slice.cpp
+++ b/src/tests/ov_helpers/ov_models/src/strided_slice.cpp
@@ -9,54 +9,6 @@
 
 namespace ngraph {
 namespace builder {
-std::shared_ptr<ov::Node> makeStridedSlice(const ov::Output<Node>& in,
-                                           const std::vector<int64_t>& begin,
-                                           const std::vector<int64_t>& end,
-                                           const std::vector<int64_t>& stride,
-                                           const element::Type& type,
-                                           const std::vector<int64_t>& begin_mask,
-                                           const std::vector<int64_t>& end_mask,
-                                           const std::vector<int64_t>& new_axis_mask,
-                                           const std::vector<int64_t>& shrink_mask,
-                                           const std::vector<int64_t>& ellipsis_mask) {
-    ov::Shape constShape = {begin.size()};
-    auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, begin.data());
-    auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, end.data());
-    auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, stride.data());
-    auto ssNode = std::make_shared<ov::op::v1::StridedSlice>(in,
-                                                             beginNode,
-                                                             endNode,
-                                                             strideNode,
-                                                             begin_mask,
-                                                             end_mask,
-                                                             new_axis_mask,
-                                                             shrink_mask,
-                                                             ellipsis_mask);
-    return ssNode;
-}
-
-std::shared_ptr<ov::Node> makeStridedSlice(const ov::Output<Node>& in,
-                                           const ov::Output<Node>& beginNode,
-                                           const ov::Output<Node>& endNode,
-                                           const ov::Output<Node>& strideNode,
-                                           const element::Type& type,
-                                           const std::vector<int64_t>& begin_mask,
-                                           const std::vector<int64_t>& end_mask,
-                                           const std::vector<int64_t>& new_axis_mask,
-                                           const std::vector<int64_t>& shrink_mask,
-                                           const std::vector<int64_t>& ellipsis_mask) {
-    auto ssNode = std::make_shared<ov::op::v1::StridedSlice>(in,
-                                                             beginNode,
-                                                             endNode,
-                                                             strideNode,
-                                                             begin_mask,
-                                                             end_mask,
-                                                             new_axis_mask,
-                                                             shrink_mask,
-                                                             ellipsis_mask);
-    return ssNode;
-}
-
 std::shared_ptr<ov::Node> makeSlice(const ov::Output<Node>& in,
                                     const std::vector<int64_t>& begin,
                                     const std::vector<int64_t>& end,


### PR DESCRIPTION
### Details:
 - Remove or deprecate makeBatchToSpace, makeSpaceToBatch, makeStridedSlice, makeSlice makeMVN builders
 - Suppress deprecation in legacy code. Remove usage in modern code

### Tickets:
 - CVS-117139	




