### PR TITLE
[PT FE] Use system model cache when running torch hub tests locally

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1447,6 +1447,7 @@ jobs:
         env:
           TYPE: ${{ github.event_name == 'schedule' && 'nightly' || 'precommit'}}
           TEST_DEVICE: CPU
+          USE_SYSTEM_CACHE: False
 
       - name: Available storage after tests
         run: |

--- a/tests/model_hub_tests/models_hub_common/constants.py
+++ b/tests/model_hub_tests/models_hub_common/constants.py
@@ -9,9 +9,9 @@ tf_hub_cache_dir = os.environ.get('TFHUB_CACHE_DIR',
                                   os.path.join(tempfile.gettempdir(), "tfhub_modules"))
 os.environ['TFHUB_CACHE_DIR'] = tf_hub_cache_dir
 
-hf_hub_cache_dir = os.environ.get('HUGGINGFACE_HUB_CACHE',
-                                  tempfile.gettempdir())
-os.environ['HUGGINGFACE_HUB_CACHE'] = hf_hub_cache_dir
+hf_hub_cache_dir = tempfile.gettempdir()
+if os.environ.get('USE_SYSTEM_CACHE', 'True') == 'False':
+    os.environ['HUGGINGFACE_HUB_CACHE'] = hf_hub_cache_dir
 
 # supported_devices : CPU, GPU, GNA
 test_device = os.environ.get('TEST_DEVICE', 'CPU;GPU').split(';')

--- a/tests/model_hub_tests/torch_tests/test_torchvision_models.py
+++ b/tests/model_hub_tests/torch_tests/test_torchvision_models.py
@@ -9,10 +9,6 @@ import torchvision.transforms.functional as F
 from openvino import convert_model
 from models_hub_common.test_convert_model import TestConvertModel
 from models_hub_common.utils import get_models_list
-from torch.export import export
-from torch.fx.experimental.proxy_tensor import make_fx
-from openvino.frontend import FrontEndManager
-from openvino.frontend.pytorch.fx_decoder import TorchFXPythonDecoder
 
 
 def get_all_models() -> list:

--- a/tests/model_hub_tests/torch_tests/test_torchvision_models.py
+++ b/tests/model_hub_tests/torch_tests/test_torchvision_models.py
@@ -94,29 +94,7 @@ class TestTorchHubConvertModel(TestConvertModel):
         return [i.numpy() for i in self.inputs]
 
     def convert_model(self, model_obj):
-        #ov_model = convert_model(model_obj, example_input=self.example)
-        em = export(model_obj, self.example)
-        mfx = make_fx(em)(*self.example)
-        mfx.eval()
-        gm = mfx
-        
-        input_shapes = []
-        input_types = []
-        for input_data in self.example:
-            input_types.append(input_data.type())
-            input_shapes.append(input_data.size())
-            
-        decoder = TorchFXPythonDecoder(gm, gm, input_shapes=input_shapes, input_types=input_types)
-        
-        fe_manager = FrontEndManager()
-        fe = fe_manager.load_by_framework("pytorch")
-        im = fe.load(decoder)
-        with torch.no_grad():
-            ov_model = fe.convert(im)
-        params = ov_model.get_parameters()
-        if params[-1].get_element_type().is_dynamic():
-            ov_model.remove_parameter(params[-1])
-        print(ov_model)
+        ov_model = convert_model(model_obj, example_input=self.example)
         return ov_model
 
     def infer_fw_model(self, model_obj, inputs):


### PR DESCRIPTION
### Details:
 - *Use system model cache when running torch hub tests locally. That helps to use tests for local validation without downloading all the models again.*

### Tickets:
 - *ticket-id*
