### PR TITLE
Remove limit for Loop inputs in bindings

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/ops/loop.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/loop.cpp
@@ -24,15 +24,7 @@ void regclass_graph_op_Loop(py::module m) {
 
     cls.def(
         py::init([](const std::shared_ptr<ov::Node>& trip_count, const std::shared_ptr<ov::Node>& execution_condition) {
-            if (MultiSubgraphHelpers::is_constant_or_parameter(trip_count) &&
-                MultiSubgraphHelpers::is_constant_or_parameter(execution_condition)) {
-                return std::make_shared<ov::op::v5::Loop>(trip_count->output(0), execution_condition->output(0));
-            } else {
-                OPENVINO_WARN
-                    << "Please specify execution_condition and trip_count as Constant or Parameter. Default Loop() "
-                       "constructor was applied.";
-                return std::make_shared<ov::op::v5::Loop>();
-            }
+            return std::make_shared<ov::op::v5::Loop>(trip_count, execution_condition);
         }),
         py::arg("trip_count"),
         py::arg("execution_condition"));

--- a/src/bindings/python/tests/test_graph/test_loop.py
+++ b/src/bindings/python/tests/test_graph/test_loop.py
@@ -65,6 +65,7 @@ def test_simple_loop():
     assert list(loop.get_output_shape(1)) == out1_shape
     assert list(loop.get_output_shape(2)) == out2_shape
 
+
 def test_loop_inputs_are_nodes():
     param_x = ov.parameter(Shape([32, 1, 10]), np.float32, "X")
     param_y = ov.parameter(Shape([32, 1, 10]), np.float32, "Y")
@@ -116,6 +117,7 @@ def test_loop_inputs_are_nodes():
     assert list(loop.get_output_shape(0)) == out0_shape
     assert list(loop.get_output_shape(1)) == out1_shape
     assert list(loop.get_output_shape(2)) == out2_shape
+
 
 def test_loop_basic():
     bool_val = np.array([1], dtype=bool)


### PR DESCRIPTION
### Details:
 - Remove binding limitation for Loop operator that inputs can be only `Constant` or `Parameter`

### Tickets:
 - [CVS-122380](https://jira.devtools.intel.com/browse/CVS-122380)
