### PR TITLE
Remove unused function from build to remove ``-Werror=unused-function``

### DIFF
--- a/src/frontends/tests/frontend/shared/test_builtin_extensions/builtin_extensions.cpp
+++ b/src/frontends/tests/frontend/shared/test_builtin_extensions/builtin_extensions.cpp
@@ -67,6 +67,7 @@ ov::OutputVector ReluToSwishTranslator(const ov::frontend::NodeContext& node) {
     return {std::make_shared<ov::opset8::Swish>(node.get_input(0))};
 }
 
+#ifdef ENABLE_OV_PADDLE_FRONTEND
 std::map<std::string, ov::OutputVector> ReluToSwishTranslatorPDPD(const ov::frontend::NodeContext& node) {
     return {{"Out", {std::make_shared<ov::opset8::Swish>(node.get_input("X"))}}};
 }
@@ -81,7 +82,7 @@ std::map<std::string, ov::OutputVector> Relu6ToReluTranslatorPaddle(const ov::fr
     ret["Out"] = {relu};
     return ret;
 }
-
+#endif
 }  // namespace
 
 class CustomElu : public ov::op::Op {


### PR DESCRIPTION
### Details:
 - If Paddle frontend is disabled the unused functions can make compile errors due to `-Werror=unused-function`


### Tickets:
 - N/A
