### PR TITLE
[GPU] Optimize Condition operation by better integrating its subnetwork primitives with the main network

### DIFF
--- a/src/plugins/intel_gpu/src/graph/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/condition.cpp
@@ -257,7 +257,7 @@ void condition_inst::postprocess_output_memory(network::ptr executed_net, cldnn:
     for (auto out_mem_map : branch.output_map) {
         auto out_mem_idx = out_mem_map.first;
         auto inner_out_id = out_mem_map.second;
-        auto mem_ptr = executed_net->get_output(inner_out_id).get_memory();
+        auto mem_ptr = executed_net->get_output_memory(inner_out_id);
         if (mem_ptr) {
             auto layout = _impl_params->get_output_layout(out_mem_idx);
             GPU_DEBUG_LOG << "Reshape output from " << mem_ptr->get_layout().to_short_string()

--- a/src/plugins/intel_gpu/src/graph/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/condition.cpp
@@ -219,8 +219,8 @@ Condition primitive is reusing memory with the input.
 */
 condition_inst::typed_primitive_inst(network& network, condition_node const& node)
     : parent(network, node),
-      _net_true(network::allocate_network(node.get_program().get_engine(), node.get_branch_true().inner_program)),
-      _net_false(network::allocate_network(node.get_program().get_engine(), node.get_branch_false().inner_program)) {
+      _net_true(network::allocate_network(network.get_stream_ptr(), node.get_branch_true().inner_program)),
+      _net_false(network::allocate_network(network.get_stream_ptr(), node.get_branch_false().inner_program)) {
     this->set_inner_networks({_net_true, _net_false});
 }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -61,7 +61,9 @@ cl_int set_kernel_arg(ocl_kernel_type& kernel, uint32_t idx, cldnn::memory::cptr
         return kernel.setArg(idx, buf);
     } else if (memory_capabilities::is_usm_type(mem->get_allocation_type())) {
         auto buf = std::dynamic_pointer_cast<const ocl::gpu_usm>(mem)->get_buffer();
-        GPU_DEBUG_TRACE_DETAIL << "kernel: " << kernel.get() << " set arg (usm) " << idx << " mem: " << buf.get() << " size: " << mem->size() << std::endl;
+        auto mem_type = std::dynamic_pointer_cast<const ocl::gpu_usm>(mem)->get_allocation_type();
+        GPU_DEBUG_TRACE_DETAIL << "kernel: " << kernel.get() << " set arg (" << mem_type << ") " << idx
+                               << " mem: " << buf.get() << " size: " << mem->size() << std::endl;
         return kernel.setArgUsm(idx, buf);
     } else {
         auto buf = std::dynamic_pointer_cast<const ocl::gpu_buffer>(mem)->get_buffer();


### PR DESCRIPTION
### Details:
This PR improves synchronization in condition operation and integrates it more closely with main pipeline

Original If operator execution (it interrupts main flow with two waits at the very beginning and at the end of its execution):

![image](https://github.com/openvinotoolkit/openvino/assets/3998162/b0acc4b3-a74d-42f9-90a0-4b84a8c8379a)

Optimized version (well-integrated with main network w/o interruptions):
![image](https://github.com/openvinotoolkit/openvino/assets/3998162/78b00a67-dd27-42ae-9645-1fcf93371ce6)

This optimization demonstrates the highest improvement in cases where condition statement is a member of ShapeOf subgraph and we can choose required branch w/o extra synchronization overheads

Fixes:
- Reuse stream from main network for sub-networks of IF operator
- Extend print for usm allocation type in verbose debug

### Tickets:
 - 125033
