### PR TITLE
[AUTO] performance data collection for inference schedule policy within AUTO plugin

### DIFF
--- a/samples/cpp/benchmark_app/benchmark_app.hpp
+++ b/samples/cpp/benchmark_app/benchmark_app.hpp
@@ -233,6 +233,10 @@ static const char exec_graph_path_message[] =
 static const char dump_config_message[] =
     "Optional. Path to JSON file to dump IE parameters, which were set by application.";
 
+// @brief message for schedule policy
+static const char schedule_policy[] =
+    "Optional. schedule policy for MULTI plugin inference, default is DEVICE_PRIORITY.";
+
 // @brief message for load config option
 static const char load_config_message[] =
     "Optional. Path to JSON file to load custom IE parameters."
@@ -312,6 +316,9 @@ DEFINE_string(api, "async", api_message);
 
 /// @brief Number of infer requests in parallel
 DEFINE_uint64(nireq, 0, infer_requests_count_message);
+
+/// @brief inference schedule policy for MULTI 
+DEFINE_string(sp, "", schedule_policy);
 
 /// @brief Number of streams to use for inference on the CPU (also affects Hetero cases)
 DEFINE_string(nstreams, "", infer_num_streams_message);
@@ -441,4 +448,5 @@ static void show_usage() {
     std::cout << "    -exec_graph_path        " << exec_graph_path_message << std::endl;
     std::cout << "    -dump_config            " << dump_config_message << std::endl;
     std::cout << "    -load_config            " << load_config_message << std::endl;
+    std::cout << "    -schedule_policy        " << schedule_policy << std::endl;
 }

--- a/samples/cpp/benchmark_app/benchmark_app.hpp
+++ b/samples/cpp/benchmark_app/benchmark_app.hpp
@@ -317,7 +317,7 @@ DEFINE_string(api, "async", api_message);
 /// @brief Number of infer requests in parallel
 DEFINE_uint64(nireq, 0, infer_requests_count_message);
 
-/// @brief inference schedule policy for MULTI 
+/// @brief inference schedule policy for MULTI
 DEFINE_string(sp, "", schedule_policy);
 
 /// @brief Number of streams to use for inference on the CPU (also affects Hetero cases)

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -878,7 +878,6 @@ int main(int argc, char* argv[]) {
             } else {
                 try {
                     nireq = compiledModel.get_property(ov::optimal_number_of_infer_requests);
-                    nireq = nireq == 0 ? 1 : nireq;
                 } catch (const std::exception& ex) {
                     OPENVINO_THROW("Every device used with the benchmark_app should support " +
                                    std::string(ov::optimal_number_of_infer_requests.name()) +

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -877,7 +877,7 @@ int main(int argc, char* argv[]) {
                 nireq = 1;
             } else {
                 try {
-                    nireq = compiledModel.get_property(ov::optimal_number_of_infer_requests) / 2;
+                    nireq = compiledModel.get_property(ov::optimal_number_of_infer_requests);
                     nireq = nireq == 0 ? 1 : nireq;
                 } catch (const std::exception& ex) {
                     OPENVINO_THROW("Every device used with the benchmark_app should support " +

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -561,6 +561,11 @@ int main(int argc, char* argv[]) {
             device_config.insert(ov::hint::allow_auto_batching(false));
         }
 
+        if (!FLAGS_sp.empty()) {
+            slog::info << "Inference schedule policy is " << FLAGS_sp << slog::endl;
+            device_config["SCHEDULE_POLICY"] = FLAGS_sp;
+        }
+
         bool isDynamicNetwork = false;
 
         if (FLAGS_load_from_file && !isNetworkCompiled) {
@@ -872,7 +877,8 @@ int main(int argc, char* argv[]) {
                 nireq = 1;
             } else {
                 try {
-                    nireq = compiledModel.get_property(ov::optimal_number_of_infer_requests);
+                    nireq = compiledModel.get_property(ov::optimal_number_of_infer_requests) / 2;
+                    nireq = nireq == 0 ? 1 : nireq;
                 } catch (const std::exception& ex) {
                     OPENVINO_THROW("Every device used with the benchmark_app should support " +
                                    std::string(ov::optimal_number_of_infer_requests.name()) +


### PR DESCRIPTION
### Details:
 - hardcoding optimal number of infer request to be half.
 - enable option to set the property `ov::intel_auto_schedule_policy`

### Tickets:
 - *ticket-id*
