### PR TITLE
[CPU][Tests] Fixed linking of ov_cpu_func_tests_subset

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/specific_tests.cmake
+++ b/src/plugins/intel_cpu/tests/functional/specific_tests.cmake
@@ -40,12 +40,10 @@ if(DEFINED ENABLE_CPU_SUBSET_TESTS_PATH)
     ${CMAKE_CURRENT_SOURCE_DIR}/test_utils/fusing_test_utils.cpp
     ${CPU_SUBSET_TEST_ABS_PATH})
 
-if(X86_64)
-    list(APPEND REQUIRED_OBJECT_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_utils/x64/filter_cpu_info.cpp)
-elseif(ARM OR AARCH64)
-    list(APPEND REQUIRED_OBJECT_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_utils/arm/filter_cpu_info.cpp)
+if(NOT (ARM OR AARCH64))
+  list(APPEND EXCLUDED_SOURCE_PATHS_FOR_SUBSET_TEST ${CMAKE_CURRENT_SOURCE_DIR}/test_utils/arm)
+elseif(NOT X86_64)
+  list(APPEND EXCLUDED_SOURCE_PATHS_FOR_SUBSET_TEST ${CMAKE_CURRENT_SOURCE_DIR}/test_utils/x64)
 endif()
 
   ov_add_test_target(


### PR DESCRIPTION
### Details:
 - *Fixed the error of linking of specific tests:*
 ```
/home/a-sidorova/projects/master/openvino/src/plugins/intel_cpu/tests/functional/test_utils/x64/filter_cpu_info.cpp:37: multiple definition of `CPUTestUtils::filterCPUInfoForDevice...
/home/a-sidorova/projects/master/openvino/src/plugins/intel_cpu/tests/functional/test_utils/arm/filter_cpu_info.cpp:15: first defined here
```
