### PR TITLE
[21042] Added new interpolation modes to regenum_graph_ResizeAlgorithm

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
@@ -464,6 +464,8 @@ static void regenum_graph_ResizeAlgorithm(py::module m) {
         .value("RESIZE_LINEAR", ov::preprocess::ResizeAlgorithm::RESIZE_LINEAR)
         .value("RESIZE_CUBIC", ov::preprocess::ResizeAlgorithm::RESIZE_CUBIC)
         .value("RESIZE_NEAREST", ov::preprocess::ResizeAlgorithm::RESIZE_NEAREST)
+        .value("RESIZE_BILINEAR_PILLOW", ov::preprocess::ResizeAlgorithm::RESIZE_BILINEAR_PILLOW)
+        .value("RESIZE_BICUBIC_PILLOW", ov::preprocess::ResizeAlgorithm::RESIZE_BICUBIC_PILLOW)
         .export_values();
 }
 


### PR DESCRIPTION
### New interpolation modes:

- ov::preprocess::ResizeAlgorithm::RESIZE_BILINEAR_PILLOW 
- ov::preprocess::ResizeAlgorithm::RESIZE_BICUBIC_PILLOW

### Tickets:
 - *Closes #21042*
