### PR TITLE
[CPU] Fix ScaledDotProductAttention build failure on ubuntu18

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -753,7 +753,6 @@ void ScaledDotProductAttention::execute(dnnl::stream strm) {
 }
 
 bool ScaledDotProductAttention::isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept {
-#if defined(OPENVINO_ARCH_X86_64)
     try {
         if (!std::dynamic_pointer_cast<const ov::op::v13::ScaledDotProductAttention>(op)) {
             errorMessage = "Only ScaledDotProductAttention operation are supported";
@@ -774,10 +773,6 @@ bool ScaledDotProductAttention::isSupportedOperation(const std::shared_ptr<const
         return false;
     }
     return true;
-#else
-    // current optimization is not suitable for ARM
-    return false;
-#endif
 }
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -433,7 +433,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_SET_CALLBACK_COMMON(manager, nmsCallback, ov::pass::ConvertNMS9ToNMSIEInternal);
     CPU_SET_CALLBACK_COMMON(manager, nmsCallback, ov::pass::ConvertMulticlassNmsToMulticlassNmsIE);
     CPU_SET_CALLBACK_COMMON(manager, nmsCallback, ov::pass::ConvertMatrixNmsToMatrixNmsIE);
-    CPU_SET_CALLBACK_COMMON(manager,
+    CPU_SET_CALLBACK_X64(manager,
         [](const_node_ptr &node) -> bool {
             std::string errorMsg;
             return node::ScaledDotProductAttention::isSupportedOperation(node, errorMsg);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -470,7 +470,6 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_DISABLE_PASS_COMMON(manager, ov::pass::ConvertTopK11ToTopK3);
     CPU_DISABLE_PASS_COMMON(manager, ov::pass::HSwishDecomposition);
     CPU_DISABLE_PASS_COMMON(manager, ov::pass::MatMulConstTransposesExtraction);
-    CPU_DISABLE_PASS_X64(manager, ov::pass::ScaledDotProductAttentionDecomposition);
     CPU_DISABLE_PASS_X64(manager, ov::pass::HSigmoidDecomposition);
 
     CPU_DISABLE_PASS_X64(manager, ov::pass::ReduceL1Decomposition);


### PR DESCRIPTION
### Details:
 - *Fix build failure on ubuntu18 after PR #20506 merged:*
    - Error: dereferencing type-punned pointer will break strict-aliasing rules
    - Error explanation: “Aliasing rules simply say that you can only access an object through its own type, its signed / unsigned variant type, or through a character type (char, signed char, unsigned char)”, from [SO](https://stackoverflow.com/a/8825257), additional reference: [C 2011 6.5 paragraph 7](https://port70.net/~nsz/c/c11/n1570.html#6.5), [strict-aliasing and type-punned](https://stackoverflow.com/a/51228315)
    - Error analysis: compiler complained [line](https://github.com/openvinotoolkit/openvino/blob/a1416ed68f467eb0a2e0a11f22b382d9e59ba877/src/plugins/intel_cpu/src/utils/plain_tensor.hpp#L226) does not contain any type reinterpretation, and error will occur when using gcc 7.5 on ubuntu 18.04, not seen in gcc 11.4 on ubuntun 22.04, assume it's a bug about gcc 7.5
    - Workaround: remove parent class of plain_tensor
 - *More clean logic for enabling SDPA decomposition for ARM*


### Tickets:
 - *125292*
