### PR TITLE
[CPU][ARM] Call `to_string()` method of ov::element::Type in ACL Convert executor

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.cpp
@@ -86,7 +86,7 @@ bool ACLConvertExecutorBuilder::isSupported(const ConvertParams& convertParams,
                     ov::element::f16,
                     ov::element::i32,
                     ov::element::f32)) {
-            DEBUG_LOG("NECopy does not support source precision: ", convertParams.srcPrc.name());
+            DEBUG_LOG("NECopy does not support source precision: ", convertParams.srcPrc.to_string());
             return false;
         }
         if ((convertParams.srcPrc == ov::element::i8 && !one_of(convertParams.dstPrc,
@@ -122,7 +122,7 @@ bool ACLConvertExecutorBuilder::isSupported(const ConvertParams& convertParams,
                                                                 ov::element::f16,
                                                                 ov::element::i32))) {
             DEBUG_LOG("NECopy does not support passed combination of source and destination precisions. ",
-                      "source precision: ", convertParams.srcPrc.name(), " destination precsion: ", convertParams.dstPrc.name());
+                      "source precision: ", convertParams.srcPrc.to_string(), " destination precsion: ", convertParams.dstPrc.to_string());
             return false;
         }
     }


### PR DESCRIPTION
The change is required to fix the build compilation with `DEBUG_CAPS` enabled:
```
no member named 'name' in 'ov::element::Type'
```