### PR TITLE
[core]Migrate Power operator to new API

### DIFF
--- a/src/core/include/openvino/op/power.hpp
+++ b/src/core/include/openvino/op/power.hpp
@@ -42,9 +42,7 @@ public:
           const AutoBroadcastSpec& auto_broadcast = AutoBroadcastSpec(AutoBroadcastType::NUMPY));
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v1

--- a/src/core/reference/include/openvino/reference/power.hpp
+++ b/src/core/reference/include/openvino/reference/power.hpp
@@ -4,22 +4,37 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 
-#include "openvino/core/shape.hpp"
-#include "openvino/op/util/attr_types.hpp"
 #include "openvino/reference/autobroadcast_binop.hpp"
 
 namespace ov {
 namespace reference {
+namespace func {
+// Usage of custom function instead of lambda gives smaller binary size.
+template <class T>
+T power(const T x, const T y) {
+    return static_cast<T>(std::pow(x, y));
+}
+}  // namespace func
+
 template <typename T>
 void power(const T* arg0, const T* arg1, T* out, size_t count) {
-    for (size_t i = 0; i < count; i++) {
-        out[i] = static_cast<T>(std::pow(arg0[i], arg1[i]));
-    }
+    std::transform(arg0, arg0 + count, arg1, out, func::power<T>);
 }
 
+/**
+ * @brief Reference implementation of binary elementwise Power operator.
+ *
+ * @param arg0            Pointer to input 0 data.
+ * @param arg1            Pointer to input 1 data.
+ * @param out             Pointer to output data.
+ * @param arg0_shape      Input 0 shape.
+ * @param arg1_shape      Input 1 shape.
+ * @param broadcast_spec  Broadcast specification mode.
+ */
 template <typename T>
 void power(const T* arg0,
            const T* arg1,
@@ -27,9 +42,7 @@ void power(const T* arg0,
            const Shape& arg0_shape,
            const Shape& arg1_shape,
            const op::AutoBroadcastSpec& broadcast_spec) {
-    autobroadcast_binop(arg0, arg1, out, arg0_shape, arg1_shape, broadcast_spec, [](T x, T y) -> T {
-        return static_cast<T>(std::pow(x, y));
-    });
+    autobroadcast_binop(arg0, arg1, out, arg0_shape, arg1_shape, broadcast_spec, func::power<T>);
 }
 }  // namespace reference
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Migrate `Power` operator to new API.
 - Refactor operator and reference implementation to reduce binary size.

### Tickets:
 - [CVS-118639](https://jira.devtools.intel.com/browse/CVS-118639)
