### PR TITLE
Remove a failing `mxnet` model from conditional compilation tests

### DIFF
--- a/tests/conditional_compilation/test_config.yml
+++ b/tests/conditional_compilation/test_config.yml
@@ -41,11 +41,6 @@
         precision: FP32
 -
     - model:
-        name: octave-resnet-26-0.25
-        type: omz
-        precision: FP32
--
-    - model:
         name: fast-neural-style-mosaic-onnx
         type: omz
         precision: FP32


### PR DESCRIPTION
### Details:
 - mxnet is an abandoned package https://github.com/apache/mxnet
 - we cannot expect updates and fixes
 - it's using a Python feature which has been removed in Python 3.11
 - it causes errors in our conditional compilation tests
 - the model being removed is specifically an mxnet model, so the scope of other frameworks will not be affected
 https://github.com/openvinotoolkit/open_model_zoo/blob/master/models/public/octave-resnet-26-0.25/model.yml#L50
 - **more details in the ticket**

### Tickets:
 - 124418
