### PR TITLE
[GHA] Alternative way to handle required pipeline checks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1376,9 +1376,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # install git (required to build pip deps from the sources)
-          # install 'g++' to build 'detectron2' and 'natten' wheels
-          sudo apt-get install --assume-yes --no-install-recommends g++ git ca-certificates
+          exit 1
 
       - name: Download OpenVINO package
         uses: actions/download-artifact@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1568,3 +1568,18 @@ jobs:
 
       - name: Show ccache stats
         run: ${SCCACHE_PATH} --show-stats
+
+  Overall_Status:
+    name: ci/gha_linux
+    needs: [Smart_CI, Build, Debian_Packages, Samples, Conformance, ONNX_Runtime, CXX_Unit_Tests, Python_Unit_Tests,
+            CPU_Functional_Tests, TensorFlow_Hub_Models_Tests, PyTorch_Models_Tests, NVIDIA_Plugin]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status of all jobs
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure') || 
+            contains(needs.*.result, 'cancelled')
+          }}
+        run: exit 1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1376,7 +1376,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          exit 1
+          # install git (required to build pip deps from the sources)
+          # install 'g++' to build 'detectron2' and 'natten' wheels
+          sudo apt-get install --assume-yes --no-install-recommends g++ git ca-certificates
 
       - name: Download OpenVINO package
         uses: actions/download-artifact@v3


### PR DESCRIPTION
### Details:
GitHub [does not allow](https://github.com/orgs/community/discussions/12395) specifying the whole workflow as required, so we have to manually add each job in a workflow to required in Branch settings (separately for each production branch), which is inconvenient. Plus, there are bugs with reporting statuses from [matrix jobs](https://github.com/actions/runner/issues/952) and [reusable workflows](https://github.com/actions/runner/issues/1917) that can block PR from merge if required checks are specified per job.

This PR tries another solution - adding a separate job for reflecting overall pipeline status. This way only this job can be added to required in Branch settings + less duplication is needed for each branch. Adding a new required job would still require adding its name to "needs" block in Overall_Status job 