### PR TITLE
[op_conformance] Fix not removing of crash for cases with several ops

### DIFF
--- a/src/tests/test_utils/functional_test_utils/include/functional_test_utils/summary/summary.hpp
+++ b/src/tests/test_utils/functional_test_utils/include/functional_test_utils/summary/summary.hpp
@@ -26,6 +26,9 @@ struct PassRate {
     double rel_passed = 0;
     double rel_all = 0;
 
+    bool isCrashReported = false;
+    bool isHangReported = false;
+
     PassRate() = default;
 
     PassRate(unsigned long p,
@@ -51,8 +54,6 @@ protected:
     std::string ts = ov::test::utils::GetTimestamp();
 
     static size_t saveReportTimeout;
-    static bool isCrashReported;
-    static bool isHangReported;
     static bool extendReport;
     static bool saveReportWithUniqueName;
     static const char* outputFolder;

--- a/src/tests/test_utils/functional_test_utils/src/summary/api_summary.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/summary/api_summary.cpp
@@ -36,8 +36,6 @@ void ApiSummaryDestroyer::initialize(ApiSummary* p) {
 
 ApiSummary::ApiSummary() : apiStats() {
     reportFilename = ov::test::utils::API_REPORT_FILENAME;
-    isCrashReported = false;
-    isHangReported = false;
 }
 
 ApiSummary& ApiSummary::getInstance() {
@@ -71,14 +69,14 @@ void ApiSummary::updateStat(ov_entity entity,
     if (cur_stat.find(real_device) == cur_stat.end()) {
         cur_stat.insert({real_device, PassRate()});
     }
-    if (isCrashReported) {
+    if (cur_stat[real_device].isCrashReported) {
         cur_stat[real_device].crashed--;
-        isCrashReported = false;
+        cur_stat[real_device].isCrashReported = false;
     } else {
         cur_stat[real_device].rel_all += rel_influence_coef;
     }
-    if (isHangReported) {
-        isHangReported = false;
+    if (cur_stat[real_device].isHangReported) {
+        cur_stat[real_device].isHangReported = false;
         return;
     }
     switch (status) {
@@ -96,7 +94,7 @@ void ApiSummary::updateStat(ov_entity entity,
     }
     case PassRate::Statuses::HANGED: {
         cur_stat[real_device].hanged++;
-        isHangReported = true;
+        cur_stat[real_device].isHangReported = true;
         break;
     }
     case PassRate::Statuses::FAILED: {
@@ -105,7 +103,7 @@ void ApiSummary::updateStat(ov_entity entity,
     }
     case PassRate::Statuses::CRASHED:
         cur_stat[real_device].crashed++;
-        isCrashReported = true;
+        cur_stat[real_device].isCrashReported = true;
         break;
     }
 }

--- a/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
@@ -60,15 +60,15 @@ void OpSummary::updateOPsStats(const ov::NodeTypeInfo& op,
         opsStats.insert({op, PassRate()});
     }
     auto& passrate = opsStats[op];
-    if (isCrashReported) {
-        isCrashReported = false;
+    if (passrate.isCrashReported) {
+        passrate.isCrashReported = false;
         if (passrate.crashed > 0)
             passrate.crashed--;
     } else {
         passrate.rel_all += rel_influence_coef;
     }
-    if (isHangReported) {
-        isHangReported = false;
+    if (passrate.isHangReported) {
+        passrate.isHangReported = false;
         return;
     }
     switch (status) {
@@ -87,12 +87,12 @@ void OpSummary::updateOPsStats(const ov::NodeTypeInfo& op,
         break;
     case PassRate::CRASHED: {
         passrate.crashed++;
-        isCrashReported = true;
+        passrate.isCrashReported = true;
         break;
     }
     case PassRate::HANGED: {
         passrate.hanged++;
-        isHangReported = true;
+        passrate.isHangReported = true;
         break;
     }
     }

--- a/src/tests/test_utils/functional_test_utils/src/summary/summary.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/summary/summary.cpp
@@ -49,8 +49,6 @@ double PassRate::getRelPassrate() const {
 
 bool Summary::extendReport = false;
 bool Summary::saveReportWithUniqueName = false;
-bool Summary::isCrashReported = false;
-bool Summary::isHangReported = false;
 size_t Summary::saveReportTimeout = 0;
 const char* Summary::outputFolder = ".";
 


### PR DESCRIPTION
### Details:
 - *Crash in reports appeared when it was being analyzed model with several ops. At the start of test it had set CRASH as status for all ops, after this status was deleted only for one ops, first in the list, and for all ops it was set right status, PASSED, for example.*

### Tickets:
 - *CVS-125419*
