### PR TITLE
[cpu]Correct assertion in `PlainTensor` member functions

### DIFF
--- a/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
+++ b/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
@@ -131,11 +131,11 @@ struct PlainTensor {
     size_t size(int i) const {
         if (i < 0)
             i += m_rank;
-        assert(i < m_rank);
+        assert(static_cast<typename std::make_unsigned<decltype(i)>::type>(i) < m_rank);
         return m_dims[i];
     }
     size_t stride(int i) const {
-        assert(i < m_rank);
+        assert(i >= 0 && static_cast<typename std::make_unsigned<decltype(i)>::type>(i) < m_rank);
         return m_strides[i];
     }
     PlainTensor(MemoryPtr mem) {


### PR DESCRIPTION
### Details:
 - Correct assertion in `PlainTensor` member functions
  - `PlainTensor::size`
  - `PlainTensor::stride`

### Tickets:
 - [CVS-125576](https://jira.devtools.intel.com/browse/CVS-125576)
