### PR TITLE
[Docs][PyOV] add missing docs

### DIFF
--- a/docs/api/ie_python_api/api.rst
+++ b/docs/api/ie_python_api/api.rst
@@ -87,6 +87,18 @@ OpenVINO Python API
    :toctree: _autosummary
    :template: custom-module-template.rst
 
+   openvino.runtime.opset12
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
+   openvino.runtime.opset13
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
    openvino.runtime.passes
 
 .. autosummary::
@@ -94,6 +106,12 @@ OpenVINO Python API
    :template: custom-module-template.rst
 
    openvino.preprocess
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
+   openvino.properties
 
 .. autosummary::
    :toctree: _autosummary

--- a/docs/api/ie_python_api/api.rst
+++ b/docs/api/ie_python_api/api.rst
@@ -147,6 +147,12 @@ OpenVINO Python API
    :toctree: _autosummary
    :template: custom-module-template.rst
 
+   openvino.properties.intel_gpu.hint
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
    openvino.properties.log
 
 .. autosummary::

--- a/docs/api/ie_python_api/api.rst
+++ b/docs/api/ie_python_api/api.rst
@@ -117,6 +117,48 @@ OpenVINO Python API
    :toctree: _autosummary
    :template: custom-module-template.rst
 
+   openvino.properties.device
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
+   openvino.properties.hint
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
+   openvino.properties.intel_auto
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
+   openvino.properties.intel_cpu
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
+   openvino.properties.intel_gpu
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
+   openvino.properties.log
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
+   openvino.properties.streams
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+
    openvino.frontend
 
 .. toctree::


### PR DESCRIPTION
### Details:
 - missed documentation for python submodules
 - TODO: port to 2023.2

### Tickets:
 - *ticket-id*
