### PR TITLE
[CPU] Fix ScaledDotProductAttension accuracy problem

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -123,7 +123,7 @@ struct MHAKernel {
                 if (auto_causal)
                     ncausal = kv_len - q_len + m + 1;
                 for (size_t n = 0; n < ncausal; n++) {
-                    auto* k = &present_key.at({b, h, n, 0});
+                    auto* k = &present_key.at({b, h, n, 0}, true);
                     attn_score[n] = dot_product(q, k, head_size, k_stride_s) * d_scale;
 
                     // apply alibi tensor
@@ -154,7 +154,7 @@ struct MHAKernel {
                 // linearly combine value
                 word_vec.assign(head_size, 0.0f);
                 for (size_t n = 0; n < ncausal; n++) {
-                    auto* v = &present_value.at({b, h, n, 0});
+                    auto* v = &present_value.at({b, h, n, 0}, true);
                     accumulate(word_vec.data(), v, head_size, attn_score[n]);
                 }
 
@@ -183,7 +183,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_ONEDNN, T> {
     using tag = dnnl::memory::format_tag;
     using dt = dnnl::memory::data_type;
 
-    void prepare_prim(dnnl::stream strm, size_t B, size_t H, size_t q_len, size_t kv_len, size_t S, bool has_out_transpose) {
+    void prepare_prim(dnnl::stream strm, size_t B, size_t H, size_t Hk, size_t q_len, size_t kv_len, size_t S, bool has_out_transpose) {
         auto make_dnnl_dims = [](const std::vector<size_t>& dims) {
             dnnl::memory::dims dnnl_dims(dims.size());
             for (size_t i = 0; i < dims.size(); i++)
@@ -192,7 +192,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_ONEDNN, T> {
         };
         auto qkv_dt = precision_of<T>::value == ov::element::f32 ? dt::f32 : dt::bf16;
         dnnl::memory::desc cur_q_md(make_dnnl_dims({B, H, q_len, S}), qkv_dt, tag::abcd);
-        dnnl::memory::desc cur_k_md(make_dnnl_dims({B, H, kv_len, S}), qkv_dt, tag::abcd);
+        dnnl::memory::desc cur_k_md(make_dnnl_dims({B, Hk, kv_len, S}), qkv_dt, tag::abcd);
         if (cur_q_md == q_md && cur_k_md == k_md)
             return;
 
@@ -204,7 +204,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_ONEDNN, T> {
         qk_prim = dnnl::matmul(qk_pd);
 
         weight_md = dnnl::memory::desc(make_dnnl_dims({B, H, q_len, kv_len}), qkv_dt, tag::abcd);
-        v_md = dnnl::memory::desc(make_dnnl_dims({B, H, kv_len, S}), qkv_dt, tag::abcd);
+        v_md = dnnl::memory::desc(make_dnnl_dims({B, Hk, kv_len, S}), qkv_dt, tag::abcd);
         out_md = dnnl::memory::desc(make_dnnl_dims({B, H, q_len, S}), qkv_dt, tag::abcd);
         if (has_out_transpose)
             out_md = out_md.permute_axes({0, 2, 1, 3});
@@ -259,12 +259,13 @@ struct MHAKernel<ScaledDotProductAttention::KT_ONEDNN, T> {
         auto H = query.size(1);
         auto q_len = query.size(2);
         auto head_size = query.size(3);
+        auto Hk = present_key.size(1);
         auto kv_len = present_key.size(2);
 
         if (d_scale == 0.0f)
             d_scale = 1.0f / sqrt(head_size);
 
-        prepare_prim(strm, B, H, q_len, kv_len, head_size, has_out_transpose);
+        prepare_prim(strm, B, H, Hk, q_len, kv_len, head_size, has_out_transpose);
         exec_qk(strm, query, present_key);
 
         PlainTensor<float> score;
@@ -495,7 +496,7 @@ struct MHASingleToken {
             std::vector<float*> cs(q_len);
             for (size_t pq = 0; pq < q_len; pq++) {
                 as[pq] = &query.at({b, h, pq, 0});
-                bs[pq] = &present_key.at({b_kv, h, pk, 0});
+                bs[pq] = &present_key.at({b_kv, h, pk, 0}, true);
                 cs[pq] = &m_attn_w.at({b, h, pq, pk});
             }
             attn_dot_products(reinterpret_cast<void**>(as.data()),
@@ -543,7 +544,7 @@ struct MHASingleToken {
                 size_t idx = 0;
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     auto b_kv = beams ? beams.at({b, pv}) : b;
-                    auto* v = &present_value.at({b_kv, h, pv, 0});
+                    auto* v = &present_value.at({b_kv, h, pv, 0}, true);
                     for (size_t pq = 0; pq < q_len; pq++) {
                         outs[idx] = &m_temp.at({ithr, b, pq, h, 0});
                         weights[idx] = m_attn_w.at({b, h, pq, pv});
@@ -636,8 +637,8 @@ struct ScaledDotProductAttention::AttentionExecutor : public ScaledDotProductAtt
         PlainTensor<T> present_key, present_value;
 
         q_input.assert_dims({B, H, L1, S});
-        k_input.assert_dims({B, H, L0 + L1, S});
-        v_input.assert_dims({B, H, L0 + L1, S});
+        k_input.assert_dims({B, 0, L0 + L1, S}, true);
+        v_input.assert_dims({B, 0, L0 + L1, S}, true);
         m_query_emb = q_input;
         present_key = k_input;
         present_value = v_input;
@@ -657,9 +658,8 @@ struct ScaledDotProductAttention::AttentionExecutor : public ScaledDotProductAtt
                 // no attn_mask but has scale, there is a 1-d fake attn_mask
                 if (input_num > 3 && attn_mask.m_rank > 1) {
                     assert(attn_mask);
-                    auto num = std::accumulate(attn_mask.m_dims, attn_mask.m_dims + attn_mask.m_rank, size_t{1}, std::multiplies<size_t>());
-                    num /= B * (L0 + L1);
-                    attn_mask = attn_mask.reshape({B, 1, num, L0 + L1});
+                    if (attn_mask.m_rank == 3)
+                        attn_mask = attn_mask.reshape({1, attn_mask.m_dims[0], attn_mask.m_dims[1], attn_mask.m_dims[2]});
                     auto_causal = false;
                     use_attn_mask = true;
                 } else {
@@ -758,11 +758,18 @@ bool ScaledDotProductAttention::isSupportedOperation(const std::shared_ptr<const
             errorMessage = "Only ScaledDotProductAttention operation are supported";
             return false;
         }
-        // expect shape: [B, H, L, S]
-        const auto inRank = op->get_input_partial_shape(0).size();
+        // expect shape of q: [B, H, L, S]
+        auto inRank = op->get_input_partial_shape(0).size();
         if (inRank != 4u) {
             errorMessage = "Doesn't support 'data' input with rank: " + std::to_string(inRank);
             return false;
+        }
+        if (op->get_input_size() > 3) {
+            inRank = op->get_input_partial_shape(3).size();
+            if (inRank > 4u) {
+                errorMessage = "Doesn't support 'attention mask' with rank: " + std::to_string(inRank);
+                return false;
+            }
         }
         // using mha should be better for static shapes
         if (!op->is_dynamic()) {

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -773,11 +773,6 @@ bool ScaledDotProductAttention::isSupportedOperation(const std::shared_ptr<const
                 errorMessage = "Doesn't support 'attention mask' with rank: " + std::to_string(inRank);
                 return false;
             }
-            // // from spec, attn mask must be >= 3 or scalar
-            // if (!one_of(inRank, 0, 1, 3, 4)) {
-            //     errorMessage = "Doesn't support 'attention mask' with rank: " + std::to_string(inRank);
-            //     return false;
-            // }
         }
         // using mha should be better for static shapes
         if (!op->is_dynamic()) {

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/scaled_attn.hpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/scaled_attn.hpp
@@ -13,12 +13,12 @@ using namespace ov::test;
 
 namespace CPULayerTestsDefinitions {
 
-typedef std::tuple<ElementType,         // netPrecision
-                   InputShape,          // shape
-                   bool,                // is_causal
-                   bool,                // has_attn
-                   bool,                // has_scale
-                   std::string,         // targetDevice
+typedef std::tuple<ElementType,                      // netPrecision
+                   std::vector<InputShape>,          // shape
+                   bool,                             // is_causal
+                   bool,                             // has_attn
+                   bool,                             // has_scale
+                   std::string,                      // targetDevice
                    CPUSpecificParams>
     ScaledAttnCPUTestParams;
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/scaled_attn.cpp
@@ -14,10 +14,52 @@ namespace CPULayerTestsDefinitions {
 namespace ScaledAttn {
 const auto cpuSpec = CPUSpecificParams{{}, {}, {"ref_any"}, "ref_any"};
 
-const std::vector<InputShape> shapes{
-    {ov::test::InputShape{ov::PartialShape{-1, 8, -1, 64},
-        {ov::Shape{1, 8, 100, 64}, ov::Shape{1, 8, 1, 64}, ov::Shape{2, 8, 10, 64}}}
-    }
+const std::vector<std::vector<InputShape>> shapes{
+    // normal case, shapes of q,k,v are same
+    {
+        // q shape
+        {ov::test::InputShape{ov::PartialShape{-1, 8, -1, 64},
+            {ov::Shape{1, 8, 100, 64}, ov::Shape{1, 8, 1, 64}, ov::Shape{2, 8, 10, 64}}}
+        },
+        // kv shape
+        {ov::test::InputShape{ov::PartialShape{-1, 8, -1, 64},
+            {ov::Shape{1, 8, 100, 64}, ov::Shape{1, 8, 1, 64}, ov::Shape{2, 8, 10, 64}}}
+        },
+        // attn shape: [B, 1, 1, L0+L1]
+        {ov::test::InputShape{ov::PartialShape{-1, 1, 1, -1},
+            {ov::Shape{1, 1, 1, 100}, ov::Shape{1, 1, 1, 1}, ov::Shape{2, 1, 1, 10}}}
+        },
+    },
+    // heads number of kv is 1, attn mask: [B, H, L1, L0+L1]
+    {
+        // q shape
+        {ov::test::InputShape{ov::PartialShape{-1, 8, -1, 64},
+            {ov::Shape{1, 8, 100, 64}, ov::Shape{1, 8, 1, 64}, ov::Shape{2, 8, 10, 64}}}
+        },
+        // kv shape
+        {ov::test::InputShape{ov::PartialShape{-1, 1, -1, 64},
+            {ov::Shape{1, 1, 100, 64}, ov::Shape{1, 1, 1, 64}, ov::Shape{2, 1, 10, 64}}}
+        },
+        // attn shape
+        {ov::test::InputShape{ov::PartialShape{-1, 8, -1, -1},
+            {ov::Shape{1, 8, 100, 100}, ov::Shape{1, 8, 1, 1}, ov::Shape{2, 8, 10, 10}}}
+        },
+    },
+    // heads number of kv is 1, attn mask: [H, L1, L0+L1]
+    {
+        // q shape
+        {ov::test::InputShape{ov::PartialShape{-1, 8, -1, 64},
+            {ov::Shape{1, 8, 100, 64}, ov::Shape{1, 8, 1, 64}, ov::Shape{2, 8, 10, 64}}}
+        },
+        // kv shape
+        {ov::test::InputShape{ov::PartialShape{-1, 1, -1, 64},
+            {ov::Shape{1, 1, 100, 64}, ov::Shape{1, 1, 1, 64}, ov::Shape{2, 1, 10, 64}}}
+        },
+        // attn shape
+        {ov::test::InputShape{ov::PartialShape{8, -1, -1},
+            {ov::Shape{8, 100, 100}, ov::Shape{8, 1, 1}, ov::Shape{8, 10, 10}}}
+        },
+    },
 };
 
 const auto params = testing::Combine(testing::Values(ElementType::f32, ElementType::bf16),

--- a/tests/model_hub_tests/torch_tests/test_hf_transformers.py
+++ b/tests/model_hub_tests/torch_tests/test_hf_transformers.py
@@ -306,9 +306,7 @@ class TestTransformersModel(TestConvertModel):
                                            ("google/flan-t5-base", "t5"),
                                            ("google/tapas-large-finetuned-wtq", "tapas"),
                                            ("gpt2", "gpt2"),
-                                           ("openai/clip-vit-large-patch14", "clip"),
-                                           # TODO, will revert
-                                           ("Rocketknight1/tiny-random-falcon-7b", "led")
+                                           ("openai/clip-vit-large-patch14", "clip")
                                            ])
     @pytest.mark.precommit
     def test_convert_model_precommit(self, name, type, ie_device):

--- a/tests/model_hub_tests/torch_tests/test_hf_transformers.py
+++ b/tests/model_hub_tests/torch_tests/test_hf_transformers.py
@@ -306,7 +306,9 @@ class TestTransformersModel(TestConvertModel):
                                            ("google/flan-t5-base", "t5"),
                                            ("google/tapas-large-finetuned-wtq", "tapas"),
                                            ("gpt2", "gpt2"),
-                                           ("openai/clip-vit-large-patch14", "clip")
+                                           ("openai/clip-vit-large-patch14", "clip"),
+                                           # TODO, will revert
+                                           ("Rocketknight1/tiny-random-falcon-7b", "led")
                                            ])
     @pytest.mark.precommit
     def test_convert_model_precommit(self, name, type, ie_device):

--- a/tests/model_hub_tests/torch_tests/test_timm.py
+++ b/tests/model_hub_tests/torch_tests/test_timm.py
@@ -55,6 +55,9 @@ class TestTimmConvertModel(TestConvertModel):
 
     def convert_model(self, model_obj):
         ov_model = convert_model(model_obj, example_input=self.example)
+        for op in ov_model.get_ops():
+            if op.get_type_name() == 'ScaledDotProductAttention':
+                print('===========================', op)
         return ov_model
 
     def infer_fw_model(self, model_obj, inputs):
@@ -73,9 +76,29 @@ class TestTimmConvertModel(TestConvertModel):
         cleanup_dir(hf_hub_cache_dir)
         super().teardown_method()
 
-    @pytest.mark.parametrize("name", ["mobilevitv2_050.cvnets_in1k",
-                                      "poolformerv2_s12.sail_in1k",
-                                      "vit_base_patch8_224.augreg_in21k"])
+    @pytest.mark.parametrize("name", ["beit_base_patch16_224.in22k_ft_in22k",
+                                      "beitv2_base_patch16_224.in1k_ft_in1k",
+                                      "coatnet_0_rw_224.sw_in1k",
+                                      "coatnet_bn_0_rw_224.sw_in1k",
+                                      "coatnet_rmlp_1_rw2_224.sw_in12k",
+                                      "coatnet_rmlp_1_rw_224.sw_in1k",
+                                      "coatnext_nano_rw_224.sw_in1k",
+                                      "maxvit_base_tf_224.in1k",
+                                      "maxvit_nano_rw_256.sw_in1k",
+                                      "maxvit_rmlp_base_rw_224.sw_in12k",
+                                      "maxxvit_rmlp_nano_rw_256.sw_in1k",
+                                      "maxxvitv2_nano_rw_256.sw_in1k",
+                                      "maxxvitv2_rmlp_base_rw_224.sw_in12k",
+                                      "tiny_vit_5m_224.dist_in22k",
+                                      "tiny_vit_11m_224.dist_in22k",
+                                      "tiny_vit_21m_224.dist_in22k",
+                                      "vit_base_r50_s16_224.orig_in21k",
+                                      "vit_relpos_base_patch16_224.sw_in1k",
+                                      "vit_relpos_base_patch16_clsgap_224.sw_in1k",
+                                      "vit_relpos_base_patch32_plus_rpn_256.sw_in1k",
+                                      "vit_relpos_medium_patch16_cls_224.sw_in1k",
+                                      "vit_relpos_medium_patch16_rpn_224.sw_in1k",
+                                      "vit_srelpos_medium_patch16_224.sw_in1k"])
     @pytest.mark.precommit
     def test_convert_model_precommit(self, name, ie_device):
         self.run(name, None, ie_device)

--- a/tests/model_hub_tests/torch_tests/test_timm.py
+++ b/tests/model_hub_tests/torch_tests/test_timm.py
@@ -55,9 +55,6 @@ class TestTimmConvertModel(TestConvertModel):
 
     def convert_model(self, model_obj):
         ov_model = convert_model(model_obj, example_input=self.example)
-        for op in ov_model.get_ops():
-            if op.get_type_name() == 'ScaledDotProductAttention':
-                print('===========================', op)
         return ov_model
 
     def infer_fw_model(self, model_obj, inputs):
@@ -76,7 +73,11 @@ class TestTimmConvertModel(TestConvertModel):
         cleanup_dir(hf_hub_cache_dir)
         super().teardown_method()
 
-    @pytest.mark.parametrize("name", ["beit_base_patch16_224.in22k_ft_in22k",
+    @pytest.mark.parametrize("name", ["mobilevitv2_050.cvnets_in1k",
+                                      "poolformerv2_s12.sail_in1k",
+                                      "vit_base_patch8_224.augreg_in21k",
+                                      # TODO: will revert
+                                      "beit_base_patch16_224.in22k_ft_in22k",
                                       "beitv2_base_patch16_224.in1k_ft_in1k",
                                       "coatnet_0_rw_224.sw_in1k",
                                       "coatnet_bn_0_rw_224.sw_in1k",

--- a/tests/model_hub_tests/torch_tests/test_timm.py
+++ b/tests/model_hub_tests/torch_tests/test_timm.py
@@ -76,30 +76,7 @@ class TestTimmConvertModel(TestConvertModel):
     @pytest.mark.parametrize("name", ["mobilevitv2_050.cvnets_in1k",
                                       "poolformerv2_s12.sail_in1k",
                                       "vit_base_patch8_224.augreg_in21k",
-                                      # TODO: will revert
-                                      "beit_base_patch16_224.in22k_ft_in22k",
-                                      "beitv2_base_patch16_224.in1k_ft_in1k",
-                                      "coatnet_0_rw_224.sw_in1k",
-                                      "coatnet_bn_0_rw_224.sw_in1k",
-                                      "coatnet_rmlp_1_rw2_224.sw_in12k",
-                                      "coatnet_rmlp_1_rw_224.sw_in1k",
-                                      "coatnext_nano_rw_224.sw_in1k",
-                                      "maxvit_base_tf_224.in1k",
-                                      "maxvit_nano_rw_256.sw_in1k",
-                                      "maxvit_rmlp_base_rw_224.sw_in12k",
-                                      "maxxvit_rmlp_nano_rw_256.sw_in1k",
-                                      "maxxvitv2_nano_rw_256.sw_in1k",
-                                      "maxxvitv2_rmlp_base_rw_224.sw_in12k",
-                                      "tiny_vit_5m_224.dist_in22k",
-                                      "tiny_vit_11m_224.dist_in22k",
-                                      "tiny_vit_21m_224.dist_in22k",
-                                      "vit_base_r50_s16_224.orig_in21k",
-                                      "vit_relpos_base_patch16_224.sw_in1k",
-                                      "vit_relpos_base_patch16_clsgap_224.sw_in1k",
-                                      "vit_relpos_base_patch32_plus_rpn_256.sw_in1k",
-                                      "vit_relpos_medium_patch16_cls_224.sw_in1k",
-                                      "vit_relpos_medium_patch16_rpn_224.sw_in1k",
-                                      "vit_srelpos_medium_patch16_224.sw_in1k"])
+                                      "beit_base_patch16_224.in22k_ft_in22k"])
     @pytest.mark.precommit
     def test_convert_model_precommit(self, name, ie_device):
         self.run(name, None, ie_device)


### PR DESCRIPTION
### Details:
 - *Fix ScaledDotProductAttension accuracy problem*
   - Error: many models from timm repo failed to pass its accuracy test
   - Reason:
     - original attn_mask assumed that its shape was like [B, 1, L0, L0+L1], this was not true in encoder-based models, these shapes are possible: [B/1, H/1, L0/1, L0+L1], [H/1, L0/1, L0+L1] or scalar
     - k,v head number of model 'Rocketknight1/tiny-random-falcon-7b' is 1 which previously requires their head number must be equal to q

### Tickets:
 - *125517*
