### PR TITLE
WIP: [CPU] Deconvolution: Added fp32 output precision check for fusing

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -329,7 +329,7 @@ bool Deconvolution::canFuse(const NodePtr& node) const {
     if (canBeExecutedInInt8())
         return canFuseSimpleOperation(node);
 
-    return (fusedWith.empty() && node->canBePerformedAsScaleShift(this));
+    return (fusedWith.empty() && node->canBePerformedAsScaleShift(this)) && node->getOriginalOutputPrecisionAtPort(0) == ov::element::f32;
 }
 
 std::pair<VectorDims, VectorDims> Deconvolution::makeDummyInOutShape() {


### PR DESCRIPTION
### Details:
 - *Added additional fp32 precision check for deconvolution post ops fusing*

### Tickets:
 - *https://github.com/openvinotoolkit/openvino/issues/21040*

### TODO:
- [ ] Cover with tests