### PR TITLE
Fixed smoke_Basic/FuseTransposeAndReorderTest issue

### DIFF
--- a/src/inference/src/cnn_network_ngraph_impl.cpp
+++ b/src/inference/src/cnn_network_ngraph_impl.cpp
@@ -118,6 +118,9 @@ ngraph::element::Type details::toLegacyType(const ngraph::element::Type& ngraph_
         if (ngraph_type == ngraph::element::i64 || ngraph_type == ngraph::element::u64 ||
             ngraph_type == ngraph::element::i32 || ngraph_type == ngraph::element::u32) {
             return ngraph::element::i32;
+        } else if (ngraph_type == ngraph::element::i8 || ngraph_type == ngraph::element::u8 ||
+                   ngraph_type == ngraph::element::i16 || ngraph_type == ngraph::element::u16) {
+            return ngraph::element::i8;
         } else if (ngraph_type != ngraph::element::f32) {
             return ngraph::element::f32;
         }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -178,8 +178,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*InferRequestIOBBlobTest.*canProcessDeallocatedOutputBlobAfterGetAndSetBlob.*)",
         // Plugin version was changed to ov::Version
         R"(.*VersionTest.*pluginCurrentVersionIsCorrect.*)",
-        // Issue: 120286
-        R"(.*smoke_Basic/FuseTransposeAndReorderTest.CompareWithRefs.*)",
         // Issue: 113703, 114763
         R"(.*smoke_If/SimpleIfTest.*Cond=0.*)",
         // Issue: 114765


### PR DESCRIPTION
### Details:
 - Avoid adding additional convert node into graph during CNNNetworkNGraphImpl, which can fix Fixed smoke_Basic/FuseTransposeAndReorderTest issue.


### Tickets:
 - 120286
