### PR TITLE
[OVC] Fixed bug related to verbose param.

### DIFF
--- a/tests/layer_tests/ovc_python_api_tests/test_ovc_cli_tool.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_ovc_cli_tool.py
@@ -40,6 +40,8 @@ def generate_ir_ovc(coverage=False, **kwargs):
         # if we omit this argument for FP32, it will be set implicitly to True as the default
         elif key == 'compress_to_fp16':
             params.append("--{}={}".format(key, value))
+        elif key == 'verbose':
+            params.append("--{}".format(key))
         elif isinstance(value, bool) and value:
             params.append("--{}".format(key))
         elif isinstance(value, bool) and not value:
@@ -174,5 +176,19 @@ class TestOVCTool(unittest.TestCase):
         assert not exit_code
 
         ov_model = core.read_model(os.path.join(self.tmp_dir, "dir", "test_model.xml"))
+        flag, msg = compare_functions(ov_model, ref_model, False)
+        assert flag, msg
+
+
+    def test_ovc_tool_verbose(self):
+        from openvino.runtime import Core
+        core = Core()
+
+        model_dir, ref_model = self.create_tf_saved_model_dir(self.tmp_dir)
+
+        exit_code, stderr = generate_ir_ovc(coverage=False, **{"input_model": model_dir, "output_model": self.tmp_dir, "verbose": ""})
+        assert not exit_code
+
+        ov_model = core.read_model(os.path.join(self.tmp_dir, "test_model.xml"))
         flag, msg = compare_functions(ov_model, ref_model, False)
         assert flag, msg

--- a/tools/ovc/openvino/tools/ovc/cli_parser.py
+++ b/tools/ovc/openvino/tools/ovc/cli_parser.py
@@ -575,9 +575,11 @@ def get_model_name_from_args(argv: argparse.Namespace):
                 raise Error('The directory "{}" is not writable'.format(argv.output_model))
             output_dir = argv.output_model
 
-    input_model = os.path.abspath(argv.input_model)
+    input_model = argv.input_model
     if isinstance(input_model, (tuple, list)) and len(input_model) > 0:
         input_model = input_model[0]
+
+    input_model = os.path.abspath(input_model)
 
     if not isinstance(input_model, (str, pathlib.Path)):
         return output_dir


### PR DESCRIPTION
Root cause analysis: 
`argv.input_model` contains `list` after arguments parsing. If `--verbose` is used, `get_model_name_from_args()` method is launched after parsing with `list` in `argv.input_model`, which leads to crush, as `list` is passed to `os.path.abspath()`.

Solution: 
Get first element from list if `argv.input_model` is list.

Ticket: CVS-125731


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update