### PR TITLE
Add CMake hint to install patchelf with pip

### DIFF
--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -187,7 +187,7 @@ if(LINUX)
                       DOC "Path to patchelf tool")
     if(NOT patchelf_program)
         set(ENABLE_WHEEL_DEFAULT OFF)
-        message(${message_mode} "patchelf is not found. It is required to build OpenVINO Runtime wheel. Install via apt-get install patchelf")
+        message(${message_mode} "patchelf is not found. It is required to build OpenVINO Runtime wheel. Install via `pip install patchelf` or `apt install patchelf`.")
     endif()
 endif()
 


### PR DESCRIPTION
`pip install patchelf` is more cross platform than apt, and does not require root access. Patchelf is needed to install a wheel, so the user will already have Python and pip installed.