### PR TITLE
[CPU] add new sub-pattern into RoPEFusionCosSinPreprocess

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -44,6 +44,13 @@ struct RoPE::RoPEExecutorRotateHalf : public RoPE::Executor {
         ov::intel_cpu::PlainTensor<T> t_dst(outputs[0]);
         ov::intel_cpu::PlainTensor<int32_t> gather;
 
+        if (t_cos.m_rank == 2) {
+            t_cos = t_cos.reshape({1, 1, t_cos.size(0), t_cos.size(1)});
+        }
+        if (t_sin.m_rank == 2) {
+            t_sin = t_sin.reshape({1, 1, t_sin.size(0), t_sin.size(1)});
+        }
+
         if (config.slice_stop - config.slice_start > 0) {
             t_src = t_src.slice(3, config.slice_start, config.slice_stop);
         }


### PR DESCRIPTION
### Details:
 - *Some common transformation simplified a sub-pattern in `RoPEFusionCosSinPreprocess`, update it to match such change*
 - *This enables ~2% latency reduction of llama2-7b-chat on RPL 13900K*

BTW, this demonstrated why complex pattern matching side plugin is bad idea.

### Tickets:
 - *ticket-id*
