### PR TITLE
[Snippets] MHA tests: bf16 inputs generation restored

### DIFF
--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -81,7 +81,9 @@ void MHA::generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticSha
     for (int i = 0; i < model_inputs.size(); ++i) {
         const auto& model_input = model_inputs[i];
         ov::Tensor tensor;
-        tensor = ov::test::utils::create_and_fill_tensor(model_input.get_element_type(), model_input.get_shape(), 2, -1, 256);
+        // To avoid big relative errors in the vicinity of zero, only positive values are generated for bf16 precision
+        int start_from = model_input.get_element_type() == ov::element::bf16 ? 0 : -1;
+        tensor = ov::test::utils::create_and_fill_tensor(model_input.get_element_type(), model_input.get_shape(), 2, start_from, 256);
         inputs.insert({model_input.get_node_shared_ptr(), tensor});
     }
 }


### PR DESCRIPTION
### Details:
After "[TESTS] Fix random generator for custom signed types" #20393 some snippets MHA instances started to fail on SPR. This PR restores data generation for bf16 in MHA tests

### Tickets:
 - *CVS-125674*
