### PR TITLE
[GHA] Add GPU stub job to collect statistics

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1576,6 +1576,17 @@ jobs:
       - name: Show ccache stats
         run: ${SCCACHE_PATH} --show-stats
 
+  GPU_Stub:
+    needs: [Build, Smart_CI]
+    runs-on: ubuntu-latest
+    if: fromJSON(needs.smart_ci.outputs.affected_components).GPU
+    steps:
+      - name: GPU stub
+        run: |
+          echo "This is only a stub to collect statistics of GPU runs filtered by Smart CI. 
+          It will help us to estimate hardware requirements"
+        shell: bash
+
   Overall_Status:
     name: ci/gha_linux
     needs: [Smart_CI, Build, Debian_Packages, Samples, Conformance, ONNX_Runtime, CXX_Unit_Tests, Python_Unit_Tests,


### PR DESCRIPTION
To estimate the amount of hardware needed to cover our needs, we need to collect real-life statistics from PRs that would require running GPU tests with Smart CI rules enabled (how many executions we have per hour, etc.)