### PR TITLE
Modify python test cases which are failing during parallel execution

### DIFF
--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
@@ -31,18 +31,16 @@ class TestKerasStackedRNNCells(CommonTF2LayerTest):
         return tf2_net, ref_net
 
     test_data = [
-        dict(input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32,
-             rnn_cells="LSTMCell"),
-        dict(input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32,
-             rnn_cells="GRUCell")
+        (["x1"], [[5, 4, 3]], tf.float32, "LSTMCell"),
+        (["x1"], [[5, 4, 3]], tf.float32, "GRUCell")
     ]
 
-    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_names, input_shapes, input_type, rnn_cells", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
-    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
-                                   use_new_frontend):
+    def test_keras_stackedrnncells(self, input_names, input_shapes, input_type, rnn_cells, ie_device, precision, ir_version, temp_dir, use_old_api, use_new_frontend):
+        params = {"input_names": input_names, "input_shapes": input_shapes, "input_type": input_type,"rnn_cells": rnn_cells}
         self._test(*self.create_keras_stackedrnncells_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -45,17 +45,15 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
 
     # Tests for bilinear interpolation
     test_data_bilinear = [
-        pytest.param(dict(input_names=["x1"], input_shapes=[[1, 6, 2, 1]], input_type=tf.float32,
-                          size=(3, 1), data_format='channels_last', interpolation='bilinear'),
-                     marks=pytest.mark.precommit_tf_fe),
-        dict(input_names=["x1"], input_shapes=[[1, 3, 1, 6]], input_type=tf.float32,
-             size=(5, 2), data_format='channels_last', interpolation='bilinear'),
+        pytest.param((["x1"], [[1, 6, 2, 1]], tf.float32, (3, 1), 'channels_last', 'bilinear'), marks=pytest.mark.precommit_tf_fe),
+        (["x1"], [[1, 3, 1, 6]], tf.float32, (5, 2), 'channels_last', 'bilinear')
     ]
 
-    @pytest.mark.parametrize("params", test_data_bilinear)
+    @pytest.mark.parametrize("input_names, input_shapes, input_type, size, data_format, interpolation", test_data_bilinear)
     @pytest.mark.nightly
-    def test_keras_upsampling2d_bilinear(self, params, ie_device, precision, ir_version, temp_dir,
+    def test_keras_upsampling2d_bilinear(self, input_names, input_shapes, input_type, size, data_format, interpolation, ie_device, precision, ir_version, temp_dir,
                                          use_old_api, use_new_frontend):
+        params = {"input_names": input_names, "input_shapes": input_shapes, "input_type": input_type, "size": size, "data_format": data_format, "interpolation": interpolation}
         self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
@@ -22,19 +22,17 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
         return tf2_net, ref_net
 
     test_data_channels_last = [
-        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]], input_type=tf.float32,
-             padding=2, data_format='channels_last'),
-        dict(input_names=["x1"], input_shapes=[[3, 2, 4, 6]], input_type=tf.float32,
-             padding=(3, 0), data_format='channels_last'),
-        pytest.param(dict(input_names=["x1"], input_shapes=[[1, 3, 8, 7]], input_type=tf.float32,
-                          padding=((5, 1), (3, 4)), data_format='channels_last'), marks=pytest.mark.precommit_tf_fe),
+        (["x1"], [[5, 4, 8, 3]], tf.float32, 2, 'channels_last'),
+        (["x1"], [[3, 2, 4, 6]], tf.float32, (3, 0), 'channels_last'),
+        pytest.param((["x1"], [[1, 3, 8, 7]], tf.float32, ((5, 1), (3, 4))), marks=pytest.mark.precommit_tf_fe),
     ]
 
-    @pytest.mark.parametrize("params", test_data_channels_last)
+    @pytest.mark.parametrize("input_names, input_shapes, input_type, padding, data_format", test_data_channels_last)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_zeropadding2d_channels_last(self, params, ie_device, precision, ir_version,
+    def test_keras_zeropadding2d_channels_last(self, input_names, input_shapes, input_type, padding, data_format, ie_device, precision, ir_version,
                                                temp_dir, use_old_api):
+        params = {"input_names": input_names, "input_shapes": input_shapes, "input_type": input_type, "padding": padding, "data_format": data_format}
         self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
@@ -97,23 +97,16 @@ class TestMapFN(CommonTF2LayerTest):
                    **params)
 
     test_multiple_inputs_outputs_int32 = [
-        dict(fn=lambda x: x[0] * x[1] + x[2],
-             input_type=tf.int32,
-             fn_output_signature=tf.int32, back_prop=True,
-             input_names=["x1", "x2", "x3"],
-             input_shapes=[[2, 1, 3], [2, 1, 3], [2, 1, 3]]),
-        pytest.param(dict(fn=lambda x: (x[0] + x[1] + x[2], x[0] - x[2] + x[1], 2 + x[2]),
-                          input_type=tf.int32,
-                          fn_output_signature=(tf.int32, tf.int32, tf.int32), back_prop=True,
-                          input_names=["x1", "x2", "x3"],
-                          input_shapes=[[2, 1, 3, 4], [2, 1, 3, 4], [2, 1, 3, 4]]),
+        (lambda x: x[0] * x[1] + x[2], tf.int32, tf.int32, True, ["x1", "x2", "x3"], [[2, 1, 3], [2, 1, 3], [2, 1, 3]]),
+        pytest.param(lambda x: (x[0] + x[1] + x[2], x[0] - x[2] + x[1], 2 + x[2]), tf.int32, (tf.int32, tf.int32, tf.int32), True, ["x1", "x2", "x3"], [[2, 1, 3, 4], [2, 1, 3, 4], [2, 1, 3, 4]],
                      marks=[pytest.mark.xfail(reason="61587"), pytest.mark.precommit_tf_fe])
     ]
 
-    @pytest.mark.parametrize("params", test_multiple_inputs_outputs_int32)
+    @pytest.mark.parametrize("fn, input_type, fn_output_signature, back_prop, input_names, input_shapes", test_multiple_inputs_outputs_int32)
     @pytest.mark.nightly
-    def test_multiple_inputs_outputs_int32(self, params, ie_device, precision, ir_version, temp_dir,
+    def test_multiple_inputs_outputs_int32(self, fn, input_type, fn_output_signature, back_prop, input_names, input_shapes, ie_device, precision, ir_version, temp_dir,
                                            use_old_api, use_new_frontend):
+        params = {"fn": fn, "input_type": input_type, "fn_output_signature": fn_output_signature, "back_prop": back_prop, "input_names": input_names, "input_shapes": input_shapes}
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
                    **params)


### PR DESCRIPTION
* Addressing the "Known limitation" issue for python test cases which failed parallel execution.

### Details:- 
- Previously few python test cases had dictionaries in their parameters list.
- Now converted the dictionaries to tuples to maintain order while executing the tests in parallel.

### Tickets:
 - *[ticket-id](https://github.com/openvinotoolkit/openvino/issues/20919)*
