### PR TITLE
[GNA] Use OV thread_local implementation

### DIFF
--- a/src/plugins/intel_gna/src/backend/gna_limitations.cpp
+++ b/src/plugins/intel_gna/src/backend/gna_limitations.cpp
@@ -677,7 +677,7 @@ constexpr uint32_t Limitations::kBytesPerCropElement;
 constexpr uint32_t Limitations::kBytesPerConcatElement;
 constexpr uint32_t Limitations::kMemoryPageSize;
 
-InferenceEngine::ThreadLocal<std::shared_ptr<Limitations>> Limitations::kInstance{nullptr};
+ov::threading::ThreadLocal<std::shared_ptr<Limitations>> Limitations::kInstance{nullptr};
 
 Limitations::Limitations(const DeviceVersion& target) {
     m_use_only_16bit_conv_weights =

--- a/src/plugins/intel_gna/src/backend/gna_limitations.cpp
+++ b/src/plugins/intel_gna/src/backend/gna_limitations.cpp
@@ -677,7 +677,7 @@ constexpr uint32_t Limitations::kBytesPerCropElement;
 constexpr uint32_t Limitations::kBytesPerConcatElement;
 constexpr uint32_t Limitations::kMemoryPageSize;
 
-thread_local std::shared_ptr<Limitations> Limitations::k_instance{nullptr};
+InferenceEngine::ThreadLocal<std::shared_ptr<Limitations>> Limitations::kInstance{nullptr};
 
 Limitations::Limitations(const DeviceVersion& target) {
     m_use_only_16bit_conv_weights =
@@ -689,7 +689,13 @@ Limitations::Limitations(const DeviceVersion& target) {
 }
 
 void Limitations::init(const DeviceVersion& compile_target) {
-    k_instance = std::shared_ptr<Limitations>(new Limitations(compile_target));
+    auto& localInstance = kInstance.local();
+    localInstance.reset(new Limitations(compile_target));
+}
+
+void Limitations::deinit() {
+    auto& localInstance = kInstance.local();
+    localInstance.reset();
 }
 
 size_t Limitations::get_min_batch_to_fit_in_buffer(InferenceEngine::DataPtr input) {

--- a/src/plugins/intel_gna/src/backend/gna_limitations.hpp
+++ b/src/plugins/intel_gna/src/backend/gna_limitations.hpp
@@ -20,9 +20,9 @@
 #include "legacy/ngraph_ops/fully_connected.hpp"
 #include "ngraph/opsets/opset7.hpp"
 #include "ngraph/opsets/opset9.hpp"
+#include "openvino/runtime/threading/thread_local.hpp"
 #include "ops/gna_convolution.hpp"
 #include "ops/gna_max_pool.hpp"
-#include "threading/ie_thread_local.hpp"
 
 namespace ov {
 namespace intel_gna {
@@ -316,7 +316,7 @@ private:
     size_t m_mem_alignment = 0;
     std::shared_ptr<cnn2d::AbstractValidator> m_cnn_validator;
 
-    static InferenceEngine::ThreadLocal<std::shared_ptr<Limitations>> kInstance;
+    static ov::threading::ThreadLocal<std::shared_ptr<Limitations>> kInstance;
 };
 
 inline std::shared_ptr<Limitations> Limitations::get_instance() {

--- a/src/plugins/intel_gna/src/gna_plugin.cpp
+++ b/src/plugins/intel_gna/src/gna_plugin.cpp
@@ -1429,4 +1429,6 @@ InferenceEngine::QueryNetworkResult GNAPlugin::QueryNetwork(
 GNAPlugin::~GNAPlugin() {
     if (gnadevice)
         gnadevice->close();
+
+    Limitations::deinit();
 }

--- a/src/plugins/intel_gna/tests/deprecated/unit/engines/gna/I8_quantisation_test.cpp
+++ b/src/plugins/intel_gna/tests/deprecated/unit/engines/gna/I8_quantisation_test.cpp
@@ -52,6 +52,10 @@ protected:
     void SetUp() override {
         Limitations::init(target::DeviceVersion::Default);
     }
+
+    void TearDown() override {
+        Limitations::deinit();
+    }
 };
 
 // TODO: add test for FC weights after quantization

--- a/src/plugins/intel_gna/tests/deprecated/unit/engines/gna/i16_quantisation_test.cpp
+++ b/src/plugins/intel_gna/tests/deprecated/unit/engines/gna/i16_quantisation_test.cpp
@@ -54,6 +54,10 @@ protected:
     void SetUp() override {
         Limitations::init(target::DeviceVersion::Default);
     }
+
+    void TearDown() override {
+        Limitations::deinit();
+    }
 };
 
 template <class T>

--- a/src/plugins/intel_gna/tests/unit/backend/gna_limitations_test.cpp
+++ b/src/plugins/intel_gna/tests/unit/backend/gna_limitations_test.cpp
@@ -287,6 +287,10 @@ protected:
         ASSERT_TRUE(validator);
     }
 
+    void TearDown() override {
+        Limitations::deinit();
+    }
+
     std::shared_ptr<cnn2d::AbstractValidator> validator;
 };
 

--- a/src/plugins/intel_gna/tests/unit/gna_get_aligned_split_sizes.cpp
+++ b/src/plugins/intel_gna/tests/unit/gna_get_aligned_split_sizes.cpp
@@ -65,6 +65,7 @@ void RunVariadicSplitSupportedTest(DeviceVersion device_version, std::vector<Var
                                              split_lengths));
         ASSERT_TRUE(Limitations::is_split_supported(split, false) == result);
     }
+    Limitations::deinit();
 }
 
 TEST(CheckSplitSupported, CheckVariadicSplitSupported_GNA3_5) {
@@ -108,6 +109,7 @@ void RunSplitSupportedTest(DeviceVersion device_version, std::vector<SplitParame
             num_splits);
         ASSERT_TRUE(Limitations::is_split_supported(split, false) == result);
     }
+    Limitations::deinit();
 }
 
 TEST(CheckSplitSupported, CheckSplitSupported_GNA3_5) {

--- a/src/plugins/intel_gna/tests/unit/gna_memory_alignment.cpp
+++ b/src/plugins/intel_gna/tests/unit/gna_memory_alignment.cpp
@@ -152,11 +152,13 @@ class MemoryAlignmentTest : public ::testing::Test {};
 TEST(MemoryAlignmentTest, getMemoryAlignmentBytes_Expect64ByteAlignmentWhenTargetIsGNA3_5) {
     Limitations::init(DeviceVersion::GNA3_5);
     EXPECT_EQ(Limitations::get_instance()->get_memory_alignment(), 64);
+    Limitations::deinit();
 }
 
 TEST(MemoryAlignmentTest, getMemoryAlignmentBytes_Expect16ByteAlignmentWhenTargetIsGNA3_6) {
     Limitations::init(DeviceVersion::GNA3_6);
     EXPECT_EQ(Limitations::get_instance()->get_memory_alignment(), 16);
+    Limitations::deinit();
 }
 
 }  // namespace testing

--- a/src/plugins/intel_gna/tests/unit/transformations/gna_decompose_2d_convolution.cpp
+++ b/src/plugins/intel_gna/tests/unit/transformations/gna_decompose_2d_convolution.cpp
@@ -295,6 +295,7 @@ class Decompose2DConvTestInvalidFixture : public ov::test::TestsCommon,
                                           public ::testing::WithParamInterface<fqDecompose2DConvParams> {
 public:
     void SetUp() override;
+    void TearDown() override;
 
 public:
     std::shared_ptr<ngraph::Function> function, reference_function;
@@ -339,12 +340,17 @@ void Decompose2DConvTestInvalidFixture::SetUp() {
                                               conv_params);
 }
 
+void Decompose2DConvTestInvalidFixture::TearDown() {
+    Limitations::deinit();
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 
 class Decompose2DConvTestFixture : public ov::test::TestsCommon,
                                    public ::testing::WithParamInterface<fqDecompose2DConvParams> {
 public:
     void SetUp() override;
+    void TearDown() override;
 
     std::shared_ptr<ngraph::Function> get_reference(const bool& fq,
                                                     const modelType& model,
@@ -383,6 +389,10 @@ void Decompose2DConvTestFixture::SetUp() {
                                     graph_data,
                                     conv_params);
     reference_function = get_reference(fq, model, input_shape, graph_data, conv_params);
+}
+
+void Decompose2DConvTestFixture::TearDown() {
+    Limitations::deinit();
 }
 
 std::shared_ptr<ngraph::Node> ReshapeBiasConst(std::shared_ptr<ngraph::opset7::Add> conv_bias,

--- a/src/plugins/intel_gna/tests/unit/transformations/gna_insert_copy_layer.cpp
+++ b/src/plugins/intel_gna/tests/unit/transformations/gna_insert_copy_layer.cpp
@@ -44,6 +44,7 @@ public:
         return result.str();
     }
     void SetUp() override;
+    void TearDown() override;
     virtual void Validate();
     virtual void Run();
 
@@ -63,6 +64,9 @@ void InsertCopyLayerTest::Validate() {
 void InsertCopyLayerTest::SetUp() {
     std::tie(m_device_ver, m_axis, m_inputs_num) = this->GetParam();
     Limitations::init(m_device_ver);
+}
+void InsertCopyLayerTest::TearDown() {
+    Limitations::deinit();
 }
 
 void InsertCopyLayerTest::Run() {
@@ -212,6 +216,7 @@ public:
 
     void TearDown() override {
         m_func.reset();
+        Limitations::deinit();
     }
 
     void RunPasses(ngraph::pass::Manager& m) {

--- a/src/plugins/intel_gna/tests/unit/transformations/gna_split_convolution_with_large_buffer_size.cpp
+++ b/src/plugins/intel_gna/tests/unit/transformations/gna_split_convolution_with_large_buffer_size.cpp
@@ -270,6 +270,7 @@ class SplitConvolutionFixture : public ov::test::TestsCommon,
                                 public ::testing::WithParamInterface<std::tuple<DeviceVersion, TestParams>> {
 public:
     void SetUp() override;
+    void TearDown() override;
 
 public:
     std::shared_ptr<ngraph::Function> function, reference_function;
@@ -288,6 +289,10 @@ void SplitConvolutionFixture::SetUp() {
     Limitations::init(device_version);
     function = transformed_graph.createFunction();
     reference_function = reference_graph.createFunction();
+}
+
+void SplitConvolutionFixture::TearDown() {
+    Limitations::deinit();
 }
 
 void execute_test(std::shared_ptr<ngraph::Function> function,

--- a/src/plugins/intel_gna/tests/unit/transformations/gna_split_eltwise.cpp
+++ b/src/plugins/intel_gna/tests/unit/transformations/gna_split_eltwise.cpp
@@ -134,6 +134,7 @@ class SplitEltwiseTestSuiteFixture : public ov::test::TestsCommon,
                                      public ::testing::WithParamInterface<EltwiseSplitParams> {
 public:
     void SetUp() override;
+    void TearDown() override;
 
 public:
     std::shared_ptr<ngraph::Function> function, reference_function;
@@ -149,6 +150,10 @@ void SplitEltwiseTestSuiteFixture::SetUp() {
     Limitations::init(device_ver);
     function = createFunction(shape, with_const, with_fq, type, false);
     reference_function = createFunction(shape, with_const, with_fq, type, true);
+}
+
+void SplitEltwiseTestSuiteFixture::TearDown() {
+    Limitations::deinit();
 }
 
 void execute_test(std::shared_ptr<ngraph::Function> function, std::shared_ptr<ngraph::Function> reference_function) {


### PR DESCRIPTION
### Details:
 - Use InferenceEngine::ThreadLocal instead of the local_thread variable to prevent AppVerifier from detecting a memory leak

### Tickets:
 - 124826
