### PR TITLE
[core]Remove deprecated function from Loop

### DIFF
--- a/src/core/dev_api/validation_util.hpp
+++ b/src/core/dev_api/validation_util.hpp
@@ -91,5 +91,13 @@ bool try_apply_auto_padding(const PartialShape& image_shape,
 /// @param tensors  Input tensors vector to get their shapes.
 /// @return Vector of partial shapes same size as input tensor vector.
 OPENVINO_API std::vector<PartialShape> get_tensors_partial_shapes(const TensorVector& tensors);
+
+/// \brief Check if rank is compatible to any of others ranks.
+///
+/// \param r       Rank to check.
+/// \param others  List of ranks used to check compatibility.
+///
+/// \return True if rank compatible to any of others, otherwise false.
+OPENVINO_API bool is_rank_compatible_any_of(const Rank& r, std::initializer_list<Rank> others);
 }  // namespace util
 }  // namespace ov

--- a/src/core/include/openvino/core/validation_util.hpp
+++ b/src/core/include/openvino/core/validation_util.hpp
@@ -180,13 +180,4 @@ OPENVINO_API bool has_no_labels(const TensorLabel& labels);
 OPENVINO_DEPRECATED("This function is deprecated and will be moved to dev api in 2024.0 release.")
 OPENVINO_API std::vector<PartialShape> get_node_input_partial_shapes(const ov::Node& node);
 
-/// \brief Check if rank is compatible to any of rank from container.
-///
-/// \param rank   Rank to check.
-/// \param ranks  VEctor of ranks used to check input rank compatibility.
-///
-/// \return True if rank compatible to any from ranks, otherwise false.
-OPENVINO_DEPRECATED("This function is deprecated and will be moved to dev api in 2024.0 release.")
-OPENVINO_API bool is_rank_compatible_any_of(const ov::Rank& rank, const std::vector<ov::Rank>& ranks);
-
 }  // namespace ov

--- a/src/core/shape_inference/include/convolution_shape_inference_util.hpp
+++ b/src/core/shape_inference/include/convolution_shape_inference_util.hpp
@@ -285,12 +285,10 @@ void append_spatial_shape(const TOp* op,
 namespace validate {
 template <class TShape>
 void data_shape(const ov::op::util::ConvolutionBase* op, const TShape& data_shape) {
-    OPENVINO_SUPPRESS_DEPRECATED_START
     NODE_VALIDATION_CHECK(op,
-                          is_rank_compatible_any_of(data_shape.rank(), {3, 4, 5}),
+                          ov::util::is_rank_compatible_any_of(data_shape.rank(), {3, 4, 5}),
                           "Expected a 3D, 4D or 5D tensor for the input. Got: ",
                           data_shape);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 template <class TShape>

--- a/src/core/shape_inference/include/pooling_shape_inference_util.hpp
+++ b/src/core/shape_inference/include/pooling_shape_inference_util.hpp
@@ -30,12 +30,10 @@ template <class TOp, class TShape>
 void attributes(const TOp* op, const TShape& data_shape, const Strides& dilations) {
     const auto& data_rank = data_shape.rank();
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     NODE_VALIDATION_CHECK(op,
-                          is_rank_compatible_any_of(data_rank, {3, 4, 5}),
+                          ov::util::is_rank_compatible_any_of(data_rank, {3, 4, 5}),
                           "Expected a 3D, 4D or 5D tensor for the input. Got: ",
                           data_shape);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
     const auto& kernel = op->get_kernel();
     const auto num_spatial = kernel.size();
@@ -252,7 +250,7 @@ TRShape out_shape_infer(const TOp* op, const std::vector<TShape>& input_shapes, 
 
     OPENVINO_SUPPRESS_DEPRECATED_START
     NODE_VALIDATION_CHECK(op,
-                          is_rank_compatible_any_of(data_rank, {3, 4, 5}),
+                          ov::util::is_rank_compatible_any_of(data_rank, {3, 4, 5}),
                           "Expected a 3D, 4D or 5D tensor for the input. Got: ",
                           data_shape);
     OPENVINO_SUPPRESS_DEPRECATED_END

--- a/src/core/shape_inference/include/scatter_elements_update_shape_inference.hpp
+++ b/src/core/shape_inference/include/scatter_elements_update_shape_inference.hpp
@@ -22,13 +22,11 @@ std::vector<TRShape> shape_infer(const util::ScatterElementsUpdateBase* op,
     const auto& updates_shape = input_shapes[2];
     const auto& axis_shape = input_shapes[3];
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     NODE_VALIDATION_CHECK(op,
-                          is_rank_compatible_any_of(axis_shape.rank(), {0, 1}),
+                          ov::util::is_rank_compatible_any_of(axis_shape.rank(), {0, 1}),
                           "Axis input shape are required to be scalar or 1D tensor. ",
                           "Got: ",
                           axis_shape);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
     const auto& data_rank = data_shape.rank();
     const auto& indices_rank = indices_shape.rank();

--- a/src/core/shape_inference/include/squeeze_shape_inference.hpp
+++ b/src/core/shape_inference/include/squeeze_shape_inference.hpp
@@ -40,12 +40,10 @@ std::vector<TRShape> shape_infer(const Squeeze* op,
         unique_axes.reset(new std::set<int64_t>());
     } else if (number_of_inputs == 2) {
         const auto& axes_shape = input_shapes[1];
-        OPENVINO_SUPPRESS_DEPRECATED_START
         NODE_VALIDATION_CHECK(op,
-                              axes_shape.is_dynamic() || is_rank_compatible_any_of(axes_shape.rank(), {0, 1}),
+                              axes_shape.is_dynamic() || ov::util::is_rank_compatible_any_of(axes_shape.rank(), {0, 1}),
                               "Second input (axes) should not be of rank higher than 1. Got: ",
                               axes_shape.rank().get_length());
-        OPENVINO_SUPPRESS_DEPRECATED_END
 
         std::vector<int64_t> axes;
         if (arg_rank.is_static() && axes_shape.is_static()) {

--- a/src/core/shape_inference/include/unsqueeze_shape_inference.hpp
+++ b/src/core/shape_inference/include/unsqueeze_shape_inference.hpp
@@ -12,12 +12,10 @@ namespace v0 {
 
 template <class TOp>
 void check_unsqueeze_axes_rank(const TOp* op, const Rank& rank) {
-    OPENVINO_SUPPRESS_DEPRECATED_START
     NODE_VALIDATION_CHECK(op,
-                          is_rank_compatible_any_of(rank, {0, 1}),
+                          ov::util::is_rank_compatible_any_of(rank, {0, 1}),
                           "Second input (axes) should not be of rank higher than 1. Got: ",
                           rank);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 template <class TShape, class TRShape = result_shape_t<TShape>>

--- a/src/core/src/validation_util.cpp
+++ b/src/core/src/validation_util.cpp
@@ -1433,5 +1433,11 @@ std::vector<PartialShape> get_tensors_partial_shapes(const TensorVector& tensors
     }
     return shapes;
 }
+
+bool is_rank_compatible_any_of(const Rank& r, std::initializer_list<Rank> others) {
+    return std::any_of(others.begin(), others.end(), [&r](const Rank& other) {
+        return r.compatible(other);
+    });
+}
 }  // namespace util
 }  // namespace ov

--- a/src/core/src/validation_util.cpp
+++ b/src/core/src/validation_util.cpp
@@ -1164,12 +1164,6 @@ std::vector<ov::PartialShape> ov::get_node_input_partial_shapes(const ov::Node& 
     return out;
 }
 
-bool ov::is_rank_compatible_any_of(const ov::Rank& rank, const std::vector<Rank>& ranks) {
-    return std::any_of(ranks.cbegin(), ranks.cend(), [&rank](const Rank& r) {
-        return rank.compatible(r);
-    });
-}
-
 bool ov::util::are_unique(const std::vector<int64_t>& data) {
     return std::unordered_set<int64_t>(data.begin(), data.cend()).size() == data.size();
 }


### PR DESCRIPTION
### Details:
 - Improve validation of inputs ranks.
 - Move Loop into `ov::op::v5` namespace.
 - Migrate `is_rank_compatible_any_of` to dev API and use new version.

### Tickets:
 - [CVS-118622](https://jira.devtools.intel.com/browse/CVS-118622)
