### PR TITLE
[core]Migrate `get_node_input_partial_shapes` to dev API

### DIFF
--- a/src/common/transformations/src/ov_ops/augru_cell.cpp
+++ b/src/common/transformations/src/ov_ops/augru_cell.cpp
@@ -63,9 +63,7 @@ void ov::op::internal::AUGRUCell::validate_and_infer_types() {
                           "Element types for inputs do not match.");
 
     // Get input partial shape for all inputs
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     std::vector<ov::PartialShape> output_shapes = shape_infer(this, input_shapes);
 
     // Set output type and shape

--- a/src/common/transformations/src/ov_ops/augru_sequence.cpp
+++ b/src/common/transformations/src/ov_ops/augru_sequence.cpp
@@ -60,9 +60,7 @@ void ov::op::internal::AUGRUSequence::validate_and_infer_types() {
                               element::Type::merge(result_et, result_et, get_input_element_type(6)),
                           "Element types for inputs do not match.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     std::vector<ov::PartialShape> output_shapes = shape_infer(this, input_shapes);
 
     // Set output size, type and shape

--- a/src/common/transformations/src/ov_ops/multiclass_nms_ie_internal.cpp
+++ b/src/common/transformations/src/ov_ops/multiclass_nms_ie_internal.cpp
@@ -39,9 +39,7 @@ std::shared_ptr<Node> op::internal::MulticlassNmsIEInternal::clone_with_new_inpu
 void op::internal::MulticlassNmsIEInternal::validate_and_infer_types() {
     INTERNAL_OP_SCOPE(internal_MulticlassNmsIEInternal_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes, false, true);
 

--- a/src/core/dev_api/validation_util.hpp
+++ b/src/core/dev_api/validation_util.hpp
@@ -91,5 +91,12 @@ bool try_apply_auto_padding(const PartialShape& image_shape,
 /// @param tensors  Input tensors vector to get their shapes.
 /// @return Vector of partial shapes same size as input tensor vector.
 OPENVINO_API std::vector<PartialShape> get_tensors_partial_shapes(const TensorVector& tensors);
+
+/// \brief Get the node input partial shapes.
+///
+/// \param node   Node to extract input shapes.
+///
+/// \return Vector of PartialShapes of each input.
+OPENVINO_API std::vector<PartialShape> get_node_input_partial_shapes(const ov::Node& node);
 }  // namespace util
 }  // namespace ov

--- a/src/core/include/openvino/core/validation_util.hpp
+++ b/src/core/include/openvino/core/validation_util.hpp
@@ -172,14 +172,6 @@ OPENVINO_API bool is_valid_axes_order(const std::vector<int64_t>& axes_order, co
 OPENVINO_DEPRECATED("This function is deprecated and will be moved to dev api in 2024.0 release.")
 OPENVINO_API bool has_no_labels(const TensorLabel& labels);
 
-/// \brief Get the node input partial shapes.
-///
-/// \param node   Node to extract input shapes.
-///
-/// \return Vector of PartialShapes of each input.
-OPENVINO_DEPRECATED("This function is deprecated and will be moved to dev api in 2024.0 release.")
-OPENVINO_API std::vector<PartialShape> get_node_input_partial_shapes(const ov::Node& node);
-
 /// \brief Check if rank is compatible to any of rank from container.
 ///
 /// \param rank   Rank to check.

--- a/src/core/src/op/adaptive_avg_pool.cpp
+++ b/src/core/src/op/adaptive_avg_pool.cpp
@@ -17,9 +17,7 @@ op::v8::AdaptiveAvgPool::AdaptiveAvgPool(const Output<Node>& data, const Output<
 void op::v8::AdaptiveAvgPool::validate_and_infer_types() {
     OV_OP_SCOPE(v8_AdaptiveAvgPool_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, get_input_element_type(0), output_shape);
 }
 

--- a/src/core/src/op/adaptive_max_pool.cpp
+++ b/src/core/src/op/adaptive_max_pool.cpp
@@ -30,9 +30,7 @@ void op::v8::AdaptiveMaxPool::validate_and_infer_types() {
                           m_index_element_type == element::i64 || m_index_element_type == element::i32,
                           "Index element type must be i32 or i64");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this));
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
 
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
     set_output_type(1, m_index_element_type, output_shapes[1]);

--- a/src/core/src/op/avg_pool.cpp
+++ b/src/core/src/op/avg_pool.cpp
@@ -43,9 +43,8 @@ bool ov::op::v1::AvgPool::visit_attributes(AttributeVisitor& visitor) {
 void ov::op::v1::AvgPool::validate_and_infer_types() {
     OV_OP_SCOPE(v1_AvgPool_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this), m_pads_begin, m_pads_end);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shapes =
+        shape_infer(this, ov::util::get_node_input_partial_shapes(*this), m_pads_begin, m_pads_end);
     set_output_type(0, get_input_element_type(0), output_shapes.front());
 }
 

--- a/src/core/src/op/batch_to_space.cpp
+++ b/src/core/src/op/batch_to_space.cpp
@@ -50,9 +50,7 @@ void BatchToSpace::validate_and_infer_types() {
                           "block_shape and crops inputs must have integer element type. Got: ",
                           inputs_integer_et);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, data_et, output_shape);
 }
 

--- a/src/core/src/op/binary_convolution.cpp
+++ b/src/core/src/op/binary_convolution.cpp
@@ -52,9 +52,7 @@ void ov::op::v1::BinaryConvolution::validate_and_infer_types() {
 
     // TODO: Add NodeValidationCheck to filters et once u1 is supported in OpenVINO Python API
     // (#52715)
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     auto num_spatial = convolution::calculate_num_spatial(this, input_shapes);
     if (num_spatial != util::num_spatial_undefined) {

--- a/src/core/src/op/bucketize.cpp
+++ b/src/core/src/op/bucketize.cpp
@@ -45,9 +45,7 @@ void op::v3::Bucketize::validate_and_infer_types() {
                           "Output type must be i32 or i64. Got: ",
                           m_output_type);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     if (get_input_partial_shape(0).is_dynamic()) {

--- a/src/core/src/op/convolution.cpp
+++ b/src/core/src/op/convolution.cpp
@@ -54,9 +54,7 @@ void op::v1::Convolution::validate_and_infer_types() {
                           "Element types must be numeric. Got: ",
                           result_et);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     auto num_spatial = convolution::calculate_num_spatial(this, input_shapes);
     if (num_spatial != util::num_spatial_undefined) {
@@ -219,9 +217,7 @@ void op::v1::ConvolutionBackpropData::validate_and_infer_types() {
                               ").");
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto out_spatial_shape = get_output_shape();
     auto num_spatial = convolution::calculate_num_spatial(this, input_shapes, out_spatial_shape);
 

--- a/src/core/src/op/ctc_loss.cpp
+++ b/src/core/src/op/ctc_loss.cpp
@@ -60,9 +60,7 @@ void op::v4::CTCLoss::validate_and_infer_types() {
                               input_et);
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, ov::get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, logits_type, output_shape);
 }
 

--- a/src/core/src/op/deformable_convolution.cpp
+++ b/src/core/src/op/deformable_convolution.cpp
@@ -94,9 +94,7 @@ void op::v8::DeformableConvolution::validate_and_infer_types() {
                               mask_et);
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     auto num_spatial = deformable_conv::calculate_num_spatial(this, input_shapes);
     if (num_spatial != convolution::num_spatial_undefined) {
@@ -200,9 +198,7 @@ void op::v1::DeformableConvolution::validate_and_infer_types() {
                           "Element type of inputs must be numeric. Got: ",
                           result_et);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     auto num_spatial = deformable_conv::calculate_num_spatial(this, input_shapes);
     if (num_spatial != convolution::num_spatial_undefined) {

--- a/src/core/src/op/deformable_psroi_pooling.cpp
+++ b/src/core/src/op/deformable_psroi_pooling.cpp
@@ -71,9 +71,7 @@ bool op::v1::DeformablePSROIPooling::visit_attributes(AttributeVisitor& visitor)
 void op::v1::DeformablePSROIPooling::validate_and_infer_types() {
     OV_OP_SCOPE(v1_DeformablePSROIPooling_validate_and_infer_types);
     const auto& input_et = get_input_element_type(0);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     set_output_type(0, input_et, shape_infer(this, input_shapes)[0]);
 }
 

--- a/src/core/src/op/depth_to_space.cpp
+++ b/src/core/src/op/depth_to_space.cpp
@@ -43,9 +43,7 @@ std::shared_ptr<Node> DepthToSpace::clone_with_new_inputs(const OutputVector& ne
 void DepthToSpace::validate_and_infer_types() {
     OV_OP_SCOPE(v0_DepthToSpace_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, get_input_element_type(0), output_shape);
 }
 

--- a/src/core/src/op/detection_output.cpp
+++ b/src/core/src/op/detection_output.cpp
@@ -34,9 +34,7 @@ void ov::op::v0::DetectionOutput::validate_and_infer_types() {
     NODE_VALIDATION_CHECK(this, m_attrs.num_classes > 0, "Number of classes must be greater than zero");
     validate_base(m_attrs);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     auto output_shapes = shape_infer(this, input_shapes);
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
 }
@@ -93,9 +91,7 @@ void ov::op::v8::DetectionOutput::validate_and_infer_types() {
     OV_OP_SCOPE(v8_DetectionOutput_validate_and_infer_types);
     validate_base(m_attrs);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     auto output_shapes = shape_infer(this, input_shapes);
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
 }

--- a/src/core/src/op/einsum.cpp
+++ b/src/core/src/op/einsum.cpp
@@ -188,9 +188,7 @@ void op::v7::Einsum::validate_and_infer_types() {
                               "Inputs to Einsum operation must have the same type.");
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 

--- a/src/core/src/op/embedding_segments_sum.cpp
+++ b/src/core/src/op/embedding_segments_sum.cpp
@@ -93,9 +93,7 @@ void op::v3::EmbeddingSegmentsSum::validate_and_infer_types() {
                               ")");
     }
     const auto& result_et = get_input_element_type(EMB_TABLE);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto result_shapes = shape_infer(this, input_shapes);
 
     if (result_shapes[EMB_TABLE].rank().is_dynamic() || result_shapes[EMB_TABLE][0].is_dynamic()) {

--- a/src/core/src/op/experimental_detectron_topkrois.cpp
+++ b/src/core/src/op/experimental_detectron_topkrois.cpp
@@ -40,7 +40,7 @@ void op::v6::ExperimentalDetectronTopKROIs::validate_and_infer_types() {
                           "ROIs and probabilities of ROIs must same floating-point type.");
 
     OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     OPENVINO_SUPPRESS_DEPRECATED_START
 
     const auto output_shapes = shape_infer(this, input_shapes);

--- a/src/core/src/op/eye.cpp
+++ b/src/core/src/op/eye.cpp
@@ -58,9 +58,7 @@ void Eye::validate_and_infer_types() {
                               input_et);
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, get_out_type(), output_shape);
 }
 

--- a/src/core/src/op/gather_elements.cpp
+++ b/src/core/src/op/gather_elements.cpp
@@ -26,9 +26,7 @@ void op::v6::GatherElements::validate_and_infer_types() {
                           "indices must be of int32 or int64 type. But instead got: ",
                           indices_type);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
     set_output_type(0, data_type, output_shapes[0]);
 }

--- a/src/core/src/op/gather_tree.cpp
+++ b/src/core/src/op/gather_tree.cpp
@@ -51,9 +51,7 @@ void op::v1::GatherTree::validate_and_infer_types() {
                           "Element type of inputs must be numeric. Got: ",
                           result_et);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, ov::get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, result_et, output_shape);
 }
 }  // namespace ov

--- a/src/core/src/op/grid_sample.cpp
+++ b/src/core/src/op/grid_sample.cpp
@@ -80,9 +80,7 @@ void GridSample::validate_and_infer_types() {
                               "The element type of the grid input tensor must be a floating point type.");
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto out_shapes = shape_infer(this, input_shapes);
     set_output_type(0, get_input_element_type(0), out_shapes[0]);
 }

--- a/src/core/src/op/group_conv.cpp
+++ b/src/core/src/op/group_conv.cpp
@@ -54,9 +54,7 @@ void op::v1::GroupConvolution::validate_and_infer_types() {
                           "Element type of inputs must be numeric. Got: ",
                           result_et);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     auto num_spatial = convolution::calculate_num_spatial(this, input_shapes);
     if (num_spatial != convolution::num_spatial_undefined) {
@@ -241,9 +239,7 @@ void op::v1::GroupConvolutionBackpropData::validate_and_infer_types() {
                               ").");
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto out_spatial_shape = get_convolution_output_shape();
     auto num_spatial = convolution::calculate_num_spatial(this, input_shapes, out_spatial_shape);
 

--- a/src/core/src/op/group_normalization.cpp
+++ b/src/core/src/op/group_normalization.cpp
@@ -32,9 +32,7 @@ bool op::v12::GroupNormalization::visit_attributes(AttributeVisitor& visitor) {
 
 void op::v12::GroupNormalization::validate_and_infer_types() {
     OV_OP_SCOPE(v12_GroupNormalization_validate_and_infer_types);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this));
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
 
     set_output_type(0, get_input_element_type(0), output_shapes.at(0));
 }

--- a/src/core/src/op/gru_cell.cpp
+++ b/src/core/src/op/gru_cell.cpp
@@ -94,9 +94,7 @@ void op::v3::GRUCell::validate_and_infer_types() {
                           "Element types for X, initial_hidden_state, W, R and B inputs do not "
                           "match.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     set_output_type(0, result_et, output_shapes[0]);

--- a/src/core/src/op/gru_sequence.cpp
+++ b/src/core/src/op/gru_sequence.cpp
@@ -56,9 +56,7 @@ void op::v5::GRUSequence::validate_and_infer_types() {
                           "Element types for X, initial_hidden_state, W, R and B inputs do not "
                           "match.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     // Set output size, type and shape

--- a/src/core/src/op/interpolate.cpp
+++ b/src/core/src/op/interpolate.cpp
@@ -42,10 +42,7 @@ void ov::op::v0::Interpolate::validate_and_infer_types() {
                           "output shape must be an integral number.");
     set_input_is_relevant_to_shape(1);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = ov::get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
-
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes, make_tensor_accessor());
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
 }
@@ -124,9 +121,7 @@ void ov::op::v4::Interpolate::validate_and_infer_types() {
                           "Unsupported interpolation mode used with version 4 of the Interpolate op: ",
                           as_string(m_attrs.mode));
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes =
         shape_infer(this, input_shapes, m_attrs.pads_begin, m_attrs.pads_end, make_tensor_accessor());
@@ -325,9 +320,7 @@ void op::v11::Interpolate::validate_and_infer_types() {
         validate_axes_element_type(get_input_element_type(2));
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes =
         shape_infer(this, input_shapes, m_attrs.pads_begin, m_attrs.pads_end, make_tensor_accessor());

--- a/src/core/src/op/lstm_sequence.cpp
+++ b/src/core/src/op/lstm_sequence.cpp
@@ -148,9 +148,7 @@ void op::v0::LSTMSequence::validate_and_infer_types() {
     for (size_t i = 0; i <= 6; ++i)
         set_input_is_relevant_to_shape(i);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     auto output_shapes = shape_infer(this, input_shapes);
 
     // Set output size, type and shape
@@ -207,9 +205,7 @@ void op::v5::LSTMSequence::validate_and_infer_types() {
     for (size_t i = 0; i <= 6; ++i)
         set_input_is_relevant_to_shape(i);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     auto output_shapes = shape_infer(this, input_shapes);
 
     // Set output size, type and shape

--- a/src/core/src/op/matrix_nms.cpp
+++ b/src/core/src/op/matrix_nms.cpp
@@ -58,9 +58,7 @@ void op::v8::MatrixNms::validate() {
 void op::v8::MatrixNms::validate_and_infer_types() {
     OV_OP_SCOPE(v8_MatrixNms_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     validate();

--- a/src/core/src/op/max_pool.cpp
+++ b/src/core/src/op/max_pool.cpp
@@ -40,7 +40,8 @@ void MaxPool::validate_and_infer_types() {
     OV_OP_SCOPE(v1_MaxPool_validate_and_infer_types);
 
     OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this), m_pads_begin, m_pads_end);
+    const auto output_shapes =
+        shape_infer(this, ov::util::get_node_input_partial_shapes(*this), m_pads_begin, m_pads_end);
     OPENVINO_SUPPRESS_DEPRECATED_END
     set_output_type(0, get_input_element_type(0), output_shapes.front());
 }
@@ -168,7 +169,8 @@ void MaxPool::validate_and_infer_types() {
     }
 
     OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this), m_pads_begin, m_pads_end);
+    const auto output_shapes =
+        shape_infer(this, ov::util::get_node_input_partial_shapes(*this), m_pads_begin, m_pads_end);
     OPENVINO_SUPPRESS_DEPRECATED_END
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
     set_output_type(1, m_index_element_type, output_shapes[1]);

--- a/src/core/src/op/multiclass_nms.cpp
+++ b/src/core/src/op/multiclass_nms.cpp
@@ -28,9 +28,7 @@ std::shared_ptr<Node> MulticlassNms::clone_with_new_inputs(const OutputVector& n
 
 void MulticlassNms::validate_and_infer_types() {
     OV_OP_SCOPE(MulticlassNms_v9_validate_and_infer_types);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes, false);
 
@@ -74,9 +72,7 @@ std::shared_ptr<Node> MulticlassNms::clone_with_new_inputs(const OutputVector& n
 void MulticlassNms::validate_and_infer_types() {
     OV_OP_SCOPE(MulticlassNms_v9_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes, false);
 

--- a/src/core/src/op/multinomial.cpp
+++ b/src/core/src/op/multinomial.cpp
@@ -45,9 +45,7 @@ bool op::v13::Multinomial::visit_attributes(AttributeVisitor& visitor) {
 void op::v13::Multinomial::validate_and_infer_types() {
     OV_OP_SCOPE(v13_Multinomial_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 

--- a/src/core/src/op/nms_rotated.cpp
+++ b/src/core/src/op/nms_rotated.cpp
@@ -81,9 +81,7 @@ bool op::v13::NMSRotated::visit_attributes(AttributeVisitor& visitor) {
 void op::v13::NMSRotated::validate_and_infer_types() {
     OV_OP_SCOPE(v13_NMSRotated_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 

--- a/src/core/src/op/non_max_suppression.cpp
+++ b/src/core/src/op/non_max_suppression.cpp
@@ -71,9 +71,7 @@ bool op::v1::NonMaxSuppression::visit_attributes(AttributeVisitor& visitor) {
 void op::v1::NonMaxSuppression::validate_and_infer_types() {
     OV_OP_SCOPE(v1_NonMaxSuppression_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 
@@ -171,9 +169,7 @@ void op::v3::NonMaxSuppression::validate_and_infer_types() {
                           m_output_type == element::i64 || m_output_type == element::i32,
                           "Output type must be i32 or i64");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 
@@ -263,9 +259,7 @@ std::shared_ptr<Node> op::v4::NonMaxSuppression::clone_with_new_inputs(const Out
 void op::v4::NonMaxSuppression::validate_and_infer_types() {
     OV_OP_SCOPE(v4_NonMaxSuppression_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 
@@ -529,9 +523,7 @@ bool op::v5::NonMaxSuppression::visit_attributes(AttributeVisitor& visitor) {
 void op::v5::NonMaxSuppression::validate_and_infer_types() {
     OV_OP_SCOPE(v5_NonMaxSuppression_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 
@@ -766,9 +758,7 @@ bool op::v9::NonMaxSuppression::visit_attributes(AttributeVisitor& visitor) {
 void op::v9::NonMaxSuppression::validate_and_infer_types() {
     OV_OP_SCOPE(v9_NonMaxSuppression_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 

--- a/src/core/src/op/proposal.cpp
+++ b/src/core/src/op/proposal.cpp
@@ -42,9 +42,7 @@ void op::v0::Proposal::validate_and_infer_types() {
     OV_OP_SCOPE(v0_Proposal_validate_and_infer_types);
 
     validate_element_types();
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto intput_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto intput_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, intput_shapes);
 
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
@@ -95,7 +93,7 @@ void op::v4::Proposal::validate_and_infer_types() {
 
     validate_element_types();
     OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto intput_shapes = get_node_input_partial_shapes(*this);
+    const auto intput_shapes = ov::util::get_node_input_partial_shapes(*this);
     OPENVINO_SUPPRESS_DEPRECATED_END
     const auto output_shapes = shape_infer(this, intput_shapes);
     const auto& out_et = get_input_element_type(0);

--- a/src/core/src/op/psroi_pooling.cpp
+++ b/src/core/src/op/psroi_pooling.cpp
@@ -53,9 +53,7 @@ void PSROIPooling::validate_and_infer_types() {
                           coords_et.is_real(),
                           "Coords' data type must be floating point. Got " + coords_et.to_string());
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this));
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
     set_output_type(0, feat_maps_et, output_shapes[0]);
 }
 

--- a/src/core/src/op/random_uniform.cpp
+++ b/src/core/src/op/random_uniform.cpp
@@ -49,9 +49,7 @@ void RandomUniform::validate_and_infer_types() {
                           validate::out_et(out_et) && (out_et == min_et),
                           "'min_val' and 'max_val' should have the same type as 'out_type' attribute.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     set_output_type(0, out_et, output_shapes.front());

--- a/src/core/src/op/reshape.cpp
+++ b/src/core/src/op/reshape.cpp
@@ -39,9 +39,7 @@ void Reshape::validate_and_infer_types() {
                           shape_pattern_et.is_integral_number(),
                           "PartialShape pattern must be an integral number.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    auto input_shapes = ov::get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_START
+    auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
     set_output_type(0, get_input_element_type(0), output_shapes.front());
 }

--- a/src/core/src/op/reverse.cpp
+++ b/src/core/src/op/reverse.cpp
@@ -47,9 +47,7 @@ void ov::op::v1::Reverse::validate_and_infer_types() {
                               "In 'index' mode the second input must contain integer values.");
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, get_input_element_type(0), output_shape);
 }
 

--- a/src/core/src/op/reverse_sequence.cpp
+++ b/src/core/src/op/reverse_sequence.cpp
@@ -38,9 +38,7 @@ void op::v0::ReverseSequence::validate_and_infer_types() {
                           "Sequence lengths element type must be numeric type. Got: ",
                           seq_lengths_et);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, get_input_element_type(0), output_shape);
 
     OPENVINO_SUPPRESS_DEPRECATED_START

--- a/src/core/src/op/rnn_cell.cpp
+++ b/src/core/src/op/rnn_cell.cpp
@@ -74,9 +74,7 @@ void op::v0::RNNCell::validate_and_infer_types() {
     for (size_t i = 0; i <= 4; ++i)
         set_input_is_relevant_to_shape(i);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     auto output_shapes = shape_infer(this, input_shapes);
     set_output_type(0, result_et, output_shapes[0]);
 }

--- a/src/core/src/op/rnn_sequence.cpp
+++ b/src/core/src/op/rnn_sequence.cpp
@@ -50,9 +50,7 @@ void op::v5::RNNSequence::validate_and_infer_types() {
                           "Element types for X, initial_hidden_state, W, R and B inputs do not "
                           "match.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     auto output_shapes = shape_infer(this, input_shapes);
 
     // Mark inputs which are relevant to output parameters

--- a/src/core/src/op/roi_align.cpp
+++ b/src/core/src/op/roi_align.cpp
@@ -52,9 +52,7 @@ void op::v3::ROIAlign::validate_and_infer_types() {
     const auto out_et = roi_align::validate::data_and_roi_et(this);
     roi_align::validate::batch_indicies_et(this);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     auto output_shape = shape_infer(this, input_shapes).front();
     set_output_type(0, out_et, output_shape);
@@ -125,9 +123,7 @@ void op::v9::ROIAlign::validate_and_infer_types() {
     const auto out_et = roi_align::validate::data_and_roi_et(this);
     roi_align::validate::batch_indicies_et(this);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     auto output_shape = shape_infer(this, input_shapes).front();
     set_output_type(0, out_et, output_shape);

--- a/src/core/src/op/roi_pooling.cpp
+++ b/src/core/src/op/roi_pooling.cpp
@@ -41,9 +41,7 @@ void ROIPooling::validate_and_infer_types() {
                           " and: ",
                           coords_et);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this));
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
     set_output_type(0, feat_maps_et, output_shapes[0]);
 
     const auto& feat_maps_ps = get_input_partial_shape(0);

--- a/src/core/src/op/roll.cpp
+++ b/src/core/src/op/roll.cpp
@@ -29,9 +29,7 @@ void Roll::validate_and_infer_types() {
                           axes_et.is_dynamic() || axes_et == element::i32 || axes_et == element::i64,
                           "Axes must have int32 or int64 element type.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, get_input_element_type(0), output_shape);
 }
 

--- a/src/core/src/op/select.cpp
+++ b/src/core/src/op/select.cpp
@@ -40,9 +40,7 @@ void op::v1::Select::validate_and_infer_types() {
                           element::Type::merge(result_et, get_input_element_type(1), get_input_element_type(2)),
                           "Argument 1 and 2 element types must match.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
     set_output_type(0, result_et, output_shapes[0]);
 }

--- a/src/core/src/op/shuffle_channels.cpp
+++ b/src/core/src/op/shuffle_channels.cpp
@@ -47,9 +47,7 @@ size_t op::ShuffleChannels::get_zero_based_axis() const {
 void op::ShuffleChannels::validate_and_infer_types() {
     OV_OP_SCOPE(v0_ShuffleChannels_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, get_input_element_type(0), output_shape);
 }
 

--- a/src/core/src/op/slice.cpp
+++ b/src/core/src/op/slice.cpp
@@ -66,9 +66,7 @@ void Slice::validate_and_infer_types() {
         }
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     set_input_is_relevant_to_shape(0);

--- a/src/core/src/op/space_to_batch.cpp
+++ b/src/core/src/op/space_to_batch.cpp
@@ -56,9 +56,7 @@ void SpaceToBatch::validate_and_infer_types() {
                           "pads_end must be an integral number but got (",
                           pads_end_type,
                           ").");
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, data_type, output_shape);
 }
 

--- a/src/core/src/op/space_to_depth.cpp
+++ b/src/core/src/op/space_to_depth.cpp
@@ -46,9 +46,7 @@ std::shared_ptr<Node> SpaceToDepth::clone_with_new_inputs(const OutputVector& ne
 void SpaceToDepth::validate_and_infer_types() {
     OV_OP_SCOPE(v0_SpaceToDepth_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     set_output_type(0, get_input_element_type(0), output_shape);
 }
 

--- a/src/core/src/op/split.cpp
+++ b/src/core/src/op/split.cpp
@@ -50,9 +50,7 @@ void Split::validate_and_infer_types() {
                           "Attribute 'num_splits' must be greater than zero. Got: ",
                           m_num_splits);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     for (size_t i = 0; i < m_num_splits; ++i) {

--- a/src/core/src/op/squeeze.cpp
+++ b/src/core/src/op/squeeze.cpp
@@ -37,9 +37,7 @@ Squeeze::Squeeze(const Output<Node>& data) : Op({data}) {
 void Squeeze::validate_and_infer_types() {
     OV_OP_SCOPE(v0_Squeeze_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     set_output_type(0, get_input_element_type(0), output_shapes[0]);

--- a/src/core/src/op/strided_slice.cpp
+++ b/src/core/src/op/strided_slice.cpp
@@ -156,9 +156,7 @@ void op::v1::StridedSlice::validate_and_infer_types() {
     set_input_is_relevant_to_shape(2);
     set_input_is_relevant_to_shape(3);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
 
     const auto output_shapes = shape_infer(this, input_shapes);
 

--- a/src/core/src/op/tile.cpp
+++ b/src/core/src/op/tile.cpp
@@ -28,9 +28,7 @@ void Tile::validate_and_infer_types() {
                           repeats_et.is_integral(),
                           "Tile repeats must have any integer element type, but has ",
                           repeats_et);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this));
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
 
     set_input_is_relevant_to_shape(0);

--- a/src/core/src/op/transpose.cpp
+++ b/src/core/src/op/transpose.cpp
@@ -27,9 +27,7 @@ void Transpose::validate_and_infer_types() {
 
     set_input_is_relevant_to_shape(ORDER);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     set_output_type(ARG, get_input_element_type(ARG), output_shapes[ARG_T]);

--- a/src/core/src/op/unsqueeze.cpp
+++ b/src/core/src/op/unsqueeze.cpp
@@ -21,9 +21,7 @@ ov::op::v0::Unsqueeze::Unsqueeze(const ov::Output<ov::Node>& data, const ov::Out
 void ov::op::v0::Unsqueeze::validate_and_infer_types() {
     OV_OP_SCOPE(v0_Unsqueeze_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     set_output_type(0, get_input_element_type(0), output_shapes[0]);

--- a/src/core/src/op/util/convert_color_i420_base.cpp
+++ b/src/core/src/op/util/convert_color_i420_base.cpp
@@ -21,10 +21,8 @@ ov::op::util::ConvertColorI420Base::ConvertColorI420Base(const Output<Node>& arg
 void ov::op::util::ConvertColorI420Base::validate_and_infer_types() {
     OV_OP_SCOPE(v8_Convert_I420_Base_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
     const auto& y_type = get_input_element_type(0);
     auto out_type = y_type;

--- a/src/core/src/op/util/convert_color_nv12_base.cpp
+++ b/src/core/src/op/util/convert_color_nv12_base.cpp
@@ -20,10 +20,8 @@ ov::op::util::ConvertColorNV12Base::ConvertColorNV12Base(const Output<Node>& arg
 void ov::op::util::ConvertColorNV12Base::validate_and_infer_types() {
     OV_OP_SCOPE(v8_Convert_NV12_Base_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
     auto out_type = get_input_element_type(0);
     if (get_input_size() == 2) {

--- a/src/core/src/op/util/embeddingbag_offsets_base.cpp
+++ b/src/core/src/op/util/embeddingbag_offsets_base.cpp
@@ -77,9 +77,7 @@ void ov::op::util::EmbeddingBagOffsetsBase::validate_and_infer_types() {
     }
 
     const auto& result_et = get_input_element_type(EMB_TABLE);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     set_output_type(0, result_et, shape_infer(this, input_shapes)[0]);
 }
 

--- a/src/core/src/op/util/embeddingbag_packed_base.cpp
+++ b/src/core/src/op/util/embeddingbag_packed_base.cpp
@@ -40,9 +40,7 @@ void ov::op::util::EmbeddingBagPackedBase::validate_and_infer_types() {
     }
 
     const auto& emb_et = get_input_element_type(EMB_TABLE);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     set_output_type(0, emb_et, shape_infer(this, input_shapes)[0]);
 }
 

--- a/src/core/src/op/util/pad_base.cpp
+++ b/src/core/src/op/util/pad_base.cpp
@@ -98,9 +98,7 @@ void op::util::PadBase::validate_and_infer_types() {
                           pads_end_element_type,
                           ").");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this));
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
     set_output_type(0, result_et, output_shapes[0]);
 }
 

--- a/src/core/src/op/util/scatter_elements_update_base.cpp
+++ b/src/core/src/op/util/scatter_elements_update_base.cpp
@@ -22,7 +22,6 @@ ov::op::util::ScatterElementsUpdateBase::ScatterElementsUpdateBase(const Output<
 
 void ov::op::util::ScatterElementsUpdateBase::validate_and_infer_types() {
     OV_OP_SCOPE(util_ScatterElementsUpdateBase_validate_and_infer_types);
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const element::Type& data_et = get_input_element_type(0);
     const element::Type& indices_et = get_input_element_type(1);
     const element::Type& updates_et = get_input_element_type(2);
@@ -43,8 +42,7 @@ void ov::op::util::ScatterElementsUpdateBase::validate_and_infer_types() {
                           data_et,
                           " and: ",
                           updates_et);
-    const auto output_shape = shape_infer(this, get_node_input_partial_shapes(*this)).front();
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shape = shape_infer(this, ov::util::get_node_input_partial_shapes(*this)).front();
     element::Type out_et = get_input_element_type(0);
     std::ignore = element::Type::merge(out_et, get_input_element_type(0), get_input_element_type(2));
     set_output_type(0, out_et, output_shape);

--- a/src/core/src/op/util/topk_base.cpp
+++ b/src/core/src/op/util/topk_base.cpp
@@ -44,9 +44,7 @@ void ov::op::util::TopKBase::validate_and_infer_types() {
 
     set_axis(get_input_partial_shape(0).rank(), get_provided_axis());
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto output_shapes = shape_infer(this, get_node_input_partial_shapes(*this));
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
 
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
     set_output_type(1, m_index_element_type, output_shapes[1]);

--- a/src/core/src/op/variadic_split.cpp
+++ b/src/core/src/op/variadic_split.cpp
@@ -70,9 +70,7 @@ void VariadicSplit::validate_and_infer_types() {
         set_input_is_relevant_to_value(i);
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    const auto input_shapes = get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
     const auto output_shapes = shape_infer(this, input_shapes);
 
     const auto& data_type = get_input_element_type(0);

--- a/src/core/src/validation_util.cpp
+++ b/src/core/src/validation_util.cpp
@@ -1433,5 +1433,15 @@ std::vector<PartialShape> get_tensors_partial_shapes(const TensorVector& tensors
     }
     return shapes;
 }
+
+std::vector<PartialShape> get_node_input_partial_shapes(const Node& node) {
+    std::vector<PartialShape> shapes;
+    shapes.reserve(node.get_input_size());
+    for (size_t i = 0; i < node.get_input_size(); ++i) {
+        shapes.push_back(node.get_input_partial_shape(i));
+    }
+    return shapes;
+}
+
 }  // namespace util
 }  // namespace ov

--- a/src/core/src/validation_util.cpp
+++ b/src/core/src/validation_util.cpp
@@ -1155,15 +1155,6 @@ bool ov::is_valid_axes_order(const std::vector<int64_t>& axes_order, const size_
            std::all_of(axes_order.cbegin(), axes_order.cend(), ov::cmp::Between<int64_t, ov::cmp::LOWER>(0, size));
 }
 
-std::vector<ov::PartialShape> ov::get_node_input_partial_shapes(const ov::Node& node) {
-    std::vector<PartialShape> out;
-    out.reserve(node.get_input_size());
-    for (size_t i = 0; i < node.get_input_size(); ++i) {
-        out.push_back(node.get_input_partial_shape(i));
-    }
-    return out;
-}
-
 bool ov::is_rank_compatible_any_of(const ov::Rank& rank, const std::vector<Rank>& ranks) {
     return std::any_of(ranks.cbegin(), ranks.cend(), [&rank](const Rank& r) {
         return rank.compatible(r);


### PR DESCRIPTION
### Details:
 - Migrate `ov::get_node_input_partial_shapes` -> `ov::util::get_node_input_partial_shapes` in dev API
 - Use new version.
 - Remove deprecated version.

### Tickets:
 - [CVS-126145](https://jira.devtools.intel.com/browse/CVS-126145)
