### PR TITLE
[core]Refactor leftovers after migration to new API

### DIFF
--- a/src/core/include/openvino/op/result.hpp
+++ b/src/core/include/openvino/op/result.hpp
@@ -24,7 +24,6 @@ public:
     /// \param arg Node that produces the input tensor.
     Result(const Output<Node>& arg);
 
-    bool visit_attributes(AttributeVisitor& visitor) override;
     void validate_and_infer_types() override;
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/src/core/src/op/result.cpp
+++ b/src/core/src/op/result.cpp
@@ -41,10 +41,11 @@ bool Result::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
 
     if (outputs.empty()) {
         outputs.emplace_back(inputs[0].get_element_type(), inputs[0].get_shape());
-    } else if (!outputs[0]) {
-        outputs[0] = Tensor(inputs[0].get_element_type(), inputs[0].get_shape());
     } else {
         OPENVINO_ASSERT(outputs.size() == 1);
+        if (!outputs[0]) {
+            outputs[0] = Tensor(inputs[0].get_element_type(), inputs[0].get_shape());
+        }
     }
 
     outputs[0].set_shape(inputs[0].get_shape());

--- a/src/core/src/op/result.cpp
+++ b/src/core/src/op/result.cpp
@@ -10,18 +10,15 @@
 
 #include "itt.hpp"
 
-using namespace ov;
+namespace ov {
+namespace op {
+namespace v0 {
 
-op::v0::Result::Result(const Output<Node>& arg) : Op({arg}) {
+Result::Result(const Output<Node>& arg) : Op({arg}) {
     constructor_validate_and_infer_types();
 }
 
-bool op::v0::Result::visit_attributes(AttributeVisitor& visitor) {
-    OV_OP_SCOPE(v0_Result_visit_attributes);
-    return true;
-}
-
-void op::v0::Result::validate_and_infer_types() {
+void Result::validate_and_infer_types() {
     OV_OP_SCOPE(v0_Result_validate_and_infer_types);
     NODE_VALIDATION_CHECK(this, get_input_size() == 1, "Argument has ", get_input_size(), " outputs (1 expected).");
 
@@ -31,52 +28,55 @@ void op::v0::Result::validate_and_infer_types() {
     output.set_tensor_ptr(input.get_tensor_ptr());
 }
 
-std::shared_ptr<Node> op::v0::Result::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> Result::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v0_Result_clone_with_new_inputs);
     check_new_args_count(this, new_args);
 
-    auto res = std::make_shared<Result>(new_args.at(0));
-    return std::move(res);
+    return std::make_shared<Result>(new_args.at(0));
 }
 
-bool op::v0::Result::evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) const {
+bool Result::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v0_Result_evaluate);
     OPENVINO_ASSERT(inputs.size() == 1);
-    if (outputs.empty())
-        outputs.emplace_back(ov::Tensor(inputs[0].get_element_type(), inputs[0].get_shape()));
-    else
+
+    if (outputs.empty()) {
+        outputs.emplace_back(inputs[0].get_element_type(), inputs[0].get_shape());
+    } else if (!outputs[0]) {
+        outputs[0] = Tensor(inputs[0].get_element_type(), inputs[0].get_shape());
+    } else {
         OPENVINO_ASSERT(outputs.size() == 1);
-    if (!outputs[0])
-        outputs[0] = ov::Tensor(inputs[0].get_element_type(), inputs[0].get_shape());
-    if (inputs[0].get_shape() != outputs[0].get_shape())
-        outputs[0].set_shape(inputs[0].get_shape());
+    }
+
+    outputs[0].set_shape(inputs[0].get_shape());
     void* output = outputs[0].data();
-    void* input = inputs[0].data();
+    const void* input = inputs[0].data();
     memcpy(output, input, outputs[0].get_byte_size());
 
     return true;
 }
 
-bool op::v0::Result::has_evaluate() const {
+bool Result::has_evaluate() const {
     OV_OP_SCOPE(v0_Result_has_evaluate);
     return true;
 }
 
-bool op::v0::Result::constant_fold(OutputVector& output_values, const OutputVector& inputs_values) {
+bool Result::constant_fold(OutputVector& output_values, const OutputVector& inputs_values) {
     return false;
 }
 
-ov::Layout op::v0::Result::get_layout() const {
+ov::Layout Result::get_layout() const {
     return ov::layout::get_layout(output(0));
 }
 
-void op::v0::Result::set_layout(const ov::Layout& layout) {
+void Result::set_layout(const ov::Layout& layout) {
     ov::layout::set_layout(output(0), layout);
 }
+}  // namespace v0
+}  // namespace op
 
-ov::AttributeAdapter<ResultVector>::AttributeAdapter(ResultVector& ref) : m_ref(ref) {}
+AttributeAdapter<ResultVector>::AttributeAdapter(ResultVector& ref) : m_ref(ref) {}
 
-bool ov::AttributeAdapter<ResultVector>::visit_attributes(AttributeVisitor& visitor) {
+bool AttributeAdapter<ResultVector>::visit_attributes(AttributeVisitor& visitor) {
     size_t size = m_ref.size();
     visitor.on_attribute("size", size);
     if (size != m_ref.size()) {
@@ -92,8 +92,9 @@ bool ov::AttributeAdapter<ResultVector>::visit_attributes(AttributeVisitor& visi
         }
         visitor.on_attribute(index.str(), id);
         if (!m_ref[i]) {
-            m_ref[i] = ov::as_type_ptr<ov::op::v0::Result>(visitor.get_registered_node(id));
+            m_ref[i] = as_type_ptr<op::v0::Result>(visitor.get_registered_node(id));
         }
     }
     return true;
 }
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Remove `visit_attributes` as is same as base class.
 - Minor re-factor of evaluate.
 
### Tickets:
 - [CVS-118645](https://jira.devtools.intel.com/browse/CVS-118645)
