### PR TITLE
[packaging] Fixed python component naming format for APT

### DIFF
--- a/cmake/packaging/debian.cmake
+++ b/cmake/packaging/debian.cmake
@@ -317,7 +317,7 @@ macro(ov_cpack_settings)
         list(APPEND CPACK_COMPONENT_PYOPENVINO_PACKAGE_${pyversion}_DEPENDS ${installed_plugins})
         list(APPEND CPACK_COMPONENT_PYOPENVINO_PACKAGE_${pyversion}_DEPENDS ${frontends})
 
-        set(CPACK_DEBIAN_PYOPENVINO_PACKAGE_${pyversion}_PACKAGE_NAME "python3-openvino")
+        set(CPACK_DEBIAN_PYOPENVINO_PACKAGE_${pyversion}_PACKAGE_NAME "python3-openvino-${cpack_name_ver}")
         set(python_package "${CPACK_DEBIAN_PYOPENVINO_PACKAGE_${pyversion}_PACKAGE_NAME} (= ${cpack_full_ver})")
         set(CPACK_DEBIAN_PYOPENVINO_PACKAGE_${pyversion}_PACKAGE_DEPENDS "python3, python3-numpy")
 
@@ -368,6 +368,7 @@ macro(ov_cpack_settings)
         set(python_samples_package "${CPACK_DEBIAN_PYTHON_SAMPLES_PACKAGE_NAME} (= ${cpack_full_ver})")
         set(CPACK_DEBIAN_PYTHON_SAMPLES_PACKAGE_DEPENDS "python3, ${python_package}")
         set(CPACK_DEBIAN_PYTHON_SAMPLES_PACKAGE_ARCHITECTURE "all")
+        ov_debian_generate_conflicts(${OV_CPACK_COMP_PYTHON_SAMPLES} ${conflicting_versions})
         set(python_samples_copyright "generic")
     endif()
 


### PR DESCRIPTION
### Details:
 - Updated python component naming format
 - Added conflict versions f)or python-samples

### Tickets:
 - [*ticket-id*](https://community.intel.com/t5/Intel-Distribution-of-OpenVINO/Error-while-installing-openvino-2023-1-0-on-Ubuntu-20-04/m-p/1546442#M30300)
