### PR TITLE
[core]Migrate ReadValue operator to new API

### DIFF
--- a/src/core/include/openvino/op/read_value.hpp
+++ b/src/core/include/openvino/op/read_value.hpp
@@ -75,11 +75,9 @@ public:
         return m_variable->get_info().variable_id;
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs,
-                  const HostTensorVector& inputs,
+    bool evaluate(TensorVector& outputs,
+                  const TensorVector& inputs,
                   const EvaluationContext& evaluation_context) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
     bool has_evaluate() const override;
 
     bool constant_fold(OutputVector& output_values, const OutputVector& inputs_values) override;

--- a/src/core/src/op/read_value.cpp
+++ b/src/core/src/op/read_value.cpp
@@ -46,12 +46,12 @@ bool ReadValue::visit_attributes(AttributeVisitor& visitor) {
 }  // namespace v3
 
 namespace v6 {
-ReadValue::ReadValue(const shared_ptr<Variable>& variable) {
+ReadValue::ReadValue(const std::shared_ptr<util::Variable>& variable) {
     m_variable = variable;
     constructor_validate_and_infer_types();
 }
 
-ReadValue::ReadValue(const Output<Node>& init_value, const std::shared_ptr<Variable>& variable)
+ReadValue::ReadValue(const Output<Node>& init_value, const std::shared_ptr<util::Variable>& variable)
     : ReadValueBase({init_value}) {
     m_variable = variable;
     constructor_validate_and_infer_types();

--- a/src/core/src/op/read_value.cpp
+++ b/src/core/src/op/read_value.cpp
@@ -2,58 +2,62 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/read_value.hpp"
+#include "openvino/op/read_value.hpp"
 
 #include "itt.hpp"
-#include "ngraph/op/util/variable_context.hpp"
-#include "ngraph/ops.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/util/variable_context.hpp"
+#include "validation_util.hpp"
 
-using namespace std;
-using namespace ngraph;
+namespace ov {
+namespace op {
+namespace v3 {
 
-op::v3::ReadValue::ReadValue(const Output<Node>& init_value, const std::string& variable_id)
+ReadValue::ReadValue(const Output<Node>& init_value, const std::string& variable_id)
     : ReadValueBase({init_value}),
       m_variable_id(variable_id) {
     constructor_validate_and_infer_types();
 }
 
-void op::v3::ReadValue::validate_and_infer_types() {
+void ReadValue::validate_and_infer_types() {
     OV_OP_SCOPE(v3_ReadValue_validate_and_infer_types);
-    auto arg_t = get_input_element_type(0);
+    const auto& arg_t = get_input_element_type(0);
     const auto& input_shape = get_input_partial_shape(0);
 
-    VariableInfo info = {input_shape, arg_t, m_variable_id};
+    util::VariableInfo info = {input_shape, arg_t, m_variable_id};
     if (m_variable == nullptr)
-        m_variable = std::make_shared<Variable>(info);
+        m_variable = std::make_shared<util::Variable>(info);
     else
         m_variable->update(info);
     set_output_type(0, arg_t, input_shape);
 }
 
-shared_ptr<Node> op::v3::ReadValue::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> ReadValue::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v3_ReadValue_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    return make_shared<ReadValue>(new_args.at(0), m_variable_id);
+    return std::make_shared<ReadValue>(new_args.at(0), m_variable_id);
 }
 
-bool op::v3::ReadValue::visit_attributes(AttributeVisitor& visitor) {
+bool ReadValue::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(v3_ReadValue_visit_attributes);
     visitor.on_attribute("variable_id", m_variable_id);
     return true;
 }
+}  // namespace v3
 
-op::v6::ReadValue::ReadValue(const shared_ptr<Variable>& variable) {
+namespace v6 {
+ReadValue::ReadValue(const shared_ptr<Variable>& variable) {
     m_variable = variable;
     constructor_validate_and_infer_types();
 }
 
-op::v6::ReadValue::ReadValue(const Output<Node>& init_value, const shared_ptr<Variable>& variable)
+ReadValue::ReadValue(const Output<Node>& init_value, const std::shared_ptr<Variable>& variable)
     : ReadValueBase({init_value}) {
     m_variable = variable;
     constructor_validate_and_infer_types();
 }
 
-void op::v6::ReadValue::validate_and_infer_types() {
+void ReadValue::validate_and_infer_types() {
     OV_OP_SCOPE(v6_ReadValue_validate_and_infer_types);
 
     OPENVINO_ASSERT(m_variable, "Variable is not initialized.");
@@ -101,15 +105,15 @@ void op::v6::ReadValue::validate_and_infer_types() {
     set_output_type(0, variable_type, variable_shape);
 }
 
-shared_ptr<Node> op::v6::ReadValue::clone_with_new_inputs(const OutputVector& new_args) const {
+std::shared_ptr<Node> ReadValue::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v6_ReadValue_clone_with_new_inputs);
     check_new_args_count(this, new_args);
 
     switch (new_args.size()) {
     case 0:
-        return make_shared<ReadValue>(m_variable);
+        return std::make_shared<ReadValue>(m_variable);
     case 1:
-        return make_shared<ReadValue>(new_args[0], m_variable);
+        return std::make_shared<ReadValue>(new_args[0], m_variable);
     default:
         OPENVINO_THROW("Unable to clone ReadValue ",
                        this->get_friendly_name(),
@@ -118,7 +122,7 @@ shared_ptr<Node> op::v6::ReadValue::clone_with_new_inputs(const OutputVector& ne
     }
 }
 
-bool op::v6::ReadValue::visit_attributes(AttributeVisitor& visitor) {
+bool ReadValue::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(v6_ReadValue_visit_attributes);
     visitor.on_attribute("variable_id", m_variable);
 
@@ -129,42 +133,45 @@ bool op::v6::ReadValue::visit_attributes(AttributeVisitor& visitor) {
     return true;
 }
 
-void op::v6::ReadValue::revalidate_and_infer_types() {
+void ReadValue::revalidate_and_infer_types() {
     Node::revalidate_and_infer_types();
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-bool op::v6::ReadValue::evaluate(const HostTensorVector& outputs,
-                                 const HostTensorVector& inputs,
-                                 const EvaluationContext& evaluation_context) const {
+bool ReadValue::evaluate(TensorVector& outputs,
+                         const TensorVector& inputs,
+                         const EvaluationContext& evaluation_context) const {
     OV_OP_SCOPE(v6_ReadValue_evaluate);
+    OPENVINO_ASSERT(outputs.size() == 1);
+    OPENVINO_ASSERT(inputs.size() == 1);
+
     const auto& found_context = evaluation_context.find("VariableContext");
     NODE_VALIDATION_CHECK(this, found_context != evaluation_context.end(), "VariableContext not found.");
 
-    const auto& variable_values = found_context->second.as<VariableContext>().get_variable_values();
+    const auto& variable_values = found_context->second.as<util::VariableContext>().get_variable_values();
     const auto& var_value = variable_values.find(m_variable);
 
-    bool use_context = var_value != variable_values.end() && !var_value->second->get_reset();
+    const auto use_context = var_value != variable_values.end() && !var_value->second->get_reset();
 
-    // initial value (inputs[0]) is not supported, use zeros
-    auto zero_const = make_shared<v0::Constant>(inputs[0]->get_element_type(), inputs[0]->get_shape(), 0);
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    auto zero_tensor = make_shared<HostTensor>(zero_const);
-    const auto& input_tensor = use_context ? var_value->second->get_value() : zero_tensor;
-    OPENVINO_SUPPRESS_DEPRECATED_END
-    outputs[0]->set_unary(input_tensor);
-
-    void* input = input_tensor->get_data_ptr();
-    outputs[0]->write(input, outputs[0]->get_size_in_bytes());
+    auto& output = outputs[0];
+    if (use_context) {
+        const auto& ctx_tensor = var_value->second->get_state();
+        output.set_shape(ctx_tensor.get_shape());
+        std::memcpy(output.data(), ctx_tensor.data(), output.get_byte_size());
+    } else {
+        output.set_shape(inputs[0].get_shape());
+        std::memset(output.data(), 0, output.get_byte_size());
+    }
     return true;
 }
-OPENVINO_SUPPRESS_DEPRECATED_END
 
-bool op::v6::ReadValue::has_evaluate() const {
+bool ReadValue::has_evaluate() const {
     OV_OP_SCOPE(v6_ReadValue_has_evaluate);
     return true;
 }
 
-bool op::v6::ReadValue::constant_fold(OutputVector& output_values, const OutputVector& inputs_values) {
+bool ReadValue::constant_fold(OutputVector& output_values, const OutputVector& inputs_values) {
     return false;
 }
+}  // namespace v6
+}  // namespace op
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Remove legacy namespace, classes and use of utils functions

### Tickets:
 - [CVS-118642](https://jira.devtools.intel.com/browse/CVS-118642)
