### PR TITLE
[subgraphs_dumper] Fix sporadic cache volume growth

### DIFF
--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/cache/op_cache.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/cache/op_cache.cpp
@@ -64,6 +64,7 @@ void OpCache::update_cache(const std::shared_ptr<ov::Node>& node,
         return;
     // cloned_node->set_friendly_name(ov::test::functional::get_node_version(cloned_node));
     for (auto &&it : m_ops_cache) {
+        in_info_is_matched = true;
         if (m_manager.match(it.first, cloned_node)) {
             // std::cout << "Match " << cloned_node->get_type_info().name <<  " " << cloned_node->get_friendly_name() <<
             //        " with " << it.first->get_friendly_name() << std::endl;

--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/conformance_helper_tools/find_models_for_subgraphs_dumper.py
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/conformance_helper_tools/find_models_for_subgraphs_dumper.py
@@ -78,7 +78,10 @@ def generate_model_list_file(input_str: str, re_exp_file_path: str, output_file_
                 dirs = [model_dir_path]
                 if dir_re_exp != "*":
                     if is_latest_only:
-                        dirs = [find_latest_dir(model_dir_path, dir_re_exp)]
+                        try:
+                            dirs = [find_latest_dir(model_dir_path, dir_re_exp)]
+                        except:
+                            dirs = []
                     else:
                         dirs = Path(model_dir_path).glob(dir_re_exp)
                 for dir in dirs:


### PR DESCRIPTION
### Details:
 - *if list of models include several similar models some with constant and some with parameter, but file with model with constant goes fist, all models with parameters will defined as new because in_info_is_matched will be false*

### Tickets:
 - *ticket-id*
