### PR TITLE
[CI] [GHA] Increase timeout in the RICS-V workflow

### DIFF
--- a/.github/workflows/linux_riscv.yml
+++ b/.github/workflows/linux_riscv.yml
@@ -41,7 +41,7 @@ jobs:
 
   Build:
     needs: Smart_CI
-    timeout-minutes: 150
+    timeout-minutes: 200
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Should fix:
* https://github.com/openvinotoolkit/openvino/actions/runs/7021201351/job/19102703185 - #21130 
* https://github.com/openvinotoolkit/openvino/actions/runs/7024520570/job/19113457541 - master