### PR TITLE
[CPU] fix issue that reshape node didn't update last second input value

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -65,9 +65,6 @@ Reshape::Reshape(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
 }
 
 bool Reshape::needShapeInfer() const {
-    if (inputShapesModified()) {
-        return true;
-    }
     const auto& mem = getParentEdgesAtPort(1)[0]->getMemory();
     if (lastSecondInputValues.empty()) {
         lastSecondInputValues.resize(mem.getStaticDims()[0], 0);
@@ -80,6 +77,9 @@ bool Reshape::needShapeInfer() const {
             }
             return true;
         }
+    }
+    if (inputShapesModified()) {
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
### Details:
 - *in the issue, when the first input shape don't change, reshape node will not update the last second input value, in some case, it will cause needshapeInfer return wrong result.*

### Tickets:
 - *https://github.com/openvinotoolkit/openvino/issues/21051*
