### PR TITLE
[TF FE] Disable memory sharing for GPU.

### DIFF
--- a/src/bindings/python/src/openvino/frontend/tensorflow/node_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/node_decoder.py
@@ -91,6 +91,9 @@ class TFGraphNodeDecoder(DecoderBase):
             if not self.m_inner_graph:
                 variable_value = TFGraphNodeDecoder.get_variable(self.m_operation)
                 if variable_value is not None:
+                    # Disable sharing for variables which are not on CPU
+                    if "device:CPU" not in variable_value.device:
+                        self.m_shared_memory = False
                     # does not copy data
                     self.m_parsed_content = variable_value.__array__()
 


### PR DESCRIPTION
Root cause analysis: 
When model weights are located on GPU weights sharing leads to memory loss.

Solution: 
Turn off memory sharing for variables which are located on GPU.

Ticket: 126201

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update