### PR TITLE
[Snippets] Added PassConfig and PositionedPasses for PassPipeline

### DIFF
--- a/src/common/snippets/include/snippets/lowered/pass/pass.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/pass.hpp
@@ -58,23 +58,17 @@ public:
     void register_pass(const snippets::pass::PassPosition& position, const std::shared_ptr<Pass>& pass);
     void register_pass(const std::shared_ptr<Pass>& pass);
 
-    template<typename T, bool Enable = true, class... Args>
+    template<typename T, class... Args>
     void register_pass(Args&&... args) {
         static_assert(std::is_base_of<Pass, T>::value, "Pass not derived from lowered::Pass");
         auto pass = std::make_shared<T>(std::forward<Args>(args)...);
         register_pass(pass);
-        if (!Enable && !m_pass_config->is_enabled<T>()) {
-            m_pass_config->disable<T>();
-        }
     }
-    template<typename T, class Pos, bool Enable = true, class... Args, std::enable_if<std::is_same<snippets::pass::PassPosition, Pos>::value, bool>() = true>
+    template<typename T, class Pos, class... Args, std::enable_if<std::is_same<snippets::pass::PassPosition, Pos>::value, bool>() = true>
     void register_pass(const snippets::pass::PassPosition& position, Args&&... args) {
         static_assert(std::is_base_of<Pass, T>::value, "Pass not derived from lowered::Pass");
         auto pass = std::make_shared<T>(std::forward<Args>(args)...);
         register_pass(position, pass);
-        if (!Enable && !m_pass_config->is_enabled<T>()) {
-            m_pass_config->disable<T>();
-        }
     }
 
     void register_positioned_passes(const std::vector<PositionedPassLowered>& pos_passes);

--- a/src/common/snippets/include/snippets/lowered/pass/pass_config.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/pass_config.hpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "snippets/lowered/linear_ir.hpp"
+
+#include "openvino/core/rtti.hpp"
+#include "openvino/core/type.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+/**
+ * @interface PassConfig
+ * @brief Represents a transformations config that is used for disabling/enabling
+ *        passes registered inside lowered::pass::PassPipeline
+ * @ingroup snippets
+ */
+class PassConfig {
+public:
+    PassConfig() = default;
+
+    void disable(const DiscreteTypeInfo& type_info);
+    template <class T>
+    void disable() {
+        disable(T::get_type_info_static());
+    }
+
+    void enable(const DiscreteTypeInfo& type_info);
+    template <class T>
+    void enable() {
+        enable(T::get_type_info_static());
+    }
+
+    bool is_disabled(const DiscreteTypeInfo& type_info) const;
+    template <class T>
+    bool is_disabled() const {
+        return is_disabled(T::get_type_info_static());
+    }
+
+    bool is_enabled(const DiscreteTypeInfo& type_info) const;
+    template <class T>
+    bool is_enabled() const {
+        return is_enabled(T::get_type_info_static());
+    }
+
+private:
+    std::unordered_set<DiscreteTypeInfo> m_disabled;
+    std::unordered_set<DiscreteTypeInfo> m_enabled;
+};
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -104,14 +104,14 @@ public:
                                 const std::vector<ov::element::Type>& input_precisions = {},
                                 const std::vector<ov::element::Type>& output_precisions = {},
                                 const std::vector<pass::Manager::PositionedPass>& data_flow_passes = {},
-                                const lowered::pass::PassPipeline& control_flow_passes_pre_common = {},
-                                const lowered::pass::PassPipeline& control_flow_passes_post_common = {},
+                                const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = nullptr,
+                                const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
                                 size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,
                                 const std::shared_ptr<IShapeInferSnippetsFactory>& factory = nullptr,
                                 const void* compile_params = nullptr);
 
-    snippets::Schedule generate_from_linear_ir(const lowered::pass::PassPipeline& backend_passes_pre_common = {},
-                                               const lowered::pass::PassPipeline& backend_passes_post_common = {},
+    snippets::Schedule generate_from_linear_ir(const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = nullptr,
+                                               const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
                                                const void* compile_params = nullptr) const;
     IShapeInferSnippets::Result shape_infer(const std::vector<VectorDimsRef>& input_shapes);
 
@@ -149,8 +149,8 @@ public:
 private:
     void control_flow_transformations(lowered::LinearIR& linear_ir,
                                       LoweringResult& lowering_result,
-                                      const lowered::pass::PassPipeline& backend_passes_pre_common,
-                                      const lowered::pass::PassPipeline& backend_passes_post_common) const;
+                                      const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = nullptr,
+                                      const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {}) const;
     void init_config();
     // Count of Subgraph virtual ports:
     //  - Potential non-scalar Constants that will be created after some transformations (At the moment it's relevant only for FakeQuantize decomposition)

--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -13,6 +13,7 @@
 #include "snippets/pass/manager.hpp"
 #include "snippets/shape_inference/shape_inference.hpp"
 #include "snippets/lowered/pass/pass.hpp"
+#include "snippets/pass/positioned_pass.hpp"
 
 #include "snippets/generator.hpp"
 
@@ -103,17 +104,16 @@ public:
     snippets::Schedule generate(const BlockedShapeVector& blocked_input_shapes = {},
                                 const std::vector<ov::element::Type>& input_precisions = {},
                                 const std::vector<ov::element::Type>& output_precisions = {},
-                                const std::vector<pass::Manager::PositionedPass>& data_flow_passes = {},
+                                const std::vector<snippets::pass::Manager::PositionedPassBase>& data_flow_passes = {},
                                 const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = std::make_shared<lowered::pass::PassConfig>(),
-                                const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
+                                const std::vector<snippets::lowered::pass::PassPipeline::PositionedPassLowered>& lowered_backend_passes = {},
                                 size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,
                                 const std::shared_ptr<IShapeInferSnippetsFactory>& factory = nullptr,
                                 const void* compile_params = nullptr);
 
-    snippets::Schedule
-    generate_from_linear_ir(const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = std::make_shared<lowered::pass::PassConfig>(),
-                            const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
-                            const void* compile_params = nullptr) const;
+    Schedule generate_from_linear_ir(const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = std::make_shared<lowered::pass::PassConfig>(),
+                                     const std::vector<snippets::lowered::pass::PassPipeline::PositionedPassLowered>& lowered_backend_passes = {},
+                                     const void* compile_params = nullptr) const;
     IShapeInferSnippets::Result shape_infer(const std::vector<VectorDimsRef>& input_shapes);
 
     // plugin sets generator for a snippet to some specific generator.
@@ -141,7 +141,7 @@ public:
     void data_flow_transformations(const BlockedShapeVector& blocked_input_shapes = {},
                                    const std::vector<ov::element::Type>& input_precisions = {},
                                    const std::vector<ov::element::Type>& output_precisions = {},
-                                   const std::vector<snippets::pass::Manager::PositionedPass>& = {});
+                                   const std::vector<snippets::pass::Manager::PositionedPassBase>& = {});
     std::shared_ptr<lowered::LinearIR>
     convert_body_to_linear_ir(size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,
                               const std::shared_ptr<IShapeInferSnippetsFactory>& shape_infer_factory = std::make_shared<IShapeInferSnippetsFactory>());
@@ -151,7 +151,7 @@ private:
     void control_flow_transformations(lowered::LinearIR& linear_ir,
                                       LoweringResult& lowering_result,
                                       const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = std::make_shared<lowered::pass::PassConfig>(),
-                                      const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {}) const;
+                                      const std::vector<snippets::lowered::pass::PassPipeline::PositionedPassLowered>& lowered_backend_passes = {}) const;
     void init_config();
     // Count of Subgraph virtual ports:
     //  - Potential non-scalar Constants that will be created after some transformations (At the moment it's relevant only for FakeQuantize decomposition)

--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -104,15 +104,16 @@ public:
                                 const std::vector<ov::element::Type>& input_precisions = {},
                                 const std::vector<ov::element::Type>& output_precisions = {},
                                 const std::vector<pass::Manager::PositionedPass>& data_flow_passes = {},
-                                const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = nullptr,
+                                const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = std::make_shared<lowered::pass::PassConfig>(),
                                 const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
                                 size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,
                                 const std::shared_ptr<IShapeInferSnippetsFactory>& factory = nullptr,
                                 const void* compile_params = nullptr);
 
-    snippets::Schedule generate_from_linear_ir(const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = nullptr,
-                                               const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
-                                               const void* compile_params = nullptr) const;
+    snippets::Schedule
+    generate_from_linear_ir(const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = std::make_shared<lowered::pass::PassConfig>(),
+                            const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
+                            const void* compile_params = nullptr) const;
     IShapeInferSnippets::Result shape_infer(const std::vector<VectorDimsRef>& input_shapes);
 
     // plugin sets generator for a snippet to some specific generator.
@@ -149,7 +150,7 @@ public:
 private:
     void control_flow_transformations(lowered::LinearIR& linear_ir,
                                       LoweringResult& lowering_result,
-                                      const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = nullptr,
+                                      const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = std::make_shared<lowered::pass::PassConfig>(),
                                       const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {}) const;
     void init_config();
     // Count of Subgraph virtual ports:

--- a/src/common/snippets/include/snippets/pass/manager.hpp
+++ b/src/common/snippets/include/snippets/pass/manager.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "positioned_pass.hpp"
+
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/pass.hpp"
 #include "openvino/pass/validate.hpp"
@@ -24,40 +26,7 @@ public:
     ~Manager() override = default;
     using PassBase = ov::pass::PassBase;
     using Validate = ov::pass::Validate;
-    /**
-    * @brief PassPosition describes a particular position in a transformation pipeline,
-     *       where a new transformation should be inserted.
-     * @param pass_name name of the anchor pass, the new pass will be inserted before/after it.
-     *        Empty pass_name could mean either beginning or the end of the pipeline depending on the `after` flag.
-     *        No default value. Note that pass names namespaces are not supported, ov::PassName and snippets::PassName
-     *        are considered identical.
-     * @param after `true` if the new pass should be inserted before the anchor pass, `false` otherwise (default).
-     *        If `pass_name` is empty, `true` means the end, and `false` - the beginning of the pipeline.
-     * @param pass_instance the number of the pass with matching `pass_name` to be considered as the anchor pass.
-     *        0 (default) means the first pass with `pass_name` will be considered as the anchor pass.
-    * @ingroup snippets
-    */
-    class PassPosition {
-    public:
-        enum class Place {Before, After, PipelineStart, PipelineEnd};
-        using PassListType = std::vector<std::shared_ptr<ov::pass::PassBase>>;
-        explicit PassPosition(Place pass_place);
-        explicit PassPosition(Place pass_place, const DiscreteTypeInfo& pass_type_info, size_t pass_instance = 0);
-
-        PassListType::const_iterator get_insert_position(const PassListType& pass_list) const;
-
-    private:
-        const DiscreteTypeInfo m_pass_type_info = {};
-        const size_t m_pass_instance{0};
-        const Place m_place{Place::Before};
-    };
-    struct PositionedPass {
-        PassPosition position;
-        std::shared_ptr<PassBase> pass;
-        PositionedPass(PassPosition arg_pos, std::shared_ptr<PassBase> arg_pass)
-        : position(std::move(arg_pos)), pass(std::move(arg_pass)) {
-        }
-    };
+    using PositionedPassBase = PositionedPass<PassBase>;
 
     template <typename T, class... Args>
     std::shared_ptr<T> register_pass(Args&&... args) {
@@ -76,7 +45,7 @@ public:
     }
 
     std::shared_ptr<PassBase> register_pass_instance(const PassPosition& pass_id, const std::shared_ptr<PassBase>& pass);
-    void register_positioned_passes(const std::vector<PositionedPass>& pos_passes);
+    void register_positioned_passes(const std::vector<PositionedPassBase>& pos_passes);
 
 protected:
     std::shared_ptr<Manager::PassBase> insert_pass_instance(const PassPosition& position, const std::shared_ptr<PassBase>& pass);

--- a/src/common/snippets/include/snippets/pass/manager.hpp
+++ b/src/common/snippets/include/snippets/pass/manager.hpp
@@ -42,10 +42,12 @@ public:
         enum class Place {Before, After, PipelineStart, PipelineEnd};
         using PassListType = std::vector<std::shared_ptr<ov::pass::PassBase>>;
         explicit PassPosition(Place pass_place);
-        explicit PassPosition(Place pass_place, std::string pass_name, size_t pass_instance = 0);
+        explicit PassPosition(Place pass_place, const DiscreteTypeInfo& pass_type_info, size_t pass_instance = 0);
+
         PassListType::const_iterator get_insert_position(const PassListType& pass_list) const;
+
     private:
-        const std::string m_pass_name;
+        const DiscreteTypeInfo m_pass_type_info = {};
         const size_t m_pass_instance{0};
         const Place m_place{Place::Before};
     };

--- a/src/common/snippets/include/snippets/pass/positioned_pass.hpp
+++ b/src/common/snippets/include/snippets/pass/positioned_pass.hpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/manager.hpp"
+#include "openvino/pass/pass.hpp"
+#include "openvino/pass/validate.hpp"
+
+#include <typeinfo>
+
+
+namespace ov {
+namespace snippets {
+namespace pass {
+
+/**
+* @brief PassPosition describes a particular position in a transformation pipeline,
+ *       where a new transformation should be inserted.
+ * @param pass_name name of the anchor pass, the new pass will be inserted before/after it.
+ *        Empty pass_name could mean either beginning or the end of the pipeline depending on the `after` flag.
+ *        No default value. Note that pass names namespaces are not supported, ov::PassName and snippets::PassName
+ *        are considered identical.
+ * @param after `true` if the new pass should be inserted before the anchor pass, `false` otherwise (default).
+ *        If `pass_name` is empty, `true` means the end, and `false` - the beginning of the pipeline.
+ * @param pass_instance the number of the pass with matching `pass_name` to be considered as the anchor pass.
+ *        0 (default) means the first pass with `pass_name` will be considered as the anchor pass.
+* @ingroup snippets
+*/
+class PassPosition {
+public:
+    enum class Place { Before, After, PipelineStart, PipelineEnd };
+
+    explicit PassPosition(Place pass_place);
+    explicit PassPosition(Place pass_place, const DiscreteTypeInfo& pass_type_info, size_t pass_instance = 0);
+
+    template<typename PassType>
+    typename std::vector<std::shared_ptr<PassType>>::const_iterator get_insert_position(const std::vector<std::shared_ptr<PassType>>& pass_list) const;
+
+private:
+    const DiscreteTypeInfo m_pass_type_info = {};
+    const size_t m_pass_instance{0};
+    const Place m_place{Place::Before};
+};
+
+template<typename PassType>
+struct PositionedPass {
+    PositionedPass(PassPosition arg_pos, std::shared_ptr<PassType> arg_pass)
+        : position(arg_pos), pass(std::move(arg_pass)) {}
+
+    PassPosition position;
+    std::shared_ptr<PassType> pass;
+};
+
+template<typename PassType>
+typename std::vector<std::shared_ptr<PassType>>::const_iterator PassPosition::get_insert_position(
+    const std::vector<std::shared_ptr<PassType>>& pass_list) const {
+    size_t pass_count = 0;
+    auto match = [this, &pass_count](const std::shared_ptr<PassType>& p) {
+        if (p->get_type_info() == m_pass_type_info) {
+            if (m_pass_instance == pass_count)
+                return true;
+            pass_count++;
+        }
+        return false;
+    };
+    switch (m_place) {
+        case Place::PipelineStart: return pass_list.cbegin();
+        case Place::PipelineEnd: return pass_list.cend();
+        case Place::Before:
+        case Place::After: {
+            auto insert_it = std::find_if(pass_list.cbegin(), pass_list.cend(), match);
+            OPENVINO_ASSERT(insert_it != pass_list.cend(), "PassPosition ", m_pass_type_info, " cannot be found");
+            return m_place == Place::After ?  std::next(insert_it) : insert_it;
+        }
+        default:
+            OPENVINO_THROW("Unsupported Place type in PassPosition::get_insert_position");
+    }
+}
+
+} // namespace pass
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/lowered/pass/pass.cpp
+++ b/src/common/snippets/src/lowered/pass/pass.cpp
@@ -17,15 +17,18 @@ PassPipeline::PassPipeline(const std::shared_ptr<PassConfig>& pass_config) : m_p
 }
 
 void PassPipeline::register_pass(const snippets::pass::PassPosition& position, const std::shared_ptr<Pass>& pass) {
+    OPENVINO_ASSERT(pass != nullptr, "PassPipeline cannot register empty pass!");
     m_passes.insert(position.get_insert_position(m_passes), pass);
 }
 
 void PassPipeline::register_pass(const std::shared_ptr<Pass>& pass) {
+    OPENVINO_ASSERT(pass != nullptr, "PassPipeline cannot register empty pass!");
     m_passes.push_back(pass);
 }
 
 void PassPipeline::run(LinearIR& linear_ir) const {
     for (const auto& pass : m_passes) {
+        OPENVINO_ASSERT(pass != nullptr, "PassPipeline has empty pass!");
         if (m_pass_config->is_disabled(pass->get_type_info())) {
             continue;
         }

--- a/src/common/snippets/src/lowered/pass/pass.cpp
+++ b/src/common/snippets/src/lowered/pass/pass.cpp
@@ -16,7 +16,7 @@ PassPipeline::PassPipeline(const std::shared_ptr<PassConfig>& pass_config) : m_p
     OPENVINO_ASSERT(m_pass_config != nullptr, "PassConfig is not initialized!");
 }
 
-void PassPipeline::register_pass(const PassPosition& position, const std::shared_ptr<Pass>& pass) {
+void PassPipeline::register_pass(const snippets::pass::PassPosition& position, const std::shared_ptr<Pass>& pass) {
     m_passes.insert(position.get_insert_position(m_passes), pass);
 }
 
@@ -33,49 +33,10 @@ void PassPipeline::run(LinearIR& linear_ir) const {
     }
 }
 
-void PassPipeline::register_positioned_passes(const std::vector<PositionedPass>& pos_passes) {
+void PassPipeline::register_positioned_passes(const std::vector<PositionedPassLowered>& pos_passes) {
     for (const auto& pp : pos_passes)
         register_pass(pp.position, pp.pass);
 }
-
-PassPipeline::PassPosition::PassPosition(Place pass_place)
-    : m_pass_type_info(DiscreteTypeInfo()), m_pass_instance(0), m_place(pass_place) {
-    OPENVINO_ASSERT(utils::one_of(m_place, Place::PipelineStart, Place::PipelineEnd),
-                    "Invalid arg: pass_type_info and pass_instance args could be omitted only for Place::PipelineStart/Place::PipelineEnd");
-}
-PassPipeline::PassPosition::PassPosition(Place pass_place, const DiscreteTypeInfo& pass_type_info, size_t pass_instance)
-    : m_pass_type_info(pass_type_info), m_pass_instance(pass_instance), m_place(pass_place) {
-    OPENVINO_ASSERT(utils::one_of(m_place, Place::Before, Place::After) && m_pass_type_info != DiscreteTypeInfo(),
-                    "Invalid args combination: pass_place must be Place::Before/Place::After and m_pass_type_info must be non-empty");
-}
-
-std::vector<std::shared_ptr<Pass>>::const_iterator
-PassPipeline::PassPosition::get_insert_position(const std::vector<std::shared_ptr<Pass>>& pass_list) const {
-    size_t pass_count = 0;
-    auto match = [this, &pass_count](const std::shared_ptr<Pass>& p) {
-        if (p->get_type_info() == m_pass_type_info) {
-            if (m_pass_instance == pass_count)
-                return true;
-            pass_count++;
-        }
-        return false;
-    };
-    switch (m_place) {
-        case Place::PipelineStart: return pass_list.cbegin();
-        case Place::PipelineEnd: return pass_list.cend();
-        case Place::Before:
-        case Place::After: {
-            auto insert_it = std::find_if(pass_list.cbegin(), pass_list.cend(), match);
-            OPENVINO_ASSERT(insert_it != pass_list.cend(), "PassPipeline failed to find pass ", m_pass_type_info);
-            return m_place == Place::After ? std::next(insert_it) : insert_it;
-        }
-        default:
-            OPENVINO_THROW("Unsupported Place type in PassPosition::get_insert_position");
-    }
-}
-
-PassPipeline::PositionedPass::PositionedPass(PassPosition arg_pos, std::shared_ptr<Pass> arg_pass)
-    : position(std::move(arg_pos)), pass(std::move(arg_pass)) {}
 
 } // namespace pass
 } // namespace lowered

--- a/src/common/snippets/src/lowered/pass/pass.cpp
+++ b/src/common/snippets/src/lowered/pass/pass.cpp
@@ -4,11 +4,21 @@
 
 #include "snippets/lowered/pass/pass.hpp"
 
+#include "snippets/utils.hpp"
 
 namespace ov {
 namespace snippets {
 namespace lowered {
 namespace pass {
+
+PassPipeline::PassPipeline() : m_pass_config(std::make_shared<PassConfig>()) {}
+PassPipeline::PassPipeline(const std::shared_ptr<PassConfig>& pass_config) : m_pass_config(pass_config) {
+    OPENVINO_ASSERT(m_pass_config != nullptr, "PassConfig is not initialized!");
+}
+
+void PassPipeline::register_pass(const PassPosition& position, const std::shared_ptr<Pass>& pass) {
+    m_passes.insert(position.get_insert_position(m_passes), pass);
+}
 
 void PassPipeline::register_pass(const std::shared_ptr<Pass>& pass) {
     m_passes.push_back(pass);
@@ -16,9 +26,56 @@ void PassPipeline::register_pass(const std::shared_ptr<Pass>& pass) {
 
 void PassPipeline::run(LinearIR& linear_ir) const {
     for (const auto& pass : m_passes) {
+        if (m_pass_config->is_disabled(pass->get_type_info())) {
+            continue;
+        }
         pass->run(linear_ir);
     }
 }
+
+void PassPipeline::register_positioned_passes(const std::vector<PositionedPass>& pos_passes) {
+    for (const auto& pp : pos_passes)
+        register_pass(pp.position, pp.pass);
+}
+
+PassPipeline::PassPosition::PassPosition(Place pass_place)
+    : m_pass_type_info(DiscreteTypeInfo()), m_pass_instance(0), m_place(pass_place) {
+    OPENVINO_ASSERT(utils::one_of(m_place, Place::PipelineStart, Place::PipelineEnd),
+                    "Invalid arg: pass_type_info and pass_instance args could be omitted only for Place::PipelineStart/Place::PipelineEnd");
+}
+PassPipeline::PassPosition::PassPosition(Place pass_place, const DiscreteTypeInfo& pass_type_info, size_t pass_instance)
+    : m_pass_type_info(pass_type_info), m_pass_instance(pass_instance), m_place(pass_place) {
+    OPENVINO_ASSERT(utils::one_of(m_place, Place::Before, Place::After) && m_pass_type_info != DiscreteTypeInfo(),
+                    "Invalid args combination: pass_place must be Place::Before/Place::After and m_pass_type_info must be non-empty");
+}
+
+std::vector<std::shared_ptr<Pass>>::const_iterator
+PassPipeline::PassPosition::get_insert_position(const std::vector<std::shared_ptr<Pass>>& pass_list) const {
+    size_t pass_count = 0;
+    auto match = [this, &pass_count](const std::shared_ptr<Pass>& p) {
+        if (p->get_type_info() == m_pass_type_info) {
+            if (m_pass_instance == pass_count)
+                return true;
+            pass_count++;
+        }
+        return false;
+    };
+    switch (m_place) {
+        case Place::PipelineStart: return pass_list.cbegin();
+        case Place::PipelineEnd: return pass_list.cend();
+        case Place::Before:
+        case Place::After: {
+            auto insert_it = std::find_if(pass_list.cbegin(), pass_list.cend(), match);
+            OPENVINO_ASSERT(insert_it != pass_list.cend(), "PassPipeline failed to find pass ", m_pass_type_info);
+            return m_place == Place::After ? std::next(insert_it) : insert_it;
+        }
+        default:
+            OPENVINO_THROW("Unsupported Place type in PassPosition::get_insert_position");
+    }
+}
+
+PassPipeline::PositionedPass::PositionedPass(PassPosition arg_pos, std::shared_ptr<Pass> arg_pass)
+    : position(std::move(arg_pos)), pass(std::move(arg_pass)) {}
 
 } // namespace pass
 } // namespace lowered

--- a/src/common/snippets/src/lowered/pass/pass_config.cpp
+++ b/src/common/snippets/src/lowered/pass/pass_config.cpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/lowered/pass/pass_config.hpp"
+
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+void PassConfig::disable(const DiscreteTypeInfo& type_info) {
+    m_enabled.erase(type_info);
+    m_disabled.insert(type_info);
+}
+
+void PassConfig::enable(const DiscreteTypeInfo& type_info) {
+    m_enabled.insert(type_info);
+    m_disabled.erase(type_info);
+}
+
+bool PassConfig::is_disabled(const DiscreteTypeInfo& type_info) const {
+    return m_disabled.count(type_info);
+}
+
+bool PassConfig::is_enabled(const DiscreteTypeInfo& type_info) const {
+    return m_enabled.count(type_info);
+}
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -381,7 +381,7 @@ std::shared_ptr<Subgraph> Subgraph::clone() const {
 void Subgraph::data_flow_transformations(const BlockedShapeVector& blocked_input_shapes,
                                          const std::vector<ov::element::Type>& input_precisions,
                                          const std::vector<ov::element::Type>& output_precisions,
-                                         const std::vector<snippets::pass::Manager::PositionedPass>& backend_passes) {
+                                         const std::vector<snippets::pass::Manager::PositionedPassBase>& backend_passes) {
     INTERNAL_OP_SCOPE(Subgraph);
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::data_flow_transformations")
 
@@ -412,7 +412,7 @@ void Subgraph::data_flow_transformations(const BlockedShapeVector& blocked_input
 void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
                                             LoweringResult& lowering_result,
                                             const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config,
-                                            const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes) const {
+                                            const std::vector<snippets::lowered::pass::PassPipeline::PositionedPassLowered>& lowered_backend_passes) const {
     INTERNAL_OP_SCOPE(Subgraph);
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::control_flow_transformations")
 
@@ -449,9 +449,9 @@ void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
 snippets::Schedule Subgraph::generate(const BlockedShapeVector& blocked_input_shapes,
                                       const std::vector<ov::element::Type>& input_precisions,
                                       const std::vector<ov::element::Type>& output_precisions,
-                                      const std::vector<snippets::pass::Manager::PositionedPass>& data_flow_backend_passes,
+                                      const std::vector<snippets::pass::Manager::PositionedPassBase>& data_flow_backend_passes,
                                       const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config,
-                                      const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes,
+                                      const std::vector<snippets::lowered::pass::PassPipeline::PositionedPassLowered>& lowered_backend_passes,
                                       size_t min_parallel_work_amount, size_t min_kernel_work_amount,
                                       const std::shared_ptr<IShapeInferSnippetsFactory>& factory,
                                       const void* compile_params) {
@@ -461,7 +461,7 @@ snippets::Schedule Subgraph::generate(const BlockedShapeVector& blocked_input_sh
 }
 
 snippets::Schedule Subgraph::generate_from_linear_ir(const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config,
-                                                     const std::vector<lowered::pass::PassPipeline::PositionedPass>& backed_passes,
+                                                     const std::vector<snippets::lowered::pass::PassPipeline::PositionedPassLowered>& backed_passes,
                                                      const void* compile_params) const {
     INTERNAL_OP_SCOPE(Subgraph);
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::generate")

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -424,7 +424,7 @@ void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
     const size_t vector_size = get_generator()->get_target_machine()->get_lanes();
     const int32_t buffer_allocation_rank = static_cast<int32_t>(linear_ir.get_config().m_loop_depth);
 
-    lowered::pass::PassPipeline pipeline(lowered_pass_config ? lowered_pass_config : std::make_shared<lowered::pass::PassConfig>());
+    lowered::pass::PassPipeline pipeline(lowered_pass_config);
     pipeline.register_pass<lowered::pass::MarkLoops>(vector_size);
     pipeline.register_pass<lowered::pass::SoftmaxDecomposition>(vector_size);
     pipeline.register_pass<lowered::pass::FuseLoops>();

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -17,7 +17,6 @@
 #include "snippets/pass/set_softmax_ports.hpp"
 #include "snippets/pass/canonicalization.hpp"
 #include "snippets/pass/align_element_types.hpp"
-#include "snippets/lowered/pass/validate_shapes.hpp"
 
 #include "snippets/utils.hpp"
 
@@ -42,6 +41,8 @@
 #include "snippets/lowered/pass/insert_loops.hpp"
 #include "snippets/lowered/pass/optimize_domain.hpp"
 #include "snippets/lowered/pass/insert_perf_count.hpp"
+#include "snippets/lowered/pass/validate_shapes.hpp"
+#include "snippets/lowered/pass/pass_config.hpp"
 
 #include "transformations/utils/utils.hpp"
 
@@ -410,8 +411,8 @@ void Subgraph::data_flow_transformations(const BlockedShapeVector& blocked_input
 
 void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
                                             LoweringResult& lowering_result,
-                                            const lowered::pass::PassPipeline& backend_passes_pre_common,
-                                            const lowered::pass::PassPipeline& backend_passes_post_common) const {
+                                            const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config,
+                                            const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes) const {
     INTERNAL_OP_SCOPE(Subgraph);
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::control_flow_transformations")
 
@@ -423,61 +424,44 @@ void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
     const size_t vector_size = get_generator()->get_target_machine()->get_lanes();
     const int32_t buffer_allocation_rank = static_cast<int32_t>(linear_ir.get_config().m_loop_depth);
 
-    // We have to call MarkLoops before backend markup passes
-    // because these passes can update subtensor but not insert Loop (e.g. when loop increment is equal to the corresponding dim)
-    // If MarkLoops is called on such LIR, it inserts Eltwise-like loops which might not reflect backend expectations
-    // It should be fixed by ticket 113666
-    lowered::pass::PassPipeline markup_pipeline;
-    markup_pipeline.register_pass<lowered::pass::MarkLoops>(vector_size);
-    markup_pipeline.run(linear_ir);
-
-    // Ticket: 113666
-    // TODO: Make pass pipeline with backend passes more flexible
-    backend_passes_pre_common.run(linear_ir);
-
-    lowered::pass::PassPipeline common_pipeline;
-    common_pipeline.register_pass<lowered::pass::SoftmaxDecomposition>(vector_size);
-    common_pipeline.register_pass<lowered::pass::FuseLoops>();
-    common_pipeline.register_pass<lowered::pass::SplitLoops>();
-    common_pipeline.register_pass<lowered::pass::MoveResultOutOfLoop>();
-    common_pipeline.register_pass<lowered::pass::InsertBuffers>(buffer_allocation_rank);
-    common_pipeline.register_pass<lowered::pass::InsertLoadStore>(vector_size);
-    common_pipeline.register_pass<lowered::pass::MoveScalarToConsumer>();
-    common_pipeline.register_pass<lowered::pass::InsertBroadcastMove>();
-    common_pipeline.register_pass<lowered::pass::LoadMoveBroadcastToBroadcastLoad>();
-
-    common_pipeline.register_pass<lowered::pass::ValidateShapes>();
-
-    common_pipeline.register_pass<lowered::pass::ValidateLoops>();
-    common_pipeline.register_pass<lowered::pass::InitLoops>();
-    common_pipeline.register_pass<lowered::pass::InsertLoops>();
-    common_pipeline.run(linear_ir);
-
-    backend_passes_post_common.run(linear_ir);
-
-    lowered::pass::PassPipeline final_pipeline;
-    final_pipeline.register_pass<lowered::pass::AllocateBuffers>(lowering_result.buffer_scratchpad_size, linear_ir.get_config().m_are_buffers_optimized);
-    final_pipeline.register_pass<lowered::pass::CleanRepeatedDataPointerShifts>();
-    final_pipeline.register_pass<lowered::pass::PropagateLayout>();
-    final_pipeline.run(linear_ir);
+    lowered::pass::PassPipeline pipeline(lowered_pass_config ? lowered_pass_config : std::make_shared<lowered::pass::PassConfig>());
+    pipeline.register_pass<lowered::pass::MarkLoops>(vector_size);
+    pipeline.register_pass<lowered::pass::SoftmaxDecomposition>(vector_size);
+    pipeline.register_pass<lowered::pass::FuseLoops>();
+    pipeline.register_pass<lowered::pass::SplitLoops>();
+    pipeline.register_pass<lowered::pass::MoveResultOutOfLoop>();
+    pipeline.register_pass<lowered::pass::InsertBuffers>(buffer_allocation_rank);
+    pipeline.register_pass<lowered::pass::InsertLoadStore>(vector_size);
+    pipeline.register_pass<lowered::pass::MoveScalarToConsumer>();
+    pipeline.register_pass<lowered::pass::InsertBroadcastMove>();
+    pipeline.register_pass<lowered::pass::LoadMoveBroadcastToBroadcastLoad>();
+    pipeline.register_pass<lowered::pass::ValidateShapes>();
+    pipeline.register_pass<lowered::pass::ValidateLoops>();
+    pipeline.register_pass<lowered::pass::InitLoops>();
+    pipeline.register_pass<lowered::pass::InsertLoops>();
+    pipeline.register_pass<lowered::pass::AllocateBuffers>(lowering_result.buffer_scratchpad_size, linear_ir.get_config().m_are_buffers_optimized);
+    pipeline.register_pass<lowered::pass::CleanRepeatedDataPointerShifts>();
+    pipeline.register_pass<lowered::pass::PropagateLayout>();
+    pipeline.register_positioned_passes(lowered_backend_passes);
+    pipeline.run(linear_ir);
 }
 
 snippets::Schedule Subgraph::generate(const BlockedShapeVector& blocked_input_shapes,
                                       const std::vector<ov::element::Type>& input_precisions,
                                       const std::vector<ov::element::Type>& output_precisions,
                                       const std::vector<snippets::pass::Manager::PositionedPass>& data_flow_backend_passes,
-                                      const lowered::pass::PassPipeline& backend_passes_pre_common,
-                                      const lowered::pass::PassPipeline& backend_passes_post_common,
+                                      const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config,
+                                      const std::vector<lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes,
                                       size_t min_parallel_work_amount, size_t min_kernel_work_amount,
                                       const std::shared_ptr<IShapeInferSnippetsFactory>& factory,
                                       const void* compile_params) {
     data_flow_transformations(blocked_input_shapes, input_precisions, output_precisions, data_flow_backend_passes);
     convert_body_to_linear_ir(min_parallel_work_amount, min_kernel_work_amount, factory);
-    return generate_from_linear_ir(backend_passes_pre_common, backend_passes_post_common, compile_params);
+    return generate_from_linear_ir(lowered_pass_config, lowered_backend_passes, compile_params);
 }
 
-snippets::Schedule Subgraph::generate_from_linear_ir(const lowered::pass::PassPipeline& backend_passes_pre_common,
-                                                     const lowered::pass::PassPipeline& backend_passes_post_common,
+snippets::Schedule Subgraph::generate_from_linear_ir(const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config,
+                                                     const std::vector<lowered::pass::PassPipeline::PositionedPass>& backed_passes,
                                                      const void* compile_params) const {
     INTERNAL_OP_SCOPE(Subgraph);
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::generate")
@@ -489,7 +473,7 @@ snippets::Schedule Subgraph::generate_from_linear_ir(const lowered::pass::PassPi
     OPENVINO_ASSERT(m_linear_ir, "Attempt to call generate, when linear IR was not initialized");
     auto linear_ir {*m_linear_ir->clone()};
     LoweringResult lowering_result;
-    control_flow_transformations(linear_ir, lowering_result, backend_passes_pre_common, backend_passes_post_common);
+    control_flow_transformations(linear_ir, lowering_result, lowered_pass_config, backed_passes);
 #ifdef SNIPPETS_DEBUG_CAPS
     if (linear_ir.get_config().perf_count_mode == lowered::PerfCountMode::Chrono) {
         lowered::pass::InsertPerfCount perf_count_pass;

--- a/src/common/snippets/src/pass/manager.cpp
+++ b/src/common/snippets/src/pass/manager.cpp
@@ -8,40 +8,6 @@
 namespace ov {
 namespace snippets {
 namespace pass {
-Manager::PassPosition::PassPosition(Place pass_place) : m_place(pass_place) {
-    OPENVINO_ASSERT(m_place == Place::PipelineStart || m_place == Place::PipelineEnd,
-                    "Invalid arg: pass_type_info and pass_instance args could be omitted only for Place::PipelineStart/Place::PipelineEnd");
-}
-Manager::PassPosition::PassPosition(Place pass_place, const DiscreteTypeInfo& pass_type_info, size_t pass_instance)
-: m_pass_type_info(pass_type_info), m_pass_instance(pass_instance), m_place(pass_place) {
-    OPENVINO_ASSERT((m_place == Place::Before || m_place == Place::After) && m_pass_type_info != DiscreteTypeInfo(),
-                    "Invalid args combination: pass_place must be Place::Before/Place::After and pass_type_info must be non-empty");
-}
-
-Manager::PassPosition::PassListType::const_iterator
-Manager::PassPosition::get_insert_position(const PassListType& pass_list) const {
-    size_t pass_count = 0;
-    auto match = [this, &pass_count](const std::shared_ptr<PassBase>& p) {
-        if (p->get_type_info() == m_pass_type_info) {
-            if (m_pass_instance == pass_count)
-                return true;
-            pass_count++;
-        }
-        return false;
-    };
-    switch (m_place) {
-        case Place::PipelineStart: return pass_list.cbegin();
-        case Place::PipelineEnd: return pass_list.cend();
-        case Place::Before:
-        case Place::After: {
-            auto insert_it = std::find_if(pass_list.cbegin(), pass_list.cend(), match);
-            OPENVINO_ASSERT(insert_it != pass_list.cend(), "snippets::pass::Manager failed to find pass ", m_pass_type_info);
-            return m_place == Place::After ?  std::next(insert_it) : insert_it;
-        }
-        default:
-            OPENVINO_THROW("Unsupported Place type in PassPosition::get_insert_position");
-    }
-}
 
 std::shared_ptr<Manager::PassBase> Manager::register_pass_instance(const PassPosition& position,
                                                                    const std::shared_ptr<PassBase>& pass) {
@@ -49,7 +15,7 @@ std::shared_ptr<Manager::PassBase> Manager::register_pass_instance(const PassPos
     return insert_pass_instance(position, pass);
 }
 
-void Manager::register_positioned_passes(const std::vector<PositionedPass>& pos_passes) {
+void Manager::register_positioned_passes(const std::vector<PositionedPassBase>& pos_passes) {
     for (const auto& pp : pos_passes)
         register_pass_instance(pp.position, pp.pass);
 }

--- a/src/common/snippets/src/pass/positioned_pass.cpp
+++ b/src/common/snippets/src/pass/positioned_pass.cpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/pass/positioned_pass.hpp"
+
+
+namespace ov {
+namespace snippets {
+namespace pass {
+
+PassPosition::PassPosition(Place pass_place) : m_place(pass_place) {
+    OPENVINO_ASSERT(m_place == Place::PipelineStart || m_place == Place::PipelineEnd,
+                    "Invalid arg: pass_type_info and pass_instance args could be omitted only for Place::PipelineStart/Place::PipelineEnd");
+}
+
+PassPosition::PassPosition(Place pass_place, const DiscreteTypeInfo& pass_type_info, size_t pass_instance)
+: m_pass_type_info(pass_type_info), m_pass_instance(pass_instance), m_place(pass_place) {
+    OPENVINO_ASSERT((m_place == Place::Before || m_place == Place::After) && m_pass_type_info != DiscreteTypeInfo(),
+                    "Invalid args combination: pass_place must be Place::Before/Place::After and pass_type_info must be non-empty");
+}
+
+} // namespace pass
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/tests/include/lowered/pass/buffer_allocation.hpp
+++ b/src/common/snippets/tests/include/lowered/pass/buffer_allocation.hpp
@@ -27,10 +27,11 @@ public:
 
 protected:
     void SetUp() override;
-    void ApplyTransformations(bool is_optimized, bool with_split_loops);
+    void ApplyTransformations(const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& pass_config);
     void Validate();
 
     virtual std::shared_ptr<ov::Model> GetModel() const = 0;
+    virtual std::shared_ptr<ov::snippets::lowered::pass::PassConfig> GetPassConfig();
 
     static void MarkOp(const std::shared_ptr<ov::Node>& node, const std::vector<size_t>& subtensor);
 
@@ -42,6 +43,9 @@ protected:
 
     size_t m_loop_depth = 2;
     size_t m_vector_size = 16;
+
+    bool m_is_buffer_optimized = true;
+    bool m_with_split_loops = true;
 };
 
 class EltwiseBufferAllocationTest : public BufferAllocationTest {

--- a/src/common/snippets/tests/include/lowering_utils.hpp
+++ b/src/common/snippets/tests/include/lowering_utils.hpp
@@ -62,8 +62,8 @@ public:
             getLoweredSubgraph(const std::shared_ptr<Model>& f,
                                const ov::PartialShape& master_shape,
                                const std::vector<ov::snippets::pass::Manager::PositionedPass>& backend_passes = {},
-                               const ov::snippets::lowered::pass::PassPipeline& lowered_pre_common = {},
-                               const ov::snippets::lowered::pass::PassPipeline& lowered_post_common = {},
+                               const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& lowered_pass_config = nullptr,
+                               const std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
                                const std::shared_ptr<ov::snippets::Generator>& generator = nullptr,
                                size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,
                                const std::shared_ptr<IShapeInferSnippetsFactory>& factory = std::make_shared<IShapeInferSnippetsFactory>());

--- a/src/common/snippets/tests/include/lowering_utils.hpp
+++ b/src/common/snippets/tests/include/lowering_utils.hpp
@@ -61,10 +61,10 @@ public:
     static std::shared_ptr<ov::snippets::op::Subgraph>
             getLoweredSubgraph(const std::shared_ptr<Model>& f,
                                const ov::PartialShape& master_shape,
-                               const std::vector<ov::snippets::pass::Manager::PositionedPass>& backend_passes = {},
+                               const std::vector<ov::snippets::pass::Manager::PositionedPassBase>& backend_passes = {},
                                const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& lowered_pass_config =
                                     std::make_shared<ov::snippets::lowered::pass::PassConfig>(),
-                               const std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
+                               const std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPassLowered>& lowered_backend_passes = {},
                                const std::shared_ptr<ov::snippets::Generator>& generator = nullptr,
                                size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,
                                const std::shared_ptr<IShapeInferSnippetsFactory>& factory = std::make_shared<IShapeInferSnippetsFactory>());

--- a/src/common/snippets/tests/include/lowering_utils.hpp
+++ b/src/common/snippets/tests/include/lowering_utils.hpp
@@ -62,7 +62,8 @@ public:
             getLoweredSubgraph(const std::shared_ptr<Model>& f,
                                const ov::PartialShape& master_shape,
                                const std::vector<ov::snippets::pass::Manager::PositionedPass>& backend_passes = {},
-                               const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& lowered_pass_config = nullptr,
+                               const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& lowered_pass_config =
+                                    std::make_shared<ov::snippets::lowered::pass::PassConfig>(),
                                const std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes = {},
                                const std::shared_ptr<ov::snippets::Generator>& generator = nullptr,
                                size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,

--- a/src/common/snippets/tests/src/lowering_utils.cpp
+++ b/src/common/snippets/tests/src/lowering_utils.cpp
@@ -109,8 +109,8 @@ std::shared_ptr<ov::snippets::op::Subgraph>
         LoweringTests::getLoweredSubgraph(const std::shared_ptr<Model> &f,
                                           const ov::PartialShape& master_shape,
                                           const std::vector<ov::snippets::pass::Manager::PositionedPass>& backend_passes,
-                                          const ov::snippets::lowered::pass::PassPipeline& lowered_pre_common,
-                                          const ov::snippets::lowered::pass::PassPipeline& lowered_post_common,
+                                          const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& lowered_pass_config,
+                                          const std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes,
                                           const std::shared_ptr<ov::snippets::Generator>& generator,
                                           size_t min_parallel_work_amount, size_t min_kernel_work_amount,
                                           const std::shared_ptr<IShapeInferSnippetsFactory>& factory) {
@@ -118,7 +118,7 @@ std::shared_ptr<ov::snippets::op::Subgraph>
     subgraph->set_generator(generator == nullptr ? std::make_shared<DummyGenerator>() : generator);
     subgraph->set_tile_rank(2);
     // Note: lowered_pipeline would have no effect on subgraph body, since it's applied on linear IR
-    subgraph->generate({}, {}, {}, backend_passes, lowered_pre_common, lowered_post_common, min_parallel_work_amount, min_kernel_work_amount, factory);
+    subgraph->generate({}, {}, {}, backend_passes, lowered_pass_config, lowered_backend_passes, min_parallel_work_amount, min_kernel_work_amount, factory);
     return subgraph;
 }
 

--- a/src/common/snippets/tests/src/lowering_utils.cpp
+++ b/src/common/snippets/tests/src/lowering_utils.cpp
@@ -108,9 +108,9 @@ std::shared_ptr<ov::snippets::op::Subgraph> LoweringTests::getSubgraph(const std
 std::shared_ptr<ov::snippets::op::Subgraph>
         LoweringTests::getLoweredSubgraph(const std::shared_ptr<Model> &f,
                                           const ov::PartialShape& master_shape,
-                                          const std::vector<ov::snippets::pass::Manager::PositionedPass>& backend_passes,
+                                          const std::vector<ov::snippets::pass::Manager::PositionedPassBase>& backend_passes,
                                           const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& lowered_pass_config,
-                                          const std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPass>& lowered_backend_passes,
+                                          const std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPassLowered>& lowered_backend_passes,
                                           const std::shared_ptr<ov::snippets::Generator>& generator,
                                           size_t min_parallel_work_amount, size_t min_kernel_work_amount,
                                           const std::shared_ptr<IShapeInferSnippetsFactory>& factory) {

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -11,13 +11,16 @@
 #include "openvino/core/rt_info.hpp"
 #include "openvino/pass/visualize_tree.hpp"
 #include "shape_inference/custom/subgraph.hpp"
-#include "snippets/lowered/linear_ir.hpp"
-#include "snippets/lowered/pass/optimize_domain.hpp"
 #include "snippets/op/subgraph.hpp"
 #include "snippets/pass/hash.hpp"
 #include "snippets/pass/matmul_to_brgemm.hpp"
-#include "transformations/cpu_opset/common/pass/convert_to_swish_cpu.hpp"
+#include "snippets/pass/propagate_precision.hpp"
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/pass/optimize_domain.hpp"
+#include "snippets/lowered/pass/insert_loops.hpp"
+#include "snippets/lowered/pass/mark_loops.hpp"
 #include "transformations/defs.hpp"
+#include "transformations/cpu_opset/common/pass/convert_to_swish_cpu.hpp"
 #include "transformations/snippets/x64/pass/lowered/brgemm_blocking.hpp"
 #include "transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.hpp"
 #include "transformations/snippets/x64/pass/lowered/set_brgemm_copy_b_buffers_shape.hpp"
@@ -339,12 +342,13 @@ void Snippet::initOptimalPrimitiveDescriptor() {
         // MatMul has to be decomposed to Brgemm operations before enforcement
         // Note, MatMul decomposition will be run later again for case if BF16 enforcement is not happened
         SNIPPETS_REGISTER_PASS(PassPosition(Place::PipelineStart), ov::snippets::pass::MatMulToBrgemm);
-        SNIPPETS_REGISTER_PASS(PassPosition(Place::After, "MatMulToBrgemm"), pass::EnforcePrecision, element::f32, element::bf16);
+        SNIPPETS_REGISTER_PASS(PassPosition(Place::After, ov::snippets::pass::MatMulToBrgemm::get_type_info_static()),
+                               pass::EnforcePrecision, element::f32, element::bf16);
     }
-
-    SNIPPETS_REGISTER_PASS(PassPosition(Place::Before, "PropagatePrecision"), ov::intel_cpu::pass::BrgemmToBrgemmCPU);
-    SNIPPETS_REGISTER_PASS(PassPosition(Place::Before, "PropagatePrecision"), ov::intel_cpu::pass::SetBrgemmCPUBlockingParams);
-
+    SNIPPETS_REGISTER_PASS(PassPosition(Place::Before, ov::snippets::pass::PropagatePrecision::get_type_info_static()),
+                           ov::intel_cpu::pass::BrgemmToBrgemmCPU);
+    SNIPPETS_REGISTER_PASS(PassPosition(Place::After, ov::intel_cpu::pass::BrgemmToBrgemmCPU::get_type_info_static()),
+                           ov::intel_cpu::pass::SetBrgemmCPUBlockingParams);
     SNIPPETS_REGISTER_PASS(PassPosition(Place::PipelineEnd), ov::intel_cpu::pass::RemoveConverts);
     SNIPPETS_REGISTER_PASS(PassPosition(Place::PipelineEnd), ov::intel_cpu::pass::MulAddToFMA);
 
@@ -586,14 +590,26 @@ Snippet::SnippetJitExecutor::SnippetJitExecutor(SnippetAttrs attrs, bool is_dyna
 }
 
 void Snippet::SnippetJitExecutor::generate(const jit_snippets_compile_args* jcp) {
-    ov::snippets::lowered::pass::PassPipeline control_flow_markup_pipeline;
-    CPU_REGISTER_PASS_X64(control_flow_markup_pipeline, ov::intel_cpu::pass::BrgemmBlocking)
+    std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPass> backend_passes;
 
-    ov::snippets::lowered::pass::PassPipeline control_flow_pipeline;
-    CPU_REGISTER_PASS_X64(control_flow_pipeline, ov::intel_cpu::pass::FuseLoadStoreConvert)
-    CPU_REGISTER_PASS_X64(control_flow_pipeline, ov::intel_cpu::pass::SetBrgemmCopyBBuffersShape);
-    schedule = snippetAttrs.snippet->generate_from_linear_ir(control_flow_markup_pipeline,
-                                                             control_flow_pipeline,
+#if defined(OPENVINO_ARCH_X86_64)
+    using PassPosition = ov::snippets::lowered::pass::PassPipeline::PassPosition;
+    using Place = PassPosition::Place;
+#   define SNIPPETS_REGISTER_PASS(PASS_POS, PASS, ...) \
+        backend_passes.emplace_back(PASS_POS, std::make_shared<PASS>(__VA_ARGS__))
+#else
+#    define SNIPPETS_REGISTER_PASS(PASS_POS, PASS, ...)
+#endif  // OPENVINO_ARCH_X86_64
+
+    SNIPPETS_REGISTER_PASS(PassPosition(Place::After, ov::snippets::lowered::pass::MarkLoops::get_type_info_static()),
+                           ov::intel_cpu::pass::BrgemmBlocking);
+    SNIPPETS_REGISTER_PASS(PassPosition(Place::After, ov::snippets::lowered::pass::InsertLoops::get_type_info_static()),
+                           ov::intel_cpu::pass::FuseLoadStoreConvert);
+    SNIPPETS_REGISTER_PASS(PassPosition(Place::After, ov::intel_cpu::pass::FuseLoadStoreConvert::get_type_info_static()),
+                           ov::intel_cpu::pass::SetBrgemmCopyBBuffersShape);
+
+    schedule = snippetAttrs.snippet->generate_from_linear_ir(std::make_shared<ov::snippets::lowered::pass::PassConfig>(),
+                                                             backend_passes,
                                                              reinterpret_cast<const void*>(jcp));
 }
 

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -9,12 +9,12 @@
 #include "onednn/dnnl.h"
 #include "openvino/core/parallel.hpp"
 #include "openvino/core/rt_info.hpp"
-#include "openvino/pass/visualize_tree.hpp"
 #include "shape_inference/custom/subgraph.hpp"
 #include "snippets/op/subgraph.hpp"
 #include "snippets/pass/hash.hpp"
 #include "snippets/pass/matmul_to_brgemm.hpp"
 #include "snippets/pass/propagate_precision.hpp"
+#include "snippets/pass/positioned_pass.hpp"
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/lowered/pass/optimize_domain.hpp"
 #include "snippets/lowered/pass/insert_loops.hpp"
@@ -325,11 +325,10 @@ void Snippet::initOptimalPrimitiveDescriptor() {
     // * precision propagation & align element types
     // * data flow optimizations
     // The result of these transformations will be reused by all shapes
-    using Manager = snippets::pass::Manager;
-    std::vector<Manager::PositionedPass> backend_passes;
+    std::vector<ov::snippets::pass::Manager::PositionedPassBase> backend_passes;
 #if defined(OPENVINO_ARCH_X86_64)
-    using PassPosition = snippets::pass::Manager::PassPosition;
-    using Place = snippets::pass::Manager::PassPosition::Place;
+    using PassPosition = ov::snippets::pass::PassPosition;
+    using Place = PassPosition::Place;
 #   define SNIPPETS_REGISTER_PASS(PASS_POS, PASS, ...) \
             backend_passes.emplace_back(PASS_POS, std::make_shared<PASS>(__VA_ARGS__))
 #else
@@ -590,10 +589,10 @@ Snippet::SnippetJitExecutor::SnippetJitExecutor(SnippetAttrs attrs, bool is_dyna
 }
 
 void Snippet::SnippetJitExecutor::generate(const jit_snippets_compile_args* jcp) {
-    std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPass> backend_passes;
+    std::vector<ov::snippets::lowered::pass::PassPipeline::PositionedPassLowered> backend_passes;
 
 #if defined(OPENVINO_ARCH_X86_64)
-    using PassPosition = ov::snippets::lowered::pass::PassPipeline::PassPosition;
+    using PassPosition = ov::snippets::pass::PassPosition;
     using Place = PassPosition::Place;
 #   define SNIPPETS_REGISTER_PASS(PASS_POS, PASS, ...) \
         backend_passes.emplace_back(PASS_POS, std::make_shared<PASS>(__VA_ARGS__))

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/mul_add_to_fma.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/mul_add_to_fma.cpp
@@ -121,7 +121,7 @@ public:
 
 protected:
     void SetUp() override {
-        using PassPosition = ov::snippets::pass::Manager::PassPosition;
+        using PassPosition = ov::snippets::pass::PassPosition;
         LoweringTests::SetUp();
         std::vector<PartialShape> inputShapes(3);
         size_t add_input_idx;
@@ -140,7 +140,7 @@ protected:
 
     std::shared_ptr<SnippetsFunctionBase> snippets_model;
     std::shared_ptr<ov::snippets::Generator> generator;
-    std::vector<ov::snippets::pass::Manager::PositionedPass> backend_passes;
+    std::vector<ov::snippets::pass::Manager::PositionedPassBase> backend_passes;
 };
 
 TEST_P(MulAddToFMATests, MulAddToFMATests) {

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/mul_add_to_fma.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/mul_add_to_fma.cpp
@@ -147,7 +147,7 @@ TEST_P(MulAddToFMATests, MulAddToFMATests) {
     auto subgraph = getLoweredSubgraph(snippets_model->getOriginal(),
                                        master_shape,
                                        backend_passes,
-                                       {},
+                                       std::make_shared<ov::snippets::lowered::pass::PassConfig>(),
                                        {},
                                        generator,
                                        8, 256,


### PR DESCRIPTION
### Details:
 - *Added support of PassConfig to lowered PassPipeline to allow developers to enable/disable transformations*
 - *Added support of PositionedPasses to lowered PassPipeline to allow developers to insert backend specific transformations in needed parts of pipeline without the common pipeline splitting*
 - *Change `std::string m_pass_name` to `DiscreteTypeInfo m_pass_type_info` in Snippets Manager for data flow transformations*

### Tickets:
 - *113666, 126214*
