### PR TITLE
fix parse_freq_info_linux for wrong cpu frequency information

### DIFF
--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -601,6 +601,16 @@ void parse_freq_info_linux(const std::vector<std::vector<std::string>> system_in
 
     std::vector<int> line_value_0(PROC_TYPE_TABLE_SIZE, 0);
 
+    auto clean_up_output = [&]() {
+        _processors = 0;
+        _cores = 0;
+        _numa_nodes = 0;
+        _sockets = 0;
+        _cpu_mapping_table.clear();
+        _proc_type_table.clear();
+        return;
+    };
+
     for (int n = 0; n < _processors; n++) {
         if (-1 == _cpu_mapping_table[n][CPU_MAP_SOCKET_ID]) {
             std::string::size_type pos = 0;
@@ -618,6 +628,10 @@ void parse_freq_info_linux(const std::vector<std::vector<std::string>> system_in
                 core_1 = std::stoi(sub_str);
                 sub_str = system_info_table[n][0].substr(endpos1 + 1);
                 core_2 = std::stoi(sub_str);
+                if ((core_1 != n) && (core_2 != n)) {
+                    clean_up_output();
+                    return;
+                }
 
                 _cpu_mapping_table[core_1][CPU_MAP_PROCESSOR_ID] = core_1;
                 _cpu_mapping_table[core_1][CPU_MAP_SOCKET_ID] = std::stoi(system_info_table[core_1][1]);

--- a/src/inference/tests/unit/cpu_map_parser/freq_parser_linux.cpp
+++ b/src/inference/tests/unit/cpu_map_parser/freq_parser_linux.cpp
@@ -967,6 +967,22 @@ LinuxCpuMapTestCase freq_1sockets_4cores = {
     {},
 };
 
+LinuxCpuMapTestCase freq_1sockets_4cores_2 = {
+    0,
+    0,
+    0,
+    0,
+    {},
+    {},
+    {
+        {"0-3", "-1", "1848000"},
+        {"0-3", "-1", "1848000"},
+        {"0-3", "-1", "1848000"},
+        {"0-3", "-1", "1848000"},
+    },
+    {},
+};
+
 TEST_P(LinuxCpuMapFreqParserTests, LinuxFreq) {}
 
 INSTANTIATE_TEST_SUITE_P(CPUMap,
@@ -986,7 +1002,8 @@ INSTANTIATE_TEST_SUITE_P(CPUMap,
                                          freq_1sockets_12cores_hyperthreading,
                                          freq_1sockets_8cores_hyperthreading,
                                          freq_1sockets_8cores_hyperthreading_1,
-                                         freq_1sockets_4cores));
+                                         freq_1sockets_4cores,
+                                         freq_1sockets_4cores_2));
 
 #endif
 }  // namespace


### PR DESCRIPTION
### Details:
 - *fix parse_freq_info_linux for wrong cpu frequency information*

### Tickets:
 - *126304*
