### PR TITLE
[chore] Return old AKS runner back for Linux RISC-V

### DIFF
--- a/.github/workflows/linux_riscv.yml
+++ b/.github/workflows/linux_riscv.yml
@@ -45,7 +45,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: aks-linux-16-cores-32gb
+    runs-on: aks-linux-16-cores
     container:
       image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04
       volumes:


### PR DESCRIPTION
### Details:
Apparently, after https://github.com/openvinotoolkit/openvino/pull/21282 Linux RISC-V hangs, let's check that