### PR TITLE
[GPU] Fix scatter update axis name

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/loop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/loop_inst.h
@@ -328,8 +328,6 @@ public:
     // num_iteration is used for slicing input memory
     int64_t get_num_iterations();
 
-    void update_backedge_exec_deps(const cldnn::program_node& node, const cldnn::primitive_id& backedge_from_prim_id);
-
     std::vector<event::ptr> preprocess_memory_for_body_network(int64_t current_iteration_idx);
     std::vector<event::ptr> postprocess_memory_for_body_network(int64_t current_iteration_idx);
 

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -573,35 +573,6 @@ void loop_inst::preprocess_backedge_memory() {
             GPU_DEBUG_LOG << idx << ") add back_edge mapping with SINGLE_SHARED type, backedge_mem("
                             << backedge_mem << "), initial_mem(" << initial_mem << ")" << std::endl;
         }
-
-        if (backedge_to_prim->_node != nullptr) {
-            update_backedge_exec_deps(backedge_to_prim->get_node(), backedge_from_prim->id());
-        }
-    }
-}
-
-void loop_inst::update_backedge_exec_deps(const cldnn::program_node& node, const cldnn::primitive_id& backedge_from_prim_id) {
-    // Add _exec_deps for backedge primitives to prevent early execution in body network
-    // In below topology, input and result has shared memory as they are backedge_to/from.
-    // When op2 executes earlier thant op1, input is updated with op2 result and op1 has wrong input value if there is no proper _exec_deps.
-    // input(backedge_to) ------> op1 ----->
-    //                    |
-    //                    L-----> op2 -----> result (backedge_from)
-    for (auto& user : node.get_users()) {
-        if (user->can_be_optimized()) {
-            // Run until non opt out user
-            update_backedge_exec_deps(*user, backedge_from_prim_id);
-        } else {
-            auto user_primitive_id = user->get_primitive()->id;
-            auto user_primitive = body_network->get_primitive(user_primitive_id);
-
-            const auto backedge_from_prim = body_network->get_primitive(backedge_from_prim_id);
-            if (std::find(backedge_from_prim->_exec_deps.begin(), backedge_from_prim->_exec_deps.end(), user_primitive)
-                != backedge_from_prim->_exec_deps.end()) {
-                backedge_from_prim->_exec_dep_ids.push_back(user_primitive_id);
-                backedge_from_prim->_exec_deps.push_back(user_primitive);
-            }
-        }
     }
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/common_types.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/common_types.h
@@ -492,6 +492,8 @@ enum class ScatterUpdateAxis {
     Y,
     Z,
     W,
+    U,
+    V,
     FEATURE,
     BATCH,
 };


### PR DESCRIPTION
### Details:
 - Fix scatter update axis name
 - Remove _exec_deps control for backedge_from because this is not required after https://github.com/openvinotoolkit/openvino/pull/21333
    - Previously, we organized execution order based on dependency for input-output buffer sharing from loop-body
    - With PR-21333, we are not sharing buffer between input and output when loop input has multiple outputs.
    - Therefore, there is no need to adjust exec order.
 
### Tickets:
 - 125865
