### PR TITLE
[GPU] Allow to set empty tensor for inner network of condition primitive

### DIFF
--- a/src/plugins/intel_gpu/src/graph/input_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/input_layout.cpp
@@ -43,7 +43,8 @@ event::ptr input_layout_inst::set_data(memory::ptr mem) {
     auto& engine = get_network().get_engine();
     auto& stream = get_network().get_stream();
 
-    if (mem->is_allocated_by(engine)) {
+    // Allow to set dummy simple_attached_memory empty tensor as network input
+    if (mem->is_allocated_by(engine) || mem->get_layout().count() == 0) {
         OPENVINO_ASSERT(!_outputs.empty(), "[GPU] Can't set data for empty input memory");
         _outputs[0] = mem;
         ev = stream.create_user_event(true);


### PR DESCRIPTION
### Details:
 - This change fixes segmentation fault in case the condition's dependency doesn't have output memory due to an empty tensor. In such a case, memory reallocation will be skipped for dependency, and dummy simple_attached_memory with an empty tensor layout is created and passed to the inner network

### Tickets:
 - 126403
