### PR TITLE
[TF FE] Fixed Trackable import for Python 3.9-3.11.

### DIFF
--- a/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
@@ -352,7 +352,11 @@ def extract_model_graph(argv):
         from tensorflow.python.training.tracking.base import Trackable  # pylint: disable=no-name-in-module,import-error
         trackable_is_imported = True
     except:
-        log.warning("Could not import tensorflow.python.training.tracking.base.Trackable type.")
+        try:
+            from tensorflow.python.trackable.base import Trackable
+            trackable_is_imported = True
+        except:
+            log.warning("Could not import tensorflow.python.training.tracking.base.Trackable type.")
     env_setup = get_environment_setup("tf")
     if isinstance(model, tf.Graph):
         return True


### PR DESCRIPTION
Root cause analysis: 
OVC fails to import Trackable type for Python 3.9-3.11, as this class was moved from:
`tensorflow.python.training.tracking.base.Trackable`
to:
`tensorflow.python.trackable.base.Trackable`

Solution: 
Try to import Trackable from both old and new path.

Ticket: -


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A