### PR TITLE
Fix: https://github.com/openvinotoolkit/openvino/issues/20623

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -624,7 +624,7 @@ private:
                 if (i > 0) {
                     // empty second half on sse
                     cmp(reg_rt_shape, 0);
-                    jbe(label_end);
+                    jbe(label_end, T_NEAR);
                 }
 
                 Xbyak::Label label_sse_full_size;
@@ -1117,7 +1117,7 @@ private:
                 if (i > 0) {
                     // empty second half on sse
                     cmp(reg_rt_shape, 0);
-                    jbe(label_end);
+                    jbe(label_end, T_NEAR);
                 }
 
                 Xbyak::Label label_sse_full_size;


### PR DESCRIPTION
### Details:
 - *Changing jbe instruction default param from **T_AUTO** to **T_NEAR** *
 - *The update only work for SSE41, so there is no regresion risk for AVX2 and later ISA*
 - *Related to https://github.com/openvinotoolkit/openvino/issues/20623*
