### PR TITLE
Revert "[CPU tests] migrate sub_graph test cases to be 2.0 - part 3"

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/any_layout.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/any_layout.cpp
@@ -4,8 +4,9 @@
 
 #include "test_utils/cpu_test_utils.hpp"
 
-namespace ov {
-namespace test {
+using namespace InferenceEngine;
+
+namespace SubgraphTestsDefinitions {
 
 class AnyLayoutOnInputsAndOutputs : public ::testing::TestWithParam<ov::Shape> {
 public:
@@ -16,18 +17,18 @@ public:
     }
 
 protected:
-    std::shared_ptr<ov::Model>
+    std::shared_ptr<ngraph::Function>
     create_test_function(const ov::Shape & shape) {
-        auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+        auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, shape);
 
         float shift = 1.0f;
-        auto shift_node = std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape{1}, &shift);
+        auto shift_node = std::make_shared<ngraph::op::Constant>(ov::element::f32, ov::Shape{1}, &shift);
 
-        auto add = std::make_shared<ov::op::v1::Add>(param, shift_node);
+        auto add = std::make_shared<ngraph::op::v1::Add>(param, shift_node);
 
-        auto result = std::make_shared<ov::op::v0::Result>(add);
+        auto result = std::make_shared<ngraph::op::Result>(add);
 
-        return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param});
+        return std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
     }
 
     void Run() {
@@ -38,21 +39,38 @@ protected:
         std::vector<float> output_data(shape_size);
         std::vector<float> expected_output(shape_size, 3);
 
-        // Create model
-        auto function = create_test_function(shape);
+        // Create CNNNetwork
+        auto ngraph_function = create_test_function(shape);
+        auto cnn = InferenceEngine::CNNNetwork(ngraph_function);
 
-        auto input = ov::Tensor(ov::element::f32, shape, input_data.data());
-        auto output = ov::Tensor(ov::element::f32, shape, output_data.data());
+        // Fill inputs and outputs
+        std::vector<std::string> input_names;
+        std::vector<std::string> out_names;
+        for (const auto& it : cnn.getInputsInfo()) {
+            input_names.push_back(it.first);
+        }
+        for (const auto& it : cnn.getOutputsInfo()) {
+            out_names.push_back(it.first);
+        }
 
-        // Load model
-        Core core;
-        auto compiled_model = core.compile_model(function, "CPU");
+        BlobMap inputBlobs;
+        BlobMap outputBlobs;
+
+        TensorDesc tensorDescInp1(Precision::FP32, shape, Layout::ANY);
+        TensorDesc tensorDescOut(Precision::FP32, shape, Layout::ANY);
+
+        inputBlobs[input_names[0]] = make_shared_blob<float>(tensorDescInp1, input_data.data());
+        outputBlobs[out_names[0]]  = make_shared_blob<float>(tensorDescOut, output_data.data());
+
+        // Load network
+        Core ie;
+        ExecutableNetwork executable_network = ie.LoadNetwork(cnn, "CPU");
 
         // Infer
-        auto infer_req = compiled_model.create_infer_request();
-        infer_req.set_input_tensor(input);
-        infer_req.set_output_tensor(output);
-        infer_req.infer();
+        InferRequest infer_request = executable_network.CreateInferRequest();
+        infer_request.SetInput(inputBlobs);
+        infer_request.SetOutput(outputBlobs);
+        infer_request.Infer();
 
         ASSERT_EQ(output_data, expected_output);
     }
@@ -73,5 +91,4 @@ INSTANTIATE_TEST_SUITE_P(AnyLayoutOnInputsAndOutputs,
                          ::testing::ValuesIn(AnyLayoutOnInputsAndOutputsParams),
                          AnyLayoutOnInputsAndOutputs::getTestCaseName);
 
-}  // namespace test
-}  // namespace ov
+}   // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/split_matmul_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/split_matmul_concat.cpp
@@ -6,10 +6,12 @@
 #include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
+using namespace ngraph;
+using namespace InferenceEngine;
 using namespace CPUTestUtils;
+using namespace ov::test;
 
-namespace ov {
-namespace test {
+namespace SubgraphTestsDefinitions {
 
 /*
             ---------------
@@ -105,9 +107,9 @@ protected:
         const auto& inShapeB = inputDynamicShapes[1];
 
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ElementType::f32, inShapeA)};
-        std::shared_ptr<Node> inputB = ngraph::builder::makeConstant<float>(ElementType::f32, inShapeB.get_shape(), {}, true);
+        std::shared_ptr<Node> inputB = builder::makeConstant<float>(ElementType::f32, inShapeB.get_shape(), {}, true);
 
-        auto split = ngraph::builder::makeVariadicSplit(params[0], {1, 1}, 0);
+        auto split = builder::makeVariadicSplit(params[0], {1, 1}, 0);
 
         auto matMul = std::make_shared<ov::op::v0::MatMul>(split->output(0), inputB, transpA, transpB);
 
@@ -141,5 +143,4 @@ INSTANTIATE_TEST_SUITE_P(smoke_FC_2D_FP32, SplitMatMulConcatTest, testParams2D_F
 
 } // namespace
 
-}  // namespace test
-}  // namespace ov
+} // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/strided_slice_zero_dims.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/strided_slice_zero_dims.cpp
@@ -6,8 +6,11 @@
 #include "ov_models/utils/ov_helpers.hpp"
 #include "ov_models/builders.hpp"
 
-namespace ov {
-namespace test {
+using namespace InferenceEngine;
+using namespace ov::test;
+using namespace ngraph;
+
+namespace SubgraphTestsDefinitions {
 
 /*
     param1 [56]   param2 [-1, -1, 768] (dynamic shape)
@@ -37,12 +40,12 @@ public:
         for (auto&& shape : inputDynamicShapes) {
             inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape));
         }
-        auto end = ngraph::builder::makeConstant(element::i64, {1}, std::vector<int64_t>{2147483647});
-        auto stride  = ngraph::builder::makeConstant(element::i64, {1}, std::vector<int64_t>{1});
-        auto indices = ngraph::builder::makeConstant(element::i64, {1}, std::vector<int64_t>{1});
-        auto axes = ngraph::builder::makeConstant(element::i64, {1}, std::vector<int64_t>{0});
-        auto shapeOf = std::make_shared<ov::op::v3::ShapeOf>(inputParams[1]);
-        auto gather = std::make_shared<ov::op::v8::Gather>(shapeOf, indices, axes);
+        auto end = builder::makeConstant(element::i64, {1}, std::vector<int64_t>{2147483647});
+        auto stride  = builder::makeConstant(element::i64, {1}, std::vector<int64_t>{1});
+        auto indices = builder::makeConstant(element::i64, {1}, std::vector<int64_t>{1});
+        auto axes = builder::makeConstant(element::i64, {1}, std::vector<int64_t>{0});
+        auto shapeOf = std::make_shared<opset9::ShapeOf>(inputParams[1]);
+        auto gather = std::make_shared<opset9::Gather>(shapeOf, indices, axes);
         auto strided_slice = std::make_shared<ov::op::v1::StridedSlice>(inputParams.front(),
                                                                         gather,
                                                                         end,
@@ -53,7 +56,7 @@ public:
                                                                         std::vector<int64_t>{},
                                                                         std::vector<int64_t>{});
         NodeVector results{strided_slice};
-        function = std::make_shared<ov::Model>(results, inputParams, "StridedSliceStaticShape");
+        function = std::make_shared<Function>(results, inputParams, "StridedSliceStaticShape");
     }
 };
 
@@ -61,5 +64,4 @@ TEST_F(StridedSliceZeroDimsTest, smoke_CompareWithRefs) {
     run();
 }
 
-}  // namespace test
-}  // namespace ov
+} // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/subgraph_serialize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/subgraph_serialize.cpp
@@ -12,8 +12,7 @@
 using namespace CPUTestUtils;
 using namespace ov::opset9;
 
-namespace ov {
-namespace test {
+namespace SubgraphTestsDefinitions {
 
 class SubgraphSnippetSerializationTest : public ::testing::Test, public CPUTestsBase {};
 
@@ -147,5 +146,4 @@ TEST_F(SubgraphSnippetSerializationTest, smoke_SerializeSubgraphWithResultAs1stO
 
     ASSERT_TRUE(results.valid) << results.message;
 }
-}  // namespace test
-}  // namespace ov
+} // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/test_utils/arm/filter_cpu_info.cpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/arm/filter_cpu_info.cpp
@@ -4,9 +4,11 @@
 
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/filter_cpu_info.hpp"
+#include "ie_ngraph_utils.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "utils/rt_info/memory_formats_attribute.hpp"
 #include "utils/general_utils.h"
+#include <cstdint>
 
 namespace CPUTestUtils {
 

--- a/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.cpp
@@ -3,11 +3,12 @@
 //
 
 #include "cpu_test_utils.hpp"
-
+#include "ie_ngraph_utils.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "utils/rt_info/memory_formats_attribute.hpp"
 #include "transformations/rt_info/primitives_priority_attribute.hpp"
 #include "utils/general_utils.h"
-#include "utils/rt_info/memory_formats_attribute.hpp"
+#include <cstdint>
 
 namespace CPUTestUtils {
 const char* CPUTestsBase::any_type = "any_type";
@@ -146,14 +147,14 @@ void CPUTestsBase::CheckPluginRelatedResultsImpl(const std::shared_ptr<const ov:
             OPENVINO_ASSERT(rtInfo.end() != it);
             return it->second.as<std::string>();
         };
-        auto getExecValueOutputsLayout = [] (const std::shared_ptr<ov::Node>& node) -> std::string {
+        auto getExecValueOutputsLayout = [] (const std::shared_ptr<ngraph::Node>& node) -> std::string {
             auto rtInfo = node->get_rt_info();
-            auto it = rtInfo.find(ov::exec_model_info::OUTPUT_LAYOUTS);
+            auto it = rtInfo.find(ExecGraphInfoSerialization::OUTPUT_LAYOUTS);
             OPENVINO_ASSERT(rtInfo.end() != it);
             return it->second.as<std::string>();
         };
         // skip policy
-        auto should_be_skipped = [] (const ov::PartialShape &partialShape, cpu_memory_format_t fmt) {
+        auto should_be_skipped = [] (const ngraph::PartialShape &partialShape, cpu_memory_format_t fmt) {
             if (partialShape.is_dynamic()) {
                 return false;
             }
@@ -164,7 +165,7 @@ void CPUTestsBase::CheckPluginRelatedResultsImpl(const std::shared_ptr<const ov:
             return skip_unsquized_1D || permule_of_1;
         };
 
-        if (nodeType.count(getExecValue(ov::exec_model_info::LAYER_TYPE))) {
+        if (nodeType.count(getExecValue(ExecGraphInfoSerialization::LAYER_TYPE))) {
             ASSERT_LE(inFmts.size(), node->get_input_size());
             ASSERT_LE(outFmts.size(), node->get_output_size());
             for (size_t i = 0; i < inFmts.size(); i++) {
@@ -210,7 +211,7 @@ void CPUTestsBase::CheckPluginRelatedResultsImpl(const std::shared_ptr<const ov:
             }
 
             for (size_t i = 0; i < fmtsNum; i++) {
-                const auto actualOutputMemoryFormat = getExecValue(ov::exec_model_info::OUTPUT_LAYOUTS);
+                const auto actualOutputMemoryFormat = getExecValue(ExecGraphInfoSerialization::OUTPUT_LAYOUTS);
                 const auto shape = node->get_output_partial_shape(i);
 
                 if (should_be_skipped(shape, outFmts[i]))
@@ -218,7 +219,7 @@ void CPUTestsBase::CheckPluginRelatedResultsImpl(const std::shared_ptr<const ov:
                 ASSERT_EQ(outFmts[i], cpu_str2fmt(actualOutputMemoryFormats[i].c_str()));
             }
 
-            auto primType = getExecValue(ov::exec_model_info::IMPL_TYPE);
+            auto primType = getExecValue(ExecGraphInfoSerialization::IMPL_TYPE);
 
             ASSERT_TRUE(primTypeCheck(primType)) << "primType is unexpected : " << primType << " Expected : " << selectedType;
         }
@@ -269,11 +270,11 @@ std::string CPUTestsBase::getPrimitiveType() const {
 #else
 std::string CPUTestsBase::getPrimitiveType() const {
     std::string isaType;
-    if (ov::with_cpu_x86_avx512f()) {
+    if (InferenceEngine::with_cpu_x86_avx512f()) {
         isaType = "jit_avx512";
-    } else if (ov::with_cpu_x86_avx2()) {
+    } else if (InferenceEngine::with_cpu_x86_avx2()) {
         isaType = "jit_avx2";
-    } else if (ov::with_cpu_x86_sse42()) {
+    } else if (InferenceEngine::with_cpu_x86_sse42()) {
         isaType = "jit_sse42";
     } else {
         isaType = "ref";
@@ -284,13 +285,13 @@ std::string CPUTestsBase::getPrimitiveType() const {
 
 std::string CPUTestsBase::getISA(bool skip_amx) const {
     std::string isaType;
-    if (!skip_amx && ov::with_cpu_x86_avx512_core_amx()) {
+    if (!skip_amx && InferenceEngine::with_cpu_x86_avx512_core_amx()) {
         isaType = "avx512_amx";
-    } else if (ov::with_cpu_x86_avx512f()) {
+    } else if (InferenceEngine::with_cpu_x86_avx512f()) {
         isaType = "avx512";
-    } else if (ov::with_cpu_x86_avx2()) {
+    } else if (InferenceEngine::with_cpu_x86_avx2()) {
         isaType = "avx2";
-    } else if (ov::with_cpu_x86_sse42()) {
+    } else if (InferenceEngine::with_cpu_x86_sse42()) {
         isaType = "sse42";
     } else {
         isaType = "";
@@ -336,25 +337,25 @@ CPUTestsBase::makeCPUInfo(const std::vector<cpu_memory_format_t>& inFmts,
     return cpuInfo;
 }
 
-std::shared_ptr<ov::Model>
-CPUTestsBase::makeNgraphFunction(const ov::element::Type &ngPrc, ov::ParameterVector &params,
-                                 const std::shared_ptr<ov::Node> &lastNode, std::string name) {
+std::shared_ptr<ngraph::Function>
+CPUTestsBase::makeNgraphFunction(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params,
+                                 const std::shared_ptr<ngraph::Node> &lastNode, std::string name) {
    auto newLastNode = modifyGraph(ngPrc, params, lastNode);
-   ov::ResultVector results;
+   ngraph::ResultVector results;
 
    for (size_t i = 0; i < newLastNode->get_output_size(); i++)
-        results.push_back(std::make_shared<ov::op::v0::Result>(newLastNode->output(i)));
+        results.push_back(std::make_shared<ngraph::opset1::Result>(newLastNode->output(i)));
 
-   return std::make_shared<ov::Model>(results, params, name);
+   return std::make_shared<ngraph::Function>(results, params, name);
 }
 
-std::shared_ptr<ov::Node>
-CPUTestsBase::modifyGraph(const ov::element::Type &ngPrc, ov::ParameterVector &params, const std::shared_ptr<ov::Node> &lastNode) {
+std::shared_ptr<ngraph::Node>
+CPUTestsBase::modifyGraph(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params, const std::shared_ptr<ngraph::Node> &lastNode) {
     lastNode->get_rt_info() = getCPUInfo();
     return lastNode;
 }
 
-std::string CPUTestsBase::makeSelectedTypeStr(std::string implString, ov::element::Type_t elType) {
+std::string CPUTestsBase::makeSelectedTypeStr(std::string implString, ngraph::element::Type_t elType) {
     implString.push_back('_');
     implString += ov::element::Type(elType).get_type_name();
     return implString;
@@ -417,7 +418,7 @@ std::vector<CPUSpecificParams> filterCPUSpecificParams(const std::vector<CPUSpec
 
     std::vector<CPUSpecificParams> filteredParamsVector = paramsVector;
 
-    if (!ov::with_cpu_x86_avx512f()) {
+    if (!InferenceEngine::with_cpu_x86_avx512f()) {
         for (auto& param : filteredParamsVector) {
             adjustBlockedFormatByIsa(std::get<0>(param));
             adjustBlockedFormatByIsa(std::get<1>(param));
@@ -440,7 +441,7 @@ inline void CheckNumberOfNodesWithTypeImpl(std::shared_ptr<const ov::Model> func
             return it->second.as<std::string>();
         };
 
-        if (nodeTypes.count(getExecValue(ov::exec_model_info::LAYER_TYPE))) {
+        if (nodeTypes.count(getExecValue(ExecGraphInfoSerialization::LAYER_TYPE))) {
             actualNodeCount++;
         }
     }

--- a/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.hpp
@@ -4,15 +4,13 @@
 
 #pragma once
 
-#include "openvino/runtime/compiled_model.hpp"
-#include "openvino/runtime/exec_model_info.hpp"
-#include "openvino/runtime/system_conf.hpp"
+#include <string>
+#include "ie_system_conf.h"
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "transformations/rt_info/primitives_priority_attribute.hpp"
-
-// To be removed
+#include <exec_graph_info.hpp>
+#include <openvino/runtime/compiled_model.hpp>
 #include "ie_system_conf.h"
-#include "exec_graph_info.hpp"
 
 namespace CPUTestUtils {
     typedef enum {
@@ -130,13 +128,13 @@ public:
                                const std::vector<cpu_memory_format_t>& outFmts,
                                const std::vector<std::string>& priority);
    //TODO: change to setter method
-    static std::string makeSelectedTypeStr(std::string implString, ov::element::Type_t elType);
+    static std::string makeSelectedTypeStr(std::string implString, ngraph::element::Type_t elType);
     void updateSelectedType(const std::string& primitiveType, const ov::element::Type netType, const ov::AnyMap& config);
 
     CPUInfo getCPUInfo() const;
-    std::shared_ptr<ov::Model> makeNgraphFunction(const ov::element::Type &ngPrc,
-                                                         ov::ParameterVector &params,
-                                                         const std::shared_ptr<ov::Node> &lastNode,
+    std::shared_ptr<ngraph::Function> makeNgraphFunction(const ngraph::element::Type &ngPrc,
+                                                         ngraph::ParameterVector &params,
+                                                         const std::shared_ptr<ngraph::Node> &lastNode,
                                                          std::string name);
 
     void CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, const std::set<std::string>& nodeType) const;
@@ -155,9 +153,9 @@ protected:
      * @param lastNode The last node of the initial graph.
      * @return The last node of the modified graph.
      */
-    virtual std::shared_ptr<ov::Node> modifyGraph(const ov::element::Type &ngPrc,
-                                                      ov::ParameterVector &params,
-                                                      const std::shared_ptr<ov::Node> &lastNode);
+    virtual std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
+                                                      ngraph::ParameterVector &params,
+                                                      const std::shared_ptr<ngraph::Node> &lastNode);
 
     virtual bool primTypeCheck(std::string primType) const;
 

--- a/src/plugins/intel_cpu/tests/functional/test_utils/fusing_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/fusing_test_utils.cpp
@@ -8,6 +8,7 @@ using namespace LayerTestsDefinitions;
 
 namespace CPUTestUtils {
 
+
 std::string CpuTestWithFusing::getTestCaseName(fusingSpecificParams params) {
     std::ostringstream result;
     std::vector<std::string> fusedOps;
@@ -24,10 +25,10 @@ std::string CpuTestWithFusing::getTestCaseName(fusingSpecificParams params) {
     return result.str();
 }
 
-std::shared_ptr<ov::Node>
-CpuTestWithFusing::modifyGraph(const ov::element::Type &ngPrc, ov::ParameterVector &params, const std::shared_ptr<ov::Node> &lastNode) {
+std::shared_ptr<ngraph::Node>
+CpuTestWithFusing::modifyGraph(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params, const std::shared_ptr<ngraph::Node> &lastNode) {
     CPUTestsBase::modifyGraph(ngPrc, params, lastNode);
-    std::shared_ptr<ov::Node> retNode = lastNode;
+    std::shared_ptr<ngraph::Node> retNode = lastNode;
     if (postOpMgrPtr) {
         retNode = postOpMgrPtr->addPostOps(ngPrc, params, lastNode);
     }
@@ -41,7 +42,7 @@ void CpuTestWithFusing::CheckFusingResults(const std::shared_ptr<const ov::Model
     for (const auto & op : function->get_ops()) {
         const auto &rtInfo = op->get_rt_info();
 
-        auto getExecValue = [](const std::string &paramName, const ov::Node::RTMap& rtInfo) -> std::string {
+        auto getExecValue = [](const std::string &paramName, const ngraph::Node::RTMap& rtInfo) -> std::string {
             auto it = rtInfo.find(paramName);
             OPENVINO_ASSERT(rtInfo.end() != it);
             return it->second.as<std::string>();
@@ -75,9 +76,9 @@ void CpuTestWithFusing::CheckPluginRelatedResultsImpl(const std::shared_ptr<cons
     CheckFusingResults(function, nodeType);
 }
 
-std::shared_ptr<ov::Node>
-postFunctionMgr::addPostOps(const ov::element::Type &ngPrc, ov::ParameterVector &params, const std::shared_ptr<ov::Node> &lastNode) const {
-    auto clonedPostFunction = ov::clone_model(*_pFunction);
+std::shared_ptr<ngraph::Node>
+postFunctionMgr::addPostOps(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params, const std::shared_ptr<ngraph::Node> &lastNode) const {
+    auto clonedPostFunction = ngraph::clone_function(*_pFunction);
     clonedPostFunction->set_friendly_name(_pFunction->get_friendly_name());
     clonedPostFunction->replace_node(clonedPostFunction->get_parameters()[0], lastNode);
     return clonedPostFunction->get_result()->get_input_node_shared_ptr(0);
@@ -89,9 +90,9 @@ std::string postFunctionMgr::getFusedOpsNames() const {
 
 postNodesMgr::postNodesMgr(std::vector<postNodeBuilder> postNodes) : _postNodes(std::move(postNodes)) {}
 
-std::shared_ptr<ov::Node>
-postNodesMgr::addPostOps(const ov::element::Type &ngPrc, ov::ParameterVector &params, const std::shared_ptr<ov::Node> &lastNode) const {
-    std::shared_ptr<ov::Node> tmpNode = lastNode;
+std::shared_ptr<ngraph::Node>
+postNodesMgr::addPostOps(const ngraph::element::Type &ngPrc, ngraph::ParameterVector &params, const std::shared_ptr<ngraph::Node> &lastNode) const {
+    std::shared_ptr<ngraph::Node> tmpNode = lastNode;
 
     postNodeConfig cfg{lastNode, tmpNode, ngPrc, params};
 

--- a/src/plugins/intel_cpu/tests/functional/test_utils/fusing_test_utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/fusing_test_utils.hpp
@@ -4,55 +4,51 @@
 
 #pragma once
 
-#include "common_test_utils/node_builders/activation.hpp"
 #include "cpu_test_utils.hpp"
-#include "openvino/runtime/system_conf.hpp"
-#include "ov_models/utils/data_utils.hpp"
-#include "shared_test_classes/single_layer/activation.hpp"
-
-using namespace ov::test;
+#include <memory>
+#include <shared_test_classes/single_layer/activation.hpp>
 
 namespace CPUTestUtils {
 
 struct postNodeConfig {
-    const std::shared_ptr<ov::Node> target;
-    std::shared_ptr<ov::Node> input;
-    const ov::element::Type& type;
-    ov::ParameterVector& params;
+    const std::shared_ptr<ngraph::Node> target;
+    std::shared_ptr<ngraph::Node> input;
+    const ngraph::element::Type& type;
+    ngraph::ParameterVector& params;
 };
 
 struct postNodeBuilder {
-    std::function<std::shared_ptr<ov::Node>(postNodeConfig& cfg)> makeNode;
+    std::function<std::shared_ptr<ngraph::Node>(postNodeConfig& cfg)> makeNode;
     std::string name;
 };
 
 class postOpMgr {
 public:
-    virtual std::shared_ptr<ov::Node> addPostOps(const ov::element::Type& ngPrc,
-                                                 ov::ParameterVector& params,
-                                                 const std::shared_ptr<ov::Node>& lastNode) const = 0;
+    virtual std::shared_ptr<ngraph::Node> addPostOps(const ngraph::element::Type &ngPrc,
+                                                     ngraph::ParameterVector &params,
+                                                     const std::shared_ptr<ngraph::Node> &lastNode) const = 0;
     virtual std::string getFusedOpsNames() const = 0;
     virtual ~postOpMgr() = default;
 };
 
 class postFunctionMgr : public postOpMgr {
 public:
-    postFunctionMgr(std::shared_ptr<ov::Model> function) : _pFunction(std::move(function)) {}
-    std::shared_ptr<ov::Node> addPostOps(const ov::element::Type& ngPrc,
-                                         ov::ParameterVector& params,
-                                         const std::shared_ptr<ov::Node>& lastNode) const override;
+    postFunctionMgr(std::shared_ptr<ngraph::Function> function) : _pFunction(std::move(function)) {}
+    std::shared_ptr<ngraph::Node> addPostOps(const ngraph::element::Type &ngPrc,
+                                             ngraph::ParameterVector &params,
+                                             const std::shared_ptr<ngraph::Node> &lastNode) const override;
     std::string getFusedOpsNames() const override;
 
 private:
-    std::shared_ptr<ov::Model> _pFunction;
+    std::shared_ptr<ngraph::Function> _pFunction;
 };
 
 class postNodesMgr : public postOpMgr {
 public:
     postNodesMgr(std::vector<postNodeBuilder> postNodes);
-    std::shared_ptr<ov::Node> addPostOps(const ov::element::Type& ngPrc,
-                                         ov::ParameterVector& params,
-                                         const std::shared_ptr<ov::Node>& lastNode) const override;
+    std::shared_ptr<ngraph::Node> addPostOps(const ngraph::element::Type &ngPrc,
+                                             ngraph::ParameterVector &params,
+                                             const std::shared_ptr<ngraph::Node> &lastNode) const override;
     std::string getFusedOpsNames() const override;
 
 private:
@@ -72,9 +68,9 @@ protected:
     /**
      * @brief This function adds post operations.
      */
-    std::shared_ptr<ov::Node> modifyGraph(const ov::element::Type& ngPrc,
-                                          ov::ParameterVector& params,
-                                          const std::shared_ptr<ov::Node>& lastNode) override;
+    std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
+                                              ngraph::ParameterVector &params,
+                                              const std::shared_ptr<ngraph::Node> &lastNode) override;
 
     void CheckPluginRelatedResultsImpl(const std::shared_ptr<const ov::Model>& function, const std::set<std::string>& nodeType) const override;
 
@@ -103,25 +99,25 @@ static int getChannelAxis(const ov::AxisSet &axes, bool keep_dims) {
     return channelAxis;
 }
 
-static int getFusingAxis(const std::shared_ptr<ov::Node>& node) {
-    if (std::dynamic_pointer_cast<const ov::op::v0::MatMul>(node)) {
+static int getFusingAxis(const std::shared_ptr<ngraph::Node>& node) {
+    if (std::dynamic_pointer_cast<const ngraph::opset1::MatMul>(node)) {
         return node->get_output_partial_shape(0).size() - 1; // last dimension
-    } else if (const auto reduce = std::dynamic_pointer_cast<const ov::op::util::ArithmeticReductionKeepDims>(node)) {
+    } else if (const auto reduce = std::dynamic_pointer_cast<const ngraph::op::util::ArithmeticReductionKeepDims>(node)) {
         return getChannelAxis(reduce->get_reduction_axes(), reduce->get_keep_dims());
-    } else if (const auto reduce = std::dynamic_pointer_cast<const ov::op::util::LogicalReductionKeepDims>(node)) {
+    } else if (const auto reduce = std::dynamic_pointer_cast<const ngraph::op::util::LogicalReductionKeepDims>(node)) {
         return getChannelAxis(reduce->get_reduction_axes(), reduce->get_keep_dims());
     } else {
         return 1; // second dimension
     }
 }
 
-static ov::Shape generatePerChannelShape(const std::shared_ptr<ov::Node>& node) {
+static ngraph::Shape generatePerChannelShape(const std::shared_ptr<ngraph::Node>& node) {
     const auto shape = node->get_output_partial_shape(0);
     if (shape.size() == 0)
         OPENVINO_THROW("If shape.size() == 0 then PerTensor fusing tests are N/A");
     if (shape.size() == 1)
         OPENVINO_THROW("If shape.size() == 1 then Granularity can be PerTensor only");
-    ov::Shape perChannelShape(shape.size(), 1);
+    ngraph::Shape perChannelShape(shape.size(), 1);
     const auto channelAxis = getFusingAxis(node);
     if (channelAxis >= 0)
         perChannelShape[channelAxis] = shape[channelAxis].get_length();
@@ -134,176 +130,176 @@ const auto emptyFusingSpec = fusingSpecificParams{nullptr, {}};
 
 const auto fusingRelu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Relu);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Relu);
             }, "Relu"}}), {"Relu"}};
 
 const auto fusingElu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Elu, {}, {2.0f});
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Elu, {}, {2.0f});
             }, "Elu"}}), {"Elu"}};
 
 const auto fusingGelu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Gelu);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Gelu);
             }, "Gelu"}}), {"Gelu"}};
 
 const auto fusingSigmoid = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Sigmoid);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Sigmoid);
             }, "Sigmoid"}}), {"Sigmoid"}};
 
 const auto fusingClamp = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Clamp, {}, {3.0f, 6.0f});
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Clamp, {}, {3.0f, 6.0f});
             }, "Clamp"}}), {"Clamp"}};
 
 const auto fusingTanh = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Tanh);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Tanh);
             }, "Tanh"}}), {"Tanh"}};
 
 const auto fusingAbs = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Abs);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Abs);
             }, "Abs"}}), {"Abs"}};
 
 const auto fusingSqrt = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Sqrt);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Sqrt);
             }, "Sqrt"}}), {"Sqrt"}};
 
 const auto fusingPReluPerChannel = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
-                auto data = NGraphFunctions::Utils::generateVector<ov::element::Type_t::f32>(ov::shape_size(newShape));
-                return utils::make_activation(cfg.input, cfg.type, utils::LeakyRelu, newShape, data);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
+                auto data = NGraphFunctions::Utils::generateVector<ngraph::element::Type_t::f32>(ngraph::shape_size(newShape));
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::LeakyRelu, newShape, data);
             }, "PRelu(PerChannel)"}}), {"PRelu"}};
 
 const auto fusingPReluPerTensor = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                ov::Shape shape(1, 1);
-                auto data = NGraphFunctions::Utils::generateVector<ov::element::Type_t::f32>(ov::shape_size(shape));
-                return utils::make_activation(cfg.input, cfg.type, utils::LeakyRelu, shape, data);
+                ngraph::Shape shape(1, 1);
+                auto data = NGraphFunctions::Utils::generateVector<ngraph::element::Type_t::f32>(ngraph::shape_size(shape));
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::LeakyRelu, shape, data);
             }, "PRelu(PerTensor)"}}), {"PRelu"}};
 
 const auto fusingSwish = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Swish, {}, {1.0f});
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Swish, {}, {1.0f});
             }, "Swish"}}), {"Swish"}};
 
 const auto fusingSoftPlus = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::SoftPlus, {}, {});
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::SoftPlus, {}, {});
             }, "SoftPlus"}}), {"SoftPlus"}};
 
 const auto fusingHSwish = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::HSwish, {}, {});
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::HSwish, {}, {});
             }, "HSwish"}}), {"HSwish"}};
 
 const auto fusingMish = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Mish, {}, {});
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Mish, {}, {});
             }, "Mish"}}), {"Mish"}};
 
 const auto fusingHSigmoid = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::HSigmoid);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::HSigmoid);
             }, "HSigmoid"}}), {"HSigmoid"}};
 
 const auto fusingReluAdd = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Relu);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Relu);
             }, "Relu"},
             {[](postNodeConfig& cfg){
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Add>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Add>(cfg.input, constNode);
             }, "Add(PerChannel)"}}), {"Relu", "Add"}};
 
 const auto fusingReluScaleShift = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Relu);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Relu);
             }, "Relu"},
             {[](postNodeConfig& cfg){
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Multiply>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Multiply>(cfg.input, constNode);
             }, "Multiply(PerChannel)"},
             {[](postNodeConfig& cfg){
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Add>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Add>(cfg.input, constNode);
             }, "Add(PerChannel)"}}), {"Relu", "Add"}};
 
 const auto fusingScaleShift = fusingSpecificParams{ std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg) {
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Multiply>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Multiply>(cfg.input, constNode);
             }, "Multiply(PerChannel)"},
             {[](postNodeConfig& cfg) {
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Add>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Add>(cfg.input, constNode);
             }, "Add(PerChannel)"}}), {"Add"} };
 
 const auto fusingClampRoundAddRelu = fusingSpecificParams{ std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Clamp, {}, {3.0f, 6.0f});
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Clamp, {}, {3.0f, 6.0f});
             }, "Clamp"},
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::RoundHalfToEven);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::RoundHalfToEven);
             }, "RoundHalfToEven"},
             {[](postNodeConfig& cfg){
-                ov::Shape secondMultInShape(1, 1);
+                ngraph::Shape secondMultInShape(1, 1);
                 auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Add>(cfg.input, secondMultInput);
+                return std::make_shared<ngraph::opset1::Add>(cfg.input, secondMultInput);
             }, "AddPerTensor"},
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Relu);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Relu);
             }, "Relu"}}), {"Clamp", "Round", "Add", "Relu"}};
 
 const auto fusingScaleShiftAndFakeQuantizePerChannel = fusingSpecificParams{ std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg) {
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Multiply>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Multiply>(cfg.input, constNode);
             }, "Multiply(PerChannel)"},
             {[](postNodeConfig& cfg) {
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Add>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Add>(cfg.input, constNode);
             }, "Add(PerChannel)"},
             {[](postNodeConfig& cfg){
                 auto localPrc = cfg.input->get_element_type();
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
-                // auto newShape = ov::Shape(cfg.inputNode->get_output_partial_shape(0).size(), 1);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
+                // auto newShape = ngraph::Shape(cfg.inputNode->get_output_partial_shape(0).size(), 1);
                 return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
             }, "FakeQuantize(PerChannel)"}}), {"FakeQuantize"}};
 
 const auto fusingFakeQuantizePerTensor = fusingSpecificParams{ std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
                 auto localPrc = cfg.input->get_element_type();
-                ov::Shape newShape(cfg.input->get_output_partial_shape(0).size(), 1);
+                ngraph::Shape newShape(cfg.input->get_output_partial_shape(0).size(), 1);
                 return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
             }, "FakeQuantize(PerTensor)"}}), {"FakeQuantize"} };
 
 const auto fusingFakeQuantizePerChannel = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
                 auto localPrc = cfg.input->get_element_type();
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
             }, "FakeQuantize(PerChannel)"}}), {"FakeQuantize"}};
 
 const auto fusingFakeQuantizePerChannelRelu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg){
                 auto localPrc = cfg.input->get_element_type();
-                ov::Shape newShape = generatePerChannelShape(cfg.target);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.target);
                 return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
             }, "FakeQuantize(PerChannel)"},
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Relu);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Relu);
             }, "Relu"}}), {"FakeQuantize", "Relu"}};
 
 const auto fusingFQPerChannelSigmoidFQPerChannel = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
@@ -312,19 +308,19 @@ const auto fusingFQPerChannelSigmoidFQPerChannel = fusingSpecificParams{std::mak
             auto shape = cfg.input->get_output_partial_shape(0);
             if (shape.size() == 1)
                 OPENVINO_THROW("If shape.size() == 1 then Granularity can be PerTensor only");
-            ov::Shape newShape(shape.size(), 1);
+            ngraph::Shape newShape(shape.size(), 1);
             newShape[1] = shape[1].get_length();
             return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
         }, "FakeQuantize(PerChannel)"},
         {[](postNodeConfig& cfg){
-            return utils::make_activation(cfg.input, cfg.type, utils::Sigmoid);
+            return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Sigmoid);
         }, "Sigmoid"},
         {[](postNodeConfig& cfg){
             auto localPrc = cfg.input->get_element_type();
             auto shape = cfg.input->get_output_partial_shape(0);
             if (shape.size() == 1)
                 OPENVINO_THROW("If shape.size() == 1 then Granularity can be PerTensor only");
-            ov::Shape newShape(shape.size(), 1);
+            ngraph::Shape newShape(shape.size(), 1);
             newShape[1] = shape[1].get_length();
             return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
         }, "FakeQuantize(PerChannel)"}}), {"FakeQuantize", "Sigmoid", "FakeQuantize"}};
@@ -335,30 +331,30 @@ const auto fusingFQPerChannelSigmoidFQPerTensor = fusingSpecificParams{std::make
             auto shape = cfg.input->get_output_partial_shape(0);
             if (shape.size() == 1)
                 OPENVINO_THROW("If shape.size() == 1 then Granularity can be PerTensor only");
-            ov::Shape newShape(shape.size(), 1);
+            ngraph::Shape newShape(shape.size(), 1);
             newShape[1] = shape[1].get_length();
             return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
         }, "FakeQuantize(PerChannel)"},
         {[](postNodeConfig& cfg){
-            return utils::make_activation(cfg.input, cfg.type, utils::Sigmoid);
+            return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Sigmoid);
         }, "Sigmoid"},
         {[](postNodeConfig& cfg){
             auto localPrc = cfg.input->get_element_type();
             auto shape = cfg.input->get_output_partial_shape(0);
             if (shape.size() == 1)
                 OPENVINO_THROW("If shape.size() == 1 then Granularity can be PerTensor only");
-            ov::Shape newShape(shape.size(), 1);
+            ngraph::Shape newShape(shape.size(), 1);
             return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
         }, "FakeQuantize(PerTensor)"}}), {"FakeQuantize", "Sigmoid", "FakeQuantize"}};
 
 const auto fusingFakeQuantizePerTensorRelu = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
             {[](postNodeConfig& cfg) {
                 auto localPrc = cfg.input->get_element_type();
-                auto newShape = ov::Shape(cfg.input->get_output_partial_shape(0).size(), 1);
+                auto newShape = ngraph::Shape(cfg.input->get_output_partial_shape(0).size(), 1);
                 return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
             }, "FakeQuantize(PerTensor)"},
             {[](postNodeConfig& cfg){
-                return utils::make_activation(cfg.input, cfg.type, utils::Relu);
+                return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Relu);
             }, "Relu"}}), {"FakeQuantize", "Relu"}};
 
 const auto fusingSum = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
@@ -366,7 +362,7 @@ const auto fusingSum = fusingSpecificParams{std::make_shared<postNodesMgr>(std::
                 auto shape = cfg.input->get_output_partial_shape(0);
                 ov::ParameterVector newParams{std::make_shared<ov::op::v0::Parameter>(cfg.type, shape)};
                 cfg.params.insert(cfg.params.end(), newParams.begin(), newParams.end());
-                return std::make_shared<ov::op::v1::Add>(cfg.input, newParams[0]);
+                return std::make_shared<ngraph::opset1::Add>(cfg.input, newParams[0]);
             }, "Add(Parameters)"}}), {"Add"}};
 
 const auto fusingSumEluFQ = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
@@ -374,116 +370,116 @@ const auto fusingSumEluFQ = fusingSpecificParams{std::make_shared<postNodesMgr>(
             auto shape = cfg.input->get_output_partial_shape(0);
             ov::ParameterVector newParams{std::make_shared<ov::op::v0::Parameter>(cfg.type, shape)};
             cfg.params.insert(cfg.params.end(), newParams.begin(), newParams.end());
-            return std::make_shared<ov::op::v1::Add>(cfg.input, newParams[0]);
+            return std::make_shared<ngraph::opset1::Add>(cfg.input, newParams[0]);
         }, "Add(Parameters)"},
         {[](postNodeConfig& cfg){
-            return utils::make_activation(cfg.input, cfg.type, utils::Elu, {}, {2.0f});
+            return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::Elu, {}, {2.0f});
         }, "Elu"},
         {[](postNodeConfig& cfg) {
             auto localPrc = cfg.input->get_element_type();
-            auto newShape = ov::Shape(cfg.input->get_output_partial_shape(0).size(), 1);
+            auto newShape = ngraph::Shape(cfg.input->get_output_partial_shape(0).size(), 1);
             return ngraph::builder::makeFakeQuantize(cfg.input, localPrc, 256, newShape);
         }, "FakeQuantize(PerTensor)"}}), {"Add", "Elu", "FakeQuantize"}};
 
 const auto fusingMultiplyPerTensor = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
-            ov::Shape secondMultInShape(1, 1);
+            ngraph::Shape secondMultInShape(1, 1);
             auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Multiply>(cfg.input, secondMultInput);
+            return std::make_shared<ngraph::op::v1::Multiply>(cfg.input, secondMultInput);
         }, "Multiply(PerTensor)"}}), {"Multiply"}};
 
 const auto fusingMultiplyPerChannel = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
-            ov::Shape secondMultInShape = generatePerChannelShape(cfg.target);
+            ngraph::Shape secondMultInShape = generatePerChannelShape(cfg.target);
             auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Multiply>(cfg.input, secondMultInput);
+            return std::make_shared<ngraph::opset1::Multiply>(cfg.input, secondMultInput);
         }, "Multiply(PerChannel)"}}), {"Multiply"}};
 
 const auto fusingMultiplyAddPerChannel = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg) {
-                ov::Shape newShape = generatePerChannelShape(cfg.input);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.input);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Multiply>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Multiply>(cfg.input, constNode);
         }, "Multiply(PerChannel)"},
         {[](postNodeConfig& cfg) {
-                ov::Shape newShape = generatePerChannelShape(cfg.input);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.input);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Add>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Add>(cfg.input, constNode);
         }, "Add(PerChannel)"}}), {"Add"} };
 
 const auto fusingAddPerTensor = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
-            ov::Shape secondMultInShape(1, 1);
+            ngraph::Shape secondMultInShape(1, 1);
             auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Add>(cfg.input, secondMultInput);
+            return std::make_shared<ngraph::opset1::Add>(cfg.input, secondMultInput);
         }, "Add(PerTensor)"}}), {"Add"}};
 
 const auto fusingAddPerChannel = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
-            ov::Shape secondMultInShape = generatePerChannelShape(cfg.target);
+            ngraph::Shape secondMultInShape = generatePerChannelShape(cfg.target);
             auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Add>(cfg.input, secondMultInput);
+            return std::make_shared<ngraph::opset1::Add>(cfg.input, secondMultInput);
         }, "Add(PerChannel)"}}), {"Add"}};
 
 const auto fusingSubtractPerTensor = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
-            ov::Shape secondMultInShape(1, 1);
+            ngraph::Shape secondMultInShape(1, 1);
             auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Subtract>(cfg.input, secondMultInput);
+            return std::make_shared<ngraph::opset1::Subtract>(cfg.input, secondMultInput);
         }, "Subtract(PerTensor)"}}), {"Subtract"}};
 
 const auto fusingSubtractPerChannel = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
-            ov::Shape secondMultInShape = generatePerChannelShape(cfg.target);
+            ngraph::Shape secondMultInShape = generatePerChannelShape(cfg.target);
             auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Subtract>(cfg.input, secondMultInput);
+            return std::make_shared<ngraph::opset1::Subtract>(cfg.input, secondMultInput);
         }, "Subtract(PerChannel)"}}), {"Subtract"}};
 
 const auto fusingDividePerTensor = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
-            ov::Shape secondMultInShape(1, 1);
+            ngraph::Shape secondMultInShape(1, 1);
             auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Divide>(cfg.input, secondMultInput);
+            return std::make_shared<ngraph::opset1::Divide>(cfg.input, secondMultInput);
         }, "Divide(PerTensor)"}}), {"Divide"}};
 
 const auto fusingDividePerChannel = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
-            ov::Shape secondMultInShape = generatePerChannelShape(cfg.target);
+            ngraph::Shape secondMultInShape = generatePerChannelShape(cfg.target);
             auto secondMultInput = ngraph::builder::makeConstant(cfg.type, secondMultInShape, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Divide>(cfg.input, secondMultInput);
+            return std::make_shared<ngraph::opset1::Divide>(cfg.input, secondMultInput);
         }, "Divide(PerChannel)"}}), {"Divide"}};
 
 const auto fusingPRelu1D = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
             auto shape = cfg.input->get_output_partial_shape(0);
-            ov::Shape newShape({static_cast<size_t>(shape[1].get_length())});
-            auto data = NGraphFunctions::Utils::generateVector<ov::element::Type_t::f32>(ov::shape_size(newShape));
-            return utils::make_activation(cfg.input, cfg.type, utils::LeakyRelu, newShape, data);
+            ngraph::Shape newShape({static_cast<size_t>(shape[1].get_length())});
+            auto data = NGraphFunctions::Utils::generateVector<ngraph::element::Type_t::f32>(ngraph::shape_size(newShape));
+            return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::LeakyRelu, newShape, data);
         }, "PRelu1D"}}), {"PRelu"}};
 
 const auto fusingPRelu1DScaleShift = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg){
             auto shape = cfg.input->get_output_partial_shape(0);
-            ov::Shape newShape({static_cast<size_t>(shape[1].get_length())});
-            auto data = NGraphFunctions::Utils::generateVector<ov::element::Type_t::f32>(ov::shape_size(newShape));
-            return utils::make_activation(cfg.input, cfg.type, utils::LeakyRelu, newShape, data);
+            ngraph::Shape newShape({static_cast<size_t>(shape[1].get_length())});
+            auto data = NGraphFunctions::Utils::generateVector<ngraph::element::Type_t::f32>(ngraph::shape_size(newShape));
+            return ngraph::builder::makeActivation(cfg.input, cfg.type, ngraph::helpers::LeakyRelu, newShape, data);
         }, "PRelu1D"},
         {[](postNodeConfig& cfg) {
-                ov::Shape newShape = generatePerChannelShape(cfg.input);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.input);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Multiply>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Multiply>(cfg.input, constNode);
         }, "Multiply(PerChannel)"},
         {[](postNodeConfig& cfg) {
-                ov::Shape newShape = generatePerChannelShape(cfg.input);
+                ngraph::Shape newShape = generatePerChannelShape(cfg.input);
                 auto constNode = ngraph::builder::makeConstant(cfg.type, newShape, std::vector<float>{}, true);
-                return std::make_shared<ov::op::v1::Add>(cfg.input, constNode);
+                return std::make_shared<ngraph::opset1::Add>(cfg.input, constNode);
         }, "Add(PerChannel)"}}), {"Add"} };
 
 const auto fusingBias = fusingSpecificParams{std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg) {
             size_t last_dim = cfg.input->get_output_partial_shape(0).rbegin()->get_length();
-            auto bias = ngraph::builder::makeConstant(cfg.type, ov::Shape{last_dim}, std::vector<float>{}, true);
-            return std::make_shared<ov::op::v1::Add>(cfg.input, bias);
+            auto bias = ngraph::builder::makeConstant(cfg.type, ngraph::Shape{last_dim}, std::vector<float>{}, true);
+            return std::make_shared<ngraph::opset1::Add>(cfg.input, bias);
         }, "fusingBias"}}), {"Add"}};
 
 } // namespace CPUTestUtils

--- a/src/plugins/intel_cpu/tests/functional/test_utils/x64/filter_cpu_info.cpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/x64/filter_cpu_info.cpp
@@ -4,6 +4,7 @@
 
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/filter_cpu_info.hpp"
+#include "ie_ngraph_utils.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "utils/rt_info/memory_formats_attribute.hpp"
 #include "utils/general_utils.h"


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#21386
Regression caught in Jenkins postcommit: 

```
build ie ERROR: ../../repos/openvino/src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/activation.hpp:11:27: error: default argument given for parameter 4 of ‘std::shared_ptr<ov::Node> ov::test::utils::make_activation(const ov::Output<ov::Node>&, const ov::element::Type&, ov::test::utils::ActivationTypes, ov::Shape, std::vector<float>)’ [-fpermissive]
build ie ERROR: ../../repos/openvino/src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/activation.hpp:11:27: error: default argument given for parameter 5 of ‘std::shared_ptr<ov::Node> ov::test::utils::make_activation(const ov::Output<ov::Node>&, const ov::element::Type&, ov::test::utils::ActivationTypes, ov::Shape, std::vector<float>)’ [-fpermissive]
build ie ERROR: FAILED: src/plugins/intel_cpu/tests/functional/CMakeFiles/ov_cpu_func_tests.dir/subgraph_tests/src/remove_convert.cpp.o 
```