### PR TITLE
[GPU] faster model caching

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -162,6 +162,7 @@ public:
     bool is_internal_program() const { return is_internal; }
     const nodes_ordering& get_processing_order() const;
     nodes_ordering& get_processing_order();
+    const std::vector<primitive_id>& get_allocating_order(bool forced_update = false);
     uint32_t get_prog_id() { return prog_id; }
     stream& get_stream() { return *_stream; }
     stream::ptr get_stream_ptr() const { return _stream; }
@@ -285,6 +286,7 @@ public:
 
     void save(cldnn::BinaryOutputBuffer& ob) const;
     void load(cldnn::BinaryInputBuffer& ib);
+    bool is_loaded_from_cache() const { return _loaded_from_cache; }
 
 private:
     uint32_t prog_id = 0;
@@ -297,6 +299,7 @@ private:
     std::list<program_node*> inputs;
     std::vector<program_node*> outputs;
     nodes_ordering processing_order;
+    std::vector<primitive_id> allocating_order;
     std::unique_ptr<pass_manager> pm;
     bool is_internal;
     bool _is_body_program;
@@ -305,6 +308,7 @@ private:
     std::unique_ptr<ImplementationsCache> _impls_cache;
     const size_t _impls_cache_capacity = 10000;
     std::shared_ptr<ICompilationContext> _compilation_context;
+    bool _loaded_from_cache = false;
 
     std::map<primitive_id, std::shared_ptr<program_node>> nodes_map;
     std::list<primitive_id> optimized_out;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -70,7 +70,7 @@ struct memory {
     void set_reused(bool reused = true) { _reused = reused; }
 
     virtual event::ptr copy_from(stream& /* stream */, const memory& /* other */, bool blocking = true) = 0;
-    virtual event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */, bool blocking = true) = 0;
+    virtual event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */, bool blocking = true, size_t dst_offset = 0, size_t data_size = 0) = 0;
 
     virtual event::ptr copy_to(stream& stream, memory& other, bool blocking = true) { return other.copy_from(stream, *this, blocking); }
     virtual event::ptr copy_to(stream& /* stream */, void* /* host_ptr */, bool blocking = true) = 0;
@@ -112,7 +112,7 @@ struct simple_attached_memory : memory {
     event::ptr copy_from(stream& /* stream */, const memory& /* other */, bool /* blocking */) override {
         OPENVINO_THROW("[GPU] copy_from is not implemented for simple_attached_memory");
     }
-    event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */, bool /* blocking */) override {
+    event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */, bool /* blocking */, size_t /* dst_offset */, size_t /* data_size */) override {
         OPENVINO_THROW("[GPU] copy_from is not implemented for simple_attached_memory");
     }
     event::ptr copy_to(stream& /* stream */, memory& /* other */, bool /* blocking */) override {

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -329,7 +329,8 @@ network::network(program::ptr program, const ExecutionConfig& config, stream::pt
     calculate_weights_cache_capacity();
     allocate_primitives();
     configure_primitives_second_output();
-    check_names();
+    if (!_program->is_loaded_from_cache())
+        check_names();
     build_insts_deps();
     build_exec_order();
     validate_primitives();
@@ -694,39 +695,12 @@ layout network::get_output_layout(const primitive_id& output_id) const {
 
 void network::allocate_primitives() {
     GPU_DEBUG_DEFINE_MEM_LOGGER("allocate_primitives");
-    std::vector<std::shared_ptr<program_node>> nodes_to_allocate{};
+    const auto& ao = _program->get_allocating_order();
+    for (auto& node_id : ao) {
+        allocate_primitive_instance(_program->get_node(node_id));
+    }
+
     auto& po = _program->get_processing_order();
-    for (auto node : po) {
-        nodes_to_allocate.push_back(_program->get_node_ptr(node->id()));
-    }
-
-    std::sort(nodes_to_allocate.begin(),
-              nodes_to_allocate.end(),
-              [&po](std::shared_ptr<program_node> const& lhs, std::shared_ptr<program_node> const& rhs) {
-                    auto lhs_layout = lhs->get_output_layout();
-                    auto rhs_layout = rhs->get_output_layout();
-                    if (lhs_layout.is_dynamic() && lhs_layout.has_upper_bound()) {
-                        lhs_layout.set_tensor(lhs_layout.get_tensor());
-                    }
-                    if (rhs_layout.is_dynamic() && rhs_layout.has_upper_bound()) {
-                        rhs_layout.set_tensor(rhs_layout.get_tensor());
-                    }
-
-                    if (rhs_layout.is_dynamic() && !rhs_layout.has_upper_bound() && lhs_layout.is_dynamic() && !lhs_layout.has_upper_bound()) {
-                        return po.get_processing_number(lhs.get()) < po.get_processing_number(rhs.get());
-                    }
-
-                    if (rhs_layout.is_dynamic())
-                        return true;
-                    if (lhs_layout.is_dynamic())
-                        return false;
-
-                    return (lhs_layout.bytes_count() > rhs_layout.bytes_count());
-              });
-
-    for (auto const& node : nodes_to_allocate) {
-        allocate_primitive_instance(*node);
-    }
 
     for (auto const& node : po) {
         if (node->get_preferred_impl_type() == impl_types::onednn) {

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -740,6 +740,47 @@ program::nodes_ordering& program::get_processing_order() { return processing_ord
 
 const program::nodes_ordering& program::get_processing_order() const { return processing_order; }
 
+const std::vector<primitive_id>& program::get_allocating_order(bool forced_update) {
+    if (!forced_update && allocating_order.size() > 0)
+        return allocating_order;
+
+    std::vector<std::shared_ptr<program_node>> nodes_to_allocate{};
+    auto& po = get_processing_order();
+    for (auto node : po) {
+        nodes_to_allocate.push_back(get_node_ptr(node->id()));
+    }
+
+    std::sort(nodes_to_allocate.begin(),
+            nodes_to_allocate.end(),
+            [&po](std::shared_ptr<program_node> const& lhs, std::shared_ptr<program_node> const& rhs) {
+                    auto lhs_layout = lhs->get_output_layout();
+                    auto rhs_layout = rhs->get_output_layout();
+                    if (lhs_layout.is_dynamic() && lhs_layout.has_upper_bound()) {
+                        lhs_layout.set_tensor(lhs_layout.get_tensor());
+                    }
+                    if (rhs_layout.is_dynamic() && rhs_layout.has_upper_bound()) {
+                        rhs_layout.set_tensor(rhs_layout.get_tensor());
+                    }
+
+                    if (rhs_layout.is_dynamic() && !rhs_layout.has_upper_bound() && lhs_layout.is_dynamic() && !lhs_layout.has_upper_bound()) {
+                        return po.get_processing_number(lhs.get()) < po.get_processing_number(rhs.get());
+                    }
+
+                    if (rhs_layout.is_dynamic())
+                        return true;
+                    if (lhs_layout.is_dynamic())
+                        return false;
+
+                    return (lhs_layout.bytes_count() > rhs_layout.bytes_count());
+            });
+
+    for (auto const& node : nodes_to_allocate) {
+        allocating_order.emplace_back(node->id());
+    }
+
+    return allocating_order;
+}
+
 void program::prepare_memory_dependencies() {
     if (!_config.get_property(ov::intel_gpu::enable_memory_pool))
         return;
@@ -1787,6 +1828,11 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
         ob << p_info.is_cpu;
         ob << p_info.exec_id;
     }
+
+    ob << allocating_order.size();
+    for (auto const& node_id : allocating_order) {
+        ob << node_id;
+    }
 }
 
 void program::load(cldnn::BinaryInputBuffer& ib) {
@@ -1853,6 +1899,7 @@ void program::load(cldnn::BinaryInputBuffer& ib) {
 
     ib >> _is_body_program;
     ib >> _can_be_optimized;
+    _loaded_from_cache = true;
 
     get_processing_order().load(ib, *this);
 
@@ -1921,5 +1968,14 @@ void program::load(cldnn::BinaryInputBuffer& ib) {
         primitive_info p_info(original_id, type_id, c_dependencies, c_users, c_fused_ids,
                               output_layout, layout_str, kernel_id, runtime_precision, is_cpu, exec_id);
         prim_info.emplace_back(p_info);
+    }
+
+    size_t allocating_order_size;
+    ib >> allocating_order_size;
+    allocating_order.clear();
+    for (size_t i = 0; i < allocating_order_size; i++) {
+        primitive_id node_id;
+        ib >> node_id;
+        allocating_order.emplace_back(node_id);
     }
 }

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1782,12 +1782,12 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
 
     ob << _is_body_program;
     ob << _can_be_optimized;
-    get_processing_order().save(ob);
+    processing_order.save(ob);
 
     {
         auto& kernels_cache = get_kernels_cache();
         std::vector<primitive_id> impl_ids;
-        for (auto& node : get_processing_order()) {
+        for (auto& node : processing_order) {
             if (node->get_selected_impl() != nullptr) {
                 impl_ids.emplace_back(node->id());
                 kernels_cache.add_to_cached_kernels(node->get_selected_impl()->get_kernels());
@@ -1901,7 +1901,7 @@ void program::load(cldnn::BinaryInputBuffer& ib) {
     ib >> _can_be_optimized;
     _loaded_from_cache = true;
 
-    get_processing_order().load(ib, *this);
+    processing_order.load(ib, *this);
 
     {
         auto& kernels_cache = get_kernels_cache();

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
@@ -41,7 +41,7 @@ struct gpu_buffer : public lockable_gpu_mem, public memory {
     }
 
     event::ptr copy_from(stream& stream, const memory& other, bool blocking) override;
-    event::ptr copy_from(stream& stream, const void* host_ptr, bool blocking) override;
+    event::ptr copy_from(stream& stream, const void* host_ptr, bool blocking, size_t dst_offset, size_t data_size) override;
 
     event::ptr copy_to(stream& stream, void* other , bool blocking) override;
 
@@ -68,7 +68,7 @@ struct gpu_image2d : public lockable_gpu_mem, public memory {
     }
 
     event::ptr copy_from(stream& stream, const memory& other, bool blocking) override;
-    event::ptr copy_from(stream& stream, const void* other, bool blocking) override;
+    event::ptr copy_from(stream& stream, const void* other, bool blocking, size_t dst_offset, size_t data_size) override;
 
     event::ptr copy_to(stream& stream, memory& other, bool blocking) override;
     event::ptr copy_to(stream& stream, void* other, bool blocking) override;
@@ -120,7 +120,7 @@ struct gpu_usm : public lockable_gpu_mem, public memory {
     shared_mem_params get_internal_params() const override;
 
     event::ptr copy_from(stream& stream, const memory& other, bool blocking) override;
-    event::ptr copy_from(stream& stream, const void* host_ptr, bool blocking) override;
+    event::ptr copy_from(stream& stream, const void* host_ptr, bool blocking, size_t dst_offset, size_t data_size) override;
 
     event::ptr copy_to(stream& stream, void* host_ptr, bool blocking) override;
 #ifdef ENABLE_ONEDNN_FOR_GPU

--- a/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
@@ -341,3 +341,83 @@ INSTANTIATE_TEST_SUITE_P(cldnn_usm, copy_between_gpu_buffer_and_gpu_usm, ::testi
     usm_test_params{ allocation_type::usm_host },
     usm_test_params{ allocation_type::usm_device },
 }));
+
+class offset_usm_copy : public BaseUSMTest {};
+TEST_P(offset_usm_copy, basic) {
+    auto p = GetParam();
+    if (!supports_usm()) {
+        return;
+    }
+    try {
+        ocl::ocl_stream stream(*_engine, {});
+
+        size_t values_count = 100;
+        size_t values_bytes_count = values_count * sizeof(float);
+        std::vector<float> src_buffer(values_count);
+        std::iota(src_buffer.begin(), src_buffer.end(), 0.0f);
+
+        cldnn::layout linear_layout = cldnn::layout(cldnn::data_types::f32, cldnn::format::bfyx, cldnn::tensor(1, 1, int32_t(values_count), 1));
+        auto usm_host_src = _engine->allocate_memory(linear_layout, allocation_type::usm_host);
+
+        // Fill usm_host_src memory.
+        cldnn::mem_lock<float> lock(usm_host_src, stream);
+        std::copy(src_buffer.begin(), src_buffer.end(), lock.data());
+
+        // Create dst memory
+        auto mem_dst = _engine->allocate_memory(linear_layout, p.type);
+
+        // Fill dst memory
+        switch (p.type) {
+        case allocation_type::usm_host:
+        case allocation_type::usm_shared: 
+        case allocation_type::usm_device:
+        {
+            auto casted = std::dynamic_pointer_cast<ocl::gpu_usm>(mem_dst);
+            auto ev = casted->copy_from(stream, usm_host_src->buffer_ptr(), true, 32, 32);
+            ev->wait();
+            break;
+        }
+        case allocation_type::cl_mem: {
+            auto casted = std::dynamic_pointer_cast<ocl::gpu_buffer>(mem_dst);
+            auto ev = casted->copy_from(stream, usm_host_src->buffer_ptr(), true, 32, 32);
+            ev->wait();
+            break;
+        }
+        default:
+            FAIL() << "Not supported allocation type!";
+        }
+
+        // Read from dst mem
+        std::vector<float> dst_buffer(values_count);
+        switch (p.type) {
+        case allocation_type::usm_host:
+        case allocation_type::usm_shared: {
+            cldnn::mem_lock<float> lock(mem_dst, stream);
+            std::memcpy(dst_buffer.data(), lock.data(), values_bytes_count);
+            break;
+        }
+        case allocation_type::usm_device: 
+        case allocation_type::cl_mem: {
+            auto host_buf = _engine->allocate_memory(linear_layout, allocation_type::usm_host);
+            host_buf->copy_from(stream, *mem_dst);
+            {
+                cldnn::mem_lock<float> lock(host_buf, stream);
+                std::memcpy(dst_buffer.data(), lock.data(), values_bytes_count);
+            }
+            break;
+        }
+        default:
+            FAIL() << "Not supported allocation type!";
+        }
+        bool are_equal = std::equal(src_buffer.begin(), src_buffer.begin() + 8, dst_buffer.begin() + 8);
+        ASSERT_EQ(true, are_equal);
+    } catch (const char* msg) {
+        FAIL() << msg;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(cldnn_usm, offset_usm_copy, ::testing::ValuesIn(std::vector<usm_test_params>{
+    usm_test_params{ allocation_type::cl_mem },
+    usm_test_params{ allocation_type::usm_host },
+    usm_test_params{ allocation_type::usm_device },
+}));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/condition_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/condition_gpu_test.cpp
@@ -891,10 +891,6 @@ TEST_F(condition_gpu_tests, negative_same_names_within_different_networks) {
     this->test_negative_same_names_within_different_networks(false);
 }
 
-TEST_F(condition_gpu_tests, negative_same_names_within_different_networks_cache) {
-    this->test_negative_same_names_within_different_networks(true);
-}
-
 TEST_F(condition_gpu_tests, empty_body) {
     this->test_empty_body(false);
 }


### PR DESCRIPTION
### Details:
 - Speed up large data loading by overlapping blob file reading and data transfer
 - Serialization of nodes allocation order
 - Skip `check_names()` when building `cldnn::network` from cached `cldnn::program`

### Tickets:
 - 126609
