### PR TITLE
Add [rename conformance ir] input shape to hash name for Convolution

### DIFF
--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/rename_conformance_ir.py
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/rename_conformance_ir.py
@@ -106,9 +106,16 @@ def generate_node_hash(node):
             str_to_hash += re.sub(r"[\s+\[\]\{\}\']", "", str(node.get_attributes()))
         except:
             logger.error(f"Impossible to get attributes for {node.name}")
-
         try:
             partial_shape = input.get_partial_shape()
+
+            if 'Convolution' in str(input_node.get_type_info().name):
+                offset = 2
+                if 'GroupConvolution' in str(input_node.get_type_info().name) or\
+                   'GroupConvolutionBackpropData' in str(input_node.get_type_info().name):
+                    offset = 3
+                shape_str += '[' + ','.join([str(val) for val in list(partial_shape)[offset:]]) + ']'
+
             shape_str += str(len(partial_shape))
             shape_str += str(partial_shape.is_dynamic)
         except:


### PR DESCRIPTION
### Details:
 - *add shape to name for hashing for Convolution, because some values of shape are important for comparation and if two irs have same attributes and shape type, they could have different kernels of shape and it will be deferent irs*
 - *...*

### Tickets:
 - *ticket-id*
