### PR TITLE
Allow to load extension by relative path in frontends, node factory

### DIFF
--- a/src/core/dev_api/openvino/core/so_extension.hpp
+++ b/src/core/dev_api/openvino/core/so_extension.hpp
@@ -28,8 +28,20 @@ private:
     std::shared_ptr<void> m_so;
 };
 
+inline std::string resolve_extension_path(const std::string& path) {
+    std::string retvalue;
+    try {
+        const std::string absolute_path = ov::util::get_absolute_file_path(path);
+        retvalue = ov::util::file_exists(absolute_path) ? absolute_path : path;
+    } catch (const std::runtime_error&) {
+        retvalue = path;
+    }
+    return retvalue;
+}
+
 inline std::vector<Extension::Ptr> load_extensions(const std::string& path) {
-    auto so = ov::util::load_shared_object(path.c_str());
+    const std::string resolved_path = resolve_extension_path(path);
+    auto so = ov::util::load_shared_object(resolved_path.c_str());
     using CreateFunction = void(std::vector<Extension::Ptr>&);
     std::vector<Extension::Ptr> extensions;
     reinterpret_cast<CreateFunction*>(ov::util::get_symbol(so, "create_extensions"))(extensions);

--- a/src/inference/src/core.cpp
+++ b/src/inference/src/core.cpp
@@ -13,20 +13,6 @@
 #include "openvino/runtime/iremote_context.hpp"
 #include "openvino/util/file_util.hpp"
 
-namespace {
-std::string resolve_extension_path(const std::string& path) {
-    std::string retvalue;
-    try {
-        const std::string absolute_path = ov::util::get_absolute_file_path(path);
-        retvalue = ov::util::file_exists(absolute_path) ? absolute_path : path;
-    } catch (const std::runtime_error&) {
-        retvalue = path;
-    }
-    return retvalue;
-}
-
-}  // namespace
-
 namespace ov {
 
 std::string find_plugins_xml(const std::string& xml_file) {
@@ -166,8 +152,7 @@ void Core::add_extension(const InferenceEngine::IExtensionPtr& extension) {
 
 void Core::add_extension(const std::string& library_path) {
     try {
-        const std::string path = resolve_extension_path(library_path);
-        add_extension(ov::detail::load_extensions(path));
+        add_extension(ov::detail::load_extensions(library_path));
     } catch (const std::runtime_error&) {
         try {
             // Try to load legacy extension
@@ -186,8 +171,7 @@ void Core::add_extension(const std::string& library_path) {
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 void Core::add_extension(const std::wstring& library_path) {
     try {
-        const std::string path = resolve_extension_path(ov::util::wstring_to_string(library_path));
-        add_extension(ov::detail::load_extensions(ov::util::string_to_wstring(path)));
+        add_extension(ov::detail::load_extensions(library_path));
     } catch (const std::runtime_error&) {
         try {
             // Try to load legacy extension


### PR DESCRIPTION
### Details:
 - Now, common `load_extensions` calls `resolve_extension_path`. It allows to load extension from multiple places in unified manner
 - Before this fix, I can load extension by relative path via `Core`, but cannot do it via `ov::Frontend` or `NodeFactory`