### PR TITLE
[CPU tests] migrate single layer test cases to be API 2.0 - part 5

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/select.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/select.cpp
@@ -2,58 +2,55 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <common_test_utils/ov_tensor_utils.hpp>
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/fusing_test_utils.hpp"
-#include "ov_models/builders.hpp"
 
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
-using namespace ov::test;
+namespace ov {
+namespace test {
 
-namespace CPULayerTestsDefinitions {
-
-using selectParams = std::tuple<std::vector<InputShape>,         // input shapes
-                                ElementType,                     // Then/Else precision
-                                ngraph::op::AutoBroadcastSpec,   // broadcast
+using selectParams = std::tuple<std::vector<InputShape>,    // input shapes
+                                ElementType,                // Then/Else precision
+                                ov::op::AutoBroadcastSpec,  // broadcast
                                 fusingSpecificParams>;
 
 class SelectLayerCPUTest : public testing::WithParamInterface<selectParams>,
                            virtual public SubgraphBaseTest,
                            public CpuTestWithFusing {
 public:
-   static std::string getTestCaseName(testing::TestParamInfo<selectParams> obj) {
-       std::vector<InputShape> shapes;
-       ElementType precision;
-       ngraph::op::AutoBroadcastSpec broadcast;
-       fusingSpecificParams fusingParams;
-       std::tie(shapes, precision, broadcast, fusingParams) = obj.param;
+    static std::string getTestCaseName(testing::TestParamInfo<selectParams> obj) {
+        std::vector<InputShape> shapes;
+        ElementType precision;
+        ov::op::AutoBroadcastSpec broadcast;
+        fusingSpecificParams fusingParams;
+        std::tie(shapes, precision, broadcast, fusingParams) = obj.param;
 
-       std::ostringstream result;
-       result << "Condition_prc_" << ElementType::boolean << "_Then_Else_prc_" << precision << "_";
-       result << "IS=(";
-       for (const auto& shape : shapes) {
-           result << shape.first << "_";
-       }
-       result << ")_TS=(";
-       for (const auto& shape : shapes) {
-           for (const auto& item : shape.second) {
-               result << ov::test::utils::vec2str(item) << "_";
-           }
-       }
-       result << "Broadcast=" << broadcast.m_type;
-       result << CpuTestWithFusing::getTestCaseName(fusingParams);
+        std::ostringstream result;
+        result << "Condition_prc_" << ElementType::boolean << "_Then_Else_prc_" << precision << "_";
+        result << "IS=(";
+        for (const auto& shape : shapes) {
+            result << shape.first << "_";
+        }
+        result << ")_TS=(";
+        for (const auto& shape : shapes) {
+            for (const auto& item : shape.second) {
+                result << ov::test::utils::vec2str(item) << "_";
+            }
+        }
+        result << "Broadcast=" << broadcast.m_type;
+        result << CpuTestWithFusing::getTestCaseName(fusingParams);
 
-       return result.str();
-   }
+        return result.str();
+    }
 
 protected:
-   void SetUp() override {
+    void SetUp() override {
         abs_threshold = 0;
         targetDevice = ov::test::utils::DEVICE_CPU;
         std::vector<InputShape> shapes;
         ElementType precision;
-        ngraph::op::AutoBroadcastSpec broadcast;
+        ov::op::AutoBroadcastSpec broadcast;
         fusingSpecificParams fusingParams;
         std::tie(shapes, precision, broadcast, fusingParams) = this->GetParam();
         init_input_shapes(shapes);
@@ -69,14 +66,26 @@ protected:
         auto select = std::make_shared<ov::op::v1::Select>(parameters[0], parameters[1], parameters[2], broadcast);
 
         function = makeNgraphFunction(precision, parameters, select, "Eltwise");
-   }
+    }
 
-   void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
         inputs.clear();
         const auto& modelInputs = function->inputs();
-        auto condTensor = ov::test::utils::create_and_fill_tensor(modelInputs[0].get_element_type(), targetInputStaticShapes[0], 3, -1, 2);
-        auto thenTensor = ov::test::utils::create_and_fill_tensor(modelInputs[1].get_element_type(), targetInputStaticShapes[1], 10, -10, 2);
-        auto elseTensor = ov::test::utils::create_and_fill_tensor(modelInputs[2].get_element_type(), targetInputStaticShapes[2], 10, 0, 2);
+        auto condTensor = ov::test::utils::create_and_fill_tensor(modelInputs[0].get_element_type(),
+                                                                  targetInputStaticShapes[0],
+                                                                  3,
+                                                                  -1,
+                                                                  2);
+        auto thenTensor = ov::test::utils::create_and_fill_tensor(modelInputs[1].get_element_type(),
+                                                                  targetInputStaticShapes[1],
+                                                                  10,
+                                                                  -10,
+                                                                  2);
+        auto elseTensor = ov::test::utils::create_and_fill_tensor(modelInputs[2].get_element_type(),
+                                                                  targetInputStaticShapes[2],
+                                                                  10,
+                                                                  0,
+                                                                  2);
         inputs.insert({modelInputs[0].get_node_shared_ptr(), condTensor});
         inputs.insert({modelInputs[1].get_node_shared_ptr(), thenTensor});
         inputs.insert({modelInputs[2].get_node_shared_ptr(), elseTensor});
@@ -88,12 +97,7 @@ TEST_P(SelectLayerCPUTest, CompareWithRefs) {
     CheckPluginRelatedResults(compiledModel, std::set<std::string>{"Eltwise", "Subgraph"});
 }
 
-const std::vector<ElementType> precisions = {
-    ElementType::f32,
-    ElementType::i32,
-    ElementType::bf16,
-    ElementType::i8
-};
+const std::vector<ElementType> precisions = {ElementType::f32, ElementType::i32, ElementType::bf16, ElementType::i8};
 
 const std::vector<fusingSpecificParams> fusingParamsSet{
     emptyFusingSpec,
@@ -104,106 +108,68 @@ const std::vector<fusingSpecificParams> fusingParamsSet{
 const std::vector<std::vector<InputShape>> inShapesDynamicNumpy = {
     {
         // Condition
-        {
-            {-1, -1, -1, -1},
-            {{5, 1, 2, 1}, {1, 1, 1, 1}, {5, 9, 8, 7}}
-        },
+        {{-1, -1, -1, -1}, {{5, 1, 2, 1}, {1, 1, 1, 1}, {5, 9, 8, 7}}},
         // Then
-        {
-            {-1, -1, -1, -1, -1},
-            {{8, 1, 9, 1, 1}, {1, 1, 1, 1, 1}, {21, 5, 9, 8, 7}}
-        },
+        {{-1, -1, -1, -1, -1}, {{8, 1, 9, 1, 1}, {1, 1, 1, 1, 1}, {21, 5, 9, 8, 7}}},
         // Else
-        {
-            {-1, -1, -1, -1},
-            {{5, 1, 2, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}
-        },
+        {{-1, -1, -1, -1}, {{5, 1, 2, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}},
     },
     {
         // Condition
-        {
-            {-1, -1},
-            {{8, 1}, {10, 5}, {8, 7}}
-        },
+        {{-1, -1}, {{8, 1}, {10, 5}, {8, 7}}},
         // Then
-        {
-            {-1, -1, -1, -1, -1},
-            {{2, 1, 1, 8, 1}, {7, 8, 3, 10, 5}, {1, 1, 1, 8, 1}}
-        },
+        {{-1, -1, -1, -1, -1}, {{2, 1, 1, 8, 1}, {7, 8, 3, 10, 5}, {1, 1, 1, 8, 1}}},
         // Else
-        {
-            {-1, -1, -1},
-            {{9, 1, 1}, {3, 10, 5}, {1, 1, 7}}
-        },
+        {{-1, -1, -1}, {{9, 1, 1}, {3, 10, 5}, {1, 1, 7}}},
     },
     {
         // Condition
-        {
-            {{2, 8}, {3, 7}, {1, 10}, {1, 6}, {1, 10}},
-            {{5, 4, 1, 1, 1}, {8, 5, 5, 5, 1}, {2, 3, 4, 5, 6}}
-        },
+        {{{2, 8}, {3, 7}, {1, 10}, {1, 6}, {1, 10}}, {{5, 4, 1, 1, 1}, {8, 5, 5, 5, 1}, {2, 3, 4, 5, 6}}},
         // Then
-        {
-            {-1, -1, -1, -1, -1},
-            {{5, 1, 8, 1, 1}, {8, 1, 1, 1, 8}, {2, 3, 4, 5, 6}}
-        },
+        {{-1, -1, -1, -1, -1}, {{5, 1, 8, 1, 1}, {8, 1, 1, 1, 8}, {2, 3, 4, 5, 6}}},
         // Else
-        {
-            {{1, 5}, {1, 11}, {5, 5}, {1, 8}},
-            {{1, 1, 5, 1}, {5, 5, 5, 8}, {3, 4, 5, 6}}
-        },
+        {{{1, 5}, {1, 11}, {5, 5}, {1, 8}}, {{1, 1, 5, 1}, {5, 5, 5, 8}, {3, 4, 5, 6}}},
     },
     {
         // Condition
-        {
-            {{1, 10}},
-            {{4}, {10}, {1}}
-        },
+        {{{1, 10}}, {{4}, {10}, {1}}},
         // Then
-        {
-            {{1, 15}, {2, 7}, {1, 6}, {5, 12}, {1, 20}},
-            {{8, 5, 6, 6, 1}, {15, 7, 6, 10, 10}, {2, 5, 4, 5, 3}}
-        },
+        {{{1, 15}, {2, 7}, {1, 6}, {5, 12}, {1, 20}}, {{8, 5, 6, 6, 1}, {15, 7, 6, 10, 10}, {2, 5, 4, 5, 3}}},
         // Else
-        {
-            {{2, 10}, {1, 16}},
-            {{6, 4}, {10, 10}, {5, 1}}
-        },
+        {{{2, 10}, {1, 16}}, {{6, 4}, {10, 10}, {5, 1}}},
     },
 };
 
 const auto numpyCases = ::testing::Combine(::testing::ValuesIn(inShapesDynamicNumpy),
                                            ::testing::ValuesIn(precisions),
-                                           ::testing::Values(ngraph::op::AutoBroadcastType::NUMPY),
+                                           ::testing::Values(ov::op::AutoBroadcastType::NUMPY),
                                            ::testing::ValuesIn(fusingParamsSet));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefsNumpy_dynamic, SelectLayerCPUTest, numpyCases, SelectLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefsNumpy_dynamic,
+                         SelectLayerCPUTest,
+                         numpyCases,
+                         SelectLayerCPUTest::getTestCaseName);
 
 const std::vector<std::vector<InputShape>> inShapesDynamicNone = {
     {
         // Condition
-        {
-            {{1, 10}, -1, {10, 20}, {1, 5}},
-            {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}}
-        },
+        {{{1, 10}, -1, {10, 20}, {1, 5}}, {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}}},
         // Then
-        {
-            {-1, {16, 16}, -1, -1},
-            {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}}
-        },
+        {{-1, {16, 16}, -1, -1}, {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}}},
         // Else
-        {
-            {-1, -1, -1, -1},
-            {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}}
-        },
+        {{-1, -1, -1, -1}, {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}}},
     },
 };
 
 const auto noneCases = ::testing::Combine(::testing::ValuesIn(inShapesDynamicNone),
                                           ::testing::ValuesIn(precisions),
-                                          ::testing::Values(ngraph::op::AutoBroadcastType::NONE),
+                                          ::testing::Values(ov::op::AutoBroadcastType::NONE),
                                           ::testing::ValuesIn(fusingParamsSet));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefsNone_dynamic, SelectLayerCPUTest, noneCases, SelectLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefsNone_dynamic,
+                         SelectLayerCPUTest,
+                         noneCases,
+                         SelectLayerCPUTest::getTestCaseName);
 
-} // namespace CPULayerTestsDefinitions
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/shape_ops.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/shape_ops.cpp
@@ -2,39 +2,32 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
-#include "ov_models/builders.hpp"
-#include <common_test_utils/ov_tensor_utils.hpp>
 
-using namespace ngraph;
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
-using namespace ov::test;
 
-namespace CPULayerTestsDefinitions {
+namespace ov {
+namespace test {
 
-enum class shapeNodeType {
-    Reshape,
-    Squeeze,
-    Unsqueeze,
-    ReshapeWithNonZero
-};
+enum class shapeNodeType { Reshape, Squeeze, Unsqueeze, ReshapeWithNonZero };
 
 inline std::ostream& operator<<(std::ostream& os, shapeNodeType type) {
     switch (type) {
-        case shapeNodeType::Reshape:
-            os << "Reshape";
-            break;
-        case shapeNodeType::Squeeze:
-            os << "Squeeze";
-            break;
-        case shapeNodeType::Unsqueeze:
-            os << "Unsqueeze";
-            break;
-        case shapeNodeType::ReshapeWithNonZero:
-            os << "ReshapeWithNonZero";
-            break;
+    case shapeNodeType::Reshape:
+        os << "Reshape";
+        break;
+    case shapeNodeType::Squeeze:
+        os << "Squeeze";
+        break;
+    case shapeNodeType::Unsqueeze:
+        os << "Unsqueeze";
+        break;
+    case shapeNodeType::ReshapeWithNonZero:
+        os << "ReshapeWithNonZero";
+        break;
     }
     return os;
 }
@@ -44,21 +37,22 @@ struct inputDescription {
     std::vector<std::vector<int>> data;
 };
 
-using shapeOpsParams = std::tuple<
-    inputDescription,                  // input shapes
-    ngraph::helpers::InputLayerType,   // second input type
-    shapeNodeType,                     // node type
-    Precision,                         // precision
-    ngraph::element::Type_t,           // second input precision
-    bool>;                             // special zero
+using shapeOpsParams = std::tuple<inputDescription,                 // input shapes
+                                  ov::test::utils::InputLayerType,  // second input type
+                                  shapeNodeType,                    // node type
+                                  ov::element::Type,                // type
+                                  ov::element::Type_t,              // second input type
+                                  bool>;                            // special zero
 
-class ShapeOpsCPUTest : public testing::WithParamInterface<shapeOpsParams>, virtual public SubgraphBaseTest, public CPUTestsBase {
+class ShapeOpsCPUTest : public testing::WithParamInterface<shapeOpsParams>,
+                        virtual public SubgraphBaseTest,
+                        public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<shapeOpsParams> obj) {
         inputDescription inpDesc;
-        ngraph::helpers::InputLayerType secondType;
+        ov::test::utils::InputLayerType secondType;
         shapeNodeType nodeType;
-        Precision prc;
+        ov::element::Type prc;
         bool specialZero;
         element::Type_t tmpSecondInPrc;
         std::tie(inpDesc, secondType, nodeType, prc, tmpSecondInPrc, specialZero) = obj.param;
@@ -66,7 +60,7 @@ public:
         std::ostringstream result;
         result << nodeType << "_";
         result << "IS=";
-        result  << ov::test::utils::partialShape2str({inpDesc.inputShape.first}) << "_";
+        result << ov::test::utils::partialShape2str({inpDesc.inputShape.first}) << "_";
         result << "TS=(";
         for (const auto& shape : inpDesc.inputShape.second) {
             result << ov::test::utils::vec2str(shape) << "_";
@@ -91,33 +85,38 @@ protected:
             const auto& funcInput = funcInputs[i];
             ov::runtime::Tensor tensor;
             if (i == 1) {
-#define RESHAPE_TEST_CASE(INT_TYPE) \
-        case ov::element::Type_t::INT_TYPE: { \
-                    tensor = ov::runtime::Tensor{ov::element::INT_TYPE, targetInputStaticShapes[i]}; \
-                    auto inputData = tensor.data<ov::element_type_traits<ov::element::INT_TYPE>::value_type>(); \
-                    ASSERT_TRUE(idx < data.size()); \
-                    for (size_t j = 0lu; j < data[idx].size(); ++j) { \
-                            inputData[j] =  data[idx][j]; \
-                    } \
-                    break; \
-             }
+#define RESHAPE_TEST_CASE(INT_TYPE)                                                                 \
+    case ov::element::Type_t::INT_TYPE: {                                                           \
+        tensor = ov::runtime::Tensor{ov::element::INT_TYPE, targetInputStaticShapes[i]};            \
+        auto inputData = tensor.data<ov::element_type_traits<ov::element::INT_TYPE>::value_type>(); \
+        ASSERT_TRUE(idx < data.size());                                                             \
+        for (size_t j = 0lu; j < data[idx].size(); ++j) {                                           \
+            inputData[j] = data[idx][j];                                                            \
+        }                                                                                           \
+        break;                                                                                      \
+    }
                 switch (secondInPrc) {
                     RESHAPE_TEST_CASE(i64)
                     RESHAPE_TEST_CASE(i32)
-                    default:
-                          FAIL() << "We shouldn't get here.";
+                default:
+                    FAIL() << "We shouldn't get here.";
 #undef RESHAPE_TEST_CASE
                 }
             } else {
                 if (isWithNonZero) {
                     // fill tensor with all zero, so the NonZero op will create 0 shape as the input of reshape op
-                    tensor = utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 1, 0);
+                    tensor =
+                        utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 1, 0);
                 } else {
                     if (funcInput.get_element_type().is_real()) {
-                        tensor = utils::create_and_fill_tensor(
-                                funcInput.get_element_type(), targetInputStaticShapes[i], 10, 0, 1000);
+                        tensor = utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                               targetInputStaticShapes[i],
+                                                               10,
+                                                               0,
+                                                               1000);
                     } else {
-                        tensor = utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i]);
+                        tensor =
+                            utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i]);
                     }
                 }
             }
@@ -135,9 +134,9 @@ protected:
         targetDevice = ov::test::utils::DEVICE_CPU;
 
         inputDescription inpDesc;
-        ngraph::helpers::InputLayerType secondType;
+        ov::test::utils::InputLayerType secondType;
         shapeNodeType nodeType;
-        Precision prc;
+        ov::element::Type prc;
         bool specialZero;
         std::tie(inpDesc, secondType, nodeType, prc, secondInPrc, specialZero) = this->GetParam();
 
@@ -147,23 +146,22 @@ protected:
             // so the input of reshape is i32.
             selectedType = std::string("unknown_I32");
         } else {
-            selectedType = std::string("unknown_") + prc.name();
+            selectedType = std::string("unknown_") + prc.get_type_name();
         }
 
         data = inpDesc.data;
 
-
-        std::vector<InputShape> inputShapes =
-                {inpDesc.inputShape, InputShape{{static_cast<ov::Dimension::value_type>(inpDesc.data[0].size())},
-                                                std::vector<Shape>(inpDesc.inputShape.second.size(), {inpDesc.data[0].size()})}};
+        std::vector<InputShape> inputShapes = {
+            inpDesc.inputShape,
+            InputShape{{static_cast<ov::Dimension::value_type>(inpDesc.data[0].size())},
+                       std::vector<Shape>(inpDesc.inputShape.second.size(), {inpDesc.data[0].size()})}};
         init_input_shapes(inputShapes);
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(prc);
-        ov::ParameterVector inputs{std::make_shared<ov::op::v0::Parameter>(ngPrc, inputDynamicShapes.front())};
+        ov::ParameterVector inputs{std::make_shared<ov::op::v0::Parameter>(prc, inputDynamicShapes.front())};
         auto dataInput = inputs.front();
         dataInput->set_friendly_name("param_1");
-        std::shared_ptr<ngraph::Node> secondaryInput;
-        if (secondType == ngraph::helpers::InputLayerType::PARAMETER) {
+        std::shared_ptr<ov::Node> secondaryInput;
+        if (secondType == ov::test::utils::InputLayerType::PARAMETER) {
             auto param = std::make_shared<ov::op::v0::Parameter>(secondInPrc, inputDynamicShapes.back());
             param->set_friendly_name("param_2");
             secondaryInput = param;
@@ -172,28 +170,28 @@ protected:
             secondaryInput = ngraph::builder::makeConstant(secondInPrc, {inpDesc.data[0].size()}, inpDesc.data[0]);
         }
 
-        std::shared_ptr<ngraph::Node> shapeOps;
+        std::shared_ptr<ov::Node> shapeOps;
         switch (nodeType) {
-            case shapeNodeType::Reshape: {
-                shapeOps = std::make_shared<ngraph::opset1::Reshape>(dataInput, secondaryInput, specialZero);
-                break;
-            }
-            case shapeNodeType::Squeeze: {
-                shapeOps = std::make_shared<ngraph::opset1::Squeeze>(dataInput, secondaryInput);
-                break;
-            }
-            case shapeNodeType::Unsqueeze: {
-                shapeOps = std::make_shared<ngraph::opset1::Unsqueeze>(dataInput, secondaryInput);
-                break;
-            }
-            case shapeNodeType::ReshapeWithNonZero: {
-                auto nonZero = std::make_shared<ngraph::opset3::NonZero>(dataInput);
-                shapeOps = std::make_shared<ngraph::opset1::Reshape>(nonZero, secondaryInput, specialZero);
-                break;
-            }
+        case shapeNodeType::Reshape: {
+            shapeOps = std::make_shared<ov::op::v1::Reshape>(dataInput, secondaryInput, specialZero);
+            break;
+        }
+        case shapeNodeType::Squeeze: {
+            shapeOps = std::make_shared<ov::op::v0::Squeeze>(dataInput, secondaryInput);
+            break;
+        }
+        case shapeNodeType::Unsqueeze: {
+            shapeOps = std::make_shared<ov::op::v0::Unsqueeze>(dataInput, secondaryInput);
+            break;
+        }
+        case shapeNodeType::ReshapeWithNonZero: {
+            auto nonZero = std::make_shared<ov::op::v3::NonZero>(dataInput);
+            shapeOps = std::make_shared<ov::op::v1::Reshape>(nonZero, secondaryInput, specialZero);
+            break;
+        }
         }
 
-        function = makeNgraphFunction(ngPrc, inputs, shapeOps, "ShapeOpsCPUTest");
+        function = makeNgraphFunction(prc, inputs, shapeOps, "ShapeOpsCPUTest");
     }
 
 private:
@@ -211,106 +209,123 @@ TEST_P(ShapeOpsCPUTest, CompareWithRefs) {
 namespace reshapeTest {
 const std::vector<ov::element::Type_t> secondInPrcs{ov::element::Type_t::i64, ov::element::Type_t::i32};
 
-inputDescription noBounds{{{-1, -1, -1, -1},
-                           {ngraph::Shape{2, 5, 7, 3}, ngraph::Shape{10, 6, 10, 5}, ngraph::Shape{10, 6, 10, 5}, ngraph::Shape{1, 2, 5, 5}}},
-                           {std::vector<int>{1, -1, 0}, std::vector<int>{-1, 60, 2}, std::vector<int>{10, 30, 10}, std::vector<int>{5, 10, -1}}};
+inputDescription noBounds{
+    {{-1, -1, -1, -1},
+     {ov::Shape{2, 5, 7, 3}, ov::Shape{10, 6, 10, 5}, ov::Shape{10, 6, 10, 5}, ov::Shape{1, 2, 5, 5}}},
+    {std::vector<int>{1, -1, 0},
+     std::vector<int>{-1, 60, 2},
+     std::vector<int>{10, 30, 10},
+     std::vector<int>{5, 10, -1}}};
 
 const auto params = ::testing::Combine(::testing::Values(noBounds),
-                                       ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
+                                       ::testing::Values(ov::test::utils::InputLayerType::PARAMETER),
                                        ::testing::Values(shapeNodeType::Reshape),
-                                       ::testing::Values(Precision::FP32),
+                                       ::testing::Values(ov::element::f32),
                                        ::testing::ValuesIn(secondInPrcs),
                                        ::testing::Values(true));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic, ShapeOpsCPUTest, params, ShapeOpsCPUTest::getTestCaseName);
 
-inputDescription noBounds_const{{{{1, 10}, {2, 6}, {1, 15}, {3, 11}},
-                                 {ngraph::Shape{2, 5, 7, 3}, ngraph::Shape{10, 6, 10, 5}, ngraph::Shape{1, 2, 5, 5}}},
-                                 {std::vector<int>{2, -1, 0}}};
+inputDescription noBounds_const{
+    {{{1, 10}, {2, 6}, {1, 15}, {3, 11}}, {ov::Shape{2, 5, 7, 3}, ov::Shape{10, 6, 10, 5}, ov::Shape{1, 2, 5, 5}}},
+    {std::vector<int>{2, -1, 0}}};
 
 const auto params_const = ::testing::Combine(::testing::Values(noBounds_const),
-                                             ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
+                                             ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
                                              ::testing::Values(shapeNodeType::Reshape),
-                                             ::testing::Values(Precision::FP32),
+                                             ::testing::Values(ov::element::f32),
                                              ::testing::ValuesIn(secondInPrcs),
                                              ::testing::Values(true));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic_const, ShapeOpsCPUTest, params_const, ShapeOpsCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic_const,
+                         ShapeOpsCPUTest,
+                         params_const,
+                         ShapeOpsCPUTest::getTestCaseName);
 
-inputDescription shape_dynBatch{{{{1, 10}, 5, 7, 3},
-                                 {ngraph::Shape{2, 5, 7, 3}, ngraph::Shape{10, 5, 7, 3}, ngraph::Shape{1, 5, 7, 3}}},
-                                 {std::vector<int>{-1, 15, 7}}};
+inputDescription shape_dynBatch{
+    {{{1, 10}, 5, 7, 3}, {ov::Shape{2, 5, 7, 3}, ov::Shape{10, 5, 7, 3}, ov::Shape{1, 5, 7, 3}}},
+    {std::vector<int>{-1, 15, 7}}};
 
 const auto params_dynBatch = ::testing::Combine(::testing::Values(shape_dynBatch),
-                                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
+                                                ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
                                                 ::testing::Values(shapeNodeType::Reshape),
-                                                ::testing::Values(Precision::FP32),
+                                                ::testing::Values(ov::element::f32),
                                                 ::testing::ValuesIn(secondInPrcs),
                                                 ::testing::Values(true));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynBatch, ShapeOpsCPUTest, params_dynBatch, ShapeOpsCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynBatch,
+                         ShapeOpsCPUTest,
+                         params_dynBatch,
+                         ShapeOpsCPUTest::getTestCaseName);
 
 // test cases about NonZero connect with reshape
 // the output shape of NonZero is {4. 0}
 // the output shapes of reshapes are {1, 0 ,4} {4, 0, 1} {2, 0, 2}
-inputDescription shape_NonZero{{{-1, -1, -1, -1},
-                                 {ngraph::Shape{4, 5, 7, 3}, ngraph::Shape{6, 3, 4, 8}, ngraph::Shape{2, 2, 3, 9}}},
-                                 {std::vector<int>{-1, 0, 4}, std::vector<int>{0, 0, -1}, std::vector<int>{2, 0, 2}}};
+inputDescription shape_NonZero{
+    {{-1, -1, -1, -1}, {ov::Shape{4, 5, 7, 3}, ov::Shape{6, 3, 4, 8}, ov::Shape{2, 2, 3, 9}}},
+    {std::vector<int>{-1, 0, 4}, std::vector<int>{0, 0, -1}, std::vector<int>{2, 0, 2}}};
 
 const auto params_NonZero = ::testing::Combine(::testing::Values(shape_NonZero),
-                                                ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
-                                                ::testing::Values(shapeNodeType::ReshapeWithNonZero),
-                                                ::testing::Values(Precision::FP32),
-                                                ::testing::ValuesIn(secondInPrcs),
-                                                ::testing::Values(true));
+                                               ::testing::Values(ov::test::utils::InputLayerType::PARAMETER),
+                                               ::testing::Values(shapeNodeType::ReshapeWithNonZero),
+                                               ::testing::Values(ov::element::f32),
+                                               ::testing::ValuesIn(secondInPrcs),
+                                               ::testing::Values(true));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_NonZero, ShapeOpsCPUTest, params_NonZero, ShapeOpsCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_NonZero,
+                         ShapeOpsCPUTest,
+                         params_NonZero,
+                         ShapeOpsCPUTest::getTestCaseName);
 
 // test cases about reshape with empty tensor
-inputDescription shape_EmptyTensor{{{-1, 2, 2},
-                                 {ngraph::Shape{0, 2, 2}, ngraph::Shape{2, 2, 2}}},
-                                 {std::vector<int>{0, 4}, std::vector<int>{2, 4}}};
+inputDescription shape_EmptyTensor{{{-1, 2, 2}, {ov::Shape{0, 2, 2}, ov::Shape{2, 2, 2}}},
+                                   {std::vector<int>{0, 4}, std::vector<int>{2, 4}}};
 
 const auto params_EmptyTensor = ::testing::Combine(::testing::Values(shape_EmptyTensor),
-                                                ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
-                                                ::testing::Values(shapeNodeType::Reshape),
-                                                ::testing::Values(Precision::FP32),
-                                                ::testing::ValuesIn(secondInPrcs),
-                                                ::testing::Values(false));
+                                                   ::testing::Values(ov::test::utils::InputLayerType::PARAMETER),
+                                                   ::testing::Values(shapeNodeType::Reshape),
+                                                   ::testing::Values(ov::element::f32),
+                                                   ::testing::ValuesIn(secondInPrcs),
+                                                   ::testing::Values(false));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_EmptyTensor, ShapeOpsCPUTest, params_EmptyTensor, ShapeOpsCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_EmptyTensor,
+                         ShapeOpsCPUTest,
+                         params_EmptyTensor,
+                         ShapeOpsCPUTest::getTestCaseName);
 
 // test cases about NeedShapeInfer return right result
-inputDescription shape_NeedShapeInfer{{{-1, -1},
-                                 {ngraph::Shape{640, 80}, ngraph::Shape{640, 80}, ngraph::Shape{1280, 40}, ngraph::Shape{1280, 40}}},
-                                 {std::vector<int>{320, 160}, std::vector<int>{640, 80}, std::vector<int>{320, 160}, std::vector<int>{640, 80}}};
+inputDescription shape_NeedShapeInfer{
+    {{-1, -1}, {ov::Shape{640, 80}, ov::Shape{640, 80}, ov::Shape{1280, 40}, ov::Shape{1280, 40}}},
+    {std::vector<int>{320, 160}, std::vector<int>{640, 80}, std::vector<int>{320, 160}, std::vector<int>{640, 80}}};
 
 const auto params_NeedShapeInfer = ::testing::Combine(::testing::Values(shape_NeedShapeInfer),
-                                                ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
-                                                ::testing::Values(shapeNodeType::Reshape),
-                                                ::testing::Values(Precision::FP32),
-                                                ::testing::ValuesIn(secondInPrcs),
-                                                ::testing::Values(false));
+                                                      ::testing::Values(ov::test::utils::InputLayerType::PARAMETER),
+                                                      ::testing::Values(shapeNodeType::Reshape),
+                                                      ::testing::Values(ov::element::f32),
+                                                      ::testing::ValuesIn(secondInPrcs),
+                                                      ::testing::Values(false));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_NeedShapeInfer, ShapeOpsCPUTest, params_NeedShapeInfer, ShapeOpsCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_NeedShapeInfer,
+                         ShapeOpsCPUTest,
+                         params_NeedShapeInfer,
+                         ShapeOpsCPUTest::getTestCaseName);
 
-} // namespace reshapeTest
+}  // namespace reshapeTest
 
 namespace squeezeTest {
 const std::vector<ov::element::Type_t> secondInPrcs{ov::element::Type_t::i64, ov::element::Type_t::i32};
-inputDescription noBounds{{{-1, -1, -1, -1, -1, -1},
-                           {
-                                ngraph::Shape{2, 5, 1, 7, 3, 1},
-                                ngraph::Shape{10, 1, 1, 6, 10, 5},
-                                ngraph::Shape{10, 6, 10, 5, 1, 1},
-                                ngraph::Shape{1, 1, 5, 1, 5}
-                           }},
-                           {std::vector<int>{2, 5}, std::vector<int>{1, 2}, std::vector<int>{4, 5}, std::vector<int>{0, 1}}};
+inputDescription noBounds{
+    {{-1, -1, -1, -1, -1, -1},
+     {ov::Shape{2, 5, 1, 7, 3, 1},
+      ov::Shape{10, 1, 1, 6, 10, 5},
+      ov::Shape{10, 6, 10, 5, 1, 1},
+      ov::Shape{1, 1, 5, 1, 5}}},
+    {std::vector<int>{2, 5}, std::vector<int>{1, 2}, std::vector<int>{4, 5}, std::vector<int>{0, 1}}};
 
 const auto params = ::testing::Combine(::testing::Values(noBounds),
-                                       ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
+                                       ::testing::Values(ov::test::utils::InputLayerType::PARAMETER),
                                        ::testing::Values(shapeNodeType::Squeeze),
-                                       ::testing::Values(Precision::FP32),
+                                       ::testing::Values(ov::element::f32),
                                        ::testing::ValuesIn(secondInPrcs),
                                        ::testing::Values(true));
 
@@ -318,31 +333,35 @@ const auto params = ::testing::Combine(::testing::Values(noBounds),
 // enable after CPU plug-in will support dynamic rank
 // INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic, ShapeOpsCPUTest, params, ShapeOpsCPUTest::getTestCaseName);
 
-inputDescription noBounds_const{{{{1, 10}, {1, 15}, {2, 6}, {1, 15}, {3, 11}, {1, 15}},
-                                 {ngraph::Shape{2, 1, 5, 7, 3, 1}, ngraph::Shape{10, 1, 6, 10, 5, 1}, ngraph::Shape{1, 1, 2, 5, 5, 1}}},
-                                 {std::vector<int>{1, 5}}};
+inputDescription noBounds_const{
+    {{{1, 10}, {1, 15}, {2, 6}, {1, 15}, {3, 11}, {1, 15}},
+     {ov::Shape{2, 1, 5, 7, 3, 1}, ov::Shape{10, 1, 6, 10, 5, 1}, ov::Shape{1, 1, 2, 5, 5, 1}}},
+    {std::vector<int>{1, 5}}};
 
 const auto params_const = ::testing::Combine(::testing::Values(noBounds_const),
-                                             ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
+                                             ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
                                              ::testing::Values(shapeNodeType::Squeeze),
-                                             ::testing::Values(Precision::FP32),
+                                             ::testing::Values(ov::element::f32),
                                              ::testing::ValuesIn(secondInPrcs),
                                              ::testing::Values(true));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic_const, ShapeOpsCPUTest, params_const, ShapeOpsCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic_const,
+                         ShapeOpsCPUTest,
+                         params_const,
+                         ShapeOpsCPUTest::getTestCaseName);
 
-} // namespace squeezeTest
+}  // namespace squeezeTest
 
 namespace unsqueezeTest {
 const std::vector<ov::element::Type_t> secondInPrcs{ov::element::Type_t::i64, ov::element::Type_t::i32};
-inputDescription noBounds{{{-1, -1, -1, -1},
-                           {ngraph::Shape{2, 5, 7, 3}, ngraph::Shape{10, 6, 10, 5}, ngraph::Shape{10, 6, 10, 5}, ngraph::Shape{5, 1, 5}}},
-                           {std::vector<int>{2, 5}, std::vector<int>{1, 2}, std::vector<int>{4, 5}, std::vector<int>{0, 1}}};
+inputDescription noBounds{
+    {{-1, -1, -1, -1}, {ov::Shape{2, 5, 7, 3}, ov::Shape{10, 6, 10, 5}, ov::Shape{10, 6, 10, 5}, ov::Shape{5, 1, 5}}},
+    {std::vector<int>{2, 5}, std::vector<int>{1, 2}, std::vector<int>{4, 5}, std::vector<int>{0, 1}}};
 
 const auto params = ::testing::Combine(::testing::Values(noBounds),
-                                       ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
+                                       ::testing::Values(ov::test::utils::InputLayerType::PARAMETER),
                                        ::testing::Values(shapeNodeType::Unsqueeze),
-                                       ::testing::Values(Precision::FP32),
+                                       ::testing::Values(ov::element::f32),
                                        ::testing::ValuesIn(secondInPrcs),
                                        ::testing::Values(true));
 
@@ -350,19 +369,23 @@ const auto params = ::testing::Combine(::testing::Values(noBounds),
 // enable after CPU plug-in will support dynamic rank
 // INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic, ShapeOpsCPUTest, params, ShapeOpsCPUTest::getTestCaseName);
 
-inputDescription noBounds_const{{{{1, 10}, {1, 15}, {2, 20}, {3, 7}},
-                                 {ngraph::Shape{2, 5, 7, 3}, ngraph::Shape{10, 6, 10, 5}, ngraph::Shape{1, 2, 5, 5}}},
-                                 {std::vector<int>{1, 3}}};
+inputDescription noBounds_const{
+    {{{1, 10}, {1, 15}, {2, 20}, {3, 7}}, {ov::Shape{2, 5, 7, 3}, ov::Shape{10, 6, 10, 5}, ov::Shape{1, 2, 5, 5}}},
+    {std::vector<int>{1, 3}}};
 
 const auto params_const = ::testing::Combine(::testing::Values(noBounds_const),
-                                             ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
+                                             ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
                                              ::testing::Values(shapeNodeType::Unsqueeze),
-                                             ::testing::Values(Precision::FP32),
+                                             ::testing::Values(ov::element::f32),
                                              ::testing::ValuesIn(secondInPrcs),
                                              ::testing::Values(true));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic_const, ShapeOpsCPUTest, params_const, ShapeOpsCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic_const,
+                         ShapeOpsCPUTest,
+                         params_const,
+                         ShapeOpsCPUTest::getTestCaseName);
 
-} // namespace unsqueezeTest
+}  // namespace unsqueezeTest
 
-} // namespace CPULayerTestsDefinitions
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/shapeof.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/shapeof.cpp
@@ -2,34 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "test_utils/cpu_test_utils.hpp"
-
 #include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
+#include "test_utils/cpu_test_utils.hpp"
 
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
 
 using InputShape = ov::test::InputShape;
 using ElementType = ov::element::Type_t;
 
-namespace CPULayerTestsDefinitions {
-typedef std::tuple<
-        InputShape,
-        ElementType                // Net precision
-> ShapeOfLayerTestParams;
+namespace ov {
+namespace test {
+typedef std::tuple<InputShape,
+                   ElementType  // Net type
+                   >
+    ShapeOfLayerTestParams;
 
-typedef std::tuple<
-        ShapeOfLayerTestParams,
-        CPUSpecificParams
-> ShapeOfLayerCPUTestParamsSet;
+typedef std::tuple<ShapeOfLayerTestParams, CPUSpecificParams> ShapeOfLayerCPUTestParamsSet;
 
 class ShapeOfLayerCPUTest : public testing::WithParamInterface<ShapeOfLayerCPUTestParamsSet>,
-                            virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
+                            virtual public ov::test::SubgraphBaseTest,
+                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ShapeOfLayerCPUTestParamsSet> obj) {
-        CPULayerTestsDefinitions::ShapeOfLayerTestParams basicParamsSet;
+        ShapeOfLayerTestParams basicParamsSet;
         CPUSpecificParams cpuParams;
         std::tie(basicParamsSet, cpuParams) = obj.param;
         ElementType netPr;
@@ -50,11 +47,12 @@ public:
         result << ")";
         return result.str();
     }
+
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
 
-        CPULayerTestsDefinitions::ShapeOfLayerTestParams basicParamsSet;
+        ShapeOfLayerTestParams basicParamsSet;
         CPUSpecificParams cpuParams;
         std::tie(basicParamsSet, cpuParams) = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
@@ -72,7 +70,7 @@ protected:
         for (auto&& shape : inputDynamicShapes)
             params.push_back(std::make_shared<ov::op::v0::Parameter>(inType, shape));
 
-        auto shapeOf = std::make_shared<ngraph::opset3::ShapeOf>(params.front(), ngraph::element::i32);
+        auto shapeOf = std::make_shared<ov::op::v3::ShapeOf>(params.front(), ov::element::i32);
 
         function = makeNgraphFunction(netPrecision, params, shapeOf, "ShapeOf");
     }
@@ -85,69 +83,41 @@ TEST_P(ShapeOfLayerCPUTest, CompareWithRefs) {
 
 namespace {
 
-const std::vector<ElementType> netPrecisions = {
-        ElementType::f32,
-        ElementType::bf16,
-        ElementType::i32,
-        ElementType::i8
-};
+const std::vector<ElementType> netPrecisions = {ElementType::f32, ElementType::bf16, ElementType::i32, ElementType::i8};
 
-std::vector<ov::test::InputShape> inShapesDynamic3d = {
-        {
-            {-1, -1, -1},
-            {
-                { 8, 16, 4 },
-                { 8, 16, 3 },
-                { 8, 16, 2 }
-            }
-        }
-};
+std::vector<ov::test::InputShape> inShapesDynamic3d = {{{-1, -1, -1}, {{8, 16, 4}, {8, 16, 3}, {8, 16, 2}}}};
 
 std::vector<ov::test::InputShape> inShapesDynamic4d = {
-        {
-            {-1, -1, -1, -1},
-            {
-                { 8, 16, 3, 4 },
-                { 8, 16, 3, 3 },
-                { 8, 16, 3, 2 }
-            }
-        },
+    {{-1, -1, -1, -1}, {{8, 16, 3, 4}, {8, 16, 3, 3}, {8, 16, 3, 2}}},
 };
 
 std::vector<ov::test::InputShape> inShapesDynamic5d = {
-        {
-            { -1, -1, -1, -1, -1 },
-            {
-                { 8, 16, 3, 2, 4 },
-                { 8, 16, 3, 2, 3 },
-                { 8, 16, 3, 2, 2 }
-            }
-        }
-};
-const auto params5dDynamic = ::testing::Combine(
-        ::testing::Combine(
-                ::testing::ValuesIn(inShapesDynamic5d),
-                ::testing::ValuesIn(netPrecisions)),
-        ::testing::Values(emptyCPUSpec));
+    {{-1, -1, -1, -1, -1}, {{8, 16, 3, 2, 4}, {8, 16, 3, 2, 3}, {8, 16, 3, 2, 2}}}};
+const auto params5dDynamic =
+    ::testing::Combine(::testing::Combine(::testing::ValuesIn(inShapesDynamic5d), ::testing::ValuesIn(netPrecisions)),
+                       ::testing::Values(emptyCPUSpec));
 
-const auto params4dDynamic = ::testing::Combine(
-        ::testing::Combine(
-                ::testing::ValuesIn(inShapesDynamic4d),
-                ::testing::ValuesIn(netPrecisions)),
-        ::testing::Values(emptyCPUSpec));
+const auto params4dDynamic =
+    ::testing::Combine(::testing::Combine(::testing::ValuesIn(inShapesDynamic4d), ::testing::ValuesIn(netPrecisions)),
+                       ::testing::Values(emptyCPUSpec));
 
-const auto params3dDynamic = ::testing::Combine(
-        ::testing::Combine(
-                ::testing::ValuesIn(inShapesDynamic3d),
-                ::testing::ValuesIn(netPrecisions)),
-        ::testing::Values(emptyCPUSpec));
+const auto params3dDynamic =
+    ::testing::Combine(::testing::Combine(::testing::ValuesIn(inShapesDynamic3d), ::testing::ValuesIn(netPrecisions)),
+                       ::testing::Values(emptyCPUSpec));
 
 // We don't check static case, because of constant folding
-INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf3dDynamicLayoutTest, ShapeOfLayerCPUTest,
-                         params3dDynamic, ShapeOfLayerCPUTest::getTestCaseName);
-INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf4dDynamicLayoutTest, ShapeOfLayerCPUTest,
-                         params4dDynamic, ShapeOfLayerCPUTest::getTestCaseName);
-INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf5dDynamicLayoutTest, ShapeOfLayerCPUTest,
-                         params5dDynamic, ShapeOfLayerCPUTest::getTestCaseName);
-} // namespace
-} // namespace CPULayerTestsDefinitions
+INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf3dDynamicLayoutTest,
+                         ShapeOfLayerCPUTest,
+                         params3dDynamic,
+                         ShapeOfLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf4dDynamicLayoutTest,
+                         ShapeOfLayerCPUTest,
+                         params4dDynamic,
+                         ShapeOfLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_ShapeOf5dDynamicLayoutTest,
+                         ShapeOfLayerCPUTest,
+                         params5dDynamic,
+                         ShapeOfLayerCPUTest::getTestCaseName);
+}  // namespace
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/shuffle_channels.cpp
@@ -3,26 +3,23 @@
 //
 
 #include "shared_test_classes/single_layer/shuffle_channels.hpp"
-#include "test_utils/cpu_test_utils.hpp"
-#include "ov_models/builders.hpp"
+
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
+#include "test_utils/cpu_test_utils.hpp"
 
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
-using namespace ngraph::opset3;
-using namespace ov::test;
+namespace ov {
+namespace test {
 
-namespace CPULayerTestsDefinitions {
-
-using ShuffleChannelsLayerCPUTestParamsSet = std::tuple<
-        InputShape,                                             // Input shape
-        ElementType,                                            // Input element type
-        LayerTestsDefinitions::shuffleChannelsSpecificParams,
-        CPUSpecificParams>;
+using ShuffleChannelsLayerCPUTestParamsSet = std::tuple<InputShape,   // Input shape
+                                                        ElementType,  // Input element type
+                                                        LayerTestsDefinitions::shuffleChannelsSpecificParams,
+                                                        CPUSpecificParams>;
 
 class ShuffleChannelsLayerCPUTest : public testing::WithParamInterface<ShuffleChannelsLayerCPUTestParamsSet>,
-                                     virtual public SubgraphBaseTest, public CPUTestsBase {
+                                    virtual public SubgraphBaseTest,
+                                    public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ShuffleChannelsLayerCPUTestParamsSet> obj) {
         InputShape shapes;
@@ -141,118 +138,106 @@ std::vector<CPUSpecificParams> filterCPUInfoForDevice5DBlock() {
 }
 /* ========== */
 
-const std::vector<ElementType> inputElementType = {
-        ElementType::f32,
-        ElementType::bf16,
-        ElementType::i8
-};
+const std::vector<ElementType> inputElementType = {ElementType::f32, ElementType::bf16, ElementType::i8};
 
-const auto shuffleChannelsParams4D = ::testing::Combine(
-        ::testing::ValuesIn(std::vector<int>{-4, -2, 0, 1, 3}),
-        ::testing::ValuesIn(std::vector<int>{1, 2, 4})
-);
+const auto shuffleChannelsParams4D = ::testing::Combine(::testing::ValuesIn(std::vector<int>{-4, -2, 0, 1, 3}),
+                                                        ::testing::ValuesIn(std::vector<int>{1, 2, 4}));
 
-const auto shuffleChannelsParams5D = ::testing::Combine(
-        ::testing::ValuesIn(std::vector<int>{-5, -3, -1, 0, 1, 3}),
-        ::testing::ValuesIn(std::vector<int>{1, 2, 3})
-);
+const auto shuffleChannelsParams5D = ::testing::Combine(::testing::ValuesIn(std::vector<int>{-5, -3, -1, 0, 1, 3}),
+                                                        ::testing::ValuesIn(std::vector<int>{1, 2, 3}));
 
-const auto shuffleChannelsParams4DBlock = ::testing::Combine(
-        ::testing::ValuesIn(std::vector<int>{-4, -2, -1, 0, 2, 3}),
-        ::testing::ValuesIn(std::vector<int>{1, 2, 4})
-);
+const auto shuffleChannelsParams4DBlock = ::testing::Combine(::testing::ValuesIn(std::vector<int>{-4, -2, -1, 0, 2, 3}),
+                                                             ::testing::ValuesIn(std::vector<int>{1, 2, 4}));
 
-const auto shuffleChannelsParams5DBlock = ::testing::Combine(
-        ::testing::ValuesIn(std::vector<int>{-5, -2, -1, 0, 2, 3, 4}),
-        ::testing::ValuesIn(std::vector<int>{1, 2, 3})
-);
+const auto shuffleChannelsParams5DBlock =
+    ::testing::Combine(::testing::ValuesIn(std::vector<int>{-5, -2, -1, 0, 2, 3, 4}),
+                       ::testing::ValuesIn(std::vector<int>{1, 2, 3}));
 
 const std::vector<InputShape> inputShapesDynamic4D = {
-        {{-1, -1, -1, -1},
-         {{8, 4, 4, 4}, {8, 16, 8, 4}, {8, 4, 4, 4}}},
+    {{-1, -1, -1, -1}, {{8, 4, 4, 4}, {8, 16, 8, 4}, {8, 4, 4, 4}}},
 
-        {{-1, 8, -1, -1},
-         {{8, 8, 8, 8}, {8, 8, 4, 16}, {8, 8, 8, 8}}},
+    {{-1, 8, -1, -1}, {{8, 8, 8, 8}, {8, 8, 4, 16}, {8, 8, 8, 8}}},
 
-        {{{4, 32}, {4, 32}, {4, 32}, {4, 32}},
-         {{4, 12, 8, 8}, {8, 32, 12, 4}, {4, 12, 8, 8}}},
+    {{{4, 32}, {4, 32}, {4, 32}, {4, 32}}, {{4, 12, 8, 8}, {8, 32, 12, 4}, {4, 12, 8, 8}}},
 };
 
 const std::vector<InputShape> inputShapesDynamic5D = {
-        {{-1, -1, -1, -1, -1},
-         {{6, 6, 6, 6, 6}, {12, 6, 12, 12, 12}, {6, 6, 6, 6, 6}}},
+    {{-1, -1, -1, -1, -1}, {{6, 6, 6, 6, 6}, {12, 6, 12, 12, 12}, {6, 6, 6, 6, 6}}},
 
-        {{-1, 18, -1, -1, -1},
-         {{6, 18, 12, 6, 12}, {6, 18, 6, 6, 6}, {6, 18, 12, 6, 12}}},
+    {{-1, 18, -1, -1, -1}, {{6, 18, 12, 6, 12}, {6, 18, 6, 6, 6}, {6, 18, 12, 6, 12}}},
 
-        {{{6, 24}, {6, 24}, {6, 24}, {6, 24}, {6, 24}},
-         {{24, 12, 6, 6, 6}, {12, 24, 6, 12, 12}, {24, 12, 6, 6, 6}}},
+    {{{6, 24}, {6, 24}, {6, 24}, {6, 24}, {6, 24}}, {{24, 12, 6, 6, 6}, {12, 24, 6, 12, 12}, {24, 12, 6, 6, 6}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsStatic4D, ShuffleChannelsLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation({{16, 24, 32, 40}})),
-                                 ::testing::ValuesIn(inputElementType),
-                                 shuffleChannelsParams4D,
-                                 ::testing::ValuesIn(filterCPUInfoForDevice4D())),
-                        ShuffleChannelsLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_ShuffleChannelsStatic4D,
+    ShuffleChannelsLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation({{16, 24, 32, 40}})),
+                       ::testing::ValuesIn(inputElementType),
+                       shuffleChannelsParams4D,
+                       ::testing::ValuesIn(filterCPUInfoForDevice4D())),
+    ShuffleChannelsLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsDynamic4D, ShuffleChannelsLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesDynamic4D),
-                                 ::testing::ValuesIn(inputElementType),
-                                 shuffleChannelsParams4D,
-                                 ::testing::ValuesIn(filterCPUInfoForDevice4D())),
-                        ShuffleChannelsLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsStatic5D, ShuffleChannelsLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation({{6, 24, 12, 12, 6}})),
-                                 ::testing::ValuesIn(inputElementType),
-                                 shuffleChannelsParams5D,
-                                 ::testing::ValuesIn(filterCPUInfoForDevice5D())),
+INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsDynamic4D,
+                         ShuffleChannelsLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic4D),
+                                            ::testing::ValuesIn(inputElementType),
+                                            shuffleChannelsParams4D,
+                                            ::testing::ValuesIn(filterCPUInfoForDevice4D())),
                          ShuffleChannelsLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsDynamic5D, ShuffleChannelsLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesDynamic5D),
-                                 ::testing::ValuesIn(inputElementType),
-                                 shuffleChannelsParams5D,
-                                 ::testing::ValuesIn(filterCPUInfoForDevice5D())),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_ShuffleChannelsStatic5D,
+    ShuffleChannelsLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation({{6, 24, 12, 12, 6}})),
+                       ::testing::ValuesIn(inputElementType),
+                       shuffleChannelsParams5D,
+                       ::testing::ValuesIn(filterCPUInfoForDevice5D())),
+    ShuffleChannelsLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsDynamic5D,
+                         ShuffleChannelsLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic5D),
+                                            ::testing::ValuesIn(inputElementType),
+                                            shuffleChannelsParams5D,
+                                            ::testing::ValuesIn(filterCPUInfoForDevice5D())),
                          ShuffleChannelsLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsStatic4DBlock, ShuffleChannelsLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation({{40, 32, 24, 16}})),
-                                 ::testing::ValuesIn(inputElementType),
-                                 shuffleChannelsParams4DBlock,
-                                 ::testing::ValuesIn(filterCPUInfoForDevice4DBlock())),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_ShuffleChannelsStatic4DBlock,
+    ShuffleChannelsLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation({{40, 32, 24, 16}})),
+                       ::testing::ValuesIn(inputElementType),
+                       shuffleChannelsParams4DBlock,
+                       ::testing::ValuesIn(filterCPUInfoForDevice4DBlock())),
+    ShuffleChannelsLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsDynamic4DBlock,
+                         ShuffleChannelsLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic4D),
+                                            ::testing::ValuesIn(inputElementType),
+                                            shuffleChannelsParams4DBlock,
+                                            ::testing::ValuesIn(filterCPUInfoForDevice4DBlock())),
                          ShuffleChannelsLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsDynamic4DBlock, ShuffleChannelsLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesDynamic4D),
-                                 ::testing::ValuesIn(inputElementType),
-                                 shuffleChannelsParams4DBlock,
-                                 ::testing::ValuesIn(filterCPUInfoForDevice4DBlock())),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_ShuffleChannelsStatic5DBlock,
+    ShuffleChannelsLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation({{18, 12, 18, 12, 30}})),
+                       ::testing::ValuesIn(inputElementType),
+                       shuffleChannelsParams5DBlock,
+                       ::testing::ValuesIn(filterCPUInfoForDevice5DBlock())),
+    ShuffleChannelsLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsDynamic5DBlock,
+                         ShuffleChannelsLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic5D),
+                                            ::testing::ValuesIn(inputElementType),
+                                            shuffleChannelsParams5DBlock,
+                                            ::testing::ValuesIn(filterCPUInfoForDevice5DBlock())),
                          ShuffleChannelsLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsStatic5DBlock, ShuffleChannelsLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation({{18, 12, 18, 12, 30}})),
-                                 ::testing::ValuesIn(inputElementType),
-                                 shuffleChannelsParams5DBlock,
-                                 ::testing::ValuesIn(filterCPUInfoForDevice5DBlock())),
-                         ShuffleChannelsLayerCPUTest::getTestCaseName);
+}  // namespace
 
-INSTANTIATE_TEST_SUITE_P(smoke_ShuffleChannelsDynamic5DBlock, ShuffleChannelsLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesDynamic5D),
-                                 ::testing::ValuesIn(inputElementType),
-                                 shuffleChannelsParams5DBlock,
-                                 ::testing::ValuesIn(filterCPUInfoForDevice5DBlock())),
-                         ShuffleChannelsLayerCPUTest::getTestCaseName);
-
-} // namespace
-
-} // namespace CPULayerTestsDefinitions
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/slice.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/slice.cpp
@@ -2,38 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
-#include "test_utils/cpu_test_utils.hpp"
-#include "shared_test_classes/base/ov_subgraph.hpp"
 #include <common_test_utils/ov_tensor_utils.hpp>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "test_utils/cpu_test_utils.hpp"
 
 using namespace CPUTestUtils;
 using namespace ov::test;
 
-namespace CPULayerTestsDefinitions {
-
 struct Slice8SpecificParams {
-        std::vector<int64_t> start;
-        std::vector<int64_t> stop;
-        std::vector<int64_t> step;
-        std::vector<int64_t> axes;
+    std::vector<int64_t> start;
+    std::vector<int64_t> stop;
+    std::vector<int64_t> step;
+    std::vector<int64_t> axes;
 };
 
-typedef std::tuple<
-    std::vector<InputShape>,         // Parameters shapes
-    Slice8SpecificParams,            // Slice-8 specific parameters
-    ngraph::helpers::InputLayerType, // Secondary input types
-    ElementType,                     // Network precision
-    CPUSpecificParams                // CPU specific parameters
-> Slice8LayerTestCPUParam;
+typedef std::tuple<std::vector<InputShape>,          // Parameters shapes
+                   Slice8SpecificParams,             // Slice-8 specific parameters
+                   ov::test::utils::InputLayerType,  // Secondary input types
+                   ElementType,                      // Network precision
+                   CPUSpecificParams                 // CPU specific parameters
+                   >
+    Slice8LayerTestCPUParam;
 
 class Slice8LayerCPUTest : public testing::WithParamInterface<Slice8LayerTestCPUParam>,
-                                 virtual public SubgraphBaseTest, public CPUTestsBase {
+                           virtual public SubgraphBaseTest,
+                           public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<Slice8LayerTestCPUParam> obj) {
         std::vector<InputShape> shapes;
         Slice8SpecificParams params;
-        ngraph::helpers::InputLayerType secondaryInputType;
+        ov::test::utils::InputLayerType secondaryInputType;
         ElementType netPrecision;
         CPUSpecificParams cpuParams;
         std::tie(shapes, params, secondaryInputType, netPrecision, cpuParams) = obj.param;
@@ -49,10 +48,10 @@ public:
                 result << ov::test::utils::vec2str(item) << "_";
             }
         }
-        result << "start="  << ov::test::utils::vec2str(params.start) << "_";
-        result << "stop="   << ov::test::utils::vec2str(params.stop) << "_";
-        result << "step="   << ov::test::utils::vec2str(params.step) << "_";
-        result << "axes="   << ov::test::utils::vec2str(params.axes) << "_";
+        result << "start=" << ov::test::utils::vec2str(params.start) << "_";
+        result << "stop=" << ov::test::utils::vec2str(params.stop) << "_";
+        result << "step=" << ov::test::utils::vec2str(params.step) << "_";
+        result << "axes=" << ov::test::utils::vec2str(params.axes) << "_";
         result << "netPRC=" << netPrecision << "_";
         result << "secondaryInputType=" << secondaryInputType << "_";
         result << CPUTestsBase::getTestCaseName(cpuParams);
@@ -61,8 +60,11 @@ public:
     }
 
 protected:
-   void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override {
-        std::vector<void*> inputValues = {sliceParams.start.data(), sliceParams.stop.data(), sliceParams.step.data(), sliceParams.axes.data()};
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        std::vector<void*> inputValues = {sliceParams.start.data(),
+                                          sliceParams.stop.data(),
+                                          sliceParams.step.data(),
+                                          sliceParams.axes.data()};
 
         inputs.clear();
         const auto& funcInputs = function->inputs();
@@ -71,16 +73,20 @@ protected:
             ov::Tensor tensor;
             if (i == 0u)
                 // Fill the slice input0 tensor with random data.
-                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 10, 1, 1);
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[i],
+                                                                 10,
+                                                                 1,
+                                                                 1);
             else
                 // Fill the slice input1~input4 with specified data.
-                tensor = ov::Tensor{ov::element::i64, targetInputStaticShapes[i], inputValues[i-1]};
+                tensor = ov::Tensor{ov::element::i64, targetInputStaticShapes[i], inputValues[i - 1]};
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
         }
     }
     void SetUp() override {
         std::vector<InputShape> shapes;
-        ngraph::helpers::InputLayerType secondaryInputType;
+        ov::test::utils::InputLayerType secondaryInputType;
         ElementType netPrecision;
         CPUSpecificParams cpuParams;
         std::tie(shapes, sliceParams, secondaryInputType, netPrecision, cpuParams) = this->GetParam();
@@ -102,42 +108,50 @@ protected:
         for (auto&& shape : inputDynamicShapes) {
             params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
         }
-        std::shared_ptr<ngraph::Node> sliceNode;
-        if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
+        std::shared_ptr<ov::Node> sliceNode;
+        if (secondaryInputType == ov::test::utils::InputLayerType::PARAMETER) {
             // Slice start, stop, step, axes are parameters.
-            auto startNode = std::make_shared<ngraph::opset1::Parameter>(ov::element::i64, ov::Shape{sliceParams.start.size()});
-            auto stopdNode = std::make_shared<ngraph::opset1::Parameter>(ov::element::i64, ov::Shape{sliceParams.stop.size()});
-            auto stepNode = std::make_shared<ngraph::opset1::Parameter>(ov::element::i64, ov::Shape{sliceParams.step.size()});
+            auto startNode =
+                std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{sliceParams.start.size()});
+            auto stopdNode =
+                std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{sliceParams.stop.size()});
+            auto stepNode =
+                std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{sliceParams.step.size()});
 
-            params.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(startNode));
-            params.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(stopdNode));
-            params.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(stepNode));
+            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(startNode));
+            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(stopdNode));
+            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(stepNode));
             if (!sliceParams.axes.empty()) {
                 // With axes parameter
-                auto axesNode = std::make_shared<ngraph::opset1::Parameter>(ov::element::i64, ov::Shape{sliceParams.axes.size()});
-                params.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(axesNode));
+                auto axesNode =
+                    std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{sliceParams.axes.size()});
+                params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(axesNode));
                 sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], startNode, stopdNode, stepNode, axesNode);
             } else {
-                //without axes parameter
+                // without axes parameter
                 sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], startNode, stopdNode, stepNode);
             }
-        } else if (secondaryInputType == ngraph::helpers::InputLayerType::CONSTANT) {
+        } else if (secondaryInputType == ov::test::utils::InputLayerType::CONSTANT) {
             // Slice start, stop, step, axes are const.
             ov::Shape constShape = {sliceParams.start.size()};
-            auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.start.data());
-            auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.stop.data());
-            auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.step.data());
+            auto beginNode =
+                std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.start.data());
+            auto endNode =
+                std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.stop.data());
+            auto strideNode =
+                std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.step.data());
             if (!sliceParams.axes.empty()) {
                 // With axes parameter
-                auto axesNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.axes.data());
+                auto axesNode =
+                    std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, sliceParams.axes.data());
                 sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], beginNode, endNode, strideNode, axesNode);
             } else {
-                //without axes parameter
+                // without axes parameter
                 sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], beginNode, endNode, strideNode);
             }
         } else {
             // Not supported others.
-            OPENVINO_THROW("Slice8LayerCPUTest: Unsupported ngraph::helpers::InputLayerType , value: ",
+            OPENVINO_THROW("Slice8LayerCPUTest: Unsupported ov::test::utils::InputLayerType , value: ",
                            secondaryInputType);
         }
 
@@ -153,437 +167,378 @@ TEST_P(Slice8LayerCPUTest, CompareWithRefs) {
 
 namespace {
 
-const std::vector<ngraph::helpers::InputLayerType> inputLayerTypes = {
-        ngraph::helpers::InputLayerType::CONSTANT,
-        ngraph::helpers::InputLayerType::PARAMETER
-};
+const std::vector<ov::test::utils::InputLayerType> inputLayerTypes = {ov::test::utils::InputLayerType::CONSTANT,
+                                                                      ov::test::utils::InputLayerType::PARAMETER};
 
-const auto cpuParams_nChw16c = CPUSpecificParams {{nChw16c}, {nChw16c}, {}, {}};
-const auto cpuParams_nCdhw16c = CPUSpecificParams {{nCdhw16c}, {nCdhw16c}, {}, {}};
+const auto cpuParams_nChw16c = CPUSpecificParams{{nChw16c}, {nChw16c}, {}, {}};
+const auto cpuParams_nCdhw16c = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {}, {}};
 
-const auto cpuParams_nChw8c = CPUSpecificParams {{nChw8c}, {nChw8c}, {}, {}};
-const auto cpuParams_nCdhw8c = CPUSpecificParams {{nCdhw8c}, {nCdhw8c}, {}, {}};
+const auto cpuParams_nChw8c = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, {}};
+const auto cpuParams_nCdhw8c = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, {}};
 
-const auto cpuParams_nhwc = CPUSpecificParams {{nhwc}, {nhwc}, {}, {}};
-const auto cpuParams_ndhwc = CPUSpecificParams {{ndhwc}, {ndhwc}, {}, {}};
+const auto cpuParams_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {}, {}};
+const auto cpuParams_ndhwc = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, {}};
 
-const auto cpuParams_nchw = CPUSpecificParams {{nchw}, {nchw}, {}, {}};
-const auto cpuParams_ncdhw = CPUSpecificParams {{ncdhw}, {ncdhw}, {}, {}};
+const auto cpuParams_nchw = CPUSpecificParams{{nchw}, {nchw}, {}, {}};
+const auto cpuParams_ncdhw = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, {}};
 
-const std::vector<ElementType> inputPrecisions = {
-        ElementType::f32,
-        ElementType::bf16,
-        ElementType::i8
-};
+const std::vector<ElementType> inputPrecisions = {ElementType::f32, ElementType::bf16, ElementType::i8};
 
-const std::vector<std::vector<InputShape>> inputShapesDynamic2D = {
-    {
-        { // Origin dynamic shape
-            {-1, -1},
-            { // Dynamic shapes instances
-                {32, 20}, {16, 16}, {24, 16}
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            {-1, 16},
-            { // Dynamic shapes instances
-                {16, 16}, {20, 16}, {32, 16}
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            { {16, 32}, {16, 32} },
-            { // Dynamic shapes instances
-                {16, 32}, {32, 16}, {24, 24}
-            }
-        }
-    }
-};
+const std::vector<std::vector<InputShape>> inputShapesDynamic2D = {{{// Origin dynamic shape
+                                                                     {-1, -1},
+                                                                     {// Dynamic shapes instances
+                                                                      {32, 20},
+                                                                      {16, 16},
+                                                                      {24, 16}}}},
+                                                                   {{// Origin dynamic shape
+                                                                     {-1, 16},
+                                                                     {// Dynamic shapes instances
+                                                                      {16, 16},
+                                                                      {20, 16},
+                                                                      {32, 16}}}},
+                                                                   {{// Origin dynamic shape
+                                                                     {{16, 32}, {16, 32}},
+                                                                     {// Dynamic shapes instances
+                                                                      {16, 32},
+                                                                      {32, 16},
+                                                                      {24, 24}}}}};
 
-const std::vector<Slice8SpecificParams> paramsPlain2D = {
-        Slice8SpecificParams{ { 0, 10 }, { 16, 16 }, { 1, 1 }, { 0, 1 } },
-        Slice8SpecificParams{ { 2, 5 }, { 16, 8 }, { 1, 1 }, { } },
-        Slice8SpecificParams{ { 2, 5 }, { 16, 16 }, { 1, 2 }, { 0, 1 } },
-        Slice8SpecificParams{ { 0, 0 }, { 16, 16 }, { 1, 2 }, { 1, 0} },
-        Slice8SpecificParams{ { 0 }, { 16 }, { 2 }, { 0 } },
-        Slice8SpecificParams{ { 0 }, { 16 }, { 1 }, { 1 } }
-};
+const std::vector<Slice8SpecificParams> paramsPlain2D = {Slice8SpecificParams{{0, 10}, {16, 16}, {1, 1}, {0, 1}},
+                                                         Slice8SpecificParams{{2, 5}, {16, 8}, {1, 1}, {}},
+                                                         Slice8SpecificParams{{2, 5}, {16, 16}, {1, 2}, {0, 1}},
+                                                         Slice8SpecificParams{{0, 0}, {16, 16}, {1, 2}, {1, 0}},
+                                                         Slice8SpecificParams{{0}, {16}, {2}, {0}},
+                                                         Slice8SpecificParams{{0}, {16}, {1}, {1}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Static_2D, Slice8LayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(static_shapes_to_test_representation({{32, 20}})),
-                                ::testing::ValuesIn(paramsPlain2D),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::ValuesIn(inputPrecisions),
-                                ::testing::Values(emptyCPUSpec)),
-                        Slice8LayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Static_2D,
+                         Slice8LayerCPUTest,
+                         ::testing::Combine(::testing::Values(static_shapes_to_test_representation({{32, 20}})),
+                                            ::testing::ValuesIn(paramsPlain2D),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::Values(emptyCPUSpec)),
+                         Slice8LayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Dynamic_2D, Slice8LayerCPUTest,
-                        ::testing::Combine(
-                            ::testing::ValuesIn(inputShapesDynamic2D),
-                            ::testing::ValuesIn(paramsPlain2D),
-                            ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                            ::testing::ValuesIn(inputPrecisions),
-                            ::testing::Values(emptyCPUSpec)),
-                        Slice8LayerCPUTest::getTestCaseName);
-
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Dynamic_2D,
+                         Slice8LayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic2D),
+                                            ::testing::ValuesIn(paramsPlain2D),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::Values(emptyCPUSpec)),
+                         Slice8LayerCPUTest::getTestCaseName);
 
 const std::vector<Slice8SpecificParams> testCasesCommon4D = {
-        Slice8SpecificParams{ { 0, 2, 5, 4 }, { 1, 4, 28, 27 }, { 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 1, 0, 0 }, { 20, 3, 32, 1 }, { 1, 1, 1, 1 }, { 3, 1, 2, 0 } },
-        Slice8SpecificParams{ { 0, 0, 10, 0 }, { 1, 3, 20, 20 }, { 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 20, 20 }, { 1, 5, 26, 25 }, { 1, 1, 2, 1 }, { 0, 1, 3, 2 } },
-        Slice8SpecificParams{ { 0, 0, 0, 20 }, { 1, 2, 30, 30 }, { 1, 1, 2, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 2, 10 }, { 1, 3, 32, 20 }, { 1, 1, 1, 1 }, { 0, 1, 2, 3 } },
-        Slice8SpecificParams{ { 0, 1, 0, 10 }, { 1, 5, 32, 30 }, { 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 1, 2, 10 }, { 1, 5, 32, 18 }, { 1, 1, 1, 2 }, { 0, 1, 2, 3 } },
-        Slice8SpecificParams{ { 0, 0, 2, 10 }, { 1, 8, 32, 18 }, { 1, 2, 1, 2 },  { } },
-        Slice8SpecificParams{ { 0, 0, 10 }, { 2, 32, 18 }, { 1, 1, 1 }, { 1, 2, 3 } },
-        Slice8SpecificParams{ { 0, 10 }, { 2, 32 }, { 1, 1 }, { 1, 3 } }
-};
+    Slice8SpecificParams{{0, 2, 5, 4}, {1, 4, 28, 27}, {1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 1, 0, 0}, {20, 3, 32, 1}, {1, 1, 1, 1}, {3, 1, 2, 0}},
+    Slice8SpecificParams{{0, 0, 10, 0}, {1, 3, 20, 20}, {1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 20, 20}, {1, 5, 26, 25}, {1, 1, 2, 1}, {0, 1, 3, 2}},
+    Slice8SpecificParams{{0, 0, 0, 20}, {1, 2, 30, 30}, {1, 1, 2, 1}, {}},
+    Slice8SpecificParams{{0, 0, 2, 10}, {1, 3, 32, 20}, {1, 1, 1, 1}, {0, 1, 2, 3}},
+    Slice8SpecificParams{{0, 1, 0, 10}, {1, 5, 32, 30}, {1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 1, 2, 10}, {1, 5, 32, 18}, {1, 1, 1, 2}, {0, 1, 2, 3}},
+    Slice8SpecificParams{{0, 0, 2, 10}, {1, 8, 32, 18}, {1, 2, 1, 2}, {}},
+    Slice8SpecificParams{{0, 0, 10}, {2, 32, 18}, {1, 1, 1}, {1, 2, 3}},
+    Slice8SpecificParams{{0, 10}, {2, 32}, {1, 1}, {1, 3}}};
 
-const std::vector<std::vector<ov::Shape>> inputShapesStatic4D = {
-    {{ 1, 5, 32, 32 }}, {{ 2, 5, 32, 48 }}
-};
+const std::vector<std::vector<ov::Shape>> inputShapesStatic4D = {{{1, 5, 32, 32}}, {{2, 5, 32, 48}}};
 
-const std::vector<std::vector<InputShape>> inputShapesDynamic4D = {
-    {
-        { // Origin dynamic shape
-            {-1, -1, -1, -1},
-            { // Dynamic shapes instances
-                { 1, 5, 32, 32 }, { 2, 5, 32, 32 }, { 1, 5, 64, 64 }
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            {-1, 5, -1, -1},
-            { // Dynamic shapes instances
-                { 1, 5, 32, 32 }, { 2, 5, 32, 32 }, { 3, 5, 32, 36 }
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            {{1, 5}, 5, {32, 64}, {32, 64}},
-            { // Dynamic shapes instances
-                { 2, 5, 32, 32 }, { 1, 5, 48, 32 }, { 5, 5, 32, 32 }
-            }
-        }
-    }
-};
+const std::vector<std::vector<InputShape>> inputShapesDynamic4D = {{{// Origin dynamic shape
+                                                                     {-1, -1, -1, -1},
+                                                                     {// Dynamic shapes instances
+                                                                      {1, 5, 32, 32},
+                                                                      {2, 5, 32, 32},
+                                                                      {1, 5, 64, 64}}}},
+                                                                   {{// Origin dynamic shape
+                                                                     {-1, 5, -1, -1},
+                                                                     {// Dynamic shapes instances
+                                                                      {1, 5, 32, 32},
+                                                                      {2, 5, 32, 32},
+                                                                      {3, 5, 32, 36}}}},
+                                                                   {{// Origin dynamic shape
+                                                                     {{1, 5}, 5, {32, 64}, {32, 64}},
+                                                                     {// Dynamic shapes instances
+                                                                      {2, 5, 32, 32},
+                                                                      {1, 5, 48, 32},
+                                                                      {5, 5, 32, 32}}}}};
 
 const std::vector<CPUSpecificParams> CPUParamsCommon4D = {
-        cpuParams_nchw,
-        cpuParams_nhwc,
+    cpuParams_nchw,
+    cpuParams_nhwc,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_4D, Slice8LayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic4D)),
-                                ::testing::ValuesIn(testCasesCommon4D),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::ValuesIn(inputPrecisions),
-                                ::testing::ValuesIn(CPUParamsCommon4D)),
-                        Slice8LayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_4D,
+    Slice8LayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic4D)),
+                       ::testing::ValuesIn(testCasesCommon4D),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsCommon4D)),
+    Slice8LayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D, Slice8LayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapesDynamic4D),
-                                ::testing::ValuesIn(testCasesCommon4D),
-                                ::testing::ValuesIn(inputLayerTypes),
-                                ::testing::ValuesIn(inputPrecisions),
-                                ::testing::ValuesIn(CPUParamsCommon4D)),
-                        Slice8LayerCPUTest::getTestCaseName);
-
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D,
+                         Slice8LayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic4D),
+                                            ::testing::ValuesIn(testCasesCommon4D),
+                                            ::testing::ValuesIn(inputLayerTypes),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsCommon4D)),
+                         Slice8LayerCPUTest::getTestCaseName);
 
 const std::vector<Slice8SpecificParams> testCasesBlocked4DSubset1 = {
-        Slice8SpecificParams{ { 0, 0, 0, 0 }, { 1, 32, 32, 32 }, { 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 16, 0 }, { 1, 32, 32, 32 }, { 1, 1, 1, 1 }, { 0, 3, 2, 1 } },
-        Slice8SpecificParams{ { 0, 0, 0 }, { 32, 32, 16 }, { 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 0 }, { 16, 32, 32 }, { 1, 1, 1 }, { 1, 3, 2 } },
+    Slice8SpecificParams{{0, 0, 0, 0}, {1, 32, 32, 32}, {1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 16, 0}, {1, 32, 32, 32}, {1, 1, 1, 1}, {0, 3, 2, 1}},
+    Slice8SpecificParams{{0, 0, 0}, {32, 32, 16}, {1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 0}, {16, 32, 32}, {1, 1, 1}, {1, 3, 2}},
 };
 
 const std::vector<Slice8SpecificParams> testCasesBlocked4DSubset2 = {
-       Slice8SpecificParams{ { 0, 0, 5, 4 }, { 1, 16, 28, 27 }, { 1, 1, 1, 1 }, { 0, 1, 2, 3 } },
-       Slice8SpecificParams{ { 0, 16, 0, 0 }, { 1, 32, 10, 10 }, { 1, 1, 1, 1 }, { } },
-       Slice8SpecificParams{ { 0, 0, 10, 0 }, { 16, 1, 20, 10 }, { 1, 1, 1, 1 }, { 1, 0, 2, 3 } },
-       Slice8SpecificParams{ { 0, 0, 20, 20 }, { 1, 32, 25, 25 }, { 1, 1, 1, 1 }, { 0, 1, 3, 2 } },
-       Slice8SpecificParams{ { 0, 16, 0, 20 }, { 32, 32, 1, 30 }, { 1, 1, 1, 2 }, { 2, 1, 0, 3 } },
-       Slice8SpecificParams{ { 0, 16, 2, 10 }, { 1, 32, 32, 20 }, { 1, 1, 2, 1 }, { 0, 1, 2, 3 } },
-       Slice8SpecificParams{ { 0, 16, 0, 0 }, { 2, 64, 32, 20 }, { 1, 1, 1, 1 }, { 0, 1, 2, 3 } },
-       Slice8SpecificParams{ { 0, 32, 0, 0 }, { 2, 50, 32, 20 }, { 1, 1, 1, 1 }, { } },
-       Slice8SpecificParams{ { 0, 0, 0, 0 }, { 32, 12, 2, 20 }, { 1, 1, 1, 1 }, { 0, 3, 2, 1 } },
-       Slice8SpecificParams{ { 0, -16, 0, 10 }, { 2, 100, 32, 20 }, { 1, 1, 1, 1 }, { } },
-       Slice8SpecificParams{ { 0, -16, 0, 0 }, { 2, -4, 32, 20 }, { 1, 1, 1, 1 }, { } },
-       Slice8SpecificParams{ { 0, -32, 0, 0 }, { 2, -12, 32, 20 }, { 1, 1, 1, 1 }, { } }
-};
+    Slice8SpecificParams{{0, 0, 5, 4}, {1, 16, 28, 27}, {1, 1, 1, 1}, {0, 1, 2, 3}},
+    Slice8SpecificParams{{0, 16, 0, 0}, {1, 32, 10, 10}, {1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 10, 0}, {16, 1, 20, 10}, {1, 1, 1, 1}, {1, 0, 2, 3}},
+    Slice8SpecificParams{{0, 0, 20, 20}, {1, 32, 25, 25}, {1, 1, 1, 1}, {0, 1, 3, 2}},
+    Slice8SpecificParams{{0, 16, 0, 20}, {32, 32, 1, 30}, {1, 1, 1, 2}, {2, 1, 0, 3}},
+    Slice8SpecificParams{{0, 16, 2, 10}, {1, 32, 32, 20}, {1, 1, 2, 1}, {0, 1, 2, 3}},
+    Slice8SpecificParams{{0, 16, 0, 0}, {2, 64, 32, 20}, {1, 1, 1, 1}, {0, 1, 2, 3}},
+    Slice8SpecificParams{{0, 32, 0, 0}, {2, 50, 32, 20}, {1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 0, 0}, {32, 12, 2, 20}, {1, 1, 1, 1}, {0, 3, 2, 1}},
+    Slice8SpecificParams{{0, -16, 0, 10}, {2, 100, 32, 20}, {1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, -16, 0, 0}, {2, -4, 32, 20}, {1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, -32, 0, 0}, {2, -12, 32, 20}, {1, 1, 1, 1}, {}}};
 
-const std::vector<std::vector<ov::Shape>> inputShapesBlockedStatic4DSubset1 = {
-    {{ 1, 32, 32, 32 }}, {{ 1, 32, 32, 64 }}
-};
+const std::vector<std::vector<ov::Shape>> inputShapesBlockedStatic4DSubset1 = {{{1, 32, 32, 32}}, {{1, 32, 32, 64}}};
 
-const std::vector<std::vector<ov::Shape>> inputShapesBlockedStatic4DSubset2 = {
-    {{ 1, 64, 32, 32 }}, {{ 1, 64, 32, 64 }}
-};
+const std::vector<std::vector<ov::Shape>> inputShapesBlockedStatic4DSubset2 = {{{1, 64, 32, 32}}, {{1, 64, 32, 64}}};
 
-const std::vector<std::vector<InputShape>> inputShapesBlockedDynamic4DSubset1 = {
-    {
-        { // Origin dynamic shape
-            {-1, 32, -1, -1},
-            { // Dynamic shapes instances
-                { 1, 32, 32, 32 }, { 2, 32, 32, 32 }, { 3, 32, 32, 48 }
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            {{1, 5}, 32, {32, 64}, {32, 64}},
-            { // Dynamic shapes instances
-                { 2, 32, 32, 32 }, { 1, 32, 48, 32 }, { 5, 32, 32, 48 }
-            }
-        }
-    }
-};
+const std::vector<std::vector<InputShape>> inputShapesBlockedDynamic4DSubset1 = {{{// Origin dynamic shape
+                                                                                   {-1, 32, -1, -1},
+                                                                                   {// Dynamic shapes instances
+                                                                                    {1, 32, 32, 32},
+                                                                                    {2, 32, 32, 32},
+                                                                                    {3, 32, 32, 48}}}},
+                                                                                 {{// Origin dynamic shape
+                                                                                   {{1, 5}, 32, {32, 64}, {32, 64}},
+                                                                                   {// Dynamic shapes instances
+                                                                                    {2, 32, 32, 32},
+                                                                                    {1, 32, 48, 32},
+                                                                                    {5, 32, 32, 48}}}}};
 
-const std::vector<std::vector<InputShape>> inputShapesBlockedDynamic4DSubset2 = {
-    {
-        { // Origin dynamic shape
-            {-1, 64, -1, -1},
-            { // Dynamic shapes instances
-                { 1, 64, 64, 32 }, { 2, 64, 32, 32 }, { 3, 64, 32, 48 }
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            {{1, 5}, 64, {32, 64}, {32, 64}},
-            { // Dynamic shapes instances
-                { 2, 64, 32, 32 }, { 1, 64, 48, 32 }, { 1, 64, 64, 64 }
-            }
-        }
-    }
-};
+const std::vector<std::vector<InputShape>> inputShapesBlockedDynamic4DSubset2 = {{{// Origin dynamic shape
+                                                                                   {-1, 64, -1, -1},
+                                                                                   {// Dynamic shapes instances
+                                                                                    {1, 64, 64, 32},
+                                                                                    {2, 64, 32, 32},
+                                                                                    {3, 64, 32, 48}}}},
+                                                                                 {{// Origin dynamic shape
+                                                                                   {{1, 5}, 64, {32, 64}, {32, 64}},
+                                                                                   {// Dynamic shapes instances
+                                                                                    {2, 64, 32, 32},
+                                                                                    {1, 64, 48, 32},
+                                                                                    {1, 64, 64, 64}}}}};
 
 const std::vector<CPUSpecificParams> CPUParamsBlocked4D = {
-        cpuParams_nChw16c,
-        cpuParams_nChw8c,
+    cpuParams_nChw16c,
+    cpuParams_nChw8c,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_4D_Subset1, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset1)),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset1),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_4D_Subset1,
+    Slice8LayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset1)),
+                       ::testing::ValuesIn(testCasesBlocked4DSubset1),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsBlocked4D)),
+    Slice8LayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D_Subset1,
+                         Slice8LayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesBlockedDynamic4DSubset1),
+                                            ::testing::ValuesIn(testCasesBlocked4DSubset1),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsBlocked4D)),
                          Slice8LayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D_Subset1, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesBlockedDynamic4DSubset1),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset1),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
-                         Slice8LayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_4D_Subset2,
+    Slice8LayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset2)),
+                       ::testing::ValuesIn(testCasesBlocked4DSubset2),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsBlocked4D)),
+    Slice8LayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_4D_Subset2, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset2)),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset2),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D_Subset2,
+                         Slice8LayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesBlockedDynamic4DSubset2),
+                                            ::testing::ValuesIn(testCasesBlocked4DSubset2),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsBlocked4D)),
                          Slice8LayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D_Subset2, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesBlockedDynamic4DSubset2),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset2),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
-                         Slice8LayerCPUTest::getTestCaseName);
-
 
 const std::vector<Slice8SpecificParams> testCasesCommon5D = {
-        Slice8SpecificParams{ { 0, 2, 0, 5, 4 }, { 1, 4, 5, 28, 27 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 10, 0, 0 }, { 1, 5, 20, 32, 20 }, { 1, 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 1, 10, 0, 0 }, { 20, 3, 20, 32, 1 }, { 1, 1, 1, 1, 1 }, { 4, 1, 2, 3, 0 } },
-        Slice8SpecificParams{ { 0, 20, 0, 0, 20 }, { 1, 30, 20, 5, 26 }, { 1, 1, 1, 2, 2 }, { 0, 3, 2, 1, 4 } },
-        Slice8SpecificParams{ { 0, 0, 10, 0, 20 }, { 1, 2, 20, 30, 30 }, { 1, 1, 2, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 2, 10, 0 }, { 1, 5, 10, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 1, 0, 10, 0 }, { 1, 5, 20, 32, 32 }, { 1, 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 0, 0, 0 }, { 1, 5, 10, 16, 16 }, { 1, 1, 2, 1, 1 }, { 0, 1, 2, 3, 4 } }
-};
+    Slice8SpecificParams{{0, 2, 0, 5, 4}, {1, 4, 5, 28, 27}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 0, 10, 0, 0}, {1, 5, 20, 32, 20}, {1, 1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 1, 10, 0, 0}, {20, 3, 20, 32, 1}, {1, 1, 1, 1, 1}, {4, 1, 2, 3, 0}},
+    Slice8SpecificParams{{0, 20, 0, 0, 20}, {1, 30, 20, 5, 26}, {1, 1, 1, 2, 2}, {0, 3, 2, 1, 4}},
+    Slice8SpecificParams{{0, 0, 10, 0, 20}, {1, 2, 20, 30, 30}, {1, 1, 2, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 2, 10, 0}, {1, 5, 10, 32, 20}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 1, 0, 10, 0}, {1, 5, 20, 32, 32}, {1, 1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 0, 0, 0}, {1, 5, 10, 16, 16}, {1, 1, 2, 1, 1}, {0, 1, 2, 3, 4}}};
 
-const std::vector<std::vector<ov::Shape>> inputShapesStatic5D = {
-    {{ 1, 5, 20, 32, 32 }}, {{ 2, 5, 32, 32, 32 }}
-};
+const std::vector<std::vector<ov::Shape>> inputShapesStatic5D = {{{1, 5, 20, 32, 32}}, {{2, 5, 32, 32, 32}}};
 
-const std::vector<std::vector<InputShape>> inputShapesDynamic5D = {
-    {
-        { // Origin dynamic shape
-            {-1, -1, -1, -1, -1},
-            { // Dynamic shapes instances
-                { 1, 5, 32, 32, 32 }, { 1, 5, 32, 32, 48 }, { 1, 5, 64, 64, 64 }, { 1, 10, 32, 32, 32 }
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            {-1, 5, -1, -1, -1},
-            { // Dynamic shapes instances
-                { 1, 5, 32, 32, 48 }, { 1, 5, 32, 48, 32 }, { 1, 5, 48, 32, 32 }
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            {{1, 5}, 5, {32, 64}, {32, 64}, {32, 64}},
-            { // Dynamic shapes instances
-                { 2, 5, 32, 32, 32 }, { 1, 5, 48, 32, 32 }, { 5, 5, 32, 32, 48 }
-            }
-        }
-    }
-};
+const std::vector<std::vector<InputShape>> inputShapesDynamic5D = {{{// Origin dynamic shape
+                                                                     {-1, -1, -1, -1, -1},
+                                                                     {// Dynamic shapes instances
+                                                                      {1, 5, 32, 32, 32},
+                                                                      {1, 5, 32, 32, 48},
+                                                                      {1, 5, 64, 64, 64},
+                                                                      {1, 10, 32, 32, 32}}}},
+                                                                   {{// Origin dynamic shape
+                                                                     {-1, 5, -1, -1, -1},
+                                                                     {// Dynamic shapes instances
+                                                                      {1, 5, 32, 32, 48},
+                                                                      {1, 5, 32, 48, 32},
+                                                                      {1, 5, 48, 32, 32}}}},
+                                                                   {{// Origin dynamic shape
+                                                                     {{1, 5}, 5, {32, 64}, {32, 64}, {32, 64}},
+                                                                     {// Dynamic shapes instances
+                                                                      {2, 5, 32, 32, 32},
+                                                                      {1, 5, 48, 32, 32},
+                                                                      {5, 5, 32, 32, 48}}}}};
 
 const std::vector<CPUSpecificParams> CPUParamsCommon5D = {
-        cpuParams_ncdhw,
-        cpuParams_ndhwc,
+    cpuParams_ncdhw,
+    cpuParams_ndhwc,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_5D, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic5D)),
-                                 ::testing::ValuesIn(testCasesCommon5D),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsCommon5D)),
-                        Slice8LayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_5D,
+    Slice8LayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic5D)),
+                       ::testing::ValuesIn(testCasesCommon5D),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsCommon5D)),
+    Slice8LayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesDynamic5D),
-                                 ::testing::ValuesIn(testCasesCommon5D),
-                                 ::testing::ValuesIn(inputLayerTypes),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsCommon5D)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D,
+                         Slice8LayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic5D),
+                                            ::testing::ValuesIn(testCasesCommon5D),
+                                            ::testing::ValuesIn(inputLayerTypes),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsCommon5D)),
                          Slice8LayerCPUTest::getTestCaseName);
 
 const std::vector<Slice8SpecificParams> testCasesBlocked5DSubset1 = {
-        Slice8SpecificParams{ { 0, 0, 0, 5, 4 }, { 1, 16, 5, 28, 27 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 10, 0, 0 }, { 1, 16, 20, 32, 20 }, { 1, 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 0, 20, 20 }, { 16, 1, 20, 26, 30 }, { 1, 1, 1, 2, 2 }, { 1, 0, 2, 4, 3 } },
-        Slice8SpecificParams{ { 0, 0, 10, 0, 20 }, { 1, 16, 20, 30, 30 }, { 1, 1, 2, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 2, 10, 0 }, { 1, 16, 10, 32, 20 }, { 1, 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 0, 10, 0 }, { 1, 8, 20, 32, 32 }, { 1, 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 0, 0, 0, 0 }, { 1, 16, 10, 16, 16 }, { 1, 1, 2, 1, 1 }, { 0, 1, 2, 3, 4 } },
+    Slice8SpecificParams{{0, 0, 0, 5, 4}, {1, 16, 5, 28, 27}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 0, 10, 0, 0}, {1, 16, 20, 32, 20}, {1, 1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 0, 20, 20}, {16, 1, 20, 26, 30}, {1, 1, 1, 2, 2}, {1, 0, 2, 4, 3}},
+    Slice8SpecificParams{{0, 0, 10, 0, 20}, {1, 16, 20, 30, 30}, {1, 1, 2, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 2, 10, 0}, {1, 16, 10, 32, 20}, {1, 1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 0, 10, 0}, {1, 8, 20, 32, 32}, {1, 1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 0, 0, 0, 0}, {1, 16, 10, 16, 16}, {1, 1, 2, 1, 1}, {0, 1, 2, 3, 4}},
 };
 
 const std::vector<Slice8SpecificParams> testCasesBlocked5DSubset2 = {
-        Slice8SpecificParams{ { 0, 0, 0, 5, 4 }, { 1, 16, 5, 28, 27 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 5, 4 }, { 16, 5, 28, 27 }, { 1, 1, 1, 1 }, { 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 10, 0, 0 }, { 1, 16, 20, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 0, 20, 20 }, { 1, 20, 16, 30, 26 }, { 1, 1, 1, 2, 2 }, { 0, 2, 1, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 10, 0, 20 }, { 1, 16, 20, 30, 30 }, { 1, 1, 2, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 2, 10, 0 }, { 1, 16, 10, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 0, 10, 0 }, { 1, 8, 20, 32, 32 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 0, 0, 0 }, { 10, 16, 1, 16, 16 }, { 2, 1, 1, 1, 1 }, { 2, 1, 0, 3, 4 } },
-        Slice8SpecificParams{ { 0, 0, 0, 0, 0 }, { 1, 25, 20, 10, 10 }, { 1, 1, 1, 1, 1 }, { } },
-        Slice8SpecificParams{ { 0, 16, 0, 0, 0 }, { 1, 25, 20, 10, 10 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
-        Slice8SpecificParams{ { 0, 16, 0, 0, 0 }, { 1, 64, 20, 10, 10 }, { 1, 1, 1, 1, 1 }, { 0, 1, 2, 3, 4 } },
+    Slice8SpecificParams{{0, 0, 0, 5, 4}, {1, 16, 5, 28, 27}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 0, 5, 4}, {16, 5, 28, 27}, {1, 1, 1, 1}, {1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 0, 10, 0, 0}, {1, 16, 20, 32, 20}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 0, 0, 20, 20}, {1, 20, 16, 30, 26}, {1, 1, 1, 2, 2}, {0, 2, 1, 3, 4}},
+    Slice8SpecificParams{{0, 0, 10, 0, 20}, {1, 16, 20, 30, 30}, {1, 1, 2, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 0, 2, 10, 0}, {1, 16, 10, 32, 20}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 0, 0, 10, 0}, {1, 8, 20, 32, 32}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 0, 0, 0, 0}, {10, 16, 1, 16, 16}, {2, 1, 1, 1, 1}, {2, 1, 0, 3, 4}},
+    Slice8SpecificParams{{0, 0, 0, 0, 0}, {1, 25, 20, 10, 10}, {1, 1, 1, 1, 1}, {}},
+    Slice8SpecificParams{{0, 16, 0, 0, 0}, {1, 25, 20, 10, 10}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
+    Slice8SpecificParams{{0, 16, 0, 0, 0}, {1, 64, 20, 10, 10}, {1, 1, 1, 1, 1}, {0, 1, 2, 3, 4}},
 };
 
-const std::vector<std::vector<ov::Shape>> inputShapesBlockedStatic5DSubset1 = {
-    {{ 1, 16, 32, 32, 32 }}, {{ 2, 16, 32, 32, 32 }}, {{ 2, 32, 32, 32, 32 }}
-};
+const std::vector<std::vector<ov::Shape>> inputShapesBlockedStatic5DSubset1 = {{{1, 16, 32, 32, 32}},
+                                                                               {{2, 16, 32, 32, 32}},
+                                                                               {{2, 32, 32, 32, 32}}};
 
-const std::vector<std::vector<ov::Shape>> inputShapesBlockedStatic5DSubset2 = {
-    {{ 1, 64, 32, 32, 32 }}, {{ 2, 64, 32, 64, 32 }}, {{ 2, 64, 32, 32, 32 }}
-};
+const std::vector<std::vector<ov::Shape>> inputShapesBlockedStatic5DSubset2 = {{{1, 64, 32, 32, 32}},
+                                                                               {{2, 64, 32, 64, 32}},
+                                                                               {{2, 64, 32, 32, 32}}};
 
 const std::vector<std::vector<InputShape>> inputShapesBlockedDynamic5DSubset1 = {
-    {
-        { // Origin dynamic shape
-            {-1, 16, -1, -1, -1},
-            { // Dynamic shapes instances
-                { 1, 16, 32, 32, 32 }, { 2, 16, 32, 32, 32 }, { 2, 16, 32, 32, 32 }
-            }
-        }
-    },
-    {
-        { // Origin dynamic shape
-            {{1, 5}, 16, {16, 32}, {16, 32}, {16, 32}},
-            { // Dynamic shapes instances
-                { 1, 16, 32, 32, 32 }, { 2, 16, 32, 32, 32 }, { 1, 16, 20, 32, 32 }
-            }
-        }
-    }
-};
+    {{// Origin dynamic shape
+      {-1, 16, -1, -1, -1},
+      {// Dynamic shapes instances
+       {1, 16, 32, 32, 32},
+       {2, 16, 32, 32, 32},
+       {2, 16, 32, 32, 32}}}},
+    {{// Origin dynamic shape
+      {{1, 5}, 16, {16, 32}, {16, 32}, {16, 32}},
+      {// Dynamic shapes instances
+       {1, 16, 32, 32, 32},
+       {2, 16, 32, 32, 32},
+       {1, 16, 20, 32, 32}}}}};
 
 const std::vector<std::vector<InputShape>> inputShapesBlockedDynamic5DSubset2 = {
     {
-        { // Origin dynamic shape
-            {-1, 64, -1, -1, -1},
-            { // Dynamic shapes instances
-                { 1, 64, 64, 32, 32 }, { 2, 64, 32, 32, 32 }, { 3, 64, 32, 48, 32 }
-            }
-        },
+        {// Origin dynamic shape
+         {-1, 64, -1, -1, -1},
+         {// Dynamic shapes instances
+          {1, 64, 64, 32, 32},
+          {2, 64, 32, 32, 32},
+          {3, 64, 32, 48, 32}}},
     },
-    {
-        { // Origin dynamic shape
-            {{1, 5}, 64, {16, 32}, {16, 32}, {16, 32}},
-            { // Dynamic shapes instances
-                { 1, 64, 32, 32, 32 }, { 2, 64, 32, 32, 32 }, { 1, 64, 20, 32, 32 }
-            }
-        }
-    }
-};
+    {{// Origin dynamic shape
+      {{1, 5}, 64, {16, 32}, {16, 32}, {16, 32}},
+      {// Dynamic shapes instances
+       {1, 64, 32, 32, 32},
+       {2, 64, 32, 32, 32},
+       {1, 64, 20, 32, 32}}}}};
 
 const std::vector<CPUSpecificParams> CPUParamsBlocked5D = {
-        cpuParams_nCdhw16c,
-        cpuParams_nCdhw8c,
+    cpuParams_nCdhw16c,
+    cpuParams_nCdhw8c,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_5D_Subset1, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic5DSubset1)),
-                                 ::testing::ValuesIn(testCasesBlocked5DSubset1),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked5D)),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_5D_Subset1,
+    Slice8LayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic5DSubset1)),
+                       ::testing::ValuesIn(testCasesBlocked5DSubset1),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsBlocked5D)),
+    Slice8LayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset1,
+                         Slice8LayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesBlockedDynamic5DSubset1),
+                                            ::testing::ValuesIn(testCasesBlocked5DSubset1),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsBlocked5D)),
                          Slice8LayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset1, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesBlockedDynamic5DSubset1),
-                                 ::testing::ValuesIn(testCasesBlocked5DSubset1),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked5D)),
-                         Slice8LayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_5D_Subset2,
+    Slice8LayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset2)),
+                       ::testing::ValuesIn(testCasesBlocked4DSubset2),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsBlocked4D)),
+    Slice8LayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_5D_Subset2, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset2)),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset2),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
-                         Slice8LayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset2, Slice8LayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesBlockedDynamic5DSubset2),
-                                 ::testing::ValuesIn(testCasesBlocked5DSubset2),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked5D)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset2,
+                         Slice8LayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesBlockedDynamic5DSubset2),
+                                            ::testing::ValuesIn(testCasesBlocked5DSubset2),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsBlocked5D)),
                          Slice8LayerCPUTest::getTestCaseName);
 
 /* Descriptors check */
@@ -597,44 +552,29 @@ TEST_P(Slice8LayerDescriptorCPUTest, DescriptorsCheck) {
 }
 
 const std::vector<Slice8SpecificParams> testCasesDescriptors = {
-        Slice8SpecificParams{ { 0, -4, 0, 0 }, { 0, 2147483647, 0, 0 }, { 1, 1, 1, 1 }, { 0, 1, 2, 3 } },
-        Slice8SpecificParams{ { 0, 5, 0, 0 }, { 1, 20, 28, 27 }, { 1, 1, 1, 1 }, { 0, 1, 2, 3 } },
-        Slice8SpecificParams{ { 0, 0, 0, 0 }, { 1, 2147483647, 32, 32 }, { 1, 2, 1, 1 }, { 0, 1, 2, 3 } }
-};
+    Slice8SpecificParams{{0, -4, 0, 0}, {0, 2147483647, 0, 0}, {1, 1, 1, 1}, {0, 1, 2, 3}},
+    Slice8SpecificParams{{0, 5, 0, 0}, {1, 20, 28, 27}, {1, 1, 1, 1}, {0, 1, 2, 3}},
+    Slice8SpecificParams{{0, 0, 0, 0}, {1, 2147483647, 32, 32}, {1, 2, 1, 1}, {0, 1, 2, 3}}};
 
-const std::vector<std::vector<InputShape>> inputShapesDescriptors = {
-    {
-        { {},
-            { // Static shapes
-                { 1, 16, 32, 32 }
-            }
-        }
-    },
-    {
-        { {},
-            { // Static shapes
-                { 1, 17, 32, 32 }
-            }
-        }
-    },
-    {
-        { // Origin dynamic shapes
-            {1, -1, 32, 32},
-            { // Dynamic shapes instances
-                { 1, 16, 32, 32 }, { 1, 32, 32, 32 }
-            }
-        }
-    }
-};
+const std::vector<std::vector<InputShape>> inputShapesDescriptors = {{{{},
+                                                                       {// Static shapes
+                                                                        {1, 16, 32, 32}}}},
+                                                                     {{{},
+                                                                       {// Static shapes
+                                                                        {1, 17, 32, 32}}}},
+                                                                     {{// Origin dynamic shapes
+                                                                       {1, -1, 32, 32},
+                                                                       {// Dynamic shapes instances
+                                                                        {1, 16, 32, 32},
+                                                                        {1, 32, 32, 32}}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_Slice8LayerDescriptorCPUTest, Slice8LayerDescriptorCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesDescriptors),
-                                 ::testing::ValuesIn(testCasesDescriptors),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::Values(ElementType::f32),
-                                 ::testing::Values(cpuParams_nChw8c)),
+INSTANTIATE_TEST_SUITE_P(smoke_Slice8LayerDescriptorCPUTest,
+                         Slice8LayerDescriptorCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDescriptors),
+                                            ::testing::ValuesIn(testCasesDescriptors),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::Values(cpuParams_nChw8c)),
                          Slice8LayerDescriptorCPUTest::getTestCaseName);
 
-} // namespace
-} // namespace CPULayerTestsDefinitions
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_batch.cpp
@@ -2,42 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <common_test_utils/ov_tensor_utils.hpp>
-#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "ov_models/builders.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
-using namespace ov::test;
 
-namespace CPULayerTestsDefinitions  {
+namespace ov {
+namespace test {
 
 namespace {
-    std::vector<int64_t> blockShape, padsBegin, padsEnd;
-    ov::Shape paramShape;
+std::vector<int64_t> blockShape, padsBegin, padsEnd;
+ov::Shape paramShape;
 }  // namespace
 
-using SpaceToBatchLayerTestCPUParams = std::tuple<
-        std::vector<InputShape>,            // Input shapes
-        std::vector<int64_t>,               // block shape
-        std::vector<int64_t>,               // pads begin
-        std::vector<int64_t>,               // pads end
-        Precision ,                         // Network precision
-        CPUSpecificParams>;
+using SpaceToBatchLayerTestCPUParams = std::tuple<std::vector<InputShape>,  // Input shapes
+                                                  std::vector<int64_t>,     // block shape
+                                                  std::vector<int64_t>,     // pads begin
+                                                  std::vector<int64_t>,     // pads end
+                                                  ov::element::Type,        // Network type
+                                                  CPUSpecificParams>;
 
 class SpaceToBatchCPULayerTest : public testing::WithParamInterface<SpaceToBatchLayerTestCPUParams>,
-                                 virtual public SubgraphBaseTest, public CPUTestsBase {
+                                 virtual public SubgraphBaseTest,
+                                 public CPUTestsBase {
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<SpaceToBatchLayerTestCPUParams> &obj) {
+    static std::string getTestCaseName(const testing::TestParamInfo<SpaceToBatchLayerTestCPUParams>& obj) {
         std::vector<InputShape> inputShapes;
-        Precision netPrecision;
+        ov::element::Type netPrecision;
         CPUSpecificParams cpuParams;
         std::tie(inputShapes, blockShape, padsBegin, padsEnd, netPrecision, cpuParams) = obj.param;
         std::ostringstream result;
         if (inputShapes.front().first.size() != 0) {
             result << "IS=(";
-            for (const auto &shape : inputShapes) {
+            for (const auto& shape : inputShapes) {
                 result << ov::test::utils::partialShape2str({shape.first}) << "_";
             }
             result.seekp(-1, result.cur);
@@ -52,7 +51,7 @@ public:
         result << "blockShape=" << ov::test::utils::vec2str(blockShape) << "_";
         result << "padsBegin=" << ov::test::utils::vec2str(padsBegin) << "_";
         result << "padsEnd=" << ov::test::utils::vec2str(padsEnd) << "_";
-        result << "netPRC=" << netPrecision.name() << "_";
+        result << "netPRC=" << netPrecision.get_type_name() << "_";
         result << CPUTestsBase::getTestCaseName(cpuParams);
         return result.str();
     }
@@ -64,22 +63,26 @@ public:
             const auto& funcInput = funcInputs[i];
             ov::Tensor tensor;
             if (i == 0U) {
-                tensor = utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 2560, 0, 256);
+                tensor = utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                       targetInputStaticShapes[i],
+                                                       2560,
+                                                       0,
+                                                       256);
             } else if (i == 1U) {
                 tensor = ov::Tensor(funcInput.get_element_type(), paramShape);
-                auto *dataPtr = tensor.data<int64_t>();
+                auto* dataPtr = tensor.data<int64_t>();
                 for (size_t j = 0; j < blockShape.size(); j++) {
                     dataPtr[j] = blockShape[j];
                 }
             } else if (i == 2U) {
                 tensor = ov::Tensor(funcInput.get_element_type(), paramShape);
-                auto *dataPtr = tensor.data<int64_t>();
+                auto* dataPtr = tensor.data<int64_t>();
                 for (size_t j = 0; j < padsBegin.size(); j++) {
                     dataPtr[j] = padsBegin[j];
                 }
             } else if (i == 3U) {
                 tensor = ov::Tensor(funcInput.get_element_type(), paramShape);
-                auto *dataPtr = tensor.data<int64_t>();
+                auto* dataPtr = tensor.data<int64_t>();
                 for (size_t j = 0; j < padsEnd.size(); j++) {
                     dataPtr[j] = padsEnd[j];
                 }
@@ -92,21 +95,20 @@ protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
         std::vector<InputShape> inputShapes;
-        Precision netPrecision;
+        ov::element::Type netPrecision;
         CPUSpecificParams cpuParams;
         std::tie(inputShapes, blockShape, padsBegin, padsEnd, netPrecision, cpuParams) = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
-        auto ngPrec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         const std::vector<InputShape> inputShapesVec{inputShapes};
         init_input_shapes(inputShapesVec);
 
-        if (strcmp(netPrecision.name(), "U8") == 0)
-            selectedType = std::string("ref_any_") + "I8";
+        if (strcmp(netPrecision.get_type_name().c_str(), "u8") == 0)
+            selectedType = std::string("ref_any_") + "i8";
         else
-            selectedType = std::string("ref_any_") + netPrecision.name();
+            selectedType = std::string("ref_any_") + netPrecision.get_type_name();
 
-        ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ngPrec, inputDynamicShapes.front())};
+        ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes.front())};
         paramShape = {params[0]->get_partial_shape().size()};
 
         std::shared_ptr<ov::Node> in2, in3, in4;
@@ -132,17 +134,15 @@ TEST_P(SpaceToBatchCPULayerTest, CompareWithRefs) {
 
 namespace {
 
-const std::vector<Precision> netPrecision = {
-        Precision::U8,
-        Precision::I8,
-        Precision::I32,
-        Precision::FP32,
-        Precision::BF16
-};
+const std::vector<ov::element::Type> netPrecision = {ov::element::u8,
+                                                     ov::element::i8,
+                                                     ov::element::i32,
+                                                     ov::element::f32,
+                                                     ov::element::bf16};
 
 const std::vector<std::vector<int64_t>> blockShape4D1 = {{1, 2, 1, 2}, {1, 1, 2, 2}, {1, 2, 2, 2}};
 const std::vector<std::vector<int64_t>> padsBegin4D1 = {{0, 0, 0, 1}, {0, 0, 2, 1}, {0, 0, 4, 3}};
-const std::vector<std::vector<int64_t>> padsEnd4D1   = {{0, 0, 0, 1}, {0, 0, 4, 1}, {0, 0, 2, 3}};
+const std::vector<std::vector<int64_t>> padsEnd4D1 = {{0, 0, 0, 1}, {0, 0, 4, 1}, {0, 0, 2, 3}};
 
 std::vector<std::vector<ov::Shape>> staticInputShapes4D1 = {
     {{1, 16, 8, 12}, {4}, {4}, {4}},
@@ -150,233 +150,212 @@ std::vector<std::vector<ov::Shape>> staticInputShapes4D1 = {
 };
 
 std::vector<std::vector<InputShape>> dynamicInputShapes4D1 = {
-    {
-        {{-1, -1, -1, -1}, {{1, 6, 4, 8}, {2, 4, 8, 10}, {1, 8, 4, 10}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}}
-    },
-    {
-        {{{1, 4}, {2, 16}, 6, -1}, {{4, 8, 6, 4}, {1, 6, 6, 8}, {2, 12, 6, 4}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}}
-    }
-};
+    {{{-1, -1, -1, -1}, {{1, 6, 4, 8}, {2, 4, 8, 10}, {1, 8, 4, 10}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}}},
+    {{{{1, 4}, {2, 16}, 6, -1}, {{4, 8, 6, 4}, {1, 6, 6, 8}, {2, 12, 6, 4}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}}}};
 
 std::vector<std::vector<InputShape>> dynamicInputShapes4D1Blocked = {
-    {
-        {{-1, 16, -1, -1}, {{1, 16, 4, 6}, {2, 16, 6, 6}, {4, 16, 4, 8}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}}
-    }
-};
+    {{{-1, 16, -1, -1}, {{1, 16, 4, 6}, {2, 16, 6, 6}, {4, 16, 4, 8}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}}}};
 
-
-const std::vector<std::vector<int64_t>> blockShape4D2 = { {1, 2, 4, 3}, {1, 4, 4, 1}};
+const std::vector<std::vector<int64_t>> blockShape4D2 = {{1, 2, 4, 3}, {1, 4, 4, 1}};
 const std::vector<std::vector<int64_t>> padsBegin4D2 = {{0, 0, 0, 0}, {0, 0, 4, 3}};
-const std::vector<std::vector<int64_t>> padsEnd4D2   = {{0, 0, 4, 0}, {0, 0, 4, 3}};
+const std::vector<std::vector<int64_t>> padsEnd4D2 = {{0, 0, 4, 0}, {0, 0, 4, 3}};
 
 std::vector<std::vector<ov::Shape>> staticInputShapes4D2 = {
-        {{1, 16, 12, 12}, {4}, {4}, {4}},
-        {{1, 32, 12, 15}, {4}, {4}, {4}},
+    {{1, 16, 12, 12}, {4}, {4}, {4}},
+    {{1, 32, 12, 15}, {4}, {4}, {4}},
 };
 
 std::vector<std::vector<InputShape>> dynamicInputShapes4D2 = {
-    {
-        {{-1, -1, -1, -1}, {{1, 4, 8, 9}, {2, 8, 12, 9}, {6, 12, 4, 12}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}}
-    },
-    {
-        {{2, {4, 16}, -1, -1}, {{2, 8, 4, 9}, {2, 4, 8, 6}, {2, 12, 12, 3}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}}
-    }
-};
+    {{{-1, -1, -1, -1}, {{1, 4, 8, 9}, {2, 8, 12, 9}, {6, 12, 4, 12}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}}},
+    {{{2, {4, 16}, -1, -1}, {{2, 8, 4, 9}, {2, 4, 8, 6}, {2, 12, 12, 3}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}}}};
 
 std::vector<std::vector<InputShape>> dynamicInputShapes4D2Blocked = {
-    {
-        {{-1, 16, -1, -1}, {{2, 16, 4, 15}, {2, 16, 8, 12}, {3, 16, 12, 9}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}},
-        {{4}, {{4}, {4}, {4}}}
-    }
-};
+    {{{-1, 16, -1, -1}, {{2, 16, 4, 15}, {2, 16, 8, 12}, {3, 16, 12, 9}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}},
+     {{4}, {{4}, {4}, {4}}}}};
 
-const std::vector<CPUSpecificParams> cpuParamsWithBlock_4D = {
-        CPUSpecificParams({nChw16c}, {nChw16c}, {}, {}),
-        CPUSpecificParams({nChw8c}, {nChw8c}, {}, {}),
-        CPUSpecificParams({nhwc}, {nhwc}, {}, {}),
-        CPUSpecificParams({nchw}, {nchw}, {}, {})
-};
+const std::vector<CPUSpecificParams> cpuParamsWithBlock_4D = {CPUSpecificParams({nChw16c}, {nChw16c}, {}, {}),
+                                                              CPUSpecificParams({nChw8c}, {nChw8c}, {}, {}),
+                                                              CPUSpecificParams({nhwc}, {nhwc}, {}, {}),
+                                                              CPUSpecificParams({nchw}, {nchw}, {}, {})};
 
-const std::vector<CPUSpecificParams> cpuParams_4D = {
-        CPUSpecificParams({nhwc}, {nhwc}, {}, {}),
-        CPUSpecificParams({nchw}, {nchw}, {}, {})
-};
+const std::vector<CPUSpecificParams> cpuParams_4D = {CPUSpecificParams({nhwc}, {nhwc}, {}, {}),
+                                                     CPUSpecificParams({nchw}, {nchw}, {}, {})};
 
-const auto staticSpaceToBatchParamsSet4D1 = ::testing::Combine(
-        ::testing::ValuesIn(static_shapes_to_test_representation(staticInputShapes4D1)),
-        ::testing::ValuesIn(blockShape4D1),
-        ::testing::ValuesIn(padsBegin4D1),
-        ::testing::ValuesIn(padsEnd4D1),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParams_4D));
+const auto staticSpaceToBatchParamsSet4D1 =
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(staticInputShapes4D1)),
+                       ::testing::ValuesIn(blockShape4D1),
+                       ::testing::ValuesIn(padsBegin4D1),
+                       ::testing::ValuesIn(padsEnd4D1),
+                       ::testing::ValuesIn(netPrecision),
+                       ::testing::ValuesIn(cpuParams_4D));
 
-const auto dynamicSpaceToBatchParamsSet4D1 = ::testing::Combine(
-        ::testing::ValuesIn(dynamicInputShapes4D1),
-        ::testing::ValuesIn(blockShape4D1),
-        ::testing::ValuesIn(padsBegin4D1),
-        ::testing::ValuesIn(padsEnd4D1),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParams_4D));
+const auto dynamicSpaceToBatchParamsSet4D1 = ::testing::Combine(::testing::ValuesIn(dynamicInputShapes4D1),
+                                                                ::testing::ValuesIn(blockShape4D1),
+                                                                ::testing::ValuesIn(padsBegin4D1),
+                                                                ::testing::ValuesIn(padsEnd4D1),
+                                                                ::testing::ValuesIn(netPrecision),
+                                                                ::testing::ValuesIn(cpuParams_4D));
 
-const auto dynamicSpaceToBatchParamsWithBlockedSet4D1 = ::testing::Combine(
-        ::testing::ValuesIn(dynamicInputShapes4D1Blocked),
-        ::testing::ValuesIn(blockShape4D1),
-        ::testing::ValuesIn(padsBegin4D1),
-        ::testing::ValuesIn(padsEnd4D1),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParamsWithBlock_4D));
+const auto dynamicSpaceToBatchParamsWithBlockedSet4D1 =
+    ::testing::Combine(::testing::ValuesIn(dynamicInputShapes4D1Blocked),
+                       ::testing::ValuesIn(blockShape4D1),
+                       ::testing::ValuesIn(padsBegin4D1),
+                       ::testing::ValuesIn(padsEnd4D1),
+                       ::testing::ValuesIn(netPrecision),
+                       ::testing::ValuesIn(cpuParamsWithBlock_4D));
 
-const auto staticSpaceToBatchParamsSet4D2 = ::testing::Combine(
-        ::testing::ValuesIn(static_shapes_to_test_representation(staticInputShapes4D2)),
-        ::testing::ValuesIn(blockShape4D2),
-        ::testing::ValuesIn(padsBegin4D2),
-        ::testing::ValuesIn(padsEnd4D2),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParams_4D));
+const auto staticSpaceToBatchParamsSet4D2 =
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(staticInputShapes4D2)),
+                       ::testing::ValuesIn(blockShape4D2),
+                       ::testing::ValuesIn(padsBegin4D2),
+                       ::testing::ValuesIn(padsEnd4D2),
+                       ::testing::ValuesIn(netPrecision),
+                       ::testing::ValuesIn(cpuParams_4D));
 
-const auto dynamicSpaceToBatchParamsSet4D2 = ::testing::Combine(
-        ::testing::ValuesIn(dynamicInputShapes4D2),
-        ::testing::ValuesIn(blockShape4D2),
-        ::testing::ValuesIn(padsBegin4D2),
-        ::testing::ValuesIn(padsEnd4D2),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParams_4D));
+const auto dynamicSpaceToBatchParamsSet4D2 = ::testing::Combine(::testing::ValuesIn(dynamicInputShapes4D2),
+                                                                ::testing::ValuesIn(blockShape4D2),
+                                                                ::testing::ValuesIn(padsBegin4D2),
+                                                                ::testing::ValuesIn(padsEnd4D2),
+                                                                ::testing::ValuesIn(netPrecision),
+                                                                ::testing::ValuesIn(cpuParams_4D));
 
-const auto dynamicSpaceToBatchParamsWithBlockedSet4D2 = ::testing::Combine(
-        ::testing::ValuesIn(dynamicInputShapes4D2Blocked),
-        ::testing::ValuesIn(blockShape4D2),
-        ::testing::ValuesIn(padsBegin4D2),
-        ::testing::ValuesIn(padsEnd4D2),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParamsWithBlock_4D));
+const auto dynamicSpaceToBatchParamsWithBlockedSet4D2 =
+    ::testing::Combine(::testing::ValuesIn(dynamicInputShapes4D2Blocked),
+                       ::testing::ValuesIn(blockShape4D2),
+                       ::testing::ValuesIn(padsBegin4D2),
+                       ::testing::ValuesIn(padsEnd4D2),
+                       ::testing::ValuesIn(netPrecision),
+                       ::testing::ValuesIn(cpuParamsWithBlock_4D));
 
-INSTANTIATE_TEST_SUITE_P(smoke_StaticSpaceToBatchCPULayerTestCase1_4D, SpaceToBatchCPULayerTest,
-                         staticSpaceToBatchParamsSet4D1, SpaceToBatchCPULayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_StaticSpaceToBatchCPULayerTestCase1_4D,
+                         SpaceToBatchCPULayerTest,
+                         staticSpaceToBatchParamsSet4D1,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCase1_4D, SpaceToBatchCPULayerTest,
-                         dynamicSpaceToBatchParamsSet4D1, SpaceToBatchCPULayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCase1_4D,
+                         SpaceToBatchCPULayerTest,
+                         dynamicSpaceToBatchParamsSet4D1,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCaseWithBlocked1_4D, SpaceToBatchCPULayerTest,
-                         dynamicSpaceToBatchParamsWithBlockedSet4D1, SpaceToBatchCPULayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCaseWithBlocked1_4D,
+                         SpaceToBatchCPULayerTest,
+                         dynamicSpaceToBatchParamsWithBlockedSet4D1,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_StaticSpaceToBatchCPULayerTestCase2_4D, SpaceToBatchCPULayerTest,
-                         staticSpaceToBatchParamsSet4D2, SpaceToBatchCPULayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_StaticSpaceToBatchCPULayerTestCase2_4D,
+                         SpaceToBatchCPULayerTest,
+                         staticSpaceToBatchParamsSet4D2,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCase2_4D, SpaceToBatchCPULayerTest,
-                         dynamicSpaceToBatchParamsSet4D2, SpaceToBatchCPULayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCase2_4D,
+                         SpaceToBatchCPULayerTest,
+                         dynamicSpaceToBatchParamsSet4D2,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCaseWithBlocked2_4D, SpaceToBatchCPULayerTest,
-                         dynamicSpaceToBatchParamsWithBlockedSet4D2, SpaceToBatchCPULayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCaseWithBlocked2_4D,
+                         SpaceToBatchCPULayerTest,
+                         dynamicSpaceToBatchParamsWithBlockedSet4D2,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
-std::vector<std::vector<ov::Shape>> staticInputShapes4DPE = {
-    {{1, 2, 9, 1}, {4}, {4}, {4}}
-};
-INSTANTIATE_TEST_SUITE_P(smoke_StaticSpaceToBatch_4D_parallel_block_edge, SpaceToBatchCPULayerTest,
-        ::testing::Combine(
-                ::testing::ValuesIn(static_shapes_to_test_representation(staticInputShapes4DPE)),
-                ::testing::Values(std::vector<int64_t>{1, 4, 3, 1}),
-                ::testing::Values(std::vector<int64_t>{0, 1, 2, 0}),
-                ::testing::Values(std::vector<int64_t>{0, 1, 4, 0}),
-                ::testing::Values(Precision::FP32),
-                ::testing::Values(CPUSpecificParams{})),
-        SpaceToBatchCPULayerTest::getTestCaseName);
+std::vector<std::vector<ov::Shape>> staticInputShapes4DPE = {{{1, 2, 9, 1}, {4}, {4}, {4}}};
+INSTANTIATE_TEST_SUITE_P(
+    smoke_StaticSpaceToBatch_4D_parallel_block_edge,
+    SpaceToBatchCPULayerTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(staticInputShapes4DPE)),
+                       ::testing::Values(std::vector<int64_t>{1, 4, 3, 1}),
+                       ::testing::Values(std::vector<int64_t>{0, 1, 2, 0}),
+                       ::testing::Values(std::vector<int64_t>{0, 1, 4, 0}),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(CPUSpecificParams{})),
+    SpaceToBatchCPULayerTest::getTestCaseName);
 
 const std::vector<std::vector<int64_t>> blockShape5D = {{1, 1, 2, 2, 1}, {1, 2, 4, 1, 3}};
 const std::vector<std::vector<int64_t>> padsBegin5D = {{0, 0, 0, 0, 0}, {0, 0, 4, 0, 0}, {0, 0, 0, 2, 3}};
-const std::vector<std::vector<int64_t>> padsEnd5D   = {{0, 0, 0, 0, 0}, {0, 0, 0, 4, 3}, {0, 0, 4, 2, 3}};
+const std::vector<std::vector<int64_t>> padsEnd5D = {{0, 0, 0, 0, 0}, {0, 0, 0, 4, 3}, {0, 0, 4, 2, 3}};
 
-std::vector<std::vector<ov::Shape>> staticInputShapes5D = {
-    {{2, 16, 4, 6, 12}, {5}, {5}, {5}},
-    {{1, 32, 8, 8, 6}, {5}, {5}, {5}},
-    {{1, 16, 4, 12, 12}, {5}, {5}, {5}}
-};
+std::vector<std::vector<ov::Shape>> staticInputShapes5D = {{{2, 16, 4, 6, 12}, {5}, {5}, {5}},
+                                                           {{1, 32, 8, 8, 6}, {5}, {5}, {5}},
+                                                           {{1, 16, 4, 12, 12}, {5}, {5}, {5}}};
 
 std::vector<std::vector<InputShape>> dynamicInputShapes5D = {
-    {
-        {{-1, -1, -1, -1, -1}, {{2, 2, 12, 4, 15}, {4, 4, 8, 6, 9}, {3, 6, 4, 2, 12}}},
-        {{5}, {{5}, {5}, {5}}},
-        {{5}, {{5}, {5}, {5}}},
-        {{5}, {{5}, {5}, {5}}}
-    },
-    {
-        {{{1, 10}, {2, 20}, {4, 50}, -1, -1}, {{3, 12, 8, 6, 9}, {5, 10, 4, 8, 15}, {6, 8, 20, 4, 12}}},
-        {{5}, {{5}, {5}, {5}}},
-        {{5}, {{5}, {5}, {5}}},
-        {{5}, {{5}, {5}, {5}}}
-    }
-};
+    {{{-1, -1, -1, -1, -1}, {{2, 2, 12, 4, 15}, {4, 4, 8, 6, 9}, {3, 6, 4, 2, 12}}},
+     {{5}, {{5}, {5}, {5}}},
+     {{5}, {{5}, {5}, {5}}},
+     {{5}, {{5}, {5}, {5}}}},
+    {{{{1, 10}, {2, 20}, {4, 50}, -1, -1}, {{3, 12, 8, 6, 9}, {5, 10, 4, 8, 15}, {6, 8, 20, 4, 12}}},
+     {{5}, {{5}, {5}, {5}}},
+     {{5}, {{5}, {5}, {5}}},
+     {{5}, {{5}, {5}, {5}}}}};
 
 std::vector<std::vector<InputShape>> dynamicInputShapes5DBlocked = {
-    {
-        {{-1, 16, -1, -1, -1}, {{2, 16, 4, 6, 9}, {5, 16, 16, 4, 6}, {7, 16, 8, 2, 3}}},
-        {{5}, {{5}, {5}, {5}}},
-        {{5}, {{5}, {5}, {5}}},
-        {{5}, {{5}, {5}, {5}}}
-    }
-};
+    {{{-1, 16, -1, -1, -1}, {{2, 16, 4, 6, 9}, {5, 16, 16, 4, 6}, {7, 16, 8, 2, 3}}},
+     {{5}, {{5}, {5}, {5}}},
+     {{5}, {{5}, {5}, {5}}},
+     {{5}, {{5}, {5}, {5}}}}};
 
-const std::vector<CPUSpecificParams> cpuParamsWithBlock_5D = {
-        CPUSpecificParams({nCdhw16c}, {nCdhw16c}, {}, {}),
-        CPUSpecificParams({nCdhw8c}, {nCdhw8c}, {}, {}),
-        CPUSpecificParams({ndhwc}, {ndhwc}, {}, {}),
-        CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})
-};
+const std::vector<CPUSpecificParams> cpuParamsWithBlock_5D = {CPUSpecificParams({nCdhw16c}, {nCdhw16c}, {}, {}),
+                                                              CPUSpecificParams({nCdhw8c}, {nCdhw8c}, {}, {}),
+                                                              CPUSpecificParams({ndhwc}, {ndhwc}, {}, {}),
+                                                              CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})};
 
-const std::vector<CPUSpecificParams> cpuParams_5D = {
-        CPUSpecificParams({ndhwc}, {ndhwc}, {}, {}),
-        CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})
-};
+const std::vector<CPUSpecificParams> cpuParams_5D = {CPUSpecificParams({ndhwc}, {ndhwc}, {}, {}),
+                                                     CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})};
 
-const auto staticSpaceToBatchParamsSet5D = ::testing::Combine(
-        ::testing::ValuesIn(static_shapes_to_test_representation(staticInputShapes5D)),
-        ::testing::ValuesIn(blockShape5D),
-        ::testing::ValuesIn(padsBegin5D),
-        ::testing::ValuesIn(padsEnd5D),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParamsWithBlock_5D));
+const auto staticSpaceToBatchParamsSet5D =
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(staticInputShapes5D)),
+                       ::testing::ValuesIn(blockShape5D),
+                       ::testing::ValuesIn(padsBegin5D),
+                       ::testing::ValuesIn(padsEnd5D),
+                       ::testing::ValuesIn(netPrecision),
+                       ::testing::ValuesIn(cpuParamsWithBlock_5D));
 
-const auto dynamicSpaceToBatchParamsSet5D = ::testing::Combine(
-        ::testing::ValuesIn(dynamicInputShapes5D),
-        ::testing::ValuesIn(blockShape5D),
-        ::testing::ValuesIn(padsBegin5D),
-        ::testing::ValuesIn(padsEnd5D),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParams_5D));
+const auto dynamicSpaceToBatchParamsSet5D = ::testing::Combine(::testing::ValuesIn(dynamicInputShapes5D),
+                                                               ::testing::ValuesIn(blockShape5D),
+                                                               ::testing::ValuesIn(padsBegin5D),
+                                                               ::testing::ValuesIn(padsEnd5D),
+                                                               ::testing::ValuesIn(netPrecision),
+                                                               ::testing::ValuesIn(cpuParams_5D));
 
-const auto dynamicSpaceToBatchParamsWithBlockedSet5D = ::testing::Combine(
-        ::testing::ValuesIn(dynamicInputShapes5DBlocked),
-        ::testing::ValuesIn(blockShape5D),
-        ::testing::ValuesIn(padsBegin5D),
-        ::testing::ValuesIn(padsEnd5D),
-        ::testing::ValuesIn(netPrecision),
-        ::testing::ValuesIn(cpuParamsWithBlock_5D));
+const auto dynamicSpaceToBatchParamsWithBlockedSet5D =
+    ::testing::Combine(::testing::ValuesIn(dynamicInputShapes5DBlocked),
+                       ::testing::ValuesIn(blockShape5D),
+                       ::testing::ValuesIn(padsBegin5D),
+                       ::testing::ValuesIn(padsEnd5D),
+                       ::testing::ValuesIn(netPrecision),
+                       ::testing::ValuesIn(cpuParamsWithBlock_5D));
 
-INSTANTIATE_TEST_SUITE_P(smoke_StaticSpaceToBatchCPULayerTestCase_5D, SpaceToBatchCPULayerTest,
-                         staticSpaceToBatchParamsSet5D, SpaceToBatchCPULayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_StaticSpaceToBatchCPULayerTestCase_5D,
+                         SpaceToBatchCPULayerTest,
+                         staticSpaceToBatchParamsSet5D,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCase_5D, SpaceToBatchCPULayerTest,
-                         dynamicSpaceToBatchParamsSet5D, SpaceToBatchCPULayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCase_5D,
+                         SpaceToBatchCPULayerTest,
+                         dynamicSpaceToBatchParamsSet5D,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCaseWithBlocked_5D, SpaceToBatchCPULayerTest,
-                         dynamicSpaceToBatchParamsWithBlockedSet5D, SpaceToBatchCPULayerTest::getTestCaseName);
-
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicSpaceToBatchCPULayerTestCaseWithBlocked_5D,
+                         SpaceToBatchCPULayerTest,
+                         dynamicSpaceToBatchParamsWithBlockedSet5D,
+                         SpaceToBatchCPULayerTest::getTestCaseName);
 
 }  // namespace
-}  // namespace CPULayerTestsDefinitions
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_depth.cpp
@@ -2,34 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "shared_test_classes/single_layer/space_to_depth.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/filter_cpu_info.hpp"
-#include "shared_test_classes/base/ov_subgraph.hpp"
 
-
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
-using namespace ngraph::opset3;
 using namespace ov::test;
 
-namespace CPULayerTestsDefinitions {
-
-using SpaceToDepthLayerCPUTestParamSet = std::tuple<
-        InputShape,                                     // Input shape
-        ElementType,                                    // Input element type
-        SpaceToDepth::SpaceToDepthMode,                 // Mode
-        std::size_t,                                    // Block size
-        CPUSpecificParams
->;
+using SpaceToDepthLayerCPUTestParamSet = std::tuple<InputShape,                                  // Input shape
+                                                    ElementType,                                 // Input element type
+                                                    ov::op::v0::SpaceToDepth::SpaceToDepthMode,  // Mode
+                                                    std::size_t,                                 // Block size
+                                                    CPUSpecificParams>;
 
 class SpaceToDepthLayerCPUTest : public testing::WithParamInterface<SpaceToDepthLayerCPUTestParamSet>,
-                                 virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
+                                 virtual public ov::test::SubgraphBaseTest,
+                                 public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<SpaceToDepthLayerCPUTestParamSet> obj) {
         InputShape shapes;
         ElementType inType;
-        SpaceToDepth::SpaceToDepthMode mode;
+        ov::op::v0::SpaceToDepth::SpaceToDepthMode mode;
         std::size_t blockSize;
         CPUSpecificParams cpuParams;
         std::tie(shapes, inType, mode, blockSize, cpuParams) = obj.param;
@@ -42,25 +35,26 @@ public:
         }
         results << "Prc=" << inType << "_";
         switch (mode) {
-            case SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST:
-                results << "BLOCKS_FIRST_";
-                break;
-            case SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST:
-                results << "DEPTH_FIRST_";
-                break;
-            default:
-                throw std::runtime_error("Unsupported SpaceToDepthMode");
+        case ov::op::v0::SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST:
+            results << "BLOCKS_FIRST_";
+            break;
+        case ov::op::v0::SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST:
+            results << "DEPTH_FIRST_";
+            break;
+        default:
+            throw std::runtime_error("Unsupported SpaceToDepthMode");
         }
         results << "BS=" << blockSize << "_";
         results << CPUTestsBase::getTestCaseName(cpuParams);
 
         return results.str();
     }
+
 protected:
     void SetUp() override {
         InputShape shapes;
         ElementType inType;
-        SpaceToDepth::SpaceToDepthMode mode;
+        ov::op::v0::SpaceToDepth::SpaceToDepthMode mode;
         std::size_t blockSize;
         CPUSpecificParams cpuParams;
         std::tie(shapes, inType, mode, blockSize, cpuParams) = this->GetParam();
@@ -69,7 +63,7 @@ protected:
         if (selectedType.empty()) {
             selectedType = getPrimitiveType();
         }
-        selectedType = selectedType + "_" + InferenceEngine::details::convertPrecision(inType).name();
+        selectedType = selectedType + "_" + ov::element::Type(inType).get_type_name();
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes({shapes});
 
@@ -77,7 +71,7 @@ protected:
         for (auto&& shape : inputDynamicShapes) {
             params.push_back(std::make_shared<ov::op::v0::Parameter>(inType, shape));
         }
-        auto d2s = std::make_shared<ov::op::v0::SpaceToDepth> (params[0], mode, blockSize);
+        auto d2s = std::make_shared<ov::op::v0::SpaceToDepth>(params[0], mode, blockSize);
         function = makeNgraphFunction(inType, params, d2s, "SpaceToDepthCPU");
     }
 };
@@ -89,109 +83,88 @@ TEST_P(SpaceToDepthLayerCPUTest, CompareWithRefs) {
 
 namespace {
 
-const auto cpuParams_nChw16c = CPUSpecificParams {{nChw16c}, {nChw16c}, {}, {}};
-const auto cpuParams_nCdhw16c = CPUSpecificParams {{nCdhw16c}, {nCdhw16c}, {}, {}};
+const auto cpuParams_nChw16c = CPUSpecificParams{{nChw16c}, {nChw16c}, {}, {}};
+const auto cpuParams_nCdhw16c = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {}, {}};
 
-const auto cpuParams_nChw8c = CPUSpecificParams {{nChw8c}, {nChw8c}, {}, {}};
-const auto cpuParams_nCdhw8c = CPUSpecificParams {{nCdhw8c}, {nCdhw8c}, {}, {}};
+const auto cpuParams_nChw8c = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, {}};
+const auto cpuParams_nCdhw8c = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, {}};
 
-const auto cpuParams_nhwc = CPUSpecificParams {{nhwc}, {nhwc}, {}, {}};
-const auto cpuParams_ndhwc = CPUSpecificParams {{ndhwc}, {ndhwc}, {}, {}};
+const auto cpuParams_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {}, {}};
+const auto cpuParams_ndhwc = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, {}};
 
-const auto cpuParams_nchw = CPUSpecificParams {{nchw}, {nchw}, {}, {}};
-const auto cpuParams_ncdhw = CPUSpecificParams {{ncdhw}, {ncdhw}, {}, {}};
+const auto cpuParams_nchw = CPUSpecificParams{{nchw}, {nchw}, {}, {}};
+const auto cpuParams_ncdhw = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, {}};
 
-const std::vector<CPUSpecificParams> CPUParams4D = {
-        cpuParams_nhwc,
-        cpuParams_nchw
-};
+const std::vector<CPUSpecificParams> CPUParams4D = {cpuParams_nhwc, cpuParams_nchw};
 
-const std::vector<CPUSpecificParams> CPUParamsBlocked4D = {
-        cpuParams_nChw16c,
-        cpuParams_nChw8c,
-        cpuParams_nhwc
-};
+const std::vector<CPUSpecificParams> CPUParamsBlocked4D = {cpuParams_nChw16c, cpuParams_nChw8c, cpuParams_nhwc};
 
-const std::vector<CPUSpecificParams> CPUParams5D = {
-        cpuParams_ndhwc,
-        cpuParams_ncdhw
-};
+const std::vector<CPUSpecificParams> CPUParams5D = {cpuParams_ndhwc, cpuParams_ncdhw};
 
-const std::vector<CPUSpecificParams> CPUParamsBlocked5D = {
-        cpuParams_nCdhw16c,
-        cpuParams_nCdhw8c,
-        cpuParams_ndhwc
-};
+const std::vector<CPUSpecificParams> CPUParamsBlocked5D = {cpuParams_nCdhw16c, cpuParams_nCdhw8c, cpuParams_ndhwc};
 
-const std::vector<ElementType> inputElementType = {
-        ElementType::f32,
-        ElementType::bf16,
-        ElementType::i8
-};
+const std::vector<ElementType> inputElementType = {ElementType::f32, ElementType::bf16, ElementType::i8};
 
-const std::vector<SpaceToDepth::SpaceToDepthMode> SpaceToDepthModes = {
-        SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST,
-        SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST
-};
+const std::vector<ov::op::v0::SpaceToDepth::SpaceToDepthMode> SpaceToDepthModes = {
+    ov::op::v0::SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST,
+    ov::op::v0::SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST};
 
 /* *========================* Static Shapes Tests *========================* */
 
 namespace static_shapes {
 
-const std::vector<ov::Shape> inputShapesBS2_4D = {{1, 16, 2, 2}, {1, 16, 4, 2},
-                                                  {1, 32, 6, 8}, {2, 32, 4, 6},
-                                                  {2, 48, 4, 4}, {2, 64, 8, 2}};
+const std::vector<ov::Shape> inputShapesBS2_4D =
+    {{1, 16, 2, 2}, {1, 16, 4, 2}, {1, 32, 6, 8}, {2, 32, 4, 6}, {2, 48, 4, 4}, {2, 64, 8, 2}};
 
-const std::vector<ov::Shape> inputShapesBS3_4D = {
-    {1, 2, 3, 3}, {1, 3, 3, 6}, {1, 5, 6, 3}, {2, 5, 9, 3}, {3, 5, 6, 6}};
+const std::vector<ov::Shape> inputShapesBS3_4D = {{1, 2, 3, 3}, {1, 3, 3, 6}, {1, 5, 6, 3}, {2, 5, 9, 3}, {3, 5, 6, 6}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthBS2_4D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::ValuesIn(static_shapes_to_test_representation(inputShapesBS2_4D)),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::ValuesIn(SpaceToDepthModes),
-                                 testing::Values(1, 2),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked4D))),
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthBS2_4D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::ValuesIn(static_shapes_to_test_representation(inputShapesBS2_4D)),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::ValuesIn(SpaceToDepthModes),
+                                          testing::Values(1, 2),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked4D))),
                          SpaceToDepthLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthStaticBS3_4D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::ValuesIn(static_shapes_to_test_representation(inputShapesBS3_4D)),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::ValuesIn(SpaceToDepthModes),
-                                 testing::Values(1, 3),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParams4D))),
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthStaticBS3_4D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::ValuesIn(static_shapes_to_test_representation(inputShapesBS3_4D)),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::ValuesIn(SpaceToDepthModes),
+                                          testing::Values(1, 3),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParams4D))),
                          SpaceToDepthLayerCPUTest::getTestCaseName);
 
-const std::vector<ov::Shape> inputShapesBS2_5D = {
-        {1, 16, 2, 2, 2}, {1, 16, 4, 4, 2}, {1, 32, 2, 6, 2}, {2, 32, 4, 2, 2}, {1, 48, 6, 2, 2}, {2, 64, 2, 2, 6}
-};
+const std::vector<ov::Shape> inputShapesBS2_5D =
+    {{1, 16, 2, 2, 2}, {1, 16, 4, 4, 2}, {1, 32, 2, 6, 2}, {2, 32, 4, 2, 2}, {1, 48, 6, 2, 2}, {2, 64, 2, 2, 6}};
 
-const std::vector<ov::Shape> inputShapesBS3_5D = {
-        {1, 2, 3, 3, 3}, {1, 2, 3, 6, 9}, {1, 5, 6, 3, 3}, {2, 5, 3, 9, 3}, {3, 5, 3, 3, 6}
-};
+const std::vector<ov::Shape> inputShapesBS3_5D = {{1, 2, 3, 3, 3},
+                                                  {1, 2, 3, 6, 9},
+                                                  {1, 5, 6, 3, 3},
+                                                  {2, 5, 3, 9, 3},
+                                                  {3, 5, 3, 3, 6}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthStaticBS2_5D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::ValuesIn(static_shapes_to_test_representation(inputShapesBS2_5D)),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::ValuesIn(SpaceToDepthModes),
-                                 testing::Values(1, 2),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked5D))),
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthStaticBS2_5D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::ValuesIn(static_shapes_to_test_representation(inputShapesBS2_5D)),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::ValuesIn(SpaceToDepthModes),
+                                          testing::Values(1, 2),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked5D))),
                          SpaceToDepthLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthStaticBS3_5D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::ValuesIn(static_shapes_to_test_representation(inputShapesBS3_5D)),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::ValuesIn(SpaceToDepthModes),
-                                 testing::Values(1, 3),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParams5D))),
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthStaticBS3_5D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::ValuesIn(static_shapes_to_test_representation(inputShapesBS3_5D)),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::ValuesIn(SpaceToDepthModes),
+                                          testing::Values(1, 3),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParams5D))),
                          SpaceToDepthLayerCPUTest::getTestCaseName);
 
-} // namespace static_shapes
+}  // namespace static_shapes
 /* *========================* *==================* *========================* */
-
 
 /* *========================* Dynamic Shapes Tests *========================* */
 namespace dynamic_shapes {
@@ -223,52 +196,51 @@ const std::vector<InputShape> inputShapesBlocked5D = {
      {{1, 32, 4, 16, 10}, {1, 32, 18, 6, 14}, {3, 32, 2, 14, 12}, {1, 32, 18, 6, 14}}},  // target
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamic4D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::ValuesIn(inputShapes4D),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::ValuesIn(SpaceToDepthModes),
-                                 testing::Values(1, 2, 3),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParams4D))),
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamic4D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::ValuesIn(inputShapes4D),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::ValuesIn(SpaceToDepthModes),
+                                          testing::Values(1, 2, 3),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParams4D))),
                          SpaceToDepthLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamicBlocksFirstBlocked4D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::Values(inputShapes4D[1]),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::Values(SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST),
-                                 testing::Values(1, 2, 3),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked4D))),
-                        SpaceToDepthLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamicDepthFirstBlocked4D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::Values(inputShapes4D[1]),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::Values(SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST),
-                                 testing::Values(1, 2),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked4D))),
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamicBlocksFirstBlocked4D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::Values(inputShapes4D[1]),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::Values(ov::op::v0::SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST),
+                                          testing::Values(1, 2, 3),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked4D))),
                          SpaceToDepthLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamic5D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::ValuesIn(inputShapes5D),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::ValuesIn(SpaceToDepthModes),
-                                 testing::Values(1, 2, 3),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParams5D))),
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamicDepthFirstBlocked4D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::Values(inputShapes4D[1]),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::Values(ov::op::v0::SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST),
+                                          testing::Values(1, 2),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked4D))),
                          SpaceToDepthLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamicCPUSpecific5D, SpaceToDepthLayerCPUTest,
-                         testing::Combine(
-                                 testing::ValuesIn(inputShapesBlocked5D),
-                                 testing::ValuesIn(inputElementType),
-                                 testing::ValuesIn(SpaceToDepthModes),
-                                 testing::Values(1, 2),
-                                 testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked5D))),
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamic5D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::ValuesIn(inputShapes5D),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::ValuesIn(SpaceToDepthModes),
+                                          testing::Values(1, 2, 3),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParams5D))),
                          SpaceToDepthLayerCPUTest::getTestCaseName);
-} // namespace dynamic_shapes
+
+INSTANTIATE_TEST_SUITE_P(smoke_CPUSpaceToDepthDynamicCPUSpecific5D,
+                         SpaceToDepthLayerCPUTest,
+                         testing::Combine(testing::ValuesIn(inputShapesBlocked5D),
+                                          testing::ValuesIn(inputElementType),
+                                          testing::ValuesIn(SpaceToDepthModes),
+                                          testing::Values(1, 2),
+                                          testing::ValuesIn(filterCPUInfoForDevice(CPUParamsBlocked5D))),
+                         SpaceToDepthLayerCPUTest::getTestCaseName);
+}  // namespace dynamic_shapes
 /* *========================* *==================* *========================* */
 
-} // namespace
-} // namespace CPULayerTestsDefinitions
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/split.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/split.cpp
@@ -3,25 +3,22 @@
 //
 
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include "ov_models/builders.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 
 using namespace ov::test;
 using namespace CPUTestUtils;
 
-namespace CPULayerTestsDefinitions {
-
-typedef std::tuple<
-        size_t,                    // Num splits
-        int64_t,                   // Axis
-        ElementType,               // Net precision
-        InputShape,                // Input shapes
-        std::vector<size_t>,       // Used outputs indices
-        CPUSpecificParams
-> splitCPUTestParams;
+typedef std::tuple<size_t,               // Num splits
+                   int64_t,              // Axis
+                   ElementType,          // Net precision
+                   InputShape,           // Input shapes
+                   std::vector<size_t>,  // Used outputs indices
+                   CPUSpecificParams>
+    splitCPUTestParams;
 
 class SplitLayerCPUTest : public testing::WithParamInterface<splitCPUTestParams>,
-                          virtual public SubgraphBaseTest, public CPUTestsBase {
+                          virtual public SubgraphBaseTest,
+                          public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<splitCPUTestParams> obj) {
         size_t numSplits;
@@ -75,21 +72,22 @@ protected:
         for (auto&& shape : inputDynamicShapes)
             params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));
 
-        auto split_axis_op = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i64, ov::Shape{}, std::vector<int64_t>{axis});
+        auto split_axis_op =
+            std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i64, ov::Shape{}, std::vector<int64_t>{axis});
         auto split = std::make_shared<ov::op::v1::Split>(params[0], split_axis_op, numSplits);
 
-        ngraph::ResultVector results;
+        ov::ResultVector results;
 
         for (size_t i = 0; i < outIndices.size(); i++) {
-            // This WA is necessary because result nodes connected to the same output of the split node (or any node) are deduplicated
-            // on the CNNNetwork level. It might not be needed when the CPU plugin moves completely to nGraph.
-            // This is still a single layer test since the Relu nodes are added only as a WA.
+            // This WA is necessary because result nodes connected to the same output of the split node (or any node)
+            // are deduplicated on the CNNNetwork level. It might not be needed when the CPU plugin moves completely to
+            // model. This is still a single layer test since the Relu nodes are added only as a WA.
 
-            auto fakeEltwise = std::make_shared<ngraph::opset5::Relu>(split->output(outIndices[i]));
-            results.push_back(std::make_shared<ngraph::opset5::Result>(fakeEltwise));
+            auto fakeEltwise = std::make_shared<ov::op::v0::Relu>(split->output(outIndices[i]));
+            results.push_back(std::make_shared<ov::op::v0::Result>(fakeEltwise));
         }
         split->get_rt_info() = getCPUInfo();
-        function = std::make_shared<ngraph::Function>(results, params, "split");
+        function = std::make_shared<ov::Model>(results, params, "split");
     }
 };
 
@@ -124,477 +122,360 @@ const auto blocked16_4D_ref = CPUSpecificParams{{nChw16c}, {nChw16c}, {}, "ref"}
 const auto blocked16_5D_ref = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {}, "ref"};
 
 // List of precisions natively supported by onednn.
-const std::vector<ElementType> netPrecisions = {
-        ElementType::i8,
-        ElementType::i32,
-        ElementType::f32,
-        ElementType::bf16
-};
+const std::vector<ElementType> netPrecisions = {ElementType::i8, ElementType::i32, ElementType::f32, ElementType::bf16};
 
 const std::vector<std::vector<size_t>> outIndices3 = {{0, 1, 2}, {0, 1, 1, 0, 2}, {0, 0, 0, 2}};
 const std::vector<std::vector<size_t>> outIndices4 = {{0, 1, 2, 3}, {0, 1, 1, 0, 2, 3}, {0, 0, 0, 2, 3}};
 
 const std::vector<InputShape> inputShapes4D_Nspc2NcspSpecial = {
-        { {}, {{3, 8, 11, 9}} },
-        {
-            // dynamic
-            {-1, -1, -1, -1},
-            // target
-            {
-                {1, 4, 5, 7},
-                {3, 8, 5, 9},
-                {5, 16, 1, 8}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, {1, 64}, {1, 25}, {2, 10}},
-            // target
-            {
-                {2, 8, 5, 7},
-                {1, 4, 10, 2},
-                {3, 16, 5, 9}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, 8, 5, 7},
-            // target
-            {
-                {2, 8, 5, 7},
-                {1, 8, 5, 7},
-                {2, 8, 5, 7},
-            }
-        },
+    {{}, {{3, 8, 11, 9}}},
+    {// dynamic
+     {-1, -1, -1, -1},
+     // target
+     {{1, 4, 5, 7}, {3, 8, 5, 9}, {5, 16, 1, 8}}},
+    {// dynamic
+     {{1, 5}, {1, 64}, {1, 25}, {2, 10}},
+     // target
+     {{2, 8, 5, 7}, {1, 4, 10, 2}, {3, 16, 5, 9}}},
+    {// dynamic
+     {{1, 5}, 8, 5, 7},
+     // target
+     {
+         {2, 8, 5, 7},
+         {1, 8, 5, 7},
+         {2, 8, 5, 7},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Nspc2NcspSpecial, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(4),
-                                ::testing::Values(1),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes4D_Nspc2NcspSpecial),
-                                ::testing::ValuesIn(outIndices4),
-                                ::testing::Values(perChannelsToPlanar_4D)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Nspc2NcspSpecial,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(4),
+                                            ::testing::Values(1),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes4D_Nspc2NcspSpecial),
+                                            ::testing::ValuesIn(outIndices4),
+                                            ::testing::Values(perChannelsToPlanar_4D)),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes5D_Nspc2NcspSpecial = {
-        { {}, {{3, 9, 5, 9, 11}} },
-        {
-            // dynamic
-            {-1, -1, -1, -1, -1},
-            // target
-            {
-                {1, 12, 5, 7, 5},
-                {3, 6, 8, 9, 1},
-                {5, 9, 1, 8, 2}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, {1, 64}, {1, 25}, {2, 10}, {1, 64}},
-            // target
-            {
-                {2, 6, 5, 7, 7},
-                {1, 3, 10, 2, 11},
-                {3, 9, 4, 9, 8}
-            }
-        },
+    {{}, {{3, 9, 5, 9, 11}}},
+    {// dynamic
+     {-1, -1, -1, -1, -1},
+     // target
+     {{1, 12, 5, 7, 5}, {3, 6, 8, 9, 1}, {5, 9, 1, 8, 2}}},
+    {// dynamic
+     {{1, 5}, {1, 64}, {1, 25}, {2, 10}, {1, 64}},
+     // target
+     {{2, 6, 5, 7, 7}, {1, 3, 10, 2, 11}, {3, 9, 4, 9, 8}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Nspc2NcspSpecial, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(3),
-                                ::testing::Values(1),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes5D_Nspc2NcspSpecial),
-                                ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(perChannelsToPlanar_5D)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Nspc2NcspSpecial,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(3),
+                                            ::testing::Values(1),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes5D_Nspc2NcspSpecial),
+                                            ::testing::ValuesIn(outIndices3),
+                                            ::testing::Values(perChannelsToPlanar_5D)),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_planar = {
-        { {}, {{3, 24, 24, 9}} },
-        {
-            // dynamic
-            {-1, -1, -1, -1},
-            // target
-            {
-                {1, 15, 12, 9},
-                {3, 1, 9, 12},
-                {5, 5, 6, 6}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, {1, 64}, {1, 48}, {2, 48}},
-            // target
-            {
-                {2, 5, 6, 9},
-                {1, 7, 12, 6},
-                {3, 11, 9, 3}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, 5, 6, 9},
-            // target
-            {
-                {2, 5, 6, 9},
-                {1, 5, 6, 9},
-            }
-        },
+    {{}, {{3, 24, 24, 9}}},
+    {// dynamic
+     {-1, -1, -1, -1},
+     // target
+     {{1, 15, 12, 9}, {3, 1, 9, 12}, {5, 5, 6, 6}}},
+    {// dynamic
+     {{1, 5}, {1, 64}, {1, 48}, {2, 48}},
+     // target
+     {{2, 5, 6, 9}, {1, 7, 12, 6}, {3, 11, 9, 3}}},
+    {// dynamic
+     {{1, 5}, 5, 6, 9},
+     // target
+     {
+         {2, 5, 6, 9},
+         {1, 5, 6, 9},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_planar, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(3),
-                                ::testing::Values(2, 3),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes4D_planar),
-                                ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(planar_4D_ref, perChannels_4D)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_planar,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(3),
+                                            ::testing::Values(2, 3),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes4D_planar),
+                                            ::testing::ValuesIn(outIndices3),
+                                            ::testing::Values(planar_4D_ref, perChannels_4D)),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_block = {
-        { {}, {{3, 16, 12, 12}} },
-        {
-            // dynamic
-            {-1, 16, -1, -1},
-            // target
-            {
-                {1, 16, 12, 12},
-                {3, 16, 12, 12},
-                {5, 16, 12, 12}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, 16, {1, 48}, {2, 24}},
-            // target
-            {
-                {2, 16, 12, 12},
-                {1, 16, 12, 12},
-                {3, 16, 12, 12}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, 16, 12, 12},
-            // target
-            {
-                {2, 16, 12, 12},
-                {1, 16, 12, 12}
-            }
-        },
+    {{}, {{3, 16, 12, 12}}},
+    {// dynamic
+     {-1, 16, -1, -1},
+     // target
+     {{1, 16, 12, 12}, {3, 16, 12, 12}, {5, 16, 12, 12}}},
+    {// dynamic
+     {{1, 5}, 16, {1, 48}, {2, 24}},
+     // target
+     {{2, 16, 12, 12}, {1, 16, 12, 12}, {3, 16, 12, 12}}},
+    {// dynamic
+     {{1, 5}, 16, 12, 12},
+     // target
+     {{2, 16, 12, 12}, {1, 16, 12, 12}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Block8, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(3),
-                                ::testing::Values(2, 3),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes4D_block),
-                                ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(blocked8_4D_ref)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Block8,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(3),
+                                            ::testing::Values(2, 3),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes4D_block),
+                                            ::testing::ValuesIn(outIndices3),
+                                            ::testing::Values(blocked8_4D_ref)),
+                         SplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Block16, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(4),
-                                ::testing::Values(2, 3),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes4D_block),
-                                ::testing::ValuesIn(outIndices4),
-                                ::testing::Values(blocked16_4D_ref)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Block16,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(4),
+                                            ::testing::Values(2, 3),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes4D_block),
+                                            ::testing::ValuesIn(outIndices4),
+                                            ::testing::Values(blocked16_4D_ref)),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes5D_planar = {
-        { {}, {{3, 5, 3, 6, 12}} },
-        {
-            // dynamic
-            {-1, -1, -1, -1, -1},
-            // target
-            {
-                {1, 15, 12, 3, 9},
-                {3, 1, 6, 12, 3},
-                {5, 5, 6, 6, 6}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, {1, 64}, {1, 48}, {2, 48}, {1, 40}},
-            // target
-            {
-                {2, 5, 12, 3, 6},
-                {1, 7, 12, 6, 9},
-                {3, 11, 9, 3, 30}
-            }
-        },
+    {{}, {{3, 5, 3, 6, 12}}},
+    {// dynamic
+     {-1, -1, -1, -1, -1},
+     // target
+     {{1, 15, 12, 3, 9}, {3, 1, 6, 12, 3}, {5, 5, 6, 6, 6}}},
+    {// dynamic
+     {{1, 5}, {1, 64}, {1, 48}, {2, 48}, {1, 40}},
+     // target
+     {{2, 5, 12, 3, 6}, {1, 7, 12, 6, 9}, {3, 11, 9, 3, 30}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_planar, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(3),
-                                ::testing::Values(2, 3, 4),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes5D_planar),
-                                ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(planar_5D_ref, perChannels_5D)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_planar,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(3),
+                                            ::testing::Values(2, 3, 4),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes5D_planar),
+                                            ::testing::ValuesIn(outIndices3),
+                                            ::testing::Values(planar_5D_ref, perChannels_5D)),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes5D_block = {
-        { {}, {{3, 16, 24, 12, 36}} },
-        {
-            // dynamic
-            {-1, 16, -1, -1, -1},
-            // target
-            {
-                {1, 16, 12, 24, 24},
-                {3, 16, 12, 12, 12},
-                {5, 16, 12, 12, 24}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, 16, {1, 48}, {2, 24}, {3, 64}},
-            // target
-            {
-                {2, 16, 12, 12, 24},
-                {1, 16, 12, 12, 24},
-                {3, 16, 12, 12, 12}
-            }
-        },
+    {{}, {{3, 16, 24, 12, 36}}},
+    {// dynamic
+     {-1, 16, -1, -1, -1},
+     // target
+     {{1, 16, 12, 24, 24}, {3, 16, 12, 12, 12}, {5, 16, 12, 12, 24}}},
+    {// dynamic
+     {{1, 5}, 16, {1, 48}, {2, 24}, {3, 64}},
+     // target
+     {{2, 16, 12, 12, 24}, {1, 16, 12, 12, 24}, {3, 16, 12, 12, 12}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Block8, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(3),
-                                ::testing::Values(2, 3, 4),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes5D_block),
-                                ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(blocked8_5D_ref)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Block8,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(3),
+                                            ::testing::Values(2, 3, 4),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes5D_block),
+                                            ::testing::ValuesIn(outIndices3),
+                                            ::testing::Values(blocked8_5D_ref)),
+                         SplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Block16, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(4),
-                                ::testing::Values(2, 3, 4),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes5D_block),
-                                ::testing::ValuesIn(outIndices4),
-                                ::testing::Values(blocked16_5D_ref)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Block16,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(4),
+                                            ::testing::Values(2, 3, 4),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes5D_block),
+                                            ::testing::ValuesIn(outIndices4),
+                                            ::testing::Values(blocked16_5D_ref)),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes3D = {
-        { {}, {{14, 28, 21}} },
-        {
-            // dynamic
-            {-1, -1, -1},
-            // target
-            {
-                {7, 21, 14},
-                {21, 7, 14},
-                {21, 14, 7},
-            }
-        },
-        {
-            // dynamic
-            {{1, 60}, {1, 50}, {1, 48}},
-            // target
-            {
-                {14, 21, 7},
-                {21, 7, 14},
-                {7, 14, 21},
-            }
-        },
+    {{}, {{14, 28, 21}}},
+    {// dynamic
+     {-1, -1, -1},
+     // target
+     {
+         {7, 21, 14},
+         {21, 7, 14},
+         {21, 14, 7},
+     }},
+    {// dynamic
+     {{1, 60}, {1, 50}, {1, 48}},
+     // target
+     {
+         {14, 21, 7},
+         {21, 7, 14},
+         {7, 14, 21},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split3D, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(7),
-                                ::testing::Values(1, 2),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::Values(std::vector<size_t>({})),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
-                                SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split3D,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(7),
+                                            ::testing::Values(1, 2),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes3D),
+                                            ::testing::Values(std::vector<size_t>({})),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes2D = {
-        { {}, {{6, 12}} },
-        {
-            // dynamic
-            {-1, -1},
-            // target
-            {
-                {2, 8},
-                {10, 4},
-                {2, 6},
-            }
-        },
-        {
-            // dynamic
-            {{1, 60}, {1, 50}},
-            // target
-            {
-                {2, 4},
-                {4, 4},
-                {6, 12},
-            }
-        },
+    {{}, {{6, 12}}},
+    {// dynamic
+     {-1, -1},
+     // target
+     {
+         {2, 8},
+         {10, 4},
+         {2, 6},
+     }},
+    {// dynamic
+     {{1, 60}, {1, 50}},
+     // target
+     {
+         {2, 4},
+         {4, 4},
+         {6, 12},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split2D, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(2),
-                                ::testing::Values(1),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes2D),
-                                ::testing::Values(std::vector<size_t>({})),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split2D,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(2),
+                                            ::testing::Values(1),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes2D),
+                                            ::testing::Values(std::vector<size_t>({})),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+                         SplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split1D_static, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(5),
-                                ::testing::Values(0),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InputShape{ {}, {{10}} }),
-                                ::testing::Values(std::vector<size_t>({})),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
-                            SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split1D_static,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(5),
+                                            ::testing::Values(0),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(InputShape{{}, {{10}}}),
+                                            ::testing::Values(std::vector<size_t>({})),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes1D = {
-        {
-            // dynamic
-            {-1},
-            // target
-            {
-                {5},
-                {15},
-                {10},
-            }
-        },
-        {
-            // dynamic
-            {{1, 60}},
-            // target
-            {
-                {15},
-                {5},
-                {10},
-            }
-        },
+    {// dynamic
+     {-1},
+     // target
+     {
+         {5},
+         {15},
+         {10},
+     }},
+    {// dynamic
+     {{1, 60}},
+     // target
+     {
+         {15},
+         {5},
+         {10},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split1D, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(5),
-                                ::testing::Values(0),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes1D),
-                                ::testing::Values(std::vector<size_t>({})),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
-                            SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split1D,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(5),
+                                            ::testing::Values(0),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes1D),
+                                            ::testing::Values(std::vector<size_t>({})),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_dynBatch = {
-        {
-            // dynamic
-            {{1, 10}, 6, 6, 9},
-            // target
-            {
-                {6, 6, 6, 9},
-                {9, 6, 6, 9},
-            }
-        },
+    {// dynamic
+     {{1, 10}, 6, 6, 9},
+     // target
+     {
+         {6, 6, 6, 9},
+         {9, 6, 6, 9},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_by_batch, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(3),
-                                ::testing::Values(1),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::ValuesIn(inputShapes4D_dynBatch),
-                                ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(planar_4D_ref, perChannels_4D)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_by_batch,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(3),
+                                            ::testing::Values(1),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::ValuesIn(inputShapes4D_dynBatch),
+                                            ::testing::ValuesIn(outIndices3),
+                                            ::testing::Values(planar_4D_ref, perChannels_4D)),
+                         SplitLayerCPUTest::getTestCaseName);
 
 // ============================================== inPlace cases ============================================
-const std::vector<InputShape> inputShapes4D_inPlace_0 = {
-        {{}, {{3, 24, 24, 9}}},
-        {{}, {{6, 24, 24}}},
-        {{}, {{9, 24}}},
-        {
-            // dynamic
-            {3, -1, -1, -1, -1},
-            // target
-            {
-                {3, 24, 6, 9, 4},
-                {3, 12, 12, 15, 5},
-            }
-        },
-        {
-            // dynamic
-            {6, -1, -1, -1},
-            // target
-            {
-                {6, 24, 6, 9},
-                {6, 12, 12, 15},
-            }
-        },
-        {
-            // dynamic
-            {9, -1, -1},
-            // target
-            {
-                {9, 24, 6},
-                {9, 12, 12},
-            }
-        }
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_Split_CPU_planar_inPlace_0, SplitLayerCPUTest,
-                    ::testing::Combine(
-                            ::testing::Values(3),
-                            ::testing::Values(0),
-                            ::testing::Values(ElementType::f32),
-                            ::testing::ValuesIn(inputShapes4D_inPlace_0),
-                            ::testing::Values(std::vector<size_t>{}),
-                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
-                    SplitLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Block8inPlace_1, SplitLayerCPUTest,
-                    ::testing::Combine(
-                            ::testing::Values(4),
-                            ::testing::Values(1),
-                            ::testing::ValuesIn(netPrecisions),
-                            ::testing::Values(InputShape{ {}, {{1, 32, 5, 6}} },
-                                              InputShape{ {1, 32, -1, -1},
+const std::vector<InputShape> inputShapes4D_inPlace_0 = {{{}, {{3, 24, 24, 9}}},
+                                                         {{}, {{6, 24, 24}}},
+                                                         {{}, {{9, 24}}},
+                                                         {// dynamic
+                                                          {3, -1, -1, -1, -1},
+                                                          // target
                                                           {
-                                                              {1, 32, 5, 6},
-                                                              {1, 32, 5, 2},
-                                                              {1, 32, 5, 8}
-                                                           } }),
-                            ::testing::ValuesIn(outIndices4),
-                            ::testing::Values(planar_4D, blocked8_4D)),
-                    SplitLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Block16inPlace_1, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(3),
-                                ::testing::Values(1),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InputShape{ {}, {{1, 48, 5, 6, 3}} },
-                                              InputShape{ {1, 48, -1, -1, 3},
+                                                              {3, 24, 6, 9, 4},
+                                                              {3, 12, 12, 15, 5},
+                                                          }},
+                                                         {// dynamic
+                                                          {6, -1, -1, -1},
+                                                          // target
                                                           {
-                                                              {1, 48, 5, 6, 3},
-                                                              {1, 48, 5, 2, 3},
-                                                              {1, 48, 5, 8, 3}
-                                                           } }),
-                                ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(planar_5D, blocked16_5D)),
-                        SplitLayerCPUTest::getTestCaseName);
+                                                              {6, 24, 6, 9},
+                                                              {6, 12, 12, 15},
+                                                          }},
+                                                         {// dynamic
+                                                          {9, -1, -1},
+                                                          // target
+                                                          {
+                                                              {9, 24, 6},
+                                                              {9, 12, 12},
+                                                          }}};
 
-} // namespace
+INSTANTIATE_TEST_SUITE_P(smoke_Split_CPU_planar_inPlace_0,
+                         SplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(3),
+                                            ::testing::Values(0),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(inputShapes4D_inPlace_0),
+                                            ::testing::Values(std::vector<size_t>{}),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+                         SplitLayerCPUTest::getTestCaseName);
 
-} // namespace CPULayerTestsDefinitions
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Split4D_CPU_Block8inPlace_1,
+    SplitLayerCPUTest,
+    ::testing::Combine(::testing::Values(4),
+                       ::testing::Values(1),
+                       ::testing::ValuesIn(netPrecisions),
+                       ::testing::Values(InputShape{{}, {{1, 32, 5, 6}}},
+                                         InputShape{{1, 32, -1, -1}, {{1, 32, 5, 6}, {1, 32, 5, 2}, {1, 32, 5, 8}}}),
+                       ::testing::ValuesIn(outIndices4),
+                       ::testing::Values(planar_4D, blocked8_4D)),
+    SplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Split5D_CPU_Block16inPlace_1,
+    SplitLayerCPUTest,
+    ::testing::Combine(::testing::Values(3),
+                       ::testing::Values(1),
+                       ::testing::ValuesIn(netPrecisions),
+                       ::testing::Values(InputShape{{}, {{1, 48, 5, 6, 3}}},
+                                         InputShape{{1, 48, -1, -1, 3},
+                                                    {{1, 48, 5, 6, 3}, {1, 48, 5, 2, 3}, {1, 48, 5, 8, 3}}}),
+                       ::testing::ValuesIn(outIndices3),
+                       ::testing::Values(planar_5D, blocked16_5D)),
+    SplitLayerCPUTest::getTestCaseName);
+
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/strided_slice.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/strided_slice.cpp
@@ -2,15 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <shared_test_classes/single_layer/strided_slice.hpp>
-#include "ov_models/builders.hpp"
-#include "test_utils/cpu_test_utils.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include <common_test_utils/ov_tensor_utils.hpp>
+#include "test_utils/cpu_test_utils.hpp"
 
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
-using namespace LayerTestsDefinitions;
 using namespace ov;
 using namespace test;
 
@@ -27,20 +23,21 @@ struct StridedSliceParams {
     std::vector<int64_t> ellipsisAxisMask;
 };
 
-typedef std::tuple<
-        InputShape,                         // Input shapes
-        StridedSliceParams,
-        ngraph::helpers::InputLayerType,    // Secondary input types
-        ElementType,                        // Element type
-        CPUSpecificParams> StridedSliceLayerCPUTestParamSet;
+typedef std::tuple<InputShape,  // Input shapes
+                   StridedSliceParams,
+                   ov::test::utils::InputLayerType,  // Secondary input types
+                   ElementType,                      // Element type
+                   CPUSpecificParams>
+    StridedSliceLayerCPUTestParamSet;
 
 class StridedSliceLayerCPUTest : public testing::WithParamInterface<StridedSliceLayerCPUTestParamSet>,
-                                 virtual public SubgraphBaseTest, public CPUTestsBase {
+                                 virtual public SubgraphBaseTest,
+                                 public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<StridedSliceLayerCPUTestParamSet> obj) {
         InputShape shapes;
         StridedSliceParams params;
-        ngraph::helpers::InputLayerType secondaryInputType;
+        ov::test::utils::InputLayerType secondaryInputType;
         ElementType dataType;
         CPUSpecificParams cpuParams;
         std::tie(shapes, params, secondaryInputType, dataType, cpuParams) = obj.param;
@@ -58,16 +55,19 @@ public:
         results << "stride=" << ov::test::utils::vec2str(params.strides) << "_";
         results << "begin_m=" << ov::test::utils::vec2str(params.beginMask) << "_";
         results << "end_m=" << ov::test::utils::vec2str(params.endMask) << "_";
-        results << "new_axis_m=" << (params.newAxisMask.empty() ? "def" : ov::test::utils::vec2str(params.newAxisMask)) << "_";
-        results << "shrink_m=" << (params.shrinkAxisMask.empty() ? "def" : ov::test::utils::vec2str(params.shrinkAxisMask)) << "_";
-        results << "ellipsis_m=" << (params.ellipsisAxisMask.empty() ? "def" : ov::test::utils::vec2str(params.ellipsisAxisMask)) << "_";
+        results << "new_axis_m=" << (params.newAxisMask.empty() ? "def" : ov::test::utils::vec2str(params.newAxisMask))
+                << "_";
+        results << "shrink_m="
+                << (params.shrinkAxisMask.empty() ? "def" : ov::test::utils::vec2str(params.shrinkAxisMask)) << "_";
+        results << "ellipsis_m="
+                << (params.ellipsisAxisMask.empty() ? "def" : ov::test::utils::vec2str(params.ellipsisAxisMask)) << "_";
         results << CPUTestsBase::getTestCaseName(cpuParams);
 
         return results.str();
     }
 
 protected:
-    void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override {
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
         std::vector<void*> inputValues = {ssParams.begin.data(), ssParams.end.data(), ssParams.strides.data()};
 
         inputs.clear();
@@ -76,9 +76,13 @@ protected:
             const auto& funcInput = funcInputs[i];
             ov::Tensor tensor;
             if (i == 0) {
-                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 10, 1, 1);
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[i],
+                                                                 10,
+                                                                 1,
+                                                                 1);
             } else {
-                tensor = ov::Tensor{ov::element::i64, targetInputStaticShapes[i], inputValues[i-1]};
+                tensor = ov::Tensor{ov::element::i64, targetInputStaticShapes[i], inputValues[i - 1]};
             }
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
         }
@@ -86,7 +90,7 @@ protected:
 
     void SetUp() override {
         InputShape shapes;
-        ngraph::helpers::InputLayerType secondaryInputType;
+        ov::test::utils::InputLayerType secondaryInputType;
         CPUSpecificParams cpuParams;
         ov::element::Type dataType;
         std::tie(shapes, ssParams, secondaryInputType, dataType, cpuParams) = this->GetParam();
@@ -108,7 +112,7 @@ protected:
             params.push_back(std::make_shared<ov::op::v0::Parameter>(dataType, shape));
         }
         ov::NodeVector ss_inputs;
-        if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
+        if (secondaryInputType == ov::test::utils::InputLayerType::PARAMETER) {
             ov::Shape inShape = {ssParams.begin.size()};
 
             auto beginNode = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inShape);
@@ -125,9 +129,11 @@ protected:
             ss_inputs.push_back(strideNode);
         } else {
             ov::Shape constShape = {ssParams.begin.size()};
-            auto beginNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.begin.data());
+            auto beginNode =
+                std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.begin.data());
             auto endNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.end.data());
-            auto strideNode = std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.strides.data());
+            auto strideNode =
+                std::make_shared<ov::op::v0::Constant>(ov::element::i64, constShape, ssParams.strides.data());
 
             ss_inputs.push_back(params[0]);
             ss_inputs.push_back(beginNode);
@@ -157,343 +163,500 @@ TEST_P(StridedSliceLayerCPUTest, CompareWithRefs) {
 
 namespace {
 
-const auto cpuParams_nChw16c = CPUSpecificParams {{nChw16c}, {nChw16c}, {}, {}};
-const auto cpuParams_nCdhw16c = CPUSpecificParams {{nCdhw16c}, {nCdhw16c}, {}, {}};
+const auto cpuParams_nChw16c = CPUSpecificParams{{nChw16c}, {nChw16c}, {}, {}};
+const auto cpuParams_nCdhw16c = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {}, {}};
 
-const auto cpuParams_nChw8c = CPUSpecificParams {{nChw8c}, {nChw8c}, {}, {}};
-const auto cpuParams_nCdhw8c = CPUSpecificParams {{nCdhw8c}, {nCdhw8c}, {}, {}};
+const auto cpuParams_nChw8c = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, {}};
+const auto cpuParams_nCdhw8c = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, {}};
 
-const auto cpuParams_nhwc = CPUSpecificParams {{nhwc}, {nhwc}, {}, {}};
-const auto cpuParams_ndhwc = CPUSpecificParams {{ndhwc}, {ndhwc}, {}, {}};
+const auto cpuParams_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {}, {}};
+const auto cpuParams_ndhwc = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, {}};
 
-const auto cpuParams_nchw = CPUSpecificParams {{nchw}, {nchw}, {}, {}};
-const auto cpuParams_ncdhw = CPUSpecificParams {{ncdhw}, {ncdhw}, {}, {}};
+const auto cpuParams_nchw = CPUSpecificParams{{nchw}, {nchw}, {}, {}};
+const auto cpuParams_ncdhw = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, {}};
 
-const std::vector<ElementType> inputPrecisions = {
-        ElementType::f32,
-        ElementType::bf16,
-        ElementType::i8
-};
+const std::vector<ElementType> inputPrecisions = {ElementType::f32, ElementType::bf16, ElementType::i8};
 
-const std::vector<ngraph::helpers::InputLayerType> inputLayerTypes = {
-        ngraph::helpers::InputLayerType::CONSTANT,
-        ngraph::helpers::InputLayerType::PARAMETER
-};
+const std::vector<ov::test::utils::InputLayerType> inputLayerTypes = {ov::test::utils::InputLayerType::CONSTANT,
+                                                                      ov::test::utils::InputLayerType::PARAMETER};
 
 const std::vector<InputShape> inputShapesDynamic2D = {
-        {{-1, -1},
-         {{32, 20}, {16, 16}, {24, 16}}},
+    {{-1, -1}, {{32, 20}, {16, 16}, {24, 16}}},
 
-        {{-1, 16},
-         {{16, 16}, {20, 16}, {32, 16}}},
+    {{-1, 16}, {{16, 16}, {20, 16}, {32, 16}}},
 
-        {{{16, 32}, {16, 32}},
-         {{16, 32}, {32, 16}, {24, 24}}},
+    {{{16, 32}, {16, 32}}, {{16, 32}, {32, 16}, {24, 24}}},
 };
 
 const std::vector<StridedSliceParams> paramsPlain2D = {
-        StridedSliceParams{ { 2, 5 }, { 16, 8 }, { 1, 1 }, { 0, 0 }, { 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { -10, -11 }, { -2, -3 }, { 1, 1 }, { 0, 0 }, { 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { -16, -17 }, { -2, -3 }, { 1, 1 }, { 0, 0 }, { 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 2, 44 }, { 55, -2 }, { 2, 3 }, { 0, 1 }, { 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 2, -7 }, { 1, -2 }, { 2, 3 }, { 1, 0 }, { 1, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 2 }, { 22 }, { 2 }, { 0 }, { 0 },  { },  { },  { } },
+    StridedSliceParams{{2, 5}, {16, 8}, {1, 1}, {0, 0}, {0, 0}, {}, {}, {}},
+    StridedSliceParams{{-10, -11}, {-2, -3}, {1, 1}, {0, 0}, {0, 0}, {}, {}, {}},
+    StridedSliceParams{{-16, -17}, {-2, -3}, {1, 1}, {0, 0}, {0, 0}, {}, {}, {}},
+    StridedSliceParams{{2, 44}, {55, -2}, {2, 3}, {0, 1}, {0, 0}, {}, {}, {}},
+    StridedSliceParams{{2, -7}, {1, -2}, {2, 3}, {1, 0}, {1, 0}, {}, {}, {}},
+    StridedSliceParams{{2}, {22}, {2}, {0}, {0}, {}, {}, {}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Static_2D, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation({{32, 20}})),
-                                 ::testing::ValuesIn(paramsPlain2D),
-                                 ::testing::ValuesIn(inputLayerTypes),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::Values(emptyCPUSpec)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Static_2D,
+                         StridedSliceLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation({{32, 20}})),
+                                            ::testing::ValuesIn(paramsPlain2D),
+                                            ::testing::ValuesIn(inputLayerTypes),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::Values(emptyCPUSpec)),
                          StridedSliceLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Dynamic_2D, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                             ::testing::ValuesIn(inputShapesDynamic2D),
-                             ::testing::ValuesIn(paramsPlain2D),
-                             ::testing::ValuesIn(inputLayerTypes),
-                             ::testing::ValuesIn(inputPrecisions),
-                             ::testing::Values(emptyCPUSpec)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Dynamic_2D,
+                         StridedSliceLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic2D),
+                                            ::testing::ValuesIn(paramsPlain2D),
+                                            ::testing::ValuesIn(inputLayerTypes),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::Values(emptyCPUSpec)),
                          StridedSliceLayerCPUTest::getTestCaseName);
 
 const std::vector<StridedSliceParams> testCasesCommon4D = {
-        StridedSliceParams{ { 0, 2, 5, 4 }, { 1, 4, 28, 27 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10, 0 }, { 1, 3, 20, 20 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 1, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 20, 20 }, { 1, 5, 25, 26 }, { 1, 1, 1, 2 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 20 }, { 1, 2, 30, 30 }, { 1, 1, 2, 1 }, { 0, 0, 0, 1 }, { 0, 1, 0, 1 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 2, 10 }, { 1, 3, 32, 20 }, { 1, 1, 1, 1 }, { 0, 0, 1, 1 }, { 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 1, 0, 10 }, { 1, 5, 32, 30 }, { 1, 1, 1, 1 }, { 0, 1, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 2, 10 }, { 1, 8, 32, 18 }, { 1, 2, 1, 2 },  { 0, 0, 1, 0 }, { 0, 0, 0, 1 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10 }, { 0, 32, 18 }, { 1, 1, 1 }, { 1, 1, 0 }, { 1, 1, 0 },  { },  { },  { 1, 0, 0 } },
-        StridedSliceParams{ { 0, 4, 10 }, { 1, 8, 0 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 1, 1 },  { },  { },  { 0, 0, 1 } }
-};
+    StridedSliceParams{{0, 2, 5, 4}, {1, 4, 28, 27}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 10, 0}, {1, 3, 20, 20}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 1, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 20, 20}, {1, 5, 25, 26}, {1, 1, 1, 2}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 0, 20}, {1, 2, 30, 30}, {1, 1, 2, 1}, {0, 0, 0, 1}, {0, 1, 0, 1}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 2, 10}, {1, 3, 32, 20}, {1, 1, 1, 1}, {0, 0, 1, 1}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 1, 0, 10}, {1, 5, 32, 30}, {1, 1, 1, 1}, {0, 1, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 2, 10}, {1, 8, 32, 18}, {1, 2, 1, 2}, {0, 0, 1, 0}, {0, 0, 0, 1}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 10}, {0, 32, 18}, {1, 1, 1}, {1, 1, 0}, {1, 1, 0}, {}, {}, {1, 0, 0}},
+    StridedSliceParams{{0, 4, 10}, {1, 8, 0}, {1, 1, 1}, {1, 0, 1}, {1, 1, 1}, {}, {}, {0, 0, 1}}};
 
-const std::vector<Shape> inputShapesStatic4D = {
-    { 1, 5, 32, 32 }, { 2, 5, 32, 48 }
-};
+const std::vector<Shape> inputShapesStatic4D = {{1, 5, 32, 32}, {2, 5, 32, 48}};
 
 const std::vector<InputShape> inputShapesDynamic4D = {
-        {{-1, -1, -1, -1},
-         {{ 1, 5, 32, 32 }, { 2, 5, 32, 32 }, { 1, 5, 64, 64 }, {0, 0, 0, 0}}},
+    {{-1, -1, -1, -1}, {{1, 5, 32, 32}, {2, 5, 32, 32}, {1, 5, 64, 64}, {0, 0, 0, 0}}},
 
-        {{-1, 5, -1, -1},
-         {{ 1, 5, 32, 32 }, { 2, 5, 32, 32 }, { 3, 5, 32, 36 }, {0, 5, 0, 0}}},
+    {{-1, 5, -1, -1}, {{1, 5, 32, 32}, {2, 5, 32, 32}, {3, 5, 32, 36}, {0, 5, 0, 0}}},
 
-        {{{1, 5}, 5, {32, 64}, {32, 64}},
-         {{ 2, 5, 32, 32 }, { 1, 5, 48, 32 }, { 5, 5, 32, 32 }}},
+    {{{1, 5}, 5, {32, 64}, {32, 64}}, {{2, 5, 32, 32}, {1, 5, 48, 32}, {5, 5, 32, 32}}},
 };
 
 const std::vector<CPUSpecificParams> CPUParamsCommon4D = {
-        cpuParams_nchw,
-        cpuParams_nhwc,
+    cpuParams_nchw,
+    cpuParams_nhwc,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_4D, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic4D)),
-                                 ::testing::ValuesIn(testCasesCommon4D),
-                                 ::testing::ValuesIn(inputLayerTypes),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsCommon4D)),
-                         StridedSliceLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_4D,
+    StridedSliceLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic4D)),
+                       ::testing::ValuesIn(testCasesCommon4D),
+                       ::testing::ValuesIn(inputLayerTypes),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsCommon4D)),
+    StridedSliceLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                             ::testing::ValuesIn(inputShapesDynamic4D),
-                             ::testing::ValuesIn(testCasesCommon4D),
-                             ::testing::ValuesIn(inputLayerTypes),
-                             ::testing::ValuesIn(inputPrecisions),
-                             ::testing::ValuesIn(CPUParamsCommon4D)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D,
+                         StridedSliceLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic4D),
+                                            ::testing::ValuesIn(testCasesCommon4D),
+                                            ::testing::ValuesIn(inputLayerTypes),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsCommon4D)),
                          StridedSliceLayerCPUTest::getTestCaseName);
 
 const std::vector<StridedSliceParams> testCasesBlocked4DSubset1 = {
-        StridedSliceParams{ { 0, 0, 0, 0 }, { 1, 32, 32, 32 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 16, 0 }, { 1, 32, 32, 32 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 1 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0 }, { 1, 32, 32, 16 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 1 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0 }, { 1, 16, 32, 32 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 1 },  { },  { },  { } },
+    StridedSliceParams{{0, 0, 0, 0}, {1, 32, 32, 32}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 16, 0}, {1, 32, 32, 32}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 1}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 0, 0}, {1, 32, 32, 16}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 1}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 0, 0}, {1, 16, 32, 32}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 1}, {}, {}, {}},
 };
 
 const std::vector<StridedSliceParams> testCasesBlocked4DSubset2 = {
-       StridedSliceParams{ { 0, 0, 5, 4 }, { 1, 16, 28, 27 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, 16, 0, 0 }, { 1, 32, 10, 10 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, 0, 20, 20 }, { 1, 32, 25, 25 }, { 1, 1, 1, 1 }, { 0, 1, 0, 0 }, { 0, 1, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, 16, 2, 10 }, { 1, 32, 32, 20 }, { 1, 1, 2, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, 16, 0, 0 }, { 2, 64, 32, 20 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, 32, 0, 0 }, { 2, 50, 32, 20 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, 0, 0, 0 }, { 2, 12, 32, 20 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, -16, 0, 10 }, { 2, 100, 32, 20 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, -32, 0, 0 }, { 2, -12, 32, 20 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-       StridedSliceParams{ { 0, 10 }, { 0, 20 }, { 1, 1 }, { 1, 0 }, { 1, 0 },  { },  { },  { 1, 0 } },
-       StridedSliceParams{ { 0, 16, 0 }, { 2, 32, 0 }, { 1, 1, 1 }, { 1, 0, 1 }, { 1, 1, 1 },  { },  { },  { 0, 0, 1 } },
+    StridedSliceParams{{0, 0, 5, 4}, {1, 16, 28, 27}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 16, 0, 0}, {1, 32, 10, 10}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 20, 20}, {1, 32, 25, 25}, {1, 1, 1, 1}, {0, 1, 0, 0}, {0, 1, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 16, 2, 10}, {1, 32, 32, 20}, {1, 1, 2, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 16, 0, 0}, {2, 64, 32, 20}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 32, 0, 0}, {2, 50, 32, 20}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 0, 0}, {2, 12, 32, 20}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, -16, 0, 10}, {2, 100, 32, 20}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, -32, 0, 0}, {2, -12, 32, 20}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 10}, {0, 20}, {1, 1}, {1, 0}, {1, 0}, {}, {}, {1, 0}},
+    StridedSliceParams{{0, 16, 0}, {2, 32, 0}, {1, 1, 1}, {1, 0, 1}, {1, 1, 1}, {}, {}, {0, 0, 1}},
 };
 
-const std::vector<Shape> inputShapesBlockedStatic4DSubset1 = {
-        { 1, 32, 32, 32 }, { 1, 32, 32, 64 }
-};
+const std::vector<Shape> inputShapesBlockedStatic4DSubset1 = {{1, 32, 32, 32}, {1, 32, 32, 64}};
 
-const std::vector<Shape> inputShapesBlockedStatic4DSubset2 = {
-        { 1, 64, 32, 32 }, { 1, 64, 32, 64 }
-};
+const std::vector<Shape> inputShapesBlockedStatic4DSubset2 = {{1, 64, 32, 32}, {1, 64, 32, 64}};
 
 const std::vector<InputShape> inputShapesBlockedDynamic4DSubset1 = {
-        {{-1, 32, -1, -1},
-         {{ 1, 32, 32, 32 }, { 2, 32, 32, 32 }, { 3, 32, 32, 48 }}},
+    {{-1, 32, -1, -1}, {{1, 32, 32, 32}, {2, 32, 32, 32}, {3, 32, 32, 48}}},
 
-        {{{1, 5}, 32, {32, 64}, {32, 64}},
-         {{ 2, 32, 32, 32 }, { 1, 32, 48, 32 }, { 5, 32, 32, 48 }}},
+    {{{1, 5}, 32, {32, 64}, {32, 64}}, {{2, 32, 32, 32}, {1, 32, 48, 32}, {5, 32, 32, 48}}},
 };
 
 const std::vector<InputShape> inputShapesBlockedDynamic4DSubset2 = {
-        {{-1, 64, -1, -1},
-         {{ 1, 64, 64, 32 }, { 2, 64, 32, 32 }, { 3, 64, 32, 48 }}},
+    {{-1, 64, -1, -1}, {{1, 64, 64, 32}, {2, 64, 32, 32}, {3, 64, 32, 48}}},
 
-         {{{1, 5}, 64, {32, 64}, {32, 64}},
-          {{ 2, 64, 32, 32 }, { 1, 64, 48, 32 }, { 1, 64, 64, 64 }}},
+    {{{1, 5}, 64, {32, 64}, {32, 64}}, {{2, 64, 32, 32}, {1, 64, 48, 32}, {1, 64, 64, 64}}},
 };
 
 const std::vector<CPUSpecificParams> CPUParamsBlocked4D = {
-        cpuParams_nChw16c,
-        cpuParams_nChw8c,
+    cpuParams_nChw16c,
+    cpuParams_nChw8c,
 };
 
-const std::vector<ngraph::helpers::InputLayerType> inputLayerTypesBlocked = {
-        ngraph::helpers::InputLayerType::CONSTANT,
+const std::vector<ov::test::utils::InputLayerType> inputLayerTypesBlocked = {
+    ov::test::utils::InputLayerType::CONSTANT,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_4D_Subset1, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset1)),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset1),
-                                 ::testing::ValuesIn(inputLayerTypesBlocked),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_4D_Subset1,
+    StridedSliceLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset1)),
+                       ::testing::ValuesIn(testCasesBlocked4DSubset1),
+                       ::testing::ValuesIn(inputLayerTypesBlocked),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsBlocked4D)),
+    StridedSliceLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D_Subset1,
+                         StridedSliceLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesBlockedDynamic4DSubset1),
+                                            ::testing::ValuesIn(testCasesBlocked4DSubset1),
+                                            ::testing::ValuesIn(inputLayerTypesBlocked),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsBlocked4D)),
                          StridedSliceLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D_Subset1, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesBlockedDynamic4DSubset1),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset1),
-                                 ::testing::ValuesIn(inputLayerTypesBlocked),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
-                         StridedSliceLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_4D_Subset2,
+    StridedSliceLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset2)),
+                       ::testing::ValuesIn(testCasesBlocked4DSubset2),
+                       ::testing::ValuesIn(inputLayerTypesBlocked),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsBlocked4D)),
+    StridedSliceLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_4D_Subset2, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset2)),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset2),
-                                 ::testing::ValuesIn(inputLayerTypesBlocked),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
-                         StridedSliceLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D_Subset2, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesBlockedDynamic4DSubset2),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset2),
-                                 ::testing::ValuesIn(inputLayerTypesBlocked),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_4D_Subset2,
+                         StridedSliceLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesBlockedDynamic4DSubset2),
+                                            ::testing::ValuesIn(testCasesBlocked4DSubset2),
+                                            ::testing::ValuesIn(inputLayerTypesBlocked),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsBlocked4D)),
                          StridedSliceLayerCPUTest::getTestCaseName);
 
 const std::vector<StridedSliceParams> testCasesCommon5D = {
-        StridedSliceParams{ { 0, 2, 0, 5, 4 }, { 1, 4, 5, 28, 27 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10, 0, 0 }, { 1, 5, 20, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 1, 10, 0, 0 }, { 1, 3, 20, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 1, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 20, 20 }, { 1, 5, 20, 30, 26 }, { 1, 1, 1, 2, 2 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10, 0, 20 }, { 1, 2, 20, 30, 30 }, { 1, 1, 2, 1, 1 }, { 0, 0, 0, 0, 1 }, { 0, 1, 0, 1, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 2, 10, 0 }, { 1, 5, 10, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 0, 1, 1, 0 }, { 0, 0, 0, 0, 1 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 1, 0, 10, 0 }, { 1, 5, 20, 32, 32 }, { 1, 1, 1, 1, 1 }, { 0, 1, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0, 0 }, { 1, 5, 10, 16, 16 }, { 1, 1, 2, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
+    StridedSliceParams{{0, 2, 0, 5, 4},
+                       {1, 4, 5, 28, 27},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 10, 0, 0},
+                       {1, 5, 20, 32, 20},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 1, 10, 0, 0},
+                       {1, 3, 20, 32, 20},
+                       {1, 1, 1, 1, 1},
+                       {0, 1, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 20, 20},
+                       {1, 5, 20, 30, 26},
+                       {1, 1, 1, 2, 2},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 10, 0, 20},
+                       {1, 2, 20, 30, 30},
+                       {1, 1, 2, 1, 1},
+                       {0, 0, 0, 0, 1},
+                       {0, 1, 0, 1, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 2, 10, 0},
+                       {1, 5, 10, 32, 20},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 1, 1, 0},
+                       {0, 0, 0, 0, 1},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 1, 0, 10, 0},
+                       {1, 5, 20, 32, 32},
+                       {1, 1, 1, 1, 1},
+                       {0, 1, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 0, 0},
+                       {1, 5, 10, 16, 16},
+                       {1, 1, 2, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
 };
 
-const std::vector<Shape> inputShapesStatic5D = {
-        { 1, 5, 20, 32, 32 }, { 2, 5, 32, 32, 32 }
-};
+const std::vector<Shape> inputShapesStatic5D = {{1, 5, 20, 32, 32}, {2, 5, 32, 32, 32}};
 
 const std::vector<InputShape> inputShapesDynamic5D = {
-        {{-1, -1, -1, -1, -1},
-         {{ 1, 5, 32, 32, 32 }, { 1, 5, 32, 32, 48 }, { 1, 5, 64, 64, 64 }, { 1, 10, 32, 32, 32 }, {0, 0, 0, 0, 0}}},
+    {{-1, -1, -1, -1, -1},
+     {{1, 5, 32, 32, 32}, {1, 5, 32, 32, 48}, {1, 5, 64, 64, 64}, {1, 10, 32, 32, 32}, {0, 0, 0, 0, 0}}},
 
-        {{-1, 5, -1, -1, -1},
-         {{ 1, 5, 32, 32, 48 }, { 1, 5, 32, 48, 32 }, { 1, 5, 48, 32, 32 }, {0, 5, 0, 0, 0}}},
+    {{-1, 5, -1, -1, -1}, {{1, 5, 32, 32, 48}, {1, 5, 32, 48, 32}, {1, 5, 48, 32, 32}, {0, 5, 0, 0, 0}}},
 
-        {{{1, 5}, 5, {32, 64}, {32, 64}, {32, 64}},
-         {{ 2, 5, 32, 32, 32 }, { 1, 5, 48, 32, 32 }, { 5, 5, 32, 32, 48 }}},
+    {{{1, 5}, 5, {32, 64}, {32, 64}, {32, 64}}, {{2, 5, 32, 32, 32}, {1, 5, 48, 32, 32}, {5, 5, 32, 32, 48}}},
 };
 
 const std::vector<CPUSpecificParams> CPUParamsCommon5D = {
-        cpuParams_ncdhw,
-        cpuParams_ndhwc,
+    cpuParams_ncdhw,
+    cpuParams_ndhwc,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_5D, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic5D)),
-                                 ::testing::ValuesIn(testCasesCommon5D),
-                                 ::testing::ValuesIn(inputLayerTypes),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsCommon5D)),
-                        StridedSliceLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_5D,
+    StridedSliceLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic5D)),
+                       ::testing::ValuesIn(testCasesCommon5D),
+                       ::testing::ValuesIn(inputLayerTypes),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsCommon5D)),
+    StridedSliceLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesDynamic5D),
-                                 ::testing::ValuesIn(testCasesCommon5D),
-                                 ::testing::ValuesIn(inputLayerTypes),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsCommon5D)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D,
+                         StridedSliceLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDynamic5D),
+                                            ::testing::ValuesIn(testCasesCommon5D),
+                                            ::testing::ValuesIn(inputLayerTypes),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsCommon5D)),
                          StridedSliceLayerCPUTest::getTestCaseName);
 
 const std::vector<StridedSliceParams> testCasesBlocked5DSubset1 = {
-        StridedSliceParams{ { 0, 0, 0, 5, 4 }, { 1, 16, 5, 28, 27 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10, 0, 0 }, { 1, 16, 20, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 1, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 20, 20 }, { 1, 16, 20, 30, 26 }, { 1, 1, 1, 2, 2 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10, 0, 20 }, { 1, 16, 20, 30, 30 }, { 1, 1, 2, 1, 1 }, { 0, 0, 0, 0, 1 }, { 0, 1, 0, 1, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 2, 10, 0 }, { 1, 16, 10, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 0, 1, 1, 0 }, { 0, 0, 0, 0, 1 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 10, 0 }, { 1, 8, 20, 32, 32 }, { 1, 1, 1, 1, 1 }, { 0, 1, 0, 0, 0 }, { 0, 1, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0, 0 }, { 1, 16, 10, 16, 16 }, { 1, 1, 2, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
+    StridedSliceParams{{0, 0, 0, 5, 4},
+                       {1, 16, 5, 28, 27},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 10, 0, 0},
+                       {1, 16, 20, 32, 20},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 1, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 20, 20},
+                       {1, 16, 20, 30, 26},
+                       {1, 1, 1, 2, 2},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 10, 0, 20},
+                       {1, 16, 20, 30, 30},
+                       {1, 1, 2, 1, 1},
+                       {0, 0, 0, 0, 1},
+                       {0, 1, 0, 1, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 2, 10, 0},
+                       {1, 16, 10, 32, 20},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 1, 1, 0},
+                       {0, 0, 0, 0, 1},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 10, 0},
+                       {1, 8, 20, 32, 32},
+                       {1, 1, 1, 1, 1},
+                       {0, 1, 0, 0, 0},
+                       {0, 1, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 0, 0},
+                       {1, 16, 10, 16, 16},
+                       {1, 1, 2, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
 };
 
 const std::vector<StridedSliceParams> testCasesBlocked5DSubset2 = {
-        StridedSliceParams{ { 0, 0, 0, 5, 4 }, { 1, 16, 5, 28, 27 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10, 0, 0 }, { 1, 16, 20, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10, 0, 0 }, { 1, 16, 20, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 1, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 20, 20 }, { 1, 16, 20, 30, 26 }, { 1, 1, 1, 2, 2 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 10, 0, 20 }, { 1, 16, 20, 30, 30 }, { 1, 1, 2, 1, 1 }, { 0, 0, 0, 0, 1 }, { 0, 1, 0, 1, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 2, 10, 0 }, { 1, 16, 10, 32, 20 }, { 1, 1, 1, 1, 1 }, { 0, 0, 1, 1, 0 }, { 0, 0, 0, 0, 1 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 10, 0 }, { 1, 8, 20, 32, 32 }, { 1, 1, 1, 1, 1 }, { 0, 1, 0, 0, 0 }, { 0, 1, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0, 0 }, { 1, 16, 10, 16, 16 }, { 1, 1, 2, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0, 0 }, { 1, 25, 20, 10, 10 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 16, 0, 0, 0 }, { 1, 25, 20, 10, 10 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 16, 0, 0, 0 }, { 1, 64, 20, 10, 10 }, { 1, 1, 1, 1, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0 },  { },  { },  { } },
+    StridedSliceParams{{0, 0, 0, 5, 4},
+                       {1, 16, 5, 28, 27},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 10, 0, 0},
+                       {1, 16, 20, 32, 20},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 10, 0, 0},
+                       {1, 16, 20, 32, 20},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 1, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 20, 20},
+                       {1, 16, 20, 30, 26},
+                       {1, 1, 1, 2, 2},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 10, 0, 20},
+                       {1, 16, 20, 30, 30},
+                       {1, 1, 2, 1, 1},
+                       {0, 0, 0, 0, 1},
+                       {0, 1, 0, 1, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 2, 10, 0},
+                       {1, 16, 10, 32, 20},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 1, 1, 0},
+                       {0, 0, 0, 0, 1},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 10, 0},
+                       {1, 8, 20, 32, 32},
+                       {1, 1, 1, 1, 1},
+                       {0, 1, 0, 0, 0},
+                       {0, 1, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 0, 0},
+                       {1, 16, 10, 16, 16},
+                       {1, 1, 2, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 0, 0},
+                       {1, 25, 20, 10, 10},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 16, 0, 0, 0},
+                       {1, 25, 20, 10, 10},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
+    StridedSliceParams{{0, 16, 0, 0, 0},
+                       {1, 64, 20, 10, 10},
+                       {1, 1, 1, 1, 1},
+                       {0, 0, 0, 0, 0},
+                       {0, 0, 0, 0, 0},
+                       {},
+                       {},
+                       {}},
 };
 
-const std::vector<Shape> inputShapesBlockedStatic5DSubset1 = {
-        { 1, 16, 32, 32, 32 }, { 2, 16, 32, 32, 32 }, { 2, 32, 32, 32, 32 }
-};
+const std::vector<Shape> inputShapesBlockedStatic5DSubset1 = {{1, 16, 32, 32, 32},
+                                                              {2, 16, 32, 32, 32},
+                                                              {2, 32, 32, 32, 32}};
 
-const std::vector<Shape> inputShapesBlockedStatic5DSubset2 = {
-        { 1, 64, 32, 32, 32 }, { 2, 64, 32, 64, 32 }, { 2, 64, 32, 32, 32 }
-};
+const std::vector<Shape> inputShapesBlockedStatic5DSubset2 = {{1, 64, 32, 32, 32},
+                                                              {2, 64, 32, 64, 32},
+                                                              {2, 64, 32, 32, 32}};
 
 const std::vector<InputShape> inputShapesBlockedDynamic5DSubset1 = {
-        {{-1, 16, -1, -1, -1},
-         {{ 1, 16, 32, 32, 32 }, { 2, 16, 32, 32, 32 }, { 2, 16, 32, 32, 32 }}},
+    {{-1, 16, -1, -1, -1}, {{1, 16, 32, 32, 32}, {2, 16, 32, 32, 32}, {2, 16, 32, 32, 32}}},
 
-        {{{1, 5}, 16, {16, 32}, {16, 32}, {16, 32}},
-         {{ 1, 16, 32, 32, 32 }, { 2, 16, 32, 32, 32 }, { 1, 16, 20, 32, 32 }}},
+    {{{1, 5}, 16, {16, 32}, {16, 32}, {16, 32}}, {{1, 16, 32, 32, 32}, {2, 16, 32, 32, 32}, {1, 16, 20, 32, 32}}},
 };
 
 const std::vector<InputShape> inputShapesBlockedDynamic5DSubset2 = {
-        {{-1, 64, -1, -1, -1},
-         {{ 1, 64, 64, 32, 32 }, { 2, 64, 32, 32, 32 }, { 3, 64, 32, 48, 32 }}},
+    {{-1, 64, -1, -1, -1}, {{1, 64, 64, 32, 32}, {2, 64, 32, 32, 32}, {3, 64, 32, 48, 32}}},
 
-        {{{1, 5}, 64, {16, 32}, {16, 32}, {16, 32}},
-         {{ 1, 64, 32, 32, 32 }, { 2, 64, 32, 32, 32 }, { 1, 64, 20, 32, 32 }}},
+    {{{1, 5}, 64, {16, 32}, {16, 32}, {16, 32}}, {{1, 64, 32, 32, 32}, {2, 64, 32, 32, 32}, {1, 64, 20, 32, 32}}},
 };
 
 const std::vector<CPUSpecificParams> CPUParamsBlocked5D = {
-        cpuParams_nCdhw16c,
-        cpuParams_nCdhw8c,
+    cpuParams_nCdhw16c,
+    cpuParams_nCdhw8c,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_5D_Subset1, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic5DSubset1)),
-                                 ::testing::ValuesIn(testCasesBlocked5DSubset1),
-                                 ::testing::ValuesIn(inputLayerTypesBlocked),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked5D)),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_5D_Subset1,
+    StridedSliceLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic5DSubset1)),
+                       ::testing::ValuesIn(testCasesBlocked5DSubset1),
+                       ::testing::ValuesIn(inputLayerTypesBlocked),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsBlocked5D)),
+    StridedSliceLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset1,
+                         StridedSliceLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesBlockedDynamic5DSubset1),
+                                            ::testing::ValuesIn(testCasesBlocked5DSubset1),
+                                            ::testing::ValuesIn(inputLayerTypesBlocked),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsBlocked5D)),
                          StridedSliceLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset1, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesBlockedDynamic5DSubset1),
-                                 ::testing::ValuesIn(testCasesBlocked5DSubset1),
-                                 ::testing::ValuesIn(inputLayerTypesBlocked),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked5D)),
-                         StridedSliceLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_CompareWithRefs_Common_Static_5D_Subset2,
+    StridedSliceLayerCPUTest,
+    ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset2)),
+                       ::testing::ValuesIn(testCasesBlocked4DSubset2),
+                       ::testing::ValuesIn(inputLayerTypesBlocked),
+                       ::testing::ValuesIn(inputPrecisions),
+                       ::testing::ValuesIn(CPUParamsBlocked4D)),
+    StridedSliceLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Static_5D_Subset2, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(static_shapes_to_test_representation(inputShapesBlockedStatic4DSubset2)),
-                                 ::testing::ValuesIn(testCasesBlocked4DSubset2),
-                                 ::testing::ValuesIn(inputLayerTypesBlocked),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked4D)),
-                         StridedSliceLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset2, StridedSliceLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesBlockedDynamic5DSubset2),
-                                 ::testing::ValuesIn(testCasesBlocked5DSubset2),
-                                 ::testing::ValuesIn(inputLayerTypesBlocked),
-                                 ::testing::ValuesIn(inputPrecisions),
-                                 ::testing::ValuesIn(CPUParamsBlocked5D)),
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset2,
+                         StridedSliceLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesBlockedDynamic5DSubset2),
+                                            ::testing::ValuesIn(testCasesBlocked5DSubset2),
+                                            ::testing::ValuesIn(inputLayerTypesBlocked),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::ValuesIn(CPUParamsBlocked5D)),
                          StridedSliceLayerCPUTest::getTestCaseName);
 
 /* Descriptors check */
@@ -505,27 +668,39 @@ TEST_P(StridedSliceLayerDescriptorCPUTest, DescriptorsCheck) {
 }
 
 const std::vector<StridedSliceParams> testCasesDescriptors = {
-        StridedSliceParams{ { 0, -4, 0, 0 }, { 0, 2147483647, 0, 0 }, { 1, 1, 1, 1 }, { 1, 0, 1, 1 }, { 1, 0, 1, 1 }, { },  { },  { } },
-        StridedSliceParams{ { 0, 5, 0, 0 }, { 1, 20, 28, 27 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0 }, { 1, 2147483647, 32, 32 }, { 1, 2, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  { },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0 }, { 1, 2147483647, 32, 32 }, { 1, 2, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  { },  {0, 1, 0, 0 },  { } },
-        StridedSliceParams{ { 0, 0, 0, 0 }, { 1, 2147483647, 32, 32 }, { 1, 2, 1, 1 }, { 0, 0, 0, 0 }, { 0, 0, 0, 0 },  {0, 0, 1, 0 },  { },  { } },
+    StridedSliceParams{{0, -4, 0, 0}, {0, 2147483647, 0, 0}, {1, 1, 1, 1}, {1, 0, 1, 1}, {1, 0, 1, 1}, {}, {}, {}},
+    StridedSliceParams{{0, 5, 0, 0}, {1, 20, 28, 27}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 0, 0}, {1, 2147483647, 32, 32}, {1, 2, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, {}, {}, {}},
+    StridedSliceParams{{0, 0, 0, 0},
+                       {1, 2147483647, 32, 32},
+                       {1, 2, 1, 1},
+                       {0, 0, 0, 0},
+                       {0, 0, 0, 0},
+                       {},
+                       {0, 1, 0, 0},
+                       {}},
+    StridedSliceParams{{0, 0, 0, 0},
+                       {1, 2147483647, 32, 32},
+                       {1, 2, 1, 1},
+                       {0, 0, 0, 0},
+                       {0, 0, 0, 0},
+                       {0, 0, 1, 0},
+                       {},
+                       {}},
 };
 
-const std::vector<InputShape> inputShapesDescriptors = {
-        {{}, {{ 1, 16, 32, 32 }}},
-        {{}, {{ 1, 17, 32, 32 }}},
-        {{1, -1, 32, 32}, {{ 1, 16, 32, 32 }, { 1, 32, 32, 32 }}}
-};
+const std::vector<InputShape> inputShapesDescriptors = {{{}, {{1, 16, 32, 32}}},
+                                                        {{}, {{1, 17, 32, 32}}},
+                                                        {{1, -1, 32, 32}, {{1, 16, 32, 32}, {1, 32, 32, 32}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_StridedSliceLayerDescriptorCPUTest, StridedSliceLayerDescriptorCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputShapesDescriptors),
-                                 ::testing::ValuesIn(testCasesDescriptors),
-                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                 ::testing::Values(ElementType::f32),
-                                 ::testing::Values(cpuParams_nChw8c)),
+INSTANTIATE_TEST_SUITE_P(smoke_StridedSliceLayerDescriptorCPUTest,
+                         StridedSliceLayerDescriptorCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapesDescriptors),
+                                            ::testing::ValuesIn(testCasesDescriptors),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::Values(cpuParams_nChw8c)),
                          StridedSliceLayerDescriptorCPUTest::getTestCaseName);
 
-} // namespace
-} // namespace CPULayerTestsDefinitions
+}  // namespace
+}  // namespace CPULayerTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/tensor_iterator.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/tensor_iterator.cpp
@@ -2,29 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <shared_test_classes/single_layer/tensor_iterator.hpp>
+#include "common_test_utils/node_builders/activation.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include "ov_models/builders.hpp"
-#include <common_test_utils/ov_tensor_utils.hpp>
 
-using namespace InferenceEngine;
 using namespace ov;
 using namespace test;
 
-namespace CPULayerTestsDefinitions {
-
-using TensorIteratorParams = typename std::tuple<
-        std::vector<InputShape>,                    // Input shapes
-        ngraph::op::RecurrentSequenceDirection,     // Direction
-        ElementType>;                               // element type
-
+using TensorIteratorParams = typename std::tuple<std::vector<InputShape>,             // Input shapes
+                                                 ov::op::RecurrentSequenceDirection,  // Direction
+                                                 ElementType>;                        // element type
 
 class TensorIteratorCPUTest : public testing::WithParamInterface<TensorIteratorParams>,
                               virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<TensorIteratorParams> obj) {
         std::vector<InputShape> shapes;
-        ngraph::op::RecurrentSequenceDirection direction;
+        ov::op::RecurrentSequenceDirection direction;
         ElementType inType;
         std::tie(shapes, direction, inType) = obj.param;
 
@@ -45,7 +39,7 @@ public:
 protected:
     void SetUp() override {
         std::vector<InputShape> shapes;
-        ngraph::op::RecurrentSequenceDirection direction;
+        ov::op::RecurrentSequenceDirection direction;
         ElementType inType;
         std::tie(shapes, direction, inType) = this->GetParam();
 
@@ -53,31 +47,31 @@ protected:
         init_input_shapes({shapes});
 
         const size_t sequence_axis = 1;
-        auto tensor_iterator = std::make_shared<ngraph::opset5::TensorIterator>();
+        auto tensor_iterator = std::make_shared<ov::op::v0::TensorIterator>();
         ov::ParameterVector params;
         for (auto&& shape : inputDynamicShapes) {
             params.push_back(std::make_shared<ov::op::v0::Parameter>(inType, shape));
         }
 
-        ngraph::ParameterVector body_params;
+        ov::ParameterVector body_params;
         for (size_t i = 0; i < shapes.size(); i++) {
-            ngraph::PartialShape shape = shapes[i].first;
+            ov::PartialShape shape = shapes[i].first;
             shape[sequence_axis] = 1;
-            auto paramNode = std::make_shared<ngraph::opset1::Parameter>(inType, shape);
+            auto paramNode = std::make_shared<ov::op::v0::Parameter>(inType, shape);
             body_params.push_back(paramNode);
         }
-        auto tanh = ngraph::builder::makeActivation(body_params[0], inType, ngraph::helpers::Tanh);
-        auto relu = ngraph::builder::makeActivation(body_params[1], inType, ngraph::helpers::Relu);
-        auto add = std::make_shared<ngraph::opset1::Add>(tanh, relu);
+        auto tanh = ov::test::utils::make_activation(body_params[0], inType, ov::test::utils::ActivationTypes::Tanh);
+        auto relu = ov::test::utils::make_activation(body_params[1], inType, ov::test::utils::ActivationTypes::Relu);
+        auto add = std::make_shared<ov::op::v1::Add>(tanh, relu);
 
-        auto body = std::make_shared<ov::Model>(ngraph::OutputVector{add}, body_params, "body");
+        auto body = std::make_shared<ov::Model>(ov::OutputVector{add}, body_params, "body");
         tensor_iterator->set_function(body);
 
-        if (direction == ngraph::op::RecurrentSequenceDirection::FORWARD) {
+        if (direction == ov::op::RecurrentSequenceDirection::FORWARD) {
             tensor_iterator->set_sliced_input(body_params[0], params[0], 0, 1, 1, -1, sequence_axis);
             tensor_iterator->set_sliced_input(body_params[1], params[1], 0, 1, 1, -1, sequence_axis);
             tensor_iterator->get_concatenated_slices(add, 0, 1, 1, -1, sequence_axis);
-        } else if (direction == ngraph::op::RecurrentSequenceDirection::REVERSE) {
+        } else if (direction == ov::op::RecurrentSequenceDirection::REVERSE) {
             tensor_iterator->set_sliced_input(body_params[0], params[0], -1, -1, 1, 0, sequence_axis);
             tensor_iterator->set_sliced_input(body_params[1], params[1], -1, -1, 1, 0, sequence_axis);
             tensor_iterator->get_concatenated_slices(add, -1, -1, 1, 0, sequence_axis);
@@ -85,7 +79,7 @@ protected:
             NGRAPH_CHECK(false, "Bidirectional case is not supported.");
         }
 
-        function = std::make_shared<ov::Model>(ngraph::OutputVector{tensor_iterator->output(0)}, params);
+        function = std::make_shared<ov::Model>(ov::OutputVector{tensor_iterator->output(0)}, params);
     }
 };
 
@@ -95,64 +89,51 @@ TEST_P(TensorIteratorCPUTest, CompareWithRefs) {
 
 namespace {
 
-const std::vector<ElementType> inputPrecisions = {
-        ElementType::f32,
-        ElementType::bf16,
-        ElementType::i8
-};
+const std::vector<ElementType> inputPrecisions = {ElementType::f32, ElementType::bf16, ElementType::i8};
 
-std::vector<ngraph::op::RecurrentSequenceDirection> direction = {ngraph::op::RecurrentSequenceDirection::FORWARD,
-                                                                 ngraph::op::RecurrentSequenceDirection::REVERSE};
-std::vector<std::vector<InputShape>> inputs = {
-    {  //first test suit
-        {   //dynamic shape for first input
-            {-1, -1, -1},
-            {  // target static shapes
-                {10, 12, 10},
-                {10, 8, 10},
-                {1, 8, 2},
-                {5, 3, 3}
-            }
-        },
-        {   //dynamic shape for second input
-            {-1, -1, -1},
-            {  // target static shapes
-                {1, 12, 1},
-                {1, 8, 1},
-                {5, 8, 2},
-                {5, 3, 3}
-            }
-        },
-    },
+std::vector<ov::op::RecurrentSequenceDirection> direction = {ov::op::RecurrentSequenceDirection::FORWARD,
+                                                             ov::op::RecurrentSequenceDirection::REVERSE};
+std::vector<std::vector<InputShape>> inputs = {{
+                                                   // first test suit
+                                                   {// dynamic shape for first input
+                                                    {-1, -1, -1},
+                                                    {// target static shapes
+                                                     {10, 12, 10},
+                                                     {10, 8, 10},
+                                                     {1, 8, 2},
+                                                     {5, 3, 3}}},
+                                                   {// dynamic shape for second input
+                                                    {-1, -1, -1},
+                                                    {// target static shapes
+                                                     {1, 12, 1},
+                                                     {1, 8, 1},
+                                                     {5, 8, 2},
+                                                     {5, 3, 3}}},
+                                               },
 
-    {  //second test suit
-        {   //dynamic shape for first input
-            {{1, 12}, 5, {1, 12}},
-            {  // target static shapes
-                {1, 5, 1},
-                {5, 5, 5},
-                {1, 5, 1},
-                {5, 5, 5}
-             }
-        },
-        {   //dynamic shape for second input
-            {{1, 12}, 5, {1, 12}},
-            {  // target static shapes
-                {1, 5, 1},
-                {1, 5, 1},
-                {5, 5, 1},
-                {5, 5, 5}
-            }
-        },
-    }
-};
+                                               {
+                                                   // second test suit
+                                                   {// dynamic shape for first input
+                                                    {{1, 12}, 5, {1, 12}},
+                                                    {// target static shapes
+                                                     {1, 5, 1},
+                                                     {5, 5, 5},
+                                                     {1, 5, 1},
+                                                     {5, 5, 5}}},
+                                                   {// dynamic shape for second input
+                                                    {{1, 12}, 5, {1, 12}},
+                                                    {// target static shapes
+                                                     {1, 5, 1},
+                                                     {1, 5, 1},
+                                                     {5, 5, 1},
+                                                     {5, 5, 5}}},
+                                               }};
 
-INSTANTIATE_TEST_SUITE_P(smoke_TensorIteratorSimple, TensorIteratorCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(inputs),
-                                 ::testing::ValuesIn(direction),
-                                 ::testing::ValuesIn(inputPrecisions)),
+INSTANTIATE_TEST_SUITE_P(smoke_TensorIteratorSimple,
+                         TensorIteratorCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputs),
+                                            ::testing::ValuesIn(direction),
+                                            ::testing::ValuesIn(inputPrecisions)),
                          TensorIteratorCPUTest::getTestCaseName);
 
 }  // namespace
-} // namespace CPULayerTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/tile.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/tile.cpp
@@ -3,27 +3,22 @@
 //
 
 #include "test_utils/cpu_test_utils.hpp"
-#include "ov_models/builders.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include <common_test_utils/ov_tensor_utils.hpp>
 
 using namespace CPUTestUtils;
 
-namespace CPULayerTestsDefinitions {
+using TileLayerTestParamsSet = typename std::tuple<std::vector<ov::test::InputShape>,  // Input shapes
+                                                   std::vector<int64_t>,               // Repeats
+                                                   ov::element::Type_t,                // Network precision
+                                                   bool,                               // Is Repeats input constant
+                                                   std::string>;                       // Device name
 
-using TileLayerTestParamsSet = typename std::tuple<
-        std::vector<ov::test::InputShape>,     // Input shapes
-        std::vector<int64_t>,                  // Repeats
-        ov::element::Type_t,                   // Network precision
-        bool,                                  // Is Repeats input constant
-        std::string>;                          // Device name
-
-typedef std::tuple<
-        TileLayerTestParamsSet,
-        CPUSpecificParams> TileLayerCPUTestParamsSet;
+typedef std::tuple<TileLayerTestParamsSet, CPUSpecificParams> TileLayerCPUTestParamsSet;
 
 class TileLayerCPUTest : public testing::WithParamInterface<TileLayerCPUTestParamsSet>,
-                         virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
+                         virtual public ov::test::SubgraphBaseTest,
+                         public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<TileLayerCPUTestParamsSet> obj) {
         TileLayerTestParamsSet basicParamsSet;
@@ -48,7 +43,7 @@ public:
                 result << ov::test::utils::vec2str(item) << "_";
             }
         }
-        result << "Repeats=" << ov::test::utils::vec2str(repeats)  << "_";
+        result << "Repeats=" << ov::test::utils::vec2str(repeats) << "_";
         result << "netPrec=" << netPrecision << "_";
         result << "constRepeats=" << (isRepeatsConst ? "True" : "False") << "_";
         result << "trgDev=" << deviceName;
@@ -71,12 +66,12 @@ protected:
         bool isRepeatsConst;
         std::tie(inputShapes, repeatsData, netPrecision, isRepeatsConst, targetDevice) = basicParamsSet;
 
-        selectedType += std::string("_") + InferenceEngine::details::convertPrecision(netPrecision).name();
+        selectedType += std::string("_") + ov::element::Type(netPrecision).get_type_name();
 
         if (inputShapes.front().first.rank() != 0) {
             inputDynamicShapes.push_back(inputShapes.front().first);
             if (!isRepeatsConst) {
-                inputDynamicShapes.push_back({ static_cast<int64_t>(repeatsData.size()) });
+                inputDynamicShapes.push_back({static_cast<int64_t>(repeatsData.size())});
             }
         }
         const size_t targetStaticShapeSize = inputShapes.front().second.size();
@@ -84,16 +79,18 @@ protected:
         for (size_t i = 0lu; i < targetStaticShapeSize; ++i) {
             targetStaticShapes[i].push_back(inputShapes.front().second[i]);
             if (!isRepeatsConst)
-                targetStaticShapes[i].push_back({ repeatsData.size() });
+                targetStaticShapes[i].push_back({repeatsData.size()});
         }
 
         ov::ParameterVector functionParams;
         if (inputDynamicShapes.empty()) {
-            functionParams.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, targetStaticShapes.front().front()));
+            functionParams.push_back(
+                std::make_shared<ov::op::v0::Parameter>(netPrecision, targetStaticShapes.front().front()));
         } else {
             functionParams.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes.front()));
             if (!isRepeatsConst) {
-                functionParams.push_back(std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputDynamicShapes[1]));
+                functionParams.push_back(
+                    std::make_shared<ov::op::v0::Parameter>(ov::element::i64, inputDynamicShapes[1]));
                 functionParams.back()->set_friendly_name("repeats");
             }
         }
@@ -101,15 +98,16 @@ protected:
 
         std::shared_ptr<ov::Node> tileNode;
         if (isRepeatsConst) {
-            tileNode = std::make_shared<ov::op::v0::Tile>(functionParams[0],
-                    ov::op::v0::Constant::create(ov::element::i64, { repeatsData.size() }, repeatsData));
+            tileNode = std::make_shared<ov::op::v0::Tile>(
+                functionParams[0],
+                ov::op::v0::Constant::create(ov::element::i64, {repeatsData.size()}, repeatsData));
         } else {
             tileNode = std::make_shared<ov::op::v0::Tile>(functionParams[0], functionParams[1]);
         }
         function = makeNgraphFunction(netPrecision, functionParams, tileNode, "CPUTile");
     }
 
-    void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override {
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
         inputs.clear();
         const auto& funcInputs = function->inputs();
         for (size_t i = 0lu; i < funcInputs.size(); i++) {
@@ -123,10 +121,14 @@ protected:
                 }
             } else {
                 if (funcInput.get_element_type().is_real()) {
-                    tensor = ov::test::utils::create_and_fill_tensor(
-                        funcInput.get_element_type(), targetInputStaticShapes[i], 10, 0, 1000);
+                    tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                     targetInputStaticShapes[i],
+                                                                     10,
+                                                                     0,
+                                                                     1000);
                 } else {
-                    tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i]);
+                    tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                     targetInputStaticShapes[i]);
                 }
             }
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
@@ -158,186 +160,124 @@ const auto cpuParams_ndhwc = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "ref"};
 /* ========== */
 
 /* PARAMS */
-const std::vector<ov::element::Type_t> netPrecisions = {
-    ov::element::f32,
-    ov::element::bf16,
-    ov::element::i32,
-    ov::element::i8
-};
+const std::vector<ov::element::Type_t> netPrecisions = {ov::element::f32,
+                                                        ov::element::bf16,
+                                                        ov::element::i32,
+                                                        ov::element::i8};
 
-const std::vector<std::vector<ov::test::InputShape>> staticInputShapes4D = {
-    {
-        {{},
-            { // Static shapes
-                {2, 16, 3, 4}
-            }
-        }
-    },
-    {
-        {{},
-            { // Static shapes
-                {1, 16, 1, 1}
-            }
-        }
-    }
-};
+const std::vector<std::vector<ov::test::InputShape>> staticInputShapes4D = {{{{},
+                                                                              {// Static shapes
+                                                                               {2, 16, 3, 4}}}},
+                                                                            {{{},
+                                                                              {// Static shapes
+                                                                               {1, 16, 1, 1}}}}};
 const std::vector<std::vector<ov::test::InputShape>> dynamicInputShapes4D = {
-    {
-        { // Origin dynamic shapes
-            {ov::Dimension(1, 20), ov::Dimension(10, 20), ov::Dimension(1, 20), ov::Dimension(1, 20)},
-            { // Dynamic shapes instances
-                {2, 16, 3, 4},
-                {1, 16, 1, 1},
-                {1, 16, 2, 3}
-            }
-         }
-    },
-    {
-        { // Origin dynamic shapes
-            {-1, -1, -1, -1},
-            { // Dynamic shapes instances
-                {3, 15, 5, 7},
-                {4, 55, 8, 24}
-            }
-        }
-    }
-};
+    {{// Origin dynamic shapes
+      {ov::Dimension(1, 20), ov::Dimension(10, 20), ov::Dimension(1, 20), ov::Dimension(1, 20)},
+      {// Dynamic shapes instances
+       {2, 16, 3, 4},
+       {1, 16, 1, 1},
+       {1, 16, 2, 3}}}},
+    {{// Origin dynamic shapes
+      {-1, -1, -1, -1},
+      {// Dynamic shapes instances
+       {3, 15, 5, 7},
+       {4, 55, 8, 24}}}}};
 
-const std::vector<std::vector<ov::test::InputShape>> staticInputShapes5D = {
-    {
-        {{},
-            { // Static shapes
-                {2, 16, 2, 3, 4}
-            }
-        }
-    }
-};
+const std::vector<std::vector<ov::test::InputShape>> staticInputShapes5D = {{{{},
+                                                                              {// Static shapes
+                                                                               {2, 16, 2, 3, 4}}}}};
 const std::vector<std::vector<ov::test::InputShape>> dynamicInputShapes5D = {
-    {
-        { // Origin dynamic shapes
-            {ov::Dimension(1, 20), ov::Dimension(1, 20), ov::Dimension(1, 20), ov::Dimension(1, 20), ov::Dimension(1, 70)},
-            { // Dynamic shapes instances
-                {2, 16, 2, 3, 4},
-                {1, 16, 8, 5, 4},
-                {8, 1, 2, 3, 64}
-            }
-        }
-    },
-    {
-        { // Origin dynamic shapes
-            {-1, -1, -1, -1, -1},
-            { // Dynamic shapes instances
-                {2, 16, 2, 3, 4},
-                {1, 16, 8, 5, 4},
-                {8, 1, 2, 3, 64}
-            }
-        }
-    }
-};
+    {{// Origin dynamic shapes
+      {ov::Dimension(1, 20), ov::Dimension(1, 20), ov::Dimension(1, 20), ov::Dimension(1, 20), ov::Dimension(1, 70)},
+      {// Dynamic shapes instances
+       {2, 16, 2, 3, 4},
+       {1, 16, 8, 5, 4},
+       {8, 1, 2, 3, 64}}}},
+    {{// Origin dynamic shapes
+      {-1, -1, -1, -1, -1},
+      {// Dynamic shapes instances
+       {2, 16, 2, 3, 4},
+       {1, 16, 8, 5, 4},
+       {8, 1, 2, 3, 64}}}}};
 
-const std::vector<std::vector<int64_t>> repeats4D = {
-        {2, 3},
-        {1, 2, 3},
-        {1, 1, 1, 1},
-        {1, 1, 2, 3},
-        {1, 2, 1, 3},
-        {2, 1, 1, 1},
-        {2, 3, 1, 1}
-};
-const std::vector<std::vector<int64_t>> repeats5D = {
-        {1, 2, 3},
-        {1, 1, 2, 3},
-        {1, 1, 1, 2, 3},
-        {1, 2, 1, 1, 3},
-        {2, 1, 1, 1, 1},
-        {2, 3, 1, 1, 1}
-};
+const std::vector<std::vector<int64_t>> repeats4D =
+    {{2, 3}, {1, 2, 3}, {1, 1, 1, 1}, {1, 1, 2, 3}, {1, 2, 1, 3}, {2, 1, 1, 1}, {2, 3, 1, 1}};
+const std::vector<std::vector<int64_t>> repeats5D =
+    {{1, 2, 3}, {1, 1, 2, 3}, {1, 1, 1, 2, 3}, {1, 2, 1, 1, 3}, {2, 1, 1, 1, 1}, {2, 3, 1, 1, 1}};
 
 const std::vector<CPUSpecificParams> CPUParams4D = {
-        cpuParams_nchw,
-        cpuParams_nChw16c,
-        cpuParams_nChw8c,
-        cpuParams_nhwc,
+    cpuParams_nchw,
+    cpuParams_nChw16c,
+    cpuParams_nChw8c,
+    cpuParams_nhwc,
 };
 
 const std::vector<CPUSpecificParams> CPUParams5D = {
-        cpuParams_ncdhw,
-        cpuParams_nCdhw16c,
-        cpuParams_nCdhw8c,
-        cpuParams_ndhwc,
+    cpuParams_ncdhw,
+    cpuParams_nCdhw16c,
+    cpuParams_nCdhw8c,
+    cpuParams_ndhwc,
 };
 /* ============= */
 
 /* INSTANCES */
-INSTANTIATE_TEST_CASE_P(smoke_StaticShape4D, TileLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        ::testing::ValuesIn(staticInputShapes4D),
-                                        ::testing::ValuesIn(repeats4D),
-                                        ::testing::ValuesIn(netPrecisions),
-                                        ::testing::Values(true),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(CPUParams4D)),
+INSTANTIATE_TEST_CASE_P(smoke_StaticShape4D,
+                        TileLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(staticInputShapes4D),
+                                                              ::testing::ValuesIn(repeats4D),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(true),
+                                                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(CPUParams4D)),
                         TileLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_DynamicShape4D, TileLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        ::testing::ValuesIn(dynamicInputShapes4D),
-                                        ::testing::ValuesIn(repeats4D),
-                                        ::testing::ValuesIn(netPrecisions),
-                                        ::testing::Values(true, false),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+INSTANTIATE_TEST_CASE_P(smoke_DynamicShape4D,
+                        TileLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(dynamicInputShapes4D),
+                                                              ::testing::ValuesIn(repeats4D),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(true, false),
+                                                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                           ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         TileLayerCPUTest::getTestCaseName);
 
-const std::vector<std::vector<ov::test::InputShape>> dynBatchInputShapes4D = {
-    { // Origin dynamic shapes
-        {
-            {{1, 20}, 16, 3, 4},
-            { // Dynamic shapes instances
-                {2, 16, 3, 4},
-                {1, 16, 3, 4},
-                {3, 16, 3, 4}
-            }
-        }
-    }
-};
+const std::vector<std::vector<ov::test::InputShape>> dynBatchInputShapes4D = {{// Origin dynamic shapes
+                                                                               {{{1, 20}, 16, 3, 4},
+                                                                                {// Dynamic shapes instances
+                                                                                 {2, 16, 3, 4},
+                                                                                 {1, 16, 3, 4},
+                                                                                 {3, 16, 3, 4}}}}};
 
-INSTANTIATE_TEST_CASE_P(smoke_DynBatch4D, TileLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                    ::testing::ValuesIn(dynBatchInputShapes4D),
-                                    ::testing::Values(std::vector<int64_t>{1, 2, 1, 3}),
-                                    ::testing::ValuesIn(netPrecisions),
-                                    ::testing::Values(true),
-                                    ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+INSTANTIATE_TEST_CASE_P(smoke_DynBatch4D,
+                        TileLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(dynBatchInputShapes4D),
+                                                              ::testing::Values(std::vector<int64_t>{1, 2, 1, 3}),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(true),
+                                                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                           ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         TileLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_StaticShape5D, TileLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        ::testing::ValuesIn(staticInputShapes5D),
-                                        ::testing::ValuesIn(repeats5D),
-                                        ::testing::ValuesIn(netPrecisions),
-                                        ::testing::Values(true),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(CPUParams5D)),
+INSTANTIATE_TEST_CASE_P(smoke_StaticShape5D,
+                        TileLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(staticInputShapes5D),
+                                                              ::testing::ValuesIn(repeats5D),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(true),
+                                                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                           ::testing::ValuesIn(CPUParams5D)),
                         TileLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_DynamicShape5D, TileLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        ::testing::ValuesIn(dynamicInputShapes5D),
-                                        ::testing::ValuesIn(repeats5D),
-                                        ::testing::ValuesIn(netPrecisions),
-                                        ::testing::Values(true, false),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+INSTANTIATE_TEST_CASE_P(smoke_DynamicShape5D,
+                        TileLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(dynamicInputShapes5D),
+                                                              ::testing::ValuesIn(repeats5D),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(true, false),
+                                                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                           ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         TileLayerCPUTest::getTestCaseName);
 /* ========= */
 
-} // namespace
-
-} // namespace CPULayerTestsDefinitions
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/topk.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/topk.cpp
@@ -2,42 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <common_test_utils/ov_tensor_utils.hpp>
-#include "test_utils/cpu_test_utils.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include "ov_models/builders.hpp"
+#include "test_utils/cpu_test_utils.hpp"
 
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
 using namespace ov::test;
 using SortMode = ov::op::TopKMode;
 using SortType = ov::op::TopKSortType;
 
-namespace CPULayerTestsDefinitions {
+typedef std::tuple<int64_t,                     // keepK
+                   int64_t,                     // axis
+                   SortMode,                    // mode
+                   std::tuple<SortType, bool>,  // sort and stable
+                   ElementType,                 // Net type
+                   ElementType,                 // Input type
+                   ElementType,                 // Output type
+                   InputShape                   // inputShape
+                   >
+    basicTopKParams;
 
-typedef std::tuple<
-        int64_t,                    // keepK
-        int64_t,                    // axis
-        SortMode,                   // mode
-        std::tuple<SortType, bool>, // sort and stable
-        ElementType,                // Net precision
-        ElementType,                // Input precision
-        ElementType,                // Output precision
-        InputShape                  // inputShape
-> basicTopKParams;
-
-typedef std::tuple<
-        basicTopKParams,
-        CPUSpecificParams,
-        std::map<std::string, std::string>> TopKLayerCPUTestParamsSet;
+typedef std::tuple<basicTopKParams, CPUSpecificParams, ov::AnyMap> TopKLayerCPUTestParamsSet;
 
 class TopKLayerCPUTest : public testing::WithParamInterface<TopKLayerCPUTestParamsSet>,
-                         virtual public SubgraphBaseTest, public CPUTestsBase {
+                         virtual public SubgraphBaseTest,
+                         public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<TopKLayerCPUTestParamsSet> obj) {
         basicTopKParams basicParamsSet;
         CPUSpecificParams cpuParams;
-        std::map<std::string, std::string> additionalConfig;
+        ov::AnyMap additionalConfig;
         std::tie(basicParamsSet, cpuParams, additionalConfig) = obj.param;
 
         int64_t keepK, axis;
@@ -60,7 +54,8 @@ public:
         result << "netPRC=" << netPrecision << "_";
         result << "inPRC=" << inPrc << "_";
         result << "outPRC=" << outPrc << "_";
-        result << "IS=" << ov::test::utils::partialShape2str({inputShape.first}) << "_" << "TS=(";
+        result << "IS=" << ov::test::utils::partialShape2str({inputShape.first}) << "_"
+               << "TS=(";
         for (const auto& shape : inputShape.second) {
             result << ov::test::utils::vec2str(shape) << "_";
         }
@@ -70,8 +65,8 @@ public:
         if (!additionalConfig.empty()) {
             result << "_PluginConf";
             for (auto& item : additionalConfig) {
-                if (item.second == PluginConfigParams::YES)
-                    result << "_" << item.first << "=" << item.second;
+                if (item.second == ov::element::bf16)
+                    result << "_" << item.first << "=" << item.second.as<std::string>();
             }
         }
 
@@ -84,7 +79,7 @@ protected:
 
         basicTopKParams basicParamsSet;
         CPUSpecificParams cpuParams;
-        std::map<std::string, std::string> additionalConfig;
+        ov::AnyMap additionalConfig;
         std::tie(basicParamsSet, cpuParams, additionalConfig) = this->GetParam();
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
@@ -98,13 +93,13 @@ protected:
         sort = std::get<0>(sortTypeStable);
         stable = std::get<1>(sortTypeStable);
 
-        if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES)
+        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16)
             inPrc = outPrc = netPrecision = ElementType::bf16;
         else
             inPrc = outPrc = netPrecision;
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        selectedType = getPrimitiveType() + "_" + InferenceEngine::details::convertPrecision(netPrecision).name();
+        selectedType = getPrimitiveType() + "_" + ov::element::Type(netPrecision).get_type_name();
 
         staticShape = inputShape.first.rank() == 0;
         if (staticShape) {
@@ -123,22 +118,22 @@ protected:
         if (staticShape) {
             auto k = std::make_shared<ov::op::v0::Constant>(ElementType::i64, ov::Shape{}, &keepK);
             topk = std::dynamic_pointer_cast<ov::op::v11::TopK>(
-                    std::make_shared<ov::op::v11::TopK>(params[0], k, axis, mode, sort, ElementType::i32, stable));
+                std::make_shared<ov::op::v11::TopK>(params[0], k, axis, mode, sort, ElementType::i32, stable));
         } else {
             auto k = std::make_shared<ov::op::v0::Parameter>(ElementType::i64, inputDynamicShapes[1]);
             params.push_back(k);
             topk = std::dynamic_pointer_cast<ov::op::v11::TopK>(
-                    std::make_shared<ov::op::v11::TopK>(params[0], k, axis, mode, sort, ElementType::i32, stable));
+                std::make_shared<ov::op::v11::TopK>(params[0], k, axis, mode, sort, ElementType::i32, stable));
         }
 
         topk->get_rt_info() = getCPUInfo();
 
-        ngraph::ResultVector results;
+        ov::ResultVector results;
         for (size_t i = 0; i < topk->get_output_size(); i++) {
             results.push_back(std::make_shared<ov::op::v0::Result>(topk->output(i)));
         }
 
-        function = std::make_shared<ngraph::Function>(results, params, "TopK");
+        function = std::make_shared<ov::Model>(results, params, "TopK");
     }
 
     void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
@@ -160,7 +155,7 @@ protected:
             std::vector<int> data(size);
 
             // For int32, deliberately set big numbers which are not accurately representable in fp32
-            int start = netPrecision == ElementType::i32 ? pow(2, 30) + 1 : - static_cast<int>(size / 2);
+            int start = netPrecision == ElementType::i32 ? pow(2, 30) + 1 : -static_cast<int>(size / 2);
             size_t set_size = sort == SortType::SORT_VALUES && stable ? size / 2 : size;
             std::iota(data.begin(), data.begin() + set_size, start);
             if (sort == SortType::SORT_VALUES && stable) {
@@ -170,12 +165,12 @@ protected:
             std::shuffle(data.begin(), data.end(), gen);
 
             if (netPrecision == ElementType::f32) {
-                auto *rawBlobDataPtr = static_cast<float *>(tensor.data());
+                auto* rawBlobDataPtr = static_cast<float*>(tensor.data());
                 for (size_t i = 0; i < size; ++i) {
                     rawBlobDataPtr[i] = static_cast<float>(data[i]);
                 }
             } else {
-                auto *rawBlobDataPtr = static_cast<int32_t *>(tensor.data());
+                auto* rawBlobDataPtr = static_cast<int32_t*>(tensor.data());
                 for (size_t i = 0; i < size; ++i) {
                     rawBlobDataPtr[i] = static_cast<int32_t>(data[i]);
                 }
@@ -190,11 +185,11 @@ protected:
             if (O * A * I != size)
                 FAIL() << "Incorrect blob shape " << shape;
 
-            auto *rawBlobDataPtr = static_cast<ov::bfloat16 *>(tensor.data());
+            auto* rawBlobDataPtr = static_cast<ov::bfloat16*>(tensor.data());
             for (size_t o = 0; o < O; o++) {
                 for (size_t i = 0; i < I; i++) {
                     std::vector<int> data(A);
-                    int start = - static_cast<int>(A / 2);
+                    int start = -static_cast<int>(A / 2);
                     std::iota(data.begin(), data.end(), start);
                     const size_t seed = (o + 1) * (i + 1);
                     std::mt19937 gen(seed);
@@ -248,68 +243,57 @@ const std::vector<ElementType> netPrecisions = {
     ElementType::f32,
 };
 
-std::vector<std::map<std::string, std::string>> additionalConfig = {
-    {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}},
-    {{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES}}
-};
+std::vector<ov::AnyMap> additionalConfig = {{{ov::hint::inference_precision(ov::element::f32)}},
+                                            {{ov::hint::inference_precision(ov::element::bf16)}}};
 
 const std::vector<int64_t> axes = {0, 1, 2, 3};
 const std::vector<int64_t> k = {1, 5, 7, 18, 21};
 
-const std::vector<SortMode> modes = {
-    SortMode::MIN,
-    SortMode::MAX
-};
+const std::vector<SortMode> modes = {SortMode::MIN, SortMode::MAX};
 
 const std::vector<std::tuple<SortType, bool>> sortTypeStable = {
     std::tuple<SortType, bool>{SortType::SORT_VALUES, false},
     std::tuple<SortType, bool>{SortType::SORT_VALUES, true},
-    std::tuple<SortType, bool>{SortType::SORT_INDICES, false}
-};
+    std::tuple<SortType, bool>{SortType::SORT_INDICES, false}};
 
 std::vector<ov::test::InputShape> inputShapes = {
     {{}, {{21, 21, 21, 21}}},
 };
 
 std::vector<ov::test::InputShape> inputShapesDynamic = {
-    {{21, {20, 25}, 21, {20, 25}}, {{21, 21, 21, 21}, {21, 22, 21, 23}}}
-};
+    {{21, {20, 25}, 21, {20, 25}}, {{21, 21, 21, 21}, {21, 22, 21, 23}}}};
 
-std::vector<CPUSpecificParams> cpuParams = {
-    CPUSpecificParams({nChw16c, x}, {nChw16c, nChw16c}, {}, {}),
-    CPUSpecificParams({nchw, x}, {nchw, nchw}, {}, {}),
-    CPUSpecificParams({nhwc, x}, {nhwc, nhwc}, {}, {})
-};
+std::vector<CPUSpecificParams> cpuParams = {CPUSpecificParams({nChw16c, x}, {nChw16c, nChw16c}, {}, {}),
+                                            CPUSpecificParams({nchw, x}, {nchw, nchw}, {}, {}),
+                                            CPUSpecificParams({nhwc, x}, {nhwc, nhwc}, {}, {})};
 
-INSTANTIATE_TEST_CASE_P(smoke_TopK, TopKLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(
-            ::testing::ValuesIn(k),
-            ::testing::ValuesIn(axes),
-            ::testing::ValuesIn(modes),
-            ::testing::ValuesIn(sortTypeStable),
-            ::testing::ValuesIn(netPrecisions),
-            ::testing::Values(ElementType::undefined),
-            ::testing::Values(ElementType::undefined),
-            ::testing::ValuesIn(inputShapes)),
-        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
-        ::testing::ValuesIn(additionalConfig)),
-    TopKLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_TopK,
+                        TopKLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(k),
+                                                              ::testing::ValuesIn(axes),
+                                                              ::testing::ValuesIn(modes),
+                                                              ::testing::ValuesIn(sortTypeStable),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(ElementType::undefined),
+                                                              ::testing::Values(ElementType::undefined),
+                                                              ::testing::ValuesIn(inputShapes)),
+                                           ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
+                                           ::testing::ValuesIn(additionalConfig)),
+                        TopKLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_TopK_dynamic, TopKLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(
-            ::testing::Values(1),
-            ::testing::ValuesIn(axes),
-            ::testing::ValuesIn(modes),
-            ::testing::ValuesIn(sortTypeStable),
-            ::testing::ValuesIn(netPrecisions),
-            ::testing::Values(ElementType::undefined),
-            ::testing::Values(ElementType::undefined),
-            ::testing::ValuesIn(inputShapesDynamic)),
-        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
-        ::testing::ValuesIn(additionalConfig)),
-    TopKLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_TopK_dynamic,
+                        TopKLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::Values(1),
+                                                              ::testing::ValuesIn(axes),
+                                                              ::testing::ValuesIn(modes),
+                                                              ::testing::ValuesIn(sortTypeStable),
+                                                              ::testing::ValuesIn(netPrecisions),
+                                                              ::testing::Values(ElementType::undefined),
+                                                              ::testing::Values(ElementType::undefined),
+                                                              ::testing::ValuesIn(inputShapesDynamic)),
+                                           ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
+                                           ::testing::ValuesIn(additionalConfig)),
+                        TopKLayerCPUTest::getTestCaseName);
 
 const std::vector<int64_t> k_int32 = {1, 5, 7, 9};
 
@@ -318,115 +302,107 @@ std::vector<ov::test::InputShape> inputShapes_int32 = {
 };
 
 std::vector<ov::test::InputShape> inputShapesDynamic_int32 = {
-    {{9, {5, 10}, 9, {5, 10}}, {{9, 9, 9, 9}, {9, 10, 9, 10}}}
-};
+    {{9, {5, 10}, 9, {5, 10}}, {{9, 9, 9, 9}, {9, 10, 9, 10}}}};
 
-INSTANTIATE_TEST_CASE_P(smoke_TopK_int32, TopKLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(
-            ::testing::ValuesIn(k_int32),
-            ::testing::ValuesIn(axes),
-            ::testing::ValuesIn(modes),
-            ::testing::ValuesIn(sortTypeStable),
-            ::testing::Values(ElementType::i32),
-            ::testing::Values(ElementType::undefined),
-            ::testing::Values(ElementType::undefined),
-            ::testing::ValuesIn(inputShapes_int32)),
-        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
-        ::testing::Values(additionalConfig[0])),
-    TopKLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_TopK_int32,
+                        TopKLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::ValuesIn(k_int32),
+                                                              ::testing::ValuesIn(axes),
+                                                              ::testing::ValuesIn(modes),
+                                                              ::testing::ValuesIn(sortTypeStable),
+                                                              ::testing::Values(ElementType::i32),
+                                                              ::testing::Values(ElementType::undefined),
+                                                              ::testing::Values(ElementType::undefined),
+                                                              ::testing::ValuesIn(inputShapes_int32)),
+                                           ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
+                                           ::testing::Values(additionalConfig[0])),
+                        TopKLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_TopK_int32_dynamic, TopKLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(
-            ::testing::Values(1),
-            ::testing::ValuesIn(axes),
-            ::testing::ValuesIn(modes),
-            ::testing::ValuesIn(sortTypeStable),
-            ::testing::Values(ElementType::i32),
-            ::testing::Values(ElementType::undefined),
-            ::testing::Values(ElementType::undefined),
-            ::testing::ValuesIn(inputShapesDynamic_int32)),
-        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
-        ::testing::Values(additionalConfig[0])),
-    TopKLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_TopK_int32_dynamic,
+                        TopKLayerCPUTest,
+                        ::testing::Combine(::testing::Combine(::testing::Values(1),
+                                                              ::testing::ValuesIn(axes),
+                                                              ::testing::ValuesIn(modes),
+                                                              ::testing::ValuesIn(sortTypeStable),
+                                                              ::testing::Values(ElementType::i32),
+                                                              ::testing::Values(ElementType::undefined),
+                                                              ::testing::Values(ElementType::undefined),
+                                                              ::testing::ValuesIn(inputShapesDynamic_int32)),
+                                           ::testing::ValuesIn(filterCPUSpecificParams(cpuParams)),
+                                           ::testing::Values(additionalConfig[0])),
+                        TopKLayerCPUTest::getTestCaseName);
 
 std::vector<ov::test::InputShape> inputShapes_bubble_BLK_on_channel_horiz = {
     {{}, {{2, 2, 2, 2}}},
 };
 
 std::vector<ov::test::InputShape> inputShapesDynamic_bubble_BLK_on_channel_horiz = {
-    {{2, {2, 3}, 2, 2}, {{2, 2, 2, 2}, {2, 3, 2, 2}}}
-};
+    {{2, {2, 3}, 2, 2}, {{2, 2, 2, 2}, {2, 3, 2, 2}}}};
 
-INSTANTIATE_TEST_CASE_P(smoke_TopK_bubble_BLK_on_channel_horiz, TopKLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(
-            ::testing::Values(1),
-            ::testing::Values(1),
-            ::testing::ValuesIn(modes),
-            ::testing::ValuesIn(sortTypeStable),
-            ::testing::ValuesIn(netPrecisions),
-            ::testing::Values(ElementType::undefined),
-            ::testing::Values(ElementType::undefined),
-            ::testing::ValuesIn(inputShapes_bubble_BLK_on_channel_horiz)),
-        ::testing::Values(CPUSpecificParams({nChw16c, x}, {nChw16c, nChw16c}, {}, {})),
-        ::testing::ValuesIn(additionalConfig)),
+INSTANTIATE_TEST_CASE_P(
+    smoke_TopK_bubble_BLK_on_channel_horiz,
+    TopKLayerCPUTest,
+    ::testing::Combine(::testing::Combine(::testing::Values(1),
+                                          ::testing::Values(1),
+                                          ::testing::ValuesIn(modes),
+                                          ::testing::ValuesIn(sortTypeStable),
+                                          ::testing::ValuesIn(netPrecisions),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapes_bubble_BLK_on_channel_horiz)),
+                       ::testing::Values(CPUSpecificParams({nChw16c, x}, {nChw16c, nChw16c}, {}, {})),
+                       ::testing::ValuesIn(additionalConfig)),
     TopKLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_TopK_bubble_BLK_on_channel_horiz_dynamic, TopKLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(
-            ::testing::Values(1),
-            ::testing::Values(1),
-            ::testing::ValuesIn(modes),
-            ::testing::ValuesIn(sortTypeStable),
-            ::testing::ValuesIn(netPrecisions),
-            ::testing::Values(ElementType::undefined),
-            ::testing::Values(ElementType::undefined),
-            ::testing::ValuesIn(inputShapesDynamic_bubble_BLK_on_channel_horiz)),
-        ::testing::Values(CPUSpecificParams({nChw16c, x}, {nChw16c, nChw16c}, {}, {})),
-        ::testing::ValuesIn(additionalConfig)),
+INSTANTIATE_TEST_CASE_P(
+    smoke_TopK_bubble_BLK_on_channel_horiz_dynamic,
+    TopKLayerCPUTest,
+    ::testing::Combine(::testing::Combine(::testing::Values(1),
+                                          ::testing::Values(1),
+                                          ::testing::ValuesIn(modes),
+                                          ::testing::ValuesIn(sortTypeStable),
+                                          ::testing::ValuesIn(netPrecisions),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapesDynamic_bubble_BLK_on_channel_horiz)),
+                       ::testing::Values(CPUSpecificParams({nChw16c, x}, {nChw16c, nChw16c}, {}, {})),
+                       ::testing::ValuesIn(additionalConfig)),
     TopKLayerCPUTest::getTestCaseName);
 
 std::vector<ov::test::InputShape> inputShapes_top1 = {
     {{}, {{1, 1, 2, 1}}},
 };
 
-std::vector<ov::test::InputShape> inputShapesDynamic_top1 = {
-    {{1, 1, 2, {1, 2}}, {{1, 1, 2, 1}, {1, 1, 2, 2}}}
-};
+std::vector<ov::test::InputShape> inputShapesDynamic_top1 = {{{1, 1, 2, {1, 2}}, {{1, 1, 2, 1}, {1, 1, 2, 2}}}};
 
-INSTANTIATE_TEST_CASE_P(smoke_Top1, TopKLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(
-            ::testing::Values(1),
-            ::testing::Values(3),
-            ::testing::Values(SortMode::MAX),
-            ::testing::Values(std::tuple<SortType, bool>(SortType::SORT_INDICES, false)),
-            ::testing::ValuesIn(netPrecisions),
-            ::testing::Values(ElementType::undefined),
-            ::testing::Values(ElementType::undefined),
-            ::testing::ValuesIn(inputShapes_top1)),
-        ::testing::Values(CPUSpecificParams({nchw, x}, {nchw, nchw}, {}, {})),
-        ::testing::ValuesIn(additionalConfig)),
+INSTANTIATE_TEST_CASE_P(
+    smoke_Top1,
+    TopKLayerCPUTest,
+    ::testing::Combine(::testing::Combine(::testing::Values(1),
+                                          ::testing::Values(3),
+                                          ::testing::Values(SortMode::MAX),
+                                          ::testing::Values(std::tuple<SortType, bool>(SortType::SORT_INDICES, false)),
+                                          ::testing::ValuesIn(netPrecisions),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapes_top1)),
+                       ::testing::Values(CPUSpecificParams({nchw, x}, {nchw, nchw}, {}, {})),
+                       ::testing::ValuesIn(additionalConfig)),
     TopKLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke_Top1_dynamic, TopKLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(
-            ::testing::Values(1),
-            ::testing::Values(3),
-            ::testing::Values(SortMode::MAX),
-            ::testing::Values(std::tuple<SortType, bool>(SortType::SORT_INDICES, false)),
-            ::testing::ValuesIn(netPrecisions),
-            ::testing::Values(ElementType::undefined),
-            ::testing::Values(ElementType::undefined),
-            ::testing::ValuesIn(inputShapesDynamic_top1)),
-        ::testing::Values(CPUSpecificParams({nchw, x}, {nchw, nchw}, {}, {})),
-        ::testing::ValuesIn(additionalConfig)),
+INSTANTIATE_TEST_CASE_P(
+    smoke_Top1_dynamic,
+    TopKLayerCPUTest,
+    ::testing::Combine(::testing::Combine(::testing::Values(1),
+                                          ::testing::Values(3),
+                                          ::testing::Values(SortMode::MAX),
+                                          ::testing::Values(std::tuple<SortType, bool>(SortType::SORT_INDICES, false)),
+                                          ::testing::ValuesIn(netPrecisions),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapesDynamic_top1)),
+                       ::testing::Values(CPUSpecificParams({nchw, x}, {nchw, nchw}, {}, {})),
+                       ::testing::ValuesIn(additionalConfig)),
     TopKLayerCPUTest::getTestCaseName);
 
-} // namespace
-
-} // namespace CPULayerTestsDefinitions
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/unique.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/unique.cpp
@@ -2,27 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include "ov_models/builders.hpp"
 #include "test_utils/cpu_test_utils.hpp"
-#include <common_test_utils/ov_tensor_utils.hpp>
 
 using namespace CPUTestUtils;
 using namespace ov::test;
 
-namespace CPULayerTestsDefinitions {
-
-typedef std::tuple<
-        std::vector<InputShape>,             // Input shapes
-        std::tuple<bool, int>,               // Is flattened and axis
-        bool,                                // Sorted
-        ElementType,                         // Data precision
-        CPUSpecificParams,                   // CPU specific params
-        std::map<std::string, std::string>   // Additional config
-> UniqueLayerTestCPUParams;
+typedef std::tuple<std::vector<InputShape>,  // Input shapes
+                   std::tuple<bool, int>,    // Is flattened and axis
+                   bool,                     // Sorted
+                   ElementType,              // Data precision
+                   CPUSpecificParams,        // CPU specific params
+                   ov::AnyMap                // Additional config
+                   >
+    UniqueLayerTestCPUParams;
 
 class UniqueLayerTestCPU : public testing::WithParamInterface<UniqueLayerTestCPUParams>,
-                           virtual public SubgraphBaseTest, public CPUTestsBase {
+                           virtual public SubgraphBaseTest,
+                           public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<UniqueLayerTestCPUParams> obj) {
         std::vector<InputShape> inputShapes;
@@ -30,20 +28,22 @@ public:
         bool sorted;
         ElementType dataPrecision;
         CPUSpecificParams cpuParams;
-        std::map<std::string, std::string> additionalConfig;
+        ov::AnyMap additionalConfig;
 
         std::tie(inputShapes, flatOrAxis, sorted, dataPrecision, cpuParams, additionalConfig) = obj.param;
 
         std::ostringstream result;
         result << "IS=(";
         for (size_t i = 0lu; i < inputShapes.size(); i++) {
-            result << ov::test::utils::partialShape2str({inputShapes[i].first}) << (i < inputShapes.size() - 1lu ? "_" : "");
+            result << ov::test::utils::partialShape2str({inputShapes[i].first})
+                   << (i < inputShapes.size() - 1lu ? "_" : "");
         }
         result << ")_TS=";
         for (size_t i = 0lu; i < inputShapes.front().second.size(); i++) {
             result << "{";
             for (size_t j = 0lu; j < inputShapes.size(); j++) {
-                result << ov::test::utils::vec2str(inputShapes[j].second[i]) << (j < inputShapes.size() - 1lu ? "_" : "");
+                result << ov::test::utils::vec2str(inputShapes[j].second[i])
+                       << (j < inputShapes.size() - 1lu ? "_" : "");
             }
             result << "}_";
         }
@@ -51,7 +51,8 @@ public:
         if (!std::get<0>(flatOrAxis)) {
             result << "axis=" << std::get<1>(flatOrAxis) << "_";
         } else {
-            result << "flattened" << "_";
+            result << "flattened"
+                   << "_";
         }
         result << "sorted=" << (sorted ? "True" : "False") << "_";
         result << "dataPrc=" << dataPrecision;
@@ -59,9 +60,9 @@ public:
 
         if (!additionalConfig.empty()) {
             result << "_PluginConf";
-            for (auto &item : additionalConfig) {
-                if (item.second == InferenceEngine::PluginConfigParams::YES)
-                    result << "_" << item.first << "=" << item.second;
+            for (auto& item : additionalConfig) {
+                if (item.second == ov::element::bf16)
+                    result << "_" << item.first << "=" << item.second.as<std::string>();
             }
         }
 
@@ -76,7 +77,7 @@ protected:
         int axis;
         ElementType dataPrecision;
         CPUSpecificParams cpuParams;
-        std::map<std::string, std::string> additionalConfig;
+        ov::AnyMap additionalConfig;
 
         std::tie(inputShapes, flatOrAxis, sorted, dataPrecision, cpuParams, additionalConfig) = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
@@ -85,7 +86,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
         flattened = std::get<0>(flatOrAxis);
 
-        if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
+        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             if (dataPrecision == ElementType::bf16) {
@@ -104,9 +105,10 @@ protected:
             uniqueNode = std::make_shared<ov::op::v10::Unique>(params[0], sorted);
         } else {
             axis = std::get<1>(flatOrAxis);
-            uniqueNode = std::make_shared<ov::op::v10::Unique>(params[0],
-                                                               ov::op::v0::Constant::create(ov::element::i64, ov::Shape({1}), {axis}),
-                                                               sorted);
+            uniqueNode = std::make_shared<ov::op::v10::Unique>(
+                params[0],
+                ov::op::v0::Constant::create(ov::element::i64, ov::Shape({1}), {axis}),
+                sorted);
         }
 
         function = makeNgraphFunction(dataPrecision, params, uniqueNode, "UniqueCPU");
@@ -121,9 +123,15 @@ protected:
             ov::runtime::Tensor tensor;
 
             if (funcInput.get_node()->get_friendly_name() == "data") {
-                int32_t range = std::accumulate(targetInputStaticShapes[0].begin(), targetInputStaticShapes[0].end(), 1, std::multiplies<size_t>());
-                tensor = utils::create_and_fill_tensor(
-                        funcInput.get_element_type(), targetInputStaticShapes[0], range, -range / 2, 1);
+                int32_t range = std::accumulate(targetInputStaticShapes[0].begin(),
+                                                targetInputStaticShapes[0].end(),
+                                                1,
+                                                std::multiplies<size_t>());
+                tensor = utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                       targetInputStaticShapes[0],
+                                                       range,
+                                                       -range / 2,
+                                                       1);
             }
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
         }
@@ -139,22 +147,15 @@ TEST_P(UniqueLayerTestCPU, CompareWithRefs) {
 
 namespace {
 
-const std::vector<ElementType> dataPrecisionSmoke = {
-        ElementType::f32,
-        ElementType::i32
-};
-const std::vector<ElementType> dataPrecisionNightly = {
-        ElementType::bf16,
-        ElementType::i8
-};
+const std::vector<ElementType> dataPrecisionSmoke = {ElementType::f32, ElementType::i32};
+const std::vector<ElementType> dataPrecisionNightly = {ElementType::bf16, ElementType::i8};
 
-std::vector<std::tuple<bool, int>> flatOrAxis { {true, 0}, {false, 0}, {false, 1}, {false, -1} };
+std::vector<std::tuple<bool, int>> flatOrAxis{{true, 0}, {false, 0}, {false, 1}, {false, -1}};
 
-std::vector<bool> sorted { true, false};
+std::vector<bool> sorted{true, false};
 
-std::vector<std::map<std::string, std::string>> additionalConfig
-    = {{{InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::NO}},
-       {{InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::YES}}};
+std::vector<ov::AnyMap> additionalConfig = {{{ov::hint::inference_precision(ov::element::f32)}},
+                                            {{ov::hint::inference_precision(ov::element::bf16)}}};
 
 std::vector<CPUSpecificParams> getCPUInfo() {
     std::vector<CPUSpecificParams> resCPUParams;
@@ -163,121 +164,121 @@ std::vector<CPUSpecificParams> getCPUInfo() {
 }
 
 std::vector<std::vector<InputShape>> statShapes1D = {
-        {{{}, {{1}}}},     // Static shapes
-        {{{}, {{5}}}},     // Static shapes
-        {{{}, {{8}}}},     // Static shapes
-        {{{}, {{16}}}},    // Static shapes
-        {{{}, {{32}}}},    // Static shapes
-        {{{}, {{64}}}},    // Static shapes
-        {{{}, {{99}}}},    // Static shapes
+    {{{}, {{1}}}},   // Static shapes
+    {{{}, {{5}}}},   // Static shapes
+    {{{}, {{8}}}},   // Static shapes
+    {{{}, {{16}}}},  // Static shapes
+    {{{}, {{32}}}},  // Static shapes
+    {{{}, {{64}}}},  // Static shapes
+    {{{}, {{99}}}},  // Static shapes
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_static_1D, UniqueLayerTestCPU,
-             ::testing::Combine(
-                     ::testing::ValuesIn(statShapes1D),
-                     ::testing::ValuesIn(std::vector<std::tuple<bool, int>>{{true, 0}, {false, 0}}),
-                     ::testing::ValuesIn(sorted),
-                     ::testing::ValuesIn(dataPrecisionSmoke),
-                     ::testing::ValuesIn(getCPUInfo()),
-                     ::testing::Values(additionalConfig[0])),
-             UniqueLayerTestCPU::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_static_1D,
+                         UniqueLayerTestCPU,
+                         ::testing::Combine(::testing::ValuesIn(statShapes1D),
+                                            ::testing::ValuesIn(std::vector<std::tuple<bool, int>>{{true, 0},
+                                                                                                   {false, 0}}),
+                                            ::testing::ValuesIn(sorted),
+                                            ::testing::ValuesIn(dataPrecisionSmoke),
+                                            ::testing::ValuesIn(getCPUInfo()),
+                                            ::testing::Values(additionalConfig[0])),
+                         UniqueLayerTestCPU::getTestCaseName);
 
 std::vector<std::vector<InputShape>> getStaticShapes() {
     std::vector<std::vector<InputShape>> result = {
-        { { {}, { {1, 1, 1} } } },    // Static shapes
-        { { {}, { {1, 2, 1} } } },    // Static shapes
-        { { {}, { {1, 1, 3} } } },    // Static shapes
-        { { {}, { {2, 2, 1} } } },    // Static shapes
-        { { {}, { {1, 4, 1} } } },    // Static shapes
-        { { {}, { {1, 5, 1} } } },    // Static shapes
-        { { {}, { {3, 2, 1} } } },    // Static shapes
-        { { {}, { {1, 1, 7} } } },    // Static shapes
-        { { {}, { {2, 2, 2} } } },    // Static shapes
-        { { {}, { {1, 8, 1} } } },    // Static shapes
-        { { {}, { {3, 3, 1, 1} } } }, // Static shapes
-        { { {}, { {1, 5, 2, 1} } } }, // Static shapes
-        { { {}, { {1, 1, 11} } } },   // Static shapes
-        { { {}, { {32, 35, 37} } } }, // Static shapes
-        { { {}, { {2, 3, 2} } } },    // Static shapes
-        { { {}, { {1, 1, 13} } } },   // Static shapes
-        { { {}, { {7, 1, 2} } } },    // Static shapes
-        { { {}, { {3, 5, 1} } } },    // Static shapes
-        { { {}, { {4, 2, 2} } } },    // Static shapes
-        { { {}, { {1, 17, 1} } } },   // Static shapes
-        { { {}, { {3, 2, 3, 1} } } }, // Static shapes
-        { { {}, { {8, 16, 32} } } },  // Static shapes
-        { { {}, { {37, 19, 11} } } }, // Static shapes
-        { { {}, { {1, 19, 1} } } },   // Static shapes
-        { { {}, { {2, 5, 2} } } },    // Static shapes
-        { { {}, { {1, 3, 7} } } },    // Static shapes
-        { { {}, { {11, 1, 2} } } },   // Static shapes
-        { { {}, { {1, 1, 23} } } },   // Static shapes
-        { { {}, { {4, 3, 2} } } },    // Static shapes
-        { { {}, { {5, 1, 5} } } },    // Static shapes
-        { { {}, { {100, 1, 1} } } },  // Static shapes
-        { { {}, { {5, 5, 5} } } }     // Static shapes
+        {{{}, {{1, 1, 1}}}},     // Static shapes
+        {{{}, {{1, 2, 1}}}},     // Static shapes
+        {{{}, {{1, 1, 3}}}},     // Static shapes
+        {{{}, {{2, 2, 1}}}},     // Static shapes
+        {{{}, {{1, 4, 1}}}},     // Static shapes
+        {{{}, {{1, 5, 1}}}},     // Static shapes
+        {{{}, {{3, 2, 1}}}},     // Static shapes
+        {{{}, {{1, 1, 7}}}},     // Static shapes
+        {{{}, {{2, 2, 2}}}},     // Static shapes
+        {{{}, {{1, 8, 1}}}},     // Static shapes
+        {{{}, {{3, 3, 1, 1}}}},  // Static shapes
+        {{{}, {{1, 5, 2, 1}}}},  // Static shapes
+        {{{}, {{1, 1, 11}}}},    // Static shapes
+        {{{}, {{32, 35, 37}}}},  // Static shapes
+        {{{}, {{2, 3, 2}}}},     // Static shapes
+        {{{}, {{1, 1, 13}}}},    // Static shapes
+        {{{}, {{7, 1, 2}}}},     // Static shapes
+        {{{}, {{3, 5, 1}}}},     // Static shapes
+        {{{}, {{4, 2, 2}}}},     // Static shapes
+        {{{}, {{1, 17, 1}}}},    // Static shapes
+        {{{}, {{3, 2, 3, 1}}}},  // Static shapes
+        {{{}, {{8, 16, 32}}}},   // Static shapes
+        {{{}, {{37, 19, 11}}}},  // Static shapes
+        {{{}, {{1, 19, 1}}}},    // Static shapes
+        {{{}, {{2, 5, 2}}}},     // Static shapes
+        {{{}, {{1, 3, 7}}}},     // Static shapes
+        {{{}, {{11, 1, 2}}}},    // Static shapes
+        {{{}, {{1, 1, 23}}}},    // Static shapes
+        {{{}, {{4, 3, 2}}}},     // Static shapes
+        {{{}, {{5, 1, 5}}}},     // Static shapes
+        {{{}, {{100, 1, 1}}}},   // Static shapes
+        {{{}, {{5, 5, 5}}}}      // Static shapes
     };
 
     return result;
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_static, UniqueLayerTestCPU,
-                ::testing::Combine(
-                        ::testing::ValuesIn(getStaticShapes()),
-                        ::testing::ValuesIn(flatOrAxis),
-                        ::testing::ValuesIn(sorted),
-                        ::testing::ValuesIn(dataPrecisionSmoke),
-                        ::testing::ValuesIn(getCPUInfo()),
-                        ::testing::Values(additionalConfig[0])),
-                UniqueLayerTestCPU::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_static,
+                         UniqueLayerTestCPU,
+                         ::testing::Combine(::testing::ValuesIn(getStaticShapes()),
+                                            ::testing::ValuesIn(flatOrAxis),
+                                            ::testing::ValuesIn(sorted),
+                                            ::testing::ValuesIn(dataPrecisionSmoke),
+                                            ::testing::ValuesIn(getCPUInfo()),
+                                            ::testing::Values(additionalConfig[0])),
+                         UniqueLayerTestCPU::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_static, UniqueLayerTestCPU,
-                ::testing::Combine(
-                        ::testing::ValuesIn(getStaticShapes()),
-                        ::testing::ValuesIn(flatOrAxis),
-                        ::testing::ValuesIn(sorted),
-                        ::testing::ValuesIn(dataPrecisionNightly),
-                        ::testing::ValuesIn(getCPUInfo()),
-                        ::testing::Values(additionalConfig[0])),
-                UniqueLayerTestCPU::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_static,
+                         UniqueLayerTestCPU,
+                         ::testing::Combine(::testing::ValuesIn(getStaticShapes()),
+                                            ::testing::ValuesIn(flatOrAxis),
+                                            ::testing::ValuesIn(sorted),
+                                            ::testing::ValuesIn(dataPrecisionNightly),
+                                            ::testing::ValuesIn(getCPUInfo()),
+                                            ::testing::Values(additionalConfig[0])),
+                         UniqueLayerTestCPU::getTestCaseName);
 
 const std::vector<std::vector<InputShape>> dynamicInSapes = {
-   { { { ov::Dimension(1, 15), -1, -1, -1 },                               // Dynamic shape
-       { {1, 1, 1, 1}, {6, 3, 1, 2}, {4, 5, 3, 1}, {2, 7, 2, 2} } } },     // Target shapes
-   { { { -1, -1, -1, -1 },                                                 // Dynamic shape
-       { {1, 2, 1, 5}, {3, 4, 2, 3}, {5, 6, 7, 1}, {7, 8, 2, 4} } } },     // Target shapes
-   { { { ov::Dimension(2, 15), -1, -1, -1 },                               // Dynamic shape
-       { {8, 3, 3, 3}, {6, 5, 2, 5}, {4, 7, 1, 11}, {2, 9, 3, 4} } } },    // Target shapes
-   { { { 3, 4, 4, 5 },                                                     // Dynamic shape
-       { {3, 4, 4, 5}, {3, 4, 4, 5}, {3, 4, 4, 5}, {3, 4, 4, 5} } } },     // Target shapes
-   { { { -1, -1, -1, -1 },                                                 // Dynamic shape
-       { {1, 2, 1, 13}, {3, 4, 7, 2}, {5, 6, 3, 5}, {7, 8, 4, 4} } } },    // Target shapes
-   { { { -1, -1, -1, -1 },                                                 // Dynamic shape
-       { {2, 11, 1, 17}, {4, 9, 6, 3}, {6, 7, 7, 3}, {8, 3, 2, 11} } } },  // Target shapes
-   { { { 3, -1, -1, -1 },                                                  // Dynamic shape
-       { {3, 2, 1, 23}, {3, 4, 3, 8}, {3, 6, 5, 5}, {3, 8, 31, 1} } } },   // Target shapes
-   { { { -1, 3, -1, -1 },                                                  // Dynamic shape
-       { {8, 3, 8, 4}, {6, 3, 33, 1}, {4, 3, 8, 6}, {2, 3, 8, 8} } } }     // Target shapes
+    {{{ov::Dimension(1, 15), -1, -1, -1},                             // Dynamic shape
+      {{1, 1, 1, 1}, {6, 3, 1, 2}, {4, 5, 3, 1}, {2, 7, 2, 2}}}},     // Target shapes
+    {{{-1, -1, -1, -1},                                               // Dynamic shape
+      {{1, 2, 1, 5}, {3, 4, 2, 3}, {5, 6, 7, 1}, {7, 8, 2, 4}}}},     // Target shapes
+    {{{ov::Dimension(2, 15), -1, -1, -1},                             // Dynamic shape
+      {{8, 3, 3, 3}, {6, 5, 2, 5}, {4, 7, 1, 11}, {2, 9, 3, 4}}}},    // Target shapes
+    {{{3, 4, 4, 5},                                                   // Dynamic shape
+      {{3, 4, 4, 5}, {3, 4, 4, 5}, {3, 4, 4, 5}, {3, 4, 4, 5}}}},     // Target shapes
+    {{{-1, -1, -1, -1},                                               // Dynamic shape
+      {{1, 2, 1, 13}, {3, 4, 7, 2}, {5, 6, 3, 5}, {7, 8, 4, 4}}}},    // Target shapes
+    {{{-1, -1, -1, -1},                                               // Dynamic shape
+      {{2, 11, 1, 17}, {4, 9, 6, 3}, {6, 7, 7, 3}, {8, 3, 2, 11}}}},  // Target shapes
+    {{{3, -1, -1, -1},                                                // Dynamic shape
+      {{3, 2, 1, 23}, {3, 4, 3, 8}, {3, 6, 5, 5}, {3, 8, 31, 1}}}},   // Target shapes
+    {{{-1, 3, -1, -1},                                                // Dynamic shape
+      {{8, 3, 8, 4}, {6, 3, 33, 1}, {4, 3, 8, 6}, {2, 3, 8, 8}}}}     // Target shapes
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_dynamic, UniqueLayerTestCPU,
-                     ::testing::Combine(
-                             ::testing::ValuesIn(dynamicInSapes),
-                             ::testing::ValuesIn(flatOrAxis),
-                             ::testing::ValuesIn(sorted),
-                             ::testing::ValuesIn(dataPrecisionSmoke),
-                             ::testing::ValuesIn(getCPUInfo()),
-                             ::testing::Values(additionalConfig[0])),
-                     UniqueLayerTestCPU::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(nightly_dynamic, UniqueLayerTestCPU,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(dynamicInSapes),
-                                 ::testing::ValuesIn(flatOrAxis),
-                                 ::testing::ValuesIn(sorted),
-                                 ::testing::ValuesIn(dataPrecisionNightly),
-                                 ::testing::ValuesIn(getCPUInfo()),
-                                 ::testing::Values(additionalConfig[0])),
+INSTANTIATE_TEST_SUITE_P(smoke_dynamic,
+                         UniqueLayerTestCPU,
+                         ::testing::Combine(::testing::ValuesIn(dynamicInSapes),
+                                            ::testing::ValuesIn(flatOrAxis),
+                                            ::testing::ValuesIn(sorted),
+                                            ::testing::ValuesIn(dataPrecisionSmoke),
+                                            ::testing::ValuesIn(getCPUInfo()),
+                                            ::testing::Values(additionalConfig[0])),
                          UniqueLayerTestCPU::getTestCaseName);
-} // namespace
-} // namespace CPULayerTestsDefinitions
+
+INSTANTIATE_TEST_SUITE_P(nightly_dynamic,
+                         UniqueLayerTestCPU,
+                         ::testing::Combine(::testing::ValuesIn(dynamicInSapes),
+                                            ::testing::ValuesIn(flatOrAxis),
+                                            ::testing::ValuesIn(sorted),
+                                            ::testing::ValuesIn(dataPrecisionNightly),
+                                            ::testing::ValuesIn(getCPUInfo()),
+                                            ::testing::Values(additionalConfig[0])),
+                         UniqueLayerTestCPU::getTestCaseName);
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/variadic_split.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/variadic_split.cpp
@@ -2,35 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <openvino/opsets/opset10.hpp>
-
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include <common_test_utils/ov_tensor_utils.hpp>
-#include "ov_models/builders.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 
 using namespace ov::test;
 using namespace CPUTestUtils;
 
-namespace CPULayerTestsDefinitions {
 using LengthsPerInfer = std::vector<std::vector<int>>;
-typedef std::tuple<
-        InputShape,
-        int64_t,                         // Axis
-        LengthsPerInfer,                 // Split lengths
-        ngraph::helpers::InputLayerType, // lengths input type
-        ElementType,                     // Net precision
-        CPUSpecificParams
-> varSplitCPUTestParams;
+typedef std::tuple<InputShape,
+                   int64_t,                          // Axis
+                   LengthsPerInfer,                  // Split lengths
+                   ov::test::utils::InputLayerType,  // lengths input type
+                   ElementType,                      // Net precision
+                   CPUSpecificParams>
+    varSplitCPUTestParams;
 
 class VariadicSplitLayerCPUTest : public testing::WithParamInterface<varSplitCPUTestParams>,
-                                  virtual public SubgraphBaseTest, public CPUTestsBase {
+                                  virtual public SubgraphBaseTest,
+                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<varSplitCPUTestParams> obj) {
         InputShape shapes;
         int64_t axis;
         LengthsPerInfer splitLengths;
-        ngraph::helpers::InputLayerType lengthsType;
+        ov::test::utils::InputLayerType lengthsType;
         ElementType netPrecision;
         CPUSpecificParams cpuParams;
         std::tie(shapes, axis, splitLengths, lengthsType, netPrecision, cpuParams) = obj.param;
@@ -59,7 +55,7 @@ protected:
 
         InputShape inputShapes;
         int64_t axis;
-        ngraph::helpers::InputLayerType lengthsType;
+        ov::test::utils::InputLayerType lengthsType;
         ElementType netPrecision;
         CPUSpecificParams cpuParams;
         std::tie(inputShapes, axis, lengthsPerInfer, lengthsType, netPrecision, cpuParams) = this->GetParam();
@@ -68,7 +64,7 @@ protected:
         selectedType += std::string("_") + InferenceEngine::details::convertPrecision(netPrecision).name();
 
         std::vector<InputShape> shapesToInit{inputShapes};
-        if (lengthsType == ngraph::helpers::InputLayerType::PARAMETER) {
+        if (lengthsType == ov::test::utils::InputLayerType::PARAMETER) {
             std::vector<ov::Shape> lengthsStaticShapes(inputShapes.second.size(), {lengthsPerInfer[0].size()});
             shapesToInit.emplace_back(InputShape{{static_cast<int>(lengthsPerInfer[0].size())}, lengthsStaticShapes});
         }
@@ -77,25 +73,27 @@ protected:
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes[0])};
 
         std::shared_ptr<ov::Node> splitLengthsOp;
-        if (lengthsType == ngraph::helpers::InputLayerType::PARAMETER) {
-            auto param = std::make_shared<ov::opset10::Parameter>(ov::element::i32, ov::Shape{lengthsPerInfer[0].size()});
+        if (lengthsType == ov::test::utils::InputLayerType::PARAMETER) {
+            auto param =
+                std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{lengthsPerInfer[0].size()});
             params.push_back(param);
             splitLengthsOp = param;
         } else {
-            splitLengthsOp = ov::opset10::Constant::create(ov::element::i32, {lengthsPerInfer[0].size()}, lengthsPerInfer[0]);
+            splitLengthsOp =
+                ov::op::v0::Constant::create(ov::element::i32, {lengthsPerInfer[0].size()}, lengthsPerInfer[0]);
         }
 
-        auto splitAxisOp = ov::opset10::Constant::create(ov::element::i64, {}, {axis});
-        auto varSplit = std::make_shared<ov::opset10::VariadicSplit>(params[0], splitAxisOp, splitLengthsOp);
+        auto splitAxisOp = ov::op::v0::Constant::create(ov::element::i64, {}, {axis});
+        auto varSplit = std::make_shared<ov::op::v1::VariadicSplit>(params[0], splitAxisOp, splitLengthsOp);
         varSplit->get_rt_info() = getCPUInfo();
 
         ov::ResultVector results;
         for (const auto& out : varSplit->outputs())
-            results.push_back(std::make_shared<ov::opset10::Result>(out));
-        function = std::make_shared<ngraph::Function>(results, params, "VariadicSplitCPU");
+            results.push_back(std::make_shared<ov::op::v0::Result>(out));
+        function = std::make_shared<ov::Model>(results, params, "VariadicSplitCPU");
     }
 
-    void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override {
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
         inputs.clear();
         const auto& funcInputs = function->inputs();
 
@@ -116,6 +114,7 @@ protected:
             inputs.insert({funcInputs[1].get_node_shared_ptr(), lengthsTensor});
         }
     }
+
 private:
     size_t inferRequestNum = 0;
     LengthsPerInfer lengthsPerInfer;
@@ -152,447 +151,335 @@ const auto blocked16_4D_ref = CPUSpecificParams{{nChw16c}, {nChw16c}, {}, "ref"}
 const auto blocked16_5D_ref = CPUSpecificParams{{nCdhw16c}, {nCdhw16c}, {}, "ref"};
 
 // List of precisions natively supported by onednn.
-const std::vector<ElementType> netPrecisions = {
-        ElementType::i8,
-        ElementType::i32,
-        ElementType::f32,
-        ElementType::bf16
-};
+const std::vector<ElementType> netPrecisions = {ElementType::i8, ElementType::i32, ElementType::f32, ElementType::bf16};
 
-const std::vector<ngraph::helpers::InputLayerType> lengthsTypes = {
-    ngraph::helpers::InputLayerType::CONSTANT,
-    ngraph::helpers::InputLayerType::PARAMETER
-};
+const std::vector<ov::test::utils::InputLayerType> lengthsTypes = {ov::test::utils::InputLayerType::CONSTANT,
+                                                                   ov::test::utils::InputLayerType::PARAMETER};
 
 const std::vector<InputShape> inputShapes4D_Nspc2NcspSpecial = {
-        { {}, {{3, 5, 24, 9}} },
-        {
-            // dynamic
-            {-1, -1, -1, -1},
-            // target
-            {
-                {1, 8, 5, 7},
-                {3, 9, 7, 9},
-                {5, 6, 1, 8}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, {1, 64}, {1, 25}, {2, 10}},
-            // target
-            {
-                {2, 7, 5, 7},
-                {1, 10, 10, 2},
-                {3, 5, 6, 9}
-            }
-        },
+    {{}, {{3, 5, 24, 9}}},
+    {// dynamic
+     {-1, -1, -1, -1},
+     // target
+     {{1, 8, 5, 7}, {3, 9, 7, 9}, {5, 6, 1, 8}}},
+    {// dynamic
+     {{1, 5}, {1, 64}, {1, 25}, {2, 10}},
+     // target
+     {{2, 7, 5, 7}, {1, 10, 10, 2}, {3, 5, 6, 9}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_Nspc2NcspSpecial, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes4D_Nspc2NcspSpecial),
-                                ::testing::Values(1),
-                                ::testing::Values(LengthsPerInfer{{1, 2, -1, 1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(perChannelsToPlanar_4D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_Nspc2NcspSpecial,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes4D_Nspc2NcspSpecial),
+                                            ::testing::Values(1),
+                                            ::testing::Values(LengthsPerInfer{{1, 2, -1, 1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(perChannelsToPlanar_4D)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes5D_Nspc2NcspSpecial = {
-        { {}, {{3, 4, 7, 9, 3}} },
-        {
-            // dynamic
-            {-1, -1, -1, -1, -1},
-            // target
-            {
-                {1, 6, 5, 7, 5},
-                {3, 8, 6, 9, 1},
-                {5, 9, 1, 8, 2}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, {1, 64}, {1, 25}, {2, 10}, {1, 64}},
-            // target
-            {
-                {2, 5, 5, 7, 7},
-                {1, 4, 10, 2, 11},
-                {3, 7, 5, 9, 8}
-            }
-        },
+    {{}, {{3, 4, 7, 9, 3}}},
+    {// dynamic
+     {-1, -1, -1, -1, -1},
+     // target
+     {{1, 6, 5, 7, 5}, {3, 8, 6, 9, 1}, {5, 9, 1, 8, 2}}},
+    {// dynamic
+     {{1, 5}, {1, 64}, {1, 25}, {2, 10}, {1, 64}},
+     // target
+     {{2, 5, 5, 7, 7}, {1, 4, 10, 2, 11}, {3, 7, 5, 9, 8}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_Nspc2NcspSpecial, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes5D_Nspc2NcspSpecial),
-                                ::testing::Values(1),
-                                ::testing::Values(LengthsPerInfer{{2, 1, -1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(perChannelsToPlanar_5D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_Nspc2NcspSpecial,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes5D_Nspc2NcspSpecial),
+                                            ::testing::Values(1),
+                                            ::testing::Values(LengthsPerInfer{{2, 1, -1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(perChannelsToPlanar_5D)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_planar_static, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{3, 6, 5, 6}} }),
-                                ::testing::Values(2, 3),
-                                ::testing::Values(LengthsPerInfer{{1, 3, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_4D_ref, perChannels_4D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_planar_static,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(InputShape{{}, {{3, 6, 5, 6}}}),
+                                            ::testing::Values(2, 3),
+                                            ::testing::Values(LengthsPerInfer{{1, 3, -1}}),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(planar_4D_ref, perChannels_4D)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_planar = {
-        {
-            // dynamic
-            {-1, -1, -1, -1},
-            // target
-            {
-                {1, 9, 8, 7},
-                {3, 8, 6, 5},
-                {5, 3, 7, 6}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, {1, 64}, {1, 48}, {2, 48}},
-            // target
-            {
-                {2, 9, 5, 6},
-                {1, 6, 9, 8},
-                {3, 1, 6, 7}
-            }
-        },
+    {// dynamic
+     {-1, -1, -1, -1},
+     // target
+     {{1, 9, 8, 7}, {3, 8, 6, 5}, {5, 3, 7, 6}}},
+    {// dynamic
+     {{1, 5}, {1, 64}, {1, 48}, {2, 48}},
+     // target
+     {{2, 9, 5, 6}, {1, 6, 9, 8}, {3, 1, 6, 7}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_planar, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes4D_planar),
-                                ::testing::Values(2, 3),
-                                ::testing::Values(LengthsPerInfer{{1, 3, -1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_4D_ref, perChannels_4D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_planar,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes4D_planar),
+                                            ::testing::Values(2, 3),
+                                            ::testing::Values(LengthsPerInfer{{1, 3, -1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(planar_4D_ref, perChannels_4D)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_block = {
-        { {}, {{3, 16, 6, 7}} },
-        {
-            // dynamic
-            {-1, 16, -1, -1},
-            // target
-            {
-                {1, 16, 8, 7},
-                {3, 16, 7, 8},
-                {5, 16, 9, 8}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, 16, {1, 48}, {2, 24}},
-            // target
-            {
-                {2, 16, 12, 6},
-                {1, 16, 6, 9},
-                {3, 16, 7, 6}
-            }
-        },
+    {{}, {{3, 16, 6, 7}}},
+    {// dynamic
+     {-1, 16, -1, -1},
+     // target
+     {{1, 16, 8, 7}, {3, 16, 7, 8}, {5, 16, 9, 8}}},
+    {// dynamic
+     {{1, 5}, 16, {1, 48}, {2, 24}},
+     // target
+     {{2, 16, 12, 6}, {1, 16, 6, 9}, {3, 16, 7, 6}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_Block8, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes4D_block),
-                                ::testing::Values(2, 3),
-                                ::testing::Values(LengthsPerInfer{{2, 2, -1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(blocked8_4D_ref)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_Block8,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes4D_block),
+                                            ::testing::Values(2, 3),
+                                            ::testing::Values(LengthsPerInfer{{2, 2, -1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(blocked8_4D_ref)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_Block16, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes4D_block),
-                                ::testing::Values(2, 3),
-                                ::testing::Values(LengthsPerInfer{{2, 2, -1, 1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(blocked16_4D_ref)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_Block16,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes4D_block),
+                                            ::testing::Values(2, 3),
+                                            ::testing::Values(LengthsPerInfer{{2, 2, -1, 1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(blocked16_4D_ref)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_planar_static, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{3, 24, 4, 5, 6}} }),
-                                ::testing::Values(2, 3, 4),
-                                ::testing::Values(LengthsPerInfer{{2, 1, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_5D_ref, perChannels_5D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_planar_static,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(InputShape{{}, {{3, 24, 4, 5, 6}}}),
+                                            ::testing::Values(2, 3, 4),
+                                            ::testing::Values(LengthsPerInfer{{2, 1, -1}}),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(planar_5D_ref, perChannels_5D)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes5D_planar = {
-        {
-            // dynamic
-            {-1, -1, -1, -1, -1},
-            // target
-            {
-                {1, 2, 4, 6, 5},
-                {3, 1, 6, 4, 5},
-                {5, 6, 5, 7, 4}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, {1, 64}, {1, 48}, {2, 48}, {2, 40}},
-            // target
-            {
-                {2, 5, 4, 5, 6},
-                {1, 7, 5, 4, 7},
-                {3, 3, 5, 6, 4}
-            }
-        },
+    {// dynamic
+     {-1, -1, -1, -1, -1},
+     // target
+     {{1, 2, 4, 6, 5}, {3, 1, 6, 4, 5}, {5, 6, 5, 7, 4}}},
+    {// dynamic
+     {{1, 5}, {1, 64}, {1, 48}, {2, 48}, {2, 40}},
+     // target
+     {{2, 5, 4, 5, 6}, {1, 7, 5, 4, 7}, {3, 3, 5, 6, 4}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_planar, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes5D_planar),
-                                ::testing::Values(2, 3, 4),
-                                ::testing::Values(LengthsPerInfer{{2, 1, -1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_5D_ref, perChannels_5D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_planar,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes5D_planar),
+                                            ::testing::Values(2, 3, 4),
+                                            ::testing::Values(LengthsPerInfer{{2, 1, -1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(planar_5D_ref, perChannels_5D)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes5D_block = {
-        { {}, {{3, 16, 8, 5, 6}} },
-        {
-            // dynamic
-            {-1, 16, -1, -1, -1},
-            // target
-            {
-                {1, 16, 5, 6, 7},
-                {3, 16, 24, 5, 8},
-                {5, 16, 6, 7, 5}
-            }
-        },
-        {
-            // dynamic
-            {{1, 5}, 16, {1, 48}, {2, 24}, {2, 64}},
-            // target
-            {
-                {2, 16, 7, 6, 5},
-                {1, 16, 6, 5, 7},
-                {3, 16, 5, 7, 6}
-            }
-        },
+    {{}, {{3, 16, 8, 5, 6}}},
+    {// dynamic
+     {-1, 16, -1, -1, -1},
+     // target
+     {{1, 16, 5, 6, 7}, {3, 16, 24, 5, 8}, {5, 16, 6, 7, 5}}},
+    {// dynamic
+     {{1, 5}, 16, {1, 48}, {2, 24}, {2, 64}},
+     // target
+     {{2, 16, 7, 6, 5}, {1, 16, 6, 5, 7}, {3, 16, 5, 7, 6}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_Block8, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes5D_block),
-                                ::testing::Values(2, 3, 4),
-                                ::testing::Values(LengthsPerInfer{{1, 2, -1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(blocked8_5D_ref)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_Block8,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes5D_block),
+                                            ::testing::Values(2, 3, 4),
+                                            ::testing::Values(LengthsPerInfer{{1, 2, -1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(blocked8_5D_ref)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_Block16, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes5D_block),
-                                ::testing::Values(2, 3, 4),
-                                ::testing::Values(LengthsPerInfer{{2, 1, -1, 1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(blocked16_5D_ref)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_Block16,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes5D_block),
+                                            ::testing::Values(2, 3, 4),
+                                            ::testing::Values(LengthsPerInfer{{2, 1, -1, 1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(blocked16_5D_ref)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit3D_static, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{14, 7, 21}} }),
-                                ::testing::Values(1, 2),
-                                ::testing::Values(LengthsPerInfer{{2, 4, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit3D_static,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(InputShape{{}, {{14, 7, 21}}}),
+                                            ::testing::Values(1, 2),
+                                            ::testing::Values(LengthsPerInfer{{2, 4, -1}}),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes3D = {
-        {
-            // dynamic
-            {-1, -1, -1},
-            // target
-            {
-                {7, 21, 14},
-                {21, 7, 14},
-                {21, 14, 7},
-            }
-        },
-        {
-            // dynamic
-            {{1, 60}, {1, 50}, {1, 48}},
-            // target
-            {
-                {14, 21, 7},
-                {21, 7, 14},
-                {7, 14, 21},
-            }
-        },
+    {// dynamic
+     {-1, -1, -1},
+     // target
+     {
+         {7, 21, 14},
+         {21, 7, 14},
+         {21, 14, 7},
+     }},
+    {// dynamic
+     {{1, 60}, {1, 50}, {1, 48}},
+     // target
+     {
+         {14, 21, 7},
+         {21, 7, 14},
+         {7, 14, 21},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit3D, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes3D),
-                                ::testing::Values(0, 1, 2),
-                                ::testing::Values(LengthsPerInfer{{2, 4, -1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit3D,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes3D),
+                                            ::testing::Values(0, 1, 2),
+                                            ::testing::Values(LengthsPerInfer{{2, 4, -1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit2D_static, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{6, 12}} }),
-                                ::testing::Values(1),
-                                ::testing::Values(LengthsPerInfer{{2, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit2D_static,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(InputShape{{}, {{6, 12}}}),
+                                            ::testing::Values(1),
+                                            ::testing::Values(LengthsPerInfer{{2, -1}}),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes2D = {
-        {
-            // dynamic
-            {-1, -1},
-            // target
-            {
-                {3, 8},
-                {10, 4},
-                {3, 6},
-            }
-        },
-        {
-            // dynamic
-            {{1, 60}, {1, 50}},
-            // target
-            {
-                {3, 4},
-                {4, 4},
-                {6, 12},
-            }
-        },
+    {// dynamic
+     {-1, -1},
+     // target
+     {
+         {3, 8},
+         {10, 4},
+         {3, 6},
+     }},
+    {// dynamic
+     {{1, 60}, {1, 50}},
+     // target
+     {
+         {3, 4},
+         {4, 4},
+         {6, 12},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit2D, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes2D),
-                                ::testing::Values(0, 1),
-                                ::testing::Values(LengthsPerInfer{{2, -1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit2D,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes2D),
+                                            ::testing::Values(0, 1),
+                                            ::testing::Values(LengthsPerInfer{{2, -1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit1D_static, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{10}} }),
-                                ::testing::Values(0),
-                                ::testing::Values(LengthsPerInfer{{2, 1, 1, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit1D_static,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::Values(InputShape{{}, {{10}}}),
+                                            ::testing::Values(0),
+                                            ::testing::Values(LengthsPerInfer{{2, 1, 1, -1}}),
+                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"},
+                                                              CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes1D = {
-        {
-            // dynamic
-            {-1},
-            // target
-            {
-                {5},
-                {15},
-                {10},
-            }
-        },
-        {
-            // dynamic
-            {{1, 60}},
-            // target
-            {
-                {15},
-                {5},
-                {10},
-            }
-        },
+    {// dynamic
+     {-1},
+     // target
+     {
+         {5},
+         {15},
+         {10},
+     }},
+    {// dynamic
+     {{1, 60}},
+     // target
+     {
+         {15},
+         {5},
+         {10},
+     }},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit1D, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes1D),
-                                ::testing::Values(0),
-                                ::testing::Values(LengthsPerInfer{{2, 1, 1, -1}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit1D,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes1D),
+                                            ::testing::Values(0),
+                                            ::testing::Values(LengthsPerInfer{{2, 1, 1, -1}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-const std::vector<InputShape> inputShapes4D_zero_dims = {
-        {
-            // dynamic
-            {-1, -1, -1, -1},
-            // target
-            {
-                {1, 7, 7, 7},
-                {3, 7, 7, 7},
-            }
-        }
-};
+const std::vector<InputShape> inputShapes4D_zero_dims = {{// dynamic
+                                                          {-1, -1, -1, -1},
+                                                          // target
+                                                          {
+                                                              {1, 7, 7, 7},
+                                                              {3, 7, 7, 7},
+                                                          }}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_zero_dims, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes4D_zero_dims),
-                                ::testing::Values(1, 2, 3),
-                                ::testing::Values(LengthsPerInfer{{3, 4, -1}}, LengthsPerInfer{{3, -1, 4}}, LengthsPerInfer{{-1, 3, 4}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_4D_ref)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_zero_dims,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes4D_zero_dims),
+                                            ::testing::Values(1, 2, 3),
+                                            ::testing::Values(LengthsPerInfer{{3, 4, -1}},
+                                                              LengthsPerInfer{{3, -1, 4}},
+                                                              LengthsPerInfer{{-1, 3, 4}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(planar_4D_ref)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_zero_dims_nspc_ncsp, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes4D_zero_dims),
-                                ::testing::Values(1),
-                                ::testing::Values(LengthsPerInfer{{3, 4, -1}}, LengthsPerInfer{{3, -1, 4}}, LengthsPerInfer{{-1, 3, 4}}),
-                                ::testing::ValuesIn(lengthsTypes),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(perChannelsToPlanar_4D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
-
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_zero_dims_nspc_ncsp,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes4D_zero_dims),
+                                            ::testing::Values(1),
+                                            ::testing::Values(LengthsPerInfer{{3, 4, -1}},
+                                                              LengthsPerInfer{{3, -1, 4}},
+                                                              LengthsPerInfer{{-1, 3, 4}}),
+                                            ::testing::ValuesIn(lengthsTypes),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(perChannelsToPlanar_4D)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_dynamic_lengths = {
-        {
-            {1, 16, 8, 7},
-            {
-                {1, 16, 8, 7},
-                {1, 16, 8, 7},
-                {1, 16, 8, 7}
-            }
-        },
-        {
-            {-1, -1, -1, -1},
-            {
-                {1, 16, 8, 7},
-                {1, 16, 8, 7},
-                {1, 16, 8, 7}
-            }
-        },
-        {
-            {{1, 5}, -1, {1, 48}, {2, 24}},
-            {
-                {2, 16, 12, 6},
-                {1, 16, 6, 9},
-                {3, 16, 7, 6}
-            }
-        },
+    {{1, 16, 8, 7}, {{1, 16, 8, 7}, {1, 16, 8, 7}, {1, 16, 8, 7}}},
+    {{-1, -1, -1, -1}, {{1, 16, 8, 7}, {1, 16, 8, 7}, {1, 16, 8, 7}}},
+    {{{1, 5}, -1, {1, 48}, {2, 24}}, {{2, 16, 12, 6}, {1, 16, 6, 9}, {3, 16, 7, 6}}},
 };
 
 std::vector<LengthsPerInfer> lengthsPerInfer = {
@@ -601,108 +488,72 @@ std::vector<LengthsPerInfer> lengthsPerInfer = {
     LengthsPerInfer{{10, 4, 2}, {2, 4, 10}, {4, 2, 10}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_dynamic_lengths, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::ValuesIn(inputShapes4D_dynamic_lengths),
-                                ::testing::Values(1),
-                                ::testing::ValuesIn(lengthsPerInfer),
-                                ::testing::Values(ngraph::helpers::InputLayerType::PARAMETER),
-                                ::testing::Values(ElementType::f32),
-                                ::testing::Values(planar_4D_ref)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_dynamic_lengths,
+                         VariadicSplitLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes4D_dynamic_lengths),
+                                            ::testing::Values(1),
+                                            ::testing::ValuesIn(lengthsPerInfer),
+                                            ::testing::Values(ov::test::utils::InputLayerType::PARAMETER),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::Values(planar_4D_ref)),
+                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 // =========================================== in - place ============================================================//
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit_CPU_planar_inPlace_0, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{5, 6, 5, 6, 7}} },
-                                                  InputShape{ {}, {{5, 6, 5, 6}} },
-                                                  InputShape{ {}, {{5, 6, 5}} },
-                                                  InputShape{ {5, -1, -1, -1, -1},
-                                                              {
-                                                                  {5, 6, 5, 6, 7},
-                                                                  {5, 2, 5, 2, 7},
-                                                                  {5, 8, 5, 8, 7}
-                                                              } },
-                                                  InputShape{ {5, -1, -1, -1},
-                                                              {
-                                                                  {5, 6, 5, 6},
-                                                                  {5, 2, 5, 2},
-                                                                  {5, 8, 5, 8}
-                                                              } },
-                                                  InputShape{ {5, -1, -1},
-                                                              {
-                                                                  {5, 6, 5},
-                                                                  {5, 2, 5},
-                                                                  {5, 8, 5}
-                                                              } }),
-                                ::testing::Values(0),
-                                ::testing::Values(LengthsPerInfer{{1, 2, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::Values(ElementType::f32),
-                               ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_VariadicSplit_CPU_planar_inPlace_0,
+    VariadicSplitLayerCPUTest,
+    ::testing::Combine(::testing::Values(InputShape{{}, {{5, 6, 5, 6, 7}}},
+                                         InputShape{{}, {{5, 6, 5, 6}}},
+                                         InputShape{{}, {{5, 6, 5}}},
+                                         InputShape{{5, -1, -1, -1, -1},
+                                                    {{5, 6, 5, 6, 7}, {5, 2, 5, 2, 7}, {5, 8, 5, 8, 7}}},
+                                         InputShape{{5, -1, -1, -1}, {{5, 6, 5, 6}, {5, 2, 5, 2}, {5, 8, 5, 8}}},
+                                         InputShape{{5, -1, -1}, {{5, 6, 5}, {5, 2, 5}, {5, 8, 5}}}),
+                       ::testing::Values(0),
+                       ::testing::Values(LengthsPerInfer{{1, 2, -1}}),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::Values(ElementType::f32),
+                       ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+    VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit_CPU_planar_inPlace_1, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{1, 6, 5, 6, 7}} },
-                                                  InputShape{ {}, {{1, 6, 5, 6}} },
-                                                  InputShape{ {}, {{1, 6, 5}} },
-                                                  InputShape{ {1, 6, -1, -1, -1},
-                                                              {
-                                                                  {1, 6, 5, 6, 7},
-                                                                  {1, 6, 5, 2, 7},
-                                                                  {1, 6, 5, 8, 7}
-                                                              } },
-                                                  InputShape{ {1, 6, -1, -1},
-                                                              {
-                                                                  {1, 6, 5, 6},
-                                                                  {1, 6, 5, 2},
-                                                                  {1, 6, 5, 8}
-                                                              } },
-                                                  InputShape{ {1, 6, -1},
-                                                              {
-                                                                  {1, 6, 5},
-                                                                  {1, 6, 3},
-                                                                  {1, 6, 7}
-                                                              } }),
-                                ::testing::Values(1),
-                                ::testing::Values(LengthsPerInfer{{1, 2, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::Values(ElementType::f32),
-                               ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_VariadicSplit_CPU_planar_inPlace_1,
+    VariadicSplitLayerCPUTest,
+    ::testing::Combine(::testing::Values(InputShape{{}, {{1, 6, 5, 6, 7}}},
+                                         InputShape{{}, {{1, 6, 5, 6}}},
+                                         InputShape{{}, {{1, 6, 5}}},
+                                         InputShape{{1, 6, -1, -1, -1},
+                                                    {{1, 6, 5, 6, 7}, {1, 6, 5, 2, 7}, {1, 6, 5, 8, 7}}},
+                                         InputShape{{1, 6, -1, -1}, {{1, 6, 5, 6}, {1, 6, 5, 2}, {1, 6, 5, 8}}},
+                                         InputShape{{1, 6, -1}, {{1, 6, 5}, {1, 6, 3}, {1, 6, 7}}}),
+                       ::testing::Values(1),
+                       ::testing::Values(LengthsPerInfer{{1, 2, -1}}),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::Values(ElementType::f32),
+                       ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+    VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_block8_inPlace, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{1, 32, 5, 6}} },
-                                                  InputShape{ {1, 32, -1, -1},
-                                                              {
-                                                                  {1, 32, 5, 6},
-                                                                  {1, 32, 5, 2},
-                                                                  {1, 32, 5, 8}
-                                                              } }),
-                                ::testing::Values(1),
-                                ::testing::Values(LengthsPerInfer{{8, 16, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::Values(ElementType::f32),
-                               ::testing::Values(blocked8_4D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_VariadicSplit4D_CPU_block8_inPlace,
+    VariadicSplitLayerCPUTest,
+    ::testing::Combine(::testing::Values(InputShape{{}, {{1, 32, 5, 6}}},
+                                         InputShape{{1, 32, -1, -1}, {{1, 32, 5, 6}, {1, 32, 5, 2}, {1, 32, 5, 8}}}),
+                       ::testing::Values(1),
+                       ::testing::Values(LengthsPerInfer{{8, 16, -1}}),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::Values(ElementType::f32),
+                       ::testing::Values(blocked8_4D)),
+    VariadicSplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_block16_inPlace, VariadicSplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(InputShape{ {}, {{1, 64, 5, 6}} },
-                                                  InputShape{ {1, 64, -1, -1},
-                                                              {
-                                                                  {1, 64, 5, 6},
-                                                                  {1, 64, 5, 2},
-                                                                  {1, 64, 5, 8}
-                                                              } }),
-                                ::testing::Values(1),
-                                ::testing::Values(LengthsPerInfer{{16, 32, -1}}),
-                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-                                ::testing::Values(ElementType::f32),
-                               ::testing::Values(blocked16_4D)),
-                        VariadicSplitLayerCPUTest::getTestCaseName);
-} // namespace
-
-} // namespace CPULayerTestsDefinitions
+INSTANTIATE_TEST_SUITE_P(
+    smoke_VariadicSplit4D_CPU_block16_inPlace,
+    VariadicSplitLayerCPUTest,
+    ::testing::Combine(::testing::Values(InputShape{{}, {{1, 64, 5, 6}}},
+                                         InputShape{{1, 64, -1, -1}, {{1, 64, 5, 6}, {1, 64, 5, 2}, {1, 64, 5, 8}}}),
+                       ::testing::Values(1),
+                       ::testing::Values(LengthsPerInfer{{16, 32, -1}}),
+                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::Values(ElementType::f32),
+                       ::testing::Values(blocked16_4D)),
+    VariadicSplitLayerCPUTest::getTestCaseName);
+}  // namespace


### PR DESCRIPTION
### Details:
 - migrate single layer test cases to be API 2.0 - part 5
 - *...*

### Tickets:
 - *ticket-id*
