### PR TITLE
[SnippetS] Binary size reduce, executor cache disabled if enable perf count

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -47,6 +47,7 @@ ov_dependent_option (ENABLE_ONEDNN_FOR_GPU "Enable oneDNN with GPU support" ${EN
 ov_option (ENABLE_DEBUG_CAPS "enable OpenVINO debug capabilities at runtime" OFF)
 ov_dependent_option (ENABLE_GPU_DEBUG_CAPS "enable GPU debug capabilities at runtime" ON "ENABLE_DEBUG_CAPS;ENABLE_INTEL_GPU" OFF)
 ov_dependent_option (ENABLE_CPU_DEBUG_CAPS "enable CPU debug capabilities at runtime" ON "ENABLE_DEBUG_CAPS;ENABLE_INTEL_CPU" OFF)
+ov_dependent_option (ENABLE_SNIPPETS_DEBUG_CAPS "enable Snippets debug capabilities at runtime" ON "ENABLE_DEBUG_CAPS" OFF)
 
 ov_option (ENABLE_PROFILING_ITT "Build with ITT tracing. Optionally configure pre-built ittnotify library though INTEL_VTUNE_DIR variable." OFF)
 
@@ -205,6 +206,10 @@ endif()
 
 if (ENABLE_PROFILING_RAW)
     add_definitions(-DENABLE_PROFILING_RAW=1)
+endif()
+
+if (ENABLE_SNIPPETS_DEBUG_CAPS)
+    add_definitions(-DSNIPPETS_DEBUG_CAPS)
 endif()
 
 ov_print_enabled_features()

--- a/src/common/snippets/docs/debug_capabilities/README.md
+++ b/src/common/snippets/docs/debug_capabilities/README.md
@@ -1,7 +1,7 @@
 # Debug capabilities
 Debug capabilities are the set of useful debug features, most of them are controlled by environment variables.
 
-They can be activated at runtime and might be used for analyzing issues, getting more context, comparing execution results, etc.
+They can be activated at runtime and might be used to analyze issues, locate faulty code, get more execution details, benchmark execution time, etc.
 
 Use the following cmake option to enable snippets debug capabilities:
 

--- a/src/common/snippets/docs/debug_capabilities/README.md
+++ b/src/common/snippets/docs/debug_capabilities/README.md
@@ -1,0 +1,10 @@
+# Debug capabilities
+Debug capabilities are the set of useful debug features, most of them are controlled by environment variables.
+
+They can be activated at runtime and might be used for analyzing issues, getting more context, comparing execution results, etc.
+
+Use the following cmake option to enable snippets debug capabilities:
+
+`-DENABLE_DEBUG_CAPS=ON`
+
+* [Performance counters](perf_count.md)

--- a/src/common/snippets/docs/debug_capabilities/perf_count.md
+++ b/src/common/snippets/docs/debug_capabilities/perf_count.md
@@ -1,0 +1,8 @@
+# Performance counters
+
+Subgraph in the the snippets could be very large. Sometimes developers are interested the detailed performance number of part of the subgraph. This feature help to do it by inserting perf_count_begin and perf_count_end operations around the sequence of expression in LIR, which developers would like to benchmark. There is an example to insert between last parameter and first result with a transformation(src/common/snippets/src/lowered/pass/insert_perf_count.cpp). Developers could adjust it to benchmark interested sequence.
+
+There are two perf count modes.
+ - `Chrono` : perf count with chrono call. This is a universal method, and support multi-threads case to print perf count data for each thread.
+ - `BackendSpecific` : perf count provided by backend. This is for device specific requirement. For example, in sake of more light overhead and more accurate result, x86 or x86-64 CPU specific mode via reading RDTSC register is implemented. At current this CPU BackendSpecific mode only support single thread.
+ One can select prefered mode by setting perf_count_mode default value in [snippets Config](../../include/snippets/lowered/linear_ir.hpp)

--- a/src/common/snippets/docs/debug_capabilities/perf_count.md
+++ b/src/common/snippets/docs/debug_capabilities/perf_count.md
@@ -1,8 +1,8 @@
 # Performance counters
 
-Subgraph in the the snippets could be very large. Sometimes developers are interested the detailed performance number of part of the subgraph. This feature help to do it by inserting perf_count_begin and perf_count_end operations around the sequence of expression in LIR, which developers would like to benchmark. There is an example to insert between last parameter and first result with a transformation(src/common/snippets/src/lowered/pass/insert_perf_count.cpp). Developers could adjust it to benchmark interested sequence.
+Subgraph in snippets could be very large. Sometimes developers are interested the detailed performance number of part of the subgraph. This feature help to do it, by inserting a pair of PerfCountBegin and PerfCountEnd operations around a sequence of expression in LIR(linear IR), which developers would like to benchmark. There is an example to insert between last parameter and first result with a [transformation](../../src/lowered/pass/insert_perf_count.cpp). Developers could adjust it to benchmark their interested sequence.
 
 There are two perf count modes.
- - `Chrono` : perf count with chrono call. This is a universal method, and support multi-threads case to print perf count data for each thread.
- - `BackendSpecific` : perf count provided by backend. This is for device specific requirement. For example, in sake of more light overhead and more accurate result, x86 or x86-64 CPU specific mode via reading RDTSC register is implemented. At current this CPU BackendSpecific mode only support single thread.
- One can select prefered mode by setting perf_count_mode default value in [snippets Config](../../include/snippets/lowered/linear_ir.hpp)
+ - `Chrono` : Perf count via chrono call. This is a universal method, and support multi-threads scenario to print perf count data for each thread.
+ - `BackendSpecific` : Perf count provided by backend. This is for device specific requirement. For example, for sake of more light overhead and more accurate result, x86 or x86-64 CPU specific mode via reading RDTSC register is implemented. At current this x86 or x86-64 CPU BackendSpecific mode only support single thread.
+ One can select prefered mode by setting `perf_count_mode` default value in [snippets Config](../../include/snippets/lowered/linear_ir.hpp)

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace snippets {
 namespace lowered {
 
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
 // Snippets performance count mode
 // Disabled - default, w/o perf count for snippets
 // Chrono - perf count with chrono call. This is a universal method, and support multi-thread case to output perf count data for each thread.
@@ -35,7 +35,7 @@ public:
     // True if we should check runtime info for nodes to call specific needed transformations
     bool m_need_fill_tail_register = false;
     size_t m_loop_depth = 1;
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
     PerfCountMode perf_count_mode = PerfCountMode::Disabled;
 #endif
     // Some Subgraphs doesn't support domain optimization due to operations' semantics

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -14,6 +14,7 @@ namespace ov {
 namespace snippets {
 namespace lowered {
 
+#ifdef ENABLE_OPENVINO_DEBUG
 // Snippets performance count mode
 // Disabled - default, w/o perf count for snippets
 // Chrono - perf count with chrono call. This is a universal method, and support multi-thread case to output perf count data for each thread.
@@ -25,6 +26,7 @@ enum PerfCountMode {
     Chrono,
     BackendSpecific,
 };
+#endif
 
 class Config {
 public:
@@ -33,7 +35,9 @@ public:
     // True if we should check runtime info for nodes to call specific needed transformations
     bool m_need_fill_tail_register = false;
     size_t m_loop_depth = 1;
+#ifdef ENABLE_OPENVINO_DEBUG
     PerfCountMode perf_count_mode = PerfCountMode::Disabled;
+#endif
     // Some Subgraphs doesn't support domain optimization due to operations' semantics
     bool m_enable_domain_optimization = false;
     // Minimal advised work amount for parallel execution.

--- a/src/common/snippets/include/snippets/lowered/pass/insert_perf_count.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_perf_count.hpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef ENABLE_OPENVINO_DEBUG
 
 #pragma once
 
@@ -31,3 +32,4 @@ public:
 } // namespace lowered
 } // namespace snippets
 } // namespace ov
+#endif  // ENABLE_OPENVINO_DEBUG

--- a/src/common/snippets/include/snippets/lowered/pass/insert_perf_count.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_perf_count.hpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #pragma once
 
@@ -32,4 +32,4 @@ public:
 } // namespace lowered
 } // namespace snippets
 } // namespace ov
-#endif  // ENABLE_OPENVINO_DEBUG
+#endif  // SNIPPETS_DEBUG_CAPS

--- a/src/common/snippets/include/snippets/op/perf_count.hpp
+++ b/src/common/snippets/include/snippets/op/perf_count.hpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef ENABLE_OPENVINO_DEBUG
 
 #pragma once
 
@@ -91,3 +92,4 @@ private:
 } // namespace op
 } // namespace snippets
 } // namespace ov
+#endif  // ENABLE_OPENVINO_DEBUG

--- a/src/common/snippets/include/snippets/op/perf_count.hpp
+++ b/src/common/snippets/include/snippets/op/perf_count.hpp
@@ -1,7 +1,8 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef ENABLE_OPENVINO_DEBUG
+
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #pragma once
 
@@ -92,4 +93,4 @@ private:
 } // namespace op
 } // namespace snippets
 } // namespace ov
-#endif  // ENABLE_OPENVINO_DEBUG
+#endif  // SNIPPETS_DEBUG_CAPS

--- a/src/common/snippets/include/snippets/snippets_isa_tbl.hpp
+++ b/src/common/snippets/include/snippets/snippets_isa_tbl.hpp
@@ -24,7 +24,7 @@ OV_OP(Scalar, ov::snippets::op)
 OV_OP(Nop, ov::snippets::op)
 OV_OP(RankNormalization, ov::snippets::op)
 
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
 OV_OP(PerfCountBegin, ov::snippets::op)
 OV_OP(PerfCountEnd, ov::snippets::op)
 #endif

--- a/src/common/snippets/include/snippets/snippets_isa_tbl.hpp
+++ b/src/common/snippets/include/snippets/snippets_isa_tbl.hpp
@@ -24,8 +24,10 @@ OV_OP(Scalar, ov::snippets::op)
 OV_OP(Nop, ov::snippets::op)
 OV_OP(RankNormalization, ov::snippets::op)
 
+#ifdef ENABLE_OPENVINO_DEBUG
 OV_OP(PerfCountBegin, ov::snippets::op)
 OV_OP(PerfCountEnd, ov::snippets::op)
+#endif
 
 // Layout-oblivious from opset1
 

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -80,7 +80,7 @@ Generator::opRegType Generator::get_op_reg_type(const std::shared_ptr<Node>& op)
         std::dynamic_pointer_cast<op::IntermediateMemoryBuffer>(op) ||
         std::dynamic_pointer_cast<op::NewMemoryBuffer>(op) ||
         std::dynamic_pointer_cast<op::RankNormalization>(op)
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
         || std::dynamic_pointer_cast<op::PerfCountBeginBase>(op)
         || std::dynamic_pointer_cast<op::PerfCountEndBase>(op)
 #endif

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -79,9 +79,12 @@ Generator::opRegType Generator::get_op_reg_type(const std::shared_ptr<Node>& op)
         std::dynamic_pointer_cast<op::Brgemm>(op) ||
         std::dynamic_pointer_cast<op::IntermediateMemoryBuffer>(op) ||
         std::dynamic_pointer_cast<op::NewMemoryBuffer>(op) ||
-        std::dynamic_pointer_cast<op::RankNormalization>(op) ||
-        std::dynamic_pointer_cast<op::PerfCountBeginBase>(op) ||
-        std::dynamic_pointer_cast<op::PerfCountEndBase>(op))
+        std::dynamic_pointer_cast<op::RankNormalization>(op)
+#ifdef ENABLE_OPENVINO_DEBUG
+        || std::dynamic_pointer_cast<op::PerfCountBeginBase>(op)
+        || std::dynamic_pointer_cast<op::PerfCountEndBase>(op)
+#endif
+        )
         return gpr2gpr;
     else if (std::dynamic_pointer_cast<snippets::op::Load>(op) ||
              std::dynamic_pointer_cast<snippets::op::BroadcastLoad>(op))

--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef ENABLE_OPENVINO_DEBUG
 
 #include "snippets/lowered/pass/insert_perf_count.hpp"
 #include "snippets/lowered/linear_ir.hpp"
@@ -60,3 +61,4 @@ bool InsertPerfCount::run(LinearIR& linear_ir) {
 } // namespace lowered
 } // namespace snippets
 } // namespace ov
+#endif  // ENABLE_OPENVINO_DEBUG

--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #include "snippets/lowered/pass/insert_perf_count.hpp"
 #include "snippets/lowered/linear_ir.hpp"
@@ -61,4 +61,4 @@ bool InsertPerfCount::run(LinearIR& linear_ir) {
 } // namespace lowered
 } // namespace snippets
 } // namespace ov
-#endif  // ENABLE_OPENVINO_DEBUG
+#endif  // SNIPPETS_DEBUG_CAPS

--- a/src/common/snippets/src/op/perf_count.cpp
+++ b/src/common/snippets/src/op/perf_count.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef ENABLE_OPENVINO_DEBUG
 
 #include "snippets/op/perf_count.hpp"
 
@@ -113,3 +114,4 @@ void PerfCountEnd::output_perf_count() {
 } // namespace op
 } // namespace snippets
 } // namespace ov
+#endif  // ENABLE_OPENVINO_DEBUG

--- a/src/common/snippets/src/op/perf_count.cpp
+++ b/src/common/snippets/src/op/perf_count.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #include "snippets/op/perf_count.hpp"
 
@@ -114,4 +114,4 @@ void PerfCountEnd::output_perf_count() {
 } // namespace op
 } // namespace snippets
 } // namespace ov
-#endif  // ENABLE_OPENVINO_DEBUG
+#endif  // SNIPPETS_DEBUG_CAPS

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -350,7 +350,7 @@ std::shared_ptr<lowered::LinearIR>
 Subgraph::convert_body_to_linear_ir(const std::shared_ptr<IShapeInferSnippetsFactory>& shape_infer_factory) {
     lowered::Config lowering_config;
     lowering_config.m_save_expressions = config.m_has_domain_sensitive_ops;
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
     lowering_config.m_save_expressions = lowering_config.m_save_expressions || (lowering_config.perf_count_mode != lowered::PerfCountMode::Disabled);
 #endif
     lowering_config.m_need_fill_tail_register = config.m_has_domain_sensitive_ops;
@@ -496,7 +496,7 @@ snippets::Schedule Subgraph::generate_from_linear_ir(const lowered::pass::PassPi
     auto linear_ir {*m_linear_ir->clone()};
     LoweringResult lowering_result;
     control_flow_transformations(linear_ir, lowering_result, backend_passes_pre_common, backend_passes_post_common);
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
     if (linear_ir.get_config().perf_count_mode == lowered::PerfCountMode::Chrono) {
         lowered::pass::InsertPerfCount perf_count_pass;
         perf_count_pass.run(linear_ir);

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -349,8 +349,10 @@ VectorDims Subgraph::infer_master_shape() {
 std::shared_ptr<lowered::LinearIR>
 Subgraph::convert_body_to_linear_ir(const std::shared_ptr<IShapeInferSnippetsFactory>& shape_infer_factory) {
     lowered::Config lowering_config;
-    lowering_config.m_save_expressions = config.m_has_domain_sensitive_ops ||
-        (lowering_config.perf_count_mode != lowered::PerfCountMode::Disabled);
+    lowering_config.m_save_expressions = config.m_has_domain_sensitive_ops;
+#ifdef ENABLE_OPENVINO_DEBUG
+    lowering_config.m_save_expressions = lowering_config.m_save_expressions || (lowering_config.perf_count_mode != lowered::PerfCountMode::Disabled);
+#endif
     lowering_config.m_need_fill_tail_register = config.m_has_domain_sensitive_ops;
     lowering_config.m_loop_depth = tileRank;
     lowering_config.m_enable_domain_optimization = !config.m_has_domain_sensitive_ops;
@@ -494,10 +496,12 @@ snippets::Schedule Subgraph::generate_from_linear_ir(const lowered::pass::PassPi
     auto linear_ir {*m_linear_ir->clone()};
     LoweringResult lowering_result;
     control_flow_transformations(linear_ir, lowering_result, backend_passes_pre_common, backend_passes_post_common);
+#ifdef ENABLE_OPENVINO_DEBUG
     if (linear_ir.get_config().perf_count_mode == lowered::PerfCountMode::Chrono) {
         lowered::pass::InsertPerfCount perf_count_pass;
         perf_count_pass.run(linear_ir);
     }
+#endif
     m_generator->generate(linear_ir, lowering_result, compile_params);
 
     VectorDims parallel_exec_domain = linear_ir.get_master_shape();

--- a/src/common/snippets/src/shape_inference/shape_inference.cpp
+++ b/src/common/snippets/src/shape_inference/shape_inference.cpp
@@ -55,7 +55,7 @@ const IShapeInferSnippetsFactory::TRegistry IShapeInferSnippetsFactory::registry
         SHAPE_INFER_PREDEFINED(op::Scalar, SingleElementShapeInfer),
         SHAPE_INFER_PREDEFINED(op::VectorBuffer, SingleElementShapeInfer),
         SHAPE_INFER_PREDEFINED(op::LoopEnd, EmptyShapeInfer),
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
         SHAPE_INFER_PREDEFINED(op::PerfCountBegin, EmptyShapeInfer),
         SHAPE_INFER_PREDEFINED(op::PerfCountEnd, EmptyShapeInfer),
 #endif

--- a/src/common/snippets/src/shape_inference/shape_inference.cpp
+++ b/src/common/snippets/src/shape_inference/shape_inference.cpp
@@ -55,8 +55,10 @@ const IShapeInferSnippetsFactory::TRegistry IShapeInferSnippetsFactory::registry
         SHAPE_INFER_PREDEFINED(op::Scalar, SingleElementShapeInfer),
         SHAPE_INFER_PREDEFINED(op::VectorBuffer, SingleElementShapeInfer),
         SHAPE_INFER_PREDEFINED(op::LoopEnd, EmptyShapeInfer),
+#ifdef ENABLE_OPENVINO_DEBUG
         SHAPE_INFER_PREDEFINED(op::PerfCountBegin, EmptyShapeInfer),
         SHAPE_INFER_PREDEFINED(op::PerfCountEnd, EmptyShapeInfer),
+#endif
         SHAPE_INFER_PREDEFINED(op::Kernel, EmptyShapeInfer),
         SHAPE_INFER_PREDEFINED(op::Nop, EmptyShapeInfer),
         SHAPE_INFER_OP_SPECIFIC_EXTERNAL(opset1::Select, SelectShapeInfer),

--- a/src/common/snippets/tests/src/lowering_utils.cpp
+++ b/src/common/snippets/tests/src/lowering_utils.cpp
@@ -41,8 +41,10 @@ DummyTargetMachine::DummyTargetMachine(const std::vector<ov::Node::type_info_t>&
     jitters[ov::snippets::op::Kernel::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::LoopBegin::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::LoopEnd::get_type_info_static()] = dummy_functor;
+#ifdef ENABLE_OPENVINO_DEBUG
     jitters[ov::snippets::op::PerfCountBegin::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::PerfCountEnd::get_type_info_static()] = dummy_functor;
+#endif
     jitters[ov::snippets::op::Brgemm::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::IntermediateMemoryBuffer::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::NewMemoryBuffer::get_type_info_static()] = dummy_functor;

--- a/src/common/snippets/tests/src/lowering_utils.cpp
+++ b/src/common/snippets/tests/src/lowering_utils.cpp
@@ -41,7 +41,7 @@ DummyTargetMachine::DummyTargetMachine(const std::vector<ov::Node::type_info_t>&
     jitters[ov::snippets::op::Kernel::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::LoopBegin::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::LoopEnd::get_type_info_static()] = dummy_functor;
-#ifdef ENABLE_OPENVINO_DEBUG
+#ifdef SNIPPETS_DEBUG_CAPS
     jitters[ov::snippets::op::PerfCountBegin::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::PerfCountEnd::get_type_info_static()] = dummy_functor;
 #endif

--- a/src/plugins/intel_cpu/src/emitters/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/cpu_generator.cpp
@@ -14,8 +14,6 @@
 #include "jit_dnnl_emitters.hpp"
 #include "jit_dnnl_ext_emitters.hpp"
 #include "jit_conversion_emitters.hpp"
-#include "jit_perf_count_chrono_emitters.hpp"
-#include "jit_perf_count_rdtsc_emitters.hpp"
 
 #include "transformations/snippets/x64/op/load_convert.hpp"
 #include "transformations/snippets/x64/op/store_convert.hpp"
@@ -27,6 +25,12 @@
 #include "transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.hpp"
 
 #include <openvino/opsets/opset5.hpp>
+
+#ifdef CPU_DEBUG_CAPS
+#include "jit_perf_count_chrono_emitters.hpp"
+#include "jit_perf_count_rdtsc_emitters.hpp"
+#include "transformations/snippets/x64/op/perf_count_rdtsc.hpp"
+#endif
 
 namespace ov {
 
@@ -162,10 +166,12 @@ intel_cpu::CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t ho
     jitters[intel_cpu::BrgemmCPU::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(BrgemmEmitter);
     jitters[intel_cpu::BrgemmCopyB::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(BrgemmCopyBEmitter);
 
+#ifdef CPU_DEBUG_CAPS
     jitters[snippets::op::PerfCountBegin::get_type_info_static()] = CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_chrono_start_emitter);
     jitters[snippets::op::PerfCountEnd::get_type_info_static()] = CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_chrono_end_emitter);
     jitters[ov::intel_cpu::PerfCountRdtscBegin::get_type_info_static()] = CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_rdtsc_start_emitter);
     jitters[ov::intel_cpu::PerfCountRdtscEnd::get_type_info_static()] = CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_rdtsc_end_emitter);
+#endif // CPU_DEBUG_CAPS
 }
 
 size_t intel_cpu::CPUTargetMachine::get_lanes() const {
@@ -232,11 +238,15 @@ snippets::Generator::opRegType intel_cpu::CPUGenerator::get_specific_op_reg_type
         OPENVINO_THROW("Register type of the operation " + std::string(op->get_type_name()) + " isn't determined!");
 }
 bool intel_cpu::CPUGenerator::uses_precompiled_kernel(const std::shared_ptr<snippets::Emitter>& e) const {
-    return std::dynamic_pointer_cast<intel_cpu::BrgemmEmitter>(e) ||
-           std::dynamic_pointer_cast<intel_cpu::BrgemmCopyBEmitter>(e) ||
+    bool need = std::dynamic_pointer_cast<intel_cpu::BrgemmEmitter>(e) ||
+                std::dynamic_pointer_cast<intel_cpu::BrgemmCopyBEmitter>(e);
+#ifdef CPU_DEBUG_CAPS
+    need = need ||
            std::dynamic_pointer_cast<intel_cpu::jit_perf_count_chrono_start_emitter>(e) ||
            std::dynamic_pointer_cast<intel_cpu::jit_perf_count_chrono_end_emitter>(e) ||
            std::dynamic_pointer_cast<intel_cpu::jit_perf_count_rdtsc_start_emitter>(e) ||
            std::dynamic_pointer_cast<intel_cpu::jit_perf_count_rdtsc_end_emitter>(e);
+#endif // CPU_DEBUG_CAPS
+    return need;
 }
 } // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/cpu_generator.cpp
@@ -26,7 +26,7 @@
 
 #include <openvino/opsets/opset5.hpp>
 
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
 #include "jit_perf_count_chrono_emitters.hpp"
 #include "jit_perf_count_rdtsc_emitters.hpp"
 #include "transformations/snippets/x64/op/perf_count_rdtsc.hpp"
@@ -166,12 +166,12 @@ intel_cpu::CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t ho
     jitters[intel_cpu::BrgemmCPU::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(BrgemmEmitter);
     jitters[intel_cpu::BrgemmCopyB::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(BrgemmCopyBEmitter);
 
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
     jitters[snippets::op::PerfCountBegin::get_type_info_static()] = CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_chrono_start_emitter);
     jitters[snippets::op::PerfCountEnd::get_type_info_static()] = CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_chrono_end_emitter);
     jitters[ov::intel_cpu::PerfCountRdtscBegin::get_type_info_static()] = CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_rdtsc_start_emitter);
     jitters[ov::intel_cpu::PerfCountRdtscEnd::get_type_info_static()] = CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_rdtsc_end_emitter);
-#endif // CPU_DEBUG_CAPS
+#endif
 }
 
 size_t intel_cpu::CPUTargetMachine::get_lanes() const {
@@ -240,13 +240,13 @@ snippets::Generator::opRegType intel_cpu::CPUGenerator::get_specific_op_reg_type
 bool intel_cpu::CPUGenerator::uses_precompiled_kernel(const std::shared_ptr<snippets::Emitter>& e) const {
     bool need = std::dynamic_pointer_cast<intel_cpu::BrgemmEmitter>(e) ||
                 std::dynamic_pointer_cast<intel_cpu::BrgemmCopyBEmitter>(e);
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
     need = need ||
            std::dynamic_pointer_cast<intel_cpu::jit_perf_count_chrono_start_emitter>(e) ||
            std::dynamic_pointer_cast<intel_cpu::jit_perf_count_chrono_end_emitter>(e) ||
            std::dynamic_pointer_cast<intel_cpu::jit_perf_count_rdtsc_start_emitter>(e) ||
            std::dynamic_pointer_cast<intel_cpu::jit_perf_count_rdtsc_end_emitter>(e);
-#endif // CPU_DEBUG_CAPS
+#endif
     return need;
 }
 } // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_chrono_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_chrono_emitters.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef CPU_DEBUG_CAPS
 
 #include "jit_emitter.hpp"
 #include "jit_perf_count_chrono_emitters.hpp"
@@ -71,3 +72,4 @@ void jit_perf_count_chrono_end_emitter::emit_impl(const std::vector<size_t> &in_
 
 }   // namespace intel_cpu
 }   // namespace ov
+#endif // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_chrono_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_chrono_emitters.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #include "jit_emitter.hpp"
 #include "jit_perf_count_chrono_emitters.hpp"
@@ -72,4 +72,4 @@ void jit_perf_count_chrono_end_emitter::emit_impl(const std::vector<size_t> &in_
 
 }   // namespace intel_cpu
 }   // namespace ov
-#endif // CPU_DEBUG_CAPS
+#endif // SNIPPETS_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_chrono_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_chrono_emitters.hpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #pragma once
 
@@ -39,4 +39,4 @@ private:
 
 }   // namespace intel_cpu
 }   // namespace ov
-#endif // CPU_DEBUG_CAPS
+#endif // SNIPPETS_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_chrono_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_chrono_emitters.hpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef CPU_DEBUG_CAPS
 
 #pragma once
 
@@ -38,3 +39,4 @@ private:
 
 }   // namespace intel_cpu
 }   // namespace ov
+#endif // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_rdtsc_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_rdtsc_emitters.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #include "jit_emitter.hpp"
 #include "jit_perf_count_rdtsc_emitters.hpp"
@@ -85,4 +85,4 @@ void jit_perf_count_rdtsc_end_emitter::emit_impl(const std::vector<size_t> &in_i
 
 }   // namespace intel_cpu
 }   // namespace ov
-#endif // CPU_DEBUG_CAPS
+#endif // SNIPPETS_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_rdtsc_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_rdtsc_emitters.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef CPU_DEBUG_CAPS
 
 #include "jit_emitter.hpp"
 #include "jit_perf_count_rdtsc_emitters.hpp"
@@ -84,3 +85,4 @@ void jit_perf_count_rdtsc_end_emitter::emit_impl(const std::vector<size_t> &in_i
 
 }   // namespace intel_cpu
 }   // namespace ov
+#endif // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_rdtsc_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_rdtsc_emitters.hpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #pragma once
 
@@ -36,4 +36,4 @@ private:
 
 }   // namespace intel_cpu
 }   // namespace ov
-#endif // CPU_DEBUG_CAPS
+#endif // SNIPPETS_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_rdtsc_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/x64/jit_perf_count_rdtsc_emitters.hpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef CPU_DEBUG_CAPS
 
 #pragma once
 
@@ -35,3 +36,4 @@ private:
 
 }   // namespace intel_cpu
 }   // namespace ov
+#endif // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -161,7 +161,7 @@ std::map<std::string, ngraph::OpSet> Extension::getOpSets() {
         NGRAPH_OP(Subgraph, ov::snippets::op)
         NGRAPH_OP(VectorBuffer, ov::snippets::op)
         NGRAPH_OP(RankNormalization, ov::snippets::op)
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
         NGRAPH_OP(PerfCountBegin, ov::snippets::op)
         NGRAPH_OP(PerfCountEnd, ov::snippets::op)
 #endif
@@ -171,7 +171,7 @@ std::map<std::string, ngraph::OpSet> Extension::getOpSets() {
         NGRAPH_OP_X64(StoreConvertTruncation, ov::intel_cpu)
         NGRAPH_OP_X64(BrgemmCPU, ov::intel_cpu)
         NGRAPH_OP_X64(BrgemmCopyB, ov::intel_cpu)
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
         NGRAPH_OP_X64(PerfCountRdtscBegin, ov::intel_cpu)
         NGRAPH_OP_X64(PerfCountRdtscEnd, ov::intel_cpu)
 #endif

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -161,16 +161,20 @@ std::map<std::string, ngraph::OpSet> Extension::getOpSets() {
         NGRAPH_OP(Subgraph, ov::snippets::op)
         NGRAPH_OP(VectorBuffer, ov::snippets::op)
         NGRAPH_OP(RankNormalization, ov::snippets::op)
+#ifdef CPU_DEBUG_CAPS
         NGRAPH_OP(PerfCountBegin, ov::snippets::op)
         NGRAPH_OP(PerfCountEnd, ov::snippets::op)
+#endif
         NGRAPH_OP_X64(LoadConvertSaturation, ov::intel_cpu)
         NGRAPH_OP_X64(LoadConvertTruncation, ov::intel_cpu)
         NGRAPH_OP_X64(StoreConvertSaturation, ov::intel_cpu)
         NGRAPH_OP_X64(StoreConvertTruncation, ov::intel_cpu)
         NGRAPH_OP_X64(BrgemmCPU, ov::intel_cpu)
         NGRAPH_OP_X64(BrgemmCopyB, ov::intel_cpu)
+#ifdef CPU_DEBUG_CAPS
         NGRAPH_OP_X64(PerfCountRdtscBegin, ov::intel_cpu)
         NGRAPH_OP_X64(PerfCountRdtscEnd, ov::intel_cpu)
+#endif
 #undef NGRAPH_OP
 
         return opset;

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -37,6 +37,8 @@
 #include <common/primitive_hashing_utils.hpp>
 #include "snippets/pass/hash.hpp"
 
+#include "snippets/lowered/linear_ir.hpp"
+
 using namespace InferenceEngine;
 using namespace dnnl::impl::utils;
 using namespace dnnl::impl::cpu;
@@ -395,12 +397,26 @@ void Snippet::prepareParams() {
         return executor;
     };
 
-    auto cache = context->getParamsCache();
-    auto result = cache->getOrCreate(key, builder);
-    execPtr = result.first;
-    if (!execPtr) {
-        OPENVINO_THROW("Executor is not created for node ", getName(), ".");
+    auto getOrCreateExecutor = [this, &key, &builder]() {
+        auto cache = context->getParamsCache();
+        auto result = cache->getOrCreate(key, builder);
+        execPtr = result.first;
+        if (!execPtr) {
+            OPENVINO_THROW("Executor is not created for node ", getName(), ".");
+        }
+    };
+
+#ifndef CPU_DEBUG_CAPS
+    getOrCreateExecutor();
+#else
+    snippets::lowered::Config config;
+    if (config.perf_count_mode == snippets::lowered::PerfCountMode::Disabled) {
+        getOrCreateExecutor();
+    } else {
+        // in case perf count is enabled, disable executor cache by default to not miss up number for different subgraph.
+        execPtr = std::make_shared<SnippetJitExecutor>(key.attrs, is_dynamic, context->getConfig().inferencePrecision == ov::element::bf16);
     }
+#endif
 }
 
 bool Snippet::needPrepareParams() const {

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -406,14 +406,14 @@ void Snippet::prepareParams() {
         }
     };
 
-#ifndef CPU_DEBUG_CAPS
+#ifndef SNIPPETS_DEBUG_CAPS
     getOrCreateExecutor();
 #else
     snippets::lowered::Config config;
     if (config.perf_count_mode == snippets::lowered::PerfCountMode::Disabled) {
         getOrCreateExecutor();
     } else {
-        // in case perf count is enabled, disable executor cache by default to not miss up number for different subgraph.
+        // in case perf count is enabled, disable executor cache by default to not mix up perf counters for different subgraphs.
         execPtr = std::make_shared<SnippetJitExecutor>(key.attrs, is_dynamic, context->getConfig().inferencePrecision == ov::element::bf16);
     }
 #endif

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef CPU_DEBUG_CAPS
 
 #include "perf_count_rdtsc.hpp"
 
@@ -30,3 +31,4 @@ std::shared_ptr<PerfCountRdtscBegin> PerfCountRdtscEnd::get_pc_begin() {
     OPENVINO_ASSERT(pc_begin != nullptr, "PerfCountRdtscEnd last input is not connected to PerfCountRdtscBegin");
     return  pc_begin;
 }
+#endif // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #include "perf_count_rdtsc.hpp"
 
@@ -31,4 +31,4 @@ std::shared_ptr<PerfCountRdtscBegin> PerfCountRdtscEnd::get_pc_begin() {
     OPENVINO_ASSERT(pc_begin != nullptr, "PerfCountRdtscEnd last input is not connected to PerfCountRdtscBegin");
     return  pc_begin;
 }
-#endif // CPU_DEBUG_CAPS
+#endif // SNIPPETS_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
 
 #pragma once
 
@@ -54,4 +54,4 @@ public:
 
 } // namespace intel_cpu
 } // namespace ov
-#endif // CPU_DEBUG_CAPS
+#endif // SNIPPETS_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#ifdef CPU_DEBUG_CAPS
 
 #pragma once
 
@@ -53,3 +54,4 @@ public:
 
 } // namespace intel_cpu
 } // namespace ov
+#endif // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/shape_inference.cpp
@@ -39,7 +39,7 @@ const CPUShapeInferSnippetsFactory::TRegistry CPUShapeInferSnippetsFactory::spec
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::LoadConvertTruncation, PassThroughShapeInfer),
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::StoreConvertSaturation, PassThroughShapeInfer),
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::StoreConvertTruncation, PassThroughShapeInfer),
-#ifdef CPU_DEBUG_CAPS
+#ifdef SNIPPETS_DEBUG_CAPS
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::PerfCountRdtscBegin, EmptyShapeInfer),
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::PerfCountRdtscEnd, EmptyShapeInfer),
 #endif

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/shape_inference.cpp
@@ -39,8 +39,10 @@ const CPUShapeInferSnippetsFactory::TRegistry CPUShapeInferSnippetsFactory::spec
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::LoadConvertTruncation, PassThroughShapeInfer),
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::StoreConvertSaturation, PassThroughShapeInfer),
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::StoreConvertTruncation, PassThroughShapeInfer),
+#ifdef CPU_DEBUG_CAPS
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::PerfCountRdtscBegin, EmptyShapeInfer),
         SHAPE_INFER_PREDEFINED(ov::intel_cpu::PerfCountRdtscEnd, EmptyShapeInfer),
+#endif
         SHAPE_INFER_OP_SPECIFIC_EXTERNAL(ov::intel_cpu::BrgemmCPU, BrgemmShapeInfer),
         //
         SHAPE_INFER_OP_SPECIFIC(ov::intel_cpu::BrgemmCopyB),


### PR DESCRIPTION
### Details:
[snippets perf count](https://github.com/openvinotoolkit/openvino/pull/19493) follow-up:  
- *Binary size not increase.*
- *Executor cache is disabled by default if enable perf count.*

### Tickets:
 - N/A
