### PR TITLE
[GPU] Improve fake alignment logic and fix missed zero point value

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -470,6 +470,8 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
                 fc_with_bias_prim->compressed_weights = true;
                 fc_with_bias_prim->decompression_scale = desc->decompression_scale;
                 fc_with_bias_prim->decompression_zero_point = desc->decompression_zero_point;
+                if (desc->decompression_zero_point_scalar.has_value())
+                    fc_with_bias_prim->decompression_zero_point_scalar = desc->decompression_zero_point_scalar.value();
             }
             auto& new_fc_node = p.get_or_create(fc_with_bias_prim);
             fuse_bias_f(fc, new_fc_node, bias_node, eltw_node);


### PR DESCRIPTION
### Details:
 - This PR modifies fake alignment logic to take into account cases like ([batch, 1, feature] as well as [1, batch, feature]) and fixes missed zero points scalar value during bias fusion

### Tickets:
 - 126885
