### PR TITLE
[DOCS] Update of Learn OpenVINO article for 2023.2

### DIFF
--- a/docs/articles_en/learn_openvino.md
+++ b/docs/articles_en/learn_openvino.md
@@ -28,7 +28,7 @@ as well as an experienced user.
 | :doc:`OpenVINO Samples <openvino_docs_OV_UG_Samples_Overview>`  
 | The OpenVINO samples (Python and C++) are simple console applications that show how to use specific OpenVINO API features. They can assist you in executing tasks such as loading a model, running inference, querying particular device capabilities, etc.
 
-| :doc:`OpenVINO™ API 2.0 Transition Guide <openvino_2_0_transition_guide>`
-| With the release of 2022.1 OpenVINO introduced its improved API 2.0 and its new OpenVINO IR model format: IR v11. This tutorial will instruct you on how to adopt the new solution, as well as show you the benefits of the new logic of working with models.
+| :doc:`Optimize and Deploy Generative AI Models <gen_ai_guide>`
+| Detailed information on how OpenVINO accelerates Generative AI use cases and what models it supports. This tutorial provides instructions for running Generative AI models using Hugging Face Optimum Intel and Native OpenVINO APIs.
 
 @endsphinxdirective


### PR DESCRIPTION
Port from https://github.com/openvinotoolkit/openvino/pull/21539

- Removed link and description of API 2.0 Transition in Learn OpenVINO article.
- Added link and description of Generative AI Optimization and Deployment to the article.
