### PR TITLE
[CPU] Improve first token latency for 4bit compressed models

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.cpp
@@ -73,7 +73,8 @@ ov::intel_cpu::MoveFCReshapeToWeights::MoveFCReshapeToWeights() {
                 return false;
 
             const auto comparison_start_pos = expected_shape.size() - node_shape.size();
-            return std::equal(node_shape.begin(), node_shape.end(), expected_shape.begin() + comparison_start_pos);
+            return std::equal(node_shape.begin(), node_shape.end(), expected_shape.begin() + comparison_start_pos) ||
+                   std::all_of(node_shape.cbegin(), node_shape.cend(), [](int dim) { return dim == 1; });
         };
 
         const auto mul = reshape->get_input_node_shared_ptr(0);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_weights_decompression.cpp
@@ -38,6 +38,29 @@ namespace test {
  *              Bias
  */
 
+enum class DecompressionSubtractType {
+    empty,  // no decompression subtract
+    scalar, // decompression subtract with scalar shape
+    full    // decompression subtract with per-channel or grouped shape
+};
+
+inline std::ostream& operator<<(std::ostream & os, DecompressionSubtractType type) {
+    switch (type) {
+        case DecompressionSubtractType::empty:
+            os << "empty";
+            break;
+        case DecompressionSubtractType::scalar:
+            os << "scalar";
+            break;
+        case DecompressionSubtractType::full:
+            os << "full";
+            break;
+        default:
+            OPENVINO_THROW("Not supported type for DecompressionSubtractType");
+    }
+    return os;
+}
+
 struct ShapeParams {
     ShapeParams() = default;
     ShapeParams(InputShape data_shape, ov::Shape weights_shape, int weights_group_size = -1)
@@ -51,12 +74,12 @@ struct ShapeParams {
     int weights_group_size;
 };
 using MatmulWeightsDecompressionParams = std::tuple<ShapeParams,
-                                                    ov::test::ElementType,  // weights precision
-                                                    ov::test::ElementType,  // decompression precision
-                                                    bool,                   // transpose on weights
-                                                    bool,                   // decompression subtract
-                                                    bool,                   // reshape on decompression constants
-                                                    ov::AnyMap,             // additional config
+                                                    ov::test::ElementType,     // weights precision
+                                                    ov::test::ElementType,     // decompression precision
+                                                    bool,                      // transpose on weights
+                                                    DecompressionSubtractType, // decompression subtract type
+                                                    bool,                      // reshape on decompression constants
+                                                    ov::AnyMap,                // additional config
                                                     fusingSpecificParams,
                                                     bool>;  // should use decompression implementation
 
@@ -69,7 +92,7 @@ public:
         ov::test::ElementType weights_precision;
         ov::test::ElementType decompression_precision;
         bool transpose;
-        bool decompression_sub;
+        DecompressionSubtractType decompression_subtract_type;
         bool reshape_on_decompression;
         ov::AnyMap additional_config;
         fusingSpecificParams fusing_params;
@@ -79,7 +102,7 @@ public:
                  weights_precision,
                  decompression_precision,
                  transpose,
-                 decompression_sub,
+                 decompression_subtract_type,
                  reshape_on_decompression,
                  additional_config,
                  fusing_params,
@@ -92,7 +115,7 @@ public:
         result << "weights_precision=" << weights_precision << "_";
         result << "decompression_precision=" << decompression_precision << "_";
         result << "transpose_weights=" << transpose << "_";
-        result << "decompression_subtract=" << decompression_sub << "_";
+        result << "decompression_subtract=" << decompression_subtract_type << "_";
         result << "reshape_on_decompression=" << reshape_on_decompression << "_";
 
         result << "config=(";
@@ -112,7 +135,7 @@ protected:
                                                        const ov::element::Type weights_precision,
                                                        const ov::element::Type decompression_precision,
                                                        const bool transpose_weights,
-                                                       const bool add_subtract,
+                                                       const DecompressionSubtractType decompression_subtract_type,
                                                        const bool reshape_on_decompression_constant) {
         auto transpose_if_necessary = [&](const ov::Shape& shape) {
             auto result_shape = shape;
@@ -141,7 +164,8 @@ protected:
             transformed_weights_shape.insert(transformed_weights_shape.begin() + in_channel_idx + 1, group_size);
         }
 
-        auto weights = ngraph::builder::makeConstant<int8_t>(weights_precision, transformed_weights_shape, {}, true, 7);
+        auto up_to = weights_precision == ov::element::nf4 ? 15 : 7;
+        auto weights = ngraph::builder::makeConstant<int8_t>(weights_precision, transformed_weights_shape, {}, true, up_to);
         weights->set_friendly_name("Compressed_weights");
         auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, decompression_precision);
 
@@ -162,11 +186,14 @@ protected:
         auto scaleshift_const_shape = scaleshift_target_shape;
         if (reshape_on_decompression_constant)
             scaleshift_const_shape.erase(std::remove(scaleshift_const_shape.begin(), scaleshift_const_shape.end(), 1), scaleshift_const_shape.end());
-        if (add_subtract) {
-            auto shift_const = ngraph::builder::makeConstant<uint8_t>(weights_precision, scaleshift_const_shape, {}, true, 7);
+        if (decompression_subtract_type != DecompressionSubtractType::empty) {
+            auto subtract_shape = decompression_subtract_type == DecompressionSubtractType::full ? scaleshift_const_shape : Shape({});
+            auto shift_const = ngraph::builder::makeConstant<uint8_t>(weights_precision, subtract_shape, {}, true, 7);
             std::shared_ptr<ov::Node> shift_convert = std::make_shared<ov::op::v0::Convert>(shift_const, decompression_precision);
             if (reshape_on_decompression_constant) {
-                auto shift_reshape_const = ov::opset10::Constant::create(ov::element::i32, {scaleshift_target_shape.size()}, scaleshift_target_shape);
+                auto subtract_target_shape = decompression_subtract_type == DecompressionSubtractType::full
+                    ? scaleshift_target_shape : ov::Shape(std::vector<size_t>(scaleshift_const_shape.size(), 1));
+                auto shift_reshape_const = ov::opset10::Constant::create(ov::element::i32, {subtract_target_shape.size()}, subtract_target_shape);
                 auto shift_reshape = std::make_shared<ov::opset10::Reshape>(shift_convert, shift_reshape_const, false);
                 shift_convert = shift_reshape;
             }
@@ -208,7 +235,7 @@ protected:
                                             const ov::element::Type weights_precision,
                                             const ov::element::Type decompression_precision,
                                             const bool transpose_weights,
-                                            const bool add_subtract,
+                                            const DecompressionSubtractType decompression_subtract_type,
                                             const bool reshape_on_decompression) {
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(data_precision, data_shape)};
         const auto weights_subgraph = initDecompressionWeights(weights_shape,
@@ -217,7 +244,7 @@ protected:
                                                                weights_precision,
                                                                decompression_precision,
                                                                transpose_weights,
-                                                               add_subtract,
+                                                               decompression_subtract_type,
                                                                reshape_on_decompression);
         auto matMul = std::make_shared<ov::op::v0::MatMul>(params[0], weights_subgraph);
         return makeNgraphFunction(data_precision, params, matMul, "MatmulWeightsDecompression");
@@ -230,7 +257,7 @@ protected:
         ov::test::ElementType weights_precision;
         ov::test::ElementType decompression_precision;
         bool transpose_weights;
-        bool decompression_sub;
+        DecompressionSubtractType decompression_subtract_type;
         bool reshape_on_decompression;
         ov::AnyMap additional_config;
         fusingSpecificParams fusing_params;
@@ -240,7 +267,7 @@ protected:
                  weights_precision,
                  decompression_precision,
                  transpose_weights,
-                 decompression_sub,
+                 decompression_subtract_type,
                  reshape_on_decompression,
                  additional_config,
                  fusing_params,
@@ -260,7 +287,7 @@ protected:
                                 weights_precision,
                                 decompression_precision,
                                 transpose_weights,
-                                decompression_sub,
+                                decompression_subtract_type,
                                 reshape_on_decompression);
     }
 
@@ -337,7 +364,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_basic,
                                             ::testing::ValuesIn(weights_precisions_basic),
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(true),
-                                            ::testing::Values(true),
+                                            ::testing::Values(DecompressionSubtractType::full),
                                             ::testing::Values(true),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
                                             ::testing::ValuesIn(fusing_params),
@@ -350,7 +377,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_amx,
                                             ::testing::ValuesIn(weights_precisions_amx),
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(true),
-                                            ::testing::Values(true),
+                                            ::testing::Values(DecompressionSubtractType::full),
                                             ::testing::Values(true),
                                             ::testing::ValuesIn(filter_additional_config_amx()),
                                             ::testing::ValuesIn(fusing_params),
@@ -360,7 +387,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_amx,
 const std::vector<ShapeParams> input_shapes_corner_cases_basic = {
     {{{-1, -1, -1}, {{1, 4, 16}}}, {1, 16, 32}},
     {{{-1, -1, -1}, {{1, 4, 16}}}, {16, 32}},
-    {{{-1, -1, -1}, {{1, 4, 16}}}, {16, 32}, 4ul},
+    {{{-1, -1, -1}, {{1, 5, 16}}}, {16, 32}, 4ul},
     {{{-1, -1, -1}, {{1, 1, 4096}}}, {4096, 4096}, 128ul},
 };
 const std::vector<ShapeParams> input_shapes_corner_cases_amx = {
@@ -369,7 +396,8 @@ const std::vector<ShapeParams> input_shapes_corner_cases_amx = {
 };
 
 const std::vector<bool> transpose_weights = {true, false};
-const std::vector<bool> add_decompression_sub = {true, false};
+const std::vector<DecompressionSubtractType> decompression_subtract_type = {
+    DecompressionSubtractType::full, DecompressionSubtractType::scalar, DecompressionSubtractType::empty};
 const std::vector<bool> reshape_on_decompression = {true, false};
 const std::vector<ov::test::ElementType> decompression_precisions_corner_cases = {ov::element::f16, ov::element::f32};
 
@@ -379,7 +407,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_basic,
                                             ::testing::ValuesIn(weights_precisions_basic),
                                             ::testing::ValuesIn(decompression_precisions_corner_cases),
                                             ::testing::ValuesIn(transpose_weights),
-                                            ::testing::ValuesIn(add_decompression_sub),
+                                            ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::ValuesIn(reshape_on_decompression),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
                                             ::testing::Values(emptyFusingSpec),
@@ -392,7 +420,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_amx,
                                             ::testing::ValuesIn(weights_precisions_amx),
                                             ::testing::ValuesIn(decompression_precisions_corner_cases),
                                             ::testing::ValuesIn(transpose_weights),
-                                            ::testing::ValuesIn(add_decompression_sub),
+                                            ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::ValuesIn(reshape_on_decompression),
                                             ::testing::ValuesIn(filter_additional_config_amx()),
                                             ::testing::Values(emptyFusingSpec),


### PR DESCRIPTION
### Details:
 - PR improves "first token" latency for 4bit compressed LLMs on AVX2/AVX512 HW targets. 
 - OneDNN PR: https://github.com/openvinotoolkit/oneDNN/pull/221
### Tickets:
 - *[CVS-125052](https://jira.devtools.intel.com/browse/CVS-125052)*
