### PR TITLE
Mark PyTorch frontend as non-linkable

### DIFF
--- a/cmake/templates/OpenVINOConfig.cmake.in
+++ b/cmake/templates/OpenVINOConfig.cmake.in
@@ -43,9 +43,6 @@
 #   `openvino::frontend::paddle`
 #   Paddle FrontEnd target (optional)
 #
-#   `openvino::frontend::pytorch`
-#   PyTorch FrontEnd target (optional)
-#
 #   `openvino::frontend::tensorflow`
 #   TensorFlow FrontEnd target (optional)
 #

--- a/src/frontends/pytorch/src/CMakeLists.txt
+++ b/src/frontends/pytorch/src/CMakeLists.txt
@@ -3,7 +3,5 @@
 #
 
 ov_add_frontend(NAME pytorch
-                LINKABLE_FRONTEND
-                SHUTDOWN_PROTOBUF
-                FILEDESCRIPTION "FrontEnd to load and convert TorchScript models from PyTorch"
+                FILEDESCRIPTION "FrontEnd to load and convert TorchScript, TorchFX models from PyTorch"
                 LINK_LIBRARIES openvino::util openvino::core::dev)


### PR DESCRIPTION
### Details:
 - It means its headers will not be installed to end users as well as libopenvino_pytorch_frontend.so. 
 - Those files are not needed, because PyTorch frontend is only used from Python code