### PR TITLE
LP Transformation tests use SubgraphBaseTest

### DIFF
--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/batch_to_space_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/batch_to_space_transformation.hpp
@@ -37,7 +37,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_backprop_data_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_backprop_data_transformation.hpp
@@ -59,7 +59,7 @@ public:
 protected:
     void SetUp() override;
 
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_qdq_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_qdq_transformation.hpp
@@ -62,7 +62,7 @@ public:
 protected:
     void SetUp() override;
 
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_transformation.hpp
@@ -40,7 +40,7 @@ public:
 protected:
     void SetUp() override;
 
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/elementwise_branch_selection_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/elementwise_branch_selection_transformation.hpp
@@ -45,7 +45,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_transformation.hpp
@@ -34,7 +34,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp
@@ -63,7 +63,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/group_convolution_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/group_convolution_transformation.hpp
@@ -58,7 +58,7 @@ public:
 protected:
     void SetUp() override;
 
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/groupconvolution_qdq_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/groupconvolution_qdq_transformation.hpp
@@ -66,7 +66,7 @@ public:
 protected:
     void SetUp() override;
 
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_transformation.hpp
@@ -38,7 +38,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_with_constant_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_with_constant_transformation.hpp
@@ -45,7 +45,7 @@ public:
 protected:
     void SetUp() override;
 
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/move_fake_quantize_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/move_fake_quantize_transformation.hpp
@@ -47,7 +47,7 @@ public:
 protected:
     void SetUp() override;
 
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_to_group_convolution_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_to_group_convolution_transformation.hpp
@@ -39,7 +39,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_transformation.hpp
@@ -38,7 +38,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/pad_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/pad_transformation.hpp
@@ -35,6 +35,6 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/pull_reshape_through_dequantization_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/pull_reshape_through_dequantization_transformation.hpp
@@ -50,7 +50,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/recurrent_cell_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/recurrent_cell_transformation.hpp
@@ -54,7 +54,7 @@ public:
 protected:
     void SetUp() override;
 
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_max_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_max_transformation.hpp
@@ -34,6 +34,6 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_mean_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_mean_transformation.hpp
@@ -46,6 +46,6 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_min_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_min_transformation.hpp
@@ -34,6 +34,6 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_sum_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_sum_transformation.hpp
@@ -34,6 +34,6 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reshape_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reshape_transformation.hpp
@@ -36,7 +36,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/shuffle_channels_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/shuffle_channels_transformation.hpp
@@ -37,7 +37,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/space_to_batch_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/space_to_batch_transformation.hpp
@@ -37,7 +37,7 @@ public:
 
 protected:
     void SetUp() override;
-    void Run() override;
+    void run() override;
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/batch_to_space_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/batch_to_space_transformation.cpp
@@ -38,8 +38,8 @@ void BatchToSpaceTransformation::SetUp() {
         param.crops_end);
 }
 
-void BatchToSpaceTransformation::Run() {
-    LayerTestsCommon::Run();
+void BatchToSpaceTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<2>(GetParam());
     auto expected_type = params.expected_kernel_type;
@@ -54,7 +54,7 @@ void BatchToSpaceTransformation::Run() {
 
 TEST_P(BatchToSpaceTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_backprop_data_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_backprop_data_transformation.cpp
@@ -67,8 +67,8 @@ void ConvolutionBackpropDataTransformation::SetUp() {
         weights);
 }
 
-void ConvolutionBackpropDataTransformation::Run() {
-    LayerTestsCommon::Run();
+void ConvolutionBackpropDataTransformation::run() {
+    LayerTransformation::run();
 
     const auto inputShape = std::get<1>(GetParam());
     if (inputShape.second) {
@@ -80,7 +80,7 @@ void ConvolutionBackpropDataTransformation::Run() {
 
 TEST_P(ConvolutionBackpropDataTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_qdq_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_qdq_transformation.cpp
@@ -57,8 +57,8 @@ void ConvolutionQDqTransformation::SetUp() {
     this->configuration[ov::hint::inference_precision.name()] = "f32";
 }
 
-void ConvolutionQDqTransformation::Run() {
-    LayerTestsCommon::Run();
+void ConvolutionQDqTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualType = getRuntimePrecisionByType(params.layerName);
@@ -67,7 +67,7 @@ void ConvolutionQDqTransformation::Run() {
 
 TEST_P(ConvolutionQDqTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
@@ -53,8 +53,8 @@ void ConvolutionTransformation::SetUp() {
         param.fakeQuantizeOnWeights);
 }
 
-void ConvolutionTransformation::Run() {
-    LayerTestsCommon::Run();
+void ConvolutionTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualPrecision = getRuntimePrecisionByType(params.layerName);
@@ -67,7 +67,7 @@ void ConvolutionTransformation::Run() {
 
 TEST_P(ConvolutionTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/elementwise_branch_selection_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/elementwise_branch_selection_transformation.cpp
@@ -78,7 +78,7 @@ void ElementwiseBranchSelectionTransformation::run() {
 
     std::vector<std::pair<std::string, std::string>> expectedReorders = params.expectedReorders;
     if (!expectedReorders.empty()) {
-        auto rtInfo = LayerTestsCommon::getRuntimeInfo();
+        auto rtInfo = LayerTransformation::getRuntimeInfo();
         for (auto it : rtInfo) {
             const auto& typeIt = it.second.find("layerType");
             const auto type = typeIt->second.as<std::string>();

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/elementwise_branch_selection_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/elementwise_branch_selection_transformation.cpp
@@ -70,8 +70,8 @@ void ElementwiseBranchSelectionTransformation::SetUp() {
     ov::pass::InitNodeInfo().run_on_model(function);
 }
 
-void ElementwiseBranchSelectionTransformation::Run() {
-    LayerTestsCommon::Run();
+void ElementwiseBranchSelectionTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<3>(GetParam());
     const auto elementwiseType = std::get<4>(GetParam());
@@ -115,7 +115,7 @@ void ElementwiseBranchSelectionTransformation::Run() {
 
 TEST_P(ElementwiseBranchSelectionTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/eliminate_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/eliminate_fake_quantize_transformation.cpp
@@ -52,7 +52,7 @@ TEST_P(EliminateFakeQuantizeTransformation, CompareWithRefImpl) {
     EliminateFakeQuantizeTransformationTestValues testValues;
     std::tie(targetDevice, testValues) = this->GetParam();
 
-    const auto& rtInfo = LayerTestsCommon::getRuntimeInfo();
+    const auto& rtInfo = LayerTransformation::getRuntimeInfo();
 
     auto exist = testValues.expected.exist;
     auto absent = testValues.expected.absent;

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_transformation.cpp
@@ -52,8 +52,8 @@ void FakeQuantizeTransformation::SetUp() {
     ov::pass::InitNodeInfo().run_on_model(function);
 }
 
-void FakeQuantizeTransformation::Run() {
-    LayerTestsCommon::Run();
+void FakeQuantizeTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualPrecision = getRuntimePrecisionByType(params.layerName);
@@ -67,7 +67,7 @@ void FakeQuantizeTransformation::Run() {
 
 TEST_P(FakeQuantizeTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -49,8 +49,8 @@ void FakeQuantizeWithNotOptimalTransformation::SetUp() {
         testValues.dequantizationAfter);
 }
 
-void FakeQuantizeWithNotOptimalTransformation::Run() {
-    LayerTestsCommon::Run();
+void FakeQuantizeWithNotOptimalTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualType = getRuntimePrecisionByType("Convolution");
@@ -58,7 +58,7 @@ void FakeQuantizeWithNotOptimalTransformation::Run() {
 }
 
 TEST_P(FakeQuantizeWithNotOptimalTransformation, CompareWithRefImpl) {
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/group_convolution_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/group_convolution_transformation.cpp
@@ -68,8 +68,8 @@ void GroupConvolutionTransformation::SetUp() {
         addPrecisionPreserved);
 }
 
-void GroupConvolutionTransformation::Run() {
-    LayerTestsCommon::Run();
+void GroupConvolutionTransformation::run() {
+    LayerTransformation::run();
 
     const auto param = std::get<4>(GetParam());
     if (!param.layerName.empty()) {
@@ -84,7 +84,7 @@ void GroupConvolutionTransformation::Run() {
 
 TEST_P(GroupConvolutionTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/groupconvolution_qdq_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/groupconvolution_qdq_transformation.cpp
@@ -55,8 +55,8 @@ void GroupConvolutionQDqTransformation::SetUp() {
         {}, {}, {}, param.reshape, {}, "GroupConvolution", param.multiplyAfter);
 }
 
-void GroupConvolutionQDqTransformation::Run() {
-    LayerTestsCommon::Run();
+void GroupConvolutionQDqTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualType = getRuntimePrecision(params.layerName);
@@ -65,7 +65,7 @@ void GroupConvolutionQDqTransformation::Run() {
 
 TEST_P(GroupConvolutionQDqTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_transformation.cpp
@@ -74,10 +74,10 @@ void MatMulTransformation::SetUp() {
     ov::pass::InitNodeInfo().run_on_model(function);
 }
 
-void MatMulTransformation::Run() {
+void MatMulTransformation::run() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
-    LayerTestsCommon::Run();
+    LayerTransformation::run();
 
     const auto params = std::get<3>(GetParam());
     const auto actualType = getRuntimePrecision(params.expectedKernelName);
@@ -86,7 +86,7 @@ void MatMulTransformation::Run() {
 }
 
 TEST_P(MatMulTransformation, CompareWithRefImpl) {
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
@@ -73,8 +73,8 @@ void MatMulWithConstantTransformation::SetUp() {
     ov::pass::InitNodeInfo().run_on_model(function);
 }
 
-void MatMulWithConstantTransformation::Run() {
-    LayerTestsCommon::Run();
+void MatMulWithConstantTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<2>(GetParam());
     const auto actualPrecision = getRuntimePrecisionByType(params.layerName);
@@ -87,7 +87,7 @@ void MatMulWithConstantTransformation::Run() {
 
 TEST_P(MatMulWithConstantTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/move_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/move_fake_quantize_transformation.cpp
@@ -61,8 +61,8 @@ void MoveFakeQuantizeTransformation::SetUp() {
         oneInputWithSplit);
 }
 
-void MoveFakeQuantizeTransformation::Run() {
-    LayerTestsCommon::Run();
+void MoveFakeQuantizeTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<5>(GetParam());
     const auto actualPrecision = getRuntimePrecisionByType(params.layerName);
@@ -75,7 +75,7 @@ void MoveFakeQuantizeTransformation::Run() {
 
 TEST_P(MoveFakeQuantizeTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_to_group_convolution_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_to_group_convolution_transformation.cpp
@@ -53,8 +53,8 @@ void MultiplyToGroupConvolutionTransformation::SetUp() {
         param.parentHasOneConsumer);
 }
 
-void MultiplyToGroupConvolutionTransformation::Run() {
-    LayerTestsCommon::Run();
+void MultiplyToGroupConvolutionTransformation::run() {
+    LayerTransformation::run();
 
     const auto param = std::get<3>(GetParam());
     const auto actualPrecision = getRuntimePrecision(param.layerName);
@@ -67,7 +67,7 @@ void MultiplyToGroupConvolutionTransformation::Run() {
 
 TEST_P(MultiplyToGroupConvolutionTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_transformation.cpp
@@ -69,8 +69,8 @@ void MultiplyTransformation::SetUp() {
     ov::pass::InitNodeInfo().run_on_model(function);
 }
 
-void MultiplyTransformation::Run() {
-    LayerTestsCommon::Run();
+void MultiplyTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<3>(GetParam());
 
@@ -98,7 +98,7 @@ void MultiplyTransformation::Run() {
 
 TEST_P(MultiplyTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/pad_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/pad_transformation.cpp
@@ -47,8 +47,8 @@ void PadTransformation::SetUp() {
         param.padValue);
 }
 
-void PadTransformation::Run() {
-    LayerTestsCommon::Run();
+void PadTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<5>(GetParam());
     const auto actualPrecision = getRuntimePrecisionByType(params.layerName);
@@ -59,7 +59,7 @@ void PadTransformation::Run() {
 
 TEST_P(PadTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 } // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/pull_reshape_through_dequantization_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/pull_reshape_through_dequantization_transformation.cpp
@@ -79,8 +79,8 @@ void PullReshapeThroughDequantizationTransformation::SetUp() {
         "GroupConvolution");
 }
 
-void PullReshapeThroughDequantizationTransformation::Run() {
-    LayerTestsCommon::Run();
+void PullReshapeThroughDequantizationTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<5>(GetParam());
     const auto actualType = getRuntimePrecision(params.operationName);
@@ -89,7 +89,7 @@ void PullReshapeThroughDequantizationTransformation::Run() {
 
 TEST_P(PullReshapeThroughDequantizationTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/recurrent_cell_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/recurrent_cell_transformation.cpp
@@ -69,8 +69,8 @@ void RecurrentCellTransformation::SetUp() {
                                                                       });
 }
 
-void RecurrentCellTransformation::Run() {
-    LayerTestsCommon::Run();
+void RecurrentCellTransformation::run() {
+    LayerTransformation::run();
 
     if (!executableNetwork)
         return;
@@ -85,7 +85,7 @@ void RecurrentCellTransformation::Run() {
 }
 
 TEST_P(RecurrentCellTransformation, CompareWithRefImpl) {
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_max_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_max_transformation.cpp
@@ -52,8 +52,8 @@ void ReduceMaxTransformation::SetUp() {
         dequantizationAfter);
 }
 
-void ReduceMaxTransformation::Run() {
-    LayerTestsCommon::Run();
+void ReduceMaxTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualType = getRuntimePrecision(params.layerName);
@@ -62,7 +62,7 @@ void ReduceMaxTransformation::Run() {
 
 TEST_P(ReduceMaxTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 } // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_mean_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_mean_transformation.cpp
@@ -60,8 +60,8 @@ void ReduceMeanTransformation::SetUp() {
         param.dequantizationAfter);
 }
 
-void ReduceMeanTransformation::Run() {
-    LayerTestsCommon::Run();
+void ReduceMeanTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualType = getRuntimePrecision(params.layerName);
@@ -70,7 +70,7 @@ void ReduceMeanTransformation::Run() {
 
 TEST_P(ReduceMeanTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 } // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_min_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_min_transformation.cpp
@@ -52,8 +52,8 @@ void ReduceMinTransformation::SetUp() {
         dequantizationAfter);
 }
 
-void ReduceMinTransformation::Run() {
-    LayerTestsCommon::Run();
+void ReduceMinTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualType = getRuntimePrecision(params.layerName);
@@ -62,7 +62,7 @@ void ReduceMinTransformation::Run() {
 
 TEST_P(ReduceMinTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 } // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_sum_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_sum_transformation.cpp
@@ -52,8 +52,8 @@ void ReduceSumTransformation::SetUp() {
         dequantizationAfter);
 }
 
-void ReduceSumTransformation::Run() {
-    LayerTestsCommon::Run();
+void ReduceSumTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualType = getRuntimePrecision(params.layerName);
@@ -62,7 +62,7 @@ void ReduceSumTransformation::Run() {
 
 TEST_P(ReduceSumTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 } // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reshape_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reshape_transformation.cpp
@@ -46,8 +46,8 @@ void ReshapeTransformation::SetUp() {
         param.fakeQuantize);
 }
 
-void ReshapeTransformation::Run() {
-    LayerTestsCommon::Run();
+void ReshapeTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<3>(GetParam());
     auto actualPrecision = getRuntimePrecisionByType(params.layerType);
@@ -60,7 +60,7 @@ void ReshapeTransformation::Run() {
 
 TEST_P(ReshapeTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/shuffle_channels_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/shuffle_channels_transformation.cpp
@@ -47,8 +47,8 @@ void ShuffleChannelsTransformation::SetUp() {
         param.group);
 }
 
-void ShuffleChannelsTransformation::Run() {
-    LayerTestsCommon::Run();
+void ShuffleChannelsTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<4>(GetParam());
     const auto actualType = getRuntimePrecision(params.layerName);
@@ -57,7 +57,7 @@ void ShuffleChannelsTransformation::Run() {
 
 TEST_P(ShuffleChannelsTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/space_to_batch_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/space_to_batch_transformation.cpp
@@ -38,8 +38,8 @@ void SpaceToBatchTransformation::SetUp() {
         param.pads_end);
 }
 
-void SpaceToBatchTransformation::Run() {
-    LayerTestsCommon::Run();
+void SpaceToBatchTransformation::run() {
+    LayerTransformation::run();
 
     const auto params = std::get<2>(GetParam());
     auto expected_type = params.expected_kernel_type;
@@ -54,7 +54,7 @@ void SpaceToBatchTransformation::Run() {
 
 TEST_P(SpaceToBatchTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    Run();
+    run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/low_precision_transformations/layer_transformation.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/low_precision_transformations/layer_transformation.hpp
@@ -15,7 +15,7 @@
 #include <ov_ops/type_relaxed.hpp>
 
 #include "low_precision/layer_transformation.hpp"
-#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
 
 namespace LayerTestsUtils {
 
@@ -30,7 +30,7 @@ public:
 class LayerTransformationParamsFactory : public LayerTransformationParamsNGraphFactory {
 };
 
-class LayerTransformation : virtual public LayerTestsUtils::LayerTestsCommon {
+class LayerTransformation : virtual public ov::test::SubgraphBaseTest {
 protected:
     LayerTransformation();
 


### PR DESCRIPTION
### Details:
 - use SubgraphBaseTest as the base class
 - rename Run -> run

### Tickets:
 - 111374
