### PR TITLE
[CPU tests] migrate single layer test cases to be API 2.0 - part 9

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution_backprop_data.cpp
@@ -42,7 +42,7 @@ public:
         std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = obj.param;
 
         ov::op::PadType padType;
-        std::vector<uint64_t> kernel, stride, dilation;
+        std::vector<size_t> kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
         size_t convOutChannels;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = basicParamsSet;
@@ -199,7 +199,7 @@ public:
     }
 
 protected:
-    std::vector<uint64_t> kernel, stride;
+    std::vector<size_t> kernel, stride;
 
     void SetUp() override {
         rel_threshold = 1e-4f;
@@ -249,7 +249,7 @@ protected:
 private:
     ElementType prec;
     ov::op::PadType padType;
-    std::vector<uint64_t> dilation;
+    std::vector<size_t> dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
     size_t convOutChannels;
     std::vector<std::vector<int32_t>> outShapeData;
@@ -285,30 +285,30 @@ const ov::AnyMap cpuBF16PluginConfig = {
 const std::vector<std::vector<ptrdiff_t>> emptyOutputPadding = {{}};
 
 /* ============= Deconvolution params (planar layout) ============= */
-const std::vector<uint64_t> numOutChannels_Planar = {6};
+const std::vector<size_t> numOutChannels_Planar = {6};
 
 /* ============= Deconvolution params (blocked layout) ============= */
-const std::vector<uint64_t> numOutChannels_Blocked = {64};
+const std::vector<size_t> numOutChannels_Blocked = {64};
 
 /* ============= Deconvolution params (2D) ============= */
-const std::vector<std::vector<uint64_t>> kernels2d = {{3, 3}, {1, 1}};
-const std::vector<std::vector<uint64_t>> strides2d = {{1, 1}, {2, 2}};
+const std::vector<std::vector<size_t>> kernels2d = {{3, 3}, {1, 1}};
+const std::vector<std::vector<size_t>> strides2d = {{1, 1}, {2, 2}};
 const std::vector<std::vector<ptrdiff_t>> padBegins2d = {{0, 0}};
 const std::vector<std::vector<ptrdiff_t>> padEnds2d = {{0, 0}};
-const std::vector<std::vector<uint64_t>> dilations2d = {{1, 1}};
+const std::vector<std::vector<size_t>> dilations2d = {{1, 1}};
 
-const std::vector<std::vector<uint64_t>> deconvAmxKernels2d = {{3, 3}, {2, 2}};
-const std::vector<std::vector<uint64_t>> deconvAmxStrides2d = {{2, 2}};
+const std::vector<std::vector<size_t>> deconvAmxKernels2d = {{3, 3}, {2, 2}};
+const std::vector<std::vector<size_t>> deconvAmxStrides2d = {{2, 2}};
 
 /* ============= Deconvolution params (3D) ============= */
-const std::vector<std::vector<uint64_t>> kernels3d = {{3, 3, 3}, {1, 1, 1}};
-const std::vector<std::vector<uint64_t>> strides3d = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}, {1, 1, 1}};
+const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}, {2, 2, 2}};
 const std::vector<std::vector<ptrdiff_t>> padBegins3d = {{0, 0, 0}};
 const std::vector<std::vector<ptrdiff_t>> padEnds3d = {{0, 0, 0}};
-const std::vector<std::vector<uint64_t>> dilations3d = {{1, 1, 1}};
+const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}};
 
-const std::vector<std::vector<uint64_t>> deconvAmxKernels3d = {{3, 3, 3}, {2, 2, 2}};
-const std::vector<std::vector<uint64_t>> deconvAmxStrides3d = {{2, 2, 2}};
+const std::vector<std::vector<size_t>> deconvAmxKernels3d = {{3, 3, 3}, {2, 2, 2}};
+const std::vector<std::vector<size_t>> deconvAmxStrides3d = {{2, 2, 2}};
 
 /* ============= */
 
@@ -667,11 +667,11 @@ INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Blocked_BF16,
                          DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Kernel_1x1 (2D) ============= */
-const auto convParams_ExplicitPadding_1x1_2D = ::testing::Combine(::testing::Values(std::vector<uint64_t>({1, 1})),
-                                                                  ::testing::Values(std::vector<uint64_t>({1, 1})),
+const auto convParams_ExplicitPadding_1x1_2D = ::testing::Combine(::testing::Values(std::vector<size_t>({1, 1})),
+                                                                  ::testing::Values(std::vector<size_t>({1, 1})),
                                                                   ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
                                                                   ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-                                                                  ::testing::Values(std::vector<uint64_t>({1, 1})),
+                                                                  ::testing::Values(std::vector<size_t>({1, 1})),
                                                                   ::testing::ValuesIn(numOutChannels_Blocked),
                                                                   ::testing::Values(ov::op::PadType::EXPLICIT),
                                                                   ::testing::ValuesIn(emptyOutputPadding));
@@ -703,7 +703,7 @@ INSTANTIATE_TEST_SUITE_P(
     smoke_reorder_Deconv_2D,
     DeconvolutionLayerCPUTest,
     ::testing::Combine(::testing::Combine(::testing::ValuesIn(kernels2d),
-                                          ::testing::Values(std::vector<uint64_t>{1, 1}),
+                                          ::testing::Values(std::vector<size_t>{1, 1}),
                                           ::testing::ValuesIn(padBegins2d),
                                           ::testing::ValuesIn(padEnds2d),
                                           ::testing::ValuesIn(dilations2d),

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution_backprop_data.cpp
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "shared_test_classes/single_layer/convolution_backprop_data.hpp"
+#include "shared_test_classes/single_op/convolution_backprop_data.hpp"
 
 #include "common_test_utils/node_builders/convolution_backprop_data.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "cpu_shape.h"
 #include "openvino/core/preprocess/pre_post_process.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/convolution_params.hpp"
 #include "test_utils/cpu_test_utils.hpp"
@@ -19,7 +18,7 @@ using namespace CPUTestUtils;
 namespace ov {
 namespace test {
 
-using DeconvSpecParams = LayerTestsDefinitions::convBackpropDataSpecificParams;
+using DeconvSpecParams = ov::test::convBackpropDataSpecificParams;
 
 using DeconvInputData = std::tuple<InputShape,                          // data shape
                                    ov::test::utils::InputLayerType,     // 'output_shape' input type

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution_backprop_data.cpp
@@ -2,39 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <common_test_utils/ov_tensor_utils.hpp>
-#include <shared_test_classes/single_layer/convolution_backprop_data.hpp>
+#include "shared_test_classes/single_layer/convolution_backprop_data.hpp"
 
+#include "common_test_utils/node_builders/convolution_backprop_data.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "cpu_shape.h"
-#include "ov_models/builders.hpp"
 #include "openvino/core/preprocess/pre_post_process.hpp"
+#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/convolution_params.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/filter_cpu_info.hpp"
 #include "test_utils/fusing_test_utils.hpp"
-#include "common_test_utils/node_builders/convolution_backprop_data.hpp"
 
 using namespace CPUTestUtils;
-using namespace ov::test;
-
-namespace CPULayerTestsDefinitions {
+namespace ov {
+namespace test {
 
 using DeconvSpecParams = LayerTestsDefinitions::convBackpropDataSpecificParams;
 
-using DeconvInputData = std::tuple<InputShape,                           // data shape
-                                   ngraph::helpers::InputLayerType,      // 'output_shape' input type
-                                   std::vector<std::vector<int32_t>>>;   // values for 'output_shape'
+using DeconvInputData = std::tuple<InputShape,                          // data shape
+                                   ov::test::utils::InputLayerType,     // 'output_shape' input type
+                                   std::vector<std::vector<int32_t>>>;  // values for 'output_shape'
 
-using DeconvLayerCPUTestParamsSet = std::tuple<DeconvSpecParams,
-                                               DeconvInputData,
-                                               ElementType,
-                                               fusingSpecificParams,
-                                               CPUSpecificParams,
-                                               std::map<std::string, std::string>>;
+using DeconvLayerCPUTestParamsSet =
+    std::tuple<DeconvSpecParams, DeconvInputData, ElementType, fusingSpecificParams, CPUSpecificParams, ov::AnyMap>;
 
 class DeconvolutionLayerCPUTest : public testing::WithParamInterface<DeconvLayerCPUTestParamsSet>,
-                                  virtual public SubgraphBaseTest, public CpuTestWithFusing {
+                                  virtual public SubgraphBaseTest,
+                                  public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<DeconvLayerCPUTestParamsSet> obj) {
         DeconvSpecParams basicParamsSet;
@@ -42,17 +38,17 @@ public:
         ElementType prec;
         fusingSpecificParams fusingParams;
         CPUSpecificParams cpuParams;
-        std::map<std::string, std::string> additionalConfig;
+        ov::AnyMap additionalConfig;
         std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = obj.param;
 
-        ngraph::op::PadType padType;
-        InferenceEngine::SizeVector kernel, stride, dilation;
+        ov::op::PadType padType;
+        std::vector<uint64_t> kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
         size_t convOutChannels;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = basicParamsSet;
 
         InputShape inputShape;
-        ngraph::helpers::InputLayerType outShapeType;
+        ov::test::utils::InputLayerType outShapeType;
         std::vector<std::vector<int32_t>> outShapeData;
         std::tie(inputShape, outShapeType, outShapeData) = inputData;
 
@@ -88,20 +84,20 @@ public:
         if (!additionalConfig.empty()) {
             result << "_PluginConf";
             for (auto& item : additionalConfig) {
-                result << "_" << item.first << "=" << item.second;
+                result << "_" << item.first << "=" << item.second.as<std::string>();
             }
         }
 
         return result.str();
     }
 
-    void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override {
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
         if (function->get_parameters().size() != 1) {
             // WA: output_shape depends on 3rd deconvolution input data
             // but the reference implementation doesn't implement shape inference
-            // so we need to build a new ngraph function and replace the 3rd input parameter with a constant
+            // so we need to build a new function and replace the 3rd input parameter with a constant
             // to get valid output shapes
-            functionRefs = createGraph({targetInputStaticShapes[0]}, ngraph::helpers::InputLayerType::CONSTANT);
+            functionRefs = createGraph({targetInputStaticShapes[0]}, ov::test::utils::InputLayerType::CONSTANT);
         }
         inputs.clear();
         const auto& funcInputs = function->inputs();
@@ -110,9 +106,15 @@ public:
             ov::Tensor tensor;
 
             if (i == 1) {
-                tensor = ov::Tensor(funcInput.get_element_type(), targetInputStaticShapes[i], outShapeData[inferRequestNum].data());
+                tensor = ov::Tensor(funcInput.get_element_type(),
+                                    targetInputStaticShapes[i],
+                                    outShapeData[inferRequestNum].data());
             } else {
-                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 2560, 0, 256);
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[i],
+                                                                 2560,
+                                                                 0,
+                                                                 256);
             }
 
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
@@ -144,17 +146,21 @@ public:
         function = p.build();
     }
 
-    std::shared_ptr<ov::Model> createGraph(const std::vector<ov::PartialShape>& inShapes, ngraph::helpers::InputLayerType outShapeType) {
+    std::shared_ptr<ov::Model> createGraph(const std::vector<ov::PartialShape>& inShapes,
+                                           ov::test::utils::InputLayerType outShapeType) {
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(prec, inShapes.front())};
         std::shared_ptr<ov::Node> outShapeNode;
         if (!outShapeData.empty()) {
-            if (outShapeType == ngraph::helpers::InputLayerType::PARAMETER) {
+            if (outShapeType == ov::test::utils::InputLayerType::PARAMETER) {
                 OPENVINO_ASSERT(inputDynamicShapes.size() == 2);
-                auto outShapeParam = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::i32, inputDynamicShapes.back());
+                auto outShapeParam =
+                    std::make_shared<ov::op::v0::Parameter>(ov::element::i32, inputDynamicShapes.back());
                 params.push_back(outShapeParam);
                 outShapeNode = outShapeParam;
             } else {
-                outShapeNode = ngraph::opset8::Constant::create(ngraph::element::i32, {outShapeData[inferRequestNum].size()}, outShapeData[inferRequestNum]);
+                outShapeNode = ov::op::v0::Constant::create(ov::element::i32,
+                                                            {outShapeData[inferRequestNum].size()},
+                                                            outShapeData[inferRequestNum]);
             }
         }
 
@@ -165,18 +171,35 @@ public:
         std::shared_ptr<ov::Node> deconv;
         if (!outShapeData.empty()) {
             OPENVINO_ASSERT(outShapeNode != nullptr);
-            deconv = ov::test::utils::make_convolution_backprop_data(params[0], outShapeNode, prec, kernel, stride, padBegin,
-                                                                     padEnd, dilation, padType, convOutChannels);
+            deconv = ov::test::utils::make_convolution_backprop_data(params[0],
+                                                                     outShapeNode,
+                                                                     prec,
+                                                                     kernel,
+                                                                     stride,
+                                                                     padBegin,
+                                                                     padEnd,
+                                                                     dilation,
+                                                                     padType,
+                                                                     convOutChannels);
         } else {
-            deconv = ov::test::utils::make_convolution_backprop_data(params[0], prec, kernel, stride, padBegin,
-                                                                     padEnd, dilation, padType, convOutChannels, false, outPadding);
+            deconv = ov::test::utils::make_convolution_backprop_data(params[0],
+                                                                     prec,
+                                                                     kernel,
+                                                                     stride,
+                                                                     padBegin,
+                                                                     padEnd,
+                                                                     dilation,
+                                                                     padType,
+                                                                     convOutChannels,
+                                                                     false,
+                                                                     outPadding);
         }
 
         return makeNgraphFunction(prec, params, deconv, "DeconvCPU");
     }
 
 protected:
-    InferenceEngine::SizeVector kernel, stride;
+    std::vector<uint64_t> kernel, stride;
 
     void SetUp() override {
         rel_threshold = 1e-4f;
@@ -187,11 +210,11 @@ protected:
         DeconvInputData inputData;
         fusingSpecificParams fusingParams;
         CPUSpecificParams cpuParams;
-        std::map<std::string, std::string> additionalConfig;
+        ov::AnyMap additionalConfig;
         std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = this->GetParam();
 
         InputShape inputShape;
-        ngraph::helpers::InputLayerType outShapeType;
+        ov::test::utils::InputLayerType outShapeType;
         std::tie(inputShape, outShapeType, outShapeData) = inputData;
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
@@ -200,7 +223,8 @@ protected:
 
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = basicParamsSet;
 
-        if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
+        if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] ==
+            InferenceEngine::PluginConfigParams::YES) {
             inType = outType = prec = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
@@ -211,9 +235,10 @@ protected:
 
         std::vector<InputShape> paramsShapes;
         paramsShapes.push_back(inputShape);
-        if (!outShapeData.empty() && outShapeType == ngraph::helpers::InputLayerType::PARAMETER) {
+        if (!outShapeData.empty() && outShapeType == ov::test::utils::InputLayerType::PARAMETER) {
             const auto outShapeDims = ov::Shape{outShapeData.front().size()};
-            paramsShapes.push_back(InputShape{outShapeDims, std::vector<ov::Shape>(inputShape.second.size(), outShapeDims)});
+            paramsShapes.push_back(
+                InputShape{outShapeDims, std::vector<ov::Shape>(inputShape.second.size(), outShapeDims)});
         }
 
         init_input_shapes(paramsShapes);
@@ -223,8 +248,8 @@ protected:
 
 private:
     ElementType prec;
-    ngraph::op::PadType padType;
-    InferenceEngine::SizeVector dilation;
+    ov::op::PadType padType;
+    std::vector<uint64_t> dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
     size_t convOutChannels;
     std::vector<std::vector<int32_t>> outShapeData;
@@ -239,7 +264,9 @@ TEST_P(DeconvolutionLayerCPUTest, CompareWithRefs) {
         if (stride.size() > 2)
             isSupportedParams &= stride[stride.size() - 3] <= kernel[kernel.size() - 3];
         if (!isSupportedParams) {
-            GTEST_SKIP() << "Fusing with strides more than kernel size was disabled, because oneDNN deconvolution doesn't support it" << std::endl;
+            GTEST_SKIP() << "Fusing with strides more than kernel size was disabled, because oneDNN deconvolution "
+                            "doesn't support it"
+                         << std::endl;
         }
     }
 
@@ -250,228 +277,187 @@ TEST_P(DeconvolutionLayerCPUTest, CompareWithRefs) {
 namespace {
 
 /* COMMON PARAMS */
-const std::vector<fusingSpecificParams> fusingParamsSet{
-        emptyFusingSpec,
-        fusingScaleShift
-};
+const std::vector<fusingSpecificParams> fusingParamsSet{emptyFusingSpec, fusingScaleShift};
 
-const std::map<std::string, std::string> cpuEmptyPluginConfig;
-const std::map<std::string, std::string>cpuBF16PluginConfig = { { InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16,
-                                                                  InferenceEngine::PluginConfigParams::YES } };
-const std::vector<std::vector<ptrdiff_t>> emptyOutputPadding = { {} };
+const ov::AnyMap cpuEmptyPluginConfig;
+const ov::AnyMap cpuBF16PluginConfig = {
+    {InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::YES}};
+const std::vector<std::vector<ptrdiff_t>> emptyOutputPadding = {{}};
 
 /* ============= Deconvolution params (planar layout) ============= */
-const InferenceEngine::SizeVector numOutChannels_Planar = { 6 };
+const std::vector<uint64_t> numOutChannels_Planar = {6};
 
 /* ============= Deconvolution params (blocked layout) ============= */
-const InferenceEngine::SizeVector numOutChannels_Blocked = { 64 };
+const std::vector<uint64_t> numOutChannels_Blocked = {64};
 
 /* ============= Deconvolution params (2D) ============= */
-const std::vector<InferenceEngine::SizeVector> kernels2d = { {3, 3}, {1, 1} };
-const std::vector<InferenceEngine::SizeVector> strides2d = { {1, 1}, {2, 2} };
-const std::vector<std::vector<ptrdiff_t>> padBegins2d = { {0, 0} };
-const std::vector<std::vector<ptrdiff_t>> padEnds2d = { {0, 0} };
-const std::vector<InferenceEngine::SizeVector> dilations2d = { {1, 1} };
+const std::vector<std::vector<uint64_t>> kernels2d = {{3, 3}, {1, 1}};
+const std::vector<std::vector<uint64_t>> strides2d = {{1, 1}, {2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins2d = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds2d = {{0, 0}};
+const std::vector<std::vector<uint64_t>> dilations2d = {{1, 1}};
 
-
-const std::vector<InferenceEngine::SizeVector> deconvAmxKernels2d = { {3, 3}, {2, 2}};
-const std::vector<InferenceEngine::SizeVector> deconvAmxStrides2d = { {2, 2}};
+const std::vector<std::vector<uint64_t>> deconvAmxKernels2d = {{3, 3}, {2, 2}};
+const std::vector<std::vector<uint64_t>> deconvAmxStrides2d = {{2, 2}};
 
 /* ============= Deconvolution params (3D) ============= */
-const std::vector<InferenceEngine::SizeVector> kernels3d = { {3, 3, 3}, {1, 1, 1} };
-const std::vector<InferenceEngine::SizeVector> strides3d = { {1, 1, 1}, {2, 2, 2} };
-const std::vector<std::vector<ptrdiff_t>> padBegins3d = { {0, 0, 0} };
-const std::vector<std::vector<ptrdiff_t>> padEnds3d = { {0, 0, 0} };
-const std::vector<InferenceEngine::SizeVector> dilations3d = { {1, 1, 1} };
+const std::vector<std::vector<uint64_t>> kernels3d = {{3, 3, 3}, {1, 1, 1}};
+const std::vector<std::vector<uint64_t>> strides3d = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins3d = {{0, 0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds3d = {{0, 0, 0}};
+const std::vector<std::vector<uint64_t>> dilations3d = {{1, 1, 1}};
 
-const std::vector<InferenceEngine::SizeVector> deconvAmxKernels3d = { {3, 3, 3}, {2, 2, 2} };
-const std::vector<InferenceEngine::SizeVector> deconvAmxStrides3d = {  {2, 2, 2} };
+const std::vector<std::vector<uint64_t>> deconvAmxKernels3d = {{3, 3, 3}, {2, 2, 2}};
+const std::vector<std::vector<uint64_t>> deconvAmxStrides3d = {{2, 2, 2}};
 
 /* ============= */
 
 /* INSTANCES */
 /* ============= Deconvolution (Planar 2D) ============= */
-const auto convParams_ExplicitPadding_Planar_2D = ::testing::Combine(
-    ::testing::ValuesIn(kernels2d),
-    ::testing::ValuesIn(strides2d),
-    ::testing::ValuesIn(padBegins2d),
-    ::testing::ValuesIn(padEnds2d),
-    ::testing::ValuesIn(dilations2d),
-    ::testing::ValuesIn(numOutChannels_Planar),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto convParams_ExplicitPadding_Planar_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                     ::testing::ValuesIn(strides2d),
+                                                                     ::testing::ValuesIn(padBegins2d),
+                                                                     ::testing::ValuesIn(padEnds2d),
+                                                                     ::testing::ValuesIn(dilations2d),
+                                                                     ::testing::ValuesIn(numOutChannels_Planar),
+                                                                     ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                     ::testing::ValuesIn(emptyOutputPadding));
 
 const std::vector<DeconvInputData> Planar_2D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 12, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 12, -1, -1}, {{ 1, 12, 7, 7}, { 2, 12, 5, 7}, { 1, 12, 7, 7}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{15, 15}, {9, 10}, {15, 15}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 12, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 12, -1, -1}, {{1, 12, 7, 7}, {2, 12, 5, 7}, {1, 12, 7, 7}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{15, 15}, {9, 10}, {15, 15}}}};
 
 const std::vector<DeconvInputData> Planar_2D_inputs_nightly = {
-    DeconvInputData{
-        InputShape{{-1, 12, -1, -1}, {{ 2, 12, 7, 7}, { 2, 12, 5, 7}, { 1, 12, 9, 4}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 12, 7, 7}, {{ 1, 12, 7, 7}, { 2, 12, 7, 7}, { 1, 12, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    },
-    DeconvInputData{
-        InputShape{{{1, 10}, 12, 7, 7}, {{ 1, 12, 7, 7}, { 2, 12, 7, 7}, { 3, 12, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    },
+    DeconvInputData{InputShape{{-1, 12, -1, -1}, {{2, 12, 7, 7}, {2, 12, 5, 7}, {1, 12, 9, 4}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 12, 7, 7}, {{1, 12, 7, 7}, {2, 12, 7, 7}, {1, 12, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}},
+    DeconvInputData{InputShape{{{1, 10}, 12, 7, 7}, {{1, 12, 7, 7}, {2, 12, 7, 7}, {3, 12, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Planar_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Planar_2D,
-        ::testing::ValuesIn(Planar_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Planar_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Planar_2D,
+                                            ::testing::ValuesIn(Planar_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Planar_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Planar_2D,
-        ::testing::ValuesIn(Planar_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Planar_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Planar_2D,
+                                            ::testing::ValuesIn(Planar_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Planar_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Planar_2D,
-        ::testing::ValuesIn(Planar_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Planar_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Planar_2D,
+                                            ::testing::ValuesIn(Planar_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Planar_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Planar_2D,
-        ::testing::ValuesIn(Planar_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Planar_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Planar_2D,
+                                            ::testing::ValuesIn(Planar_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Deconvolution (Planar 3D) ============= */
 const std::vector<DeconvInputData> Planar_3D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 12, 7, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 12, -1, -1, -1}, {{ 2, 12, 7, 7, 7}, { 2, 12, 5, 7, 7}, { 1, 12, 9, 4, 9}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{15, 15, 15}, {9, 10, 10}, {9, 9, 9}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 12, 7, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 12, -1, -1, -1}, {{2, 12, 7, 7, 7}, {2, 12, 5, 7, 7}, {1, 12, 9, 4, 9}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{15, 15, 15}, {9, 10, 10}, {9, 9, 9}}}};
 
 const std::vector<DeconvInputData> Planar_3D_inputs_nightly = {
     DeconvInputData{
         // -1 will result deconv use 64 to infer output shape, for 3d output shape is too big for gemm bwd kernel
         //  to buffer the intermedia results
-        InputShape{{-1, 12, {5, 9}, {4, 7}, {7, 9}}, {{ 2, 12, 7, 7, 7}, { 2, 12, 5, 7, 7}, { 1, 12, 9, 4, 9}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
+        InputShape{{-1, 12, {5, 9}, {4, 7}, {7, 9}}, {{2, 12, 7, 7, 7}, {2, 12, 5, 7, 7}, {1, 12, 9, 4, 9}}},
+        ov::test::utils::InputLayerType::CONSTANT,
+        {}},
     DeconvInputData{
-        InputShape{{-1, 12, -1, -1, -1}, {{ 2, 12, 7, 7, 7}, { 2, 12, 5, 7, 7}, { 1, 12, 9, 4, 9}, { 2, 12, 7, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{10, 16, 16}}
-    },
-    DeconvInputData{
-        InputShape{{{1, 10}, 12, 7, 7, 7}, {{ 2, 12, 7, 7, 7}, { 1, 12, 7, 7, 7}, { 3, 12, 7, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15, 15}}
-    }
-};
+        InputShape{{-1, 12, -1, -1, -1}, {{2, 12, 7, 7, 7}, {2, 12, 5, 7, 7}, {1, 12, 9, 4, 9}, {2, 12, 7, 7, 7}}},
+        ov::test::utils::InputLayerType::CONSTANT,
+        {{10, 16, 16}}},
+    DeconvInputData{InputShape{{{1, 10}, 12, 7, 7, 7}, {{2, 12, 7, 7, 7}, {1, 12, 7, 7, 7}, {3, 12, 7, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15, 15}}}};
 
-const auto convParams_ExplicitPadding_Planar_3D = ::testing::Combine(
-    ::testing::ValuesIn(kernels3d),
-    ::testing::ValuesIn(strides3d),
-    ::testing::ValuesIn(padBegins3d),
-    ::testing::ValuesIn(padEnds3d),
-    ::testing::ValuesIn(dilations3d),
-    ::testing::ValuesIn(numOutChannels_Planar),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto convParams_ExplicitPadding_Planar_3D = ::testing::Combine(::testing::ValuesIn(kernels3d),
+                                                                     ::testing::ValuesIn(strides3d),
+                                                                     ::testing::ValuesIn(padBegins3d),
+                                                                     ::testing::ValuesIn(padEnds3d),
+                                                                     ::testing::ValuesIn(dilations3d),
+                                                                     ::testing::ValuesIn(numOutChannels_Planar),
+                                                                     ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                     ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_Planar_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Planar_3D,
-        ::testing::ValuesIn(Planar_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_Planar_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Planar_3D,
+                                            ::testing::ValuesIn(Planar_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_Planar_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Planar_3D,
-        ::testing::ValuesIn(Planar_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_Planar_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Planar_3D,
+                                            ::testing::ValuesIn(Planar_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Planar_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Planar_3D,
-        ::testing::ValuesIn(Planar_3D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Planar_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Planar_3D,
+                                            ::testing::ValuesIn(Planar_3D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Planar_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Planar_3D,
-        ::testing::ValuesIn(Planar_3D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Planar_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Planar_3D,
+                                            ::testing::ValuesIn(Planar_3D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Deconvolution (Blocked 2D) ============= */
 const std::vector<DeconvInputData> Blocked_2D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 67, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 67, -1, -1}, {{ 2, 67, 7, 7}, { 2, 67, 5, 7}, { 1, 67, 9, 4}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{15, 15}, {9, 10}, {9, 9}}
-    }
-};
-
+    DeconvInputData{InputShape{{}, {{2, 67, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 67, -1, -1}, {{2, 67, 7, 7}, {2, 67, 5, 7}, {1, 67, 9, 4}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{15, 15}, {9, 10}, {9, 9}}}};
 
 const auto convParams_ExplicitPadding_Blocked_2D_nightly = ::testing::Combine(
     ::testing::ValuesIn(kernels2d),
@@ -482,397 +468,352 @@ const auto convParams_ExplicitPadding_Blocked_2D_nightly = ::testing::Combine(
     ::testing::ValuesIn(padEnds2d),
     ::testing::ValuesIn(dilations2d),
     ::testing::ValuesIn(numOutChannels_Blocked),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+    ::testing::Values(ov::op::PadType::EXPLICIT),
+    ::testing::ValuesIn(emptyOutputPadding));
 
 const std::vector<DeconvInputData> Blocked_2D_inputs_nightly = {
-    DeconvInputData{
-        InputShape{{-1, 67, -1, -1}, {{ 2, 67, 7, 7}, { 2, 67, 5, 7}, { 1, 67, 9, 4}, { 2, 67, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 67, -1, -1}, {{ 2, 67, 7, 7}, { 2, 67, 5, 7}, { 1, 67, 9, 4}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    },
-    DeconvInputData{
-        InputShape{{ {1, 10}, 67, 7, 7}, {{ 2, 67, 7, 7}, { 3, 67, 7, 7}, { 1, 67, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    }
-};
+    DeconvInputData{InputShape{{-1, 67, -1, -1}, {{2, 67, 7, 7}, {2, 67, 5, 7}, {1, 67, 9, 4}, {2, 67, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 67, -1, -1}, {{2, 67, 7, 7}, {2, 67, 5, 7}, {1, 67, 9, 4}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}},
+    DeconvInputData{InputShape{{{1, 10}, 67, 7, 7}, {{2, 67, 7, 7}, {3, 67, 7, 7}, {1, 67, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}}};
 
-const auto convParams_ExplicitPadding_Blocked_2D = ::testing::Combine(
-    ::testing::ValuesIn(kernels2d),
-    ::testing::ValuesIn(strides2d),
-    ::testing::ValuesIn(padBegins2d),
-    ::testing::ValuesIn(padEnds2d),
-    ::testing::ValuesIn(dilations2d),
-    ::testing::ValuesIn(numOutChannels_Blocked),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto convParams_ExplicitPadding_Blocked_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                      ::testing::ValuesIn(strides2d),
+                                                                      ::testing::ValuesIn(padBegins2d),
+                                                                      ::testing::ValuesIn(padEnds2d),
+                                                                      ::testing::ValuesIn(dilations2d),
+                                                                      ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                      ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                      ::testing::ValuesIn(emptyOutputPadding));
 
-const auto convParams_ExplicitPadding_AMX_2D = ::testing::Combine(
-    ::testing::ValuesIn(deconvAmxKernels2d),
-    ::testing::ValuesIn(deconvAmxStrides2d),
-    ::testing::ValuesIn(padBegins2d),
-    ::testing::ValuesIn(padEnds2d),
-    ::testing::ValuesIn(dilations2d),
-    ::testing::ValuesIn(numOutChannels_Blocked),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto convParams_ExplicitPadding_AMX_2D = ::testing::Combine(::testing::ValuesIn(deconvAmxKernels2d),
+                                                                  ::testing::ValuesIn(deconvAmxStrides2d),
+                                                                  ::testing::ValuesIn(padBegins2d),
+                                                                  ::testing::ValuesIn(padEnds2d),
+                                                                  ::testing::ValuesIn(dilations2d),
+                                                                  ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                  ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                  ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Blocked_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Blocked_2D,
-        ::testing::ValuesIn(Blocked_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Blocked_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Blocked_2D,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Blocked_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Blocked_2D,
-        ::testing::ValuesIn(Blocked_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Blocked_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Blocked_2D,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_NSPC_BF16_AMX_NO_FUSING, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_AMX_2D,
-        ::testing::ValuesIn(Blocked_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn({emptyFusingSpec}),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_nspc_amx})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_NSPC_BF16_AMX_NO_FUSING,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_AMX_2D,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn({emptyFusingSpec}),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_nspc_amx})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_NSPC_INT8_AMX, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_AMX_2D,
-        ::testing::ValuesIn(Blocked_2D_inputs_smoke),
-        ::testing::Values(ElementType::i8),
-        ::testing::ValuesIn({emptyFusingSpec, fusingClampRoundAddRelu}),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_nspc_amx})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_NSPC_INT8_AMX,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_AMX_2D,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::i8),
+                                            ::testing::ValuesIn({emptyFusingSpec, fusingClampRoundAddRelu}),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_nspc_amx})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Blocked_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Blocked_2D_nightly,
-        ::testing::ValuesIn(Blocked_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Blocked_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Blocked_2D_nightly,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Blocked_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Blocked_2D_nightly,
-        ::testing::ValuesIn(Blocked_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_Deconv_2D_Blocked_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Blocked_2D_nightly,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Deconvolution (Blocked 3D) ============= */
 const std::vector<DeconvInputData> Blocked_3D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 35, 7, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 35, -1, -1, -1}, {{ 1, 35, 5, 5, 5}, { 2, 35, 5, 7, 5}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{7, 7, 7}, {7, 9, 7}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 35, 7, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 35, -1, -1, -1}, {{1, 35, 5, 5, 5}, {2, 35, 5, 7, 5}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{7, 7, 7}, {7, 9, 7}}}};
 
-const auto convParams_ExplicitPadding_Blocked_3D_nightly = ::testing::Combine(
-    ::testing::ValuesIn(kernels3d),
-    ::testing::ValuesIn({strides3d[0]}),
-    ::testing::ValuesIn(padBegins3d),
-    ::testing::ValuesIn(padEnds3d),
-    ::testing::ValuesIn(dilations3d),
-    ::testing::Values(32),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto convParams_ExplicitPadding_Blocked_3D_nightly =
+    ::testing::Combine(::testing::ValuesIn(kernels3d),
+                       ::testing::ValuesIn({strides3d[0]}),
+                       ::testing::ValuesIn(padBegins3d),
+                       ::testing::ValuesIn(padEnds3d),
+                       ::testing::ValuesIn(dilations3d),
+                       ::testing::Values(32),
+                       ::testing::Values(ov::op::PadType::EXPLICIT),
+                       ::testing::ValuesIn(emptyOutputPadding));
 
 const std::vector<DeconvInputData> Blocked_3D_inputs_nightly = {
-    DeconvInputData{
-        InputShape{{-1, 35, -1, -1, -1}, {{ 1, 35, 5, 5, 5}, { 2, 35, 5, 7, 5}, { 1, 35, 5, 5, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 35, -1, -1, -1}, {{ 1, 35, 5, 5, 5}, { 2, 35, 5, 7, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{7, 7, 7}}
-    },
-    DeconvInputData{
-        InputShape{{{1, 10}, 35, 5, 5, 5}, {{ 1, 35, 5, 5, 5}, { 2, 35, 5, 5, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{7, 7, 7}}
-    }
-};
+    DeconvInputData{InputShape{{-1, 35, -1, -1, -1}, {{1, 35, 5, 5, 5}, {2, 35, 5, 7, 5}, {1, 35, 5, 5, 5}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 35, -1, -1, -1}, {{1, 35, 5, 5, 5}, {2, 35, 5, 7, 5}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{7, 7, 7}}},
+    DeconvInputData{InputShape{{{1, 10}, 35, 5, 5, 5}, {{1, 35, 5, 5, 5}, {2, 35, 5, 5, 5}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{7, 7, 7}}}};
 
-const auto convParams_ExplicitPadding_Blocked_3D = ::testing::Combine(
-    ::testing::ValuesIn(kernels3d),
-    ::testing::ValuesIn(strides3d),
-    ::testing::ValuesIn(padBegins3d),
-    ::testing::ValuesIn(padEnds3d),
-    ::testing::ValuesIn(dilations3d),
-    ::testing::Values(32),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto convParams_ExplicitPadding_Blocked_3D = ::testing::Combine(::testing::ValuesIn(kernels3d),
+                                                                      ::testing::ValuesIn(strides3d),
+                                                                      ::testing::ValuesIn(padBegins3d),
+                                                                      ::testing::ValuesIn(padEnds3d),
+                                                                      ::testing::ValuesIn(dilations3d),
+                                                                      ::testing::Values(32),
+                                                                      ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                      ::testing::ValuesIn(emptyOutputPadding));
 
-const auto convParams_ExplicitPadding_AMX_3D = ::testing::Combine(
-    ::testing::ValuesIn(deconvAmxKernels3d),
-    ::testing::ValuesIn(deconvAmxStrides3d),
-    ::testing::ValuesIn(padBegins3d),
-    ::testing::ValuesIn(padEnds3d),
-    ::testing::ValuesIn(dilations3d),
-    ::testing::Values(32),
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto convParams_ExplicitPadding_AMX_3D = ::testing::Combine(::testing::ValuesIn(deconvAmxKernels3d),
+                                                                  ::testing::ValuesIn(deconvAmxStrides3d),
+                                                                  ::testing::ValuesIn(padBegins3d),
+                                                                  ::testing::ValuesIn(padEnds3d),
+                                                                  ::testing::ValuesIn(dilations3d),
+                                                                  ::testing::Values(32),
+                                                                  ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                  ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_Blocked_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Blocked_3D,
-        ::testing::ValuesIn(Blocked_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_Blocked_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Blocked_3D,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_Blocked_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Blocked_3D,
-        ::testing::ValuesIn(Blocked_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_Blocked_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Blocked_3D,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_NSPC_BF16_AMX_NO_FUSING,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_AMX_3D,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn({emptyFusingSpec}),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D_nspc_amx})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_NSPC_BF16_AMX_NO_FUSING, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_AMX_3D,
-        ::testing::ValuesIn(Blocked_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn({emptyFusingSpec}),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D_nspc_amx})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_NSPC_INT8_AMX,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_AMX_3D,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::i8),
+                                            ::testing::ValuesIn({emptyFusingSpec, fusingClampRoundAddRelu}),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D_nspc_amx})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_NSPC_INT8_AMX, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_AMX_3D,
-        ::testing::ValuesIn(Blocked_3D_inputs_smoke),
-        ::testing::Values(ElementType::i8),
-        ::testing::ValuesIn({emptyFusingSpec, fusingClampRoundAddRelu}),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D_nspc_amx})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Blocked_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Blocked_3D_nightly,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Blocked_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Blocked_3D_nightly,
-        ::testing::ValuesIn(Blocked_3D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Blocked_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_Blocked_3D_nightly,
-        ::testing::ValuesIn(Blocked_3D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_Deconv_3D_Blocked_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_Blocked_3D_nightly,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Kernel_1x1 (2D) ============= */
-const auto convParams_ExplicitPadding_1x1_2D = ::testing::Combine(
-        ::testing::Values(InferenceEngine::SizeVector({1, 1})),
-        ::testing::Values(InferenceEngine::SizeVector({1, 1})),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-        ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
-        ::testing::Values(InferenceEngine::SizeVector({1, 1})),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto convParams_ExplicitPadding_1x1_2D = ::testing::Combine(::testing::Values(std::vector<uint64_t>({1, 1})),
+                                                                  ::testing::Values(std::vector<uint64_t>({1, 1})),
+                                                                  ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+                                                                  ::testing::Values(std::vector<ptrdiff_t>({0, 0})),
+                                                                  ::testing::Values(std::vector<uint64_t>({1, 1})),
+                                                                  ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                  ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                  ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_1x1_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_1x1_2D,
-        ::testing::ValuesIn(Blocked_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1, conv_avx2_2D_1x1})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_1x1_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_1x1_2D,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1,
+                                                                                        conv_avx2_2D_1x1})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_1x1_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        convParams_ExplicitPadding_1x1_2D,
-        ::testing::ValuesIn(Blocked_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1, conv_avx2_2D_1x1})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_1x1_BF16,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(convParams_ExplicitPadding_1x1_2D,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_1x1,
+                                                                                        conv_avx2_2D_1x1})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Reorder + Deconvolution ============= */
-INSTANTIATE_TEST_SUITE_P(smoke_reorder_Deconv_2D, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(::testing::ValuesIn(kernels2d),
-                           ::testing::Values(InferenceEngine::SizeVector{1, 1}),
-                           ::testing::ValuesIn(padBegins2d),
-                           ::testing::ValuesIn(padEnds2d),
-                           ::testing::ValuesIn(dilations2d),
-                           ::testing::ValuesIn(numOutChannels_Blocked),
-                           ::testing::Values(ngraph::op::PadType::EXPLICIT),
-                           ::testing::ValuesIn(emptyOutputPadding)),
-        ::testing::Values(DeconvInputData{InputShape{{-1, 67, -1, -1}, {{ 1, 67, 7, 7}, { 1, 67, 9, 4}, { 1, 67, 5, 7}, { 1, 67, 7, 7}, { 1, 67, 9, 4}}},
-                                                     ngraph::helpers::InputLayerType::PARAMETER,
-                                                     {{15, 15}, {9, 9}, {9, 10}, {15, 15}, {9, 9}}}),
-        ::testing::Values(ElementType::f32),
-        ::testing::Values(emptyFusingSpec),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_reorder_Deconv_2D,
+    DeconvolutionLayerCPUTest,
+    ::testing::Combine(::testing::Combine(::testing::ValuesIn(kernels2d),
+                                          ::testing::Values(std::vector<uint64_t>{1, 1}),
+                                          ::testing::ValuesIn(padBegins2d),
+                                          ::testing::ValuesIn(padEnds2d),
+                                          ::testing::ValuesIn(dilations2d),
+                                          ::testing::ValuesIn(numOutChannels_Blocked),
+                                          ::testing::Values(ov::op::PadType::EXPLICIT),
+                                          ::testing::ValuesIn(emptyOutputPadding)),
+                       ::testing::Values(DeconvInputData{
+                           InputShape{{-1, 67, -1, -1},
+                                      {{1, 67, 7, 7}, {1, 67, 9, 4}, {1, 67, 5, 7}, {1, 67, 7, 7}, {1, 67, 9, 4}}},
+                           ov::test::utils::InputLayerType::PARAMETER,
+                           {{15, 15}, {9, 9}, {9, 10}, {15, 15}, {9, 9}}}),
+                       ::testing::Values(ElementType::f32),
+                       ::testing::Values(emptyFusingSpec),
+                       ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+                       ::testing::Values(cpuEmptyPluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Deconvolution auto padding tests ============= */
 const std::vector<DeconvInputData> inputs_2D_AutoPadding = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 67, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 67, -1, -1}, {{ 1, 67, 9, 4}, { 2, 67, 5, 7}, { 1, 67, 9, 4}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 67, -1, -1}, {{ 2, 67, 7, 7}, { 2, 67, 5, 7}, { 1, 67, 9, 4}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    },
-    DeconvInputData{
-        InputShape{{-1, 67, -1, -1}, {{ 1, 67, 9, 4}, { 2, 67, 5, 7}, { 1, 67, 9, 4}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{9, 9}, {9, 10}, {9, 9}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 67, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 67, -1, -1}, {{1, 67, 9, 4}, {2, 67, 5, 7}, {1, 67, 9, 4}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 67, -1, -1}, {{2, 67, 7, 7}, {2, 67, 5, 7}, {1, 67, 9, 4}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}},
+    DeconvInputData{InputShape{{-1, 67, -1, -1}, {{1, 67, 9, 4}, {2, 67, 5, 7}, {1, 67, 9, 4}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{9, 9}, {9, 10}, {9, 9}}}};
 
-const auto deconvParams_AutoPadding_2D = ::testing::Combine(
-    ::testing::ValuesIn(kernels2d),
-    ::testing::ValuesIn(strides2d),
-    ::testing::ValuesIn(padBegins2d),
-    ::testing::ValuesIn(padEnds2d),
-    ::testing::ValuesIn(dilations2d),
-    ::testing::ValuesIn(numOutChannels_Blocked),
-    ::testing::Values(ngraph::op::PadType::SAME_UPPER, ngraph::op::PadType::SAME_LOWER),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto deconvParams_AutoPadding_2D =
+    ::testing::Combine(::testing::ValuesIn(kernels2d),
+                       ::testing::ValuesIn(strides2d),
+                       ::testing::ValuesIn(padBegins2d),
+                       ::testing::ValuesIn(padEnds2d),
+                       ::testing::ValuesIn(dilations2d),
+                       ::testing::ValuesIn(numOutChannels_Blocked),
+                       ::testing::Values(ov::op::PadType::SAME_UPPER, ov::op::PadType::SAME_LOWER),
+                       ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_AutoPadding_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        deconvParams_AutoPadding_2D,
-        ::testing::ValuesIn(inputs_2D_AutoPadding),
-        ::testing::Values(ElementType::f32),
-        ::testing::Values(emptyFusingSpec),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D, conv_avx512_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_AutoPadding_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(deconvParams_AutoPadding_2D,
+                                            ::testing::ValuesIn(inputs_2D_AutoPadding),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D, conv_avx512_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
 
 const std::vector<DeconvInputData> inputs_3D_AutoPadding = {
-    DeconvInputData{
-        InputShape{{-1, 2, 4, {32, 64}, {32, 64}}, {{1, 2, 4, 32, 32}, {1, 2, 4, 40, 40}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{8, 64, 64}, {8, 80, 80}}
-    },
-    DeconvInputData{
-        InputShape{
-            {1, 64, 5, {1, std::numeric_limits<ov::Dimension::value_type>::max()}, {1, std::numeric_limits<ov::Dimension::value_type>::max()}},
-            {{1, 64, 5, 8, 8}}
-        },
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{10, 16, 16}}
-    },
+    DeconvInputData{InputShape{{-1, 2, 4, {32, 64}, {32, 64}}, {{1, 2, 4, 32, 32}, {1, 2, 4, 40, 40}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{8, 64, 64}, {8, 80, 80}}},
+    DeconvInputData{InputShape{{1,
+                                64,
+                                5,
+                                {1, std::numeric_limits<ov::Dimension::value_type>::max()},
+                                {1, std::numeric_limits<ov::Dimension::value_type>::max()}},
+                               {{1, 64, 5, 8, 8}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{10, 16, 16}}},
 };
 
-const auto deconvParams_AutoPadding_3D = ::testing::Combine(
-    ::testing::Values(kernels3d[0]),
-    ::testing::Values(strides3d[1]),
-    ::testing::ValuesIn(padBegins3d),
-    ::testing::ValuesIn(padEnds3d),
-    ::testing::ValuesIn(dilations3d),
-    ::testing::Values(1),
-    ::testing::Values(ngraph::op::PadType::SAME_UPPER, ngraph::op::PadType::SAME_LOWER),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto deconvParams_AutoPadding_3D =
+    ::testing::Combine(::testing::Values(kernels3d[0]),
+                       ::testing::Values(strides3d[1]),
+                       ::testing::ValuesIn(padBegins3d),
+                       ::testing::ValuesIn(padEnds3d),
+                       ::testing::ValuesIn(dilations3d),
+                       ::testing::Values(1),
+                       ::testing::Values(ov::op::PadType::SAME_UPPER, ov::op::PadType::SAME_LOWER),
+                       ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_AutoPadding_FP32, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        deconvParams_AutoPadding_3D,
-        ::testing::ValuesIn(inputs_3D_AutoPadding),
-        ::testing::Values(ElementType::f32),
-        ::testing::Values(emptyFusingSpec),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D, conv_avx512_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_3D_AutoPadding_FP32,
+                         DeconvolutionLayerCPUTest,
+                         ::testing::Combine(deconvParams_AutoPadding_3D,
+                                            ::testing::ValuesIn(inputs_3D_AutoPadding),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D, conv_avx512_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         DeconvolutionLayerCPUTest::getTestCaseName);
+
+const auto deconvParams_AutoPadding_2D_AMX =
+    ::testing::Combine(::testing::ValuesIn(deconvAmxKernels2d),
+                       ::testing::ValuesIn(deconvAmxStrides2d),
+                       ::testing::ValuesIn(padBegins2d),
+                       ::testing::ValuesIn(padEnds2d),
+                       ::testing::ValuesIn(dilations2d),
+                       ::testing::Values(256),
+                       ::testing::Values(ov::op::PadType::SAME_UPPER, ov::op::PadType::SAME_LOWER),
+                       ::testing::ValuesIn(emptyOutputPadding));
+
+const DeconvInputData inputs_2D_AutoPadding_AMX = {InputShape{{-1, 512, -1, -1}, {{1, 512, 32, 51}, {1, 512, 68, 101}}},
+                                                   ov::test::utils::InputLayerType::PARAMETER,
+                                                   {{64, 101}, {135, 202}}};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Deconv_2D_AutoPadding_AMX_BF16,
+    DeconvolutionLayerCPUTest,
+    ::testing::Combine(deconvParams_AutoPadding_2D_AMX,
+                       ::testing::Values(inputs_2D_AutoPadding_AMX),
+                       ::testing::Values(ElementType::f32),
+                       ::testing::Values(emptyFusingSpec),
+                       ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_nspc_brgconv_amx})),
+                       ::testing::Values(cpuBF16PluginConfig)),
     DeconvolutionLayerCPUTest::getTestCaseName);
 
-const auto deconvParams_AutoPadding_2D_AMX = ::testing::Combine(
-    ::testing::ValuesIn(deconvAmxKernels2d),
-    ::testing::ValuesIn(deconvAmxStrides2d),
-    ::testing::ValuesIn(padBegins2d),
-    ::testing::ValuesIn(padEnds2d),
-    ::testing::ValuesIn(dilations2d),
-    ::testing::Values(256),
-    ::testing::Values(ngraph::op::PadType::SAME_UPPER, ngraph::op::PadType::SAME_LOWER),
-    ::testing::ValuesIn(emptyOutputPadding)
-);
+}  // namespace
 
-const DeconvInputData inputs_2D_AutoPadding_AMX = {
-    InputShape{{-1, 512, -1, -1}, {{ 1, 512, 32, 51}, { 1, 512, 68, 101}}},
-    ngraph::helpers::InputLayerType::PARAMETER,
-    {{64, 101}, {135, 202}}
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_AutoPadding_AMX_BF16, DeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        deconvParams_AutoPadding_2D_AMX,
-        ::testing::Values(inputs_2D_AutoPadding_AMX),
-        ::testing::Values(ElementType::f32),
-        ::testing::Values(emptyFusingSpec),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D_nspc_brgconv_amx})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    DeconvolutionLayerCPUTest::getTestCaseName);
-
-} // namespace
-
-} // namespace CPULayerTestsDefinitions
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution.cpp
@@ -2,45 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "shared_test_classes/base/ov_subgraph.hpp"
-#include <shared_test_classes/single_layer/group_convolution.hpp>
-#include "test_utils/cpu_test_utils.hpp"
-#include "test_utils/convolution_params.hpp"
-#include "test_utils/fusing_test_utils.hpp"
-#include "test_utils/filter_cpu_info.hpp"
+#include "shared_test_classes/single_layer/group_convolution.hpp"
+
 #include "common_test_utils/node_builders/group_convolution.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "test_utils/convolution_params.hpp"
+#include "test_utils/cpu_test_utils.hpp"
+#include "test_utils/filter_cpu_info.hpp"
+#include "test_utils/fusing_test_utils.hpp"
 
-using namespace InferenceEngine;
 using namespace CPUTestUtils;
-using namespace ov::test;
-
-namespace CPULayerTestsDefinitions {
+namespace ov {
+namespace test {
 
 using groupConvSpecificParams = LayerTestsDefinitions::groupConvSpecificParams;
-using Config = std::map<std::string, std::string>;
 
-typedef std::tuple<
-        groupConvSpecificParams,
-        ElementType,
-        ElementType,    // Input precision
-        ElementType,    // Output precision
-        InputShape, // Input shapes
-        LayerTestsUtils::TargetDevice> groupConvLayerTestParamsSet;
+typedef std::tuple<groupConvSpecificParams,
+                   ElementType,
+                   ElementType,  // Input precision
+                   ElementType,  // Output precision
+                   InputShape,   // Input shapes
+                   std::string>
+    groupConvLayerTestParamsSet;
 
-typedef std::tuple<
-        groupConvLayerTestParamsSet,
-        CPUSpecificParams,
-        fusingSpecificParams,
-        Config > groupConvLayerCPUTestParamsSet;
+typedef std::tuple<groupConvLayerTestParamsSet, CPUSpecificParams, fusingSpecificParams, ov::AnyMap>
+    groupConvLayerCPUTestParamsSet;
 
 class GroupConvolutionLayerCPUTest : public testing::WithParamInterface<groupConvLayerCPUTestParamsSet>,
-                                     virtual public SubgraphBaseTest, public CpuTestWithFusing {
+                                     virtual public SubgraphBaseTest,
+                                     public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvLayerCPUTestParamsSet> obj) {
         groupConvLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
-        Config additionalConfig;
+        ov::AnyMap additionalConfig;
         std::tie(basicParamsSet, cpuParams, fusingParams, additionalConfig) = obj.param;
 
         groupConvSpecificParams groupConvParams;
@@ -49,15 +45,15 @@ public:
         InputShape inputShape;
         std::string targetDevice;
         std::tie(groupConvParams, netType, inType, outType, inputShape, targetDevice) = basicParamsSet;
-        ngraph::op::PadType padType;
-        InferenceEngine::SizeVector kernel, stride, dilation;
+        ov::op::PadType padType;
+        std::vector<size_t> kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd;
         size_t convOutChannels, numGroups;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
 
         std::ostringstream result;
         result << "IS=";
-        result  << ov::test::utils::partialShape2str({inputShape.first}) << "_";
+        result << ov::test::utils::partialShape2str({inputShape.first}) << "_";
         result << "TS=(";
         for (const auto& shape : inputShape.second) {
             result << ov::test::utils::vec2str(shape) << "_";
@@ -82,7 +78,7 @@ public:
         if (!additionalConfig.empty()) {
             result << "_PluginConf";
             for (auto& item : additionalConfig) {
-                result << "_" << item.first << "=" << item.second;
+                result << "_" << item.first << "=" << item.second.as<std::string>();
             }
         }
 
@@ -92,14 +88,14 @@ public:
 protected:
     bool isBias = false;
 
-    void checkBiasFusing(ov::CompiledModel &execNet) const {
+    void checkBiasFusing(ov::CompiledModel& execNet) const {
         auto execGraph = execNet.get_runtime_model();
         ASSERT_NE(nullptr, execGraph);
 
         bool foundConv = false;
-        for (const auto &node : execGraph->get_ops()) {
-            const auto & rtInfo = node->get_rt_info();
-            auto getExecValue = [&rtInfo](const std::string & paramName) -> std::string {
+        for (const auto& node : execGraph->get_ops()) {
+            const auto& rtInfo = node->get_rt_info();
+            auto getExecValue = [&rtInfo](const std::string& paramName) -> std::string {
                 auto it = rtInfo.find(paramName);
                 OPENVINO_ASSERT(rtInfo.end() != it);
                 return it->second.as<std::string>();
@@ -115,29 +111,30 @@ protected:
         ASSERT_TRUE(foundConv) << "Can't find Convolution node";
     }
 
-    std::shared_ptr<ngraph::Node> modifyGraph(const ngraph::element::Type &ngPrc,
-                                              ngraph::ParameterVector &params,
-                                              const std::shared_ptr<ngraph::Node> &lastNode) override {
+    std::shared_ptr<ov::Node> modifyGraph(const ov::element::Type& ngPrc,
+                                          ov::ParameterVector& params,
+                                          const std::shared_ptr<ov::Node>& lastNode) override {
         auto retNode = CpuTestWithFusing::modifyGraph(ngPrc, params, lastNode);
-        std::shared_ptr<ngraph::Node> opToShapeInfer = nullptr;
+        std::shared_ptr<ov::Node> opToShapeInfer = nullptr;
         for (auto& targetShapes : targetStaticShapes) {
             for (size_t i = targetShapes.size(); i < params.size(); ++i) {
-                const auto &shape = params[i]->get_output_partial_shape(0);
+                const auto& shape = params[i]->get_output_partial_shape(0);
                 if (shape.is_static()) {
                     targetShapes.push_back(shape.get_shape());
                 } else {
                     // It is assumed that in such tests we have second parameter only if sum fusion is tested.
-                    // Considering this fact, we need to set the appropriate static shape for the second term of the sum operation, and
-                    // it has to match the convolution output shape. So the most suitable solution here is to perform shape inference on the
-                    // convolution node
+                    // Considering this fact, we need to set the appropriate static shape for the second term of the sum
+                    // operation, and it has to match the convolution output shape. So the most suitable solution here
+                    // is to perform shape inference on the convolution node
                     if (!opToShapeInfer) {
-                        ngraph::OutputVector inputsForShapeInfer;
+                        ov::OutputVector inputsForShapeInfer;
                         for (size_t j = 0; j < lastNode->get_input_size(); j++) {
-                            if (ngraph::is_type<ngraph::opset1::Constant>(lastNode->get_input_node_ptr(j))) {
+                            if (ov::is_type<ov::op::v0::Constant>(lastNode->get_input_node_ptr(j))) {
                                 inputsForShapeInfer.push_back(lastNode->get_input_node_shared_ptr(j));
                             } else {
-                                inputsForShapeInfer.push_back(std::make_shared<ngraph::opset1::Parameter>(lastNode->get_input_element_type(j),
-                                                                                                          lastNode->get_input_partial_shape(j)));
+                                inputsForShapeInfer.push_back(
+                                    std::make_shared<ov::op::v0::Parameter>(lastNode->get_input_element_type(j),
+                                                                            lastNode->get_input_partial_shape(j)));
                             }
                         }
                         opToShapeInfer = lastNode->clone_with_new_inputs(inputsForShapeInfer);
@@ -162,7 +159,7 @@ protected:
         groupConvLayerTestParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
-        Config additionalConfig;
+        ov::AnyMap additionalConfig;
         std::tie(basicParamsSet, cpuParams, fusingParams, additionalConfig) = this->GetParam();
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
@@ -171,25 +168,25 @@ protected:
         std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 
         if (postOpMgrPtr)
-                isBias = postOpMgrPtr->getFusedOpsNames() == "Add(PerChannel)";
+            isBias = postOpMgrPtr->getFusedOpsNames() == "Add(PerChannel)";
 
         groupConvSpecificParams groupConvParams;
         InputShape inputShape;
-        auto netType   = ElementType::undefined;
+        auto netType = ElementType::undefined;
         std::tie(groupConvParams, netType, inType, outType, inputShape, targetDevice) = basicParamsSet;
 
         init_input_shapes({inputShape});
 
-        if (configuration.count(PluginConfigParams::KEY_ENFORCE_BF16) &&
-            PluginConfigParams::YES == configuration[PluginConfigParams::KEY_ENFORCE_BF16].as<std::string>()) {
-            selectedType += "_BF16";
+        if (configuration.count(ov::hint::inference_precision.name()) &&
+            ov::element::bf16 == configuration[ov::hint::inference_precision.name()].as<ov::element::Type>()) {
+            selectedType += "_bf16";
             rel_threshold = 1e-2f;
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netType);
         }
 
-        ngraph::op::PadType padType;
-        InferenceEngine::SizeVector kernel, stride, dilation;
+        ov::op::PadType padType;
+        std::vector<size_t> kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd;
         size_t convOutChannels, numGroups;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
@@ -198,8 +195,16 @@ protected:
         for (auto&& shape : inputDynamicShapes)
             params.push_back(std::make_shared<ov::op::v0::Parameter>(netType, shape));
 
-        auto groupConv = ov::test::utils::make_group_convolution(params[0], netType, kernel, stride, padBegin,
-                                                                 padEnd, dilation, padType, convOutChannels, numGroups);
+        auto groupConv = ov::test::utils::make_group_convolution(params[0],
+                                                                 netType,
+                                                                 kernel,
+                                                                 stride,
+                                                                 padBegin,
+                                                                 padEnd,
+                                                                 dilation,
+                                                                 padType,
+                                                                 convOutChannels,
+                                                                 numGroups);
         function = makeNgraphFunction(netType, params, groupConv, "groupConvolution");
     }
 };
@@ -213,9 +218,9 @@ TEST_P(ExpectFallbackGroupConvolutionLayerCPUTest, CompareWithRefs) {
     }
     ASSERT_TRUE(!selectedType.empty()) << "Node type is not defined.";
     auto function = compiledModel.get_runtime_model();
-    for (const auto &node : function->get_ops()) {
-        const auto & rtInfo = node->get_rt_info();
-        auto getExecValue = [&rtInfo](const std::string & paramName) -> std::string {
+    for (const auto& node : function->get_ops()) {
+        const auto& rtInfo = node->get_rt_info();
+        auto getExecValue = [&rtInfo](const std::string& paramName) -> std::string {
             auto it = rtInfo.find(paramName);
             OPENVINO_ASSERT(rtInfo.end() != it);
             return it->second.as<std::string>();
@@ -238,7 +243,8 @@ TEST_P(GroupConvolutionLayerCPUTest, CompareWithRefs) {
 namespace {
 
 /* GROUP CONV TEST UTILS */
-std::vector<groupConvLayerCPUTestParamsSet> filterParamsSetForDevice(std::vector<groupConvLayerCPUTestParamsSet> paramsSet) {
+std::vector<groupConvLayerCPUTestParamsSet> filterParamsSetForDevice(
+    std::vector<groupConvLayerCPUTestParamsSet> paramsSet) {
     std::vector<groupConvLayerCPUTestParamsSet> resParamsSet;
     const int cpuParamsIndex = 1;
     const int selectedTypeIndex = 3;
@@ -248,20 +254,20 @@ std::vector<groupConvLayerCPUTestParamsSet> filterParamsSetForDevice(std::vector
         auto cpuParams = std::get<cpuParamsIndex>(param);
         auto selectedTypeStr = std::get<selectedTypeIndex>(cpuParams);
 
-        if (selectedTypeStr.find("jit") != std::string::npos && !with_cpu_x86_sse42())
+        if (selectedTypeStr.find("jit") != std::string::npos && !ov::with_cpu_x86_sse42())
             continue;
-        if (selectedTypeStr.find("sse42") != std::string::npos && !with_cpu_x86_sse42())
+        if (selectedTypeStr.find("sse42") != std::string::npos && !ov::with_cpu_x86_sse42())
             continue;
-        if (selectedTypeStr.find("avx2") != std::string::npos && !with_cpu_x86_avx2())
+        if (selectedTypeStr.find("avx2") != std::string::npos && !ov::with_cpu_x86_avx2())
             continue;
-        if (selectedTypeStr.find("avx512") != std::string::npos && !with_cpu_x86_avx512f())
+        if (selectedTypeStr.find("avx512") != std::string::npos && !ov::with_cpu_x86_avx512f())
             continue;
-        if (selectedTypeStr.find("amx") != std::string::npos && !with_cpu_x86_avx512_core_amx())
+        if (selectedTypeStr.find("amx") != std::string::npos && !ov::with_cpu_x86_avx512_core_amx())
             continue;
         auto additionalConfig = std::get<configIndex>(param);
-        if (additionalConfig.count(PluginConfigParams::KEY_ENFORCE_BF16) &&
-            PluginConfigParams::YES == additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] &&
-            !with_cpu_x86_bfloat16()) {
+        if (additionalConfig.count(ov::hint::inference_precision.name()) &&
+            ov::element::bf16 == additionalConfig[ov::hint::inference_precision.name()].as<ov::element::Type>() &&
+            !ov::with_cpu_x86_bfloat16()) {
             continue;
         }
         resParamsSet.push_back(param);
@@ -272,7 +278,7 @@ std::vector<groupConvLayerCPUTestParamsSet> filterParamsSetForDevice(std::vector
 
 std::vector<CPUSpecificParams> filterCPUInfoForDeviceSupportBF16(std::vector<CPUSpecificParams> CPUParams) {
     std::vector<CPUSpecificParams> resParamsSet;
-    if (with_cpu_x86_bfloat16()) {
+    if (ov::with_cpu_x86_bfloat16()) {
         return filterCPUInfoForDevice(CPUParams);
     }
     return resParamsSet;
@@ -280,1343 +286,1133 @@ std::vector<CPUSpecificParams> filterCPUInfoForDeviceSupportBF16(std::vector<CPU
 /* ===================== */
 
 /* COMMON PARAMS */
-const std::vector<fusingSpecificParams> fusingParamsSet {
-        emptyFusingSpec,
-        // eltwise
-        fusingRelu,
-        fusingPRelu1D,
-        // depthwise
-        fusingReluScaleShift,
-        // fake quantize
-        fusingFakeQuantizePerTensorRelu,
-        fusingFakeQuantizePerChannelRelu,
-        // sum
-        fusingSumEluFQ,
-        fusingSum
-};
+const std::vector<fusingSpecificParams> fusingParamsSet{emptyFusingSpec,
+                                                        // eltwise
+                                                        fusingRelu,
+                                                        fusingPRelu1D,
+                                                        // depthwise
+                                                        fusingReluScaleShift,
+                                                        // fake quantize
+                                                        fusingFakeQuantizePerTensorRelu,
+                                                        fusingFakeQuantizePerChannelRelu,
+                                                        // sum
+                                                        fusingSumEluFQ,
+                                                        fusingSum};
 
-const std::vector<fusingSpecificParams> fusingParamsSetBF16{
-        emptyFusingSpec,
-        // eltwise
-        fusingRelu,
-        // depthwise
-        fusingReluScaleShift,
-        // sum
-        fusingSum
-};
-
+const std::vector<fusingSpecificParams> fusingParamsSetBF16{emptyFusingSpec,
+                                                            // eltwise
+                                                            fusingRelu,
+                                                            // depthwise
+                                                            fusingReluScaleShift,
+                                                            // sum
+                                                            fusingSum};
 
 /* ============= GroupConvolution params (planar layout) ============= */
-const SizeVector numOutChannels_Gemm = {6};
-const SizeVector numGroups_Gemm = {2, 3};
+const std::vector<size_t> numOutChannels_Gemm = {6};
+const std::vector<size_t> numGroups_Gemm = {2, 3};
 
 /* ============= GroupConvolution params (blocked layout) ============= */
-const SizeVector numOutChannels_Blocked = {64};
-const SizeVector numGroups_Blocked = {2, 4};
+const std::vector<size_t> numOutChannels_Blocked = {64};
+const std::vector<size_t> numGroups_Blocked = {2, 4};
 
 /* ============= GroupConvolution params (DW) ============= */
-const SizeVector numOutChannels_DW = {32};
-const SizeVector numGroups_DW = {32};
+const std::vector<size_t> numOutChannels_DW = {32};
+const std::vector<size_t> numGroups_DW = {32};
 
 /* ============= GroupConvolution params (1D) ============= */
-const std::vector<SizeVector> kernels1d = { {3}, {1} };
-const std::vector<SizeVector> strides1d = { {1}, {2} };
-const std::vector<std::vector<ptrdiff_t>> padBegins1d = { {0}, {1} };
-const std::vector<std::vector<ptrdiff_t>> padEnds1d = { {0} };
-const std::vector<SizeVector> dilations1d = { {1}, {2} };
+const std::vector<std::vector<size_t>> kernels1d = {{3}, {1}};
+const std::vector<std::vector<size_t>> strides1d = {{1}, {2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins1d = {{0}, {1}};
+const std::vector<std::vector<ptrdiff_t>> padEnds1d = {{0}};
+const std::vector<std::vector<size_t>> dilations1d = {{1}, {2}};
 
 /* ============= GroupConvolution params (2D) ============= */
-const std::vector<SizeVector> kernels2d = {{3, 3}, {1, 1}};
-const std::vector<SizeVector> strides2d = {{1, 1}, {2, 2}};
+const std::vector<std::vector<size_t>> kernels2d = {{3, 3}, {1, 1}};
+const std::vector<std::vector<size_t>> strides2d = {{1, 1}, {2, 2}};
 const std::vector<std::vector<ptrdiff_t>> padBegins2d = {{0, 0}, {1, 1}};
 const std::vector<std::vector<ptrdiff_t>> padEnds2d = {{0, 0}};
-const std::vector<SizeVector> dilations2d = {{1, 1}, {2, 2}};
+const std::vector<std::vector<size_t>> dilations2d = {{1, 1}, {2, 2}};
 
 /* ============= GroupConvolution params (3D) ============= */
-const std::vector<SizeVector> kernels3d = {{3, 3, 3}, {1, 1, 1}};
-const std::vector<SizeVector> strides3d = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}, {1, 1, 1}};
+const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}, {2, 2, 2}};
 const std::vector<std::vector<ptrdiff_t>> padBegins3d = {{0, 0, 0}, {1, 1, 1}};
 const std::vector<std::vector<ptrdiff_t>> padEnds3d = {{0, 0, 0}};
-const std::vector<SizeVector> dilations3d = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}, {2, 2, 2}};
 /* ============= */
-
 
 /* INSTANCES */
 /* ============= GroupConvolution (GEMM 1D) ============= */
-const auto groupConvParams_ExplicitPadding_Gemm_1D = ::testing::Combine(
-        ::testing::ValuesIn(kernels1d),
-        ::testing::ValuesIn(strides1d),
-        ::testing::ValuesIn(padBegins1d),
-        ::testing::ValuesIn(padEnds1d),
-        ::testing::ValuesIn(dilations1d),
-        ::testing::ValuesIn(numOutChannels_Gemm),
-        ::testing::ValuesIn(numGroups_Gemm),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+const auto groupConvParams_ExplicitPadding_Gemm_1D = ::testing::Combine(::testing::ValuesIn(kernels1d),
+                                                                        ::testing::ValuesIn(strides1d),
+                                                                        ::testing::ValuesIn(padBegins1d),
+                                                                        ::testing::ValuesIn(padEnds1d),
+                                                                        ::testing::ValuesIn(dilations1d),
+                                                                        ::testing::ValuesIn(numOutChannels_Gemm),
+                                                                        ::testing::ValuesIn(numGroups_Gemm),
+                                                                        ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_Gemm_1D = {
-        conv_gemm_1D,
-        conv_gemm_1D_nspc
-};
+const std::vector<CPUSpecificParams> CPUParams_Gemm_1D = {conv_gemm_1D, conv_gemm_1D_nspc};
 
-std::vector<InputShape> inShapesGemm1D = {
-    {{}, {{ 2, 12, 7 }}},
-    {
-        //dynamic shape
-        {{1, 200}, 12, {1, 200}},
-        { //target static shapes
-            { 2, 12, 7 },
-            { 1, 12, 5 }
-        }
-    }
-};
+std::vector<InputShape> inShapesGemm1D = {{{}, {{2, 12, 7}}},
+                                          {// dynamic shape
+                                           {{1, 200}, 12, {1, 200}},
+                                           {// target static shapes
+                                            {2, 12, 7},
+                                            {1, 12, 5}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_Gemm_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm1D),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_1D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_Gemm_with_bias_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm1D),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_1D)),
-                                ::testing::Values(fusingAddPerChannel),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_Gemm_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm1D),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_1D})), // todo: [AV] what about conv_gemm_1D_nspc?
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-/* ============= GroupConvolution (GEMM 2D) ============= */
-const auto groupConvParams_ExplicitPadding_Gemm_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn(strides2d),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_Gemm),
-        ::testing::ValuesIn(numGroups_Gemm),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-
-const std::vector<CPUSpecificParams> CPUParams_Gemm_2D = {
-        conv_gemm_2D,
-        conv_gemm_2D_nspc
-};
-
-std::vector<InputShape> inShapesGemm2D = {
-    {{}, {{ 2, 12, 7, 7 }}},
-    {
-        //dynamic shape
-        {{1, 200}, 12, -1, {1, 200}},
-        { //target static shapes
-            { 2, 12, 7, 7 },
-            { 1, 12, 5, 5 }
-        }
-    }
-};
-
-std::vector<InputShape> inShapesGemm2D_cache = {
-    {{}, {{ 2, 12, 7, 7 }}},
-    {
-        //dynamic shape
-        {{1, 200}, 12, -1, {1, 200}},
-        { //target static shapes
-            { 1, 12, 5, 5 },
-            { 1, 12, 7, 7 },
-            { 1, 12, 5, 5 }
-        }
-    }
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_Gemm_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm2D_cache),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_2D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_Gemm_with_bias_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm2D_cache),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_2D)),
-                                ::testing::Values(fusingAddPerChannel),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_Gemm_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm2D),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_2D)),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-/* ============= GroupConvolution (Gemm 3D) ============= */
-const auto groupConvParams_ExplicitPadding_Gemm_3D = ::testing::Combine(
-        ::testing::ValuesIn(kernels3d),
-        ::testing::ValuesIn(strides3d),
-        ::testing::ValuesIn(padBegins3d),
-        ::testing::ValuesIn(padEnds3d),
-        ::testing::ValuesIn(dilations3d),
-        ::testing::ValuesIn(numOutChannels_Gemm),
-        ::testing::ValuesIn(numGroups_Gemm),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-
-const std::vector<CPUSpecificParams> CPUParams_Gemm_3D = {
-        conv_gemm_3D,
-        conv_gemm_3D_nspc
-};
-
-std::vector<InputShape> inShapesGemm3D = {
-    {{}, {{ 2, 12, 7, 7, 7 }}},
-    {
-        //dynamic shape
-        {{1, 200}, 12, -1, {1, 200}, -1},
-        { //target static shapes
-            { 2, 12, 7, 7, 7 },
-            { 1, 12, 5, 5, 5 }
-        }
-    }
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_Gemm_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm3D),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_3D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_Gemm_with_bias_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm3D),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_3D)),
-                                ::testing::Values(fusingAddPerChannel),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_Gemm_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_Gemm_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inShapesGemm3D),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_3D)),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-/* ============= GroupConvolution params (brgemm_1D) ============= */
-const std::vector<SizeVector> kernels_brgemm_1d = {{3}};
-const std::vector<SizeVector> strides_brgemm_1d = { {1}, {2} };
-const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_1d = { {0}, {1} };
-const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_1d = { {0} };
-const std::vector<SizeVector> dilations_brgemm_1d = { {1}, {2} };
-
-/* ============= GroupConvolution params (brgemm_2D) ============= */
-const std::vector<SizeVector> kernels_brgemm_2d = {{3, 3}};
-const std::vector<SizeVector> strides_brgemm_2d = {{1, 1}, {2, 2}};
-const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_2d = {{0, 0}, {1, 1}};
-const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_2d = {{0, 0}};
-const std::vector<SizeVector> dilations_brgemm_2d = {{1, 1}, {2, 2}};
-
-/* ============= GroupConvolution params (brgemm_3D) ============= */
-const std::vector<SizeVector> kernels_brgemm_3d = {{3, 3, 3}};
-const std::vector<SizeVector> strides_brgemm_3d = {{1, 1, 1}, {2, 2, 2}};
-const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_3d = {{0, 0, 0}, {1, 1, 1}};
-const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_3d = {{0, 0, 0}};
-const std::vector<SizeVector> dilations_brgemm_3d = {{1, 1, 1}, {2, 2, 2}};
-/* ============= */
-
-const SizeVector numGroups_brgemm_Blocked = {2};
-
-/* ============= GroupConvolution (brgemm 1D) ============= */
-const auto groupConvParams_ExplicitPadding_brgemm_1D = ::testing::Combine(
-        ::testing::ValuesIn(kernels_brgemm_1d),
-        ::testing::ValuesIn(strides_brgemm_1d),
-        ::testing::ValuesIn(padBegins_brgemm_1d),
-        ::testing::ValuesIn(padEnds_brgemm_1d),
-        ::testing::ValuesIn(dilations_brgemm_1d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_brgemm_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-
-const std::vector<CPUSpecificParams> CPUParams_brgemm_1D_BF16 = {
-        conv_avx512_1D_nspc_brgconv
-};
-
-const std::vector<CPUSpecificParams> CPUParams_brgemm_1D_FP32 = {
-        conv_avx512_1D_nspc_brgconv
-};
-
-std::vector<InputShape> inputShapes_brgemm_1d = {
-    {{}, {{ 2, 64, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, {1, 200}},
-        { //target static shapes
-            { 2, 64, 7 },
-            { 1, 64, 9 }
-        }
-    },
-    {
-        //dynamic shapes
-        { {-1, 64, -1} },
-        { //target static shapes
-            { 2, 64, 7 },
-            { 1, 64, 14 }
-        }
-    }
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1D_FP32_fusingBias, GroupConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         groupConvParams_ExplicitPadding_brgemm_1D,
-                                         ::testing::Values(ElementType::f32),
-                                         ::testing::Values(ElementType::f32),
-                                         ::testing::Values(ElementType::undefined),
-                                         ::testing::ValuesIn(inputShapes_brgemm_1d),
-                                         ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1D_FP32)),
-                                 ::testing::Values(fusingAddPerChannel),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_Gemm_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm1D),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_1D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
                          GroupConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_1D_BF16)),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_Gemm_with_bias_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm1D),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_1D)),
+                                            ::testing::Values(fusingAddPerChannel),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-/* ============= GroupConvolution (brgemm_2D) ============= */
-const auto groupConvParams_ExplicitPadding_brgemm_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels_brgemm_2d),
-        ::testing::ValuesIn(strides_brgemm_2d),
-        ::testing::ValuesIn(padBegins_brgemm_2d),
-        ::testing::ValuesIn(padEnds_brgemm_2d),
-        ::testing::ValuesIn(dilations_brgemm_2d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_brgemm_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_Gemm_BF16,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm1D),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(
+                                                {conv_gemm_1D})),  // todo: [AV] what about conv_gemm_1D_nspc?
+                                            ::testing::ValuesIn(fusingParamsSetBF16),
+                                            ::testing::Values(cpu_bf16_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-const std::vector<CPUSpecificParams> CPUParams_brgemm_2D_FP32 = {
-        conv_avx512_2D_nspc_brgconv
-};
+/* ============= GroupConvolution (GEMM 2D) ============= */
+const auto groupConvParams_ExplicitPadding_Gemm_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                        ::testing::ValuesIn(strides2d),
+                                                                        ::testing::ValuesIn(padBegins2d),
+                                                                        ::testing::ValuesIn(padEnds2d),
+                                                                        ::testing::ValuesIn(dilations2d),
+                                                                        ::testing::ValuesIn(numOutChannels_Gemm),
+                                                                        ::testing::ValuesIn(numGroups_Gemm),
+                                                                        ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_brgemm_2D_BF16 = {
-        conv_avx512_2D_nspc_brgconv,
-        conv_avx512_2D_nspc_brgconv_amx
-};
+const std::vector<CPUSpecificParams> CPUParams_Gemm_2D = {conv_gemm_2D, conv_gemm_2D_nspc};
 
-std::vector<InputShape> inputShapes_brgemm_2d = {
-    {{}, {{ 1, 64, 7, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}},
-        { //target static shapes
-            { 2, 64, 7, 7 },
-            { 1, 64, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inShapesGemm2D = {{{}, {{2, 12, 7, 7}}},
+                                          {// dynamic shape
+                                           {{1, 200}, 12, -1, {1, 200}},
+                                           {// target static shapes
+                                            {2, 12, 7, 7},
+                                            {1, 12, 5, 5}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_2D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_2d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_2D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+std::vector<InputShape> inShapesGemm2D_cache = {{{}, {{2, 12, 7, 7}}},
+                                                {// dynamic shape
+                                                 {{1, 200}, 12, -1, {1, 200}},
+                                                 {// target static shapes
+                                                  {1, 12, 5, 5},
+                                                  {1, 12, 7, 7},
+                                                  {1, 12, 5, 5}}}};
 
-std::vector<InputShape> inputShapes_brgemm_2d_dynBatch = {
-    {
-        //dynamic shapes
-        { {1, 10}, 64, {7, 9}, {7, 9}},
-        { //target static shapes
-            { 2, 64, 7, 7 },
-            { 1, 64, 9, 9 },
-            { 3, 64, 9, 9 }
-        }
-    }
-};
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_Gemm_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm2D_cache),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_2D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_brgemm_2D_FP32_dynBatch, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_2d_dynBatch),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_2D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_Gemm_with_bias_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm2D_cache),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_2D)),
+                                            ::testing::Values(fusingAddPerChannel),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-std::vector<InputShape> inputShapes_brgemm_2d_cache = {
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}},
-        { //target static shapes
-            { 1, 64, 7, 7 },
-            { 1, 64, 9, 9 },
-            { 1, 64, 7, 7 },
-        }
-    }
-};
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_Gemm_BF16,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm2D),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_2D)),
+                                            ::testing::ValuesIn(fusingParamsSetBF16),
+                                            ::testing::Values(cpu_bf16_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_brgemm_2D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_2d_cache),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_2D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+/* ============= GroupConvolution (Gemm 3D) ============= */
+const auto groupConvParams_ExplicitPadding_Gemm_3D = ::testing::Combine(::testing::ValuesIn(kernels3d),
+                                                                        ::testing::ValuesIn(strides3d),
+                                                                        ::testing::ValuesIn(padBegins3d),
+                                                                        ::testing::ValuesIn(padEnds3d),
+                                                                        ::testing::ValuesIn(dilations3d),
+                                                                        ::testing::ValuesIn(numOutChannels_Gemm),
+                                                                        ::testing::ValuesIn(numGroups_Gemm),
+                                                                        ::testing::Values(ov::op::PadType::EXPLICIT));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_2D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_2d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_2D_BF16)),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+const std::vector<CPUSpecificParams> CPUParams_Gemm_3D = {conv_gemm_3D, conv_gemm_3D_nspc};
 
-/* ============= GroupConvolution (brgemm_3D) ============= */
-const auto groupConvParams_ExplicitPadding_brgemm_3D = ::testing::Combine(
-        ::testing::ValuesIn(kernels_brgemm_3d),
-        ::testing::ValuesIn(strides_brgemm_3d),
-        ::testing::ValuesIn(padBegins_brgemm_3d),
-        ::testing::ValuesIn(padEnds_brgemm_3d),
-        ::testing::ValuesIn(dilations_brgemm_3d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_brgemm_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+std::vector<InputShape> inShapesGemm3D = {{{}, {{2, 12, 7, 7, 7}}},
+                                          {// dynamic shape
+                                           {{1, 200}, 12, -1, {1, 200}, -1},
+                                           {// target static shapes
+                                            {2, 12, 7, 7, 7},
+                                            {1, 12, 5, 5, 5}}}};
 
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_Gemm_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_3D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm3D),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_3D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-const std::vector<CPUSpecificParams> CPUParams_brgemm_3D_FP32 = {
-        conv_avx512_3D_nspc_brgconv
-};
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_Gemm_with_bias_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_3D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm3D),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_3D)),
+                                            ::testing::Values(fusingAddPerChannel),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-const std::vector<CPUSpecificParams> CPUParams_brgemm_3D_BF16 = {
-        conv_avx512_3D_nspc_brgconv,
-        conv_avx512_3D_nspc_brgconv_amx
-};
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_Gemm_BF16,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_Gemm_3D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inShapesGemm3D),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_Gemm_3D)),
+                                            ::testing::ValuesIn(fusingParamsSetBF16),
+                                            ::testing::Values(cpu_bf16_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-std::vector<InputShape> inputShapes_brgemm_3d = {
-    {{}, {{ 1, 64, 7, 7, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}, -1},
-        { //target static shapes
-            { 2, 64, 7, 7, 7 },
-            { 1, 64, 9, 9, 9 }
-        }
-    }
-};
+/* ============= GroupConvolution params (brgemm_1D) ============= */
+const std::vector<std::vector<size_t>> kernels_brgemm_1d = {{3}};
+const std::vector<std::vector<size_t>> strides_brgemm_1d = {{1}, {2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_1d = {{0}, {1}};
+const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_1d = {{0}};
+const std::vector<std::vector<size_t>> dilations_brgemm_1d = {{1}, {2}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_3D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_3d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_3D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+/* ============= GroupConvolution params (brgemm_2D) ============= */
+const std::vector<std::vector<size_t>> kernels_brgemm_2d = {{3, 3}};
+const std::vector<std::vector<size_t>> strides_brgemm_2d = {{1, 1}, {2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_2d = {{0, 0}, {1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_2d = {{0, 0}};
+const std::vector<std::vector<size_t>> dilations_brgemm_2d = {{1, 1}, {2, 2}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_3D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_3d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_3D_BF16)),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-/* ============= GroupConvolution params (brgemm_1x1_1D) ============= */
-const std::vector<SizeVector> kernels_brgemm_1x1_1d = {{1}};
-const std::vector<SizeVector> strides_brgemm_1x1_1d = { {1}, {2} };
-const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_1x1_1d = { {0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_1x1_1d = { {0} };
-const std::vector<SizeVector> dilations_brgemm_1x1_1d = { {1}, {2} };
-
-/* ============= GroupConvolution params (brgemm_1x1_2D) ============= */
-const std::vector<SizeVector> kernels_brgemm_1x1_2d = {{1, 1}};
-const std::vector<SizeVector> strides_brgemm_1x1_2d = {{1, 1}, {2, 2}};
-const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_1x1_2d = {{0, 0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_1x1_2d = {{0, 0}};
-const std::vector<SizeVector> dilations_brgemm_1x1_2d = {{1, 1}, {2, 2}};
-
-/* ============= GroupConvolution params (brgemm_1x1_3D) ============= */
-const std::vector<SizeVector> kernels_brgemm_1x1_3d = {{1, 1, 1}};
-const std::vector<SizeVector> strides_brgemm_1x1_3d = {{1, 1, 1}, {2, 2, 2}};
-const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_1x1_3d = {{0, 0, 0}};
-const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_1x1_3d = {{0, 0, 0}};
-const std::vector<SizeVector> dilations_brgemm_1x1_3d = {{1, 1, 1}, {2, 2, 2}};
+/* ============= GroupConvolution params (brgemm_3D) ============= */
+const std::vector<std::vector<size_t>> kernels_brgemm_3d = {{3, 3, 3}};
+const std::vector<std::vector<size_t>> strides_brgemm_3d = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_3d = {{0, 0, 0}, {1, 1, 1}};
+const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_3d = {{0, 0, 0}};
+const std::vector<std::vector<size_t>> dilations_brgemm_3d = {{1, 1, 1}, {2, 2, 2}};
 /* ============= */
 
-const SizeVector numGroups_brgemm_1x1_Blocked = {2};
+const std::vector<size_t> numGroups_brgemm_Blocked = {2};
+
+/* ============= GroupConvolution (brgemm 1D) ============= */
+const auto groupConvParams_ExplicitPadding_brgemm_1D = ::testing::Combine(::testing::ValuesIn(kernels_brgemm_1d),
+                                                                          ::testing::ValuesIn(strides_brgemm_1d),
+                                                                          ::testing::ValuesIn(padBegins_brgemm_1d),
+                                                                          ::testing::ValuesIn(padEnds_brgemm_1d),
+                                                                          ::testing::ValuesIn(dilations_brgemm_1d),
+                                                                          ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                          ::testing::ValuesIn(numGroups_brgemm_Blocked),
+                                                                          ::testing::Values(ov::op::PadType::EXPLICIT));
+
+const std::vector<CPUSpecificParams> CPUParams_brgemm_1D_BF16 = {conv_avx512_1D_nspc_brgconv};
+
+const std::vector<CPUSpecificParams> CPUParams_brgemm_1D_FP32 = {conv_avx512_1D_nspc_brgconv};
+
+std::vector<InputShape> inputShapes_brgemm_1d = {{{}, {{2, 64, 7}}},
+                                                 {// dynamic shapes
+                                                  {-1, 64, {1, 200}},
+                                                  {// target static shapes
+                                                   {2, 64, 7},
+                                                   {1, 64, 9}}},
+                                                 {// dynamic shapes
+                                                  {{-1, 64, -1}},
+                                                  {// target static shapes
+                                                   {2, 64, 7},
+                                                   {1, 64, 14}}}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_1d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1D_FP32_fusingBias,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_1d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1D_FP32)),
+                                            ::testing::Values(fusingAddPerChannel),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConv_brgemm_1D_BF16,
+    GroupConvolutionLayerCPUTest,
+    ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1D,
+                                          ::testing::Values(ElementType::f32),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapes_brgemm_1d),
+                                          ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                       ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_1D_BF16)),
+                       ::testing::ValuesIn(fusingParamsSetBF16),
+                       ::testing::Values(cpu_bf16_plugin_config)),
+    GroupConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupConvolution (brgemm_2D) ============= */
+const auto groupConvParams_ExplicitPadding_brgemm_2D = ::testing::Combine(::testing::ValuesIn(kernels_brgemm_2d),
+                                                                          ::testing::ValuesIn(strides_brgemm_2d),
+                                                                          ::testing::ValuesIn(padBegins_brgemm_2d),
+                                                                          ::testing::ValuesIn(padEnds_brgemm_2d),
+                                                                          ::testing::ValuesIn(dilations_brgemm_2d),
+                                                                          ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                          ::testing::ValuesIn(numGroups_brgemm_Blocked),
+                                                                          ::testing::Values(ov::op::PadType::EXPLICIT));
+
+const std::vector<CPUSpecificParams> CPUParams_brgemm_2D_FP32 = {conv_avx512_2D_nspc_brgconv};
+
+const std::vector<CPUSpecificParams> CPUParams_brgemm_2D_BF16 = {conv_avx512_2D_nspc_brgconv,
+                                                                 conv_avx512_2D_nspc_brgconv_amx};
+
+std::vector<InputShape> inputShapes_brgemm_2d = {{{}, {{1, 64, 7, 7}}},
+                                                 {// dynamic shapes
+                                                  {-1, 64, -1, {1, 200}},
+                                                  {// target static shapes
+                                                   {2, 64, 7, 7},
+                                                   {1, 64, 9, 9}}}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_2D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_2d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_2D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+std::vector<InputShape> inputShapes_brgemm_2d_dynBatch = {{// dynamic shapes
+                                                           {{1, 10}, 64, {7, 9}, {7, 9}},
+                                                           {// target static shapes
+                                                            {2, 64, 7, 7},
+                                                            {1, 64, 9, 9},
+                                                            {3, 64, 9, 9}}}};
+
+INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_brgemm_2D_FP32_dynBatch,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_2d_dynBatch),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_2D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+std::vector<InputShape> inputShapes_brgemm_2d_cache = {{// dynamic shapes
+                                                        {-1, 64, -1, {1, 200}},
+                                                        {
+                                                            // target static shapes
+                                                            {1, 64, 7, 7},
+                                                            {1, 64, 9, 9},
+                                                            {1, 64, 7, 7},
+                                                        }}};
+
+INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_brgemm_2D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_2d_cache),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_2D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConv_brgemm_2D_BF16,
+    GroupConvolutionLayerCPUTest,
+    ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_2D,
+                                          ::testing::Values(ElementType::f32),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapes_brgemm_2d),
+                                          ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                       ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_2D_BF16)),
+                       ::testing::ValuesIn(fusingParamsSetBF16),
+                       ::testing::Values(cpu_bf16_plugin_config)),
+    GroupConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupConvolution (brgemm_3D) ============= */
+const auto groupConvParams_ExplicitPadding_brgemm_3D = ::testing::Combine(::testing::ValuesIn(kernels_brgemm_3d),
+                                                                          ::testing::ValuesIn(strides_brgemm_3d),
+                                                                          ::testing::ValuesIn(padBegins_brgemm_3d),
+                                                                          ::testing::ValuesIn(padEnds_brgemm_3d),
+                                                                          ::testing::ValuesIn(dilations_brgemm_3d),
+                                                                          ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                          ::testing::ValuesIn(numGroups_brgemm_Blocked),
+                                                                          ::testing::Values(ov::op::PadType::EXPLICIT));
+
+const std::vector<CPUSpecificParams> CPUParams_brgemm_3D_FP32 = {conv_avx512_3D_nspc_brgconv};
+
+const std::vector<CPUSpecificParams> CPUParams_brgemm_3D_BF16 = {conv_avx512_3D_nspc_brgconv,
+                                                                 conv_avx512_3D_nspc_brgconv_amx};
+
+std::vector<InputShape> inputShapes_brgemm_3d = {{{}, {{1, 64, 7, 7, 7}}},
+                                                 {// dynamic shapes
+                                                  {-1, 64, -1, {1, 200}, -1},
+                                                  {// target static shapes
+                                                   {2, 64, 7, 7, 7},
+                                                   {1, 64, 9, 9, 9}}}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_3D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_3D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_3d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_3D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConv_brgemm_3D_BF16,
+    GroupConvolutionLayerCPUTest,
+    ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_3D,
+                                          ::testing::Values(ElementType::f32),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapes_brgemm_3d),
+                                          ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                       ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_3D_BF16)),
+                       ::testing::ValuesIn(fusingParamsSetBF16),
+                       ::testing::Values(cpu_bf16_plugin_config)),
+    GroupConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupConvolution params (brgemm_1x1_1D) ============= */
+const std::vector<std::vector<size_t>> kernels_brgemm_1x1_1d = {{1}};
+const std::vector<std::vector<size_t>> strides_brgemm_1x1_1d = {{1}, {2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_1x1_1d = {{0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_1x1_1d = {{0}};
+const std::vector<std::vector<size_t>> dilations_brgemm_1x1_1d = {{1}, {2}};
+
+/* ============= GroupConvolution params (brgemm_1x1_2D) ============= */
+const std::vector<std::vector<size_t>> kernels_brgemm_1x1_2d = {{1, 1}};
+const std::vector<std::vector<size_t>> strides_brgemm_1x1_2d = {{1, 1}, {2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_1x1_2d = {{0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_1x1_2d = {{0, 0}};
+const std::vector<std::vector<size_t>> dilations_brgemm_1x1_2d = {{1, 1}, {2, 2}};
+
+/* ============= GroupConvolution params (brgemm_1x1_3D) ============= */
+const std::vector<std::vector<size_t>> kernels_brgemm_1x1_3d = {{1, 1, 1}};
+const std::vector<std::vector<size_t>> strides_brgemm_1x1_3d = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<ptrdiff_t>> padBegins_brgemm_1x1_3d = {{0, 0, 0}};
+const std::vector<std::vector<ptrdiff_t>> padEnds_brgemm_1x1_3d = {{0, 0, 0}};
+const std::vector<std::vector<size_t>> dilations_brgemm_1x1_3d = {{1, 1, 1}, {2, 2, 2}};
+/* ============= */
+
+const std::vector<size_t> numGroups_brgemm_1x1_Blocked = {2};
 
 /* ============= GroupConvolution (brgemm_1x1 1D) ============= */
-const auto groupConvParams_ExplicitPadding_brgemm_1x1_1D = ::testing::Combine(
-        ::testing::ValuesIn(kernels_brgemm_1x1_1d),
-        ::testing::ValuesIn(strides_brgemm_1x1_1d),
-        ::testing::ValuesIn(padBegins_brgemm_1x1_1d),
-        ::testing::ValuesIn(padEnds_brgemm_1x1_1d),
-        ::testing::ValuesIn(dilations_brgemm_1x1_1d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_brgemm_1x1_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+const auto groupConvParams_ExplicitPadding_brgemm_1x1_1D =
+    ::testing::Combine(::testing::ValuesIn(kernels_brgemm_1x1_1d),
+                       ::testing::ValuesIn(strides_brgemm_1x1_1d),
+                       ::testing::ValuesIn(padBegins_brgemm_1x1_1d),
+                       ::testing::ValuesIn(padEnds_brgemm_1x1_1d),
+                       ::testing::ValuesIn(dilations_brgemm_1x1_1d),
+                       ::testing::ValuesIn(numOutChannels_Blocked),
+                       ::testing::ValuesIn(numGroups_brgemm_1x1_Blocked),
+                       ::testing::Values(ov::op::PadType::EXPLICIT));
 
 const std::vector<CPUSpecificParams> CPUParams_brgemm_1x1_1D_BF16 = {
-        conv_avx512_1D_1x1_nspc_brgconv,
+    conv_avx512_1D_1x1_nspc_brgconv,
 };
 
 const std::vector<CPUSpecificParams> CPUParams_brgemm_1x1_1D_FP32 = {
-        conv_avx512_1D_1x1_nspc_brgconv,
+    conv_avx512_1D_1x1_nspc_brgconv,
 };
 
-std::vector<InputShape> inputShapes_brgemm_1x1_1d = {
-    {{}, {{ 2, 64, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, {1, 200}},
-        { //target static shapes
-            { 2, 64, 7 },
-            { 1, 64, 9 }
-        }
-    },
-    {
-        //dynamic shapes
-        { {-1, 64, -1} },
-        { //target static shapes
-            { 2, 64, 7 },
-            { 1, 64, 14 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes_brgemm_1x1_1d = {{{}, {{2, 64, 7}}},
+                                                     {// dynamic shapes
+                                                      {-1, 64, {1, 200}},
+                                                      {// target static shapes
+                                                       {2, 64, 7},
+                                                       {1, 64, 9}}},
+                                                     {// dynamic shapes
+                                                      {{-1, 64, -1}},
+                                                      {// target static shapes
+                                                       {2, 64, 7},
+                                                       {1, 64, 14}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_1D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1x1_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1x1_1d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_1D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_1D_FP32_fusingBias, GroupConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         groupConvParams_ExplicitPadding_brgemm_1x1_1D,
-                                         ::testing::Values(ElementType::f32),
-                                         ::testing::Values(ElementType::f32),
-                                         ::testing::Values(ElementType::undefined),
-                                         ::testing::ValuesIn(inputShapes_brgemm_1x1_1d),
-                                         ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_1D_FP32)),
-                                 ::testing::Values(fusingAddPerChannel),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_1D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_1x1_1d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_1D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
                          GroupConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_1D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1x1_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1x1_1d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_1x1_1D_BF16)),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_1D_FP32_fusingBias,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_1x1_1d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_1D_FP32)),
+                                            ::testing::Values(fusingAddPerChannel),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConv_brgemm_1x1_1D_BF16,
+    GroupConvolutionLayerCPUTest,
+    ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_1D,
+                                          ::testing::Values(ElementType::f32),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapes_brgemm_1x1_1d),
+                                          ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                       ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_1x1_1D_BF16)),
+                       ::testing::ValuesIn(fusingParamsSetBF16),
+                       ::testing::Values(cpu_bf16_plugin_config)),
+    GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (brgemm_1x1_2D) ============= */
-const auto groupConvParams_ExplicitPadding_brgemm_1x1_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels_brgemm_1x1_2d),
-        ::testing::ValuesIn(strides_brgemm_1x1_2d),
-        ::testing::ValuesIn(padBegins_brgemm_1x1_2d),
-        ::testing::ValuesIn(padEnds_brgemm_1x1_2d),
-        ::testing::ValuesIn(dilations_brgemm_1x1_2d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_brgemm_1x1_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+const auto groupConvParams_ExplicitPadding_brgemm_1x1_2D =
+    ::testing::Combine(::testing::ValuesIn(kernels_brgemm_1x1_2d),
+                       ::testing::ValuesIn(strides_brgemm_1x1_2d),
+                       ::testing::ValuesIn(padBegins_brgemm_1x1_2d),
+                       ::testing::ValuesIn(padEnds_brgemm_1x1_2d),
+                       ::testing::ValuesIn(dilations_brgemm_1x1_2d),
+                       ::testing::ValuesIn(numOutChannels_Blocked),
+                       ::testing::ValuesIn(numGroups_brgemm_1x1_Blocked),
+                       ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_brgemm_1x1_2D_FP32 = {
-        conv_avx512_2D_1x1_nspc_brgconv
-};
+const std::vector<CPUSpecificParams> CPUParams_brgemm_1x1_2D_FP32 = {conv_avx512_2D_1x1_nspc_brgconv};
 
-const std::vector<CPUSpecificParams> CPUParams_brgemm_1x1_2D_BF16 = {
-        conv_avx512_2D_1x1_nspc_brgconv,
-        conv_avx512_2D_1x1_nspc_brgconv_amx
-};
+const std::vector<CPUSpecificParams> CPUParams_brgemm_1x1_2D_BF16 = {conv_avx512_2D_1x1_nspc_brgconv,
+                                                                     conv_avx512_2D_1x1_nspc_brgconv_amx};
 
-std::vector<InputShape> inputShapes_brgemm_1x1_2d = {
-    {{}, {{ 1, 64, 7, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}},
-        { //target static shapes
-            { 2, 64, 7, 7 },
-            { 1, 64, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes_brgemm_1x1_2d = {{{}, {{1, 64, 7, 7}}},
+                                                     {// dynamic shapes
+                                                      {-1, 64, -1, {1, 200}},
+                                                      {// target static shapes
+                                                       {2, 64, 7, 7},
+                                                       {1, 64, 9, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_2D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1x1_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1x1_2d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_2D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_2D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_1x1_2d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_2D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-std::vector<InputShape> inputShapes_brgemm_1x1_2d_dynBatch = {
-    {
-        //dynamic shapes
-        { {1, 10}, 64, {7, 9}, {7, 9}},
-        { //target static shapes
-            { 2, 64, 7, 7 },
-            { 1, 64, 9, 9 },
-            { 3, 64, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes_brgemm_1x1_2d_dynBatch = {{// dynamic shapes
+                                                               {{1, 10}, 64, {7, 9}, {7, 9}},
+                                                               {// target static shapes
+                                                                {2, 64, 7, 7},
+                                                                {1, 64, 9, 9},
+                                                                {3, 64, 9, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_brgemm_1x1_2D_FP32_dynBatch, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1x1_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1x1_2d_dynBatch),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_2D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_brgemm_1x1_2D_FP32_dynBatch,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_1x1_2d_dynBatch),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_2D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-std::vector<InputShape> inputShapes_brgemm_1x1_2d_cache = {
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}},
-        { //target static shapes
-            { 1, 64, 7, 7 },
-            { 1, 64, 9, 9 },
-            { 1, 64, 7, 7 },
-        }
-    }
-};
+std::vector<InputShape> inputShapes_brgemm_1x1_2d_cache = {{// dynamic shapes
+                                                            {-1, 64, -1, {1, 200}},
+                                                            {
+                                                                // target static shapes
+                                                                {1, 64, 7, 7},
+                                                                {1, 64, 9, 9},
+                                                                {1, 64, 7, 7},
+                                                            }}};
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_brgemm_1x1_2D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1x1_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1x1_2d_cache),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_2D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_brgemm_1x1_2D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_1x1_2d_cache),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_2D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_2D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1x1_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1x1_2d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_1x1_2D_BF16)),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConv_brgemm_1x1_2D_BF16,
+    GroupConvolutionLayerCPUTest,
+    ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_2D,
+                                          ::testing::Values(ElementType::f32),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapes_brgemm_1x1_2d),
+                                          ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                       ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_1x1_2D_BF16)),
+                       ::testing::ValuesIn(fusingParamsSetBF16),
+                       ::testing::Values(cpu_bf16_plugin_config)),
+    GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (brgemm_1x1_3D) ============= */
-const auto groupConvParams_ExplicitPadding_brgemm_1x1_3D = ::testing::Combine(
-        ::testing::ValuesIn(kernels_brgemm_1x1_3d),
-        ::testing::ValuesIn(strides_brgemm_1x1_3d),
-        ::testing::ValuesIn(padBegins_brgemm_1x1_3d),
-        ::testing::ValuesIn(padEnds_brgemm_1x1_3d),
-        ::testing::ValuesIn(dilations_brgemm_1x1_3d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_brgemm_1x1_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-
+const auto groupConvParams_ExplicitPadding_brgemm_1x1_3D =
+    ::testing::Combine(::testing::ValuesIn(kernels_brgemm_1x1_3d),
+                       ::testing::ValuesIn(strides_brgemm_1x1_3d),
+                       ::testing::ValuesIn(padBegins_brgemm_1x1_3d),
+                       ::testing::ValuesIn(padEnds_brgemm_1x1_3d),
+                       ::testing::ValuesIn(dilations_brgemm_1x1_3d),
+                       ::testing::ValuesIn(numOutChannels_Blocked),
+                       ::testing::ValuesIn(numGroups_brgemm_1x1_Blocked),
+                       ::testing::Values(ov::op::PadType::EXPLICIT));
 
 const std::vector<CPUSpecificParams> CPUParams_brgemm_1x1_3D_FP32 = {
-        conv_avx512_3D_1x1_nspc_brgconv,
+    conv_avx512_3D_1x1_nspc_brgconv,
 };
 
 const std::vector<CPUSpecificParams> CPUParams_brgemm_1x1_3D_BF16 = {
-        conv_avx512_3D_1x1_nspc_brgconv,
-        conv_avx512_3D_1x1_nspc_brgconv_amx,
+    conv_avx512_3D_1x1_nspc_brgconv,
+    conv_avx512_3D_1x1_nspc_brgconv_amx,
 };
 
-std::vector<InputShape> inputShapes_brgemm_1x1_3d = {
-    {{}, {{ 1, 64, 7, 7, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}, -1},
-        { //target static shapes
-            { 2, 64, 7, 7, 7 },
-            { 1, 64, 9, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes_brgemm_1x1_3d = {{{}, {{1, 64, 7, 7, 7}}},
+                                                     {// dynamic shapes
+                                                      {-1, 64, -1, {1, 200}, -1},
+                                                      {// target static shapes
+                                                       {2, 64, 7, 7, 7},
+                                                       {1, 64, 9, 9, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_3D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1x1_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1x1_3d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_3D_FP32)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_3D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_brgemm_1x1_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes_brgemm_1x1_3d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_1x1_3D_BF16)),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-
-
-/* ============= GroupConvolution (1D) ============= */
-const auto groupConvParams_ExplicitPadding_1D = ::testing::Combine(
-        ::testing::ValuesIn(kernels1d),
-        ::testing::ValuesIn(strides1d),
-        ::testing::ValuesIn(padBegins1d),
-        ::testing::ValuesIn(padEnds1d),
-        ::testing::ValuesIn(dilations1d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
-
-const std::vector<CPUSpecificParams> CPUParams_1D = {
-        conv_sse42_1D,
-        conv_avx2_1D,
-        conv_avx512_1D,
-        conv_sse42_1D_nspc,
-        conv_avx2_1D_nspc,
-        conv_avx512_1D_nspc
-};
-
-std::vector<InputShape> inputShapes1d = {
-    {{}, {{ 2, 64, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, {1, 200}},
-        { //target static shapes
-            { 2, 64, 7 },
-            { 1, 64, 9 }
-        }
-    },
-    {
-        //dynamic shapes
-        { {-1, 64, -1} },
-        { //target static shapes
-            { 2, 64, 7 },
-            { 1, 64, 14 }
-        }
-    }
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes1d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_FP32_fusingBias, GroupConvolutionLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Combine(
-                                         groupConvParams_ExplicitPadding_1D,
-                                         ::testing::Values(ElementType::f32),
-                                         ::testing::Values(ElementType::f32),
-                                         ::testing::Values(ElementType::undefined),
-                                         ::testing::ValuesIn(inputShapes1d),
-                                         ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                 ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1D)),
-                                 ::testing::Values(fusingAddPerChannel),
-                                 ::testing::Values(cpuEmptyPluginConfig)),
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_brgemm_1x1_3D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_3D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes_brgemm_1x1_3d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_brgemm_1x1_3D_FP32)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
                          GroupConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes1d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_1D})), // todo: [AV] what about conv_avx512_1D_nspc?
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConv_brgemm_1x1_3D_BF16,
+    GroupConvolutionLayerCPUTest,
+    ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_brgemm_1x1_3D,
+                                          ::testing::Values(ElementType::f32),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::Values(ElementType::undefined),
+                                          ::testing::ValuesIn(inputShapes_brgemm_1x1_3d),
+                                          ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                       ::testing::ValuesIn(filterCPUInfoForDeviceSupportBF16(CPUParams_brgemm_1x1_3D_BF16)),
+                       ::testing::ValuesIn(fusingParamsSetBF16),
+                       ::testing::Values(cpu_bf16_plugin_config)),
+    GroupConvolutionLayerCPUTest::getTestCaseName);
+
+/* ============= GroupConvolution (1D) ============= */
+const auto groupConvParams_ExplicitPadding_1D = ::testing::Combine(::testing::ValuesIn(kernels1d),
+                                                                   ::testing::ValuesIn(strides1d),
+                                                                   ::testing::ValuesIn(padBegins1d),
+                                                                   ::testing::ValuesIn(padEnds1d),
+                                                                   ::testing::ValuesIn(dilations1d),
+                                                                   ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                   ::testing::ValuesIn(numGroups_Blocked),
+                                                                   ::testing::Values(ov::op::PadType::EXPLICIT));
+
+const std::vector<CPUSpecificParams> CPUParams_1D =
+    {conv_sse42_1D, conv_avx2_1D, conv_avx512_1D, conv_sse42_1D_nspc, conv_avx2_1D_nspc, conv_avx512_1D_nspc};
+
+std::vector<InputShape> inputShapes1d = {{{}, {{2, 64, 7}}},
+                                         {// dynamic shapes
+                                          {-1, 64, {1, 200}},
+                                          {// target static shapes
+                                           {2, 64, 7},
+                                           {1, 64, 9}}},
+                                         {// dynamic shapes
+                                          {{-1, 64, -1}},
+                                          {// target static shapes
+                                           {2, 64, 7},
+                                           {1, 64, 14}}}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes1d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_FP32_fusingBias,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes1d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_1D)),
+                                            ::testing::Values(fusingAddPerChannel),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_BF16,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes1d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(
+                                                {conv_avx512_1D})),  // todo: [AV] what about conv_avx512_1D_nspc?
+                                            ::testing::ValuesIn(fusingParamsSetBF16),
+                                            ::testing::Values(cpu_bf16_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (2D) ============= */
-const auto groupConvParams_ExplicitPadding_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn(strides2d),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+const auto groupConvParams_ExplicitPadding_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                   ::testing::ValuesIn(strides2d),
+                                                                   ::testing::ValuesIn(padBegins2d),
+                                                                   ::testing::ValuesIn(padEnds2d),
+                                                                   ::testing::ValuesIn(dilations2d),
+                                                                   ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                   ::testing::ValuesIn(numGroups_Blocked),
+                                                                   ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_2D = {
-        conv_sse42_2D,
-        conv_avx2_2D,
-        conv_avx512_2D,
-        conv_sse42_2D_nspc,
-        conv_avx2_2D_nspc,
-        conv_avx512_2D_nspc
-};
+const std::vector<CPUSpecificParams> CPUParams_2D =
+    {conv_sse42_2D, conv_avx2_2D, conv_avx512_2D, conv_sse42_2D_nspc, conv_avx2_2D_nspc, conv_avx512_2D_nspc};
 
-std::vector<InputShape> inputShapes2d = {
-    {{}, {{ 1, 64, 7, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}},
-        { //target static shapes
-            { 2, 64, 7, 7 },
-            { 1, 64, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes2d = {{{}, {{1, 64, 7, 7}}},
+                                         {// dynamic shapes
+                                          {-1, 64, -1, {1, 200}},
+                                          {// target static shapes
+                                           {2, 64, 7, 7},
+                                           {1, 64, 9, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes2d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes2d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-std::vector<InputShape> inputShapes2d_dynBatch = {
-    {
-        //dynamic shapes
-        { {1, 10}, 64, {7, 9}, {7, 9}},
-        { //target static shapes
-            { 2, 64, 7, 7 },
-            { 1, 64, 9, 9 },
-            { 3, 64, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes2d_dynBatch = {{// dynamic shapes
+                                                   {{1, 10}, 64, {7, 9}, {7, 9}},
+                                                   {// target static shapes
+                                                    {2, 64, 7, 7},
+                                                    {1, 64, 9, 9},
+                                                    {3, 64, 9, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_2D_FP32_dynBatch, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes2d_dynBatch),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_2D_FP32_dynBatch,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes2d_dynBatch),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-std::vector<InputShape> inputShapes2d_cache = {
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}},
-        { //target static shapes
-            { 1, 64, 7, 7 },
-            { 1, 64, 9, 9 },
-            { 1, 64, 7, 7 },
-        }
-    }
-};
+std::vector<InputShape> inputShapes2d_cache = {{// dynamic shapes
+                                                {-1, 64, -1, {1, 200}},
+                                                {
+                                                    // target static shapes
+                                                    {1, 64, 7, 7},
+                                                    {1, 64, 9, 9},
+                                                    {1, 64, 7, 7},
+                                                }}};
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_2D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes2d_cache),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupConv_2D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes2d_cache),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_2D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes2d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx512_2D_nspc})),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_BF16,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes2d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D,
+                                                                                        conv_avx512_2D_nspc})),
+                                            ::testing::ValuesIn(fusingParamsSetBF16),
+                                            ::testing::Values(cpu_bf16_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (3D) ============= */
-const auto groupConvParams_ExplicitPadding_3D = ::testing::Combine(
-        ::testing::ValuesIn(kernels3d),
-        ::testing::ValuesIn(strides3d),
-        ::testing::ValuesIn(padBegins3d),
-        ::testing::ValuesIn(padEnds3d),
-        ::testing::ValuesIn(dilations3d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+const auto groupConvParams_ExplicitPadding_3D = ::testing::Combine(::testing::ValuesIn(kernels3d),
+                                                                   ::testing::ValuesIn(strides3d),
+                                                                   ::testing::ValuesIn(padBegins3d),
+                                                                   ::testing::ValuesIn(padEnds3d),
+                                                                   ::testing::ValuesIn(dilations3d),
+                                                                   ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                   ::testing::ValuesIn(numGroups_Blocked),
+                                                                   ::testing::Values(ov::op::PadType::EXPLICIT));
 
 const std::vector<CPUSpecificParams> CPUParams_3D = {
-//        conv_sse42_3D, // not supported jit_sse42 for 3d
-        conv_avx2_3D,
-        conv_avx512_3D,
-        conv_avx2_3D_nspc,
-        conv_avx512_3D_nspc
-};
+    //        conv_sse42_3D, // not supported jit_sse42 for 3d
+    conv_avx2_3D,
+    conv_avx512_3D,
+    conv_avx2_3D_nspc,
+    conv_avx512_3D_nspc};
 
-std::vector<InputShape> inputShapes3d = {
-    {{}, {{ 1, 64, 7, 7, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 64, -1, {1, 200}, -1},
-        { //target static shapes
-            { 2, 64, 7, 7, 7 },
-            { 1, 64, 9, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes3d = {{{}, {{1, 64, 7, 7, 7}}},
+                                         {// dynamic shapes
+                                          {-1, 64, -1, {1, 200}, -1},
+                                          {// target static shapes
+                                           {2, 64, 7, 7, 7},
+                                           {1, 64, 9, 9, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes3d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_3D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes3d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_3D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes3d),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D, conv_avx512_3D_nspc})),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_BF16,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_3D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes3d),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D,
+                                                                                        conv_avx512_3D_nspc})),
+                                            ::testing::ValuesIn(fusingParamsSetBF16),
+                                            ::testing::Values(cpu_bf16_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (DW 1D) ============= */
-const auto groupConvParams_ExplicitPadding_DW_1D = ::testing::Combine(
-        ::testing::ValuesIn(kernels1d),
-        ::testing::ValuesIn(strides1d),
-        ::testing::ValuesIn(padBegins1d),
-        ::testing::ValuesIn(padEnds1d),
-        ::testing::ValuesIn(dilations1d),
-        ::testing::ValuesIn(numOutChannels_DW),
-        ::testing::ValuesIn(numGroups_DW),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+const auto groupConvParams_ExplicitPadding_DW_1D = ::testing::Combine(::testing::ValuesIn(kernels1d),
+                                                                      ::testing::ValuesIn(strides1d),
+                                                                      ::testing::ValuesIn(padBegins1d),
+                                                                      ::testing::ValuesIn(padEnds1d),
+                                                                      ::testing::ValuesIn(dilations1d),
+                                                                      ::testing::ValuesIn(numOutChannels_DW),
+                                                                      ::testing::ValuesIn(numGroups_DW),
+                                                                      ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_DW_1D = {
-        conv_sse42_dw_1D,
-        conv_avx2_dw_1D,
-        conv_avx512_dw_1D,
-        conv_sse42_dw_1D_nspc,
-        conv_avx2_dw_1D_nspc,
-        conv_avx512_dw_1D_nspc
-};
+const std::vector<CPUSpecificParams> CPUParams_DW_1D = {conv_sse42_dw_1D,
+                                                        conv_avx2_dw_1D,
+                                                        conv_avx512_dw_1D,
+                                                        conv_sse42_dw_1D_nspc,
+                                                        conv_avx2_dw_1D_nspc,
+                                                        conv_avx512_dw_1D_nspc};
 
-std::vector<InputShape> inputShapes1dDW = {
-    {{}, {{ 2, 32, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 32, {1, 200}},
-        { //target static shapes
-            { 2, 32, 7 },
-            { 1, 32, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes1dDW = {{{}, {{2, 32, 7}}},
+                                           {// dynamic shapes
+                                            {-1, 32, {1, 200}},
+                                            {// target static shapes
+                                             {2, 32, 7},
+                                             {1, 32, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_DW_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_DW_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes1dDW),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice({conv_sse42_dw_1D,
-                                                                           conv_avx2_dw_1D,
-                                                                           conv_avx512_dw_1D})), // todo: [AV] what about conv_sse42_dw_1D_nspc,
-                                                                                                 //  conv_avx2_dw_1D_nspc, conv_avx512_dw_1D_nspc?
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    smoke_GroupConv_1D_DW_FP32,
+    GroupConvolutionLayerCPUTest,
+    ::testing::Combine(
+        ::testing::Combine(groupConvParams_ExplicitPadding_DW_1D,
+                           ::testing::Values(ElementType::f32),
+                           ::testing::Values(ElementType::undefined),
+                           ::testing::Values(ElementType::undefined),
+                           ::testing::ValuesIn(inputShapes1dDW),
+                           ::testing::Values(ov::test::utils::DEVICE_CPU)),
+        ::testing::ValuesIn(filterCPUInfoForDevice(
+            {conv_sse42_dw_1D, conv_avx2_dw_1D, conv_avx512_dw_1D})),  // todo: [AV] what about conv_sse42_dw_1D_nspc,
+                                                                       //  conv_avx2_dw_1D_nspc, conv_avx512_dw_1D_nspc?
+        ::testing::ValuesIn(fusingParamsSet),
+        ::testing::Values(empty_plugin_config)),
+    GroupConvolutionLayerCPUTest::getTestCaseName);
 
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_DW_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_DW_1D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes1dDW),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_1D})), // todo: [AV] what about conv_avx512_dw_1D_nspc?
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_1D_DW_BF16,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_DW_1D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes1dDW),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(
+                                                {conv_avx512_dw_1D})),  // todo: [AV] what about conv_avx512_dw_1D_nspc?
+                                            ::testing::ValuesIn(fusingParamsSetBF16),
+                                            ::testing::Values(cpu_bf16_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (DW 2D) ============= */
-const auto groupConvParams_ExplicitPadding_DW_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn(strides2d),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_DW),
-        ::testing::ValuesIn(numGroups_DW),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+const auto groupConvParams_ExplicitPadding_DW_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                      ::testing::ValuesIn(strides2d),
+                                                                      ::testing::ValuesIn(padBegins2d),
+                                                                      ::testing::ValuesIn(padEnds2d),
+                                                                      ::testing::ValuesIn(dilations2d),
+                                                                      ::testing::ValuesIn(numOutChannels_DW),
+                                                                      ::testing::ValuesIn(numGroups_DW),
+                                                                      ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_DW_2D = {
-        conv_sse42_dw_2D,
-        conv_avx2_dw_2D,
-        conv_avx512_dw_2D,
-        conv_sse42_dw_2D_nspc,
-        conv_avx2_dw_2D_nspc,
-        conv_avx512_dw_2D_nspc
-};
+const std::vector<CPUSpecificParams> CPUParams_DW_2D = {conv_sse42_dw_2D,
+                                                        conv_avx2_dw_2D,
+                                                        conv_avx512_dw_2D,
+                                                        conv_sse42_dw_2D_nspc,
+                                                        conv_avx2_dw_2D_nspc,
+                                                        conv_avx512_dw_2D_nspc};
 
-std::vector<InputShape> inputShapes2dDW = {
-    {{}, {{ 2, 32, 7, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 32, -1, {1, 200}},
-        { //target static shapes
-            { 2, 32, 7, 7 },
-            { 1, 32, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes2dDW = {{{}, {{2, 32, 7, 7}}},
+                                           {// dynamic shapes
+                                            {-1, 32, -1, {1, 200}},
+                                            {// target static shapes
+                                             {2, 32, 7, 7},
+                                             {1, 32, 9, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_DW_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_DW_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes2dDW),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_DW_2D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_DW_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_DW_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes2dDW),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_DW_2D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
-
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_DW_BF16, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_DW_2D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes2dDW),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D, conv_avx512_dw_2D_nspc})),
-                                ::testing::ValuesIn(fusingParamsSetBF16),
-                                ::testing::Values(cpuBF16PluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_2D_DW_BF16,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_DW_2D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes2dDW),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D,
+                                                                                        conv_avx512_dw_2D_nspc})),
+                                            ::testing::ValuesIn(fusingParamsSetBF16),
+                                            ::testing::Values(cpu_bf16_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (DW 3D) ============= */
-const auto groupConvParams_ExplicitPadding_DW_3D = ::testing::Combine(
-        ::testing::ValuesIn(kernels3d),
-        ::testing::ValuesIn(strides3d),
-        ::testing::ValuesIn(padBegins3d),
-        ::testing::ValuesIn(padEnds3d),
-        ::testing::ValuesIn(dilations3d),
-        ::testing::ValuesIn(numOutChannels_DW),
-        ::testing::ValuesIn(numGroups_DW),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT)
-);
+const auto groupConvParams_ExplicitPadding_DW_3D = ::testing::Combine(::testing::ValuesIn(kernels3d),
+                                                                      ::testing::ValuesIn(strides3d),
+                                                                      ::testing::ValuesIn(padBegins3d),
+                                                                      ::testing::ValuesIn(padEnds3d),
+                                                                      ::testing::ValuesIn(dilations3d),
+                                                                      ::testing::ValuesIn(numOutChannels_DW),
+                                                                      ::testing::ValuesIn(numGroups_DW),
+                                                                      ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_DW_3D = {
-        conv_sse42_dw_3D,
-        conv_avx2_dw_3D,
-        conv_avx512_dw_3D,
-        conv_sse42_dw_3D_nspc,
-        conv_avx2_dw_3D_nspc,
-        conv_avx512_dw_3D_nspc
-};
+const std::vector<CPUSpecificParams> CPUParams_DW_3D = {conv_sse42_dw_3D,
+                                                        conv_avx2_dw_3D,
+                                                        conv_avx512_dw_3D,
+                                                        conv_sse42_dw_3D_nspc,
+                                                        conv_avx2_dw_3D_nspc,
+                                                        conv_avx512_dw_3D_nspc};
 
-std::vector<InputShape> inputShapes3dDW = {
-    {{}, {{ 2, 32, 7, 7, 7 }}},
-    {
-        //dynamic shapes
-        {-1, 32, -1, {1, 200}, -1},
-        { //target static shapes
-            { 2, 32, 7, 7, 7 },
-            { 1, 32, 9, 9, 9 }
-        }
-    }
-};
+std::vector<InputShape> inputShapes3dDW = {{{}, {{2, 32, 7, 7, 7}}},
+                                           {// dynamic shapes
+                                            {-1, 32, -1, {1, 200}, -1},
+                                            {// target static shapes
+                                             {2, 32, 7, 7, 7},
+                                             {1, 32, 9, 9, 9}}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_DW_FP32, GroupConvolutionLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Combine(
-                                        groupConvParams_ExplicitPadding_DW_3D,
-                                        ::testing::Values(ElementType::f32),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::Values(ElementType::undefined),
-                                        ::testing::ValuesIn(inputShapes3dDW),
-                                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
-                                ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_DW_3D)),
-                                ::testing::ValuesIn(fusingParamsSet),
-                                ::testing::Values(cpuEmptyPluginConfig)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupConv_3D_DW_FP32,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::Combine(::testing::Combine(groupConvParams_ExplicitPadding_DW_3D,
+                                                               ::testing::Values(ElementType::f32),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::Values(ElementType::undefined),
+                                                               ::testing::ValuesIn(inputShapes3dDW),
+                                                               ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice(CPUParams_DW_3D)),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::Values(empty_plugin_config)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 /* ========= */
-
 
 /* ============= SINGLE TEST CASES ============= */
 using VecFusingParams = std::vector<fusingSpecificParams>;
-using ConfigRelatedParams = std::tuple<Config,  VecFusingParams>; // Plugin config FusingParamsSet
+using ConfigRelatedParams = std::tuple<ov::AnyMap, VecFusingParams>;  // Plugin config FusingParamsSet
 using VecConfigRelatedParams = std::vector<ConfigRelatedParams>;
 
-std::vector<groupConvLayerCPUTestParamsSet> makeSingleGroupConvCPUTestCases(SizeVector kernels, SizeVector strides, SizeVector dilations,
-                                                                            std::vector<ptrdiff_t> padBegins, std::vector<ptrdiff_t> padEnds,
-                                                                            ngraph::op::PadType padType, int groups, int mb, SizeVector spDims,
-                                                                            int inGroupSize, int outGroupSize,
-                                                                            const std::vector<CPUSpecificParams>& CPUParams,
-                                                                            const VecConfigRelatedParams& vecConfigRelatedParams) {
+std::vector<groupConvLayerCPUTestParamsSet> makeSingleGroupConvCPUTestCases(
+    std::vector<size_t> kernels,
+    std::vector<size_t> strides,
+    std::vector<size_t> dilations,
+    std::vector<ptrdiff_t> padBegins,
+    std::vector<ptrdiff_t> padEnds,
+    ov::op::PadType padType,
+    int groups,
+    int mb,
+    std::vector<size_t> spDims,
+    int inGroupSize,
+    int outGroupSize,
+    const std::vector<CPUSpecificParams>& CPUParams,
+    const VecConfigRelatedParams& vecConfigRelatedParams) {
     int inChannels = groups * inGroupSize;
     int outChannels = groups * outGroupSize;
 
     InputShape inputShapes;
-    SizeVector targetShape;
+    std::vector<size_t> targetShape;
     targetShape.push_back(mb);
     targetShape.push_back(inChannels);
     targetShape.insert(targetShape.end(), spDims.begin(), spDims.end());
     inputShapes.second.push_back({targetShape});
 
-    groupConvSpecificParams specificParams(kernels, strides, padBegins, padEnds, dilations, outChannels, groups, padType);
+    groupConvSpecificParams
+        specificParams(kernels, strides, padBegins, padEnds, dilations, outChannels, groups, padType);
     std::vector<groupConvLayerCPUTestParamsSet> retVector;
 
     for (auto& configRelatedParams : vecConfigRelatedParams) {
         VecFusingParams fusingParams;
-        Config config;
+        ov::AnyMap config;
         std::tie(config, fusingParams) = configRelatedParams;
 
-        groupConvLayerTestParamsSet basicParamsSet(specificParams, ElementType::f32, ElementType::undefined, ElementType::undefined,
-                                                   inputShapes, ov::test::utils::DEVICE_CPU);
+        groupConvLayerTestParamsSet basicParamsSet(specificParams,
+                                                   ElementType::f32,
+                                                   ElementType::undefined,
+                                                   ElementType::undefined,
+                                                   inputShapes,
+                                                   ov::test::utils::DEVICE_CPU);
 
-        for (auto &item : CPUParams) {
-            for (auto &fusingParam : fusingParams) {
+        for (auto& item : CPUParams) {
+            for (auto& fusingParam : fusingParams) {
                 retVector.push_back(groupConvLayerCPUTestParamsSet(basicParamsSet, item, fusingParam, config));
             }
         }
     }
-    return  retVector;
+    return retVector;
 }
 
-template<typename T>
+template <typename T>
 void concatTestCases(std::vector<groupConvLayerCPUTestParamsSet>& resultVec, T tesCase) {
-    resultVec.insert(resultVec.begin(), std::make_move_iterator(tesCase.begin()), std::make_move_iterator(tesCase.end()));
+    resultVec.insert(resultVec.begin(),
+                     std::make_move_iterator(tesCase.begin()),
+                     std::make_move_iterator(tesCase.end()));
 }
 
-template<typename T, typename... Args>
+template <typename T, typename... Args>
 void concatTestCases(std::vector<groupConvLayerCPUTestParamsSet>& resultVec, T&& tesCase, Args&&... args) {
     concatTestCases(resultVec, std::forward<T>(tesCase));
     concatTestCases(resultVec, std::forward<Args>(args)...);
 }
 
-template<typename... Args>
+template <typename... Args>
 std::vector<groupConvLayerCPUTestParamsSet> generateSingleGroupConvCPUTestCases(Args&&... args) {
     std::vector<groupConvLayerCPUTestParamsSet> retVec;
     concatTestCases(retVec, std::forward<Args>(args)...);
@@ -1625,287 +1421,960 @@ std::vector<groupConvLayerCPUTestParamsSet> generateSingleGroupConvCPUTestCases(
 
 /* COMMON PARAMS */
 
-const VecConfigRelatedParams vecPrcConnectParamsFP32 = {ConfigRelatedParams{cpuEmptyPluginConfig, fusingParamsSet}};
-const VecConfigRelatedParams vecPrcConnectParams = {ConfigRelatedParams{cpuEmptyPluginConfig, fusingParamsSet},
-                                                   ConfigRelatedParams{cpuBF16PluginConfig, fusingParamsSetBF16}};
-const VecConfigRelatedParams vecPrcConnectParamsBF16 = {ConfigRelatedParams{cpuBF16PluginConfig, fusingParamsSetBF16}};
+const VecConfigRelatedParams vecPrcConnectParamsFP32 = {ConfigRelatedParams{empty_plugin_config, fusingParamsSet}};
+const VecConfigRelatedParams vecPrcConnectParams = {ConfigRelatedParams{empty_plugin_config, fusingParamsSet},
+                                                    ConfigRelatedParams{cpu_bf16_plugin_config, fusingParamsSetBF16}};
+const VecConfigRelatedParams vecPrcConnectParamsBF16 = {
+    ConfigRelatedParams{cpu_bf16_plugin_config, fusingParamsSetBF16}};
 
-const VecConfigRelatedParams vecPrcConnectParamsFP32Default = {ConfigRelatedParams{cpuEmptyPluginConfig, VecFusingParams{emptyFusingSpec}}};
-const VecConfigRelatedParams vecPrcConnectParamsDefault = {ConfigRelatedParams{cpuEmptyPluginConfig, VecFusingParams{emptyFusingSpec}},
-                                                          ConfigRelatedParams{cpuBF16PluginConfig, VecFusingParams{emptyFusingSpec}}};
+const VecConfigRelatedParams vecPrcConnectParamsFP32Default = {
+    ConfigRelatedParams{empty_plugin_config, VecFusingParams{emptyFusingSpec}}};
+const VecConfigRelatedParams vecPrcConnectParamsDefault = {
+    ConfigRelatedParams{empty_plugin_config, VecFusingParams{emptyFusingSpec}},
+    ConfigRelatedParams{cpu_bf16_plugin_config, VecFusingParams{emptyFusingSpec}}};
 
 /* ============= GEMM GroupConvolution ============= */
 const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = generateSingleGroupConvCPUTestCases(
-        //  1. is_depthwise (true, false)
-        //  2. jcp.im2col_sz (=0,>0)
-        //  3. is_blocking_applicable (true, false)
+    //  1. is_depthwise (true, false)
+    //  2. jcp.im2col_sz (=0,>0)
+    //  3. is_blocking_applicable (true, false)
 
-        //  is_depthwise == false, im2col_sz > 0
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D, vecPrcConnectParams),
-        //  is_depthwise == true
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID, 2, 1, {5, 5}, 1, 1,
-                                        CPUParams_Gemm_2D, vecPrcConnectParams),
-        //  im2col_sz == 0, is_blocking_applicable == true
-        makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 2, 2, CPUParams_Gemm_2D, vecPrcConnectParams),
-        //  is_blocking_applicable == false ((jcp.im2col_sz == 0) && (jcp.ic / jcp.oc >= 42))
-        makeSingleGroupConvCPUTestCases({1, 1}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 42, 1, CPUParams_Gemm_2D, vecPrcConnectParams),
+    //  is_depthwise == false, im2col_sz > 0
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    2,
+                                    2,
+                                    CPUParams_Gemm_2D,
+                                    vecPrcConnectParams),
+    //  is_depthwise == true
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    1,
+                                    1,
+                                    CPUParams_Gemm_2D,
+                                    vecPrcConnectParams),
+    //  im2col_sz == 0, is_blocking_applicable == true
+    makeSingleGroupConvCPUTestCases({1, 1},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    2,
+                                    2,
+                                    CPUParams_Gemm_2D,
+                                    vecPrcConnectParams),
+    //  is_blocking_applicable == false ((jcp.im2col_sz == 0) && (jcp.ic / jcp.oc >= 42))
+    makeSingleGroupConvCPUTestCases({1, 1},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    42,
+                                    1,
+                                    CPUParams_Gemm_2D,
+                                    vecPrcConnectParams),
 
-        //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {129, 129}, 4, 2, CPUParams_Gemm_2D, vecPrcConnectParamsDefault),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 3, 3, CPUParams_Gemm_2D, vecPrcConnectParamsDefault),
-        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 4, 2, CPUParams_Gemm_3D, vecPrcConnectParamsDefault),
-        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 3, 3, CPUParams_Gemm_3D, vecPrcConnectParams)
-);
+    //  "hard" cases
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {2, 2},
+                                    {1, 1},
+                                    {1, 1},
+                                    {1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    3,
+                                    2,
+                                    {129, 129},
+                                    4,
+                                    2,
+                                    CPUParams_Gemm_2D,
+                                    vecPrcConnectParamsDefault),
+    makeSingleGroupConvCPUTestCases({2, 4},
+                                    {1, 2},
+                                    {3, 2},
+                                    {2, 1},
+                                    {1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    2,
+                                    1,
+                                    {10, 10},
+                                    3,
+                                    3,
+                                    CPUParams_Gemm_2D,
+                                    vecPrcConnectParamsDefault),
+    makeSingleGroupConvCPUTestCases({3, 3, 3},
+                                    {2, 2, 2},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    3,
+                                    2,
+                                    {33, 33, 33},
+                                    4,
+                                    2,
+                                    CPUParams_Gemm_3D,
+                                    vecPrcConnectParamsDefault),
+    makeSingleGroupConvCPUTestCases({2, 3, 4},
+                                    {1, 2, 2},
+                                    {3, 1, 2},
+                                    {2, 2, 1},
+                                    {1, 1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    2,
+                                    1,
+                                    {10, 10, 10},
+                                    3,
+                                    3,
+                                    CPUParams_Gemm_3D,
+                                    vecPrcConnectParams));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GEMM_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GEMM_GroupConv,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT SSE42 GroupConvolution ============= */
 const std::vector<CPUSpecificParams> sse42_GroupConv = {conv_sse42_2D, conv_sse42_2D_nspc};
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
-        //  1. jcp.ur_w (=3,<3)
-        //  2. jcp.ur_w_tail (=0,>0)
-        //  3. jcp.kw (>7,<=7)
-        //  4. jcp.nb_oc = jcp.oc / jcp.oc_block;
-        //  5. jcp.nb_ic = jcp.ic / jcp.ic_block;
-        //  6. ocb_work
+    //  1. jcp.ur_w (=3,<3)
+    //  2. jcp.ur_w_tail (=0,>0)
+    //  3. jcp.kw (>7,<=7)
+    //  4. jcp.nb_oc = jcp.oc / jcp.oc_block;
+    //  5. jcp.nb_ic = jcp.ic / jcp.ic_block;
+    //  6. ocb_work
 
-        //  jcp.ur_w == 3, jcp.ur_w_tail == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
-        //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 4}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
-        //  jcp.ur_w == 3, jcp.ur_w_tail == 0
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 11}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
-        //  jcp.kw > 7
-        makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
-        //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 8, 16, sse42_GroupConv, vecPrcConnectParamsFP32),
-        //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 8, sse42_GroupConv, vecPrcConnectParamsFP32),
-        //  ocb_work > 1 (ocb_work == 2)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 8, 40, sse42_GroupConv, vecPrcConnectParamsFP32),
-        //  jcp.nb_ic == 2, ocb_work == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 40, sse42_GroupConv, vecPrcConnectParamsFP32),
+    //  jcp.ur_w == 3, jcp.ur_w_tail == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 10},
+                                    8,
+                                    8,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 4},
+                                    8,
+                                    8,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ur_w == 3, jcp.ur_w_tail == 0
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 11},
+                                    8,
+                                    8,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.kw > 7
+    makeSingleGroupConvCPUTestCases({3, 8},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 10},
+                                    8,
+                                    8,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.nb_oc == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    8,
+                                    16,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.nb_ic == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    16,
+                                    8,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32),
+    //  ocb_work > 1 (ocb_work == 2)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    8,
+                                    40,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.nb_ic == 2, ocb_work == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    16,
+                                    40,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32),
 
-        //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {129, 129}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 8, 8, sse42_GroupConv, vecPrcConnectParamsFP32Default)
+    //  "hard" cases
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {2, 2},
+                                    {1, 1},
+                                    {1, 1},
+                                    {1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    3,
+                                    2,
+                                    {129, 129},
+                                    8,
+                                    8,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({2, 4},
+                                    {1, 2},
+                                    {3, 2},
+                                    {2, 1},
+                                    {1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    2,
+                                    1,
+                                    {10, 10},
+                                    8,
+                                    8,
+                                    sse42_GroupConv,
+                                    vecPrcConnectParamsFP32Default)
 
-        //  not supported jit_sse42 for 3d
-        //  makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-        //                              3, 2, {33, 33, 33}, 8, 8, cpuParams_sse42_3D),
-        //  makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-        //                              2, 1, {10, 10, 10}, 8, 8, cpuParams_sse42_3D),
+    //  not supported jit_sse42 for 3d
+    //  makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1},
+    //  ov::op::PadType::EXPLICIT,
+    //                              3, 2, {33, 33, 33}, 8, 8, cpuParams_sse42_3D),
+    //  makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0},
+    //  ov::op::PadType::EXPLICIT,
+    //                              2, 1, {10, 10, 10}, 8, 8, cpuParams_sse42_3D),
 );
 
-INSTANTIATE_TEST_SUITE_P(smoke_JIT_SSE42_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_GroupConvTestCases)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_JIT_SSE42_GroupConv,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_GroupConvTestCases)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX2 GroupConvolution ============= */
 const std::vector<CPUSpecificParams> avx2_GroupConv_2D = {conv_avx2_2D, conv_avx2_2D_nspc};
 const std::vector<CPUSpecificParams> avx2_GroupConv_3D = {conv_avx2_3D, conv_avx2_3D_nspc};
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
-        //  1. jcp.ur_w (=3,<3)
-        //  2. jcp.ur_w_tail (=0,>0)
-        //  3. jcp.kw (>7,<=7)
-        //  4. jcp.nb_oc = jcp.oc / jcp.oc_block;
-        //  5. jcp.nb_ic = jcp.ic / jcp.ic_block;
-        //  6. ocb_work
+    //  1. jcp.ur_w (=3,<3)
+    //  2. jcp.ur_w_tail (=0,>0)
+    //  3. jcp.kw (>7,<=7)
+    //  4. jcp.nb_oc = jcp.oc / jcp.oc_block;
+    //  5. jcp.nb_ic = jcp.ic / jcp.ic_block;
+    //  6. ocb_work
 
-        //  jcp.ur_w == 3, jcp.ur_w_tail == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
-        //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 4}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
-        //  jcp.ur_w == 3, jcp.ur_w_tail == 0
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 11}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
-        //  jcp.kw > 7
-        makeSingleGroupConvCPUTestCases({3, 8}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
-        //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 8, 16, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
-        //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
-        //  ocb_work > 1 (ocb_work == 2)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 8, 40, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
-        //  jcp.nb_ic == 2, ocb_work == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 40, avx2_GroupConv_2D, vecPrcConnectParamsFP32),
+    //  jcp.ur_w == 3, jcp.ur_w_tail == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 10},
+                                    8,
+                                    8,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 4},
+                                    8,
+                                    8,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ur_w == 3, jcp.ur_w_tail == 0
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 11},
+                                    8,
+                                    8,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.kw > 7
+    makeSingleGroupConvCPUTestCases({3, 8},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 10},
+                                    8,
+                                    8,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.nb_oc == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    8,
+                                    16,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.nb_ic == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    16,
+                                    8,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32),
+    //  ocb_work > 1 (ocb_work == 2)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    8,
+                                    40,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.nb_ic == 2, ocb_work == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    16,
+                                    40,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32),
 
-        //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {129, 129}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 8, 8, avx2_GroupConv_2D, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 8, 8, avx2_GroupConv_3D, vecPrcConnectParamsFP32)
-);
+    //  "hard" cases
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {2, 2},
+                                    {1, 1},
+                                    {1, 1},
+                                    {1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    3,
+                                    2,
+                                    {129, 129},
+                                    8,
+                                    8,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({2, 4},
+                                    {1, 2},
+                                    {3, 2},
+                                    {2, 1},
+                                    {1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    2,
+                                    1,
+                                    {10, 10},
+                                    8,
+                                    8,
+                                    avx2_GroupConv_2D,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({3, 3, 3},
+                                    {2, 2, 2},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    3,
+                                    2,
+                                    {33, 33, 33},
+                                    8,
+                                    8,
+                                    avx2_GroupConv_3D,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({2, 3, 4},
+                                    {1, 2, 2},
+                                    {3, 1, 2},
+                                    {2, 2, 1},
+                                    {1, 1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    2,
+                                    1,
+                                    {10, 10, 10},
+                                    8,
+                                    8,
+                                    avx2_GroupConv_3D,
+                                    vecPrcConnectParamsFP32));
 
-INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX2_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX2_GroupConv,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_GroupConvTestCases)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX512 GroupConvolution ============= */
 const std::vector<CPUSpecificParams> avx512_GroupConv_2D = {conv_avx512_2D, conv_avx512_2D_nspc};
 const std::vector<CPUSpecificParams> avx512_GroupConv_3D = {conv_avx512_3D, conv_avx512_3D_nspc};
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
-        //  1. "blocked to blocked" or "planar to blocked"
-        //  2. jcp.nb_ic, jcp.nb_oc
+    //  1. "blocked to blocked" or "planar to blocked"
+    //  2. jcp.nb_ic, jcp.nb_oc
 
-        //  blocked to blocked
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 16, avx512_GroupConv_2D, vecPrcConnectParams),
-        //  jcp.nb_ic == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 32, 16, avx512_GroupConv_2D, vecPrcConnectParams),
-        //  jcp.nb_oc == 2
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        2, 1, {5, 5}, 16, 32, avx512_GroupConv_2D, vecPrcConnectParams),
+    //  blocked to blocked
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    16,
+                                    16,
+                                    avx512_GroupConv_2D,
+                                    vecPrcConnectParams),
+    //  jcp.nb_ic == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    32,
+                                    16,
+                                    avx512_GroupConv_2D,
+                                    vecPrcConnectParams),
+    //  jcp.nb_oc == 2
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    2,
+                                    1,
+                                    {5, 5},
+                                    16,
+                                    32,
+                                    avx512_GroupConv_2D,
+                                    vecPrcConnectParams),
 
-        //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 3, 2, {129, 129}, 16, 16,
-                                        avx512_GroupConv_2D, vecPrcConnectParams),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10}, 16, 16, avx512_GroupConv_2D, vecPrcConnectParamsDefault),
-        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        3, 2, {33, 33, 33}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParamsDefault),
-        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        2, 1, {10, 10, 10}, 16, 16, avx512_GroupConv_3D, vecPrcConnectParams)
-);
+    //  "hard" cases
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {2, 2},
+                                    {1, 1},
+                                    {1, 1},
+                                    {1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    3,
+                                    2,
+                                    {129, 129},
+                                    16,
+                                    16,
+                                    avx512_GroupConv_2D,
+                                    vecPrcConnectParams),
+    makeSingleGroupConvCPUTestCases({2, 4},
+                                    {1, 2},
+                                    {3, 2},
+                                    {2, 1},
+                                    {1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    2,
+                                    1,
+                                    {10, 10},
+                                    16,
+                                    16,
+                                    avx512_GroupConv_2D,
+                                    vecPrcConnectParamsDefault),
+    makeSingleGroupConvCPUTestCases({3, 3, 3},
+                                    {2, 2, 2},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    3,
+                                    2,
+                                    {33, 33, 33},
+                                    16,
+                                    16,
+                                    avx512_GroupConv_3D,
+                                    vecPrcConnectParamsDefault),
+    makeSingleGroupConvCPUTestCases({2, 3, 4},
+                                    {1, 2, 2},
+                                    {3, 1, 2},
+                                    {2, 2, 1},
+                                    {1, 1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    2,
+                                    1,
+                                    {10, 10, 10},
+                                    16,
+                                    16,
+                                    avx512_GroupConv_3D,
+                                    vecPrcConnectParams));
 
-INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX512_GroupConv, GroupConvolutionLayerCPUTest,
- ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)),
-                        GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX512_GroupConv,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT SSE42 DW GroupConvolution ============= */
 const std::vector<CPUSpecificParams> sse42_DW_2D = {conv_sse42_dw_2D, conv_sse42_dw_2D_nspc};
 const std::vector<CPUSpecificParams> sse42_DW_3D = {conv_sse42_dw_3D, conv_sse42_dw_3D_nspc};
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
-        //  1. jcp.ngroups % simd_w (=0,!=0)
-        //  2. jcp.nb_ch
-        //  3. jcp.nb_ch_blocking (=2,<2)
-        //  4. jcp.ur_w == 3
+    //  1. jcp.ngroups % simd_w (=0,!=0)
+    //  2. jcp.nb_ch
+    //  3. jcp.nb_ch_blocking (=2,<2)
+    //  4. jcp.ur_w == 3
 
-        //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 5}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32),
-        //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 2, jcp.nb_ch_blocking == 2 (jcp.ngroups == 16)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        16, 1, {5, 5}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32),
-        //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 2 (jcp.ngroups == 17) TODO: pad channels not supported for SSE42
-        //  makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-        //  17, 1, {5, 5}, 1, 1, conv_sse42_DW_2D, vecPrcConnectParamsFP32only),
-        //  jcp.ow > jcp.ur_w (jcp.ow == 7)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 9}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32),
+    //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    8,
+                                    1,
+                                    {5, 5},
+                                    1,
+                                    1,
+                                    sse42_DW_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 2, jcp.nb_ch_blocking == 2 (jcp.ngroups == 16)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    16,
+                                    1,
+                                    {5, 5},
+                                    1,
+                                    1,
+                                    sse42_DW_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 2 (jcp.ngroups == 17) TODO: pad channels not
+    //  supported for SSE42 makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0},
+    //  ov::op::PadType::VALID, 17, 1, {5, 5}, 1, 1, conv_sse42_DW_2D, vecPrcConnectParamsFP32only), jcp.ow > jcp.ur_w
+    //  (jcp.ow == 7)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    8,
+                                    1,
+                                    {5, 9},
+                                    1,
+                                    1,
+                                    sse42_DW_2D,
+                                    vecPrcConnectParamsFP32),
 
-        //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                        sse42_DW_2D, vecPrcConnectParamsFP32),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10}, 1, 1, sse42_DW_2D, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        8, 2, {33, 33, 33}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10, 10}, 1, 1, sse42_DW_3D, vecPrcConnectParamsFP32)
-);
+    //  "hard" cases
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {2, 2},
+                                    {1, 1},
+                                    {1, 1},
+                                    {1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    8,
+                                    2,
+                                    {129, 129},
+                                    1,
+                                    1,
+                                    sse42_DW_2D,
+                                    vecPrcConnectParamsFP32),
+    makeSingleGroupConvCPUTestCases({2, 4},
+                                    {1, 2},
+                                    {3, 2},
+                                    {2, 1},
+                                    {1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    8,
+                                    1,
+                                    {10, 10},
+                                    1,
+                                    1,
+                                    sse42_DW_2D,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({3, 3, 3},
+                                    {2, 2, 2},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    8,
+                                    2,
+                                    {33, 33, 33},
+                                    1,
+                                    1,
+                                    sse42_DW_3D,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({2, 3, 4},
+                                    {1, 2, 2},
+                                    {3, 1, 2},
+                                    {2, 2, 1},
+                                    {1, 1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    8,
+                                    1,
+                                    {10, 10, 10},
+                                    1,
+                                    1,
+                                    sse42_DW_3D,
+                                    vecPrcConnectParamsFP32));
 
-INSTANTIATE_TEST_SUITE_P(smoke_JIT_SSE42_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
-(JIT_SSE42_DW_GroupConvTestCases)), GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_JIT_SSE42_DW_GroupConv,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_DW_GroupConvTestCases)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX2 DW GroupConvolution ============= */
 const std::vector<CPUSpecificParams> avx2_DW_2D = {conv_avx2_dw_2D, conv_avx2_dw_2D_nspc};
 const std::vector<CPUSpecificParams> avx2_DW_3D = {conv_avx2_dw_3D, conv_avx2_dw_3D_nspc};
 const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX2_DW_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
-        //  1. jcp.ngroups % simd_w (=0,!=0)
-        //  2. jcp.nb_ch
-        //  3. jcp.nb_ch_blocking (=3,<3)
-        //  4. jcp.ur_w == 4
+    //  1. jcp.ngroups % simd_w (=0,!=0)
+    //  2. jcp.nb_ch
+    //  3. jcp.nb_ch_blocking (=3,<3)
+    //  4. jcp.ur_w == 4
 
-        //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32),
-        //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 3 (jcp.ngroups == 24)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        24, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32),
-        //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 3 (jcp.ngroups == 25)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        25, 1, {5, 5}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32),
-        //  jcp.ow > jcp.ur_w (jcp.ow == 7)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 9}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32),
+    //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    8,
+                                    1,
+                                    {5, 5},
+                                    1,
+                                    1,
+                                    avx2_DW_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 3 (jcp.ngroups == 24)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    24,
+                                    1,
+                                    {5, 5},
+                                    1,
+                                    1,
+                                    avx2_DW_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 3 (jcp.ngroups == 25)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    25,
+                                    1,
+                                    {5, 5},
+                                    1,
+                                    1,
+                                    avx2_DW_2D,
+                                    vecPrcConnectParamsFP32),
+    //  jcp.ow > jcp.ur_w (jcp.ow == 7)
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {1, 1},
+                                    {1, 1},
+                                    {0, 0},
+                                    {0, 0},
+                                    ov::op::PadType::VALID,
+                                    8,
+                                    1,
+                                    {5, 9},
+                                    1,
+                                    1,
+                                    avx2_DW_2D,
+                                    vecPrcConnectParamsFP32),
 
-        //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 8, 2, {129, 129}, 1, 1,
-                                        avx2_DW_2D, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10}, 1, 1, avx2_DW_2D, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        8, 2, {33, 33, 33}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32Default),
-        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        8, 1, {10, 10, 10}, 1, 1, avx2_DW_3D, vecPrcConnectParamsFP32)
-);
+    //  "hard" cases
+    makeSingleGroupConvCPUTestCases({3, 3},
+                                    {2, 2},
+                                    {1, 1},
+                                    {1, 1},
+                                    {1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    8,
+                                    2,
+                                    {129, 129},
+                                    1,
+                                    1,
+                                    avx2_DW_2D,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({2, 4},
+                                    {1, 2},
+                                    {3, 2},
+                                    {2, 1},
+                                    {1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    8,
+                                    1,
+                                    {10, 10},
+                                    1,
+                                    1,
+                                    avx2_DW_2D,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({3, 3, 3},
+                                    {2, 2, 2},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    {1, 1, 1},
+                                    ov::op::PadType::EXPLICIT,
+                                    8,
+                                    2,
+                                    {33, 33, 33},
+                                    1,
+                                    1,
+                                    avx2_DW_3D,
+                                    vecPrcConnectParamsFP32Default),
+    makeSingleGroupConvCPUTestCases({2, 3, 4},
+                                    {1, 2, 2},
+                                    {3, 1, 2},
+                                    {2, 2, 1},
+                                    {1, 1, 0},
+                                    ov::op::PadType::EXPLICIT,
+                                    8,
+                                    1,
+                                    {10, 10, 10},
+                                    1,
+                                    1,
+                                    avx2_DW_3D,
+                                    vecPrcConnectParamsFP32));
 
-INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX2_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
-(JIT_AVX2_DW_GroupConvTestCases)), GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX2_DW_GroupConv,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX2_DW_GroupConvTestCases)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX512 DW GroupConvolution ============= */
 const std::vector<CPUSpecificParams> avx512_DW_2D = {conv_avx512_dw_2D, conv_avx512_dw_2D_nspc};
 const std::vector<CPUSpecificParams> avx512_DW_3D = {conv_avx512_dw_3D, conv_avx512_dw_3D_nspc};
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
+const std::vector<groupConvLayerCPUTestParamsSet> JIT_AVX512_DW_GroupConvTestCases =
+    generateSingleGroupConvCPUTestCases(
         //  1. jcp.ngroups % simd_w (=0,!=0)
         //  2. jcp.nb_ch
         //  3. jcp.nb_ch_blocking (=4,<4)
         //  4. jcp.ur_w == 6
 
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 16)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        16, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParams),
+        makeSingleGroupConvCPUTestCases({3, 3},
+                                        {1, 1},
+                                        {1, 1},
+                                        {0, 0},
+                                        {0, 0},
+                                        ov::op::PadType::VALID,
+                                        16,
+                                        1,
+                                        {5, 5},
+                                        1,
+                                        1,
+                                        avx512_DW_2D,
+                                        vecPrcConnectParams),
         //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 4, jcp.nb_ch_blocking == 4 (jcp.ngroups == 64)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        64, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParams),
+        makeSingleGroupConvCPUTestCases({3, 3},
+                                        {1, 1},
+                                        {1, 1},
+                                        {0, 0},
+                                        {0, 0},
+                                        ov::op::PadType::VALID,
+                                        64,
+                                        1,
+                                        {5, 5},
+                                        1,
+                                        1,
+                                        avx512_DW_2D,
+                                        vecPrcConnectParams),
         //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 5, jcp.nb_ch_blocking == 4 (jcp.ngroups == 65)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        65, 1, {5, 5}, 1, 1, avx512_DW_2D, vecPrcConnectParams),
+        makeSingleGroupConvCPUTestCases({3, 3},
+                                        {1, 1},
+                                        {1, 1},
+                                        {0, 0},
+                                        {0, 0},
+                                        ov::op::PadType::VALID,
+                                        65,
+                                        1,
+                                        {5, 5},
+                                        1,
+                                        1,
+                                        avx512_DW_2D,
+                                        vecPrcConnectParams),
         //  jcp.ow > jcp.ur_w (jcp.ow == 7)
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::VALID,
-                                        8, 1, {5, 9}, 1, 1, avx512_DW_2D, vecPrcConnectParams),
+        makeSingleGroupConvCPUTestCases({3, 3},
+                                        {1, 1},
+                                        {1, 1},
+                                        {0, 0},
+                                        {0, 0},
+                                        ov::op::PadType::VALID,
+                                        8,
+                                        1,
+                                        {5, 9},
+                                        1,
+                                        1,
+                                        avx512_DW_2D,
+                                        vecPrcConnectParams),
         //  "hard" cases
-        makeSingleGroupConvCPUTestCases({3, 3}, {2, 2}, {1, 1}, {1, 1}, {1, 1}, ngraph::op::PadType::EXPLICIT, 16, 2, {129, 129}, 1, 1,
-                                        avx512_DW_2D, vecPrcConnectParamsDefault),
-        makeSingleGroupConvCPUTestCases({2, 4}, {1, 2}, {3, 2}, {2, 1}, {1, 0}, ngraph::op::PadType::EXPLICIT, 16, 1, {10, 10}, 1, 1,
-                                        avx512_DW_2D, vecPrcConnectParamsDefault),
-        makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, ngraph::op::PadType::EXPLICIT,
-                                        16, 2, {33, 33, 33}, 1, 1, avx512_DW_3D, vecPrcConnectParamsDefault),
-        makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0}, ngraph::op::PadType::EXPLICIT,
-                                        16, 1, {10, 10, 10}, 1, 1, avx512_DW_3D, vecPrcConnectParams)
-);
+        makeSingleGroupConvCPUTestCases({3, 3},
+                                        {2, 2},
+                                        {1, 1},
+                                        {1, 1},
+                                        {1, 1},
+                                        ov::op::PadType::EXPLICIT,
+                                        16,
+                                        2,
+                                        {129, 129},
+                                        1,
+                                        1,
+                                        avx512_DW_2D,
+                                        vecPrcConnectParamsDefault),
+        makeSingleGroupConvCPUTestCases({2, 4},
+                                        {1, 2},
+                                        {3, 2},
+                                        {2, 1},
+                                        {1, 0},
+                                        ov::op::PadType::EXPLICIT,
+                                        16,
+                                        1,
+                                        {10, 10},
+                                        1,
+                                        1,
+                                        avx512_DW_2D,
+                                        vecPrcConnectParamsDefault),
+        makeSingleGroupConvCPUTestCases({3, 3, 3},
+                                        {2, 2, 2},
+                                        {1, 1, 1},
+                                        {1, 1, 1},
+                                        {1, 1, 1},
+                                        ov::op::PadType::EXPLICIT,
+                                        16,
+                                        2,
+                                        {33, 33, 33},
+                                        1,
+                                        1,
+                                        avx512_DW_3D,
+                                        vecPrcConnectParamsDefault),
+        makeSingleGroupConvCPUTestCases({2, 3, 4},
+                                        {1, 2, 2},
+                                        {3, 1, 2},
+                                        {2, 2, 1},
+                                        {1, 1, 0},
+                                        ov::op::PadType::EXPLICIT,
+                                        16,
+                                        1,
+                                        {10, 10, 10},
+                                        1,
+                                        1,
+                                        avx512_DW_3D,
+                                        vecPrcConnectParams));
 
-INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX512_DW_GroupConv, GroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
-(JIT_AVX512_DW_GroupConvTestCases)), GroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX512_DW_GroupConv,
+                         GroupConvolutionLayerCPUTest,
+                         ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_DW_GroupConvTestCases)),
+                         GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT SSE42 1x1 Convolution (not supported with groups) ============= */
 /* ============= JIT AVX2 1x1 Convolution (not supported with groups) ============= */
@@ -1920,24 +2389,48 @@ const std::vector<CPUSpecificParams> CPUParams_Fallback_Brgemm_2D = {
     CPUSpecificParams{{nhwc}, {nhwc}, {/* non-brgconv_avx512_amx is expected */}, "brgconv_avx512_amx"},
 };
 const std::vector<CPUSpecificParams> CPUParams_Fallback_Brgemm_1D_Small_Shape = {
-        CPUSpecificParams{{nwc}, {nwc}, {/* non-brgconv_avx512_amx is expected */}, "brgconv_avx512_amx"}
-};
-const std::vector<groupConvLayerCPUTestParamsSet> BRGEMM_EXPECT_FALLBACK_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
+    CPUSpecificParams{{nwc}, {nwc}, {/* non-brgconv_avx512_amx is expected */}, "brgconv_avx512_amx"}};
+const std::vector<groupConvLayerCPUTestParamsSet> BRGEMM_EXPECT_FALLBACK_GroupConvTestCases =
+    generateSingleGroupConvCPUTestCases(
         // channel <= 16
         // https://github.com/openvinotoolkit/oneDNN/blob/6df930dab5ab0a7dfaea6100acd03b479e2fa0a8/src/cpu/x64/jit_brgemm_conv_utils.cpp#L1712
-        makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0}, ngraph::op::PadType::EXPLICIT,
-                                        4, 1, {5, 5}, 16, 16, CPUParams_Fallback_Brgemm_2D, vecPrcConnectParamsFP32),
+        makeSingleGroupConvCPUTestCases({3, 3},
+                                        {1, 1},
+                                        {1, 1},
+                                        {0, 0},
+                                        {0, 0},
+                                        ov::op::PadType::EXPLICIT,
+                                        4,
+                                        1,
+                                        {5, 5},
+                                        16,
+                                        16,
+                                        CPUParams_Fallback_Brgemm_2D,
+                                        vecPrcConnectParamsFP32),
         // small shape on amx
         //  https://github.com/openvinotoolkit/oneDNN/blob/6df930dab5ab0a7dfaea6100acd03b479e2fa0a8/src/cpu/x64/jit_brgemm_conv_utils.cpp#L1719
-        makeSingleGroupConvCPUTestCases({3}, {1}, {1}, {0}, {0}, ngraph::op::PadType::EXPLICIT,
-                                        4, 1, {3}, 32, 32, CPUParams_Fallback_Brgemm_1D_Small_Shape, vecPrcConnectParamsBF16)
-);
+        makeSingleGroupConvCPUTestCases({3},
+                                        {1},
+                                        {1},
+                                        {0},
+                                        {0},
+                                        ov::op::PadType::EXPLICIT,
+                                        4,
+                                        1,
+                                        {3},
+                                        32,
+                                        32,
+                                        CPUParams_Fallback_Brgemm_1D_Small_Shape,
+                                        vecPrcConnectParamsBF16));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BRGEMM_EXPECT_FALLBACK_GroupConv, ExpectFallbackGroupConvolutionLayerCPUTest, ::testing::ValuesIn(filterParamsSetForDevice
-(BRGEMM_EXPECT_FALLBACK_GroupConvTestCases)), ExpectFallbackGroupConvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_BRGEMM_EXPECT_FALLBACK_GroupConv,
+                         ExpectFallbackGroupConvolutionLayerCPUTest,
+                         ::testing::ValuesIn(filterParamsSetForDevice(BRGEMM_EXPECT_FALLBACK_GroupConvTestCases)),
+                         ExpectFallbackGroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= brgemm GroupConvolution test, expect fallback to other implementation, end ============= */
 
-} // namespace
+}  // namespace
 
-} // namespace CPULayerTestsDefinitions
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "shared_test_classes/single_layer/group_convolution.hpp"
+#include "shared_test_classes/single_op/group_convolution.hpp"
 
 #include "common_test_utils/node_builders/group_convolution.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
@@ -15,7 +15,7 @@ using namespace CPUTestUtils;
 namespace ov {
 namespace test {
 
-using groupConvSpecificParams = LayerTestsDefinitions::groupConvSpecificParams;
+using groupConvSpecificParams = ov::test::groupConvSpecificParams;
 
 typedef std::tuple<groupConvSpecificParams,
                    ElementType,
@@ -23,9 +23,9 @@ typedef std::tuple<groupConvSpecificParams,
                    ElementType,  // Output precision
                    InputShape,   // Input shapes
                    std::string>
-    groupConvLayerTestParamsSet;
+    groupConvLayerTestsParamsSet;
 
-typedef std::tuple<groupConvLayerTestParamsSet, CPUSpecificParams, fusingSpecificParams, ov::AnyMap>
+typedef std::tuple<groupConvLayerTestsParamsSet, CPUSpecificParams, fusingSpecificParams, ov::AnyMap>
     groupConvLayerCPUTestParamsSet;
 
 class GroupConvolutionLayerCPUTest : public testing::WithParamInterface<groupConvLayerCPUTestParamsSet>,
@@ -33,7 +33,7 @@ class GroupConvolutionLayerCPUTest : public testing::WithParamInterface<groupCon
                                      public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvLayerCPUTestParamsSet> obj) {
-        groupConvLayerTestParamsSet basicParamsSet;
+        groupConvLayerTestsParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
         ov::AnyMap additionalConfig;
@@ -156,7 +156,7 @@ protected:
     void SetUp() override {
         rel_threshold = 1e-4f;
 
-        groupConvLayerTestParamsSet basicParamsSet;
+        groupConvLayerTestsParamsSet basicParamsSet;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
         ov::AnyMap additionalConfig;
@@ -1383,12 +1383,12 @@ std::vector<groupConvLayerCPUTestParamsSet> makeSingleGroupConvCPUTestCases(
         ov::AnyMap config;
         std::tie(config, fusingParams) = configRelatedParams;
 
-        groupConvLayerTestParamsSet basicParamsSet(specificParams,
-                                                   ElementType::f32,
-                                                   ElementType::undefined,
-                                                   ElementType::undefined,
-                                                   inputShapes,
-                                                   ov::test::utils::DEVICE_CPU);
+        groupConvLayerTestsParamsSet basicParamsSet(specificParams,
+                                                    ElementType::f32,
+                                                    ElementType::undefined,
+                                                    ElementType::undefined,
+                                                    inputShapes,
+                                                    ov::test::utils::DEVICE_CPU);
 
         for (auto& item : CPUParams) {
             for (auto& fusingParam : fusingParams) {

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution_backprop_data.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "shared_test_classes/single_layer/group_convolution_backprop_data.hpp"
+#include "shared_test_classes/single_op/group_convolution_backprop_data.hpp"
 
 #include "common_test_utils/node_builders/group_convolution_backprop_data.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
@@ -17,7 +17,7 @@ using namespace CPUTestUtils;
 namespace ov {
 namespace test {
 
-using GroupDeconvSpecParams = LayerTestsDefinitions::groupConvBackpropSpecificParams;
+using GroupDeconvSpecParams = ov::test::groupConvBackpropSpecificParams;
 
 using DeconvInputData = std::tuple<InputShape,                          // data shape
                                    ov::test::utils::InputLayerType,     // 'output_shape' input type

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution_backprop_data.cpp
@@ -2,36 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "shared_test_classes/single_layer/group_convolution_backprop_data.hpp"
+
+#include "common_test_utils/node_builders/group_convolution_backprop_data.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/core/preprocess/pre_post_process.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "test_utils/convolution_params.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/filter_cpu_info.hpp"
-#include "test_utils/convolution_params.hpp"
 #include "test_utils/fusing_test_utils.hpp"
-#include "shared_test_classes/base/ov_subgraph.hpp"
-#include <common_test_utils/ov_tensor_utils.hpp>
-#include <shared_test_classes/single_layer/group_convolution_backprop_data.hpp>
-#include "openvino/core/preprocess/pre_post_process.hpp"
-#include "common_test_utils/node_builders/group_convolution_backprop_data.hpp"
 
 using namespace CPUTestUtils;
-using namespace ov::test;
-
-namespace CPULayerTestsDefinitions {
+namespace ov {
+namespace test {
 
 using GroupDeconvSpecParams = LayerTestsDefinitions::groupConvBackpropSpecificParams;
 
-using DeconvInputData = std::tuple<InputShape,                           // data shape
-                                   ngraph::helpers::InputLayerType,      // 'output_shape' input type
-                                   std::vector<std::vector<int32_t>>>;   // values for 'output_shape'
+using DeconvInputData = std::tuple<InputShape,                          // data shape
+                                   ov::test::utils::InputLayerType,     // 'output_shape' input type
+                                   std::vector<std::vector<int32_t>>>;  // values for 'output_shape'
 
-using GroupDeconvLayerCPUTestParamsSet = std::tuple<GroupDeconvSpecParams,
-                                                    DeconvInputData,
-                                                    ElementType,
-                                                    fusingSpecificParams,
-                                                    CPUSpecificParams,
-                                                    std::map<std::string, std::string>>;
+using GroupDeconvLayerCPUTestParamsSet = std::
+    tuple<GroupDeconvSpecParams, DeconvInputData, ElementType, fusingSpecificParams, CPUSpecificParams, ov::AnyMap>;
 
 class GroupDeconvolutionLayerCPUTest : public testing::WithParamInterface<GroupDeconvLayerCPUTestParamsSet>,
-                                       virtual public SubgraphBaseTest, public CpuTestWithFusing {
+                                       virtual public SubgraphBaseTest,
+                                       public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<GroupDeconvLayerCPUTestParamsSet> obj) {
         GroupDeconvSpecParams basicParamsSet;
@@ -39,17 +36,18 @@ public:
         ElementType prec;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
-        std::map<std::string, std::string> additionalConfig;
+        ov::AnyMap additionalConfig;
         std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = obj.param;
 
-        ngraph::op::PadType padType;
-        InferenceEngine::SizeVector kernel, stride, dilation;
+        ov::op::PadType padType;
+        std::vector<size_t> kernel, stride, dilation;
         std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
         size_t convOutChannels, groupNum;
-        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, groupNum, padType, outPadding) = basicParamsSet;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, groupNum, padType, outPadding) =
+            basicParamsSet;
 
         InputShape inputShape;
-        ngraph::helpers::InputLayerType outShapeType;
+        ov::test::utils::InputLayerType outShapeType;
         std::vector<std::vector<int32_t>> outShapeData;
         std::tie(inputShape, outShapeType, outShapeData) = inputData;
 
@@ -86,20 +84,20 @@ public:
         if (!additionalConfig.empty()) {
             result << "_PluginConf";
             for (auto& item : additionalConfig) {
-                result << "_" << item.first << "=" << item.second;
+                result << "_" << item.first << "=" << item.second.as<std::string>();
             }
         }
 
         return result.str();
     }
 
-    void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override {
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
         if (function->get_parameters().size() != 1) {
             // WA: output_shape depends on 3rd deconvolution input data
             // but the reference implementation doesn't implement shape inference
-            // so we need to build a new ngraph function and replace the 3rd input parameter with a constant
+            // so we need to build a new function and replace the 3rd input parameter with a constant
             // to get valid output shapes
-            functionRefs = createGraph({targetInputStaticShapes[0]}, ngraph::helpers::InputLayerType::CONSTANT);
+            functionRefs = createGraph({targetInputStaticShapes[0]}, ov::test::utils::InputLayerType::CONSTANT);
         }
         inputs.clear();
         const auto& funcInputs = function->inputs();
@@ -108,9 +106,15 @@ public:
             ov::Tensor tensor;
 
             if (i == 1) {
-                tensor = ov::Tensor(funcInput.get_element_type(), targetInputStaticShapes[i], outShapeData[inferRequestNum].data());
+                tensor = ov::Tensor(funcInput.get_element_type(),
+                                    targetInputStaticShapes[i],
+                                    outShapeData[inferRequestNum].data());
             } else {
-                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], 2560, 0, 256);
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[i],
+                                                                 2560,
+                                                                 0,
+                                                                 256);
             }
 
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
@@ -121,19 +125,20 @@ public:
     void validate() override {
         auto actualOutputs = get_plugin_outputs();
         if (function->get_parameters().size() == 2) {
-            auto pos = std::find_if(inputs.begin(), inputs.end(),
-                [](const std::pair<std::shared_ptr<ov::Node>, ov::Tensor> &params) {
-                    return params.first->get_friendly_name() == "param_1";
-                });
+            auto pos = std::find_if(inputs.begin(),
+                                    inputs.end(),
+                                    [](const std::pair<std::shared_ptr<ov::Node>, ov::Tensor>& params) {
+                                        return params.first->get_friendly_name() == "param_1";
+                                    });
             OPENVINO_ASSERT(pos != inputs.end());
             inputs.erase(pos);
         }
         auto expectedOutputs = calculate_refs();
         if (expectedOutputs.empty()) {
-                return;
+            return;
         }
         ASSERT_EQ(actualOutputs.size(), expectedOutputs.size())
-                << "nGraph interpreter has " << expectedOutputs.size() << " outputs, while IE " << actualOutputs.size();
+            << "nGraph interpreter has " << expectedOutputs.size() << " outputs, while IE " << actualOutputs.size();
 
         compare(expectedOutputs, actualOutputs);
     }
@@ -162,17 +167,21 @@ public:
         function = p.build();
     }
 
-    std::shared_ptr<ov::Model> createGraph(const std::vector<ov::PartialShape>& inShapes, ngraph::helpers::InputLayerType outShapeType) {
+    std::shared_ptr<ov::Model> createGraph(const std::vector<ov::PartialShape>& inShapes,
+                                           ov::test::utils::InputLayerType outShapeType) {
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(prec, inShapes.front())};
         std::shared_ptr<ov::Node> outShapeNode;
         if (!outShapeData.empty()) {
-            if (outShapeType == ngraph::helpers::InputLayerType::PARAMETER) {
+            if (outShapeType == ov::test::utils::InputLayerType::PARAMETER) {
                 OPENVINO_ASSERT(inputDynamicShapes.size() == 2);
-                auto outShapeParam = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::i32, inputDynamicShapes.back());
+                auto outShapeParam =
+                    std::make_shared<ov::op::v0::Parameter>(ov::element::i32, inputDynamicShapes.back());
                 params.push_back(outShapeParam);
                 outShapeNode = outShapeParam;
             } else {
-                outShapeNode = ngraph::opset8::Constant::create(ngraph::element::i32, {outShapeData[inferRequestNum].size()}, outShapeData[inferRequestNum]);
+                outShapeNode = ov::op::v0::Constant::create(ov::element::i32,
+                                                            {outShapeData[inferRequestNum].size()},
+                                                            outShapeData[inferRequestNum]);
             }
         }
 
@@ -183,18 +192,37 @@ public:
         std::shared_ptr<ov::Node> deconv;
         if (!outShapeData.empty()) {
             OPENVINO_ASSERT(outShapeNode != nullptr);
-            deconv = ov::test::utils::make_group_convolution_backprop_data(params[0], outShapeNode, prec, kernel, stride, padBegin,
-                                                                           padEnd, dilation, padType, convOutChannels, groupNum);
+            deconv = ov::test::utils::make_group_convolution_backprop_data(params[0],
+                                                                           outShapeNode,
+                                                                           prec,
+                                                                           kernel,
+                                                                           stride,
+                                                                           padBegin,
+                                                                           padEnd,
+                                                                           dilation,
+                                                                           padType,
+                                                                           convOutChannels,
+                                                                           groupNum);
         } else {
-            deconv = ov::test::utils::make_group_convolution_backprop_data(params[0], prec, kernel, stride, padBegin,
-                                                                           padEnd, dilation, padType, convOutChannels, groupNum, false, outPadding);
+            deconv = ov::test::utils::make_group_convolution_backprop_data(params[0],
+                                                                           prec,
+                                                                           kernel,
+                                                                           stride,
+                                                                           padBegin,
+                                                                           padEnd,
+                                                                           dilation,
+                                                                           padType,
+                                                                           convOutChannels,
+                                                                           groupNum,
+                                                                           false,
+                                                                           outPadding);
         }
 
         return makeNgraphFunction(prec, params, deconv, "GroupDeconvCPU");
     }
 
 protected:
-    InferenceEngine::SizeVector kernel, stride;
+    std::vector<size_t> kernel, stride;
 
     void SetUp() override {
         rel_threshold = 1e-4f;
@@ -205,21 +233,23 @@ protected:
         DeconvInputData inputData;
         CPUSpecificParams cpuParams;
         fusingSpecificParams fusingParams;
-        std::map<std::string, std::string> additionalConfig;
+        ov::AnyMap additionalConfig;
         std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = this->GetParam();
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
         std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 
-        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, groupNum,  padType, outPadding) = basicParamsSet;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, groupNum, padType, outPadding) =
+            basicParamsSet;
 
         InputShape inputShape;
-        ngraph::helpers::InputLayerType outShapeType;
+        ov::test::utils::InputLayerType outShapeType;
         std::tie(inputShape, outShapeType, outShapeData) = inputData;
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
-        if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
+        if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] ==
+            InferenceEngine::PluginConfigParams::YES) {
             inType = outType = prec = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
@@ -230,9 +260,10 @@ protected:
 
         std::vector<InputShape> paramsShapes;
         paramsShapes.push_back(inputShape);
-        if (!outShapeData.empty() && outShapeType == ngraph::helpers::InputLayerType::PARAMETER) {
+        if (!outShapeData.empty() && outShapeType == ov::test::utils::InputLayerType::PARAMETER) {
             const auto outShapeDims = ov::Shape{outShapeData.front().size()};
-            paramsShapes.push_back(InputShape{outShapeDims, std::vector<ov::Shape>(inputShape.second.size(), outShapeDims)});
+            paramsShapes.push_back(
+                InputShape{outShapeDims, std::vector<ov::Shape>(inputShape.second.size(), outShapeDims)});
         }
 
         init_input_shapes(paramsShapes);
@@ -242,8 +273,8 @@ protected:
 
 private:
     ElementType prec;
-    ngraph::op::PadType padType;
-    InferenceEngine::SizeVector dilation;
+    ov::op::PadType padType;
+    std::vector<size_t> dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
     size_t convOutChannels, groupNum;
     std::vector<std::vector<int32_t>> outShapeData;
@@ -258,7 +289,9 @@ TEST_P(GroupDeconvolutionLayerCPUTest, CompareWithRefs) {
         if (stride.size() > 2)
             isSupportedParams &= stride[stride.size() - 3] <= kernel[kernel.size() - 3];
         if (!isSupportedParams) {
-            GTEST_SKIP() << "Fusing with strides more than kernel size was disabled, because oneDNN deconvolution doesn't support it" << std::endl;
+            GTEST_SKIP() << "Fusing with strides more than kernel size was disabled, because oneDNN deconvolution "
+                            "doesn't support it"
+                         << std::endl;
         }
     }
 
@@ -270,635 +303,534 @@ namespace {
 
 std::vector<CPUSpecificParams> filterCPUInfoForDevice_BF16(std::vector<CPUSpecificParams> allParams) {
     std::vector<CPUSpecificParams> specificParams;
-    bool with_bf16 = InferenceEngine::with_cpu_x86_bfloat16();
-    std::copy_if(allParams.begin(), allParams.end(), std::back_inserter(specificParams), [with_bf16](const CPUSpecificParams& item) {
-        const auto &selected = std::get<3>(item);
-        // when no bf16 hardware amx will not work
-        if (!with_bf16 && selected.find("amx") != std::string::npos) {
-            return false;
-        }
-        return true;
-    });
+    bool with_bf16 = ov::with_cpu_x86_bfloat16();
+    std::copy_if(allParams.begin(),
+                 allParams.end(),
+                 std::back_inserter(specificParams),
+                 [with_bf16](const CPUSpecificParams& item) {
+                     const auto& selected = std::get<3>(item);
+                     // when no bf16 hardware amx will not work
+                     if (!with_bf16 && selected.find("amx") != std::string::npos) {
+                         return false;
+                     }
+                     return true;
+                 });
 
     return filterCPUInfoForDevice(specificParams);
 }
 
 /* COMMON PARAMS */
-std::vector<fusingSpecificParams> fusingParamsSet {
-        emptyFusingSpec,
-        fusingScaleShift,
+std::vector<fusingSpecificParams> fusingParamsSet{
+    emptyFusingSpec,
+    fusingScaleShift,
 };
-const std::map<std::string, std::string> cpuEmptyPluginConfig;
-const std::map<std::string, std::string> cpuBF16PluginConfig = { { InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16,
-                                                                   InferenceEngine::PluginConfigParams::YES } };
+const ov::AnyMap cpuEmptyPluginConfig;
+const ov::AnyMap cpuBF16PluginConfig = {
+    {InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::YES}};
 
-const std::vector<std::vector<size_t >> emptyOutputShape = {{}};
+const std::vector<std::vector<size_t>> emptyOutputShape = {{}};
 const std::vector<std::vector<ptrdiff_t>> emptyOutputPadding = {{}};
 
 /* ============= GroupConvolution params (planar layout) ============= */
-const InferenceEngine::SizeVector numOutChannels_Planar = {6};
-const InferenceEngine::SizeVector numGroups_Planar = {2, 3};
+const std::vector<size_t> numOutChannels_Planar = {6};
+const std::vector<size_t> numGroups_Planar = {2, 3};
 
 /* ============= GroupConvolution params (blocked layout) ============= */
-const InferenceEngine::SizeVector numOutChannels_Blocked = {64};
-const InferenceEngine::SizeVector numGroups_Blocked = {2, 4};
+const std::vector<size_t> numOutChannels_Blocked = {64};
+const std::vector<size_t> numGroups_Blocked = {2, 4};
 
 /* ============= GroupConvolution params (nspc layout) ============= */
-const InferenceEngine::SizeVector numOutChannels_nspc = {64};
-const InferenceEngine::SizeVector numGroups_nspc = {2};
+const std::vector<size_t> numOutChannels_nspc = {64};
+const std::vector<size_t> numGroups_nspc = {2};
 
 /* ============= GroupConvolution params (DW) ============= */
-const InferenceEngine::SizeVector numOutChannels_DW = {32};
-const InferenceEngine::SizeVector numGroups_DW = {32};
+const std::vector<size_t> numOutChannels_DW = {32};
+const std::vector<size_t> numGroups_DW = {32};
 
 /* ============= GroupConvolution params (2D) ============= */
-const std::vector<InferenceEngine::SizeVector> kernels2d = {{3, 3}, {1, 1}};
-const std::vector<InferenceEngine::SizeVector> strides2d = {{1, 1}, {2, 2}};
+const std::vector<std::vector<size_t>> kernels2d = {{3, 3}, {1, 1}};
+const std::vector<std::vector<size_t>> strides2d = {{1, 1}, {2, 2}};
 const std::vector<std::vector<ptrdiff_t>> padBegins2d = {{0, 0}};
 const std::vector<std::vector<ptrdiff_t>> padEnds2d = {{0, 0}};
-const std::vector<InferenceEngine::SizeVector> dilations2d = {{1, 1}};
+const std::vector<std::vector<size_t>> dilations2d = {{1, 1}};
 
 /* ============= GroupConvolution params (3D) ============= */
-const std::vector<InferenceEngine::SizeVector> kernels3d = {{3, 3, 3}, {1, 1, 1}};
-const std::vector<InferenceEngine::SizeVector> strides3d = {{1, 1, 1}, {2, 2, 2}};
+const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}, {1, 1, 1}};
+const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}, {2, 2, 2}};
 const std::vector<std::vector<ptrdiff_t>> padBegins3d = {{0, 0, 0}};
 const std::vector<std::vector<ptrdiff_t>> padEnds3d = {{0, 0, 0}};
-const std::vector<InferenceEngine::SizeVector> dilations3d = {{1, 1, 1}};
+const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}};
 /* ============= */
-
 
 /* INSTANCES */
 /* ============= GroupConvolution (Planar 2D) ============= */
 const std::vector<DeconvInputData> Planar_2D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 12, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 12, -1, -1}, {{ 1, 12, 7, 7}, { 2, 12, 5, 7}, { 1, 12, 7, 7}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{15, 15}, {9, 10}, {15, 15}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 12, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 12, -1, -1}, {{1, 12, 7, 7}, {2, 12, 5, 7}, {1, 12, 7, 7}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{15, 15}, {9, 10}, {15, 15}}}};
 
 const std::vector<DeconvInputData> Planar_2D_inputs_nightly = {
-    DeconvInputData{
-        InputShape{{-1, 12, -1, -1}, {{ 2, 12, 7, 7}, { 2, 12, 5, 7}, { 1, 12, 9, 4}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 12, -1, -1}, {{ 2, 12, 7, 7}, { 2, 12, 5, 7}, { 1, 12, 9, 4}, { 2, 12, 5, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    },
-    DeconvInputData{
-        InputShape{{{1, 10}, 12, 7, 7}, {{ 1, 12, 7, 7}, { 3, 12, 7, 7}, { 2, 12, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    }
-};
+    DeconvInputData{InputShape{{-1, 12, -1, -1}, {{2, 12, 7, 7}, {2, 12, 5, 7}, {1, 12, 9, 4}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 12, -1, -1}, {{2, 12, 7, 7}, {2, 12, 5, 7}, {1, 12, 9, 4}, {2, 12, 5, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}},
+    DeconvInputData{InputShape{{{1, 10}, 12, 7, 7}, {{1, 12, 7, 7}, {3, 12, 7, 7}, {2, 12, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}}};
 
-const auto groupConvParams_ExplicitPadding_Planar_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn(strides2d),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_Planar),
-        ::testing::ValuesIn(numGroups_Planar),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupConvParams_ExplicitPadding_Planar_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                          ::testing::ValuesIn(strides2d),
+                                                                          ::testing::ValuesIn(padBegins2d),
+                                                                          ::testing::ValuesIn(padEnds2d),
+                                                                          ::testing::ValuesIn(dilations2d),
+                                                                          ::testing::ValuesIn(numOutChannels_Planar),
+                                                                          ::testing::ValuesIn(numGroups_Planar),
+                                                                          ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                          ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Planar_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Planar_2D,
-        ::testing::ValuesIn(Planar_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Planar_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Planar_2D,
+                                            ::testing::ValuesIn(Planar_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Planar_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Planar_2D,
-        ::testing::ValuesIn(Planar_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Planar_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Planar_2D,
+                                            ::testing::ValuesIn(Planar_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Planar_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Planar_2D,
-        ::testing::ValuesIn(Planar_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Planar_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Planar_2D,
+                                            ::testing::ValuesIn(Planar_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Planar_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Planar_2D,
-        ::testing::ValuesIn(Planar_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Planar_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Planar_2D,
+                                            ::testing::ValuesIn(Planar_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (Planar 3D) ============= */
 const std::vector<DeconvInputData> Planar_3D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 12, 7, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 12, -1, -1, -1}, {{ 2, 12, 7, 7, 7}, { 2, 12, 5, 7, 7}, { 1, 12, 9, 4, 9}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{15, 15, 15}, {9, 10, 10}, {9, 9, 9}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 12, 7, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 12, -1, -1, -1}, {{2, 12, 7, 7, 7}, {2, 12, 5, 7, 7}, {1, 12, 9, 4, 9}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{15, 15, 15}, {9, 10, 10}, {9, 9, 9}}}};
 
 const std::vector<DeconvInputData> Planar_3D_inputs_nightly = {
     DeconvInputData{
-        InputShape{{-1, 12, -1, -1, -1}, {{ 2, 12, 7, 7, 7}, { 2, 12, 5, 7, 7}, { 1, 12, 9, 4, 9}, { 2, 12, 5, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 12, -1, -1, -1}, {{ 2, 12, 7, 7, 7}, { 2, 12, 5, 7, 7}, { 1, 12, 9, 4, 9}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15, 15}}
-    },
-    DeconvInputData{
-        InputShape{{{1, 10}, 12, 7, 7, 7}, {{ 3, 12, 7, 7, 7}, { 2, 12, 7, 7, 7}, { 1, 12, 7, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15, 15}}
-    }
-};
+        InputShape{{-1, 12, -1, -1, -1}, {{2, 12, 7, 7, 7}, {2, 12, 5, 7, 7}, {1, 12, 9, 4, 9}, {2, 12, 5, 7, 7}}},
+        ov::test::utils::InputLayerType::CONSTANT,
+        {}},
+    DeconvInputData{InputShape{{-1, 12, -1, -1, -1}, {{2, 12, 7, 7, 7}, {2, 12, 5, 7, 7}, {1, 12, 9, 4, 9}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15, 15}}},
+    DeconvInputData{InputShape{{{1, 10}, 12, 7, 7, 7}, {{3, 12, 7, 7, 7}, {2, 12, 7, 7, 7}, {1, 12, 7, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15, 15}}}};
 
-const auto groupConvParams_ExplicitPadding_Planar_3D = ::testing::Combine(
-        ::testing::ValuesIn(kernels3d),
-        ::testing::ValuesIn(strides3d),
-        ::testing::ValuesIn(padBegins3d),
-        ::testing::ValuesIn(padEnds3d),
-        ::testing::ValuesIn(dilations3d),
-        ::testing::ValuesIn(numOutChannels_Planar),
-        ::testing::ValuesIn(numGroups_Planar),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupConvParams_ExplicitPadding_Planar_3D = ::testing::Combine(::testing::ValuesIn(kernels3d),
+                                                                          ::testing::ValuesIn(strides3d),
+                                                                          ::testing::ValuesIn(padBegins3d),
+                                                                          ::testing::ValuesIn(padEnds3d),
+                                                                          ::testing::ValuesIn(dilations3d),
+                                                                          ::testing::ValuesIn(numOutChannels_Planar),
+                                                                          ::testing::ValuesIn(numGroups_Planar),
+                                                                          ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                          ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_Planar_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Planar_3D,
-        ::testing::ValuesIn(Planar_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_Planar_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Planar_3D,
+                                            ::testing::ValuesIn(Planar_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_Planar_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Planar_3D,
-        ::testing::ValuesIn(Planar_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_Planar_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Planar_3D,
+                                            ::testing::ValuesIn(Planar_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_3D_Planar_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Planar_3D,
-        ::testing::ValuesIn(Planar_3D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_3D_Planar_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Planar_3D,
+                                            ::testing::ValuesIn(Planar_3D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_3D_Planar_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Planar_3D,
-        ::testing::ValuesIn(Planar_3D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_3D_Planar_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Planar_3D,
+                                            ::testing::ValuesIn(Planar_3D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_3D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (Blocked 2D) ============= */
 const std::vector<DeconvInputData> Blocked_2D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 64, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1}, {{ 2, 64, 7, 7}, { 2, 64, 5, 7}, { 1, 64, 9, 5}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{15, 15}, {9, 10}, {19, 9}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 64, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1}, {{2, 64, 7, 7}, {2, 64, 5, 7}, {1, 64, 9, 5}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{15, 15}, {9, 10}, {19, 9}}}};
 
-const auto groupConvParams_ExplicitPadding_Blocked_2D_nightly = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn({strides2d[1]}),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupConvParams_ExplicitPadding_Blocked_2D_nightly =
+    ::testing::Combine(::testing::ValuesIn(kernels2d),
+                       ::testing::ValuesIn({strides2d[1]}),
+                       ::testing::ValuesIn(padBegins2d),
+                       ::testing::ValuesIn(padEnds2d),
+                       ::testing::ValuesIn(dilations2d),
+                       ::testing::ValuesIn(numOutChannels_Blocked),
+                       ::testing::ValuesIn(numGroups_Blocked),
+                       ::testing::Values(ov::op::PadType::EXPLICIT),
+                       ::testing::ValuesIn(emptyOutputPadding));
 
 const std::vector<DeconvInputData> Blocked_2D_inputs_nightly = {
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1}, {{ 2, 64, 7, 7}, { 2, 64, 5, 7}, { 1, 64, 9, 4}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1}, {{ 2, 64, 7, 7}, { 2, 64, 5, 7}, { 1, 64, 9, 4}, { 2, 64, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    },
-    DeconvInputData{
-        InputShape{{{1, 10}, 64, 7, 7}, {{ 2, 64, 7, 7}, { 3, 64, 7, 7}, { 1, 64, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    }
-};
+    DeconvInputData{InputShape{{-1, 64, -1, -1}, {{2, 64, 7, 7}, {2, 64, 5, 7}, {1, 64, 9, 4}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1}, {{2, 64, 7, 7}, {2, 64, 5, 7}, {1, 64, 9, 4}, {2, 64, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}},
+    DeconvInputData{InputShape{{{1, 10}, 64, 7, 7}, {{2, 64, 7, 7}, {3, 64, 7, 7}, {1, 64, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}}};
 
-const auto groupConvParams_ExplicitPadding_Blocked_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn(strides2d),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupConvParams_ExplicitPadding_Blocked_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                           ::testing::ValuesIn(strides2d),
+                                                                           ::testing::ValuesIn(padBegins2d),
+                                                                           ::testing::ValuesIn(padEnds2d),
+                                                                           ::testing::ValuesIn(dilations2d),
+                                                                           ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                           ::testing::ValuesIn(numGroups_Blocked),
+                                                                           ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                           ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Blocked_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Blocked_2D,
-        ::testing::ValuesIn(Blocked_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Blocked_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Blocked_2D,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Blocked_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Blocked_2D,
-        ::testing::ValuesIn(Blocked_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_Blocked_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Blocked_2D,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Blocked_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Blocked_2D_nightly,
-        ::testing::ValuesIn(Blocked_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Blocked_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Blocked_2D_nightly,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D, conv_avx2_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Blocked_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Blocked_2D_nightly,
-        ::testing::ValuesIn(Blocked_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_Blocked_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Blocked_2D_nightly,
+                                            ::testing::ValuesIn(Blocked_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (nspc 2D) ============= */
 const std::vector<DeconvInputData> nspc_2D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 64, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1}, {{ 2, 64, 7, 7}, { 2, 64, 5, 7}, { 1, 64, 9, 5}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{15, 15}, {9, 10}, {19, 9}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 64, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1}, {{2, 64, 7, 7}, {2, 64, 5, 7}, {1, 64, 9, 5}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{15, 15}, {9, 10}, {19, 9}}}};
 
-const auto groupConvParams_ExplicitPadding_nspc_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn(strides2d),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_nspc),
-        ::testing::ValuesIn(numGroups_nspc),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupConvParams_ExplicitPadding_nspc_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                        ::testing::ValuesIn(strides2d),
+                                                                        ::testing::ValuesIn(padBegins2d),
+                                                                        ::testing::ValuesIn(padEnds2d),
+                                                                        ::testing::ValuesIn(dilations2d),
+                                                                        ::testing::ValuesIn(numOutChannels_nspc),
+                                                                        ::testing::ValuesIn(numGroups_nspc),
+                                                                        ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                        ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_AMX_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_nspc_2D,
-        ::testing::ValuesIn(nspc_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::Values(emptyFusingSpec),
-        ::testing::ValuesIn(filterCPUInfoForDevice_BF16({conv_avx512_2D_nspc, conv_avx512_2D_nspc_amx})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_AMX_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_nspc_2D,
+                                            ::testing::ValuesIn(nspc_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice_BF16({conv_avx512_2D_nspc,
+                                                                                             conv_avx512_2D_nspc_amx})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (Blocked 3D) ============= */
 const std::vector<DeconvInputData> Blocked_3D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 64, 7, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1, -1}, {{ 1, 64, 5, 5, 5}, { 2, 64, 5, 7, 5}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{7, 7, 7}, {7, 9, 7}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 64, 7, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1, -1}, {{1, 64, 5, 5, 5}, {2, 64, 5, 7, 5}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{7, 7, 7}, {7, 9, 7}}}};
 
 const std::vector<DeconvInputData> Blocked_3D_inputs_nightly = {
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1, -1}, {{ 1, 64, 5, 5, 5}, { 2, 64, 5, 7, 5}, { 1, 64, 5, 5, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1, -1}, {{ 1, 64, 5, 5, 5}, { 2, 64, 5, 7, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{7, 7, 7}}
-    },
-    DeconvInputData{
-        InputShape{{{1, 10}, 64, -1, -1, -1}, {{ 1, 64, 5, 5, 5}, { 2, 64, 5, 5, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{7, 7, 7}}
-    }
-};
+    DeconvInputData{InputShape{{-1, 64, -1, -1, -1}, {{1, 64, 5, 5, 5}, {2, 64, 5, 7, 5}, {1, 64, 5, 5, 5}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1, -1}, {{1, 64, 5, 5, 5}, {2, 64, 5, 7, 5}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{7, 7, 7}}},
+    DeconvInputData{InputShape{{{1, 10}, 64, -1, -1, -1}, {{1, 64, 5, 5, 5}, {2, 64, 5, 5, 5}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{7, 7, 7}}}};
 
-const auto groupConvParams_ExplicitPadding_Blocked_3D = ::testing::Combine(
-        ::testing::ValuesIn(kernels3d),
-        ::testing::ValuesIn(strides3d),
-        ::testing::ValuesIn(padBegins3d),
-        ::testing::ValuesIn(padEnds3d),
-        ::testing::ValuesIn(dilations3d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupConvParams_ExplicitPadding_Blocked_3D = ::testing::Combine(::testing::ValuesIn(kernels3d),
+                                                                           ::testing::ValuesIn(strides3d),
+                                                                           ::testing::ValuesIn(padBegins3d),
+                                                                           ::testing::ValuesIn(padEnds3d),
+                                                                           ::testing::ValuesIn(dilations3d),
+                                                                           ::testing::ValuesIn(numOutChannels_Blocked),
+                                                                           ::testing::ValuesIn(numGroups_Blocked),
+                                                                           ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                           ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_Blocked_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Blocked_3D,
-        ::testing::ValuesIn(Blocked_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_Blocked_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Blocked_3D,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_Blocked_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Blocked_3D,
-        ::testing::ValuesIn(Blocked_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_Blocked_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Blocked_3D,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_3D_Blocked_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Blocked_3D,
-        ::testing::ValuesIn(Blocked_3D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_3D_Blocked_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Blocked_3D,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_3D_Blocked_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_Blocked_3D,
-        ::testing::ValuesIn(Blocked_3D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_3D_Blocked_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_Blocked_3D,
+                                            ::testing::ValuesIn(Blocked_3D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (nspc 3D) ============= */
 const std::vector<DeconvInputData> nspc_3D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 64, 7, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1, -1}, {{ 1, 64, 5, 5, 5}, { 2, 64, 5, 7, 5}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{7, 7, 7}, {7, 9, 7}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 64, 7, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1, -1}, {{1, 64, 5, 5, 5}, {2, 64, 5, 7, 5}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{7, 7, 7}, {7, 9, 7}}}};
 
-const auto groupConvParams_ExplicitPadding_nspc_3D = ::testing::Combine(
-        ::testing::ValuesIn(kernels3d),
-        ::testing::ValuesIn(strides3d),
-        ::testing::ValuesIn(padBegins3d),
-        ::testing::ValuesIn(padEnds3d),
-        ::testing::ValuesIn(dilations3d),
-        ::testing::ValuesIn(numOutChannels_nspc),
-        ::testing::ValuesIn(numGroups_nspc),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupConvParams_ExplicitPadding_nspc_3D = ::testing::Combine(::testing::ValuesIn(kernels3d),
+                                                                        ::testing::ValuesIn(strides3d),
+                                                                        ::testing::ValuesIn(padBegins3d),
+                                                                        ::testing::ValuesIn(padEnds3d),
+                                                                        ::testing::ValuesIn(dilations3d),
+                                                                        ::testing::ValuesIn(numOutChannels_nspc),
+                                                                        ::testing::ValuesIn(numGroups_nspc),
+                                                                        ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                        ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_nspc_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_nspc_3D,
-        ::testing::ValuesIn(nspc_3D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::Values(emptyFusingSpec),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D_nspc, conv_avx512_3D_nspc_amx})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_3D_nspc_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_nspc_3D,
+                                            ::testing::ValuesIn(nspc_3D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_3D_nspc,
+                                                                                        conv_avx512_3D_nspc_amx})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupConvolution (DW 2D) ============= */
 const std::vector<DeconvInputData> dw_2D_inputs_smoke = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 32, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 32, -1, -1}, {{ 1, 32, 5, 5}, { 2, 32, 5, 7}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{7, 7}, {7, 9}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 32, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 32, -1, -1}, {{1, 32, 5, 5}, {2, 32, 5, 7}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{7, 7}, {7, 9}}}};
 
 const std::vector<DeconvInputData> dw_2D_inputs_nightly = {
-    DeconvInputData{
-        InputShape{{-1, 32, -1, -1}, {{ 1, 32, 5, 5}, { 2, 32, 5, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 32, -1, -1}, {{ 1, 32, 5, 5}, { 2, 32, 5, 7}, { 1, 32, 5, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{7, 7}}
-    },
-    DeconvInputData{
-        InputShape{{{1, 10}, 32, 5, 5}, {{ 2, 32, 5, 5}, { 1, 32, 5, 5}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{7, 7}}
-    }
-};
+    DeconvInputData{InputShape{{-1, 32, -1, -1}, {{1, 32, 5, 5}, {2, 32, 5, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 32, -1, -1}, {{1, 32, 5, 5}, {2, 32, 5, 7}, {1, 32, 5, 5}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{7, 7}}},
+    DeconvInputData{InputShape{{{1, 10}, 32, 5, 5}, {{2, 32, 5, 5}, {1, 32, 5, 5}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{7, 7}}}};
 
-const auto groupConvParams_ExplicitPadding_DW_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn(strides2d),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_DW),
-        ::testing::ValuesIn(numGroups_DW),
-        ::testing::Values(ngraph::op::PadType::EXPLICIT),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupConvParams_ExplicitPadding_DW_2D = ::testing::Combine(::testing::ValuesIn(kernels2d),
+                                                                      ::testing::ValuesIn(strides2d),
+                                                                      ::testing::ValuesIn(padBegins2d),
+                                                                      ::testing::ValuesIn(padEnds2d),
+                                                                      ::testing::ValuesIn(dilations2d),
+                                                                      ::testing::ValuesIn(numOutChannels_DW),
+                                                                      ::testing::ValuesIn(numGroups_DW),
+                                                                      ::testing::Values(ov::op::PadType::EXPLICIT),
+                                                                      ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_DW_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_DW_2D,
-        ::testing::ValuesIn(dw_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D, conv_avx2_dw_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_DW_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_DW_2D,
+                                            ::testing::ValuesIn(dw_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D,
+                                                                                        conv_avx2_dw_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_DW_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_DW_2D,
-        ::testing::ValuesIn(dw_2D_inputs_smoke),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_DW_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_DW_2D,
+                                            ::testing::ValuesIn(dw_2D_inputs_smoke),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_DW_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_DW_2D,
-        ::testing::ValuesIn(dw_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D, conv_avx2_dw_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_DW_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_DW_2D,
+                                            ::testing::ValuesIn(dw_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D,
+                                                                                        conv_avx2_dw_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_DW_BF16, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupConvParams_ExplicitPadding_DW_2D,
-        ::testing::ValuesIn(dw_2D_inputs_nightly),
-        ::testing::Values(ElementType::f32),
-        ::testing::ValuesIn(fusingParamsSet),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D})),
-        ::testing::Values(cpuBF16PluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_GroupDeconv_2D_DW_BF16,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupConvParams_ExplicitPadding_DW_2D,
+                                            ::testing::ValuesIn(dw_2D_inputs_nightly),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::ValuesIn(fusingParamsSet),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_dw_2D})),
+                                            ::testing::Values(cpuBF16PluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= Reorder + GroupDeconvolution ============= */
-INSTANTIATE_TEST_SUITE_P(smoke_reorder_GroupDeconv_2D, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        ::testing::Combine(::testing::ValuesIn(kernels2d),
-                           ::testing::Values(InferenceEngine::SizeVector{1, 1}),
-                           ::testing::ValuesIn(padBegins2d),
-                           ::testing::ValuesIn(padEnds2d),
-                           ::testing::ValuesIn(dilations2d),
-                           ::testing::ValuesIn(numOutChannels_Blocked),
-                           ::testing::ValuesIn(numGroups_Blocked),
-                           ::testing::Values(ngraph::op::PadType::EXPLICIT),
-                           ::testing::ValuesIn(emptyOutputPadding)),
-        ::testing::Values(DeconvInputData{InputShape{{-1, 64, -1, -1}, {{ 1, 64, 7, 7}, { 2, 64, 5, 7}, { 1, 64, 9, 4}, { 1, 64, 7, 7}}},
-                                                     ngraph::helpers::InputLayerType::PARAMETER,
-                                                     {{15, 15}, {9, 10}, {9, 9}, {15, 15}}}),
-        ::testing::Values(ElementType::f32),
-        ::testing::Values(emptyFusingSpec),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
+INSTANTIATE_TEST_SUITE_P(
+    smoke_reorder_GroupDeconv_2D,
+    GroupDeconvolutionLayerCPUTest,
+    ::testing::Combine(::testing::Combine(::testing::ValuesIn(kernels2d),
+                                          ::testing::Values(std::vector<size_t>{1, 1}),
+                                          ::testing::ValuesIn(padBegins2d),
+                                          ::testing::ValuesIn(padEnds2d),
+                                          ::testing::ValuesIn(dilations2d),
+                                          ::testing::ValuesIn(numOutChannels_Blocked),
+                                          ::testing::ValuesIn(numGroups_Blocked),
+                                          ::testing::Values(ov::op::PadType::EXPLICIT),
+                                          ::testing::ValuesIn(emptyOutputPadding)),
+                       ::testing::Values(DeconvInputData{
+                           InputShape{{-1, 64, -1, -1}, {{1, 64, 7, 7}, {2, 64, 5, 7}, {1, 64, 9, 4}, {1, 64, 7, 7}}},
+                           ov::test::utils::InputLayerType::PARAMETER,
+                           {{15, 15}, {9, 10}, {9, 9}, {15, 15}}}),
+                       ::testing::Values(ElementType::f32),
+                       ::testing::Values(emptyFusingSpec),
+                       ::testing::ValuesIn(filterCPUInfoForDevice({conv_avx512_2D})),
+                       ::testing::Values(cpuEmptyPluginConfig)),
     GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= GroupDeconvolution auto padding tests ============= */
 const std::vector<DeconvInputData> inputs_2D_AutoPadding = {
-    DeconvInputData{
-        InputShape{{}, {{ 2, 64, 7, 7 }}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1}, {{ 2, 64, 7, 7}, { 2, 64, 5, 7}, { 1, 64, 9, 4}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1}, {{ 1, 64, 7, 7}, { 2, 64, 5, 7}, { 1, 64, 7, 7}}},
-        ngraph::helpers::InputLayerType::CONSTANT,
-        {{15, 15}}
-    },
-    DeconvInputData{
-        InputShape{{-1, 64, -1, -1}, {{ 2, 64, 7, 7}, { 2, 64, 5, 7}, { 1, 64, 9, 5}}},
-        ngraph::helpers::InputLayerType::PARAMETER,
-        {{15, 15}, {9, 10}, {19, 9}}
-    }
-};
+    DeconvInputData{InputShape{{}, {{2, 64, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1}, {{2, 64, 7, 7}, {2, 64, 5, 7}, {1, 64, 9, 4}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1}, {{1, 64, 7, 7}, {2, 64, 5, 7}, {1, 64, 7, 7}}},
+                    ov::test::utils::InputLayerType::CONSTANT,
+                    {{15, 15}}},
+    DeconvInputData{InputShape{{-1, 64, -1, -1}, {{2, 64, 7, 7}, {2, 64, 5, 7}, {1, 64, 9, 5}}},
+                    ov::test::utils::InputLayerType::PARAMETER,
+                    {{15, 15}, {9, 10}, {19, 9}}}};
 
-const auto groupDeconvParams_AutoPadding_2D = ::testing::Combine(
-        ::testing::ValuesIn(kernels2d),
-        ::testing::ValuesIn(strides2d),
-        ::testing::ValuesIn(padBegins2d),
-        ::testing::ValuesIn(padEnds2d),
-        ::testing::ValuesIn(dilations2d),
-        ::testing::ValuesIn(numOutChannels_Blocked),
-        ::testing::ValuesIn(numGroups_Blocked),
-        ::testing::Values(ngraph::op::PadType::SAME_UPPER, ngraph::op::PadType::SAME_LOWER),
-        ::testing::ValuesIn(emptyOutputPadding)
-);
+const auto groupDeconvParams_AutoPadding_2D =
+    ::testing::Combine(::testing::ValuesIn(kernels2d),
+                       ::testing::ValuesIn(strides2d),
+                       ::testing::ValuesIn(padBegins2d),
+                       ::testing::ValuesIn(padEnds2d),
+                       ::testing::ValuesIn(dilations2d),
+                       ::testing::ValuesIn(numOutChannels_Blocked),
+                       ::testing::ValuesIn(numGroups_Blocked),
+                       ::testing::Values(ov::op::PadType::SAME_UPPER, ov::op::PadType::SAME_LOWER),
+                       ::testing::ValuesIn(emptyOutputPadding));
 
-INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_AutoPadding_FP32, GroupDeconvolutionLayerCPUTest,
-    ::testing::Combine(
-        groupDeconvParams_AutoPadding_2D,
-        ::testing::ValuesIn(inputs_2D_AutoPadding),
-        ::testing::Values(ElementType::f32),
-        ::testing::Values(emptyFusingSpec),
-        ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D, conv_avx512_2D})),
-        ::testing::Values(cpuEmptyPluginConfig)),
-    GroupDeconvolutionLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_GroupDeconv_2D_AutoPadding_FP32,
+                         GroupDeconvolutionLayerCPUTest,
+                         ::testing::Combine(groupDeconvParams_AutoPadding_2D,
+                                            ::testing::ValuesIn(inputs_2D_AutoPadding),
+                                            ::testing::Values(ElementType::f32),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::ValuesIn(filterCPUInfoForDevice({conv_gemm_2D, conv_avx512_2D})),
+                                            ::testing::Values(cpuEmptyPluginConfig)),
+                         GroupDeconvolutionLayerCPUTest::getTestCaseName);
 
-} // namespace
+}  // namespace
 
-} // namespace CPULayerTestsDefinitions
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Migrate convolution test to 2.0
 - *...*

### Tickets:
 - *ticket-id*
