### PR TITLE
[CI] [GHA] Change Coverity trigger to nightly

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,9 +1,8 @@
 name: Coverity (Ubuntu 20.04, Python 3.11)
 on:
-  push:
-    branches:
-      - master
-      - 'releases/**'
+  schedule:
+    # run daily at 00:00
+    - cron: '0 0 * * *'
 
 concurrency:
   # github.ref is not unique in post-commit


### PR DESCRIPTION
### Details:
 - Turns out, the Coverity platform accepts only 3 builds **per day**.
