### PR TITLE
[CONFORMANCE] Specify validation entity as arg of `run_conformance`

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/README.md
+++ b/src/tests/functional/plugin/conformance/test_runner/README.md
@@ -86,6 +86,8 @@ The script has the following optional arguments:
                         NOTE: Applicable only for Opset Conformance.
 * `sm SPECIAL_MODE, --special_mode SPECIAL_MODE`
                         Specify shape mode (`static`, `dynamic` or ``) for Opset conformance or API scope type (`mandatory` or ``). Default value is ``
+*  `-e ENTITY, --entity ENTITY`
+                        Specify validation entity: `Inference`, `ImportExport` or `QueryModel` for `OP` or `ov`. Default value is `ov_compiled_model`, `ov_infer_request` or `ov_plugin` for `API`. Default value is ``(all)
 * `p PARALLEL_DEVICES, --parallel_devices PARALLEL_DEVICES`
                         Parallel over HW devices. For example run tests over `GPU.0` and `GPU.1` in case when device are the same
 * `f EXPECTED_FAILURES, --expected_failures EXPECTED_FAILURES`

--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/utils/file_utils.py
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/utils/file_utils.py
@@ -87,5 +87,5 @@ def get_ov_path(script_dir_path: os.path, ov_dir=None, is_bin=False):
     if is_bin:
         ov_dir = os.path.join(ov_dir, find_latest_dir(ov_dir, 'bin'))
         ov_dir = os.path.join(ov_dir, find_latest_dir(ov_dir))
-        ov_dir = os.path.join(ov_dir, find_latest_dir(ov_dir, [constants.DEBUG_DIR, constants.RELEASE_DIR]))
+        ov_dir = os.path.join(ov_dir, find_latest_dir(ov_dir))
     return ov_dir

--- a/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
@@ -141,9 +141,6 @@ std::map<std::string, PassRate> OpSummary::getStatisticFromReport() {
 }
 
 void OpSummary::updateOPsStats(const std::shared_ptr<ov::Model>& model, const PassRate::Statuses& status, double k) {
-    if (model->get_parameters().empty()) {
-        return;
-    }
     bool isFunctionalGraph = false;
     for (const auto& op : model->get_ordered_ops()) {
         if (!std::dynamic_pointer_cast<ov::op::v0::Parameter>(op) &&


### PR DESCRIPTION
### Details:
 - *Split of conformance runner by entities as an optional command-line arg*


### Tickets:
 - *ticket-id*
