### PR TITLE
[Python API] Added exception handling for 'None' model argument in save_model function

### DIFF
--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -165,9 +165,9 @@ PYBIND11_MODULE(_pyopenvino, m) {
         [](std::shared_ptr<ov::Model>& model,
            const py::object& xml_path,
            bool compress_to_fp16) {
-            if (model == nullptr) {
-                throw py::attribute_error("'model' argument is required and cannot be None.");
-            }
+           if (model == nullptr) {
+               throw py::attribute_error("'model' argument is required and cannot be None.");
+           }
             ov::save_model(model,
                           Common::utils::convert_path_to_string(xml_path),
                           compress_to_fp16);

--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -165,6 +165,9 @@ PYBIND11_MODULE(_pyopenvino, m) {
         [](std::shared_ptr<ov::Model>& model,
            const py::object& xml_path,
            bool compress_to_fp16) {
+            if (model == nullptr) {
+                throw py::attribute_error("'model' argument is required and cannot be None.");
+            }
             ov::save_model(model,
                           Common::utils::convert_path_to_string(xml_path),
                           compress_to_fp16);

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -571,5 +571,5 @@ def test_model_add_remove_variable():
 
 def test_save_model_with_none():
     with pytest.raises(AttributeError) as e:
-        save_model(model=None, output_model='model.xml')
+        save_model(model=None, output_model="model.xml")
     assert "'model' argument is required and cannot be None." in str(e.value)

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -568,6 +568,7 @@ def test_model_add_remove_variable():
     model.remove_variable(variable_1)
     assert len(model.get_variables()) == 1
 
+
 def test_save_model_with_none():
     with pytest.raises(AttributeError) as e:
         save_model(model=None, output_model='model.xml')

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -21,6 +21,7 @@ from openvino import (
     set_batch,
     get_batch,
     serialize,
+    save_model,
 )
 from openvino.runtime import Output
 from openvino.runtime.op.util import VariableInfo, Variable
@@ -566,3 +567,8 @@ def test_model_add_remove_variable():
     assert variable_by_id.info.variable_id == "var_id_667"
     model.remove_variable(variable_1)
     assert len(model.get_variables()) == 1
+
+def test_save_model_with_none():
+    with pytest.raises(AttributeError) as e:
+        save_model(model=None, output_model='model.xml')
+    assert "'model' argument is required and cannot be None." in str(e.value)


### PR DESCRIPTION
### Details:
 - Modified the `openvino.save_model()` function binding to perform a type check on the 'model' argument. If the argument is `None`, an `AttributeError` exception is now raised instead of segmentation fault.

![Screenshot 2023-12-13 at 2 15 58 AM](https://github.com/openvinotoolkit/openvino/assets/79010410/bdb9a315-9ca8-484f-b2b1-5daeaabe7cce)


### Tickets:
 - Closes #21086 
