### PR TITLE
Enable dinov2-base

### DIFF
--- a/tests/model_hub_tests/torch_tests/hf_transformers_models
+++ b/tests/model_hub_tests/torch_tests/hf_transformers_models
@@ -65,7 +65,7 @@ EleutherAI/pythia-6.9b,gpt_neox
 facebook/bart-large-mnli,bart
 facebook/convnextv2-tiny-22k-384,convnextv2
 facebook/detr-resnet-50,detr
-facebook/dinov2-base,dinov2,xfail,Tracing error: Please check correctness of provided example_input (but eval was correct)
+facebook/dinov2-base,dinov2
 facebook/dpr-question_encoder-single-nq-base,dpr
 facebook/encodec_24khz,encodec
 facebook/esm2_t6_8M_UR50D,esm


### PR DESCRIPTION
With the newest transformers-4.36.0 dinov-2-base started to pass

[CVS-124981](https://jira.devtools.intel.com/browse/CVS-124981)
