### PR TITLE
[PT FE] Remove unique names from FE, rely on ResolveNameCollisions

### DIFF
--- a/src/frontends/pytorch/src/frontend.cpp
+++ b/src/frontends/pytorch/src/frontend.cpp
@@ -211,7 +211,7 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& model) const {
     manager.register_pass<ov::pass::ReverseShapeAndTypeInfer>();
     // Second pass of AlignTypesRemoval after all converting transformations
     manager.register_pass<ov::frontend::pytorch::pass::AlignTypesRemoval>();
-    manager.register_pass<ov::pass::ResolveNameCollisions>();
+    manager.register_pass<ov::pass::ResolveNameCollisions>(true);
     manager.run_passes(model);
 
     apply_pytorch_conversion_transforms(model);

--- a/src/frontends/pytorch/src/node_context.cpp
+++ b/src/frontends/pytorch/src/node_context.cpp
@@ -50,7 +50,6 @@ OutputVector NodeContext::as_constant() const {
 
 std::shared_ptr<Node> NodeContext::mark_node(std::shared_ptr<Node> ov_node) const {
     ov_node = m_decoder->mark_node(ov_node);
-    m_translate_session->unique_name(ov_node);
     return ov_node;
 }
 

--- a/src/frontends/pytorch/src/translate_session.cpp
+++ b/src/frontends/pytorch/src/translate_session.cpp
@@ -402,14 +402,6 @@ Output<Node> TranslateSession::get_reverseprop_op(const std::shared_ptr<TorchDec
     return std::make_shared<PtFrameworkNode>(node, OutputVector{value}, 1, true);
 }
 
-void TranslateSession::unique_name(const std::shared_ptr<Node>& node) {
-    if (m_unique_friendly_name_set.count(node->get_friendly_name())) {
-        node->set_friendly_name(node->get_friendly_name() + '_' + std::to_string(m_friendly_name_counter++));
-    } else {
-        m_unique_friendly_name_set.insert(node->get_friendly_name());
-    }
-}
-
 }  // namespace pytorch
 }  // namespace frontend
 }  // namespace ov

--- a/src/frontends/pytorch/src/translate_session.hpp
+++ b/src/frontends/pytorch/src/translate_session.hpp
@@ -61,7 +61,6 @@ private:
 
     std::map<size_t, std::pair<size_t, Output<Node>>> m_counter_map;
     std::map<std::string, uint64_t> m_op_statistics;
-    size_t m_friendly_name_counter = 0;
 };
 
 }  // namespace pytorch

--- a/src/frontends/pytorch/src/translate_session.hpp
+++ b/src/frontends/pytorch/src/translate_session.hpp
@@ -47,9 +47,6 @@ public:
     /// \brief Gets pytorch tensor index from openvino tensor
     size_t decode_tensor_name(const Output<Node>& tensor_desc);
 
-    /// \brief Make sure Node has unique name
-    void unique_name(const std::shared_ptr<Node>& node);
-
     // Maps tensor index to initial tensor index which it is alias to, and to decoder of the node produced this alias
     // and to the output produced during conversion of this node
     std::map<size_t, std::tuple<size_t, std::shared_ptr<TorchDecoder>, Output<Node>>> m_may_be_alias;
@@ -64,7 +61,6 @@ private:
 
     std::map<size_t, std::pair<size_t, Output<Node>>> m_counter_map;
     std::map<std::string, uint64_t> m_op_statistics;
-    std::unordered_set<std::string> m_unique_friendly_name_set;
     size_t m_friendly_name_counter = 0;
 };
 


### PR DESCRIPTION
### Details:
 - *Remove generating unique names from PyTorch FrontEnd, rely on `ResolveNameCollisions` transformation. This will create more stable names, since counter will be different for each collision.*

### Tickets:
 - *None*
