### PR TITLE
[GHA] Add overall status check to more workflows

### DIFF
--- a/.github/workflows/android_arm64.yml
+++ b/.github/workflows/android_arm64.yml
@@ -169,3 +169,17 @@ jobs:
 
       - name: Show ccache stats
         run: ${SCCACHE_PATH} --show-stats
+
+  Overall_Status:
+    name: ci/gha_overall_status_android
+    needs: [Smart_CI, Build]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status of all jobs
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure') ||
+            contains(needs.*.result, 'cancelled')
+          }}
+        run: exit 1

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -242,3 +242,17 @@ jobs:
           python3 -c 'from openvino.frontend import FrontEndManager; assert len(FrontEndManager().get_available_front_ends()) == 6'
           benchmark_app --help
           ovc --help
+
+  Overall_Status:
+    name: ci/gha_overall_status_fedora
+    needs: [Smart_CI, Build, RPM_Packages]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status of all jobs
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure') ||
+            contains(needs.*.result, 'cancelled')
+          }}
+        run: exit 1

--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -346,7 +346,7 @@ jobs:
       event: ${{ github.event_name }}
 
   Overall_Status:
-    name: ci/gha_overall_status
+    name: ci/gha_overall_status_linux_arm64
     needs: [Smart_CI, Build, Debian_Packages, Samples, ONNX_Runtime, CXX_Unit_Tests, Python_Unit_Tests, CPU_Functional_Tests,
             TensorFlow_Hub_Models_Tests, TensorFlow_Hub_Performance_Models_Tests, PyTorch_Models_Tests]
     if: ${{ always() }}

--- a/.github/workflows/linux_conditional_compilation.yml
+++ b/.github/workflows/linux_conditional_compilation.yml
@@ -332,3 +332,17 @@ jobs:
     with:
       runner: 'aks-linux-8-cores-32gb'
       image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04'
+
+  Overall_Status:
+    name: ci/gha_overall_status_linux_cc
+    needs: [Smart_CI, Build, CC_Build, CPU_Functional_Tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status of all jobs
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure') || 
+            contains(needs.*.result, 'cancelled')
+          }}
+        run: exit 1

--- a/.github/workflows/linux_riscv.yml
+++ b/.github/workflows/linux_riscv.yml
@@ -206,3 +206,17 @@ jobs:
           source ${OPENVINO_BUILD_DIR}/dependencies/deactivate_conanbuild.sh
         env:
           CMAKE_TOOLCHAIN_FILE: ${{ env.OPENVINO_BUILD_DIR }}/dependencies/conan_toolchain.cmake
+
+  Overall_Status:
+    name: ci/gha_overall_status_linux_riscv
+    needs: [Smart_CI, Build]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check status of all jobs
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure') || 
+            contains(needs.*.result, 'cancelled')
+          }}
+        run: exit 1


### PR DESCRIPTION
Adding more "overall" status checks needed to make these workflows "required". Also fixes the common check name for linux_arm64 (overall status checks must be unique for each workflow, otherwise they're overwriting each other).

Sadly, there is no point in using reusable workflows to combine all our workflows and provide a single status check for all of them - we already almost hitting the [limits](https://docs.github.com/en/enterprise-server@3.11/actions/using-workflows/reusing-workflows#limitations) of 20 unique workflows reused, having 10 parent workflows (including mac & windows cc) + 9 reusable test workflows. Another option - create a separate workflow that waits for all other workflows to finish and checks their status - is not possible using [core](https://github.com/orgs/community/discussions/16059) GHA features; and any custom actions that implement this are using polling to check workflow's statuses periodically, which is prone to "API rate limit exceeded" issues, especially for long workflows like ours. Another workaround is more like a hack and requires storing all "reusable" code in one file, and having a parameter to control what have to be executed from this file, not sure if we want that. 

So looks like we need to live with separate "required" checks per workflow and wait until [required workflows](https://docs.github.com/en/enterprise-cloud@latest/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-workflows-to-pass-before-merging ) ruleset becomes available for our enterprise plan