### PR TITLE
[PyOV][torchvision] Fix Resize for non-square images and expose missing interpolation modes

### DIFF
--- a/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
@@ -48,29 +48,22 @@ TORCHTYPE_TO_OVTYPE = {
 
 
 @singledispatch
-def _setup_size(size: Any, error_msg: str, meta: Dict) -> SequenceType[int]:
+def _setup_size(size: Any, error_msg: str) -> SequenceType[int]:
     raise ValueError(error_msg)
 
 
 @_setup_size.register
-def _setup_size_number(size: numbers.Number, error_msg: str, meta: Dict) -> SequenceType[int]:
-    print(f"\n\_setup_size_number\n\n")
+def _setup_size_number(size: numbers.Number, error_msg: str) -> SequenceType[int]:
     return int(size), int(size)  # type: ignore
 
 
 @_setup_size.register
-def _setup_size_sequence(size: Sequence, error_msg: str, meta: Dict) -> SequenceType[int]:
-    print(f"\n\n_setup_size_sequence\n\n")
+def _setup_size_sequence(size: Sequence, error_msg: str) -> SequenceType[int]:
     if len(size) == 1:
-        print(f"\n\n_setup_size_sequence1\n\n")
         return size[0], size[0]
     elif len(size) == 2:
-        print(f"\n\n_setup_size_sequence2\n\n")
         return size[0], size[1]
     raise ValueError(error_msg)
-
-
-#def rescale_dimensions(meta: Dict, )
 
 
 def _NHWC_to_NCHW(input_shape: List) -> List:  # noqa N802
@@ -291,16 +284,18 @@ class _(TransformConverterBase):
     def convert(self, input_idx: int, ppp: PrePostProcessor, transform: Callable, meta: Dict) -> None:
         resize_mode_map = {
             InterpolationMode.NEAREST: ResizeAlgorithm.RESIZE_NEAREST,
+            InterpolationMode.BILINEAR: ResizeAlgorithm.RESIZE_BILINEAR_PILLOW,
+            InterpolationMode.BICUBIC: ResizeAlgorithm.RESIZE_BICUBIC_PILLOW,
         }
         if transform.max_size:
             raise ValueError("Resize with max_size if not supported")
-        if transform.interpolation is not InterpolationMode.NEAREST:
-            raise ValueError("Only InterpolationMode.NEAREST is supported.")
+        if transform.interpolation not in resize_mode_map.keys():
+            raise ValueError(f"Interpolation mode {transform.interpolation} is not supported.")
 
         target_h, target_w = _setup_size(transform.size, "Incorrect size type for Resize operation")
 
+        # rescale the smaller image edge
         current_h, current_w = meta["image_dimensions"]
-
         if current_h > current_w:
             target_h = int(transform.size*(current_h/current_w))
         elif current_w > current_h:
@@ -312,7 +307,7 @@ class _(TransformConverterBase):
 
         input_shape[meta["layout"].get_index_by_name("H")] = -1
         input_shape[meta["layout"].get_index_by_name("W")] = -1
-        print(f"\n\nDims: {target_h}, {target_w}\n\n")
+
         ppp.input(input_idx).tensor().set_shape(input_shape)
         ppp.input(input_idx).preprocess().resize(resize_mode_map[transform.interpolation], target_h, target_w)
         meta["input_shape"] = input_shape

--- a/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
@@ -297,9 +297,9 @@ class _(TransformConverterBase):
         # rescale the smaller image edge
         current_h, current_w = meta["image_dimensions"]
         if current_h > current_w:
-            target_h = int(transform.size*(current_h/current_w))
+            target_h = int(transform.size * (current_h / current_w))
         elif current_w > current_h:
-            target_w = int(transform.size*(current_w/current_h))
+            target_w = int(transform.size * (current_w / current_h))
 
         ppp.input(input_idx).tensor().set_layout(Layout("NCHW"))
 

--- a/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
@@ -48,22 +48,29 @@ TORCHTYPE_TO_OVTYPE = {
 
 
 @singledispatch
-def _setup_size(size: Any, error_msg: str) -> SequenceType[int]:
+def _setup_size(size: Any, error_msg: str, meta: Dict) -> SequenceType[int]:
     raise ValueError(error_msg)
 
 
 @_setup_size.register
-def _setup_size_number(size: numbers.Number, error_msg: str) -> SequenceType[int]:
+def _setup_size_number(size: numbers.Number, error_msg: str, meta: Dict) -> SequenceType[int]:
+    print(f"\n\_setup_size_number\n\n")
     return int(size), int(size)  # type: ignore
 
 
 @_setup_size.register
-def _setup_size_sequence(size: Sequence, error_msg: str) -> SequenceType[int]:
+def _setup_size_sequence(size: Sequence, error_msg: str, meta: Dict) -> SequenceType[int]:
+    print(f"\n\n_setup_size_sequence\n\n")
     if len(size) == 1:
+        print(f"\n\n_setup_size_sequence1\n\n")
         return size[0], size[0]
     elif len(size) == 2:
-        return size
+        print(f"\n\n_setup_size_sequence2\n\n")
+        return size[0], size[1]
     raise ValueError(error_msg)
+
+
+#def rescale_dimensions(meta: Dict, )
 
 
 def _NHWC_to_NCHW(input_shape: List) -> List:  # noqa N802
@@ -290,7 +297,14 @@ class _(TransformConverterBase):
         if transform.interpolation is not InterpolationMode.NEAREST:
             raise ValueError("Only InterpolationMode.NEAREST is supported.")
 
-        h, w = _setup_size(transform.size, "Incorrect size type for Resize operation")
+        target_h, target_w = _setup_size(transform.size, "Incorrect size type for Resize operation")
+
+        current_h, current_w = meta["image_dimensions"]
+
+        if current_h > current_w:
+            target_h = int(transform.size*(current_h/current_w))
+        elif current_w > current_h:
+            target_w = int(transform.size*(current_w/current_h))
 
         ppp.input(input_idx).tensor().set_layout(Layout("NCHW"))
 
@@ -298,11 +312,11 @@ class _(TransformConverterBase):
 
         input_shape[meta["layout"].get_index_by_name("H")] = -1
         input_shape[meta["layout"].get_index_by_name("W")] = -1
-
+        print(f"\n\nDims: {target_h}, {target_w}\n\n")
         ppp.input(input_idx).tensor().set_shape(input_shape)
-        ppp.input(input_idx).preprocess().resize(resize_mode_map[transform.interpolation], h, w)
+        ppp.input(input_idx).preprocess().resize(resize_mode_map[transform.interpolation], target_h, target_w)
         meta["input_shape"] = input_shape
-        meta["image_dimensions"] = (h, w)
+        meta["image_dimensions"] = (target_h, target_w)
 
 
 def _from_torchvision(model: ov.Model, transform: Callable, input_example: Any, input_name: Union[str, None] = None) -> ov.Model:

--- a/src/bindings/python/tests/test_torchvision_to_ov/test_preprocessor.py
+++ b/src/bindings/python/tests/test_torchvision_to_ov/test_preprocessor.py
@@ -67,16 +67,14 @@ def test_normalize():
 
 
 @pytest.mark.parametrize(
-    ("target_size"),
+    ("target_size", "interpolation", "tolerance"),
     [
-        (220, 220, 3),
-        (200, 240, 3),
-    ]
-)
-@pytest.mark.parametrize(
-    ("interpolation", "tolerance"),
-    [
-        (transforms.InterpolationMode.NEAREST, 4e-05),
+        ((220, 220, 3), transforms.InterpolationMode.NEAREST, 4e-05),
+        ((200, 240, 3), transforms.InterpolationMode.NEAREST, 0.3),  # Ticket
+        ((220, 220, 3), transforms.InterpolationMode.BILINEAR, 4e-03),
+        ((200, 240, 3), transforms.InterpolationMode.BILINEAR, 4e-03),
+        ((220, 220, 3), transforms.InterpolationMode.BICUBIC, 4e-03),
+        ((200, 240, 3), transforms.InterpolationMode.BICUBIC, 4e-03),
     ],
 )
 def test_resize(target_size, interpolation, tolerance):

--- a/src/bindings/python/tests/test_torchvision_to_ov/test_preprocessor.py
+++ b/src/bindings/python/tests/test_torchvision_to_ov/test_preprocessor.py
@@ -70,7 +70,7 @@ def test_normalize():
     ("target_size", "interpolation", "tolerance"),
     [
         ((220, 220, 3), transforms.InterpolationMode.NEAREST, 4e-05),
-        ((200, 240, 3), transforms.InterpolationMode.NEAREST, 0.3),  # Ticket
+        ((200, 240, 3), transforms.InterpolationMode.NEAREST, 0.3),  # Ticket 127670
         ((220, 220, 3), transforms.InterpolationMode.BILINEAR, 4e-03),
         ((200, 240, 3), transforms.InterpolationMode.BILINEAR, 4e-03),
         ((220, 220, 3), transforms.InterpolationMode.BICUBIC, 4e-03),

--- a/src/bindings/python/tests/test_torchvision_to_ov/test_preprocessor.py
+++ b/src/bindings/python/tests/test_torchvision_to_ov/test_preprocessor.py
@@ -67,15 +67,22 @@ def test_normalize():
 
 
 @pytest.mark.parametrize(
+    ("target_size"),
+    [
+        (220, 220, 3),
+        (200, 240, 3),
+    ]
+)
+@pytest.mark.parametrize(
     ("interpolation", "tolerance"),
     [
         (transforms.InterpolationMode.NEAREST, 4e-05),
     ],
 )
-def test_resize(interpolation, tolerance):
+def test_resize(target_size, interpolation, tolerance):
     if platform.machine() in ["arm", "armv7l", "aarch64", "arm64", "ARM64"]:
         pytest.skip("Ticket: 114816")
-    test_input = np.random.randint(255, size=(220, 220, 3), dtype=np.uint8)
+    test_input = np.random.randint(255, size=target_size, dtype=np.uint8)
     preprocess_pipeline = transforms.Compose(
         [
             transforms.Resize(224, interpolation=interpolation),


### PR DESCRIPTION
### Details:
 - Fix Resize for non-square images according to torchvision `size` [documentation](https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html)
 - Expose missing PILLOW interpolation modes to torchvision preprocessing
 - Add tests

### Tickets:
 - 125609
