### PR TITLE
[GHA] Add workflow_dispatch trigger to coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,5 +1,6 @@
 name: Coverity (Ubuntu 20.04, Python 3.11)
 on:
+  workflow_dispatch:
   schedule:
     # run daily at 00:00
     - cron: '0 0 * * *'


### PR DESCRIPTION
To be able to trigger it via GitHub API from Jenkins nightly, as we did in Azure