### PR TITLE
[GPU] Skip redundant gather in stateful model

### DIFF
--- a/src/plugins/intel_gpu/src/graph/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather.cpp
@@ -132,6 +132,23 @@ std::string gather_inst::to_string(gather_node const& node) {
     return primitive_description.str();
 }
 
+void gather_inst::on_execute() {
+    update_output_memory();
+}
+
+void gather_inst::update_output_memory() {
+    if (!can_be_optimized())
+        return;
+    if (static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+        return;
+
+    if (_node != nullptr)
+        build_deps();
+
+    _outputs[0] = input_memory_ptr();
+    _mem_allocated = false;
+}
+
 gather_inst::typed_primitive_inst(network& network, gather_node const& node) : parent(network, node) {}
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather.cpp
@@ -145,6 +145,8 @@ void gather_inst::update_output_memory() {
     if (_node != nullptr)
         build_deps();
 
+    GPU_DEBUG_TRACE_DETAIL << id() << " : update_output_memory with mem of input " << get_node().get_dependency(0).id()
+                           << " : " << input_memory_ptr()->buffer_ptr() << std::endl;
     _outputs[0] = input_memory_ptr();
     _mem_allocated = false;
 }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/dynamic_shape_gather_opts.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/dynamic_shape_gather_opts.cpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "pass_manager.h"
+#include "gather_inst.h"
+#include "program_helpers.h"
+
+using namespace cldnn;
+
+void dynamic_shape_gather_opts::run(program& p) {
+    auto itr = p.get_processing_order().begin();
+    // Set gathers that might be skipped at runtime as can_be_optimized.
+    // If not set, memory dependency will not work for the nodes that are skipped at runtime
+    while (itr != p.get_processing_order().end()) {
+        auto& node = *itr++;
+        if (!node->is_type<gather>())
+            continue;
+        auto& gather_node = node->as<gather>();
+        // Check pattern
+        auto impl_params = gather_node.get_kernel_impl_params();
+        if (gather_node.has_fused_primitives() ||
+            (impl_params->get_input_layout(0).data_type != impl_params->get_output_layout().data_type) ||
+            gather_node.get_dependency(1).is_constant() || gather_node.get_dependency(1).is_type<data>())
+            continue;
+        auto idx_rank = impl_params->get_input_layout(1).get_partial_shape().size();
+
+        if (idx_rank > 1) {
+            continue;
+        }
+        auto axis = impl_params->typed_desc<gather>()->axis;
+        if (impl_params->get_input_layout(0).get_partial_shape()[axis]  == -1
+            || impl_params->get_input_layout(1).get_partial_shape()[0] == -1
+            || impl_params->get_input_layout(0).get_partial_shape()[axis] == impl_params->get_input_layout(1).get_partial_shape()[0]) {
+            // May be skipepd
+            gather_node.can_be_optimized(true);
+            GPU_DEBUG_TRACE_DETAIL << "[dynamic_shape_gather_opts] : " << gather_node.id() << "can_be_optimized" << std::endl;
+        }
+    }
+}

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -18,6 +18,7 @@
 #include "register.hpp"
 #include "implementation_map.hpp"
 #include "concatenation_inst.h"
+#include "gather_inst.h"
 
 #include <vector>
 #include <list>
@@ -81,7 +82,7 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
     template<typename ImplType>
     static std::unique_ptr<primitive_impl> create(const typed_program_node<PType>& arg, const kernel_impl_params& impl_param) {
         // concat buffer fusing for dynamic shape is adaptively applied at runtime. So we need to build dynamic impl at build time.
-        if (impl_param.can_be_optimized() && !(impl_param.is_type<concatenation>() && impl_param.is_dynamic())) {
+        if (impl_param.can_be_optimized() && !((impl_param.is_type<concatenation>() || impl_param.is_type<gather>()) && impl_param.is_dynamic())) {
             return make_unique<ImplType>(kernel_selector::kernel_data{});
         }
         auto kernel_params = ImplType::get_kernel_params(ImplType::static_canonicalize_shapes(impl_param));

--- a/src/plugins/intel_gpu/src/graph/include/gather_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/gather_inst.h
@@ -34,6 +34,11 @@ public:
     static std::string to_string(gather_node const& node);
 
     typed_primitive_inst(network& network, gather_node const& desc);
+
+    void update_output_memory() override;
+
+private:
+    void on_execute() override;
 };
 
 using gather_inst = typed_primitive_inst<gather>;

--- a/src/plugins/intel_gpu/src/graph/include/pass_manager.h
+++ b/src/plugins/intel_gpu/src/graph/include/pass_manager.h
@@ -414,4 +414,12 @@ private:
     void run(program& p) override;
 };
 
+class dynamic_shape_gather_opts : public base_pass {
+public:
+    dynamic_shape_gather_opts() : base_pass("dynamic_shape_gather_opts") {}
+
+private:
+    void run(program& p) override;
+};
+
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -230,6 +230,7 @@ public:
 
     void build_deps();
     void do_runtime_skip_reorder();
+    void do_runtime_skip_gather();
     void do_runtime_in_place_concat();
     void configure_shape_of_dependencies();
 

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -601,6 +601,9 @@ void program::pre_optimize_graph(bool is_internal) {
     // Call shape_of subgraphs markup second time to update newely added nodes after graph
     // optimization passes
     apply_opt_pass<mark_shape_of_subgraphs>(true);
+
+    // Set gathers that might be skipped at runtime as can_be_optimized.
+    apply_opt_pass<dynamic_shape_gather_opts>();
 }
 
 void program::post_optimize_graph(bool is_internal) {

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/stateful_model.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/stateful_model.cpp
@@ -32,11 +32,11 @@ TEST(stateful_model, skip_gather_at_runtime) {
                       gather("gather",
                              input_info("kv_cache"),
                              input_info("beam_idx"),
-                             0, // axis
+                             0,                                       // axis
                              input_kv_lay.get_partial_shape().size(), // input rank
-                             ov::Shape{}, // output shape
-                             0, // batch_dim
-                             true), // support_neg_ind
+                             ov::Shape{},                             // output shape
+                             0,                                       // batch_dim
+                             true),                                   // support_neg_ind
                       concatenation("concat", {input_info("gather"), input_info("present")}, 0),
                       reorder("reorder", input_info("concat"), format::bfyx, data_types::f32)); /*output padding*/
 
@@ -45,7 +45,8 @@ TEST(stateful_model, skip_gather_at_runtime) {
 
     network network(engine, topology, config);
     auto gather_inst = network.get_primitive("gather");
-    ASSERT_EQ(gather_inst->can_be_optimized(), false);
+    ASSERT_EQ(gather_inst->get_node().can_be_optimized(), true);
+    ASSERT_EQ(gather_inst->can_be_optimized(), true);
 
     auto KV_SIZE = 24;
     auto BATCH_SIZE = 1;
@@ -66,11 +67,63 @@ TEST(stateful_model, skip_gather_at_runtime) {
     network.set_input_data("present", present_mem);
     network.set_input_data("beam_idx", beam_idx_mem);
     network.execute();
-//    ASSERT_EQ(gather_inst->can_be_optimized(), true);
+    ASSERT_EQ(gather_inst->can_be_optimized(), true);
     auto gather_output_mem = network.get_output_memory("gather");
     cldnn::mem_lock<float, mem_lock_type::read> gather_output_ptr(gather_output_mem, get_test_stream());
     for (size_t i = 0; i < gather_output_mem->get_layout().count(); ++i) {
         ASSERT_EQ(gather_output_ptr[i], kv_input_data[i]);
     }
+}
+
+TEST(stateful_model, not_skip_gather_at_runtime) {
+    auto& engine = get_test_engine();
+
+    auto input_kv_lay = layout{ov::PartialShape{-1, 32, -1, 128}, data_types::f32, format::bfyx};
+    auto input_present_lay = layout{ov::PartialShape{-1, 32, -1, 128}, data_types::f32, format::bfyx};
+    auto input_beam_idx_lay = layout{ov::PartialShape{-1}, data_types::i32, format::bfyx};
+
+    topology topology(input_layout("kv_cache", input_kv_lay),
+                      input_layout("beam_idx", input_beam_idx_lay),
+                      input_layout("present", input_present_lay),
+                      gather("gather",
+                             input_info("kv_cache"),
+                             input_info("beam_idx"),
+                             0,                                       // axis
+                             input_kv_lay.get_partial_shape().size(), // input rank
+                             ov::Shape{},                             // output shape
+                             0,                                       // batch_dim
+                             true),                                   // support_neg_ind
+                      concatenation("concat", {input_info("gather"), input_info("present")}, 0),
+                      reorder("reorder", input_info("concat"), format::bfyx, data_types::f32)); /*output padding*/
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
+    auto gather_inst = network.get_primitive("gather");
+    ASSERT_EQ(gather_inst->get_node().can_be_optimized(), true);
+    ASSERT_EQ(gather_inst->can_be_optimized(), true);
+
+    auto KV_SIZE = 24;
+    auto BATCH_SIZE = 1;
+    auto kv_cache_mem = engine.allocate_memory({{KV_SIZE, 32, BATCH_SIZE, 128}, data_types::f32, format::bfyx});
+    auto present_mem = engine.allocate_memory({{1, 32, BATCH_SIZE, 128}, data_types::f32, format::bfyx});
+    auto beam_idx_mem = engine.allocate_memory({{KV_SIZE}, data_types::i32, format::bfyx});
+    std::vector<float> kv_input_data(kv_cache_mem->get_layout().count());
+    std::vector<float> present_input_data(present_mem->get_layout().count());
+    std::vector<int32_t> beam_idx_input_data(beam_idx_mem->get_layout().count());
+    std::iota(kv_input_data.begin(), kv_input_data.end(), 0.f);
+    std::iota(present_input_data.begin(), present_input_data.end(), 0.f);
+    std::iota(beam_idx_input_data.begin(), beam_idx_input_data.end(), 0);
+    std::swap(beam_idx_input_data[0], beam_idx_input_data[1]);
+    set_values(kv_cache_mem, kv_input_data);
+    set_values(present_mem, present_input_data);
+    set_values(beam_idx_mem, beam_idx_input_data);
+
+    network.set_input_data("kv_cache", kv_cache_mem);
+    network.set_input_data("present", present_mem);
+    network.set_input_data("beam_idx", beam_idx_mem);
+    network.execute();
+    ASSERT_EQ(gather_inst->can_be_optimized(), false);
 }
 }  // stateful_model_tests

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/stateful_model.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/stateful_model.cpp
@@ -1,0 +1,76 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include <intel_gpu/primitives/input_layout.hpp>
+#include <intel_gpu/primitives/reorder.hpp>
+#include <intel_gpu/primitives/data.hpp>
+#include <intel_gpu/primitives/gather.hpp>
+#include <intel_gpu/primitives/concatenation.hpp>
+
+#include "program_wrapper.h"
+
+#include <cmath>
+#include <algorithm>
+
+using namespace cldnn;
+using namespace ::tests;
+
+namespace stateful_model_tests {
+TEST(stateful_model, skip_gather_at_runtime) {
+    auto& engine = get_test_engine();
+
+    auto input_kv_lay = layout{ov::PartialShape{-1, 32, -1, 128}, data_types::f32, format::bfyx};
+    auto input_present_lay = layout{ov::PartialShape{-1, 32, -1, 128}, data_types::f32, format::bfyx};
+    auto input_beam_idx_lay = layout{ov::PartialShape{-1}, data_types::i32, format::bfyx};
+
+    topology topology(input_layout("kv_cache", input_kv_lay),
+                      input_layout("beam_idx", input_beam_idx_lay),
+                      input_layout("present", input_present_lay),
+                      gather("gather",
+                             input_info("kv_cache"),
+                             input_info("beam_idx"),
+                             0, // axis
+                             input_kv_lay.get_partial_shape().size(), // input rank
+                             ov::Shape{}, // output shape
+                             0, // batch_dim
+                             true), // support_neg_ind
+                      concatenation("concat", {input_info("gather"), input_info("present")}, 0),
+                      reorder("reorder", input_info("concat"), format::bfyx, data_types::f32)); /*output padding*/
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
+    auto gather_inst = network.get_primitive("gather");
+    ASSERT_EQ(gather_inst->can_be_optimized(), false);
+
+    auto KV_SIZE = 24;
+    auto BATCH_SIZE = 1;
+    auto kv_cache_mem = engine.allocate_memory({{KV_SIZE, 32, BATCH_SIZE, 128}, data_types::f32, format::bfyx});
+    auto present_mem = engine.allocate_memory({{1, 32, BATCH_SIZE, 128}, data_types::f32, format::bfyx});
+    auto beam_idx_mem = engine.allocate_memory({{KV_SIZE}, data_types::i32, format::bfyx});
+    std::vector<float> kv_input_data(kv_cache_mem->get_layout().count());
+    std::vector<float> present_input_data(present_mem->get_layout().count());
+    std::vector<int32_t> beam_idx_input_data(beam_idx_mem->get_layout().count());
+    std::iota(kv_input_data.begin(), kv_input_data.end(), 0.f);
+    std::iota(present_input_data.begin(), present_input_data.end(), 0.f);
+    std::iota(beam_idx_input_data.begin(), beam_idx_input_data.end(), 0);
+    set_values(kv_cache_mem, kv_input_data);
+    set_values(present_mem, present_input_data);
+    set_values(beam_idx_mem, beam_idx_input_data);
+
+    network.set_input_data("kv_cache", kv_cache_mem);
+    network.set_input_data("present", present_mem);
+    network.set_input_data("beam_idx", beam_idx_mem);
+    network.execute();
+//    ASSERT_EQ(gather_inst->can_be_optimized(), true);
+    auto gather_output_mem = network.get_output_memory("gather");
+    cldnn::mem_lock<float, mem_lock_type::read> gather_output_ptr(gather_output_mem, get_test_stream());
+    for (size_t i = 0; i < gather_output_mem->get_layout().count(); ++i) {
+        ASSERT_EQ(gather_output_ptr[i], kv_input_data[i]);
+    }
+}
+}  // stateful_model_tests


### PR DESCRIPTION
### Details:
 - Skip gather if it is just capturing the entire inputs
 - Need to check all indices, so applied only for the target pattern (i.e., gather being used to collect beam idx)

### Tickets:
 - 127581
