### PR TITLE
[CI] [GHA] Remove not-existing reusable workflow from Linux ARM64 workflow

### DIFF
--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -322,18 +322,6 @@ jobs:
       container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04"}'
       event: ${{ github.event_name }}
 
-  TensorFlow_Hub_Performance_Models_Tests:
-    name: TensorFlow Hub Performance Models tests
-    if: ${{ 'false' }} # TODO: Enable once the dependencies are ready for arm (no tensorflow-text available for arm from PyPI)
-    # if: fromJSON(needs.smart_ci.outputs.affected_components).TF_FE.test ||
-    #     fromJSON(needs.smart_ci.outputs.affected_components).TFL_FE.test
-    needs: [ Build, Smart_CI ]
-    uses: ./.github/workflows/job_tensorflow_hub_performance_models_tests.yml
-    with:
-      runner: 'aks-linux-16-cores-arm'
-      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04"}'
-      event: ${{ github.event_name }}
-
   PyTorch_Models_Tests:
     name: PyTorch Models tests
     if: ${{ 'false' }} # TODO: Enable once the dependencies are ready for arm (no tensorflow-text available for arm from PyPI)
@@ -348,7 +336,7 @@ jobs:
   Overall_Status:
     name: ci/gha_overall_status_linux_arm64
     needs: [Smart_CI, Build, Debian_Packages, Samples, ONNX_Runtime, CXX_Unit_Tests, Python_Unit_Tests, CPU_Functional_Tests,
-            TensorFlow_Hub_Models_Tests, TensorFlow_Hub_Performance_Models_Tests, PyTorch_Models_Tests]
+            TensorFlow_Hub_Models_Tests, PyTorch_Models_Tests]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Details:
 - The workflow with tests was removed in #21654, it was not removed from the Linux ARM64 workflow. It is the cause of the broken workflow: 
![image](https://github.com/openvinotoolkit/openvino/assets/65596953/e2c05b8a-8f05-4a53-808e-7a6641b28b6b)

