### PR TITLE
[Snippets] Introduced helpers insert_node and replace_node

### DIFF
--- a/src/common/snippets/docs/snippets_design_guide.md
+++ b/src/common/snippets/docs/snippets_design_guide.md
@@ -538,7 +538,7 @@ flowchart LR
 
 `LinearIR` is our graph representation, it's an analog to an OpenVINO model. 
 It is simply a container for `Expressions`, the order of `Expressions` represents control flow. 
-`LIR` also incorporates a range of useful methods to manage the `Expressions`, for example `create_expression(...)` to build `Expressions` from OpenVINO nodes, or `replace_input(...)` to modify data dependencies between `Expressions`. 
+`LIR` also incorporates a range of useful methods to manage the `Expressions`, for example `create_expression(...)` to build `Expressions` from OpenVINO nodes. 
 Please refer to the implementation in [linear_ir.cpp](../src/lowered/linear_ir.cpp) for more details.
 
 `Expression` is the main building block of a `Linear IR`. 

--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -53,6 +53,9 @@ public:
 
     ExpressionPort get_input_port(size_t i);
     ExpressionPort get_output_port(size_t i);
+    std::vector<ExpressionPort> get_input_ports();
+    std::vector<ExpressionPort> get_output_ports();
+
     void updateShapes();
     virtual bool needShapeInfer() const {return true; }
 

--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -59,7 +59,7 @@ public:
     void updateShapes();
     virtual bool needShapeInfer() const {return true; }
 
-    std::vector<size_t> get_loop_ids() const;
+    const std::vector<size_t>& get_loop_ids() const;
     void set_loop_ids(const std::vector<size_t>& loops);
     virtual ExpressionPtr clone_with_new_inputs(const std::vector<PortConnectorPtr>& new_inputs,
                                                 const std::shared_ptr<Node>& new_node) const;

--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -47,6 +47,8 @@ public:
     size_t get_input_count() const { return m_input_port_connectors.size(); }
     size_t get_output_count() const { return m_output_port_connectors.size(); }
 
+    void set_input_port_connector(size_t port, PortConnectorPtr to);
+
     void validate() const;
 
     ExpressionPort get_input_port(size_t i);
@@ -66,8 +68,6 @@ protected:
     //       The method must be used only by Linear IR builder of expressions!
     Expression(const std::shared_ptr<Node>& n, const std::shared_ptr<IShapeInferSnippetsFactory>& factory);
     void update_node_and_connectors(const std::vector<PortConnectorPtr>& new_inputs, const std::shared_ptr<Node>& new_node);
-
-    void replace_input(size_t port, PortConnectorPtr to);
 
     std::shared_ptr<Node> m_source_node{nullptr};
     std::shared_ptr<Emitter> m_emitter{nullptr};

--- a/src/common/snippets/include/snippets/lowered/expression_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_port.hpp
@@ -43,7 +43,7 @@ public:
     std::set<ExpressionPort> get_connected_ports() const;
 
     // Note: It may be called only for input expression ports
-    //       since output ports don't support PortConnector changing (it defines by Expression creation)
+    //       since output ports don't support PortConnector changing (this is determined by the creation of the expression)
     void replace_input_port_connector(std::shared_ptr<PortConnector> to) const;
 
     friend bool operator==(const ExpressionPort& lhs, const ExpressionPort& rhs);

--- a/src/common/snippets/include/snippets/lowered/expression_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_port.hpp
@@ -42,6 +42,10 @@ public:
     //  - Output port returns all consumer ports (children)
     std::set<ExpressionPort> get_connected_ports() const;
 
+    // Note: It may be called only for input expression ports
+    //       since output ports don't support PortConnector changing (it defines by Expression creation)
+    void replace_input_port_connector(std::shared_ptr<PortConnector> to) const;
+
     friend bool operator==(const ExpressionPort& lhs, const ExpressionPort& rhs);
     friend bool operator!=(const ExpressionPort& lhs, const ExpressionPort& rhs);
     friend bool operator<(const ExpressionPort& lhs, const ExpressionPort& rhs);
@@ -51,6 +55,9 @@ private:
     Type m_type = Type::Output;
     size_t m_port_index = 0;
 };
+
+void replace_input_port_connectors(const std::set<ExpressionPort>& consumers, const std::shared_ptr<PortConnector>& to);
+
 } // namespace lowered
 } // namespace snippets
 } // namespace ov

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -141,43 +141,42 @@ public:
      * @brief Creates new Expression from `new_node` with PortConnectors `new_inputs`,
      *        sets `loops_ids` as loop identifiers and inserts the expression on the `place` in LinearIR.
      *        Also connects output ports to `consumers`
-     *        Notes:
-     *          - The helper doesn't set PortDescriptor - it's responsibility of developers
-     *          - The helper doesn't update LoopPorts of the corresponding loops - it's responsibility of developers
-     *        The helpers has these limitations because that's all depend on semantic of op.
      * @param new_node the target node
      * @param new_inputs vector of PortConnectorsPtr that will be inputs of the expression
      * @param loop_ids vector of loops ids that will be set for the expression
+     * @param update_loop_ports true - the helpers updates the corresponding loop ports after insertion otherwise - skip
      * @param place before this place expression will be inserted
      * @param consumers vector of expression port sets. These expression ports will be consumers of the expression.
      *        The vector may be empty or size of vector must be equal to output port count
      * @return new expression iterator in LinearIR
      */
-    exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<PortConnectorPtr>& new_inputs,
-                       const std::vector<size_t>& loop_ids, const constExprIt& place, const std::vector<std::set<ExpressionPort>>& consumers = {});
+    exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<PortConnectorPtr>& new_inputs, const std::vector<size_t>& loop_ids,
+                       bool update_loop_ports, const constExprIt& place, const std::vector<std::set<ExpressionPort>>& consumers = {});
     /**
      * @brief Creates new Expression from `new_node` with PortConnectors that are output PortConnectors of parent Expressions.
      *        The notes are the same as in helper above
      * @param new_node the target node
      * @param loop_ids vector of loops ids that will be set for the expression
+     * @param update_loop_ports true - the helpers updates the corresponding loop ports after insertion otherwise - skip
      * @param place before this place expression will be inserted
      * @param consumers vector of expression port sets. These expression ports will be consumers of the expression.
      *        The vector may be empty or size of vector must be equal to output port count
      * @return new expression iterator in LinearIR
      */
-    exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<size_t>& loop_ids,
+    exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<size_t>& loop_ids, bool update_loop_ports,
                        const constExprIt& place, const std::vector<std::set<ExpressionPort>>& consumers);
     /**
      * @brief The same helper as the helper above but for case when new_node has only one output.
      *        So we don't need to pass vector of ExpressionPort sets
      * @param new_node the target node
      * @param loop_ids vector of loops ids that will be set for the expression
+     * @param update_loop_ports true - the helpers updates the corresponding loop ports after insertion otherwise - skip
      * @param place before this place expression will be inserted
      * @param consumers set of expression ports. These expression ports will be consumers of the expression output.
      * @return new expression iterator in LinearIR
      */
-    exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<size_t>& loop_ids, const constExprIt& place,
-                       const std::set<ExpressionPort>& consumers = {});
+    exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<size_t>& loop_ids, bool update_loop_ports,
+                       const constExprIt& place, const std::set<ExpressionPort>& consumers = {});
     /**
      * @brief Replace one `new_node` expression with a set of other expressions.
      *        Calls the helper `insert_node` and performs substitution: removes `old_exprs`.

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -81,9 +81,6 @@ public:
 
     const ExpressionPtr& get_expr_by_node(const std::shared_ptr<Node>& n) const;
 
-    void replace_input(const std::set<ExpressionPort>& consumers, const PortConnectorPtr& to);
-    void replace_input(const ExpressionPort& expr_port, const PortConnectorPtr& to);
-
     /**
     * @brief Move an expression from the position "from" to the position immediately before "to".
      * Note: this method does NOT take care about data dependencies and no relevant checks are performed.

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -145,6 +145,9 @@ public:
     exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<PortConnectorPtr>& new_inputs,
                        const std::vector<size_t>& loop_ids, const constExprIt& place,
                        const std::set<ExpressionPort>& consumers = {});
+    exprIt replace_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<PortConnectorPtr>& new_inputs,
+                        const std::vector<size_t>& loop_ids, const constExprIt& place,
+                        const std::vector<ExpressionPtr>& old_exprs);
 
 private:
     std::shared_ptr<ShapeInferSnippetsNode> m_shape_infer = nullptr;

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -136,6 +136,16 @@ public:
     const std::shared_ptr<ShapeInferSnippetsNode>& get_shape_infer_instance() const {return m_shape_infer; }
     VectorDims get_master_shape() const;
 
+    /* ------ Helpers for work with LinearIR ----- */
+    // Create new expression fron the `node`, insert to the `place` of LinearIR and
+    // replace input PortConnectors for `consumers`
+    exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<PortConnectorPtr>& new_inputs,
+                       const std::vector<size_t>& loop_ids, const constExprIt& place,
+                       const std::vector<std::set<ExpressionPort>>& consumers);
+    exprIt insert_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<PortConnectorPtr>& new_inputs,
+                       const std::vector<size_t>& loop_ids, const constExprIt& place,
+                       const std::set<ExpressionPort>& consumers = {});
+
 private:
     std::shared_ptr<ShapeInferSnippetsNode> m_shape_infer = nullptr;
 

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -110,6 +110,7 @@ public:
     // Return outer Loop IDs
     static std::vector<size_t> get_outer_expr_loops(const ExpressionPtr& expr, size_t loop_id);
     static std::vector<size_t> get_common_outer_loops(const ExpressionPtr& lhs, const ExpressionPtr& rhs);
+    static std::vector<size_t> get_common_outer_loops(const std::vector<ExpressionPtr>& exprs);
 
     void mark_loop(LinearIR::constExprIt loop_begin_pos,
                    LinearIR::constExprIt loop_end_pos,
@@ -173,10 +174,17 @@ public:
             update_loop_port(loop_id, actual_port, target_ports, is_entry);
         }
     }
-    // Checks if there is a need to update Loop ports by new inserted expression
-    // if the expression and its sources (or consumers) have the same outer loop ids,
-    // the method tries to update ports of these loops
-    void update_loop_ports_by_inserted_expr(const ExpressionPtr& expr);
+    // The method checks the loops (LoopInfo) that the target expression is marked with and update the corresponding loop ports if needed:
+    //   - If parent of the the target expression and this expression are marked by one Loop and the parent was exit port of this Loop,
+    //     the method replace parent output port with the target expression output ports as new exit LoopPorts.
+    //     If there are other consumers of parent output port that are not by the same Loop (like in the example below),
+    //     the method just adds inserted expression output ports to existing parent output port as new exit LoopPorts.
+    //             Parent [1, 0]
+    //            /              \                                <- Adds the target expression outputs to the existing LoopPort (parent output) of Loop[1]
+    //       Another expr [2]   Target expression [1, 3]             (If Another expr is marked by Loop [1] too, the method will replace loop ports (not add))
+    //   - If the target expression and its consumers have the same outer loop ids and some of consumers are entry ports of these Loops,
+    //     the method just replace the existing entry loop ports (that contains consumer input ports) with the target expression input ports.
+    void update_loop_ports(const ExpressionPtr& expr);
     // Sort Loop Ports by expression locations in Linear IR
     void sort_loop_ports(LinearIR::constExprIt& loop_begin_pos, LinearIR::constExprIt& loop_end_pos, size_t loop_id);
 

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -109,6 +109,7 @@ public:
 
     // Return outer Loop IDs
     static std::vector<size_t> get_outer_expr_loops(const ExpressionPtr& expr, size_t loop_id);
+    static std::vector<size_t> get_common_outer_loops(const ExpressionPtr& lhs, const ExpressionPtr& rhs);
 
     void mark_loop(LinearIR::constExprIt loop_begin_pos,
                    LinearIR::constExprIt loop_end_pos,
@@ -172,6 +173,10 @@ public:
             update_loop_port(loop_id, actual_port, target_ports, is_entry);
         }
     }
+    // Checks if there is a need to update Loop ports by new inserted expression
+    // if the expression and its sources (or consumers) have the same outer loop ids,
+    // the method tries to update ports of these loops
+    void update_loop_ports_by_inserted_expr(const ExpressionPtr& expr);
     // Sort Loop Ports by expression locations in Linear IR
     void sort_loop_ports(LinearIR::constExprIt& loop_begin_pos, LinearIR::constExprIt& loop_end_pos, size_t loop_id);
 

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -175,7 +175,7 @@ public:
         }
     }
     // The method checks the loops (LoopInfo) that the target expression is marked with and update the corresponding loop ports if needed:
-    //   - If parent of the the target expression and this expression are marked by one Loop and the parent was exit port of this Loop,
+    //   - If parent of the target expression and this expression are marked by one Loop and the parent is an exit port of this Loop,
     //     the method replace parent output port with the target expression output ports as new exit LoopPorts.
     //     If there are other consumers of parent output port that are not by the same Loop (like in the example below),
     //     the method just adds inserted expression output ports to existing parent output port as new exit LoopPorts.

--- a/src/common/snippets/src/lowered/expression.cpp
+++ b/src/common/snippets/src/lowered/expression.cpp
@@ -181,6 +181,24 @@ ExpressionPort Expression::get_output_port(size_t i) {
     return ExpressionPort(this->shared_from_this(), ExpressionPort::Type::Output, i);
 }
 
+std::vector<ExpressionPort> Expression::get_input_ports() {
+    std::vector<ExpressionPort> ports;
+    ports.reserve(get_input_count());
+    for (size_t i = 0; i < get_input_count(); ++i) {
+        ports.push_back(std::move(get_input_port(i)));
+    }
+    return ports;
+}
+
+std::vector<ExpressionPort> Expression::get_output_ports() {
+    std::vector<ExpressionPort> ports;
+    ports.reserve(get_output_count());
+    for (size_t i = 0; i < get_output_count(); ++i) {
+        ports.push_back(std::move(get_output_port(i)));
+    }
+    return ports;
+}
+
 void Expression::updateShapes() {
     OPENVINO_ASSERT(m_shapeInference, "Attempt to UpdateShapes without initialized shapeInference");
     IShapeInferSnippets::Result result;

--- a/src/common/snippets/src/lowered/expression.cpp
+++ b/src/common/snippets/src/lowered/expression.cpp
@@ -104,8 +104,18 @@ void Expression::validate() const {
                     "The expression has null source node");
 }
 
-void Expression::replace_input(size_t port, PortConnectorPtr to) {
-    OPENVINO_ASSERT(port < m_input_port_connectors.size(), "Failed to replace: target input port must be less than input count!");
+void Expression::set_input_port_connector(size_t port, PortConnectorPtr to) {
+    OPENVINO_ASSERT(port < get_input_count(), "Failed to set input PortConnector: target input port must be less than input count!");
+    const auto& from = get_input_port_connector(port);
+    if (from == to)
+        return;
+
+    const auto input_port = get_input_port(port);
+    if (!to->found_consumer(input_port)) {
+        to->add_consumer(input_port);
+    }
+    from->remove_consumer(input_port);
+    // Set new PortConnector
     m_input_port_connectors[port] = std::move(to);
 }
 

--- a/src/common/snippets/src/lowered/expression.cpp
+++ b/src/common/snippets/src/lowered/expression.cpp
@@ -119,7 +119,7 @@ void Expression::set_input_port_connector(size_t port, PortConnectorPtr to) {
     m_input_port_connectors[port] = std::move(to);
 }
 
-std::vector<size_t> Expression::get_loop_ids() const {
+const std::vector<size_t>& Expression::get_loop_ids() const {
     return m_loop_ids;
 }
 
@@ -185,7 +185,7 @@ std::vector<ExpressionPort> Expression::get_input_ports() {
     std::vector<ExpressionPort> ports;
     ports.reserve(get_input_count());
     for (size_t i = 0; i < get_input_count(); ++i) {
-        ports.push_back(std::move(get_input_port(i)));
+        ports.push_back(get_input_port(i));
     }
     return ports;
 }
@@ -194,7 +194,7 @@ std::vector<ExpressionPort> Expression::get_output_ports() {
     std::vector<ExpressionPort> ports;
     ports.reserve(get_output_count());
     for (size_t i = 0; i < get_output_count(); ++i) {
-        ports.push_back(std::move(get_output_port(i)));
+        ports.push_back(get_output_port(i));
     }
     return ports;
 }

--- a/src/common/snippets/src/lowered/expression_port.cpp
+++ b/src/common/snippets/src/lowered/expression_port.cpp
@@ -48,6 +48,11 @@ std::set<ExpressionPort> ExpressionPort::get_connected_ports() const {
     OPENVINO_THROW("ExpressionPort supports only Input and Output types");
 }
 
+void ExpressionPort::replace_input_port_connector(std::shared_ptr<PortConnector> to) const {
+    OPENVINO_ASSERT(m_type == Type::Input, "Only Input Expression ports can change the corresponding PortConnector!");
+    get_expr()->set_input_port_connector(m_port_index, std::move(to));
+}
+
 bool operator==(const ExpressionPort& lhs, const ExpressionPort& rhs) {
     if (&lhs == &rhs)
         return true;
@@ -60,6 +65,12 @@ bool operator!=(const ExpressionPort& lhs, const ExpressionPort& rhs) {
 bool operator<(const ExpressionPort& lhs, const ExpressionPort& rhs) {
     OPENVINO_ASSERT(lhs.get_type() == rhs.get_type(), "Incorrect ExpressionPort comparison");
     return (lhs.get_index() < rhs.get_index()) || (lhs.get_index() == rhs.get_index() && lhs.get_expr() < rhs.get_expr());
+}
+
+void replace_input_port_connectors(const std::set<ExpressionPort>& consumers, const std::shared_ptr<PortConnector>& to) {
+    for (const auto& consumer_input : consumers) {
+        consumer_input.replace_input_port_connector(to);
+    }
 }
 
 }// namespace lowered

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -329,8 +329,8 @@ LinearIR::exprIt LinearIR::insert_node(const std::shared_ptr<ov::Node>& new_node
 LinearIR::exprIt LinearIR::replace_node(const std::shared_ptr<ov::Node>& new_node, const std::vector<ExpressionPtr>& old_exprs,
                                         const std::vector<size_t>& loop_ids, const constExprIt& place) {
     OPENVINO_ASSERT(!old_exprs.empty(), "Failed to replace node: there are no old expressions for replacing");
-     OPENVINO_ASSERT(new_node->get_output_size() == old_exprs.back()->get_output_count(),
-                    "Failed to replace node: node output port count is not equal to output count of last old expression");
+    OPENVINO_ASSERT(new_node->get_output_size() == old_exprs.back()->get_output_count(),
+                   "Failed to replace node: node output port count is not equal to output count of last old expression");
 
     std::vector<PortConnectorPtr> new_inputs(new_node->get_input_size());
     for (size_t i = 0; i < new_node->get_input_size(); ++i) {
@@ -370,8 +370,8 @@ LinearIR::exprIt LinearIR::replace_node(const std::shared_ptr<ov::Node>& new_nod
         snippets::lowered::PortDescriptorUtils::set_port_descriptor_ptr(new_node->output(i), last_old_expr->get_output_port_descriptor(0)->clone());
 
     // Notes:
-    // - we cannot automatically updated loop ports in node insertion since there are old_exprs
-    // - we should update loop ports firstly and onlyt after that - remove old exprs from linearIR
+    // - we cannot automatically update loop ports in node insertion since there are old_exprs
+    // - we should update loop ports firstly and only after that - remove old exprs from linearIR
     const auto new_expr_it = insert_node(new_node, new_inputs, loop_ids, false, place, consumers);
     const auto input_ports = new_expr_it->get()->get_input_ports();
     const auto output_ports = new_expr_it->get()->get_output_ports();

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -167,30 +167,6 @@ const ExpressionPtr& LinearIR::get_expr_by_node(const std::shared_ptr<Node>& n) 
     return found->second;
 }
 
-void LinearIR::replace_input(const std::set<ExpressionPort>& consumers, const PortConnectorPtr& to) {
-    for (const auto& consumer_input : consumers) {
-        replace_input(consumer_input, to);
-    }
-}
-
-void LinearIR::replace_input(const ExpressionPort& expr_port, const PortConnectorPtr& to) {
-    const auto port = expr_port.get_index();
-    const auto& expr = expr_port.get_expr();
-
-    OPENVINO_ASSERT(expr_port.get_type() == ExpressionPort::Type::Input, "Failed to replace: target input port must have Input type");
-    OPENVINO_ASSERT(expr_port.get_index() < expr->get_input_count(), "Failed to replace: target input port must be less than input count!");
-
-    const auto& from = expr->get_input_port_connector(port);
-    if (from == to)
-        return;
-
-    if (!to->found_consumer(expr_port)) {
-        to->add_consumer(expr_port);
-    }
-    from->remove_consumer(expr_port);
-    expr->replace_input(port, to);
-}
-
 void LinearIR::register_expression(const ExpressionPtr& expr, bool io_allowed) {
     const auto& node = expr->get_node();
     if (!io_allowed && (is_type<ov::op::v0::Result>(node) || is_type<ov::op::v0::Parameter>(node)))

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -188,7 +188,7 @@ LoopInfoPtr LinearIR::LoopManager::get_loop_info(size_t index) const {
 }
 
 std::vector<size_t> LinearIR::LoopManager::get_outer_expr_loops(const ExpressionPtr& expr, size_t loop_id) {
-    const auto loop_ids = expr->get_loop_ids();
+    const auto& loop_ids = expr->get_loop_ids();
     const auto it = std::find(loop_ids.cbegin(), loop_ids.cend(), loop_id);
     OPENVINO_ASSERT(it != loop_ids.cend(), "Loop ID hasn't been found");
     return std::vector<size_t>(loop_ids.cbegin(), it);
@@ -433,7 +433,7 @@ void LinearIR::LoopManager::fuse_loop_ports(std::vector<LinearIR::LoopManager::L
             }
 
             const auto& consumer = consumer_input.get_expr();
-            const auto loop_ids = consumer->get_loop_ids();
+            const auto& loop_ids = consumer->get_loop_ids();
             if (!is_loop_id_found(loop_ids, loop_id)) {
                 outside_consumers.insert(consumer);
             }

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -198,9 +198,7 @@ std::vector<size_t> LinearIR::LoopManager::get_common_outer_loops(const Expressi
     const auto& rhs_ids = rhs->get_loop_ids();
     const auto& lhs_ids = lhs->get_loop_ids();
     size_t idx = 0;
-    while (idx < std::min(rhs_ids.size(), lhs_ids.size())) {
-        if (rhs_ids[idx] != lhs_ids[idx])
-            break;
+    while (idx < std::min(rhs_ids.size(), lhs_ids.size()) && rhs_ids[idx] == lhs_ids[idx]) {
         idx++;
     }
     return std::vector<size_t>(rhs_ids.cbegin(), rhs_ids.cbegin() + idx);

--- a/src/common/snippets/src/lowered/pass/assign_registers.cpp
+++ b/src/common/snippets/src/lowered/pass/assign_registers.cpp
@@ -98,7 +98,7 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
 
             // TODO: Fix via common pipeline using LoopEnd:
             //       All operations `outside loop` after Horizon ops should have the same register to avoid using it in the next Loop
-            const auto current_loops_ids = expr->get_loop_ids();
+            const auto& current_loops_ids = expr->get_loop_ids();
             auto next_expr = output_tensor->get_consumers().begin()->get_expr();
             while (next_expr->get_loop_ids() == current_loops_ids) {
                 manually_assigned_vecs[next_expr->get_output_port_connector(0)] =

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -202,7 +202,7 @@ bool FuseLoops::run(LinearIR& linear_ir) {
             continue;
 
         // Outer Loop ----> Inner Loop
-        const auto current_expr_loops = expr->get_loop_ids();
+        const auto& current_expr_loops = expr->get_loop_ids();
         const auto current_loop_depth = current_expr_loops.size();
         for (size_t i = 0; i < current_loop_depth; ++i) {
             const auto current_loop_id = current_expr_loops[i];
@@ -235,7 +235,7 @@ bool FuseLoops::run(LinearIR& linear_ir) {
                         continue;
                     }
 
-                    const auto upper_loop_ids = parent_expr->get_loop_ids();
+                    const auto& upper_loop_ids = parent_expr->get_loop_ids();
                     if (upper_loop_ids.empty())
                         continue;
 
@@ -279,7 +279,7 @@ bool FuseLoops::run(LinearIR& linear_ir) {
                             continue;
                         }
 
-                        const auto lower_loop_ids = consumer_expr->get_loop_ids();
+                        const auto& lower_loop_ids = consumer_expr->get_loop_ids();
                         if (lower_loop_ids.empty())
                             continue;
 

--- a/src/common/snippets/src/lowered/pass/identify_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/identify_buffers.cpp
@@ -43,8 +43,8 @@ bool IdentifyBuffers::can_reuse_id(const ShiftPtrParams& lhs, const ShiftPtrPara
 
 bool IdentifyBuffers::are_adjacent(const std::pair<ExpressionPtr, ShiftPtrParams>& lhs,
                                    const std::pair<ExpressionPtr, ShiftPtrParams>& rhs) {
-    const auto lhs_ids = lhs.first->get_loop_ids();
-    const auto rhs_ids = rhs.first->get_loop_ids();
+    const auto& lhs_ids = lhs.first->get_loop_ids();
+    const auto& rhs_ids = rhs.first->get_loop_ids();
     const auto equal_loop_ids = lhs_ids == rhs_ids;
     if (equal_loop_ids) {  // Buffers are connected to the same Loop and have the same outer Loops
         return !can_reuse_id(lhs.second, rhs.second);

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -47,7 +47,6 @@ void InitLoops::init_ptr_increments(const LinearIR::LoopManager::LoopInfoPtr& lo
         if (loop_entry.is_incremented) {
             const auto& port = loop_entry.expr_port;
             const auto source = *port->get_connected_ports().begin();
-            const auto loop_ids = port->get_expr()->get_loop_ids();
             const auto& layout = port->get_descriptor_ptr()->get_layout();
             const auto& shape = port->get_descriptor_ptr()->get_shape();
             const auto& dim = *(layout.rbegin() + loop_entry.dim_idx);
@@ -63,7 +62,6 @@ void InitLoops::init_ptr_increments(const LinearIR::LoopManager::LoopInfoPtr& lo
         loop_exit.ptr_increment = 0;
         if (loop_exit.is_incremented) {
             const auto& port = loop_exit.expr_port;
-            const auto loop_ids = port->get_expr()->get_loop_ids();
             const auto& layout = port->get_descriptor_ptr()->get_layout();
             const auto& shape = port->get_descriptor_ptr()->get_shape();
             const auto original_dim = layout.size() - 1 - loop_exit.dim_idx;

--- a/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
@@ -57,7 +57,6 @@ bool InsertBroadcastMove::run(LinearIR& linear_ir) {
                                 "Attempt to broadcast non-1 dimension. Target dim: ", broadcasted_dim,
                                 " This dim: ", last_dims[i]);
                 const auto broadcast = std::make_shared<op::BroadcastMove>(parent_node, broadcasted_dim);
-                PortDescriptorUtils::set_port_descriptor_ptr(broadcast->output(0), parent_port.get_descriptor_ptr()->clone());
                 const auto broadcast_expr = *linear_ir.insert_node(broadcast, loop_ids, true, expr_it, { expr->get_input_port(i) });
                 // Note that BroadcastMove modified the next expr input shape, so we need to set update
                 // expr's input port descriptor to reflect the changes

--- a/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
@@ -57,7 +57,8 @@ bool InsertBroadcastMove::run(LinearIR& linear_ir) {
                                 "Attempt to broadcast non-1 dimension. Target dim: ", broadcasted_dim,
                                 " This dim: ", last_dims[i]);
                 const auto broadcast = std::make_shared<op::BroadcastMove>(parent_node, broadcasted_dim);
-                const auto broadcast_expr = *linear_ir.insert_node(broadcast, loop_ids, true, expr_it, { expr->get_input_port(i) });
+                const auto broadcast_expr = *linear_ir.insert_node(broadcast, std::vector<PortConnectorPtr>{ connectors[i] },
+                                                                   loop_ids, true, expr_it, { expr->get_input_port(i) });
                 // Note that BroadcastMove modified the next expr input shape, so we need to set update
                 // expr's input port descriptor to reflect the changes
                 expr->get_input_port_descriptor(i)->set_shape(broadcast_expr->get_output_port_descriptor(0)->get_shape());

--- a/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
@@ -61,7 +61,7 @@ bool InsertBroadcastMove::run(LinearIR& linear_ir) {
                 PortDescriptorUtils::set_port_descriptor_ptr(broadcast->output(0), connectors[i]->get_source().get_descriptor_ptr()->clone());
                 const auto broadcast_expr = linear_ir.create_expression(broadcast, {connectors[i]});
                 linear_ir.insert(expr_it, broadcast_expr);
-                linear_ir.replace_input(expr->get_input_port(i), broadcast_expr->get_output_port_connector(0));
+                expr->set_input_port_connector(i, broadcast_expr->get_output_port_connector(0));
                 // Note that BroadcastMove modified the next expr input shape, so we need to set update
                 // expr's input port descriptor to reflect the changes
                 expr->get_input_port_descriptor(i)->set_shape(broadcast_expr->get_output_port_descriptor(0)->get_shape());

--- a/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
@@ -65,7 +65,6 @@ bool InsertBroadcastMove::run(LinearIR& linear_ir) {
                 expr->get_input_port_descriptor(i)->set_shape(broadcast_expr->get_output_port_descriptor(0)->get_shape());
 
                 // Copy Loop identifies
-                broadcast_expr->set_loop_ids(loop_ids);
                 loop_manager->update_loops_port(loop_ids, expr->get_input_port(0), {broadcast_expr->get_input_port(0)}, true);
 
                 modified = true;

--- a/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_broadcastmove.cpp
@@ -39,7 +39,7 @@ bool InsertBroadcastMove::run(LinearIR& linear_ir) {
         const auto& descriptors = expr->get_input_port_descriptors();
         if (!supports_broadcasting(node) || descriptors.size() < 2)
             continue;
-        const auto loop_ids = expr->get_loop_ids();
+        const auto& loop_ids = expr->get_loop_ids();
         const auto& connectors = expr->get_input_port_connectors();
         OPENVINO_ASSERT(connectors.size() == descriptors.size(),
                         "Invalid expression configuration: connectors and descriptors size mismatch");
@@ -52,14 +52,14 @@ bool InsertBroadcastMove::run(LinearIR& linear_ir) {
         const auto broadcasted_dim = *std::max_element(last_dims.begin(), last_dims.end());
         for (size_t i = 0; i < last_dims.size(); i++) {
             const auto& parent_port = connectors[i]->get_source();
-            if (last_dims[i] != broadcasted_dim &&
-                !dont_need_broadcasting(parent_port.get_expr()->get_node())) {
+            const auto& parent_node = parent_port.get_expr()->get_node();
+            if (last_dims[i] != broadcasted_dim && !dont_need_broadcasting(parent_node)) {
                 OPENVINO_ASSERT(last_dims[i] == 1,
                                 "Attempt to broadcast non-1 dimension. Target dim: ", broadcasted_dim,
                                 " This dim: ", last_dims[i]);
-                const auto broadcast = std::make_shared<op::BroadcastMove>(node->get_input_source_output(i), broadcasted_dim);
-                PortDescriptorUtils::set_port_descriptor_ptr(broadcast->output(0), connectors[i]->get_source().get_descriptor_ptr()->clone());
-                const auto broadcast_expr = *linear_ir.insert_node(broadcast, {connectors[i]}, loop_ids, expr_it, { expr->get_input_port(i) });
+                const auto broadcast = std::make_shared<op::BroadcastMove>(parent_node, broadcasted_dim);
+                PortDescriptorUtils::set_port_descriptor_ptr(broadcast->output(0), parent_port.get_descriptor_ptr()->clone());
+                const auto broadcast_expr = *linear_ir.insert_node(broadcast, loop_ids, expr_it, { expr->get_input_port(i) });
                 // Note that BroadcastMove modified the next expr input shape, so we need to set update
                 // expr's input port descriptor to reflect the changes
                 expr->get_input_port_descriptor(i)->set_shape(broadcast_expr->get_output_port_descriptor(0)->get_shape());

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -182,7 +182,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
                                                                    m_buffer_allocation_rank);
             const auto buffer = std::make_shared<op::IntermediateMemoryBuffer>(parent->output(parent_port), allocation_shape);
             PortDescriptorUtils::set_port_descriptor_ptr(buffer->output(0), parent_expr_output.get_descriptor_ptr()->clone());
-            linear_ir.insert_node(buffer, buffer_loop_ids, pos, { *entry_port });
+            linear_ir.insert_node(buffer, buffer_loop_ids, false, pos, { *entry_port });
         }
     }
 
@@ -278,7 +278,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
             //             |    <- It should be new PortConnector
             //            Relu
             // Output port connector is automatically filled from PortDescriptor
-            linear_ir.insert_node(buffer, buffer_loop_ids, pos, { potential_consumers });
+            linear_ir.insert_node(buffer, buffer_loop_ids, false, pos, { potential_consumers });
         }
     }
 }

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -186,7 +186,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
             // Output connector is automatically filled from PortDescriptor
             const auto buffer_expr = linear_ir.create_expression(buffer, {input_connector});
             linear_ir.insert(pos, buffer_expr);
-            linear_ir.replace_input(*entry_port.get(), buffer_expr->get_output_port_connector(0));
+            entry_port->replace_input_port_connector(buffer_expr->get_output_port_connector(0));
             buffer_expr->set_loop_ids(buffer_loop_ids);
         }
     }
@@ -241,7 +241,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
                 for (const auto& buffer : buffers) {
                     const auto& buffer_out = buffer->get_output_port_connector(0);
                     const auto buffer_consumers_inputs = buffer_out->get_consumers();
-                    linear_ir.replace_input(buffer_consumers_inputs, output_connector);
+                    replace_input_port_connectors(buffer_consumers_inputs, output_connector);
                     potential_consumers.insert(buffer_consumers_inputs.begin(), buffer_consumers_inputs.end());
                     linear_ir.erase(linear_ir.find_after(expr_it, buffer));
                 }
@@ -286,7 +286,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
             // Output port connector is automatically filled from PortDescriptor
             const auto buffer_expr = linear_ir.create_expression(buffer, node_outs);
             linear_ir.insert(pos, buffer_expr);
-            linear_ir.replace_input(potential_consumers, buffer_expr->get_output_port_connector(0));
+            replace_input_port_connectors(potential_consumers, buffer_expr->get_output_port_connector(0));
             buffer_expr->set_loop_ids(buffer_loop_ids);
         }
     }

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -181,7 +181,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
                                                                    parent_expr_output,
                                                                    m_buffer_allocation_rank);
             const auto buffer = std::make_shared<op::IntermediateMemoryBuffer>(parent->output(parent_port), allocation_shape);
-            linear_ir.insert_node(buffer, buffer_loop_ids, false, pos, { *entry_port });
+            linear_ir.insert_node(buffer, std::vector<ExpressionPort>{ parent_expr_output }, buffer_loop_ids, false, pos, { *entry_port });
         }
     }
 
@@ -276,7 +276,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
             //             |    <- It should be new PortConnector
             //            Relu
             // Output port connector is automatically filled from PortDescriptor
-            linear_ir.insert_node(buffer, buffer_loop_ids, false, pos, { potential_consumers });
+            linear_ir.insert_node(buffer, std::vector<ExpressionPort>{ *exit_port }, buffer_loop_ids, false, pos, { potential_consumers });
         }
     }
 }

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -183,11 +183,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
                                                                    m_buffer_allocation_rank);
             const auto buffer = std::make_shared<op::IntermediateMemoryBuffer>(parent->output(parent_port), allocation_shape);
             PortDescriptorUtils::set_port_descriptor_ptr(buffer->output(0), parent_expr_output.get_descriptor_ptr()->clone());
-            // Output connector is automatically filled from PortDescriptor
-            const auto buffer_expr = linear_ir.create_expression(buffer, {input_connector});
-            linear_ir.insert(pos, buffer_expr);
-            entry_port->replace_input_port_connector(buffer_expr->get_output_port_connector(0));
-            buffer_expr->set_loop_ids(buffer_loop_ids);
+            linear_ir.insert_node(buffer, {input_connector}, buffer_loop_ids, pos, { *entry_port });
         }
     }
 
@@ -284,10 +280,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
             //             |    <- It should be new PortConnector
             //            Relu
             // Output port connector is automatically filled from PortDescriptor
-            const auto buffer_expr = linear_ir.create_expression(buffer, node_outs);
-            linear_ir.insert(pos, buffer_expr);
-            replace_input_port_connectors(potential_consumers, buffer_expr->get_output_port_connector(0));
-            buffer_expr->set_loop_ids(buffer_loop_ids);
+            linear_ir.insert_node(buffer, node_outs, buffer_loop_ids, pos, { potential_consumers });
         }
     }
 }

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -181,7 +181,6 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
                                                                    parent_expr_output,
                                                                    m_buffer_allocation_rank);
             const auto buffer = std::make_shared<op::IntermediateMemoryBuffer>(parent->output(parent_port), allocation_shape);
-            PortDescriptorUtils::set_port_descriptor_ptr(buffer->output(0), parent_expr_output.get_descriptor_ptr()->clone());
             linear_ir.insert_node(buffer, buffer_loop_ids, false, pos, { *entry_port });
         }
     }
@@ -269,7 +268,6 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::constExprIt& 
                                                                    *exit_port,
                                                                    m_buffer_allocation_rank);
             auto buffer = std::make_shared<op::IntermediateMemoryBuffer>(node->output(port_idx), allocation_shape);
-            PortDescriptorUtils::set_port_descriptor_ptr(buffer->output(0), exit_port->get_descriptor_ptr()->clone());
             // We cannot insert Node output connector on Buffer output because not all consumers of Node needs Buffer
             //  Example:
             //       Add

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -46,7 +46,6 @@ bool InsertLoadStore::insert_load(LinearIR& linear_ir, const LinearIR::constExpr
             return false;
 
         const auto load = std::make_shared<op::Load>(data_ngraph_output, get_count(data_expr->get_output_port_descriptor(0)));
-        PortDescriptorUtils::set_port_descriptor_ptr(load->output(0), consumer_input.get_descriptor_ptr()->clone());
         linear_ir.insert_node(load, consumer_expr->get_loop_ids(), true, linear_ir.find_after(data_expr_it, consumer_expr), { consumer_input });
         was_inserted = true;
     }
@@ -66,7 +65,6 @@ bool InsertLoadStore::insert_store(LinearIR& linear_ir, const LinearIR::constExp
 
     const auto& loop_ids = parent_expr->get_loop_ids();
     const auto store = std::make_shared<op::Store>(parent->output(port), get_count(data_expr->get_input_port_descriptor(0)));
-    PortDescriptorUtils::set_port_descriptor_ptr(store->output(0), parent_output.get_descriptor_ptr()->clone());
     const auto& insertion_pos = linear_ir.find_after(std::reverse_iterator<LinearIR::constExprIt>(data_expr_it), parent_expr).base();
     linear_ir.insert_node(store, loop_ids, true, insertion_pos, { data_expr->get_input_port(0) });
     return true;

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -52,11 +52,8 @@ bool InsertLoadStore::insert_load(LinearIR& linear_ir, const LinearIR::constExpr
         const auto loop_ids = consumer_expr->get_loop_ids();
         const auto load = std::make_shared<op::Load>(data_ngraph_output, get_count(data_expr->get_output_port_descriptor(0)));
         PortDescriptorUtils::set_port_descriptor_ptr(load->output(0), consumer_input.get_descriptor_ptr()->clone());
-        const auto load_expr = linear_ir.create_expression(load, {output_connector});
-        linear_ir.insert(linear_ir.find_after(data_expr_it, consumer_expr), load_expr);
-        consumer_input.replace_input_port_connector(load_expr->get_output_port_connector(0));
-        // Copy Loop identifies
-        load_expr->set_loop_ids(loop_ids);
+        const auto load_expr =
+            *linear_ir.insert_node(load, {output_connector}, loop_ids, linear_ir.find_after(data_expr_it, consumer_expr), { consumer_input });
 
         // Need to update all the corresponding Loops with the same Entry Point
         const auto& prev_entry_point = consumer_input;
@@ -83,12 +80,8 @@ bool InsertLoadStore::insert_store(LinearIR& linear_ir, const LinearIR::constExp
     const auto loop_ids = parent_expr->get_loop_ids();
     const auto store = std::make_shared<op::Store>(parent->output(port), get_count(data_expr->get_input_port_descriptor(0)));
     PortDescriptorUtils::set_port_descriptor_ptr(store->output(0), parent_output.get_descriptor_ptr()->clone());
-    const auto store_expr = linear_ir.create_expression(store, {input_connector});
     const auto& insertion_pos = linear_ir.find_after(std::reverse_iterator<LinearIR::constExprIt>(data_expr_it), parent_expr).base();
-    linear_ir.insert(insertion_pos, store_expr);
-    data_expr->set_input_port_connector(0, store_expr->get_output_port_connector(0));
-    // Copy Loop identifies
-    store_expr->set_loop_ids(loop_ids);
+    const auto store_expr = *linear_ir.insert_node(store, {input_connector}, loop_ids, insertion_pos, { data_expr->get_input_port(0) });
 
     // Need to update all the corresponding Loops with the same Exit Point
     const auto prev_exit_point = parent_output;

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -54,7 +54,7 @@ bool InsertLoadStore::insert_load(LinearIR& linear_ir, const LinearIR::constExpr
         PortDescriptorUtils::set_port_descriptor_ptr(load->output(0), consumer_input.get_descriptor_ptr()->clone());
         const auto load_expr = linear_ir.create_expression(load, {output_connector});
         linear_ir.insert(linear_ir.find_after(data_expr_it, consumer_expr), load_expr);
-        linear_ir.replace_input(consumer_input, load_expr->get_output_port_connector(0));
+        consumer_input.replace_input_port_connector(load_expr->get_output_port_connector(0));
         // Copy Loop identifies
         load_expr->set_loop_ids(loop_ids);
 
@@ -86,7 +86,7 @@ bool InsertLoadStore::insert_store(LinearIR& linear_ir, const LinearIR::constExp
     const auto store_expr = linear_ir.create_expression(store, {input_connector});
     const auto& insertion_pos = linear_ir.find_after(std::reverse_iterator<LinearIR::constExprIt>(data_expr_it), parent_expr).base();
     linear_ir.insert(insertion_pos, store_expr);
-    linear_ir.replace_input(data_expr->get_input_port(0), store_expr->get_output_port_connector(0));
+    data_expr->set_input_port_connector(0, store_expr->get_output_port_connector(0));
     // Copy Loop identifies
     store_expr->set_loop_ids(loop_ids);
 

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -37,27 +37,17 @@ bool InsertLoadStore::insert_load(LinearIR& linear_ir, const LinearIR::constExpr
         OPENVINO_ASSERT(consumer_inputs.size() == 1, "RankNormalization is supposed to be the only consumer");
         data_expr = first_consumer;
     }
-    const auto& loop_manager = linear_ir.get_loop_manager();
     const auto& data_ngraph_output = data_expr->get_node()->output(0);
     bool was_inserted = false;
-    for (const auto& consumer_input :  data_expr->get_output_port_connector(0)->get_consumers()) {
+    for (const auto& consumer_input : data_expr->get_output_port_connector(0)->get_consumers()) {
         const auto& consumer_expr = consumer_input.get_expr();
-        const auto port = consumer_input.get_index();
-        const auto& consumer = consumer_expr->get_node();
-        const auto ma = ov::as_type_ptr<op::MemoryAccess>(consumer);
-        if (ma && ma->is_memory_access_input_port(port))
+        const auto ma = ov::as_type_ptr<op::MemoryAccess>(consumer_expr->get_node());
+        if (ma && ma->is_memory_access_input_port(consumer_input.get_index()))
             return false;
 
-        const auto& loop_ids = consumer_expr->get_loop_ids();
         const auto load = std::make_shared<op::Load>(data_ngraph_output, get_count(data_expr->get_output_port_descriptor(0)));
         PortDescriptorUtils::set_port_descriptor_ptr(load->output(0), consumer_input.get_descriptor_ptr()->clone());
-        const auto load_expr =
-            *linear_ir.insert_node(load, loop_ids, linear_ir.find_after(data_expr_it, consumer_expr), { consumer_input });
-
-        // Need to update all the corresponding Loops with the same Entry Point
-        const auto& prev_entry_point = consumer_input;
-        const auto new_entry_point = load_expr->get_input_port(0);
-        loop_manager->update_loops_port(loop_ids, prev_entry_point, {new_entry_point}, true);
+        linear_ir.insert_node(load, consumer_expr->get_loop_ids(), true, linear_ir.find_after(data_expr_it, consumer_expr), { consumer_input });
         was_inserted = true;
     }
 
@@ -65,10 +55,8 @@ bool InsertLoadStore::insert_load(LinearIR& linear_ir, const LinearIR::constExpr
 }
 
 bool InsertLoadStore::insert_store(LinearIR& linear_ir, const LinearIR::constExprIt& data_expr_it) {
-    const auto& loop_manager = linear_ir.get_loop_manager();
     const auto& data_expr = *data_expr_it;
-    const auto& input_connector = data_expr->get_input_port_connector(0);
-    const auto& parent_output = input_connector->get_source();
+    const auto& parent_output = data_expr->get_input_port_connector(0)->get_source();
     const auto& parent_expr = parent_output.get_expr();
     const auto port = parent_output.get_index();
     const auto& parent = parent_expr->get_node();
@@ -80,26 +68,7 @@ bool InsertLoadStore::insert_store(LinearIR& linear_ir, const LinearIR::constExp
     const auto store = std::make_shared<op::Store>(parent->output(port), get_count(data_expr->get_input_port_descriptor(0)));
     PortDescriptorUtils::set_port_descriptor_ptr(store->output(0), parent_output.get_descriptor_ptr()->clone());
     const auto& insertion_pos = linear_ir.find_after(std::reverse_iterator<LinearIR::constExprIt>(data_expr_it), parent_expr).base();
-    const auto store_expr = *linear_ir.insert_node(store, loop_ids, insertion_pos, { data_expr->get_input_port(0) });
-
-    // Need to update all the corresponding Loops with the same Exit Point
-    const auto prev_exit_point = parent_output;
-    // The previous exit point but one output port can have several consumers that can be potential exit points
-    // So we should verify on the possible future exit points
-    const auto consumer_inputs = input_connector->get_consumers();
-    const auto should_be_saved = std::any_of(consumer_inputs.begin(), consumer_inputs.end(),
-                                [&data_expr](const ExpressionPort& input_port) {
-                                    const auto expr = input_port.get_expr();
-                                    // Skip the current data expr since the input of the expr is changed to Store expr
-                                    if (expr == data_expr)
-                                        return false;
-                                    const auto& node = expr->get_node();
-                                    return ov::is_type<ov::op::v0::Result>(node) || ov::is_type<op::Buffer>(node);
-                                });
-    const auto new_exit_point = store_expr->get_output_port(0);
-    const auto new_exit_points = should_be_saved ? std::vector<ExpressionPort>{prev_exit_point, new_exit_point}
-                                                 : std::vector<ExpressionPort>{new_exit_point};
-    loop_manager->update_loops_port(loop_ids, prev_exit_point, new_exit_points, false);
+    linear_ir.insert_node(store, loop_ids, true, insertion_pos, { data_expr->get_input_port(0) });
     return true;
 }
 

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -88,24 +88,18 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr&
     init_params(loop_entries);
     init_params(loop_exits);
 
+    const auto outer_loop_ids = get_outer_loop_ids(*loop_begin_pos, loop_id);
+
     const auto& loop_begin = std::make_shared<op::LoopBegin>();
-    const auto& loop_begin_expr = linear_ir.create_expression(loop_begin, std::vector<PortConnectorPtr>{});
-    linear_ir.insert(loop_begin_pos, loop_begin_expr);
+    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, std::vector<PortConnectorPtr>{}, outer_loop_ids, loop_begin_pos);
 
     const auto& loop_end = std::make_shared<op::LoopEnd>(
             loop_begin->output(0), work_amount, work_amount_increment, is_incremented, ptr_increments,
             finalization_offsets, io_data_sizes, loop_entries.size(), loop_exits.size(), loop_id);
     loop_end->has_outer_loop = has_outer_loop;
-
     // Add LoopBegin port connector
     loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
-
-    const auto& loop_end_expr = linear_ir.create_expression(loop_end, loop_end_inputs);
-    const auto& it = linear_ir.insert(loop_end_pos, loop_end_expr);
-
-    const auto outer_loop_ids = get_outer_loop_ids(*std::prev(it), loop_id);
-    loop_begin_expr->set_loop_ids(outer_loop_ids);
-    loop_end_expr->set_loop_ids(outer_loop_ids);
+    linear_ir.insert_node(loop_end, loop_end_inputs, outer_loop_ids, loop_end_pos);
 }
 
 bool InsertLoops::run(LinearIR& linear_ir) {

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -91,7 +91,7 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr&
     const auto outer_loop_ids = get_outer_loop_ids(*loop_begin_pos, loop_id);
 
     const auto& loop_begin = std::make_shared<op::LoopBegin>();
-    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, outer_loop_ids, loop_begin_pos);
+    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, outer_loop_ids, false, loop_begin_pos);
 
     const auto& loop_end = std::make_shared<op::LoopEnd>(
             loop_begin->output(0), work_amount, work_amount_increment, is_incremented, ptr_increments,
@@ -99,7 +99,7 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr&
     loop_end->has_outer_loop = has_outer_loop;
     // Add LoopBegin port connector
     loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
-    linear_ir.insert_node(loop_end, loop_end_inputs, outer_loop_ids, loop_end_pos);
+    linear_ir.insert_node(loop_end, loop_end_inputs, outer_loop_ids, false, loop_end_pos);
 }
 
 bool InsertLoops::run(LinearIR& linear_ir) {

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -91,7 +91,7 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr&
     const auto outer_loop_ids = get_outer_loop_ids(*loop_begin_pos, loop_id);
 
     const auto& loop_begin = std::make_shared<op::LoopBegin>();
-    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, std::vector<PortConnectorPtr>{}, outer_loop_ids, loop_begin_pos);
+    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, outer_loop_ids, loop_begin_pos);
 
     const auto& loop_end = std::make_shared<op::LoopEnd>(
             loop_begin->output(0), work_amount, work_amount_increment, is_incremented, ptr_increments,
@@ -119,7 +119,7 @@ bool InsertLoops::run(LinearIR& linear_ir) {
             continue;
 
         // Outer Loop ----> Inner Loop
-        const auto expr_loops = expr->get_loop_ids();
+        const auto& expr_loops = expr->get_loop_ids();
         const auto loop_depth = expr_loops.size();
         for (size_t i = 0; i < loop_depth; ++i) {
             const auto loop_id = expr_loops[i];

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -91,7 +91,7 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr&
     const auto outer_loop_ids = get_outer_loop_ids(*loop_begin_pos, loop_id);
 
     const auto& loop_begin = std::make_shared<op::LoopBegin>();
-    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, outer_loop_ids, false, loop_begin_pos);
+    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, std::vector<PortConnectorPtr>{}, outer_loop_ids, false, loop_begin_pos);
 
     const auto& loop_end = std::make_shared<op::LoopEnd>(
             loop_begin->output(0), work_amount, work_amount_increment, is_incremented, ptr_increments,

--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -46,13 +46,13 @@ bool InsertPerfCount::run(LinearIR& linear_ir) {
     const auto last_param_it = perf_count_begin_pos;
     perf_count_begin_pos = std::next(perf_count_begin_pos);
     const auto& perf_count_begin = std::make_shared<op::PerfCountBegin>();
-    linear_ir.insert_node(perf_count_begin, last_param_it->get()->get_loop_ids(), perf_count_begin_pos);
+    linear_ir.insert_node(perf_count_begin, last_param_it->get()->get_loop_ids(), false, perf_count_begin_pos);
 
     // insert perf_count_end before first result
     const auto& perf_count_end = std::make_shared<op::PerfCountEnd>(perf_count_begin->output(0));
     perf_count_end->set_friendly_name("last_parameter_to_first_result");
     // PerfCountEnd doesn't need PortConnector to PerfCountBegin
-    linear_ir.insert_node(perf_count_end, std::vector<PortConnectorPtr>{}, perf_count_end_pos->get()->get_loop_ids(), perf_count_end_pos);
+    linear_ir.insert_node(perf_count_end, std::vector<PortConnectorPtr>{}, perf_count_end_pos->get()->get_loop_ids(), false, perf_count_end_pos);
 
     return true;
 }

--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -43,16 +43,17 @@ bool InsertPerfCount::run(LinearIR& linear_ir) {
 
     // insert perf_count_begin after last parameter
     // linear_ir.insert has insert before behavior, need move to next.
+    const auto empty_inputs = std::vector<PortConnectorPtr>{};
     const auto last_param_it = perf_count_begin_pos;
     perf_count_begin_pos = std::next(perf_count_begin_pos);
     const auto& perf_count_begin = std::make_shared<op::PerfCountBegin>();
-    linear_ir.insert_node(perf_count_begin, last_param_it->get()->get_loop_ids(), false, perf_count_begin_pos);
+    linear_ir.insert_node(perf_count_begin, empty_inputs, last_param_it->get()->get_loop_ids(), false, perf_count_begin_pos);
 
     // insert perf_count_end before first result
     const auto& perf_count_end = std::make_shared<op::PerfCountEnd>(perf_count_begin->output(0));
     perf_count_end->set_friendly_name("last_parameter_to_first_result");
     // PerfCountEnd doesn't need PortConnector to PerfCountBegin
-    linear_ir.insert_node(perf_count_end, std::vector<PortConnectorPtr>{}, perf_count_end_pos->get()->get_loop_ids(), false, perf_count_end_pos);
+    linear_ir.insert_node(perf_count_end, empty_inputs, perf_count_end_pos->get()->get_loop_ids(), false, perf_count_end_pos);
 
     return true;
 }

--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -46,11 +46,12 @@ bool InsertPerfCount::run(LinearIR& linear_ir) {
     const auto last_param_it = perf_count_begin_pos;
     perf_count_begin_pos = std::next(perf_count_begin_pos);
     const auto& perf_count_begin = std::make_shared<op::PerfCountBegin>();
-    linear_ir.insert_node(perf_count_begin, std::vector<PortConnectorPtr>{}, last_param_it->get()->get_loop_ids(), perf_count_begin_pos);
+    linear_ir.insert_node(perf_count_begin, last_param_it->get()->get_loop_ids(), perf_count_begin_pos);
 
     // insert perf_count_end before first result
     const auto& perf_count_end = std::make_shared<op::PerfCountEnd>(perf_count_begin->output(0));
     perf_count_end->set_friendly_name("last_parameter_to_first_result");
+    // PerfCountEnd doesn't need PortConnector to PerfCountBegin
     linear_ir.insert_node(perf_count_end, std::vector<PortConnectorPtr>{}, perf_count_end_pos->get()->get_loop_ids(), perf_count_end_pos);
 
     return true;

--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -43,16 +43,15 @@ bool InsertPerfCount::run(LinearIR& linear_ir) {
 
     // insert perf_count_begin after last parameter
     // linear_ir.insert has insert before behavior, need move to next.
+    const auto last_param_it = perf_count_begin_pos;
     perf_count_begin_pos = std::next(perf_count_begin_pos);
     const auto& perf_count_begin = std::make_shared<op::PerfCountBegin>();
-    const auto& perf_count_begin_expr = linear_ir.create_expression(perf_count_begin, std::vector<PortConnectorPtr>{});
-    linear_ir.insert(perf_count_begin_pos, perf_count_begin_expr);
+    linear_ir.insert_node(perf_count_begin, std::vector<PortConnectorPtr>{}, last_param_it->get()->get_loop_ids(), perf_count_begin_pos);
 
     // insert perf_count_end before first result
     const auto& perf_count_end = std::make_shared<op::PerfCountEnd>(perf_count_begin->output(0));
     perf_count_end->set_friendly_name("last_parameter_to_first_result");
-    const auto& perf_count_end_expr = linear_ir.create_expression(perf_count_end, std::vector<PortConnectorPtr>{});
-    linear_ir.insert(perf_count_end_pos, perf_count_end_expr);
+    linear_ir.insert_node(perf_count_end, std::vector<PortConnectorPtr>{}, perf_count_end_pos->get()->get_loop_ids(), perf_count_end_pos);
 
     return true;
 }

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -251,14 +251,13 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
                                           LinearIR::constExprIt tail_end,
                                           const size_t tail_size) {
     const auto& config = linear_ir.get_config();
-    auto insertFill = [tail_size](const ov::Input<ov::Node>& input) -> std::shared_ptr<ov::Node> {
+    auto insertFill = [tail_size](const ov::Input<ov::Node>& input, const ExpressionPort& source) -> std::shared_ptr<ov::Node> {
         std::shared_ptr<ov::Node> fill = nullptr;
         auto& rt = input.get_rt_info();
         auto fill_rt = rt.find("set_fill");
         if (fill_rt != rt.end()) {
             const auto fill_value = fill_rt->second.as<uint32_t>();
-            fill = std::make_shared<ov::snippets::op::Fill>(input.get_source_output(), tail_size, fill_value);
-            input.get_node()->set_argument(input.get_index(), fill);
+            fill = std::make_shared<ov::snippets::op::Fill>(source.get_expr()->get_node()->output(source.get_index()), tail_size, fill_value);
         }
         return fill;
     };
@@ -279,9 +278,9 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
         if (config.m_need_fill_tail_register &&
             (ov::is_type<ov::op::v1::Maximum>(op) ||
              ov::is_type<ov::op::v1::Add>(op))) {
-            for (size_t i = 0; i < op->inputs().size(); ++i) {
-                if (auto fill = insertFill(op->input(i))) {
-                    const auto& input = expr->get_input_port_connector(i);
+            for (size_t i = 0; i < expr->get_input_count(); ++i) {
+                const auto& input = expr->get_input_port_connector(i);
+                if (auto fill = insertFill(op->input(i), input->get_source())) {
                     const auto consumers = input->get_consumers();
                     // If there are several consumers, fill expression must be inserted before first of them
                     auto fst_consumer = std::min_element(consumers.cbegin(), consumers.cend(), [&](ExpressionPort lhs, ExpressionPort rhs) {
@@ -289,7 +288,7 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
                         auto rhs_it = linear_ir.find(rhs.get_expr());
                         return std::distance(linear_ir.cbegin(), lhs_it) < std::distance(linear_ir.cbegin(), rhs_it);
                     });
-                    const auto fill_expr = *linear_ir.insert_node(fill, {input}, expr->get_loop_ids(), linear_ir.find(fst_consumer->get_expr()), consumers);
+                    const auto fill_expr = *linear_ir.insert_node(fill, expr->get_loop_ids(), linear_ir.find(fst_consumer->get_expr()), consumers);
 
                     // in_reg == out_reg since we want to modify vector reg inplace
                     const auto reg = expr->get_input_port_descriptor(0)->get_reg();

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -288,7 +288,8 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
                         auto rhs_it = linear_ir.find(rhs.get_expr());
                         return std::distance(linear_ir.cbegin(), lhs_it) < std::distance(linear_ir.cbegin(), rhs_it);
                     });
-                    const auto fill_expr = *linear_ir.insert_node(fill, expr->get_loop_ids(), true, linear_ir.find(fst_consumer->get_expr()), consumers);
+                    const auto fill_expr = *linear_ir.insert_node(fill, std::vector<ExpressionPort>{ input->get_source() }, expr->get_loop_ids(), true,
+                                                                  linear_ir.find(fst_consumer->get_expr()), consumers);
 
                     // in_reg == out_reg since we want to modify vector reg inplace
                     const auto reg = expr->get_input_port_descriptor(0)->get_reg();

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -292,7 +292,7 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
                     const auto insert_pos = linear_ir.find(fst_consumer->get_expr());
                     auto fill_expr = linear_ir.create_expression(fill, {input});
                     linear_ir.insert(insert_pos, fill_expr);
-                    linear_ir.replace_input(consumers, fill_expr->get_output_port_connector(0));
+                    replace_input_port_connectors(consumers, fill_expr->get_output_port_connector(0));
                     // in_reg == out_reg since we want to modify vector reg inplace
                     const auto reg = expr->get_input_port_descriptor(0)->get_reg();
                     fill_expr->get_input_port_descriptor(0)->set_reg(reg);

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -289,15 +289,12 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
                         auto rhs_it = linear_ir.find(rhs.get_expr());
                         return std::distance(linear_ir.cbegin(), lhs_it) < std::distance(linear_ir.cbegin(), rhs_it);
                     });
-                    const auto insert_pos = linear_ir.find(fst_consumer->get_expr());
-                    auto fill_expr = linear_ir.create_expression(fill, {input});
-                    linear_ir.insert(insert_pos, fill_expr);
-                    replace_input_port_connectors(consumers, fill_expr->get_output_port_connector(0));
+                    const auto fill_expr = *linear_ir.insert_node(fill, {input}, expr->get_loop_ids(), linear_ir.find(fst_consumer->get_expr()), consumers);
+
                     // in_reg == out_reg since we want to modify vector reg inplace
                     const auto reg = expr->get_input_port_descriptor(0)->get_reg();
                     fill_expr->get_input_port_descriptor(0)->set_reg(reg);
                     fill_expr->get_output_port_descriptor(0)->set_reg(reg);
-                    fill_expr->set_loop_ids(expr->get_loop_ids());
                 }
             }
         } else if (const auto memory_access = std::dynamic_pointer_cast<ov::snippets::op::MemoryAccess>(op)) {

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -288,7 +288,7 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
                         auto rhs_it = linear_ir.find(rhs.get_expr());
                         return std::distance(linear_ir.cbegin(), lhs_it) < std::distance(linear_ir.cbegin(), rhs_it);
                     });
-                    const auto fill_expr = *linear_ir.insert_node(fill, expr->get_loop_ids(), linear_ir.find(fst_consumer->get_expr()), consumers);
+                    const auto fill_expr = *linear_ir.insert_node(fill, expr->get_loop_ids(), true, linear_ir.find(fst_consumer->get_expr()), consumers);
 
                     // in_reg == out_reg since we want to modify vector reg inplace
                     const auto reg = expr->get_input_port_descriptor(0)->get_reg();

--- a/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
+++ b/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
@@ -26,7 +26,7 @@ bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
             const auto& interm_connector = expr->get_input_port_connector(0);
             const auto parent_expr = interm_connector->get_source().get_expr();
             const auto load = ov::as_type_ptr<op::Load>(parent_expr->get_node());
-            if (!load)
+            if (!load || expr->get_loop_ids() != parent_expr->get_loop_ids())
                 continue;
 
             // Cannot rewrite Broadcast + Load if load has more than 1 user
@@ -44,8 +44,7 @@ bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
 
             const auto& outshape = move_broadcast->get_output_partial_shape(0);
             const auto broadcastload = std::make_shared<snippets::op::BroadcastLoad>(load->input_value(0), *outshape.rbegin(), load->get_offset());
-            expr_it = linear_ir.replace_node(broadcastload, { parent_expr->get_input_port_connector(0) }, parent_expr->get_loop_ids(),
-                                             std::next(expr_it), { parent_expr, expr });
+            expr_it = linear_ir.replace_node(broadcastload, { parent_expr, expr });
             modified |= true;
         }
     }

--- a/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
+++ b/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
@@ -47,7 +47,7 @@ bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
 
             const auto& outshape = move_broadcast->get_output_partial_shape(0);
             const auto broadcastload = std::make_shared<snippets::op::BroadcastLoad>(load->input_value(0), *outshape.rbegin(), load->get_offset());
-            expr_it = linear_ir.replace_with_node(broadcastload, { parent_expr, expr });
+            expr_it = linear_ir.replace_with_node({ parent_expr, expr }, broadcastload);
             modified |= true;
         }
     }

--- a/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
+++ b/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
@@ -58,7 +58,7 @@ bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
             expr_it = linear_ir.insert(insertion_pos, broadcastload_expr);
             linear_ir.erase(linear_ir.find_before(mv_expr_it, parent_expr));
             linear_ir.erase(mv_expr_it);
-            linear_ir.replace_input(move_consumers, broadcastload_expr->get_output_port_connector(0));
+            replace_input_port_connectors(move_consumers, broadcastload_expr->get_output_port_connector(0));
             modified |= true;
         }
     }

--- a/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
+++ b/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
@@ -24,6 +24,7 @@ bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
         const auto& op = expr->get_node();
         // Match on MoveBroadcast because MoveBroadcast is rare node in bodies
         if (const auto move_broadcast = ov::as_type_ptr<op::BroadcastMove>(op)) {
+            const auto mv_expr_it = expr_it;
             const auto& interm_connector = expr->get_input_port_connector(0);
             const auto parent_expr = interm_connector->get_source().get_expr();
             const auto load = ov::as_type_ptr<op::Load>(parent_expr->get_node());
@@ -45,20 +46,16 @@ bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
 
             const auto& outshape = move_broadcast->get_output_partial_shape(0);
             const auto broadcastload = std::make_shared<snippets::op::BroadcastLoad>(load->input_value(0), *outshape.rbegin(), load->get_offset());
-            const auto move_consumers = expr->get_output_port_connector(0)->get_consumers();
             PortDescriptorUtils::set_port_descriptor_ptr(broadcastload->output(0), expr->get_output_port(0).get_descriptor_ptr()->clone());
-            const auto broadcastload_expr = linear_ir.create_expression(broadcastload, { parent_expr->get_input_port_connector(0) });
-            // Copy Loop identifies
-            broadcastload_expr->set_loop_ids(parent_expr->get_loop_ids());
+            expr_it = linear_ir.insert_node(broadcastload, { parent_expr->get_input_port_connector(0) }, parent_expr->get_loop_ids(), std::next(expr_it),
+                                            { expr->get_output_port_connector(0)->get_consumers() });
+            const auto broadcastload_expr = *expr_it;
+
             // Update the corresponding Loops with
             loop_manager->update_loops_port(parent_expr->get_loop_ids(), parent_expr->get_input_port(0), {broadcastload_expr->get_input_port(0)}, true);
 
-            const auto mv_expr_it = expr_it;
-            const auto insertion_pos = std::next(expr_it);
-            expr_it = linear_ir.insert(insertion_pos, broadcastload_expr);
             linear_ir.erase(linear_ir.find_before(mv_expr_it, parent_expr));
             linear_ir.erase(mv_expr_it);
-            replace_input_port_connectors(move_consumers, broadcastload_expr->get_output_port_connector(0));
             modified |= true;
         }
     }

--- a/src/common/snippets/src/lowered/pass/move_result_out_of_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/move_result_out_of_loop.cpp
@@ -33,7 +33,7 @@ bool MoveResultOutOfLoop::run(LinearIR& linear_ir) {
 
         const auto& input_connector = expr->get_input_port_connector(0);
         const auto& parent_expr = input_connector->get_source().get_expr();
-        const auto parent_loop_ids = parent_expr->get_loop_ids();
+        const auto& parent_loop_ids = parent_expr->get_loop_ids();
 
         // Parent is out of Loop: just verify that Result is after Parent
         if (parent_loop_ids.empty()) {

--- a/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
@@ -95,9 +95,8 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
             const auto mul = push_node(std::make_shared<ov::op::v1::Multiply>(exp.second, broadcast_pow.second));
 
             // Transfer original ExpressionPorts
-            linear_ir.replace_input((*max.first)->get_input_port(0), input_connector);
-            linear_ir.replace_input((*sub.first)->get_input_port(0), input_connector);
-            linear_ir.replace_input(output_connector->get_consumers(), (*mul.first)->get_output_port_connector(0));
+            replace_input_port_connectors({ max.first->get()->get_input_port(0), sub.first->get()->get_input_port(0) }, input_connector);
+            replace_input_port_connectors(output_connector->get_consumers(), (*mul.first)->get_output_port_connector(0));
 
             // Markup of Mul Loop
             loop_manager->mark_loop(mul.first, expr_it, inner_work_amount, m_vector_size, 0,

--- a/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
@@ -35,7 +35,7 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
             const auto& pm = matcher->get_pattern_map();
             const auto softmax = pm.at(match_softmax);
             const auto softmax_expr = *expr_it;
-            const auto softmax_loop_ids = softmax_expr->get_loop_ids();
+            const auto& softmax_loop_ids = softmax_expr->get_loop_ids();
             const auto& input_connector = softmax_expr->get_input_port_connector(0);
             const auto& output_connector = softmax_expr->get_output_port_connector(0);
             const auto tensor_out = softmax_expr->get_output_port_descriptor(0)->get_shape();

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -48,7 +48,7 @@ bool SplitLoops::run(LinearIR& linear_ir) {
         for (const auto& entry_point : loop->get_entry_points()) {
             const auto& parent_port = entry_point.expr_port->get_port_connector_ptr()->get_source();
             const auto& parent_expr = parent_port.get_expr();
-            const auto parent_loop_ids = parent_expr->get_loop_ids();
+            const auto& parent_loop_ids = parent_expr->get_loop_ids();
             if (parent_loop_ids.empty())
                 continue;
 

--- a/src/common/snippets/src/lowered/pass/validate_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_loops.cpp
@@ -44,7 +44,7 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
     auto validate_loop_ports = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](const std::vector<LoopPort>& loop_ports) {
         for (const auto& loop_port : loop_ports) {
             const auto expr = loop_port.expr_port->get_expr();
-            const auto loop_ids = expr->get_loop_ids();
+            const auto& loop_ids = expr->get_loop_ids();
             // If loop_ids of the current port is subsequence of already validated IDs, skip
             if (is_already_verified(loop_ids))
                 continue;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
@@ -61,7 +61,7 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowe
 
     linear_ir.erase(std::find(linear_ir.cbegin(), convert_expr_it, load_expr));
     linear_ir.erase(convert_expr_it);
-    linear_ir.replace_input(convert_consumers, load_convert_expr->get_output_port_connector(0));
+    replace_input_port_connectors(convert_consumers, load_convert_expr->get_output_port_connector(0));
     return true;
 }
 
@@ -113,7 +113,7 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::low
 
     linear_ir.erase(std::find(convert_expr_it, linear_ir.cend(), store_expr));
     linear_ir.erase(convert_expr_it);
-    linear_ir.replace_input(store_consumers, store_convert_expr->get_output_port_connector(0));
+    replace_input_port_connectors(store_consumers, store_convert_expr->get_output_port_connector(0));
     return true;
 }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
@@ -14,8 +14,7 @@
 
 bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowered::LinearIR& linear_ir,
                                                                   snippets::lowered::LinearIR::constExprIt& convert_it) {
-    const auto convert_expr_it = convert_it;
-    const auto& convert_expr = *convert_expr_it;
+    const auto& convert_expr = *convert_it;
     const auto& convert = ov::as_type_ptr<ov::op::v0::Convert>(convert_expr->get_node());
     const auto& input_connector = convert_expr->get_input_port_connector(0);
     if (convert->get_destination_type() != ov::element::f32 && convert->get_destination_type() != ov::element::i32)
@@ -29,6 +28,7 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowe
         ov::is_type<snippets::op::BroadcastLoad>(load_expr->get_node()))
         return false;
 
+    const auto& load_input = load_expr->get_input_port_connector(0);
     const auto consumers = input_connector->get_consumers();
     if (consumers.size() != 1)
         return false;
@@ -46,25 +46,13 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowe
         OPENVINO_THROW("Type of Convert op is undefined. Supports only fusing Load and ConvertTruncation or ConvertSaturation ops");
     }
 
-    const auto& load_loop_ids = load_expr->get_loop_ids();
-    const auto out_port = convert_expr->get_output_port(0);
-    const auto convert_consumers = out_port.get_connected_ports();
-    snippets::lowered::PortDescriptorUtils::set_port_descriptor_ptr(load_convert->output(0), out_port.get_descriptor_ptr()->clone());
-    convert_it = linear_ir.insert_node(load_convert, { load_expr->get_input_port_connector(0) }, load_loop_ids, std::next(convert_expr_it), convert_consumers);
-    const auto load_convert_expr = *convert_it;
+    convert_it = linear_ir.replace_node(load_convert, { load_input }, load_expr->get_loop_ids(), std::next(convert_it), {load_expr, convert_expr});
 
-    const auto& loop_manager = linear_ir.get_loop_manager();
-    loop_manager->update_loops_port(load_loop_ids, load_expr->get_input_port(0), {load_convert_expr->get_input_port(0)}, true);
-    loop_manager->update_loops_port(load_loop_ids, convert_expr->get_output_port(0), {load_convert_expr->get_output_port(0)}, false);
-
-    linear_ir.erase(std::find(linear_ir.cbegin(), convert_expr_it, load_expr));
-    linear_ir.erase(convert_expr_it);
     return true;
 }
 
 bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::lowered::LinearIR& linear_ir,
                                                                    snippets::lowered::LinearIR::constExprIt& convert_it) {
-    const auto convert_expr_it = convert_it;
     const auto& convert_expr = *convert_it;
     const auto& convert = ov::as_type_ptr<ov::op::v0::Convert>(convert_expr->get_node());
     const auto& input_connector = convert_expr->get_input_port_connector(0);
@@ -95,20 +83,8 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::low
         OPENVINO_THROW("Type of Convert op is undefined. Supports only fusing Store and ConvertTruncation or ConvertSaturation ops");
     }
 
-    const auto& convert_loop_ids = convert_expr->get_loop_ids();
+    convert_it = linear_ir.replace_node(store_convert, { input_connector }, convert_expr->get_loop_ids(), std::next(convert_it), {convert_expr, store_expr});
 
-    const auto out_port = store_expr->get_output_port(0);
-    const auto store_consumers = out_port.get_connected_ports();
-    snippets::lowered::PortDescriptorUtils::set_port_descriptor_ptr(store_convert->output(0), out_port.get_descriptor_ptr()->clone());
-    convert_it = linear_ir.insert_node(store_convert, { input_connector }, convert_loop_ids, std::next(convert_it), store_consumers);
-    const auto store_convert_expr = *convert_it;
-
-    const auto& loop_manager = linear_ir.get_loop_manager();
-    loop_manager->update_loops_port(convert_loop_ids, convert_expr->get_input_port(0), {store_convert_expr->get_input_port(0)}, true);
-    loop_manager->update_loops_port(convert_loop_ids, store_expr->get_output_port(0), {store_convert_expr->get_output_port(0)}, false);
-
-    linear_ir.erase(std::find(convert_expr_it, linear_ir.cend(), store_expr));
-    linear_ir.erase(convert_expr_it);
     return true;
 }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
@@ -48,7 +48,7 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowe
         OPENVINO_THROW("Type of Convert op is undefined. Supports only fusing Load and ConvertTruncation or ConvertSaturation ops");
     }
 
-    convert_it = linear_ir.replace_with_node(load_convert, {load_expr, convert_expr});
+    convert_it = linear_ir.replace_with_node({load_expr, convert_expr}, load_convert);
 
     return true;
 }
@@ -87,7 +87,7 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::low
         OPENVINO_THROW("Type of Convert op is undefined. Supports only fusing Store and ConvertTruncation or ConvertSaturation ops");
     }
 
-    convert_it = linear_ir.replace_with_node(store_convert, {convert_expr, store_expr});
+    convert_it = linear_ir.replace_with_node({convert_expr, store_expr}, store_convert);
 
     return true;
 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/fuse_load_store_and_convert.cpp
@@ -25,28 +25,28 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_load_convert(snippets::lowe
     const auto load = ov::as_type_ptr<snippets::op::Load>(load_expr->get_node());
     if (!load ||
         ov::is_type<snippets::op::LoadReshape>(load_expr->get_node()) ||
-        ov::is_type<snippets::op::BroadcastLoad>(load_expr->get_node()))
+        ov::is_type<snippets::op::BroadcastLoad>(load_expr->get_node()) ||
+        convert_expr->get_loop_ids() != load_expr->get_loop_ids())
         return false;
 
-    const auto& load_input = load_expr->get_input_port_connector(0);
     const auto consumers = input_connector->get_consumers();
     if (consumers.size() != 1)
         return false;
 
+    const auto& parent_source = load_expr->get_input_port_connector(0)->get_source();
+    const auto parent_output = parent_source.get_expr()->get_node()->output(parent_source.get_index());
     std::shared_ptr<ov::Node> load_convert = nullptr;
     if (ov::is_type<snippets::op::ConvertSaturation>(convert)) {
-        load_convert = std::make_shared<ov::intel_cpu::LoadConvertSaturation>(load->input_value(0),
-                                                                              convert->get_destination_type(),
+        load_convert = std::make_shared<ov::intel_cpu::LoadConvertSaturation>(parent_output, convert->get_destination_type(),
                                                                               load->get_count(), load->get_offset());
     } else if (ov::is_type<snippets::op::ConvertTruncation>(convert)) {
-        load_convert = std::make_shared<ov::intel_cpu::LoadConvertTruncation>(load->input_value(0),
-                                                                              convert->get_destination_type(),
+        load_convert = std::make_shared<ov::intel_cpu::LoadConvertTruncation>(parent_output, convert->get_destination_type(),
                                                                               load->get_count(), load->get_offset());
     } else {
         OPENVINO_THROW("Type of Convert op is undefined. Supports only fusing Load and ConvertTruncation or ConvertSaturation ops");
     }
 
-    convert_it = linear_ir.replace_node(load_convert, { load_input }, load_expr->get_loop_ids(), std::next(convert_it), {load_expr, convert_expr});
+    convert_it = linear_ir.replace_node(load_convert, {load_expr, convert_expr});
 
     return true;
 }
@@ -55,7 +55,6 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::low
                                                                    snippets::lowered::LinearIR::constExprIt& convert_it) {
     const auto& convert_expr = *convert_it;
     const auto& convert = ov::as_type_ptr<ov::op::v0::Convert>(convert_expr->get_node());
-    const auto& input_connector = convert_expr->get_input_port_connector(0);
     const auto& output_connector = convert_expr->get_output_port_connector(0);
     if (convert->get_input_element_type(0) != ov::element::f32 && convert->get_input_element_type(0) != ov::element::i32)
         return false;
@@ -67,23 +66,24 @@ bool ov::intel_cpu::pass::FuseLoadStoreConvert::fuse_store_convert(snippets::low
     const auto store_input = *(consumers.begin());
     const auto& store_expr = store_input.get_expr();
     const auto store = ov::as_type_ptr<snippets::op::Store>(store_expr->get_node());
-    if (!store)
+    if (!store ||
+        convert_expr->get_loop_ids() != store_expr->get_loop_ids())
         return false;
 
+    const auto& parent_source = convert_expr->get_input_port_connector(0)->get_source();
+    const auto parent_output = parent_source.get_expr()->get_node()->output(parent_source.get_index());
     std::shared_ptr<ov::Node> store_convert = nullptr;
     if (ov::is_type<snippets::op::ConvertSaturation>(convert)) {
-        store_convert = std::make_shared<ov::intel_cpu::StoreConvertSaturation>(convert->input_value(0),
-                                                                                convert->get_destination_type(),
+        store_convert = std::make_shared<ov::intel_cpu::StoreConvertSaturation>(parent_output, convert->get_destination_type(),
                                                                                 store->get_count(), store->get_offset());
     } else if (ov::is_type<snippets::op::ConvertTruncation>(convert)) {
-        store_convert = std::make_shared<ov::intel_cpu::StoreConvertTruncation>(convert->input_value(0),
-                                                                                convert->get_destination_type(),
+        store_convert = std::make_shared<ov::intel_cpu::StoreConvertTruncation>(parent_output, convert->get_destination_type(),
                                                                                 store->get_count(), store->get_offset());
     } else {
         OPENVINO_THROW("Type of Convert op is undefined. Supports only fusing Store and ConvertTruncation or ConvertSaturation ops");
     }
 
-    convert_it = linear_ir.replace_node(store_convert, { input_connector }, convert_expr->get_loop_ids(), std::next(convert_it), {convert_expr, store_expr});
+    convert_it = linear_ir.replace_node(store_convert, {convert_expr, store_expr});
 
     return true;
 }


### PR DESCRIPTION
### Details:
 - *Removed `replace_input` from LinearIR since it's not responsibility of LinearIR and added this support to `Expression` and `ExpressionPort`*
 - *Added helpers `replace_with_expr`, `replace_with_node` and `insert_node` to LinearIR to encapsulate common work with expression creation, insertion etc. Fore more details, please read briefs of the helpers in LinearIR*

### Tickets:
 - *122690, 126994*
