### PR TITLE
[GHA] Add openvino ref input to workflow_dispatch for coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,6 +1,10 @@
 name: Coverity (Ubuntu 20.04, Python 3.11)
 on:
   workflow_dispatch:
+    inputs:
+      openvinoRef:
+        description: 'Branch, tag or commit hash to clone openvino from. Taken from event context if not set'
+        type: string
   schedule:
     # run daily at 00:00
     - cron: '0 0 * * *'
@@ -50,6 +54,7 @@ jobs:
         with:
           path: ${{ env.OPENVINO_REPO }}
           submodules: 'true'
+          ref: ${{ inputs.openvinoRef }}
 
       - name: Clone OpenVINO Contrib
         uses: actions/checkout@v4


### PR DESCRIPTION
Needed to be able to run coverity on a specific commit from nightly, like we did in Azure (workflow_dispatch [doesn't support](https://github.com/github/docs/issues/590) running workflow from sha by default).