### PR TITLE
[PyOV] Allow single inputs in form of lists of simple types

### DIFF
--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -108,7 +108,8 @@ class InferRequest(_InferRequestWrapper):
                               * `numpy.ndarray` which are not C contiguous and/or not writable (WRITEABLE flag is set to False)
                               * inputs which data types are mismatched from Infer Request's inputs
                               * inputs that should be in `BF16` data type
-                              * scalar inputs (i.e. `np.float_`/`int`/`float`)
+                              * scalar inputs (i.e. `np.float_`/`str`/`bytes`/`int`/`float`)
+                              * lists of simple data types (i.e. `str`/`bytes`/`int`/`float`)
                               Keeps Tensor inputs "as-is".
 
                               Note: Use with extra care, shared data can be modified during runtime!
@@ -192,7 +193,8 @@ class InferRequest(_InferRequestWrapper):
                               * `numpy.ndarray` which are not C contiguous and/or not writable (WRITEABLE flag is set to False)
                               * inputs which data types are mismatched from Infer Request's inputs
                               * inputs that should be in `BF16` data type
-                              * scalar inputs (i.e. `np.float_`/`int`/`float`)
+                              * scalar inputs (i.e. `np.float_`/`str`/`bytes`/`int`/`float`)
+                              * lists of simple data types (i.e. `str`/`bytes`/`int`/`float`)
                               Keeps Tensor inputs "as-is".
 
                               Note: Use with extra care, shared data can be modified during runtime!
@@ -346,7 +348,8 @@ class CompiledModel(CompiledModelBase):
                               * `numpy.ndarray` which are not C contiguous and/or not writable (WRITEABLE flag is set to False)
                               * inputs which data types are mismatched from Infer Request's inputs
                               * inputs that should be in `BF16` data type
-                              * scalar inputs (i.e. `np.float_`/`int`/`float`)
+                              * scalar inputs (i.e. `np.float_`/`str`/`bytes`/`int`/`float`)
+                              * lists of simple data types (i.e. `str`/`bytes`/`int`/`float`)
                               Keeps Tensor inputs "as-is".
 
                               Note: Use with extra care, shared data can be modified during runtime!
@@ -464,7 +467,8 @@ class AsyncInferQueue(AsyncInferQueueBase):
                               * `numpy.ndarray` which are not C contiguous and/or not writable (WRITEABLE flag is set to False)
                               * inputs which data types are mismatched from Infer Request's inputs
                               * inputs that should be in `BF16` data type
-                              * scalar inputs (i.e. `np.float_`/`int`/`float`)
+                              * scalar inputs (i.e. `np.float_`/`str`/`bytes`/`int`/`float`)
+                              * lists of simple data types (i.e. `str`/`bytes`/`int`/`float`)
                               Keeps Tensor inputs "as-is".
 
                               Note: Use with extra care, shared data can be modified during runtime!

--- a/src/bindings/python/src/openvino/runtime/utils/data_helpers/data_dispatcher.py
+++ b/src/bindings/python/src/openvino/runtime/utils/data_helpers/data_dispatcher.py
@@ -15,6 +15,18 @@ ScalarTypes = Union[np.number, int, float]
 ValidKeys = Union[str, int, ConstOutput]
 
 
+def is_list_simple_type(input_list: list) -> bool:
+    for sublist in input_list:
+        if isinstance(sublist, list):
+            for element in sublist:
+                if not isinstance(element, (str, float, int, bytes)):
+                    return False
+        else:
+            if not isinstance(sublist, (str, float, int, bytes)):
+                return False
+    return True
+
+
 def get_request_tensor(
     request: _InferRequestWrapper,
     key: Optional[ValidKeys] = None,
@@ -198,14 +210,25 @@ def create_shared(
 
 
 @create_shared.register(dict)
-@create_shared.register(list)
 @create_shared.register(tuple)
 @create_shared.register(OVDict)
 def _(
-    inputs: ContainerTypes,
+    inputs: Union[dict, tuple, OVDict],
     request: _InferRequestWrapper,
 ) -> dict:
     request._inputs_data = normalize_arrays(inputs, is_shared=True)
+    return {k: value_to_tensor(v, request=request, is_shared=True, key=k) for k, v in request._inputs_data.items()}
+
+
+# Special override to perform list-related dispatch
+@create_shared.register(list)
+def _(
+    inputs: list,
+    request: _InferRequestWrapper,
+) -> dict:
+    # If list is passed to single input model and consists only of simple types
+    # i.e. str/bytes/float/int, wrap around it and pass into the dispatcher.
+    request._inputs_data = normalize_arrays([inputs] if request._is_single_input() and is_list_simple_type(inputs) else inputs, is_shared=True)
     return {k: value_to_tensor(v, request=request, is_shared=True, key=k) for k, v in request._inputs_data.items()}
 
 
@@ -348,14 +371,24 @@ def create_copied(
 
 
 @create_copied.register(dict)
-@create_copied.register(list)
 @create_copied.register(tuple)
 @create_copied.register(OVDict)
 def _(
-    inputs: ContainerTypes,
+    inputs: Union[dict, tuple, OVDict],
     request: _InferRequestWrapper,
 ) -> dict:
     return update_inputs(normalize_arrays(inputs, is_shared=False), request)
+
+
+# Special override to perform list-related dispatch
+@create_copied.register(list)
+def _(
+    inputs: list,
+    request: _InferRequestWrapper,
+) -> dict:
+    # If list is passed to single input model and consists only of simple types
+    # i.e. str/bytes/float/int, wrap around it and pass into the dispatcher.
+    return update_inputs(normalize_arrays([inputs] if request._is_single_input() and is_list_simple_type(inputs) else inputs, is_shared=False), request)
 
 
 @create_copied.register(np.ndarray)

--- a/src/bindings/python/src/openvino/runtime/utils/data_helpers/wrappers.py
+++ b/src/bindings/python/src/openvino/runtime/utils/data_helpers/wrappers.py
@@ -27,9 +27,7 @@ class _InferRequestWrapper(InferRequestBase):
         super().__init__(other)
 
     def _is_single_input(self) -> bool:
-        if len(self.input_tensors) > 1:
-            return False
-        return True
+        return len(self.input_tensors) == 1
 
 
 class OVDict(Mapping):

--- a/src/bindings/python/src/openvino/runtime/utils/data_helpers/wrappers.py
+++ b/src/bindings/python/src/openvino/runtime/utils/data_helpers/wrappers.py
@@ -26,6 +26,11 @@ class _InferRequestWrapper(InferRequestBase):
         self._inputs_data = None
         super().__init__(other)
 
+    def _is_single_input(self) -> bool:
+        if len(self.input_tensors) > 1:
+            return False
+        return True
+
 
 class OVDict(Mapping):
     """Custom OpenVINO dictionary with inference results.

--- a/src/bindings/python/tests/test_utils/test_data_dispatch.py
+++ b/src/bindings/python/tests/test_utils/test_data_dispatch.py
@@ -225,11 +225,11 @@ def test_string_array_dispatcher(device, input_data, data_type, input_shape, is_
 @pytest.mark.parametrize(
     ("input_data", "input_shape"),
     [
-        ([["śćżóąę", "data_dispatcher_test"]], [2]),
-        ([[b"abcdef", b"data_dispatcher_test"]], [2]),
-        ([[bytes("abc", encoding="utf-8"), bytes("zzzz", encoding="utf-8")]], [2]),
-        ([[["śćżóąę", "data_dispatcher_test"]]], [1, 2]),
-        ([[["śćżóąę"], ["data_dispatcher_test"]]], [2, 1]),
+        (["śćżóąę", "data_dispatcher_test"], [2]),
+        ([b"abcdef", b"data_dispatcher_test"], [2]),
+        ([bytes("abc", encoding="utf-8"), bytes("zzzz", encoding="utf-8")], [2]),
+        ([["śćżóąę", "data_dispatcher_test"]], [1, 2]),
+        ([["śćżóąę"], ["data_dispatcher_test"]], [2, 1]),
     ],
 )
 @pytest.mark.parametrize("data_type", [Type.string, str, bytes, np.str_, np.bytes_])


### PR DESCRIPTION
### Details:
 - Allowing single inputs in form of lists of simple types into inference calls (by extending the data dispatcher).
 - Previously single-input models required additional wrapping for simple types like: `[["you shall not pass"]]`. New approach in data dispatcher checks if the model has one input and passed data is of simple type (`str`/`bytes`/`float`/`int`) and wraps the incoming list automatically, thus allowing simpler syntax of: `["you shall pass"]`.
 
### Tickets:
 - related to: 107409 per request from @slyalin 
