### PR TITLE
benchmark: remove perf hint none (undefined)

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -33,6 +33,7 @@ def parse_and_check_command_line():
         parser.print_help()
         raise RuntimeError("The percentile value is incorrect. The applicable values range is [1, 100].")
 
+    # ??
     if not args.perf_hint == "none" and (arg_not_empty(args.number_streams, "") or arg_not_empty(args.number_threads, 0) or arg_not_empty(args.infer_threads_pinning, "")):
         raise Exception("-nstreams, -nthreads and -pin options are fine tune options. To use them you " \
                         "should explicitely set -hint option to none. This is not OpenVINO limitation " \
@@ -106,7 +107,7 @@ def main():
         next_step()
 
         def set_performance_hint(device):
-            perf_hint = properties.hint.PerformanceMode.UNDEFINED
+            perf_hint = properties.hint.PerformanceMode.LATENCY
             supported_properties = benchmark.core.get_property(device, properties.supported_properties())
             if properties.hint.performance_mode() in supported_properties:
                 if is_flag_set_in_command_line('hint'):
@@ -116,17 +117,14 @@ def main():
                         perf_hint = properties.hint.PerformanceMode.LATENCY
                     elif args.perf_hint == "cumulative_throughput" or args.perf_hint == "ctput":
                         perf_hint = properties.hint.PerformanceMode.CUMULATIVE_THROUGHPUT
-                    elif args.perf_hint=='none':
-                        perf_hint = properties.hint.PerformanceMode.UNDEFINED
                     else:
                         raise RuntimeError("Incorrect performance hint. Please set -hint option to"
-                            "`throughput`(tput), `latency', 'cumulative_throughput'(ctput) value or 'none'.")
+                            "`throughput`(tput), `latency', 'cumulative_throughput'(ctput) value.")
                 else:
                     perf_hint = properties.hint.PerformanceMode.THROUGHPUT if benchmark.api_type == "async" else properties.hint.PerformanceMode.LATENCY
                     logger.warning(f"Performance hint was not explicitly specified in command line. " +
                     f"Device({device}) performance hint will be set to {perf_hint}.")
-                if perf_hint != properties.hint.PerformanceMode.UNDEFINED:
-                    config[device][properties.hint.performance_mode()] = perf_hint
+                config[device][properties.hint.performance_mode()] = perf_hint
             else:
                 logger.warning(f"Device {device} does not support performance hint property(-hint).")
 

--- a/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
@@ -62,13 +62,11 @@ def parse_args():
                            'Default value is CPU. Use \'-d HETERO:<comma separated devices list>\' format to specify HETERO plugin. '
                            'Use \'-d MULTI:<comma separated devices list>\' format to specify MULTI plugin. '
                            'The application looks for a suitable plugin for the specified device.')
-    args.add_argument('-hint', '--perf_hint', type=str, required=False, default='', choices=('throughput', 'tput', 'cumulative_throughput', 'ctput', 'latency', 'none'),
-                      help='Optional. Performance hint (latency or throughput or cumulative_throughput or none). Performance hint allows the OpenVINO device to select the right model-specific settings.\n'
+    args.add_argument('-hint', '--perf_hint', type=str, required=False, default='', choices=('throughput', 'tput', 'cumulative_throughput', 'ctput', 'latency'),
+                      help='Optional. Performance hint (latency or throughput or cumulative_throughput). Performance hint allows the OpenVINO device to select the right model-specific settings.\n'
                             '\'throughput\': device performance mode will be set to THROUGHPUT. \n'
                             '\'cumulative_throughput\': device performance mode will be set to CUMULATIVE_THROUGHPUT. \n'
-                            '\'latency\': device performance mode will be set to LATENCY. \n'
-                            '\'none\': no device performance mode will be set. \n'
-                            'Using explicit \'nstreams\' or other device-specific options, please set hint to \'none\'')
+                            '\'latency\': device performance mode will be set to LATENCY.')
     args.add_argument('-niter', '--number_iterations', type=check_positive, required=False, default=None,
                       help='Optional. Number of iterations. '
                            'If not specified, the number of iterations is calculated depending on a device.')


### PR DESCRIPTION
### Details:
 - `proprties.hint.PerformanceMode.UNDEFINED` is deprecated and will be removed here: https://github.com/openvinotoolkit/openvino/pull/21675
 - So need to clean-up benchmark

### Tickets:
 - *ticket-id*
