### PR TITLE
Cleanup old RISCV cache

### DIFF
--- a/.github/workflows/cleanup_pip_cache.yml
+++ b/.github/workflows/cleanup_pip_cache.yml
@@ -1,9 +1,7 @@
 name: Cleanup PIP caches
 on:
   workflow_dispatch:
-  schedule:
-    # at 00:00 on the 1st day of every month
-    - cron: '0 0 1 * *'
+  pull_request:
 
 jobs:
   Cleanup_PIP_Caches:
@@ -13,20 +11,9 @@ jobs:
       volumes:
         - /mount:/mount
     env:
-      PIP_CACHE_PATH: /mount/caches/pip
+      CACHE_PATH: /mount/caches/ccache/ubuntu22_riscv64_Release
 
     steps:
-      - name: Pre-Collecting Cache Info
-        run: |
-          echo "Cache info: "
-          du -h -d2 ${PIP_CACHE_PATH}
-
       - name: Cleanup cache
         run: |
-          echo "Delete cache files if they have not been used in over 30 days"
-          [ ! -z "${PIP_CACHE_PATH}" ] && find ${PIP_CACHE_PATH} ! -type d -atime +30 -delete
-
-      - name: Post-Collecting Cache Info
-        run: |
-          echo "Cache info: "
-          du -h -d2 ${PIP_CACHE_PATH}
+          rm -rf ${CACHE_PATH}


### PR DESCRIPTION
it's long and problematic to cleanup locally, but we need it at least to free up the space