### PR TITLE
[op conformance] Made fixes to align with accuracy validation

### DIFF
--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/run_parallel.py
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/run_parallel.py
@@ -829,7 +829,7 @@ class TestParallelRunner:
                                     test_results[dir] += 1
                                 else:
                                     test_results[dir] = 1
-                                if dir != "passed":
+                                if dir != "passed" and dir != "skipped":
                                     fix_priority.append((ref_k or 0, test_name))
                                 ref_k = None
                                 test_cnt_real_saved_now += 1


### PR DESCRIPTION
### Details:
 - *fixed method of calculating diffs between accuracy and conformance validation results, before skipped tests and models from tests was classified as failed, now is not (this change have the gravest result)*

### Tickets:
 - *[CVS-124663](https://jira.devtools.intel.com/browse/CVS-124663)*
