### PR TITLE
[apiConformance] Move from Relu to double Concat function in import_export tests

### DIFF
--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/import_export.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/import_export.hpp
@@ -454,7 +454,7 @@ TEST_P(OVCompiledGraphImportExportTest, importExportedIENetworkConstantResultOnl
     EXPECT_EQ(outputPrecision, importedCompiledModel.output("constant").get_element_type());
 }
 
-TEST_P(OVCompiledGraphImportExportTest, ovImportExportedFunction) {
+TEST_P(OVCompiledGraphImportExportTest, importExportedFunctionConvertPrecision) {
     std::shared_ptr<InferenceEngine::Core> ie = ::PluginCache::get().ie();
     ov::CompiledModel execNet;
 


### PR DESCRIPTION
### Details:
- *Relu is not supported with boolean*
 - *also removed tests related to 1.0 api*
 - *ovImportExportedFunction renamed to importExportedFunctionConvertPrecision*

### Tickets:
 - *CVS-124449*
