### PR TITLE
[OVC] Fixed tensor names for GraphDef format.

### DIFF
--- a/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
@@ -363,7 +363,7 @@ def extract_model_graph(argv):
     if isinstance(model, tf.compat.v1.GraphDef):
         graph = tf.Graph()
         with graph.as_default():
-            tf.graph_util.import_graph_def(model)
+            tf.graph_util.import_graph_def(model, name='')
         argv["input_model"] = graph
         return True
     if isinstance(model, tf.compat.v1.Session):

--- a/tests/layer_tests/ovc_python_api_tests/test_tf.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_tf.py
@@ -938,6 +938,29 @@ class TestMoConvertTF(CommonMOConvertTest):
         assert CommonLayerTest().compare_ie_results_with_framework(ov_infer, {"Identity:0": fw_infer}, eps)
         assert CommonLayerTest().compare_ie_results_with_framework(ov_infer, {"Identity:0": [-1.8, -4.4]}, eps)
 
+
+class TFGraphDefNames(unittest.TestCase):
+    def test_graph_def_names(self):
+        from openvino.tools.ovc import convert_model
+
+        tf_model, model_ref, _ = create_tf_graph_def(None)
+        ov_model = convert_model(tf_model)
+
+        input_list = []
+        with tf.Graph().as_default() as graph:
+            tf.import_graph_def(tf_model, name='')
+            for op in graph.get_operations():
+                if op.type == "Placeholder":
+                    input_list.append(op.name)
+
+        for input in input_list:
+            found = False
+            for ov_input in ov_model.inputs:
+                if input in ov_input.get_names():
+                    found = True
+            assert found, "Could not found input {} in resulting model.".format(input)
+
+
 class TFConvertTest(unittest.TestCase):
     @pytest.mark.nightly
     @pytest.mark.precommit


### PR DESCRIPTION
Root cause analysis: 
In OVC `GraphDef` is converted to `tf.Graph` using method `tf.graph_util.import_graph_def()`. By default this method adds "`import/`" prefix to all nodes. This prefix result in mismatch of names comparing to original model.

Solution: 
To avoid adding this prefix `name=''` parameter can be set.

Ticket: 127904


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update