### PR TITLE
[GPU] Small fix for dynamic_shape_gather_opts pass

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/dynamic_shape_gather_opts.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/dynamic_shape_gather_opts.cpp
@@ -25,11 +25,11 @@ void dynamic_shape_gather_opts::run(program& p) {
             continue;
         auto idx_rank = impl_params->get_input_layout(1).get_partial_shape().size();
 
-        if (idx_rank > 1) {
+        if (idx_rank != 1) {
             continue;
         }
         auto axis = impl_params->typed_desc<gather>()->axis;
-        if (impl_params->get_input_layout(0).get_partial_shape()[axis]  == -1
+        if (impl_params->get_input_layout(0).get_partial_shape()[axis] == -1
             || impl_params->get_input_layout(1).get_partial_shape()[0] == -1
             || impl_params->get_input_layout(0).get_partial_shape()[axis] == impl_params->get_input_layout(1).get_partial_shape()[0]) {
             // May be skipepd


### PR DESCRIPTION
### Details:
 - *In the case of a 0d partial_shape, accessing an element at index 0 results in an error*
