### PR TITLE
Add more tests for model cache new feature

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
@@ -143,4 +143,8 @@ namespace {
                              CompileModelLoadFromMemoryTestBase,
                              ::testing::Combine(::testing::ValuesIn(TestCpuTargets), ::testing::ValuesIn(CpuConfigs)),
                              CompileModelLoadFromMemoryTestBase::getTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(smoke_CachingSupportCase_CPU,
+                             CompileModelCacheRuntimePropertiesTestBase,
+                             ::testing::Combine(::testing::ValuesIn(TestCpuTargets), ::testing::ValuesIn(CpuConfigs)),
+                             CompileModelCacheRuntimePropertiesTestBase::getTestCaseName);
 } // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
@@ -63,6 +63,12 @@ namespace {
                         CompileModelLoadFromFileTestBase::getTestCaseName);
 
     INSTANTIATE_TEST_SUITE_P(smoke_CachingSupportCase_GPU,
+                             CompileModelCacheRuntimePropertiesTestBase,
+                             ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_GPU),
+                                                ::testing::ValuesIn(GPULoadFromFileConfigs)),
+                             CompileModelCacheRuntimePropertiesTestBase::getTestCaseName);
+
+    INSTANTIATE_TEST_SUITE_P(smoke_CachingSupportCase_GPU,
                              CompileModelLoadFromMemoryTestBase,
                              ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_GPU),
                                                 ::testing::ValuesIn(GPULoadFromFileConfigs)),

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/caching_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/caching_tests.hpp
@@ -78,6 +78,26 @@ public:
     void run() override;
 };
 
+using compileModelCacheRuntimePropertiesParams = std::tuple<std::string,  // device name
+                                                            ov::AnyMap    // device configuration
+                                                            >;
+class CompileModelCacheRuntimePropertiesTestBase
+    : public testing::WithParamInterface<compileModelCacheRuntimePropertiesParams>,
+      virtual public SubgraphBaseTest,
+      virtual public OVPluginTestBase {
+    std::string m_cacheFolderName;
+    std::string m_modelName;
+    std::string m_weightsName;
+    std::string m_compiled_model_runtime_properties;
+
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<compileModelCacheRuntimePropertiesParams> obj);
+
+    void SetUp() override;
+    void TearDown() override;
+    void run() override;
+};
+
 using compileModelLoadFromMemoryParams = std::tuple<std::string,  // device name
                                                     ov::AnyMap    // device configuration
 >;

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/caching_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/caching_tests.cpp
@@ -334,6 +334,116 @@ TEST_P(CompileModelLoadFromFileTestBase, CanLoadFromFileWithoutException) {
     run();
 }
 
+std::string CompileModelCacheRuntimePropertiesTestBase::getTestCaseName(
+    testing::TestParamInfo<compileModelCacheRuntimePropertiesParams> obj) {
+    auto param = obj.param;
+    auto deviceName = std::get<0>(param);
+    auto configuration = std::get<1>(param);
+    std::ostringstream result;
+    std::replace(deviceName.begin(), deviceName.end(), ':', '.');
+    result << "device_name=" << deviceName << "_";
+    for (auto& iter : configuration) {
+        result << "_" << iter.first << "_" << iter.second.as<std::string>() << "_";
+    }
+    return result.str();
+}
+
+void CompileModelCacheRuntimePropertiesTestBase::SetUp() {
+    ovModelWithName funcPair;
+    std::tie(targetDevice, configuration) = GetParam();
+    target_device = targetDevice;
+    APIBaseTest::SetUp();
+    std::stringstream ss;
+    std::string filePrefix = ov::test::utils::generateTestFilePrefix();
+    ss << "testCache_" << filePrefix;
+    m_modelName = ss.str() + ".xml";
+    m_weightsName = ss.str() + ".bin";
+    for (auto& iter : configuration) {
+        ss << "_" << iter.first << "_" << iter.second.as<std::string>() << "_";
+    }
+    m_cacheFolderName = ss.str();
+    core->set_property(ov::cache_dir());
+    ov::pass::Manager manager;
+    manager.register_pass<ov::pass::Serialize>(m_modelName, m_weightsName);
+    manager.run_passes(ov::test::utils::make_conv_pool_relu({1, 3, 227, 227}, ov::element::f32));
+}
+
+void CompileModelCacheRuntimePropertiesTestBase::TearDown() {
+    ov::test::utils::removeFilesWithExt(m_cacheFolderName, "blob");
+    ov::test::utils::removeIRFiles(m_modelName, m_weightsName);
+    std::remove(m_cacheFolderName.c_str());
+    core->set_property(ov::cache_dir());
+    APIBaseTest::TearDown();
+}
+
+void CompileModelCacheRuntimePropertiesTestBase::run() {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    if (!ov::util::contains(core->get_property(target_device, ov::internal::supported_properties),
+                            ov::internal::compiled_model_runtime_properties.name())) {
+        return;
+    }
+    m_compiled_model_runtime_properties =
+        core->get_property(target_device, ov::internal::compiled_model_runtime_properties);
+    core->set_property(ov::cache_dir(m_cacheFolderName));
+
+    // First compile model to generate model cache blob.
+    // Second compile model will load from model cache.
+    for (int i = 0; i < 2; i++) {
+        {
+            ASSERT_NO_THROW(compiledModel = core->compile_model(m_modelName, targetDevice, configuration));
+            ASSERT_EQ(i != 0, compiledModel.get_property(ov::loaded_from_cache));
+            ASSERT_NO_THROW(inferRequest = compiledModel.create_infer_request());
+            ASSERT_NO_THROW(inferRequest.infer());
+        }
+        // cache is created and reused
+        ASSERT_EQ(ov::test::utils::listFilesWithExt(m_cacheFolderName, "blob").size(), 1);
+        compiledModel = {};
+        inferRequest = {};
+    }
+
+    // Modify cache blob file's header information to trigger removing old cache and to create new cache blob files.
+    auto blobs = ov::test::utils::listFilesWithExt(m_cacheFolderName, "blob");
+    for (const auto& fileName : blobs) {
+        std::string content;
+        {
+            std::ifstream inp(fileName, std::ios_base::binary);
+            std::ostringstream ostr;
+            ostr << inp.rdbuf();
+            content = ostr.str();
+        }
+        auto index = content.find(m_compiled_model_runtime_properties.c_str());
+        ASSERT_EQ(index != std::string::npos, true);
+        auto pos = m_compiled_model_runtime_properties.find(":");
+        if (index != std::string::npos) {
+            m_compiled_model_runtime_properties.replace(pos + 1, 1, "x");
+        } else {
+            m_compiled_model_runtime_properties.replace(1, 1, "x");
+        }
+        content.replace(index, m_compiled_model_runtime_properties.size(), m_compiled_model_runtime_properties);
+        std::ofstream out(fileName, std::ios_base::binary);
+        out.write(content.c_str(), static_cast<std::streamsize>(content.size()));
+    }
+
+    // Third compile model to remove old cache blob and create new model cache blob file
+    // Fourth compile model will load from model cache.
+    for (int i = 0; i < 2; i++) {
+        {
+            ASSERT_NO_THROW(compiledModel = core->compile_model(m_modelName, targetDevice, configuration));
+            ASSERT_EQ(i != 0, compiledModel.get_property(ov::loaded_from_cache));
+            ASSERT_NO_THROW(inferRequest = compiledModel.create_infer_request());
+            ASSERT_NO_THROW(inferRequest.infer());
+        }
+        // old cache has been removed and new cache is created and reused
+        ASSERT_EQ(ov::test::utils::listFilesWithExt(m_cacheFolderName, "blob").size(), 1);
+        compiledModel = {};
+        inferRequest = {};
+    }
+}
+
+TEST_P(CompileModelCacheRuntimePropertiesTestBase, CanLoadFromFileWithoutException) {
+    run();
+}
+
 std::string CompileModelLoadFromMemoryTestBase::getTestCaseName(
     testing::TestParamInfo<compileModelLoadFromMemoryParams> obj) {
     auto param = obj.param;


### PR DESCRIPTION
### Details:
   - For ov::internal::compiled_model_runtime_properties, previous [PR-21492](https://github.com/openvinotoolkit/openvino/pull/21492) only contains core level test with mock plugin, it need more test to validate plugin's behavior.

### Tickets:
 - *ticket-id*
