### PR TITLE
[CPU] Fix the shape processing of nodes fused to MatMul 

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_shape.cpp
+++ b/src/plugins/intel_cpu/src/cpu_shape.cpp
@@ -65,10 +65,9 @@ Shape mergeShapes(const Shape& lhs, const Shape& rhs) {
     VectorDims resultMaxDims(lhsMaxDims.size());
 
     for (size_t i = 0; i < resultMinDims.size(); ++i) {
-        OPENVINO_ASSERT(lhsMinDims[i] <= rhsMaxDims[i], "Couldn't merge shapes as the dims intervals are not overlapping.");
-        OPENVINO_ASSERT(rhsMinDims[i] <= lhsMaxDims[i], "Couldn't merge shapes as the dims intervals are not overlapping.");
         resultMinDims[i] = std::max(lhsMinDims[i], rhsMinDims[i]);
         resultMaxDims[i] = std::min(lhsMaxDims[i], rhsMaxDims[i]);
+        OPENVINO_ASSERT(resultMinDims[i] <= resultMaxDims[i], "Couldn't merge shapes as the dims intervals are not overlapping.");
     }
     return Shape{resultMinDims, resultMaxDims};
 }

--- a/src/plugins/intel_cpu/src/cpu_shape.cpp
+++ b/src/plugins/intel_cpu/src/cpu_shape.cpp
@@ -49,5 +49,29 @@ std::string Shape::toString() const  {
     return output.str();
 }
 
+Shape mergeShapes(const Shape& lhs, const Shape& rhs) {
+    OPENVINO_ASSERT(lhs.getRank() == rhs.getRank(),
+        "Couldn't merge shapes of different ranks: shape 1:",
+        lhs.toString(),
+        " shape 2: ",
+        rhs.toString());
+
+    const auto& lhsMinDims = lhs.getMinDims();
+    const auto& lhsMaxDims = lhs.getMaxDims();
+    const auto& rhsMinDims = rhs.getMinDims();
+    const auto& rhsMaxDims = rhs.getMaxDims();
+
+    VectorDims resultMinDims(lhsMinDims.size());
+    VectorDims resultMaxDims(lhsMaxDims.size());
+
+    for (size_t i = 0; i < resultMinDims.size(); ++i) {
+        OPENVINO_ASSERT(lhsMinDims[i] <= rhsMaxDims[i], "Couldn't merge shapes as the dims intervals are not overlapping.");
+        OPENVINO_ASSERT(rhsMinDims[i] <= lhsMaxDims[i], "Couldn't merge shapes as the dims intervals are not overlapping.");
+        resultMinDims[i] = std::max(lhsMinDims[i], rhsMinDims[i]);
+        resultMaxDims[i] = std::min(lhsMaxDims[i], rhsMaxDims[i]);
+    }
+    return Shape{resultMinDims, resultMaxDims};
+}
+
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/cpu_shape.h
+++ b/src/plugins/intel_cpu/src/cpu_shape.h
@@ -218,5 +218,17 @@ private:
     VectorDims dims;
 };
 
+/**
+ * @brief Merges two shapes overlapping their dims intervals.
+ * @note When one of the dims intervals are not overlapped an exception is thrown.
+ * @param lhs
+ * first shape
+ * @param rhs
+ * second shape
+ * @return resulting shape
+ */
+
+Shape mergeShapes(const Shape& lhs, const Shape& rhs);
+
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -207,7 +207,11 @@ Node::AttrPtr MatMul::initPrimitiveAttr(const VectorDims &dims) {
 }
 
 Node::AttrPtr MatMul::initPrimitiveAttr() {
-    auto dummyShape = MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0));
+    auto outputShape = getOutputShapeAtPort(0);
+    for (auto&& node : fusedWith) {
+        outputShape = mergeShapes(outputShape, node->getOutputShapeAtPort(0));
+    }
+    auto dummyShape = MemoryDescUtils::makeDummyShape(outputShape);
     return initPrimitiveAttr(dummyShape.getStaticDims());
 }
 
@@ -293,7 +297,7 @@ void MatMul::getSupportedDescriptors() {
 
     const auto& inputShape0 = getInputShapeAtPort(0);
     const auto& inputShape1 = getInputShapeAtPort(1);
-    const auto& outputShape = getOutputShapeAtPort(0);
+    auto outputShape = getOutputShapeAtPort(0);
 
     if (inputShape0.getRank() != inputShape1.getRank() || inputShape0.getRank() != outputShape.getRank())
         OPENVINO_THROW(errorPrefix, " has invalid dims count");
@@ -325,9 +329,14 @@ void MatMul::getSupportedDescriptors() {
         }
     }
 
+    for (auto&& node : fusedWith) {
+        outputShape = mergeShapes(outputShape, node->getOutputShapeAtPort(0));
+    }
+
     std::vector<Shape> staticInputShapes{inputShape0, inputShape1};
     if (inputShape0.isDynamic() || inputShape1.isDynamic()) {
-        std::tie(staticInputShapes[0], staticInputShapes[1]) = makeDummyInputShapes(inputShape0, inputShape1);
+        std::tie(staticInputShapes[0], staticInputShapes[1]) =
+            makeDummyInputShapes(inputShape0, inputShape1, outputShape);
     }
 
     auto staticOutputShape = outputShape.isStatic() ? outputShape : Shape(shapeInferGeneric(staticInputShapes).front());
@@ -342,14 +351,13 @@ void MatMul::getSupportedDescriptors() {
     createDescriptor({inDataDesc[0], inDataDesc[1]}, {outDataDesc});
 }
 
-std::pair<Shape, Shape> MatMul::makeDummyInputShapes(const Shape& in0, const Shape& in1) const {
+std::pair<Shape, Shape> MatMul::makeDummyInputShapes(const Shape& in0, const Shape& in1, const Shape& out) const {
     if (in0.getRank() < 2 || in1.getRank() < 2) {
         OPENVINO_THROW("Can't create dummy inputs with rank less 2");
     }
 
-    if (in0.getRank() != in1.getRank()) {
-        OPENVINO_THROW("Can't create dummy inputs if input's rank not equal");
-    }
+    OPENVINO_ASSERT((in0.getRank() == in1.getRank()) && (in1.getRank() == out.getRank()),
+        "Can't create dummy inputs if argument shapes rank is not equal");
 
     auto swapTranspDims = [&](VectorDims& in0, VectorDims& in1) {
         if (transposeIn[0]) {
@@ -362,6 +370,7 @@ std::pair<Shape, Shape> MatMul::makeDummyInputShapes(const Shape& in0, const Sha
 
     auto inDims0 = in0.getDims();
     auto inDims1 = in1.getDims();
+    auto outDims = out.getDims();
 
     auto minDims0 = in0.getMinDims();
     auto maxDims0 = in0.getMaxDims();
@@ -397,18 +406,28 @@ std::pair<Shape, Shape> MatMul::makeDummyInputShapes(const Shape& in0, const Sha
     fillDummy(inDims0.size() - 1, inDims1.size() - 2);
 
     // fill m, n
-    if (inDims0[inDims0.size() - 2] == Shape::UNDEFINED_DIM) {
+    if (outDims[outDims.size() - 2] != Shape::UNDEFINED_DIM) {
+        inDims0[inDims0.size() - 2] = outDims[outDims.size() - 2];
+    } else if (inDims0[inDims0.size() - 2] == Shape::UNDEFINED_DIM) {
         inDims0[inDims0.size() - 2] = std::min(maxDims0[inDims0.size() - 2],
                                                std::max(minDims0[inDims0.size() - 2], static_cast<Dim>(MemoryDescUtils::DEFAULT_DUMMY_VAL)));
     }
-    if (inDims1[inDims1.size() - 1] == Shape::UNDEFINED_DIM) {
+
+    if (outDims[outDims.size() - 1] != Shape::UNDEFINED_DIM) {
+        inDims1[inDims1.size() - 1] = outDims[outDims.size() - 1];
+    } else if (inDims1[inDims1.size() - 1] == Shape::UNDEFINED_DIM) {
         inDims1[inDims1.size() - 1] = std::min(maxDims1[inDims1.size() - 1],
                                                std::max(minDims1[inDims1.size() - 1], static_cast<Dim>(MemoryDescUtils::DEFAULT_DUMMY_VAL)));
     }
 
     // fill batches
     for (size_t i = 0; i < inDims0.size() - 2; i++) {
-        fillDummy(i, i);
+        if (outDims[i] != Shape::UNDEFINED_DIM) {
+            inDims0[i] = outDims[i];
+            inDims1[i] = outDims[i];
+        } else {
+            fillDummy(i, i);
+        }
     }
 
     swapTranspDims(inDims0, inDims1);

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -357,7 +357,7 @@ std::pair<Shape, Shape> MatMul::makeDummyInputShapes(const Shape& in0, const Sha
     }
 
     OPENVINO_ASSERT((in0.getRank() == in1.getRank()) && (in1.getRank() == out.getRank()),
-        "Can't create dummy inputs if argument shapes rank is not equal");
+        "Can't create dummy inputs if argument shapes ranks are not equal");
 
     auto swapTranspDims = [&](VectorDims& in0, VectorDims& in1) {
         if (transposeIn[0]) {

--- a/src/plugins/intel_cpu/src/nodes/matmul.h
+++ b/src/plugins/intel_cpu/src/nodes/matmul.h
@@ -51,7 +51,8 @@ private:
     using executorPtr = std::shared_ptr<DnnlExecutor>;
     executorPtr execPtr = nullptr;
     dnnl::memory::desc getBiasDescFrom(const DnnlMemoryDescCPtr outMemDesc);
-    std::pair<Shape, Shape> makeDummyInputShapes(const Shape& in0, const Shape& in1) const;
+    std::pair<Shape, Shape>
+    makeDummyInputShapes(const Shape& in0, const Shape& in1, const Shape& out) const;
 
     bool withBiases;
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/matmul.cpp
@@ -810,6 +810,12 @@ TEST_P(MatMulLayerCPUTestUndefShapes, CompareWithRefs) {
     CheckPluginRelatedResults(compiledModel, cpuNodeType);
 }
 
+const fusingSpecificParams matmulFullDynInputsFusingParams[] = {
+    fusingMultiplyPerChannel,
+    fusingMultiplyAddPerChannel,
+    fusingAddPerChannel
+};
+
 const auto matMulParamsDynamicFusingFullUndefShapes = ::testing::Combine(::testing::ValuesIn(IS_Dynamic_Fusing),
                                                            ::testing::Values(ElementType::f32),
                                                            ::testing::Values(ElementType::undefined),
@@ -820,7 +826,7 @@ const auto matMulParamsDynamicFusingFullUndefShapes = ::testing::Combine(::testi
 
 const auto testParamsDynamicFusingFullUndefShapes = ::testing::Combine(matMulParamsDynamicFusingFullUndefShapes,
                                                         ::testing::Values(MatMulNodeType::MatMul),
-                                                        ::testing::ValuesIn(matmulFusingParams()),
+                                                        ::testing::ValuesIn(matmulFullDynInputsFusingParams),
                                                         ::testing::ValuesIn(filterCPUInfo(filterSpecificParams())));
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/matmul.cpp
@@ -795,6 +795,40 @@ const auto testParams3D_nightly = ::testing::Combine(fullyConnectedParams3D_nigh
                                              ::testing::ValuesIn(filterCPUInfo(filterSpecificParams())));
 
 INSTANTIATE_TEST_SUITE_P(nightly_FC_3D, MatMulLayerCPUTest, testParams3D_nightly, MatMulLayerCPUTest::getTestCaseName);
+
+class MatMulLayerCPUTestUndefShapes : public MatMulLayerCPUTest {
+};
+
+TEST_P(MatMulLayerCPUTestUndefShapes, CompareWithRefs) {
+    auto second_shape = inputDynamicShapes.at(1);
+    PartialShape new_second_shape(std::vector<int64_t>(second_shape.rank().get_length(), -1));
+    std::map<size_t, ov::PartialShape> new_inputs;
+    new_inputs[0] = inputDynamicShapes.at(0);
+    new_inputs[1] = new_second_shape;
+    function->reshape(new_inputs);
+    run();
+    CheckPluginRelatedResults(compiledModel, cpuNodeType);
+}
+
+const auto matMulParamsDynamicFusingFullUndefShapes = ::testing::Combine(::testing::ValuesIn(IS_Dynamic_Fusing),
+                                                           ::testing::Values(ElementType::f32),
+                                                           ::testing::Values(ElementType::undefined),
+                                                           ::testing::Values(ElementType::undefined),
+                                                           ::testing::Values(utils::InputLayerType::PARAMETER),
+                                                           ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                                           ::testing::Values(emptyAdditionalConfig()));
+
+const auto testParamsDynamicFusingFullUndefShapes = ::testing::Combine(matMulParamsDynamicFusingFullUndefShapes,
+                                                        ::testing::Values(MatMulNodeType::MatMul),
+                                                        ::testing::ValuesIn(matmulFusingParams()),
+                                                        ::testing::ValuesIn(filterCPUInfo(filterSpecificParams())));
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_MM_Dynamic_Fusing_Full_Undef_Shapes,
+    MatMulLayerCPUTestUndefShapes,
+    testParamsDynamicFusingFullUndefShapes,
+    MatMulLayerCPUTest::getTestCaseName);
+
 }  // namespace
 }  // namespace MatMul
 }  // namespace test


### PR DESCRIPTION
### Details:
This is a bug fix, which introduces a proper post ops shapes processing when building MatMul primitive attributes.

### Tickets:
 - 121661
