### PR TITLE
[CPU][ARM] Disable transpose as reorder path for non-f32 precision

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -212,6 +212,13 @@ void Transpose::createPrimitive() {
         performAsReorder = true;
     }
 
+#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+    // Avoid using reference implementation of non-fp32 reorders on arm platforms
+    if (prec != ov::element::f32) {
+        performAsReorder = false;
+    }
+#endif
+
     if (!performAsReorder) {
         transposeParams.permuteParams.data_size = getSelectedPrimitiveDescriptor()->getConfig().inConfs[0].getMemDesc()->getPrecision().size();
         if (isInputOrderConst)


### PR DESCRIPTION
Reference reorder (spec_reference) is selected by oneDNN if `performAsReorder` is true on ARM platforms.
To avoid reference code, `performAsReorder` set explicitly to false for non-fp32 precision on arm platforms.