### PR TITLE
[TF Hub] Update precommit with model containing TensorListConcatV2 op

### DIFF
--- a/tests/model_hub_tests/tf_hub_tests/precommit_models
+++ b/tests/model_hub_tests/tf_hub_tests/precommit_models
@@ -11,10 +11,7 @@ magenta/arbitrary-image-stylization-v1-256,https://www.kaggle.com/models/google/
 small_bert/bert_en_uncased_L-4_H-256_A-4,https://www.kaggle.com/models/tensorflow/bert/frameworks/tensorFlow2/variations/bert-en-uncased-l-4-h-256-a-4/versions/2
 movinet/a5/base/kinetics-600/classification,https://www.kaggle.com/models/google/movinet/frameworks/tensorFlow2/variations/a5-base-kinetics-600-classification/versions/3
 # models with TensorListConcatV2 op
-efficientdet/lite0/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite0-detection/versions/1
-efficientdet/lite2/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite2-detection/versions/1
-efficientdet/lite3/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite3-detection/versions/1
-efficientdet/lite3x/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite3x-detection/versions/1
+efficientdet/lite0/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite0-detection/versions/1,skip,105671 - extend support for TensorList* ops when element_shape has undefined dimension
 # model with complex tensors and FFT ops
 yamnet,https://www.kaggle.com/models/google/yamnet/frameworks/tensorFlow2/variations/yamnet/versions/1
 # secure notebook models

--- a/tests/model_hub_tests/tf_hub_tests/precommit_models
+++ b/tests/model_hub_tests/tf_hub_tests/precommit_models
@@ -10,6 +10,11 @@ imagenet/mobilenet_v1_100_224/classification,https://www.kaggle.com/models/googl
 magenta/arbitrary-image-stylization-v1-256,https://www.kaggle.com/models/google/arbitrary-image-stylization-v1/frameworks/tensorFlow1/variations/256/versions/2
 small_bert/bert_en_uncased_L-4_H-256_A-4,https://www.kaggle.com/models/tensorflow/bert/frameworks/tensorFlow2/variations/bert-en-uncased-l-4-h-256-a-4/versions/2
 movinet/a5/base/kinetics-600/classification,https://www.kaggle.com/models/google/movinet/frameworks/tensorFlow2/variations/a5-base-kinetics-600-classification/versions/3
+# models with TensorListConcatV2 op
+efficientdet/lite0/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite0-detection/versions/1
+efficientdet/lite2/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite2-detection/versions/1
+efficientdet/lite3/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite3-detection/versions/1
+efficientdet/lite3x/detection,https://www.kaggle.com/models/tensorflow/efficientdet/frameworks/tensorFlow2/variations/lite3x-detection/versions/1
 # model with complex tensors and FFT ops
 yamnet,https://www.kaggle.com/models/google/yamnet/frameworks/tensorFlow2/variations/yamnet/versions/1
 # secure notebook models


### PR DESCRIPTION
**Details:** Update precommit with model containing TensorListConcatV2 op. TensorListConcatV2 support was recently added in other PR.

**Ticket:** TBD
