### PR TITLE
Modify test cases which are failing parallel execution

### DIFF
--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
@@ -31,18 +31,16 @@ class TestKerasStackedRNNCells(CommonTF2LayerTest):
         return tf2_net, ref_net
 
     test_data = [
-        dict(input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32,
-             rnn_cells="LSTMCell"),
-        dict(input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32,
-             rnn_cells="GRUCell")
+        (["x1"], [[5, 4, 3]], tf.float32, "LSTMCell"),
+        (["x1"], [[5, 4, 3]], tf.float32, "GRUCell")
     ]
 
-    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_names, input_shapes, input_type, rnn_cells", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
-    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
-                                   use_new_frontend):
+    def test_keras_stackedrnncells(self, input_names, input_shapes, input_type, rnn_cells, ie_device, precision, ir_version, temp_dir, use_old_api, use_new_frontend):
+        params = {"input_names": input_names, "input_shapes": input_shapes, "input_type": input_type,"rnn_cells": rnn_cells}
         self._test(*self.create_keras_stackedrnncells_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -54,7 +54,37 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     def test_keras_upsampling2d_nearest(self, params, input_type, data_format, interpolation,
                                         ie_device, precision, ir_version, temp_dir,
                                         use_old_api, use_new_frontend):
-        self._test(*self.create_keras_upsampling2d_net(**params, input_type=input_type, data_format=data_format,
-                                                       interpolation=interpolation, ir_version=ir_version),
+        self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)
+
+    # Tests for bilinear interpolation
+    test_data_bilinear = [
+        pytest.param((["x1"], [[1, 6, 2, 1]], tf.float32, (3, 1), 'channels_last', 'bilinear'), marks=pytest.mark.precommit_tf_fe),
+        (["x1"], [[1, 3, 1, 6]], tf.float32, (5, 2), 'channels_last', 'bilinear')
+    ]
+
+    @pytest.mark.parametrize("params", test_data_bilinear)
+    @pytest.mark.nightly
+    def test_keras_upsampling2d_bilinear(self, params, ie_device, precision, ir_version, temp_dir,
+                                         use_old_api, use_new_frontend):
+        input_names, input_shapes, input_type, size, data_format, interpolation = params
+        self._test(*self.create_keras_upsampling2d_net(input_names=input_names, input_shapes=input_shapes, input_type=input_type, size=size, data_format=data_format, interpolation=interpolation,
+        ir_version=ir_version), ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version, use_new_frontend=use_new_frontend, **params)
+
+    test_data_channels_first = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 5, 3]], input_type=tf.float32,
+             size=(3, 4), data_format='channels_first', interpolation='nearest'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 7, 2]], input_type=tf.float32,
+             size=(2, 3), data_format='channels_first', interpolation='nearest'),
+        dict(input_names=["x1"], input_shapes=[[3, 5, 4, 6]], input_type=tf.float32,
+             size=(5, 2), data_format='channels_first', interpolation='nearest'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_first)
+    @pytest.mark.nightly
+    def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
+                                               temp_dir, use_old_api, use_new_frontend):
+        self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
@@ -22,12 +22,9 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
         return tf2_net, ref_net
 
     test_data_channels_last = [
-        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]], input_type=tf.float32,
-             padding=2, data_format='channels_last'),
-        dict(input_names=["x1"], input_shapes=[[3, 2, 4, 6]], input_type=tf.float32,
-             padding=(3, 0), data_format='channels_last'),
-        pytest.param(dict(input_names=["x1"], input_shapes=[[1, 3, 8, 7]], input_type=tf.float32,
-                          padding=((5, 1), (3, 4)), data_format='channels_last'), marks=pytest.mark.precommit_tf_fe),
+        (["x1"], [[5, 4, 8, 3]], tf.float32, 2, 'channels_last'),
+        (["x1"], [[3, 2, 4, 6]], tf.float32, (3, 0), 'channels_last'),
+        pytest.param((["x1"], [[1, 3, 8, 7]], tf.float32, ((5, 1), (3, 4))), marks=pytest.mark.precommit_tf_fe),
     ]
 
     @pytest.mark.parametrize("params", test_data_channels_last)
@@ -35,7 +32,8 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
     @pytest.mark.precommit
     def test_keras_zeropadding2d_channels_last(self, params, ie_device, precision, ir_version,
                                                temp_dir, use_old_api):
-        self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
+        input_names, input_shapes, input_type, padding, data_format = params
+        self._test(*self.create_keras_zeropadding2d_net(input_names = input_names, input_shapes = input_shapes, input_type = input_type, padding = padding, data_format = data_format, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    **params)
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
@@ -97,23 +97,16 @@ class TestMapFN(CommonTF2LayerTest):
                    **params)
 
     test_multiple_inputs_outputs_int32 = [
-        dict(fn=lambda x: x[0] * x[1] + x[2],
-             input_type=tf.int32,
-             fn_output_signature=tf.int32, back_prop=True,
-             input_names=["x1", "x2", "x3"],
-             input_shapes=[[2, 1, 3], [2, 1, 3], [2, 1, 3]]),
-        pytest.param(dict(fn=lambda x: (x[0] + x[1] + x[2], x[0] - x[2] + x[1], 2 + x[2]),
-                          input_type=tf.int32,
-                          fn_output_signature=(tf.int32, tf.int32, tf.int32), back_prop=True,
-                          input_names=["x1", "x2", "x3"],
-                          input_shapes=[[2, 1, 3, 4], [2, 1, 3, 4], [2, 1, 3, 4]]),
+        (lambda x: x[0] * x[1] + x[2], tf.int32, tf.int32, True, ["x1", "x2", "x3"], [[2, 1, 3], [2, 1, 3], [2, 1, 3]]),
+        pytest.param(lambda x: (x[0] + x[1] + x[2], x[0] - x[2] + x[1], 2 + x[2]), tf.int32, (tf.int32, tf.int32, tf.int32), True, ["x1", "x2", "x3"], [[2, 1, 3, 4], [2, 1, 3, 4], [2, 1, 3, 4]],
                      marks=[pytest.mark.xfail(reason="61587"), pytest.mark.precommit_tf_fe])
     ]
 
-    @pytest.mark.parametrize("params", test_multiple_inputs_outputs_int32)
+    @pytest.mark.parametrize("fn, input_type, fn_output_signature, back_prop, input_names, input_shapes", test_multiple_inputs_outputs_int32)
     @pytest.mark.nightly
-    def test_multiple_inputs_outputs_int32(self, params, ie_device, precision, ir_version, temp_dir,
+    def test_multiple_inputs_outputs_int32(self, fn, input_type, fn_output_signature, back_prop, input_names, input_shapes, ie_device, precision, ir_version, temp_dir,
                                            use_old_api, use_new_frontend):
+        params = {"fn": fn, "input_type": input_type, "fn_output_signature": fn_output_signature, "back_prop": back_prop, "input_names": input_names, "input_shapes": input_shapes}
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
                    **params)


### PR DESCRIPTION
* Addressing the "Known limitation" issue for test cases which failed parallel execution.

### Details:
- Few tests cases failed when parallel execution is enabled.
- These failed test cases are modified in order to execute with out errors.
- After modification, two test cases failed due to inconsistent number of parameters passed to the test case.
- The two test cases which failed due to parameter inconsistency is addressed in this commit.


### Tickets:
 - *ticket-id* - [20919](https://github.com/openvinotoolkit/openvino/issues/20919)
