### PR TITLE
[CPU] fix gen_pattern::AttrAny::equal_to

### DIFF
--- a/src/plugins/intel_cpu/src/utils/gen_pattern.hpp
+++ b/src/plugins/intel_cpu/src/utils/gen_pattern.hpp
@@ -411,16 +411,16 @@ struct AttrAny {
 
     template <typename T>
     bool equal_to(const std::vector<T>& rhs) {
-        if (any.empty() && rhs.empty())
-            return true;
+        if (any.empty())
+            return rhs.empty();
         auto& vec = any.as<std::vector<T>>();
         return std::equal(vec.begin(), vec.end(), rhs.begin());
     }
 
     template <typename T, typename CT0, typename... CTs>
     bool equal_to(const std::vector<T>& rhs) {
-        if (any.empty() && rhs.empty())
-            return true;
+        if (any.empty())
+            return rhs.empty();
 
         if (any.is<std::vector<CT0>>()) {
             auto& vec = any.as<std::vector<CT0>>();


### PR DESCRIPTION
### Details:
 - when pattern contains attributes with empty initializer_list (like: `"new_axis_mask", {}`), it should only match graph node also with empty vector, otherwise should fail the match.

### Tickets:
 - CVS-127879
