### PR TITLE
[GPU] Fix allocation when usm is unavailable

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -86,7 +86,8 @@ struct kv_cache_impl : typed_primitive_impl_ocl<kv_cache> {
             auto& stream = instance.get_network().get_stream();
 
             stream.enqueue_barrier();
-            return variable.get_memory()->copy_from(stream, instance.output_memory(0), false);
+            auto out = instance.get_network().get_engine().reinterpret_buffer(instance.output_memory(0), variable.get_memory()->get_layout());
+            return variable.get_memory()->copy_from(stream, *out, false);
         }
     }
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1264,7 +1264,8 @@ primitive_inst::primitive_inst(network& network, program_node const& node, bool 
     , _needs_completion_event(is_any_user_cpu(node.get_users()) || node.is_output()) {
     // When dynamic shape node has huge upper boundary which causes bigger mem size than system max allocable mem size, do not allocate in build time.
     auto output_layout = node.get_output_layout();
-    if (allocate_memory && node.is_dynamic() && (!network.get_engine().check_allocatable(output_layout, allocation_type::usm_host))) {
+    auto& engine = network.get_engine();
+    if (allocate_memory && node.is_dynamic() && (!engine.check_allocatable(output_layout, engine.get_lockable_preferred_memory_allocation_type(false)))) {
         allocate_memory = false;
     }
     _mem_allocated = allocate_memory;


### PR DESCRIPTION
### Details:
 - Devices w/o USM support could face an exception in `check_allocatable` function due to hardcoded `usm_host` allocation type
 - Reinterpret out buffer for kv_cache primitive to ensure that src and dst buffer sizes match in copy_from impl
