### PR TITLE
[GPU] Fix faked aligned issue

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -191,13 +191,17 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
     if (orig_input_layout.format == format::bfyx && orig_output_layout.format == format::bfyx && can_apply_fake_alignment) {
         auto updated_param = orig_impl_param;
 
-        auto batch_size = std::accumulate(input_shape.begin(),
+        auto input_batch_size = std::accumulate(input_shape.begin(),
                                           input_shape.end() - 1,
+                                          size_t{1},
+                                          std::multiplies<size_t>());
+        auto output_batch_size = std::accumulate(output_shape.begin(),
+                                          output_shape.end() - 1,
                                           size_t{1},
                                           std::multiplies<size_t>());
 
         // Vector by matrix multiplication sometimes works slower if we align it
-        if (batch_size == 1 && input_shape.back() >= 1024) {
+        if (input_batch_size == 1 && output_batch_size == 1 && input_shape.back() >= 1024) {
             return std::move(orig_impl_param);
         }
 
@@ -205,14 +209,14 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         if (orig_impl_param.dev_type == cldnn::device_type::integrated_gpu) {
             auto weights_layout_dt = orig_impl_param.weights_layout.value().data_type;
             auto is_4bit = weights_layout_dt == data_types::i4 || weights_layout_dt == data_types::u4;
-            auto is_extra_alignment_needed = batch_size >= 256;
+            auto is_extra_alignment_needed = output_batch_size >= 256;
             fake_align_base = is_4bit && is_extra_alignment_needed ? 64 : 16;
         }
 
         // If input / output shape only have one dimension which is bigger than one except last dimension, preserve the index of aligned dimension.
         // ex) f16:bfyx:1x79x512:nopad -> f16:bfyx:1x80x512:nopad
         size_t aligned_input_idx = 0;
-        if (std::count_if(input_shape.begin(), input_shape.end()-1, [](size_t v){ return (v > 1); })) {
+        if (std::count_if(input_shape.begin(), input_shape.end()-1, [](size_t v){ return (v > 1); }) == 1) {
             for (size_t i = 0; i < (input_shape.size() - 1); i++) {
                 if (input_shape[i] > 1) {
                     aligned_input_idx = i;
@@ -221,7 +225,7 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
             }
         }
         size_t aligned_output_idx = 0;
-        if (std::count_if(output_shape.begin(), output_shape.end()-1, [](size_t v){ return (v > 1); })) {
+        if (std::count_if(output_shape.begin(), output_shape.end()-1, [](size_t v){ return (v > 1); }) == 1) {
             for (size_t i = 0; i < (output_shape.size() - 1); i++) {
                 if (output_shape[i] > 1) {
                     aligned_output_idx = i;
@@ -233,8 +237,8 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         std::fill(input_shape.begin(), input_shape.end() - 1, 1);
         std::fill(output_shape.begin(), output_shape.end() - 1, 1);
 
-        input_shape[aligned_input_idx] = align_to(batch_size, fake_align_base);
-        output_shape[aligned_output_idx] = align_to(batch_size, fake_align_base);
+        input_shape[aligned_input_idx]      = align_to(input_batch_size, fake_align_base);
+        output_shape[aligned_output_idx]    = align_to(output_batch_size, fake_align_base);
 
         updated_param.input_layouts[0] = layout(ov::PartialShape(input_shape),
                                                 orig_input_layout.data_type,

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -211,6 +211,11 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
 
         // If input / output shape only have one dimension which is bigger than one except last dimension, preserve the index of aligned dimension.
         // ex) f16:bfyx:1x79x512:nopad -> f16:bfyx:1x80x512:nopad
+        // Supported cases which preserve the index of aligned dimension.
+        // * Input [1, M, K], Output [1, M, N], Batch M
+        // * Input [1, 1, M, K], Output [1, 1, M, N], Batch M
+        // TODO: support other case
+        // * Input [2, M, K, 1], Output [2, M, N, 1], Batch 2M
         size_t aligned_input_idx = 0;
         if (std::count_if(input_shape.begin(), input_shape.end()-1, [](size_t v){ return (v > 1); }) == 1) {
             for (size_t i = 0; i < (input_shape.size() - 1); i++) {

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -212,7 +212,7 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         // If input / output shape only have one dimension which is bigger than one except last dimension, preserve the index of aligned dimension.
         // ex) f16:bfyx:1x79x512:nopad -> f16:bfyx:1x80x512:nopad
         size_t aligned_input_idx = 0;
-        if (std::count_if(input_shape.begin(), input_shape.end()-1, [](size_t v){ return (v > 1); })) {
+        if (std::count_if(input_shape.begin(), input_shape.end()-1, [](size_t v){ return (v > 1); }) == 1) {
             for (size_t i = 0; i < (input_shape.size() - 1); i++) {
                 if (input_shape[i] > 1) {
                     aligned_input_idx = i;
@@ -221,7 +221,7 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
             }
         }
         size_t aligned_output_idx = 0;
-        if (std::count_if(output_shape.begin(), output_shape.end()-1, [](size_t v){ return (v > 1); })) {
+        if (std::count_if(output_shape.begin(), output_shape.end()-1, [](size_t v){ return (v > 1); }) == 1) {
             for (size_t i = 0; i < (output_shape.size() - 1); i++) {
                 if (output_shape[i] > 1) {
                     aligned_output_idx = i;

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -191,17 +191,13 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
     if (orig_input_layout.format == format::bfyx && orig_output_layout.format == format::bfyx && can_apply_fake_alignment) {
         auto updated_param = orig_impl_param;
 
-        auto input_batch_size = std::accumulate(input_shape.begin(),
+        auto batch_size = std::accumulate(input_shape.begin(),
                                           input_shape.end() - 1,
-                                          size_t{1},
-                                          std::multiplies<size_t>());
-        auto output_batch_size = std::accumulate(output_shape.begin(),
-                                          output_shape.end() - 1,
                                           size_t{1},
                                           std::multiplies<size_t>());
 
         // Vector by matrix multiplication sometimes works slower if we align it
-        if (input_batch_size == 1 && output_batch_size == 1 && input_shape.back() >= 1024) {
+        if (batch_size == 1 && input_shape.back() >= 1024) {
             return std::move(orig_impl_param);
         }
 
@@ -209,14 +205,14 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         if (orig_impl_param.dev_type == cldnn::device_type::integrated_gpu) {
             auto weights_layout_dt = orig_impl_param.weights_layout.value().data_type;
             auto is_4bit = weights_layout_dt == data_types::i4 || weights_layout_dt == data_types::u4;
-            auto is_extra_alignment_needed = output_batch_size >= 256;
+            auto is_extra_alignment_needed = batch_size >= 256;
             fake_align_base = is_4bit && is_extra_alignment_needed ? 64 : 16;
         }
 
         // If input / output shape only have one dimension which is bigger than one except last dimension, preserve the index of aligned dimension.
         // ex) f16:bfyx:1x79x512:nopad -> f16:bfyx:1x80x512:nopad
         size_t aligned_input_idx = 0;
-        if (std::count_if(input_shape.begin(), input_shape.end()-1, [](size_t v){ return (v > 1); }) == 1) {
+        if (std::count_if(input_shape.begin(), input_shape.end()-1, [](size_t v){ return (v > 1); })) {
             for (size_t i = 0; i < (input_shape.size() - 1); i++) {
                 if (input_shape[i] > 1) {
                     aligned_input_idx = i;
@@ -225,7 +221,7 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
             }
         }
         size_t aligned_output_idx = 0;
-        if (std::count_if(output_shape.begin(), output_shape.end()-1, [](size_t v){ return (v > 1); }) == 1) {
+        if (std::count_if(output_shape.begin(), output_shape.end()-1, [](size_t v){ return (v > 1); })) {
             for (size_t i = 0; i < (output_shape.size() - 1); i++) {
                 if (output_shape[i] > 1) {
                     aligned_output_idx = i;
@@ -237,8 +233,8 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         std::fill(input_shape.begin(), input_shape.end() - 1, 1);
         std::fill(output_shape.begin(), output_shape.end() - 1, 1);
 
-        input_shape[aligned_input_idx]      = align_to(input_batch_size, fake_align_base);
-        output_shape[aligned_output_idx]    = align_to(output_batch_size, fake_align_base);
+        input_shape[aligned_input_idx] = align_to(batch_size, fake_align_base);
+        output_shape[aligned_output_idx] = align_to(batch_size, fake_align_base);
 
         updated_param.input_layouts[0] = layout(ov::PartialShape(input_shape),
                                                 orig_input_layout.data_type,

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -783,9 +783,11 @@ void loop_inst::concatenated_memory_mapping::slice_mem(const int64_t num_iterati
                             ") should be same with sliced_mems.size(", sliced_mems.size(), ")");
     OPENVINO_ASSERT(concatenated_mem != nullptr, "concatenated_mem should not be nullptr");
 
-    auto elem_size = ov::element::Type(concatenated_mem->get_layout().data_type).size();
-    auto concat_mem_shape = concatenated_mem->get_layout().get_shape();
-    auto sliced_mem_shape = sliced_mems.front()->get_layout().get_shape();
+    auto concat_layout = concat_data_prim->get_output_layout(io_prim_map.external_id.idx);
+    auto sliced_layout = sliced_data_prim->get_output_layout(io_prim_map.internal_id.idx);
+    auto concat_mem_shape = concat_layout.get_shape();
+    auto sliced_mem_shape = sliced_layout.get_shape();
+    auto elem_size = ov::element::Type(concat_layout.data_type).size();
     const auto stride = io_prim_map.stride;
     const auto axis = io_prim_map.axis;
     const auto step = std::abs(stride);
@@ -801,10 +803,8 @@ void loop_inst::concatenated_memory_mapping::slice_mem(const int64_t num_iterati
     }
 
     char* concat_data = reinterpret_cast<char*>(concatenated_mem->lock(stream, cldnn::mem_lock_type::read));
-
-    auto concate_layout = concatenated_mem->get_layout();
     auto dims = concat_mem_shape.size();
-    if (!format::is_default_format(concate_layout.format) || dims == 1 || concate_layout.data_padding) {
+    if (!format::is_default_format(concat_layout.format) || dims == 1 || concat_layout.data_padding) {
         // BE CAREFUL: ov::reference::split is extremely slow.
         // If we encounter any case where this code path is executed, we need to optimize it
         ov::reference::split(concat_data, concat_mem_shape, elem_size, axis, num_iters, pointers_to_data.data());
@@ -864,9 +864,11 @@ void loop_inst::concatenated_memory_mapping::concat_mem(const int64_t curent_ite
                         ") should be less than the number of sliced_mems(", sliced_mems.size(), ")");
     OPENVINO_ASSERT(concatenated_mem != nullptr, "concatenated_mem should not be nullptr");
 
-    auto elem_size = ov::element::Type(concatenated_mem->get_layout().data_type).size();
-    auto concat_mem_shape = concatenated_mem->get_layout().get_shape();
-    auto sliced_mem_shape = sliced_mems.front()->get_layout().get_shape();
+    auto concat_layout = concat_data_prim->get_output_layout(io_prim_map.external_id.idx);
+    auto sliced_layout = sliced_data_prim->get_output_layout(io_prim_map.internal_id.idx);
+    auto concat_mem_shape = concat_layout.get_shape();
+    auto sliced_mem_shape = sliced_layout.get_shape();
+    auto elem_size = ov::element::Type(concat_layout.data_type).size();
     const auto stride = io_prim_map.stride;
     const auto axis = io_prim_map.axis;
     const auto step = std::abs(stride);

--- a/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
@@ -43,7 +43,11 @@ TEST_P(fully_connected_fake_align_test, fake_alignment) {
     auto weight_layout_prim = std::make_shared<input_layout>("weight", p.weight_layout);
     auto fully_connected_prim = std::make_shared<fully_connected>("output", input_info("input"), "weight", "", p.data_type, padding(), input_size);
 
-    cldnn::program prog(engine);
+    // To use get_fake_aligned_params, set allow_new_shape_infer as true
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    cldnn::program prog(engine, config);
 
     auto& input_node = prog.get_or_create(input_layout_prim);
     auto& weight_node = prog.get_or_create(weight_layout_prim);
@@ -120,55 +124,55 @@ INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_fake_align_test,
             layout{ov::PartialShape{2, 55, 511}, data_types::f16, format::bfyx},                       // input_layout
             layout{ov::PartialShape{800, 511}, data_types::f16, format::bfyx},                         // weight layout
             data_types::f16,
-            layout{ov::PartialShape{112, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
-            layout{ov::PartialShape{112, 1, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
-            layout{ov::PartialShape{112, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{112, 1, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 112, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 112, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 112, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 112, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{55, 1, 511}, data_types::f16, format::bfyx},                       // input_layout
             layout{ov::PartialShape{800, 511}, data_types::f16, format::bfyx},                         // weight layout
             data_types::f16,
-            layout{ov::PartialShape{64, 1, 511}, data_types::f16, format::bfyx},                       // fake_aligned input layout_igpu
-            layout{ov::PartialShape{64, 1, 800}, data_types::f16, format::bfyx},                       // fake_aligned output layout_igpu
-            layout{ov::PartialShape{56, 1, 511}, data_types::f16, format::bfyx},                       // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{56, 1, 800}, data_types::f16, format::bfyx}                        // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 64, 511}, data_types::f16, format::bfyx},                       // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 64, 800}, data_types::f16, format::bfyx},                       // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 56, 511}, data_types::f16, format::bfyx},                       // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 56, 800}, data_types::f16, format::bfyx}                        // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{240, 1,  511}, data_types::f16, format::bfyx},                     // input_layout
             layout{ov::PartialShape{800, 511}, data_types::f16, format::bfyx},                         // weight layout
             data_types::f16,
-            layout{ov::PartialShape{240, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
-            layout{ov::PartialShape{240, 1, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
-            layout{ov::PartialShape{240, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{240, 1, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 240, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 240, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 240, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 240, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{241, 1, 511}, data_types::f16, format::bfyx},                      // input_layout
             layout{ov::PartialShape{800, 511}, data_types::f16, format::bfyx},                         // weight layout
             data_types::f16,
-            layout{ov::PartialShape{256, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
-            layout{ov::PartialShape{256, 1, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
-            layout{ov::PartialShape{248, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{248, 1, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 256, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 256, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 248, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 248, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{257, 1, 511}, data_types::f16, format::bfyx},                      // input_layout
             layout{ov::PartialShape{800, 511}, data_types::f16, format::bfyx},                         // weight layout
             data_types::f16,
-            layout{ov::PartialShape{272, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
-            layout{ov::PartialShape{272, 1, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
-            layout{ov::PartialShape{264, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{264, 1, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 272, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 272, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 264, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 264, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{55, 1, 511}, data_types::f16, format::bfyx, padding{{2,0,1,0}, 0}}, // input_layout
             layout{ov::PartialShape{800, 511}, data_types::f16, format::bfyx},                          // weight layout
             data_types::f16,
-            layout{ov::PartialShape{64, 1, 511}, data_types::f16, format::bfyx, padding{{2,0,1,0}, 0}}, // fake_aligned input layout_igpu
-            layout{ov::PartialShape{64, 1, 800}, data_types::f16, format::bfyx},                        // fake_aligned output layout_igpu
-            layout{ov::PartialShape{56, 1, 511}, data_types::f16, format::bfyx, padding{{2,0,1,0}, 0}}, // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{56, 1, 800}, data_types::f16, format::bfyx}                         // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 64, 511}, data_types::f16, format::bfyx, padding{{2,0,1,0}, 0}}, // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 64, 800}, data_types::f16, format::bfyx},                        // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 56, 511}, data_types::f16, format::bfyx, padding{{2,0,1,0}, 0}}, // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 56, 800}, data_types::f16, format::bfyx}                         // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{55, 1, 511}, data_types::f16, format::bfyx, padding{{0,1,1,0}, 0}}, // input_layout
@@ -185,28 +189,28 @@ INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_fake_align_test,
             layout{ov::PartialShape{240, 1, 511}, data_types::f16, format::bfyx},                      // input_layout
             layout{ov::PartialShape{800, 511}, data_types::u4, format::bfyx},                          // weight layout
             data_types::f16,
-            layout{ov::PartialShape{240, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
-            layout{ov::PartialShape{240, 1, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
-            layout{ov::PartialShape{240, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{240, 1, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 240, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 240, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 240, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 240, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{241, 1, 511}, data_types::f16, format::bfyx},                      // input_layout
             layout{ov::PartialShape{800, 511}, data_types::u4, format::bfyx},                          // weight layout
             data_types::f16,
-            layout{ov::PartialShape{256, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
-            layout{ov::PartialShape{256, 1, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
-            layout{ov::PartialShape{248, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{248, 1, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 256, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 256, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 248, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 248, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{257, 1, 511}, data_types::f16, format::bfyx},                      // input_layout
             layout{ov::PartialShape{800, 511}, data_types::u4, format::bfyx},                          // weight layout
             data_types::f16,
-            layout{ov::PartialShape{320, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
-            layout{ov::PartialShape{320, 1, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
-            layout{ov::PartialShape{264, 1, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{264, 1, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 320, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 320, 800}, data_types::f16, format::bfyx},                      // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 264, 511}, data_types::f16, format::bfyx},                      // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 264, 800}, data_types::f16, format::bfyx}                       // fake_aligned output layout_dgpu
         },
     }));
 

--- a/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
@@ -111,10 +111,10 @@ INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_fake_align_test,
             layout{ov::PartialShape{1, 55, 511}, data_types::f16, format::bfyx},                       // input_layout
             layout{ov::PartialShape{800, 511}, data_types::f16, format::bfyx},                         // weight layout
             data_types::f16,
-            layout{ov::PartialShape{64, 1, 511}, data_types::f16, format::bfyx},                       // fake_aligned input layout_igpu
-            layout{ov::PartialShape{64, 1, 800}, data_types::f16, format::bfyx},                       // fake_aligned output layout_igpu
-            layout{ov::PartialShape{56, 1, 511}, data_types::f16, format::bfyx},                       // fake_aligned input layout_dgpu
-            layout{ov::PartialShape{56, 1, 800}, data_types::f16, format::bfyx}                        // fake_aligned output layout_dgpu
+            layout{ov::PartialShape{1, 64, 511}, data_types::f16, format::bfyx},                       // fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 64, 800}, data_types::f16, format::bfyx},                       // fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 56, 511}, data_types::f16, format::bfyx},                       // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 56, 800}, data_types::f16, format::bfyx}                        // fake_aligned output layout_dgpu
         },
         {
             layout{ov::PartialShape{2, 55, 511}, data_types::f16, format::bfyx},                       // input_layout

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -72,10 +72,10 @@ public:
         const auto params_hash = primitve->type->get_fake_aligned_params(*prim_inst->get_impl_params()).hash();
         if (!engine.get_device_info().supports_immad) {
             ASSERT_EQ(primitive_hash, 14259723886449306729UL);
-            ASSERT_EQ(params_hash, 12550884704517944463UL);
+            ASSERT_EQ(params_hash, 3365957578641948513UL);
         } else {
             ASSERT_EQ(primitive_hash, 14259723886449306729UL);
-            ASSERT_EQ(params_hash, 13431018575024732575UL);
+            ASSERT_EQ(params_hash, 9831190959346679696UL);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -72,10 +72,10 @@ public:
         const auto params_hash = primitve->type->get_fake_aligned_params(*prim_inst->get_impl_params()).hash();
         if (!engine.get_device_info().supports_immad) {
             ASSERT_EQ(primitive_hash, 14259723886449306729UL);
-            ASSERT_EQ(params_hash, 3365957578641948513UL);
+            ASSERT_EQ(params_hash, 12550884704517944463UL);
         } else {
             ASSERT_EQ(primitive_hash, 14259723886449306729UL);
-            ASSERT_EQ(params_hash, 9831190959346679696UL);
+            ASSERT_EQ(params_hash, 13431018575024732575UL);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -64,7 +64,10 @@ public:
             fully_connected(key_prim_id, input_info("input"), "weights", "bias")
         );
 
-        cldnn::network::ptr net = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
+        // To use get_fake_aligned_params, set allow_new_shape_infer as true
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        cldnn::network::ptr net = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
         const auto  prim_inst = net->get_primitive(key_prim_id);
         const auto  primitve  = prim_inst->desc();
 
@@ -72,10 +75,10 @@ public:
         const auto params_hash = primitve->type->get_fake_aligned_params(*prim_inst->get_impl_params()).hash();
         if (!engine.get_device_info().supports_immad) {
             ASSERT_EQ(primitive_hash, 14259723886449306729UL);
-            ASSERT_EQ(params_hash, 3365957578641948513UL);
+            ASSERT_EQ(params_hash, 16264882325609108757UL);
         } else {
             ASSERT_EQ(primitive_hash, 14259723886449306729UL);
-            ASSERT_EQ(params_hash, 9831190959346679696UL);
+            ASSERT_EQ(params_hash, 1429546277653779203UL);
         }
     }
 


### PR DESCRIPTION
### Details:
 - *In faked aligned function, f16:bfyx:1x79x512:nopad input layout should be changed to f16:bfyx:1x89x512:nopad but currently it change input to f16:bfyx:80x1x512:nopad. this latest code change makes error in slicing memory  in loop*
 - *Fix the code to preserve the index of aligned when only one dimension is bigger than one except last dimension in faked aligned function*

### Tickets:
 - *114920*
