### PR TITLE
[CPU] Allow distinct batch size for 'sequence_length' RNN input

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -455,6 +455,8 @@ RNN::RNN(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context) 
     S = statesCount(cell_type);
     SC = rnnCellBase->get_hidden_size();
     N = {getInputShapeAtPort(0).getMinDims()[0], getInputShapeAtPort(0).getMaxDims()[0]};
+    if (!is_cell)
+        N_SEQ = {getInputShapeAtPort(sIdx).getMinDims()[0], getInputShapeAtPort(sIdx).getMaxDims()[0]};
 
     const auto& rtInfo = op->get_rt_info();
 
@@ -696,7 +698,7 @@ void RNN::fillSequenceDesc() {
     const Shape shapeNDSC {{N.minVal, D, SC}, {N.maxVal, D, SC}};
     Shape shapeNTSC {{N.minVal, T.minVal, SC}, {N.maxVal, T.maxVal, SC}};
     const Shape shapeNTDC {{N.minVal, T.minVal, DC}, {N.maxVal, T.maxVal, DC}};
-    const Shape TShape {VectorDims{N.minVal}, VectorDims{N.maxVal}};
+    const Shape TShape {VectorDims{N_SEQ.minVal}, VectorDims{N_SEQ.maxVal}};
     const Shape WShape {D, G * SC, DC};
     const Shape RShape {D, G * SC, SC};
     const Shape BShape {D, Gb * SC};

--- a/src/plugins/intel_cpu/src/nodes/rnn.h
+++ b/src/plugins/intel_cpu/src/nodes/rnn.h
@@ -122,6 +122,7 @@ private:
     };
     // Internal attributes
     Interval N;     /**< Batch value */
+    Interval N_SEQ; /**< Batch value of the 'sequence_length' input */
     Interval T;     /**< Sequence value */
     size_t DC = 0;  /**< Input data channel size */
     size_t SC = 0;  /**< State channel size value */

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_sequence.cpp
@@ -339,7 +339,6 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
         { {10}, {3}, {5}, {10}, {5} } } },          // Target shapes
 };
 
-
 namespace dynamicShapesBatchSwitch {
   const int input_size = 240;
   const int seq_length = 1;
@@ -453,6 +452,30 @@ INSTANTIATE_TEST_SUITE_P(nightly_dynamic_bf16_BatchSizeOne, LSTMSequenceCPUTest,
                                ::testing::Values(cpuParamsBatchSizeOne),
                                ::testing::Values(additionalConfig[1])),
             LSTMSequenceCPUTest::getTestCaseName);
+
+// Odd but valid use case
+std::vector<InputShape> mixedDynamicStaticBatch {
+    {{ {2, 3}, 5, 10},                         // Dynamic shape 0
+     { {2, 5, 10}, {2, 5, 10}, {2, 5, 10} } }, // Target shapes
+    {{ {2, 3}, 1, 1},                          // Dynamic shape 1
+      { {2, 1, 1}, {2, 1, 1}, {2, 1, 1} } },   // Target shapes
+    {{ {2, 3}, 1, 1},                          // Dynamic shape 2
+      { {2, 1, 1}, {2, 1, 1}, {2, 1, 1} } },   // Target shapes
+    { {2},                                     // Static shape 3
+      { {2}, {2}, {2} } }                      // Target shapes
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_dynamic_mixedDynamicStaticBatch, LSTMSequenceCPUTest,
+            ::testing::Combine(::testing::Values(mixedDynamicStaticBatch),
+                               ::testing::ValuesIn(mode),
+                               ::testing::ValuesIn(activations),
+                               ::testing::ValuesIn(clip),
+                               ::testing::ValuesIn(direction),
+                               ::testing::ValuesIn(netPrecisions),
+                               ::testing::Values(cpuParams),
+                               ::testing::Values(ov::AnyMap{})),
+            LSTMSequenceCPUTest::getTestCaseName);
+
 }  // namespace
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - In theory every input of the node can have distinct value for a dynamic batch size, even it does not make sense from the overall model perspective i.e:
   - first input batch size is completely unknown -1
   - second input batch size a range (1, 10)
   - third input batch size is the concrete value 5

In this example inference will work only when batch size 5 is used for all the inputs, but a model with such configuration still should be able to compile.

### Tickets:
 - 115477
