### PR TITLE
Get rid of builders.hpp and subgraph_builders.hpp includes

### DIFF
--- a/src/bindings/c/tests/test_model_repo.cpp
+++ b/src/bindings/c/tests/test_model_repo.cpp
@@ -6,6 +6,7 @@
 
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu_no_reshapes.hpp"
+#include "openvino/pass/serialize.hpp"
 
 namespace TestDataHelpers {
 

--- a/src/bindings/c/tests/test_model_repo.hpp
+++ b/src/bindings/c/tests/test_model_repo.hpp
@@ -11,7 +11,6 @@
 #include "openvino/pass/manager.hpp"
 #include "openvino/util/file_util.hpp"
 #include "ov_models/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace TestDataHelpers {
 

--- a/src/bindings/c/tests/test_model_repo.hpp
+++ b/src/bindings/c/tests/test_model_repo.hpp
@@ -10,7 +10,6 @@
 #include "openvino/core/visibility.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/util/file_util.hpp"
-#include "ov_models/builders.hpp"
 
 namespace TestDataHelpers {
 

--- a/src/common/low_precision_transformations/tests/is_constant_path_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/is_constant_path_transformation.cpp
@@ -5,7 +5,6 @@
 #include <memory>
 #include <gtest/gtest.h>
 
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 
 #include "ov_lpt_models/common/builders.hpp"

--- a/src/common/low_precision_transformations/tests/mat_mul_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mat_mul_transformation.cpp
@@ -15,7 +15,6 @@
 #include "layer_transformation.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/mat_mul.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "simple_low_precision_transformer.hpp"
 
 namespace {

--- a/src/common/low_precision_transformations/tests/mat_mul_with_constant_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mat_mul_with_constant_transformation.cpp
@@ -15,7 +15,6 @@
 #include "ov_lpt_models/common/constant.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/mat_mul.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "simple_low_precision_transformer.hpp"
 
 namespace {

--- a/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
@@ -19,7 +19,6 @@
 #include "ov_lpt_models/mat_mul.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 #include "simple_low_precision_transformer.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 

--- a/src/common/low_precision_transformations/tests/unit/data_precision_check.cpp
+++ b/src/common/low_precision_transformations/tests/unit/data_precision_check.cpp
@@ -7,7 +7,6 @@
 #include <ie_blob.h>
 #include "low_precision/layer_transformation.hpp"
 #include "low_precision/network_helper.hpp"
-#include "ov_models/builders.hpp"
 
 using namespace ov;
 

--- a/src/common/low_precision_transformations/tests/unit/layer_transformation_get_data_precision.cpp
+++ b/src/common/low_precision_transformations/tests/unit/layer_transformation_get_data_precision.cpp
@@ -7,7 +7,6 @@
 #include <ie_blob.h>
 #include "low_precision/layer_transformation.hpp"
 #include "low_precision/network_helper.hpp"
-#include "ov_models/builders.hpp"
 
 using namespace ov;
 

--- a/src/common/transformations/tests/common_optimizations/dimension_tracking.cpp
+++ b/src/common/transformations/tests/common_optimizations/dimension_tracking.cpp
@@ -16,7 +16,6 @@
 #include "openvino/core/model.hpp"
 #include "openvino/opsets/opset1.hpp"
 #include "openvino/pass/manager.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "transformations/common_optimizations/divide_fusion.hpp"
 #include "transformations/init_node_info.hpp"
 #include "transformations/utils/utils.hpp"

--- a/src/core/tests/type_relaxed_copy.cpp
+++ b/src/core/tests/type_relaxed_copy.cpp
@@ -9,7 +9,6 @@
 
 #include "ie_common.h"
 #include "openvino/op/matmul.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_ops/type_relaxed.hpp"
 
 using namespace ov;

--- a/src/plugins/auto/tests/functional/behavior/infer_consistency_test.hpp
+++ b/src/plugins/auto/tests/functional/behavior/infer_consistency_test.hpp
@@ -9,7 +9,7 @@
 #include "auto_func_test.hpp"
 #include "common_test_utils/include/common_test_utils/ov_tensor_utils.hpp"
 #include "common_test_utils/test_common.hpp"
-#include "ov_models/subgraph_builders.hpp"
+#include "ov_models/utils/ov_helpers.hpp"
 
 namespace ov {
 namespace auto_plugin {

--- a/src/plugins/auto_batch/tests/unit/async_infer_request_test.cpp
+++ b/src/plugins/auto_batch/tests/unit/async_infer_request_test.cpp
@@ -9,7 +9,6 @@
 #include "openvino/core/dimension_tracker.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/threading/immediate_executor.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "transformations/utils/utils.hpp"
 #include "unit_test_utils/mocks/openvino/runtime/mock_icore.hpp"
 

--- a/src/plugins/auto_batch/tests/unit/compile_model_get_runtime_model_test.cpp
+++ b/src/plugins/auto_batch/tests/unit/compile_model_get_runtime_model_test.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "mock_common.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "unit_test_utils/mocks/openvino/runtime/mock_icore.hpp"
 #include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
 

--- a/src/plugins/auto_batch/tests/unit/compile_model_set_property_test.cpp
+++ b/src/plugins/auto_batch/tests/unit/compile_model_set_property_test.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "mock_common.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "unit_test_utils/mocks/openvino/runtime/mock_icore.hpp"
 #include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
 

--- a/src/plugins/auto_batch/tests/unit/plugin_query_model_test.cpp
+++ b/src/plugins/auto_batch/tests/unit/plugin_query_model_test.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "mock_common.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "unit_test_utils/mocks/openvino/runtime/mock_icore.hpp"
 #include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
 

--- a/src/plugins/auto_batch/tests/unit/sync_infer_request_test.cpp
+++ b/src/plugins/auto_batch/tests/unit/sync_infer_request_test.cpp
@@ -9,7 +9,6 @@
 #include "openvino/core/dimension_tracker.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/threading/immediate_executor.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "transformations/utils/utils.hpp"
 #include "unit_test_utils/mocks/openvino/runtime/mock_icore.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/behavior/export_import.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/export_import.cpp
@@ -5,7 +5,6 @@
 #include "openvino/runtime/core.hpp"
 #include "openvino/runtime/compiled_model.hpp"
 #include "common_test_utils/test_common.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/hetero_synthetic.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/hetero_synthetic.cpp
@@ -5,8 +5,6 @@
 #include <vector>
 
 #include "behavior/ov_plugin/hetero_synthetic.hpp"
-#include "ov_models/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 // defined in plugin_name.cpp
 extern const char * cpu_plugin_file_name;

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/batch_to_space.cpp
@@ -4,7 +4,6 @@
 
 #include <common_test_utils/ov_tensor_utils.hpp>
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/broadcast.cpp
@@ -4,7 +4,6 @@
 
 #include <common_test_utils/ov_tensor_utils.hpp>
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/pooling.hpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/pooling.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "ov_models/builders.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/fusing_test_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/concat.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/grn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/grn.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/eltwise.cpp
@@ -5,8 +5,7 @@
 #include "single_layer_tests/classes/eltwise.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/fusing_test_utils.hpp"
-#include <ov_models/builders.hpp>
-#include <common_test_utils/ov_tensor_utils.hpp>
+#include "common_test_utils/ov_tensor_utils.hpp"
 
 using namespace CPUTestUtils;
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/one_hot.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/one_hot.cpp
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <ov_models/builders.hpp>
-#include <common_test_utils/ov_tensor_utils.hpp>
+#include "common_test_utils/ov_tensor_utils.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/prior_box.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/prior_box.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "openvino/core/partial_shape.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/range.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/range.cpp
@@ -4,8 +4,7 @@
 //
 //#include "test_utils/cpu_test_utils.hpp"
 //
-//#include "ov_models/builders.hpp"
-//#include "ov_models/utils/ov_helpers.hpp"
+////#include "ov_models/utils/ov_helpers.hpp"
 //
 //using namespace InferenceEngine;
 //using namespace CPUTestUtils;

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/roll.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/roll.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include "ov_models/builders.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 
 using namespace CPUTestUtils;

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/shapeof.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/shapeof.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_batch.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "common_test_utils/ov_tensor_utils.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/include/conv_concat.hpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/include/conv_concat.hpp
@@ -11,7 +11,6 @@
 #include "test_utils/cpu_test_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
-#include "ov_models/builders.hpp"
 
 using namespace CPUTestUtils;
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/include/conv_with_zero_point_fuse.hpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/include/conv_with_zero_point_fuse.hpp
@@ -8,7 +8,6 @@
 #include <tuple>
 #include <vector>
 
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/include/fuse_transpose_reorder.hpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/include/fuse_transpose_reorder.hpp
@@ -10,7 +10,6 @@
 
 #include "test_utils/cpu_test_utils.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
 using namespace CPUTestUtils;

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/add_convert_to_reorder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/add_convert_to_reorder.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/align_matmul_input_ranks.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/align_matmul_input_ranks.cpp
@@ -6,7 +6,6 @@
 #include <cassert>
 
 #include "common_test_utils/common_utils.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/fusing_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_const_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_const_inplace.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv3d_reshape.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv3d_reshape.cpp
@@ -4,7 +4,6 @@
 
 #include "common_test_utils/node_builders/convolution.hpp"
 #include "common_test_utils/node_builders/group_convolution.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_maxpool_activ.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_maxpool_activ.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "common_test_utils/node_builders/convolution.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/fusing_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_sum_broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_sum_broadcast.cpp
@@ -7,7 +7,6 @@
 #include "common_test_utils/node_builders/convolution.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 #include "internal_properties.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/convert_fq_rnn_to_quantized_rnn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/convert_fq_rnn_to_quantized_rnn.cpp
@@ -9,7 +9,6 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/tensor.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/fusing_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/convert_range.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/convert_range.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
-#include "ov_models/builders.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include <openvino/core/graph_util.hpp>
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/convs_and_sums.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/convs_and_sums.cpp
@@ -5,7 +5,6 @@
 #include "common_test_utils/node_builders/activation.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/custom_op_insert_convert_i64.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/custom_op_insert_convert_i64.cpp
@@ -5,7 +5,6 @@
 #include <common_test_utils/ov_tensor_utils.hpp>
 #include <openvino/op/op.hpp>
 #include <shared_test_classes/base/ov_subgraph.hpp>
-#include <ov_models/builders.hpp>
 #include "test_utils/cpu_test_utils.hpp"
 
 using namespace ov::test;

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/denormal_check.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/denormal_check.cpp
@@ -4,8 +4,8 @@
 
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
+#include "ov_models/utils/data_utils.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
-#include "ov_models/builders.hpp"
 #include "openvino/runtime/aligned_buffer.hpp"
 
 namespace ov {

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/eltwise_caching.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/eltwise_caching.cpp
@@ -35,7 +35,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "common_test_utils/node_builders/constant.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/eltwise_chain.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/eltwise_chain.cpp
@@ -10,7 +10,6 @@
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fq_fused_with_ss.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fq_fused_with_ss.cpp
@@ -4,7 +4,6 @@
 
 #include "common_test_utils/node_builders/eltwise.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fq_layer_dq_bias.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fq_layer_dq_bias.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "ov_lpt_models/markup_bias.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fullyconnected_strided_inputs_outputs.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fullyconnected_strided_inputs_outputs.cpp
@@ -4,7 +4,6 @@
 
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "openvino/core/partial_shape.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_conv_fq_with_shared_constants.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_conv_fq_with_shared_constants.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "common_test_utils/node_builders/convolution.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_muladd_ewsimple.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_muladd_ewsimple.cpp
@@ -6,7 +6,6 @@
 
 #include "common_test_utils/node_builders/activation.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
-#include "ov_models/builders.hpp"
 
 using namespace CPUTestUtils;
 using ov::test::utils::ActivationTypes;

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_non0_output_port.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_non0_output_port.cpp
@@ -4,7 +4,6 @@
 
 #include "common_test_utils/ov_tensor_utils.hpp"
 
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_scaleshift_and_fakequantize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_scaleshift_and_fakequantize.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 #include "openvino/util/common_util.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_split_concat_pair_to_interpolate.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_split_concat_pair_to_interpolate.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/input_noreorder_eltwise_bf16.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/input_noreorder_eltwise_bf16.cpp
@@ -4,7 +4,6 @@
 
 #include "common_test_utils/node_builders/eltwise.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_quantized_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_quantized_subgraph.cpp
@@ -4,7 +4,6 @@
 
 #include "test_utils/cpu_test_utils.hpp"
 #include "test_utils/fusing_test_utils.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_strided_inputs_outputs.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_strided_inputs_outputs.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
@@ -8,7 +8,6 @@
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
 #include "internal_properties.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/rotary_pos_emb.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/rotary_pos_emb.cpp
@@ -5,7 +5,6 @@
 #include <common_test_utils/ov_tensor_utils.hpp>
 #include <openvino/opsets/opset1.hpp>
 #include <openvino/opsets/opset8.hpp>
-#include <ov_models/builders.hpp>
 #include <shared_test_classes/base/ov_subgraph.hpp>
 #include <string>
 #include <tuple>

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/shape_infer_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/shape_infer_subgraph.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/shapeof_any_layout.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/shapeof_any_layout.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "common_test_utils/node_builders/activation.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/split_matmul_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/split_matmul_concat.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "test_utils/fusing_test_utils.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/subgraph_serialize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/subgraph_serialize.cpp
@@ -5,7 +5,6 @@
 #include "openvino/openvino.hpp"
 #include "openvino/opsets/opset9.hpp"
 #include "test_utils/cpu_test_utils.hpp"
-#include "ov_models/builders.hpp"
 #include "test_utils/convolution_params.hpp"
 #include "snippets/op/subgraph.hpp"
 

--- a/src/plugins/intel_cpu/tests/functional/test_utils/fusing_test_utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/fusing_test_utils.hpp
@@ -9,7 +9,6 @@
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 #include "cpu_test_utils.hpp"
 #include "openvino/runtime/system_conf.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/data_utils.hpp"
 
 using namespace ov::test;

--- a/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
@@ -5,7 +5,6 @@
 
 #include "dummy_node.hpp"
 
-#include "ov_models/builders.hpp"
 #include "nodes/memory.hpp"
 #include "nodes/softmax.h"
 #include "nodes/shapeof.h"

--- a/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
@@ -7,7 +7,6 @@
 #include "nodes/input.h"
 #include "nodes/concat.h"
 
-#include "ov_models/builders.hpp"
 
 using namespace ov::intel_cpu;
 

--- a/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
@@ -8,7 +8,6 @@
 #include "common_test_utils/node_builders/activation.hpp"
 #include "openvino/core/preprocess/pre_post_process.hpp"
 #include "openvino/runtime/core.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "transformations/utils/utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"

--- a/src/plugins/intel_gpu/tests/functional/concurrency/gpu_concurrency_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/concurrency/gpu_concurrency_tests.cpp
@@ -5,7 +5,6 @@
 
 #include "common_test_utils/test_common.hpp"
 #include "functional_test_utils/plugin_cache.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "functional_test_utils/blob_utils.hpp"
 #include "openvino/core/preprocess/pre_post_process.hpp"
 #include "transformations/utils/utils.hpp"

--- a/src/plugins/intel_gpu/tests/functional/dynamic_tests/gpu_dyn_batch_shape_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/dynamic_tests/gpu_dyn_batch_shape_tests.cpp
@@ -7,7 +7,6 @@
 #include "functional_test_utils/skip_tests_config.hpp"
 #include "functional_test_utils/ov_plugin_cache.hpp"
 #include "openvino/runtime/core.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"
 

--- a/src/plugins/intel_gpu/tests/functional/dynamic_tests/gpu_dyn_huge_input_range.cpp
+++ b/src/plugins/intel_gpu/tests/functional/dynamic_tests/gpu_dyn_huge_input_range.cpp
@@ -4,7 +4,6 @@
 #include "common_test_utils/test_constants.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "common_test_utils/test_enums.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
 namespace {

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/dx11_remote_ctx_test.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/dx11_remote_ctx_test.cpp
@@ -11,7 +11,6 @@
 #include "common_test_utils/test_common.hpp"
 #include "common_test_utils/test_constants.hpp"
 #include "common_test_utils/file_utils.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "openvino/core/preprocess/pre_post_process.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
@@ -10,7 +10,6 @@
 #include "remote_tensor_tests/helpers.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "base/ov_behavior_test_utils.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"
 #include "common_test_utils/subgraph_builders/convert_transpose.hpp"

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -632,7 +632,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTI_THREADS, GetMetricAndPri
     std::vector<std::thread> threads(2);
     // key: thread id, value: executable network
     std::map<uint32_t, ov::CompiledModel> exec_net_map;
-    std::vector<std::shared_ptr<ngraph::Function>> networks;
+    std::vector<std::shared_ptr<ov::Model>> networks;
     networks.emplace_back(simpleNetwork);
     networks.emplace_back(simpleNetwork);
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/remote.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/remote.cpp
@@ -26,7 +26,7 @@ auto AutoBatchConfigs = []() {
 
 INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_BehaviorTests, OVRemoteTest,
                         ::testing::Combine(
-                                ::testing::Values(ngraph::element::f32),
+                                ::testing::Values(ov::element::f32),
                                 ::testing::Values(::ov::test::utils::DEVICE_GPU),
                                 ::testing::ValuesIn(configs),
                                 ::testing::ValuesIn(generate_remote_params())),
@@ -34,7 +34,7 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_BehaviorTests, OVRemoteTest,
 
 INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_AutoBatch_BehaviorTests, OVRemoteTest,
                          ::testing::Combine(
-                                 ::testing::Values(ngraph::element::f32),
+                                 ::testing::Values(ov::element::f32),
                                  ::testing::Values(::ov::test::utils::DEVICE_BATCH),
                                  ::testing::ValuesIn(AutoBatchConfigs()),
                                  ::testing::ValuesIn(generate_remote_params())),

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/topk.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/topk.cpp
@@ -6,7 +6,6 @@
 #include <tuple>
 #include <vector>
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/layer_test_utils.hpp"
 
 namespace GPULayerTestsDefinitions {

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/ctc_greedy_decoder_seq_len.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/ctc_greedy_decoder_seq_len.cpp
@@ -6,8 +6,9 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <random>
+
 #include "ov_models/utils/ov_helpers.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
 #include "common_test_utils/test_constants.hpp"

--- a/src/plugins/template/tests/functional/shared_tests_instances/behavior/plugin/synthetic.cpp
+++ b/src/plugins/template/tests/functional/shared_tests_instances/behavior/plugin/synthetic.cpp
@@ -7,7 +7,6 @@
 #include "behavior/plugin/hetero_synthetic.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu_non_zero.hpp"
-#include "ov_models/builders.hpp"
 
 namespace {
 using namespace HeteroTests;

--- a/src/plugins/template/tests/functional/subgraph_reference/preprocess_opencv.cpp
+++ b/src/plugins/template/tests/functional/subgraph_reference/preprocess_opencv.cpp
@@ -11,7 +11,6 @@
 
 #    include "base_reference_test.hpp"
 #    include "openvino/core/preprocess/pre_post_process.hpp"
-#    include "ov_models/builders.hpp"
 #    include "shared_test_classes/base/layer_test_utils.hpp"
 #    include "shared_test_classes/single_layer/convert_color_i420.hpp"
 #    include "shared_test_classes/single_layer/convert_color_nv12.hpp"

--- a/src/tests/functional/plugin/shared/include/base/multi/multi_helpers.hpp
+++ b/src/tests/functional/plugin/shared/include/base/multi/multi_helpers.hpp
@@ -8,7 +8,6 @@
 #include "base/ov_behavior_test_utils.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "common_test_utils/test_constants.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "openvino/util/common_util.hpp"
 #include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"
 

--- a/src/tests/functional/plugin/shared/include/base/ov_behavior_test_utils.hpp
+++ b/src/tests/functional/plugin/shared/include/base/ov_behavior_test_utils.hpp
@@ -13,7 +13,6 @@
 
 #include <gtest/gtest.h>
 
-#include "ov_models/subgraph_builders.hpp"
 
 #include "common_test_utils/test_common.hpp"
 #include "common_test_utils/test_constants.hpp"

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/import_export.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/import_export.hpp
@@ -9,6 +9,9 @@
 #include "pugixml.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
+#include "openvino/op/concat.hpp"
+#include "openvino/op/split.hpp"
+
 namespace ov {
 namespace test {
 namespace behavior {

--- a/src/tests/functional/plugin/shared/include/behavior/executable_network/exec_graph_info.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/executable_network/exec_graph_info.hpp
@@ -11,7 +11,6 @@
 
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "base/behavior_test_utils.hpp"
-#include "ov_models/builders.hpp"
 
 #include "pugixml.hpp"
 

--- a/src/tests/functional/plugin/shared/include/behavior/infer_request/io_blob.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/infer_request/io_blob.hpp
@@ -10,6 +10,8 @@
 #include "base/behavior_test_utils.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 
+#include "openvino/op/relu.hpp"
+
 namespace BehaviorTestsDefinitions {
 using InferRequestIOBBlobTest = BehaviorTestsUtils::InferRequestTests;
 

--- a/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/infer_request_dynamic.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/infer_request_dynamic.hpp
@@ -20,7 +20,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "functional_test_utils/plugin_cache.hpp"
 #include "functional_test_utils/blob_utils.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
 // TODO [mandrono]: move current test case inside CPU plug-in and return the original tests

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/caching_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/caching_tests.hpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "functional_test_utils/plugin_cache.hpp"
 #include "common_test_utils/unicode_utils.hpp"
 #include "openvino/util/common_util.hpp"

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/auto_batching_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/auto_batching_tests.hpp
@@ -11,12 +11,12 @@
 #include <functional_test_utils/plugin_cache.hpp>
 
 #include "openvino/runtime/properties.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "functional_test_utils/blob_utils.hpp"
 #include "base/behavior_test_utils.hpp"
 #include "common_test_utils/subgraph_builders/single_conv.hpp"
 #include "common_test_utils/subgraph_builders/detection_output.hpp"
 #include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
+#include "ov_models/utils/ov_helpers.hpp"
 
 using namespace ::testing;
 using namespace InferenceEngine;

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/caching_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/caching_tests.hpp
@@ -9,7 +9,6 @@
 #include <thread>
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "openvino/core/model.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "functional_test_utils/plugin_cache.hpp"
 #include "common_test_utils/unicode_utils.hpp"
 #include "openvino/util/common_util.hpp"

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/configuration_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/configuration_tests.hpp
@@ -12,7 +12,6 @@
 #include <ie_core.hpp>
 #include <ie_parameter.hpp>
 #include <functional_test_utils/skip_tests_config.hpp>
-#include <ov_models/subgraph_builders.hpp>
 
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/test_common.hpp"

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -15,6 +15,15 @@
 #include "openvino/util/file_util.hpp"
 #include "common_test_utils/subgraph_builders/split_conv_concat.hpp"
 
+#include "openvino/op/constant.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/add.hpp"
+
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 #include <iostream>
 #define GTEST_COUT std::cerr << "[          ] [ INFO ] "

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_threading.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_threading.hpp
@@ -10,7 +10,6 @@
 #include <cpp/ie_infer_request.hpp>
 
 #include <file_utils.h>
-#include <ov_models/subgraph_builders.hpp>
 #include <functional_test_utils/blob_utils.hpp>
 #include <common_test_utils/file_utils.hpp>
 #include <common_test_utils/test_assertions.hpp>

--- a/src/tests/functional/plugin/shared/include/execution_graph_tests/runtime_precision.hpp
+++ b/src/tests/functional/plugin/shared/include/execution_graph_tests/runtime_precision.hpp
@@ -12,7 +12,6 @@
 #include <memory>
 
 #include "common_test_utils/test_common.hpp"
-#include "ov_models/builders.hpp"
 
 namespace ExecutionGraphTests {
 

--- a/src/tests/functional/plugin/shared/include/single_layer_tests/batch_norm.hpp
+++ b/src/tests/functional/plugin/shared/include/single_layer_tests/batch_norm.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "shared_test_classes/single_layer/batch_norm.hpp"
-#include "ov_models/builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/include/snippets/codegen_bert.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/codegen_bert.hpp
@@ -11,7 +11,6 @@
 
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
-#include "ov_models/builders.hpp"
 //  todo: Rewrite this test using Snippets test infrastructure. See add_convert or conv_eltwise for example
 
 namespace ov {

--- a/src/tests/functional/plugin/shared/src/behavior/infer_request/memory_states.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/infer_request/memory_states.cpp
@@ -7,8 +7,10 @@
 #include "behavior/infer_request/memory_states.hpp"
 #include "blob_factory.hpp"
 #include "functional_test_utils/plugin_cache.hpp"
+
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/sigmoid.hpp"
+#include "openvino/op/constant.hpp"
 
 namespace BehaviorTestsDefinitions {
 std::string InferRequestVariableStateTest::getTestCaseName(const testing::TestParamInfo<memoryStateParams>& obj) {

--- a/src/tests/functional/plugin/shared/src/behavior/infer_request/set_io_blob_precision.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/infer_request/set_io_blob_precision.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "behavior/infer_request/set_io_blob_precision.hpp"
-#include "ov_models/builders.hpp"
 
 using namespace InferenceEngine;
 

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/inference_chaining.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/inference_chaining.cpp
@@ -20,7 +20,6 @@
 #include "openvino/core/type/element_type_traits.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/core/model.hpp"
-#include "ov_models/builders.hpp"
 #include "openvino/runtime/infer_request.hpp"
 #include "openvino/runtime/tensor.hpp"
 #include "behavior/ov_infer_request/inference_chaining.hpp"
@@ -45,8 +44,8 @@ std::shared_ptr<ov::Model> OVInferenceChaining::getFirstStaticFunction(const ov:
     params[1]->set_friendly_name("param_1");
     params[2]->get_output_tensor(0).set_names({"input_tensor_2"});
     params[2]->set_friendly_name("param_2");
-    auto eltwise = ov::test::utils::make_eltwise(params[0], params[1], ngraph::helpers::EltwiseTypes::ADD);
-    auto eltwise2 = ov::test::utils::make_eltwise(eltwise, params[2], ngraph::helpers::EltwiseTypes::ADD);
+    auto eltwise = ov::test::utils::make_eltwise(params[0], params[1], ov::test::utils::EltwiseTypes::ADD);
+    auto eltwise2 = ov::test::utils::make_eltwise(eltwise, params[2], ov::test::utils::EltwiseTypes::ADD);
     eltwise2->get_output_tensor(0).set_names({"result_tensor_0"});
     eltwise2->set_friendly_name("result_0");
 
@@ -62,7 +61,7 @@ std::shared_ptr<ov::Model> OVInferenceChaining::getSecondStaticFunction(const ov
     params[0]->set_friendly_name("param_0");
     params[1]->get_output_tensor(0).set_names({"input_tensor_1"});
     params[1]->set_friendly_name("param_1");
-    auto eltwise = ov::test::utils::make_eltwise(params[0], params[1], ngraph::helpers::EltwiseTypes::MULTIPLY);
+    auto eltwise = ov::test::utils::make_eltwise(params[0], params[1], ov::test::utils::EltwiseTypes::MULTIPLY);
     eltwise->get_output_tensor(0).set_names({"result_tensor_0"});
     eltwise->set_friendly_name("result_0");
 
@@ -82,9 +81,9 @@ std::shared_ptr<ov::Model> OVInferenceChaining::getThirdStaticFunction(const ov:
     params[2]->set_friendly_name("param_2");
     params[3]->get_output_tensor(0).set_names({"input_tensor_3"});
     params[3]->set_friendly_name("param_3");
-    auto eltwise = ov::test::utils::make_eltwise(params[0], params[1], ngraph::helpers::EltwiseTypes::ADD);
-    auto eltwise2 = ov::test::utils::make_eltwise(eltwise, params[2], ngraph::helpers::EltwiseTypes::ADD);
-    auto eltwise3 = ov::test::utils::make_eltwise(eltwise2, params[3], ngraph::helpers::EltwiseTypes::MULTIPLY);
+    auto eltwise = ov::test::utils::make_eltwise(params[0], params[1], ov::test::utils::EltwiseTypes::ADD);
+    auto eltwise2 = ov::test::utils::make_eltwise(eltwise, params[2], ov::test::utils::EltwiseTypes::ADD);
+    auto eltwise3 = ov::test::utils::make_eltwise(eltwise2, params[3], ov::test::utils::EltwiseTypes::MULTIPLY);
     eltwise3->get_output_tensor(0).set_names({"result_tensor_0"});
     eltwise3->set_friendly_name("result_0");
 

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/iteration_chaining.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/iteration_chaining.cpp
@@ -18,14 +18,16 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/type/element_type_traits.hpp"
-#include "openvino/op/parameter.hpp"
 #include "openvino/core/model.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "openvino/runtime/infer_request.hpp"
 #include "openvino/runtime/tensor.hpp"
 #include "behavior/ov_infer_request/iteration_chaining.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
+
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/concat.hpp"
 
 namespace ov {
 namespace test {
@@ -42,7 +44,7 @@ std::shared_ptr<ov::Model> OVIterationChaining::getIterativeFunction() {
     auto concat_const = ov::test::utils::deprecated::make_constant(element::Type_t::f32, {1, 16}, std::vector<float>{}, true);
     auto concat = std::make_shared<ov::op::v0::Concat>(ov::NodeVector{params, concat_const}, 0 /*axis*/);
     auto eltwise_const = ov::test::utils::deprecated::make_constant(element::Type_t::f32, {1, 16}, std::vector<float>{}, true);
-    auto eltwise = ov::test::utils::make_eltwise(concat, eltwise_const, ngraph::helpers::EltwiseTypes::ADD);
+    auto eltwise = ov::test::utils::make_eltwise(concat, eltwise_const, ov::test::utils::EltwiseTypes::ADD);
     concat->get_output_tensor(0).set_names({"result_tensor_0"});
     concat->set_friendly_name("result_0");
     eltwise->get_output_tensor(0).set_names({"result_tensor_1"});

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/memory_states.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/memory_states.cpp
@@ -7,8 +7,10 @@
 #include "base/behavior_test_utils.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "functional_test_utils/plugin_cache.hpp"
+
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/sigmoid.hpp"
+#include "openvino/op/constant.hpp"
 
 namespace ov {
 namespace test {

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/caching_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/caching_tests.cpp
@@ -15,8 +15,6 @@
 #include "functional_test_utils/summary/api_summary.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 
-#include "ov_models/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "cpp_interfaces/interface/ie_internal_plugin_config.hpp"
 #include "openvino/core/node_vector.hpp"
 #include "openvino/op/parameter.hpp"

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/life_time.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/life_time.cpp
@@ -4,7 +4,6 @@
 
 #include <fstream>
 
-#include <ov_models/subgraph_builders.hpp>
 #include "behavior/ov_plugin/life_time.hpp"
 #include "common_test_utils/subgraph_builders/split_concat.hpp"
 

--- a/src/tests/functional/plugin/shared/src/behavior/plugin/caching_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/plugin/caching_tests.cpp
@@ -8,8 +8,6 @@
 
 #include "behavior/plugin/caching_tests.hpp"
 #include "common_test_utils/file_utils.hpp"
-#include "ov_models/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/subgraph_builders/split_conv_concat.hpp"
 #include "common_test_utils/subgraph_builders/kso_func.hpp"
 #include "common_test_utils/subgraph_builders/ti_with_lstm_cell.hpp"
@@ -17,6 +15,7 @@
 #include "common_test_utils/subgraph_builders/2_input_subtract.hpp"
 #include "common_test_utils/subgraph_builders/nested_split_conv_concat.hpp"
 #include "common_test_utils/subgraph_builders/conv_bias.hpp"
+#include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "common_test_utils/subgraph_builders/matmul_bias.hpp"
 
 using namespace InferenceEngine::details;
@@ -77,7 +76,7 @@ std::vector<nGraphFunctionWithName> LoadNetworkCacheTestBase::getNumericTypeOnly
     res.push_back(nGraphFunctionWithName { simple_function_multiply, "SimpleFunctionMultiply"});
     res.push_back(nGraphFunctionWithName { simple_function_relu, "SimpleFunctionRelu"});
     res.push_back(nGraphFunctionWithName {
-        inputShapeWrapper(ngraph::builder::subgraph::makeConvPoolRelu, {1, 1, 32, 32}),
+        inputShapeWrapper(ov::test::utils::make_conv_pool_relu, {1, 1, 32, 32}),
         "ConvPoolRelu"});
     res.push_back(nGraphFunctionWithName {
         inputShapeWrapper(ov::test::utils::make_split_conv_concat, {1, 4, 20, 20}),

--- a/src/tests/functional/plugin/shared/src/behavior/plugin/hetero_synthetic.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/plugin/hetero_synthetic.cpp
@@ -3,8 +3,6 @@
 //
 
 #include "behavior/plugin/hetero_synthetic.hpp"
-#include "ov_models/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/file_utils.hpp"
 #include "openvino/util/file_util.hpp"
 #include <random>

--- a/src/tests/functional/plugin/shared/src/behavior/plugin/stress_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/plugin/stress_tests.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "behavior/plugin/stress_tests.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/subgraph_builders/split_conv_concat.hpp"
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/execution_graph_tests/runtime_precision.cpp
+++ b/src/tests/functional/plugin/shared/src/execution_graph_tests/runtime_precision.cpp
@@ -4,6 +4,13 @@
 
 #include "execution_graph_tests/runtime_precision.hpp"
 
+#include <functional>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
+
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/node_builders/binary_convolution.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
@@ -12,12 +19,8 @@
 #include "functional_test_utils/skip_tests_config.hpp"
 #include "openvino/runtime/exec_model_info.hpp"
 
-#include <functional>
-#include <memory>
-#include <string>
-#include <tuple>
-#include <unordered_set>
-#include <vector>
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/relu.hpp"
 
 namespace ExecutionGraphTests {
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/add_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/add_transformation.cpp
@@ -11,7 +11,6 @@
 
 #include "transformations/init_node_info.hpp"
 #include "ov_lpt_models/add.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_transformation.cpp
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "transformations/init_node_info.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/concat.hpp"
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_child_and_output.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_child_and_output.cpp
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "transformations/init_node_info.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/concat.hpp"
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_different_precision_on_children.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_different_precision_on_children.cpp
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "transformations/init_node_info.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/concat.hpp"
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_intermediate_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_intermediate_transformation.cpp
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "transformations/init_node_info.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/concat.hpp"
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_neighbors_graph_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_neighbors_graph_transformation.cpp
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "transformations/init_node_info.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/concat.hpp"
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_split_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_split_transformation.cpp
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "transformations/init_node_info.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/concat.hpp"
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/depth_to_space_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/depth_to_space_transformation.cpp
@@ -15,7 +15,6 @@
 #include "openvino/op/depth_to_space.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "ov_lpt_models/depth_to_space.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_models/pass/convert_prc.hpp"
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "transformations/common_optimizations/depth_to_space_fusion.hpp"

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fully_connected_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fully_connected_transformation.cpp
@@ -15,7 +15,6 @@
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "functional_test_utils/blob_utils.hpp"
 #include "ov_models/pass/convert_prc.hpp"
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/mat_mul.hpp"
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/gemm_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/gemm_transformation.cpp
@@ -14,7 +14,6 @@
 #include "functional_test_utils/plugin_cache.hpp"
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "functional_test_utils/blob_utils.hpp"
-#include "ov_models/builders.hpp"
 
 #include "ov_lpt_models/mat_mul.hpp"
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_transformation.cpp
@@ -14,7 +14,6 @@
 #include "transformations/init_node_info.hpp"
 #include "low_precision_transformations/mat_mul_transformation.hpp"
 #include "ov_lpt_models/mat_mul.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
@@ -15,7 +15,6 @@
 #include "low_precision_transformations/mat_mul_transformation.hpp"
 #include "low_precision_transformations/mat_mul_with_constant_transformation.hpp"
 #include "ov_lpt_models/mat_mul.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_transformation.cpp
@@ -11,7 +11,6 @@
 #include "transformations/init_node_info.hpp"
 
 #include "ov_lpt_models/multiply_partial_function.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 
 namespace LayerTestsDefinitions {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/output_layers_concat.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/output_layers_concat.cpp
@@ -17,7 +17,6 @@
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 #include "ov_models/pass/convert_prc.hpp"
-#include "ov_models/builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/output_layers_concat_multi_channel.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/output_layers_concat_multi_channel.cpp
@@ -17,7 +17,6 @@
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 #include "ov_models/pass/convert_prc.hpp"
-#include "ov_models/builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/output_layers_handling_in_transformations.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/output_layers_handling_in_transformations.cpp
@@ -17,7 +17,6 @@
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 #include "ov_models/pass/convert_prc.hpp"
-#include "ov_models/builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/squeeze_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/squeeze_transformation.cpp
@@ -14,7 +14,6 @@
 #include "transformations/init_node_info.hpp"
 #include "low_precision_transformations/squeeze_transformation.hpp"
 #include "ov_lpt_models/squeeze.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/unsqueeze_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/unsqueeze_transformation.cpp
@@ -14,7 +14,6 @@
 #include "transformations/init_node_info.hpp"
 #include "low_precision_transformations/unsqueeze_transformation.hpp"
 #include "ov_lpt_models/unsqueeze.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/src/snippets/add.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/add.cpp
@@ -5,7 +5,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "snippets/add.hpp"
 #include "subgraph_simple.hpp"
-#include "ov_models/builders.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
 
 namespace ov {

--- a/src/tests/functional/plugin/shared/src/snippets/codegen_gelu.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/codegen_gelu.cpp
@@ -9,7 +9,6 @@
 #include "openvino/pass/constant_folding.hpp"
 #include "snippets/codegen_gelu.hpp"
 #include "subgraph_simple.hpp"
-#include "ov_models/builders.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
 
 namespace ov {

--- a/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
@@ -5,7 +5,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "snippets/edge_replace.hpp"
 #include "subgraph_simple.hpp"
-#include "ov_models/builders.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
 
 namespace ov {

--- a/src/tests/functional/plugin/shared/src/snippets/softmax.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/softmax.cpp
@@ -5,7 +5,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "snippets/softmax.hpp"
 #include "subgraph_softmax.hpp"
-#include "ov_models/builders.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
 
 namespace ov {

--- a/src/tests/functional/plugin/shared/src/snippets/transpose_softmax.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/transpose_softmax.cpp
@@ -5,7 +5,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "snippets/transpose_softmax.hpp"
 #include "subgraph_softmax.hpp"
-#include "ov_models/builders.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/psroi_pooling.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/psroi_pooling.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 #include <memory>
 
-#include "ov_models/builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 
 #include "shared_test_classes/base/ov_subgraph.hpp"

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/rnn_sequence.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/rnn_sequence.hpp
@@ -10,7 +10,6 @@
 #include <memory>
 
 #include "shared_test_classes/base/ov_subgraph.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/test_enums.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/softmax.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/softmax.hpp
@@ -7,7 +7,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/op/softmax.hpp"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/conv_eltwise_fusion.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/conv_eltwise_fusion.hpp
@@ -8,7 +8,6 @@
 #include <tuple>
 #include <vector>
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/conv_strides_opt.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/conv_strides_opt.hpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <tuple>
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/preprocess.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/preprocess.hpp
@@ -9,7 +9,6 @@
 #include <tuple>
 #include <vector>
 
-#include "ov_models/builders.hpp"
 #include "ov_models/preprocess/preprocess_builders.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/stateful_model.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/stateful_model.hpp
@@ -6,7 +6,6 @@
 #include <common_test_utils/ov_tensor_utils.hpp>
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
-#include "ov_models/builders.hpp"
 
 using namespace ov::test;
 

--- a/src/tests/functional/shared_test_classes/src/precomp.hpp
+++ b/src/tests/functional/shared_test_classes/src/precomp.hpp
@@ -6,9 +6,6 @@
 
 #include <gtest/gtest.h>
 
-#include "ov_models/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
-
 #include <algorithm>
 #include <functional>
 #include <initializer_list>

--- a/src/tests/functional/shared_test_classes/src/single_op/binary_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/binary_convolution.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/single_op/binary_convolution.hpp"
 
-#include "ov_models/builders.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "common_test_utils/node_builders/binary_convolution.hpp"
 

--- a/src/tests/functional/shared_test_classes/src/single_op/embedding_bag_packed_sum.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/embedding_bag_packed_sum.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "shared_test_classes/single_op/embedding_bag_packed_sum.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/embedding_bag_packed_sum.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/src/single_op/fake_quantize.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/fake_quantize.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/single_op/fake_quantize.hpp"
 
-#include "ov_models/builders.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/op/constant.hpp"

--- a/src/tests/functional/shared_test_classes/src/single_op/multinomial.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/multinomial.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/single_op/multinomial.hpp"
 
-#include "ov_models/builders.hpp"
 
 using namespace ov::test;
 

--- a/src/tests/functional/shared_test_classes/src/single_op/pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/pooling.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/single_op/pooling.hpp"
 
-#include "ov_models/builders.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/result.hpp"

--- a/src/tests/functional/shared_test_classes/src/single_op/rnn_sequence.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/rnn_sequence.cpp
@@ -7,7 +7,7 @@
 #include "transformations/op_conversions/convert_sequences_to_tensor_iterator.hpp"
 #include "shared_test_classes/single_op/rnn_sequence.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
-// #include "ov_models/utils/ov_helpers.hpp"
+#include "ov_models/utils/ov_helpers.hpp"
 
 using ov::test::utils::InputLayerType;
 using ov::test::utils::SequenceTestsMode;

--- a/src/tests/functional/shared_test_classes/src/subgraph/get_output_before_activation.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/get_output_before_activation.cpp
@@ -4,10 +4,10 @@
 
 #include "shared_test_classes/subgraph/get_output_before_activation.hpp"
 
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "common_test_utils/node_builders/activation.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
+#include "common_test_utils/test_enums.hpp"
 
 namespace ov {
 namespace test {
@@ -63,22 +63,22 @@ void OutputBeforeActivation::SetUp() {
     std::shared_ptr<ov::Node> midLayer;
     switch (outputType) {
     case ov::test::midOutputType::Sum: {
-        midLayer = ov::test::utils::make_eltwise(input0, input1, ngraph::helpers::EltwiseTypes::ADD);
+        midLayer = ov::test::utils::make_eltwise(input0, input1, ov::test::utils::EltwiseTypes::ADD);
         break;
     }
     case ov::test::midOutputType::Sub: {
-        midLayer = ov::test::utils::make_eltwise(input0, input1, ngraph::helpers::EltwiseTypes::SUBTRACT);
+        midLayer = ov::test::utils::make_eltwise(input0, input1, ov::test::utils::EltwiseTypes::SUBTRACT);
         break;
     }
     case ov::test::midOutputType::Mul: {
-        midLayer = ov::test::utils::make_eltwise(input0, input1, ngraph::helpers::EltwiseTypes::MULTIPLY);
+        midLayer = ov::test::utils::make_eltwise(input0, input1, ov::test::utils::EltwiseTypes::MULTIPLY);
         break;
     }
     default:
         GTEST_FAIL() << "Unknown midOutputType";
     }
 
-    auto act = ov::test::utils::make_activation(midLayer, element_type, ngraph::helpers::ActivationTypes::Tanh);
+    auto act = ov::test::utils::make_activation(midLayer, element_type, ov::test::utils::ActivationTypes::Tanh);
     outputs.insert(outputs.end(), {midLayer, act});
     function = std::make_shared<ov::Model>(outputs, input_parameter, "output_before_activation");
 }

--- a/src/tests/functional/shared_test_classes/src/subgraph/memory_LSTMCell.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/memory_LSTMCell.cpp
@@ -12,7 +12,6 @@
 #include "openvino/op/util/variable.hpp"
 #include "openvino/pass/low_latency.hpp"
 #include "openvino/pass/manager.hpp"
-#include "ov_models/builders.hpp"
 
 using namespace ngraph;
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/perm_conv_perm_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/perm_conv_perm_concat.cpp
@@ -6,7 +6,6 @@
 
 #include "common_test_utils/data_utils.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/convolution.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/quantized_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/quantized_convolution_backprop_data.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/subgraph/quantized_convolution_backprop_data.hpp"
 #include "common_test_utils/node_builders/convolution_backprop_data.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "ie_common.h"

--- a/src/tests/functional/shared_test_classes/src/subgraph/quantized_group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/quantized_group_convolution.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "shared_test_classes/subgraph/quantized_group_convolution.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/group_convolution.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "ov_models/utils/ov_helpers.hpp"

--- a/src/tests/functional/shared_test_classes/src/subgraph/quantized_group_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/quantized_group_convolution_backprop_data.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/subgraph/quantized_group_convolution_backprop_data.hpp"
 #include "common_test_utils/node_builders/group_convolution_backprop_data.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/functional/shared_test_classes/src/subgraph/quantized_mat_mul.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/quantized_mat_mul.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "shared_test_classes/subgraph/quantized_mat_mul.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/subgraph/range_add.hpp"
 
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/src/subgraph/reshape_permute_conv_permute_reshape_act.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/reshape_permute_conv_permute_reshape_act.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "shared_test_classes/subgraph/reshape_permute_conv_permute_reshape_act.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/convolution.hpp"
 
 namespace ov {

--- a/src/tests/functional/shared_test_classes/src/subgraph/reshape_squeeze_reshape_relu.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/reshape_squeeze_reshape_relu.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/subgraph/reshape_squeeze_reshape_relu.hpp"
 
-#include "ov_models/builders.hpp"
 
 namespace ov {
 namespace test {

--- a/src/tests/functional/shared_test_classes/src/subgraph/split_conv_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/split_conv_concat.cpp
@@ -6,7 +6,6 @@
 
 #include "common_test_utils/data_utils.hpp"
 #include "ie_common.h"
-#include "ov_models/builders.hpp"
 #include "shared_test_classes/base/layer_test_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "common_test_utils/node_builders/convolution.hpp"

--- a/src/tests/functional/shared_test_classes/src/subgraph/variadic_split_pad.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/variadic_split_pad.cpp
@@ -4,7 +4,6 @@
 
 #include "shared_test_classes/subgraph/variadic_split_pad.hpp"
 
-#include "ov_models/builders.hpp"
 
 namespace ov {
 namespace test {

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/move_dequantization_after.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/move_dequantization_after.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include "ov_lpt_models/common/dequantization_operations.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace ov {
 namespace builder {

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/round.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/round.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include "ov_lpt_models/common/dequantization_operations.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace ov {
 namespace builder {

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/subtract.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/subtract.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include "ov_lpt_models/common/dequantization_operations.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/transpose_after_mat_mul.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/transpose_after_mat_mul.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 
 #include "ov_lpt_models/common/dequantization_operations.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/add.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/add.cpp
@@ -11,7 +11,6 @@
 
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 using namespace ov::pass::low_precision;
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/align_concat_quantization_parameters.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/align_concat_quantization_parameters.cpp
@@ -10,7 +10,6 @@
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 #include "low_precision/network_helper.hpp"
 #include "ov_lpt_models/common/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace ov {
 namespace builder {

--- a/src/tests/ov_helpers/ov_lpt_models/src/assign_and_read_value.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/assign_and_read_value.cpp
@@ -9,7 +9,6 @@
 #include "openvino/opsets/opset1.hpp"
 #include "openvino/opsets/opset3.hpp"
 #include "openvino/opsets/opset6.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "openvino/op/util/variable.hpp"
 #include "openvino/op/util/assign_base.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/avg_pool.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/avg_pool.cpp
@@ -9,7 +9,6 @@
 #include "ov_lpt_models/common/builders.hpp"
 
 #include "ov_lpt_models/avg_pool.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/clamp.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/clamp.cpp
@@ -7,7 +7,6 @@
 
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/clamp.hpp"
 #include "low_precision/network_helper.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/builders.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/builders.cpp
@@ -9,7 +9,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_ops/type_relaxed.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/compose_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/compose_fake_quantize.cpp
@@ -6,7 +6,6 @@
 #include "low_precision/network_helper.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
 using namespace ov::pass::low_precision;

--- a/src/tests/ov_helpers/ov_lpt_models/src/concat.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/concat.cpp
@@ -11,7 +11,6 @@
 #include "low_precision/rt_info/intervals_alignment_attribute.hpp"
 #include "low_precision/rt_info/quantization_alignment_attribute.hpp"
 
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/convolution.cpp
@@ -6,7 +6,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include <ov_ops/type_relaxed.hpp>
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 #include "low_precision/rt_info/quantization_granularity_attribute.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/convolution_backprop_data.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/convolution_backprop_data.cpp
@@ -6,7 +6,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include <ov_ops/type_relaxed.hpp>
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/depth_to_space.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/depth_to_space.cpp
@@ -4,7 +4,6 @@
 
 #include "ov_lpt_models/depth_to_space.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/elementwise_with_multi_parent_dequantization.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/elementwise_with_multi_parent_dequantization.cpp
@@ -6,8 +6,6 @@
 #include "low_precision/network_helper.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 using namespace ov::pass::low_precision;
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize.cpp
@@ -6,7 +6,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_ops/type_relaxed.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_convolution.cpp
@@ -5,7 +5,6 @@
 #include "ov_lpt_models/fake_quantize_and_convolution.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -7,7 +7,6 @@
 #include "ov_lpt_models/fake_quantize_and_two_output_branches_with_convolution.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 #include "low_precision/network_helper.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_on_weights_and_unsupported_child.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_on_weights_and_unsupported_child.cpp
@@ -7,7 +7,6 @@
 #include "ov_lpt_models/fake_quantize_on_weights_and_unsupported_child.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 #include "low_precision/network_helper.hpp"
-#include "ov_models/builders.hpp"
 
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_precision_selection.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_precision_selection.cpp
@@ -6,7 +6,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include <ov_ops/type_relaxed.hpp>
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "low_precision/network_helper.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/fold_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fold_fake_quantize.cpp
@@ -6,7 +6,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_ops/type_relaxed.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_convert.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_convert.cpp
@@ -5,7 +5,6 @@
 #include "ov_lpt_models/fuse_convert.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_fake_quantize.cpp
@@ -7,7 +7,6 @@
 #include "openvino/opsets/opset1.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "low_precision/network_helper.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_fake_quantize_and_scale_shift.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_fake_quantize_and_scale_shift.cpp
@@ -5,7 +5,6 @@
 #include "ov_lpt_models/fuse_fake_quantize_and_scale_shift.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_multiply_to_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_multiply_to_fake_quantize.cpp
@@ -6,7 +6,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_ops/type_relaxed.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 
 #include "ov_lpt_models/common/builders.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_subtract_to_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_subtract_to_fake_quantize.cpp
@@ -6,7 +6,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_ops/type_relaxed.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 
 #include "ov_lpt_models/common/builders.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/get_dequantization.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/get_dequantization.cpp
@@ -11,7 +11,6 @@
 #include <low_precision/common/fake_quantize_dequantization.hpp>
 #include <low_precision/network_helper.hpp>
 
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/group_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/group_convolution.cpp
@@ -6,7 +6,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include <ov_ops/type_relaxed.hpp>
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/interpolate.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/interpolate.cpp
@@ -4,7 +4,6 @@
 
 #include "ov_lpt_models/interpolate.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/markup_avg_pool_precisions.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/markup_avg_pool_precisions.cpp
@@ -9,7 +9,6 @@
 #include "ov_lpt_models/common/builders.hpp"
 
 #include "ov_lpt_models/markup_avg_pool_precisions.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/markup_bias.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/markup_bias.cpp
@@ -5,7 +5,6 @@
 #include "openvino/opsets/opset1.hpp"
 #include "ov_lpt_models/markup_bias.hpp"
 #include "ov_models/utils/ov_helpers.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/mat_mul.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/mat_mul.cpp
@@ -9,7 +9,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_ops/type_relaxed.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/mat_mul_with_optimized_constant_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/mat_mul_with_optimized_constant_fake_quantize.cpp
@@ -5,7 +5,6 @@
 #include "ov_lpt_models/mat_mul_with_optimized_constant_fake_quantize.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/builders.hpp"
 
 namespace ov {
 namespace builder {

--- a/src/tests/ov_helpers/ov_lpt_models/src/max_pool.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/max_pool.cpp
@@ -7,7 +7,6 @@
 #include "openvino/opsets/opset1.hpp"
 #include <ov_ops/type_relaxed.hpp>
 #include "low_precision/network_helper.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/move_dequantization_after.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/move_dequantization_after.cpp
@@ -6,7 +6,6 @@
 #include "low_precision/network_helper.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
 using namespace ov::pass::low_precision;

--- a/src/tests/ov_helpers/ov_lpt_models/src/multiply.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/multiply.cpp
@@ -8,7 +8,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include <ov_ops/type_relaxed.hpp>
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 
 #include "ov_lpt_models/common/builders.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/multiply_partial_function.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/multiply_partial_function.cpp
@@ -8,7 +8,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include <ov_ops/type_relaxed.hpp>
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 
 #include "ov_lpt_models/common/builders.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/multiply_to_group_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/multiply_to_group_convolution.cpp
@@ -4,7 +4,6 @@
 
 #include "ov_lpt_models/multiply_to_group_convolution.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_ops/type_relaxed.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/multiply_with_one_parent.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/multiply_with_one_parent.cpp
@@ -5,7 +5,6 @@
 #include "ov_lpt_models/multiply_with_one_parent.hpp"
 
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 namespace ov {

--- a/src/tests/ov_helpers/ov_lpt_models/src/mvn.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/mvn.cpp
@@ -4,7 +4,6 @@
 
 #include "ov_lpt_models/mvn.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/normalize_dequantization.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/normalize_dequantization.cpp
@@ -4,7 +4,6 @@
 
 #include "ov_lpt_models/normalize_dequantization.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_ops/type_relaxed.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/normalize_l2.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/normalize_l2.cpp
@@ -6,7 +6,6 @@
 
 #include <ov_ops/type_relaxed.hpp>
 #include "openvino/opsets/opset1.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/pad.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/pad.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "openvino/opsets/opset12.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/pad.hpp"
 #include "low_precision/network_helper.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/precision_propagation.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/precision_propagation.cpp
@@ -11,7 +11,6 @@
 #include "low_precision/rt_info/intervals_alignment_attribute.hpp"
 #include "low_precision/rt_info/quantization_alignment_attribute.hpp"
 
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/prelu.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/prelu.cpp
@@ -8,7 +8,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_ops/type_relaxed.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "low_precision/network_helper.hpp"
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/recurrent_cell.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/recurrent_cell.cpp
@@ -12,7 +12,6 @@
 #include "low_precision/rt_info/intervals_alignment_attribute.hpp"
 #include "low_precision/rt_info/quantization_alignment_attribute.hpp"
 
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/round.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/round.cpp
@@ -7,7 +7,6 @@
 #include "ov_lpt_models/round.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 
 using namespace ov::pass::low_precision;
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/shuffle_channels.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/shuffle_channels.cpp
@@ -8,7 +8,6 @@
 #include "ov_lpt_models/common/builders.hpp"
 
 #include "ov_lpt_models/shuffle_channels.hpp"
-#include "ov_models/subgraph_builders.hpp"
 
 namespace ov {
 namespace builder {

--- a/src/tests/ov_helpers/ov_lpt_models/src/split.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/split.cpp
@@ -7,7 +7,6 @@
 
 #include "ov_lpt_models/split.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 #include "low_precision/network_helper.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/squeeze.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/squeeze.cpp
@@ -4,7 +4,6 @@
 
 #include "ov_lpt_models/squeeze.hpp"
 
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/strided_slice.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/strided_slice.cpp
@@ -8,7 +8,6 @@
 #include "openvino/opsets/opset1.hpp"
 
 #include "ov_lpt_models/common/dequantization_operations.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/strided_slice.hpp"
 
 using namespace ov::pass::low_precision;

--- a/src/tests/ov_helpers/ov_lpt_models/src/subtract.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/subtract.cpp
@@ -7,7 +7,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_lpt_models/common/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 using namespace ov::pass::low_precision;

--- a/src/tests/ov_helpers/ov_lpt_models/src/transpose_after_mat_mul.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/transpose_after_mat_mul.cpp
@@ -7,7 +7,6 @@
 
 #include "openvino/opsets/opset1.hpp"
 #include "ov_lpt_models/common/builders.hpp"
-#include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
 using namespace ov::pass::low_precision;

--- a/src/tests/ov_helpers/ov_lpt_models/src/unsqueeze.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/unsqueeze.cpp
@@ -4,7 +4,6 @@
 
 #include "ov_lpt_models/unsqueeze.hpp"
 
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_lpt_models/src/variadic_split.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/variadic_split.cpp
@@ -7,7 +7,6 @@
 
 #include "ov_lpt_models/variadic_split.hpp"
 
-#include "ov_models/builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_matmul.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_matmul.cpp
@@ -5,7 +5,6 @@
 #include "subgraph_matmul.hpp"
 #include "common_test_utils/data_utils.hpp"
 #include <snippets/op/subgraph.hpp>
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
@@ -6,7 +6,6 @@
 
 #include "common_test_utils/data_utils.hpp"
 #include <snippets/op/subgraph.hpp>
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "ov_lpt_models/common/builders.hpp"

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_softmax.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_softmax.cpp
@@ -4,7 +4,6 @@
 
 #include "subgraph_softmax.hpp"
 #include "common_test_utils/data_utils.hpp"
-#include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 #include <snippets/op/subgraph.hpp>
 


### PR DESCRIPTION
### Details:
 - Get rid of builders.hpp and subgraph_builders.hpp includes

### Tickets:
 - [CVS-117139](https://jira.devtools.intel.com/browse/CVS-117139)
