### PR TITLE
[CI][ONNX] Disable backend tests

### DIFF
--- a/src/frontends/onnx/tests/tests_python/test_backend.py
+++ b/src/frontends/onnx/tests/tests_python/test_backend.py
@@ -777,7 +777,10 @@ tests_expected_to_fail = [
     ),
     (
         skip_issue_124587,
+        "OnnxBackendNodeModelTest.test_split_variable_parts_1d_opset18_cpu",
         "OnnxBackendNodeModelTest.test_split_variable_parts_2d_opset18_cpu",
+        "OnnxBackendNodeModelTest.test_split_variable_parts_default_axis_opset13_cpu",
+        "OnnxBackendNodeModelTest.test_split_variable_parts_default_axis_opset18_cpu",
     ),
 ]
 


### PR DESCRIPTION
### Details:
Statistics
Out of 55 tests performed:
- test_split_variable_parts_default_axis_opset18_cpu failed 14 times 
- test_split_variable_parts_default_axis_opset13_cpu failed 8 times
- test_split_variable_parts_1d_opset18_cpu failed 6 times 

### Tickets:
CVS-124587
