### PR TITLE
[Snippets] Fixed iterator comparison from different lists

### DIFF
--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -85,6 +85,10 @@ public:
         void set_outer_splited_loop(bool outer_splited_loop);
         void set_first_iter_handler(FirstIterHandler handler);
 
+        // Update the parameters of existing LoopPorts
+        void update_entry_points(const std::function<void(LoopPort&)>& updater);
+        void update_exit_points(const std::function<void(LoopPort&)>& updater);
+
     private:
         size_t m_work_amount = 0;
         size_t m_increment = 0;
@@ -100,31 +104,80 @@ public:
     };
     using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 
+    /**
+     * @brief Clone Loop Manager with new expressions
+     * @param expr_map map of new and old expressions
+     * @return the copy
+     */
     std::shared_ptr<LoopManager> clone_with_new_expr(const ExressionMap& expr_map) const;
-    size_t add_loop_info(const LoopInfoPtr& loop);
-    void remove_loop_info(size_t index);
-    LoopInfoPtr get_loop_info(size_t index) const;
-    size_t get_loop_count() const { return m_map.size(); }
-    const std::map<size_t, LoopInfoPtr>& get_map() const;
 
-    // Return outer Loop IDs
+    /**
+     * @brief Get target Loop Info
+     * @param index loop ID
+     * @return the LoopInfo shared ptr
+     */
+    LoopInfoPtr get_loop_info(size_t index) const;
+    /**
+     * @brief Get count of loops
+     * @return count of loops in the map
+     */
+    size_t get_loop_count() const { return m_map.size(); }
+    /**
+     * @brief Get loop map [loop_id -> loop info]
+     * @return loop map
+     */
+    const std::map<size_t, LoopInfoPtr>& get_map() const;
+    /**
+     * @brief Get loop IDs of expression that are outer (upper) than `loop_id`
+     * @param expr the target expression
+     * @param loop_id the target loop ID
+     * @return vector of outer loop IDs
+     */
     static std::vector<size_t> get_outer_expr_loops(const ExpressionPtr& expr, size_t loop_id);
+    /**
+     * @brief Get loop IDs of expression that are common outer (upper) than `loop_id`
+     * @param lhs the first expression
+     * @param rhs the second expression
+     * @return vector of common outer loop IDs
+     */
     static std::vector<size_t> get_common_outer_loops(const ExpressionPtr& lhs, const ExpressionPtr& rhs);
+    /**
+     * @brief Get common outer loop IDs of expression set
+     * @param exprs vector of expressions
+     * @return vector of common outer loop IDs
+     */
     static std::vector<size_t> get_common_outer_loops(const std::vector<ExpressionPtr>& exprs);
 
+    /**
+     * @brief Create new LoopInfo and mark all expressions in loop bounds by new loop ID
+     * @param loop_begin_pos the first expression iterator
+     * @param loop_end_pos the next iterator after last expression
+     * @param loop_depth count of loops for marking
+     * @param vector_size increment of loop
+     */
     void mark_loop(LinearIR::constExprIt loop_begin_pos,
                    LinearIR::constExprIt loop_end_pos,
                    size_t loop_depth, size_t vector_size);
-    // Return Loop ID
+    /**
+     * @brief Create new LoopInfo and mark all expressions in loop bounds by new loop ID with more manual parameters
+     * @param loop_begin_pos the first expression iterator
+     * @param loop_end_pos the next iterator after last expression
+     * @param work_amount work amount of the loop
+     * @param increment the step of loop counter increment
+     * @param dim_idx loop iterates by this index of dimension
+     * @param entries input loop ports
+     * @param exits output loop ports
+     * @return new loop ID
+     */
     template <typename T>
     size_t mark_loop(LinearIR::constExprIt loop_begin_pos,
                      LinearIR::constExprIt loop_end_pos,
                      size_t work_amount,
-                     size_t work_amount_increment,
+                     size_t increment,
                      size_t dim_idx,
                      const std::vector<T>& entries,
                      const std::vector<T>& exits) {
-        const auto loop_info = std::make_shared<LoopManager::LoopInfo>(work_amount, work_amount_increment, entries, exits);
+        const auto loop_info = std::make_shared<LoopManager::LoopInfo>(work_amount, increment, entries, exits);
         loop_info->set_dim_idx(dim_idx);
         const auto loop_id = this->add_loop_info(loop_info);
         for (auto expr_it = loop_begin_pos; expr_it != loop_end_pos; ++expr_it) {
@@ -132,7 +185,16 @@ public:
         }
         return loop_id;
     }
-
+    /**
+     * @brief Create new LoopInfo and mark all expressions in loop bounds by new loop ID with more manual parameters
+     * @param loop_begin_pos the first expression iterator
+     * @param loop_end_pos the next iterator after last expression
+     * @param work_amount work amount of the loop
+     * @param increment the step of loop counter increment
+     * @param entries input loop ports
+     * @param exits output loop ports
+     * @return new loop ID
+     */
     template <typename T>
     size_t mark_loop(LinearIR::constExprIt loop_begin_pos,
                      LinearIR::constExprIt loop_end_pos,
@@ -147,7 +209,21 @@ public:
         }
         return loop_id;
     }
-
+    /**
+     * @brief Create new Loop and replace with it: create new LoopInfo, update loop IDs in expressions and
+     *        remove the old LoopInfo from the map if no one expression isn't mark by this `old_id`
+     * @param linear_ir linear IR
+     * @param loop_begin_pos the first expression iterator. Must be the iterator of the `linear_ir`.
+     *                       If there is explicit LoopBegin expressions in IR, loop_begin_pos must be the iterator of the LoopBegin
+     * @param loop_end_pos the next iterator after last expression iterator. Must be the iterator of the `linear_ir`.
+     *                     If there is explicit LoopEnd expressions in IR, loop_end_pos must be the next iterator of the LoopEnd
+     * @param work_amount work amount of the loop
+     * @param work_amount_increment increment of the loop
+     * @param entries input loop ports
+     * @param exits output loop ports
+     * @param old_id loop ID of the previos loop
+     * @return new loop ID
+     */
     size_t replace_with_new_loop(const LinearIR& linear_ir,
                                  LinearIR::constExprIt loop_begin_pos,
                                  LinearIR::constExprIt loop_end_pos,
@@ -156,17 +232,44 @@ public:
                                  const std::vector<LoopPort>& entries,
                                  const std::vector<LoopPort>& exits,
                                  const size_t old_id);
-
+    /**
+     * @brief Fuse two LoopInfos: fuse their informations to the one
+     * @param linear_ir linear IR
+     * @param loop_id_upper Loop ID of the Loop that is earlier in the linear IR
+     * @param loop_id_lower Loop ID of the Loop that is later in the linear IR
+     * @param fuse_into_upper True if the Loop with `loop_id_upper` ID is left and the Loop with `loop_id_lower` is removed
+     */
     void fuse_loops(const LinearIR& linear_ir, size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper = true);
+    /**
+     * @brief Fuse two loops: fuse their LoopInfos and update loop IDs in expressions
+     * @param loop_begin_target the first expression iterator of the Loop that will be left after fusion
+     * @param loop_end_target the next ietartor for the last expression of the Loop that will be left after fusion
+     * @param loop_id_upper Loop ID of the Loop that is earlier in the linear IR
+     * @param loop_id_lower Loop ID of the Loop that is later in the linear IR
+     * @param fuse_into_upper True if the Loop with `loop_id_upper` ID is left and the Loop with `loop_id_lower` is removed
+     */
     void fuse_loops(LinearIR::constExprIt loop_begin_target, LinearIR::constExprIt loop_end_target,
                     size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper = true);
-
-    // The following methods update ports of LoopInfo. They save the order of ports!
-    // Remainder: the order is important to find Loop bounds (the most first and the most last expressions)
-    //   - Update LoopPort - insert new loop target ports instead of existing.
-    //   - Update ExpressionPort in the LoopPort - with saving of port parameters. It's softer method since ExpressionPort may not be port of Loop
+    /**
+     * @brief Update Loop ports for one Loop. The method saves the order of ports since
+     *        the order of expression defines Loop bounds before explicit loop insertion (the most first and the most last expressions).
+     *        Note:
+     *         - Update LoopPort - insert new loop target ports instead of existing.
+     *         - Update ExpressionPort in the LoopPort - with saving of port parameters. It's softer method since ExpressionPort may not be port of Loop
+     * @param loop_id the target Loop ID
+     * @param actual_port the current port
+     * @param target_ports vector of the new ports (the order is important!)
+     * @param is_entry True if these ports are input, otherwise - output
+     */
     template<typename T>
     void update_loop_port(size_t loop_id, const T& actual_port, const std::vector<T>& target_ports, bool is_entry = true);
+    /**
+     * @brief Update Loop ports for several Loops.
+     * @param loop_ids the target Loop IDs
+     * @param actual_port the current port
+     * @param target_ports vector of the new ports (the order is important!)
+     * @param is_entry True if these ports are input, otherwise - output
+     */
     template<typename T>
     void update_loops_port(const std::vector<size_t>& loop_ids, const T& actual_port,
                            const std::vector<T>& target_ports, bool is_entry = true) {
@@ -174,49 +277,106 @@ public:
             update_loop_port(loop_id, actual_port, target_ports, is_entry);
         }
     }
-    // The method checks the loops (LoopInfo) that the target expression is marked with and update the corresponding loop ports if needed:
-    //   - If parent of the target expression and this expression are marked by one Loop and the parent is an exit port of this Loop,
-    //     the method replace parent output port with the target expression output ports as new exit LoopPorts.
-    //     If there are other consumers of parent output port that are not by the same Loop (like in the example below),
-    //     the method just adds inserted expression output ports to existing parent output port as new exit LoopPorts.
-    //             Parent [1, 0]
-    //            /              \                                <- Adds the target expression outputs to the existing LoopPort (parent output) of Loop[1]
-    //       Another expr [2]   Target expression [1, 3]             (If Another expr is marked by Loop [1] too, the method will replace loop ports (not add))
-    //   - If the target expression and its consumers have the same outer loop ids and some of consumers are entry ports of these Loops,
-    //     the method just replace the existing entry loop ports (that contains consumer input ports) with the target expression input ports.
+    /**
+     * @brief The method checks the loops (LoopInfo) that the target expression is marked with and update the corresponding loop ports if needed:
+     *           - If parent of the target expression and this expression are marked by one Loop and the parent is an exit port of this Loop,
+     *             the method replace parent output port with the target expression output ports as new exit LoopPorts.
+     *             If there are other consumers of parent output port that are not by the same Loop (like in the example below),
+     *             the method just adds inserted expression output ports to existing parent output port as new exit LoopPorts.
+     *                     Parent [1, 0]
+     *                    /              \                        <- Adds the target expression outputs to the existing LoopPort (parent output) of Loop[1]
+     *               Another expr [2]   Target expression [1, 3]     (If Another expr is marked by Loop [1] too, the method will replace loop ports (not add))
+     *           - If the target expression and its consumers have the same outer loop ids and some of consumers are entry ports of these Loops,
+     *             the method just replace the existing entry loop ports (that contains consumer input ports) with the target expression input ports.
+     * @param expr the target expression
+     */
     void update_loop_ports(const ExpressionPtr& expr);
-    // Sort Loop Ports by expression locations in Linear IR
+    /**
+     * @brief Sort Loop Ports by expression locations in Linear IR
+     * @param loop_begin_pos the first expression iterator of the Loop
+     * @param loop_end_pos the next iterator after the last expression
+     * @param loop_id target Loop ID
+     */
     void sort_loop_ports(LinearIR::constExprIt& loop_begin_pos, LinearIR::constExprIt& loop_end_pos, size_t loop_id);
-
-    // When the previous expression was replaced with new expressions (decomposition), the method updates the corresponding Loop.
-    // If ports of decomposed expression were the Loop ports, these Loop ports may be updated by parameters `entries` and `exits`
-    // Note: This method should be removed when Softmax decomposition will be moved on data flow pipeline since
-    //       all decompositions should be call on this pipeline
+    /**
+     * @brief When the previous expression was replaced with new expressions (decomposition), the method updates the corresponding Loop.
+     *        If ports of decomposed expression were the Loop ports, these Loop ports may be updated by parameters `entries` and `exits`
+     *        Note: This method should be removed when Softmax decomposition will be moved on data flow pipeline since
+     *              all decompositions should be call on this pipeline
+     * @param new_expr_begin the first expression iterator
+     * @param new_expr_end the next iterator after the last expression
+     * @param decomposed_expr the expression that is decomposed into several other exprs
+     * @param loop_id the new expression will be marked by this loop ID
+     * @param new_entries new input loop ports
+     * @param new_exits new output loop ports
+     */
     void expression_replacement(constExprIt new_expr_begin, constExprIt new_expr_end, const ExpressionPtr& decomposed_expr,
                                 size_t loop_id, const std::vector<ExpressionPort>& new_entries, const std::vector<ExpressionPort>& exits);
+    /**
+     * @brief Find bounds of Loop:
+     *        - If the explicit Loop exprs with the target `loop_id` have been inserted,
+     *          Loop bounds are these iterators of the corresponding LoopBegin and LoopEnd.
+     *        - Otherwise Loop bounds are iterators of the first entry loop port (or Scalar, VectorBuffer and another LoopBegin that
+     *          are in this Loop but have another `loop_id`) and the next iterator of the last exit loop port (or another LoopEnd that
+     *          are in this Loop but have another `loop_id`).
+     * @param linear_ir linear IR
+     * @param loop_id target Loop ID
+     * @return the pair of loop_begin_pos and loop_end_pos iterators
+     */
+    std::pair<LinearIR::constExprIt, LinearIR::constExprIt> get_loop_bounds(const LinearIR& linear_ir, size_t loop_id) const;
+    /**
+     * @brief Find bounds of Loop:
+     *        - If the explicit Loop exprs with the target `loop_id` have been inserted,
+     *          Loop bounds are these iterators of the corresponding LoopBegin and LoopEnd.
+     *        - Otherwise Loop bounds are iterators of the first entry loop port (or Scalar, VectorBuffer and another LoopBegin that
+     *          are in this Loop but have another `loop_id`) and the next iterator of the last exit loop port (or another LoopEnd that
+     *          are in this Loop but have another `loop_id`).
+     * @param linear_ir linear IR
+     * @param loop_id target Loop ID
+     * @param entries input loop ports
+     * @param exits output loop ports
+     * @return the pair of loop_begin_pos and loop_end_pos iterators
+     */
+    static std::pair<LinearIR::constExprIt, LinearIR::constExprIt> get_loop_bounds(const LinearIR& linear_ir, size_t loop_id,
+                                                                                   const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits);
 
-    // Note: these methods find iterators of first entry loop point and last exit point (bounds of Loop)
-    //       If there are already inserted LoopBegin and LoopEnd in Linear IR, the methods can find them as well if `loop_ops_inserted` = true
-    void get_loop_bounds(const LinearIR& linear_ir,
-                         size_t loop_id,
-                         LinearIR::constExprIt& loop_begin_pos,
-                         LinearIR::constExprIt& loop_end_pos,
-                         bool loop_ops_inserted = false) const;
-    static void get_loop_bounds(const LinearIR& linear_ir,
-                                const std::vector<LoopPort>& entries,
-                                const std::vector<LoopPort>& exits,
-                                LinearIR::constExprIt& loop_begin_pos,
-                                LinearIR::constExprIt& loop_end_pos,
-                                size_t loop_id, bool loop_ops_inserted = false);
-
+    /**
+     * @brief Get LoopPort by ExpressionPort
+     * @param expr_port the target ExpressionPort
+     * @param loop_id target Loop ID
+     * @return loop port
+     */
     LoopPort get_loop_port_by_expr_port(const ExpressionPort& expr_port, const size_t loop_id);
 
 private:
+    /**
+     * @brief Add new Loop Info to the map
+     * @param loop target loop info
+     * @return the loop ID
+     */
+    size_t add_loop_info(const LoopInfoPtr& loop);
+    /**
+     * @brief Remove LoopInfo from the map
+     * @param index the target index of Loop
+     */
+    void remove_loop_info(size_t index);
+    /**
+     * @brief Find expression ports in bounds that are connected to consumers or parent that aren't in these bounds
+     * @param loop_begin_pos the first expression iterator of the Loop
+     * @param loop_end_pos the next iterator after the last expression
+     * @param entries found input expression ports
+     * @param exits found output expression ports
+     */
     static void get_io_loop_ports(LinearIR::constExprIt loop_begin_pos,
                                   LinearIR::constExprIt loop_end_pos,
                                   std::vector<ExpressionPort>& entries,
                                   std::vector<ExpressionPort>& exits);
-
+    /**
+     * @brief Fuse exit LoopPorts of upper Loop and entry LoopPorts of lower Loop
+     * @param exit_points ref of exit LoopPorts of upper Loop
+     * @param entry_points ref of entry LoopPorts of lower Loop
+     * @param loop_id ID of the new Loop after fusion
+     */
     static void fuse_loop_ports(std::vector<LinearIR::LoopManager::LoopPort>& exit_points,
                                 std::vector<LinearIR::LoopManager::LoopPort>& entry_points,
                                 size_t loop_id);
@@ -233,6 +393,7 @@ private:
     //                                         for `before` the new Loop is the most outer Loop
     void insert_loop_id(const ExpressionPtr& expr, size_t new_id, bool before = true, size_t target_id = SIZE_MAX);
     void insert_loop_ids(const ExpressionPtr& expr, const std::vector<size_t>& new_ids, bool before = true, size_t target_id = SIZE_MAX);
+    static bool is_loop_id_found(const ExpressionPtr& expr, size_t id);
 
     std::map<size_t, LoopInfoPtr> m_map = {};
     size_t next_id = 0;

--- a/src/common/snippets/include/snippets/lowered/pass/insert_tail_loop.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_tail_loop.hpp
@@ -24,7 +24,7 @@ class InsertTailLoop : public Pass {
 public:
     OPENVINO_RTTI("InsertTailLoop", "Pass")
     bool run(LinearIR& linear_ir) override;
-    static LinearIR::container copy_loop(const LinearIR& linear_ir, const size_t loop_id);
+    static LinearIR::constExprIt insert_copy_loop(LinearIR& linear_ir, const size_t loop_id, const LinearIR::constExprIt& insert_pos);
 
     static constexpr size_t existing_subtensor_value = SIZE_MAX;
     static void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -68,10 +68,9 @@ void FuseLoops::move(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_m
     std::map<size_t, std::pair<LinearIR::constExprIt, LinearIR::constExprIt>> outer_loops;  // The map: LoopID -> [ LoopBegin, LoopEnd ]
     const auto outer_loop_ids = LinearIR::LoopManager::get_outer_expr_loops(*loop_begin_pos, loop_id);
     for (const auto& loop_id : outer_loop_ids) {
-        LinearIR::constExprIt begin, end;
-        loop_manager->get_loop_bounds(linear_ir, loop_id, begin, end);
+        const auto loop_bounds = loop_manager->get_loop_bounds(linear_ir, loop_id);
         // save previos iterator since the current iterator can be moved
-        outer_loops[loop_id] = {std::prev(begin), end};
+        outer_loops[loop_id] = {std::prev(loop_bounds.first), loop_bounds.second};
     }
      // Secondly, move expressions
     for (auto it = loop_begin_pos; it != loop_end_pos;) {
@@ -122,7 +121,7 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::Loo
         return false;
 
     LinearIR::constExprIt target_loop_begin_pos, target_loop_end_pos;
-    loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
+    std::tie(target_loop_begin_pos, target_loop_end_pos) = loop_manager->get_loop_bounds(linear_ir, target_loop_id);
     loop_manager->fuse_loops(target_loop_begin_pos, target_loop_end_pos, target_loop_id, current_loop_id, false);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
     loop_current->set_work_amount(std::max(loop_current->get_work_amount(), loop_target->get_work_amount()));
@@ -167,7 +166,7 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::Loo
         return false;
 
     LinearIR::constExprIt target_loop_begin_pos, target_loop_end_pos;
-    loop_manager->get_loop_bounds(linear_ir, target_loop_id, target_loop_begin_pos, target_loop_end_pos);
+    std::tie(target_loop_begin_pos, target_loop_end_pos) = loop_manager->get_loop_bounds(linear_ir, target_loop_id);
     loop_manager->fuse_loops(target_loop_begin_pos, target_loop_end_pos, current_loop_id, target_loop_id);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
     loop_current->set_work_amount(std::max(loop_current->get_work_amount(), loop_target->get_work_amount()));
@@ -212,7 +211,7 @@ bool FuseLoops::run(LinearIR& linear_ir) {
 
             const auto current_loop_info = loop_manager->get_loop_info(current_loop_id);
             LinearIR::constExprIt current_loop_begin_pos, current_loop_end_pos;
-            loop_manager->get_loop_bounds(linear_ir, current_loop_id, current_loop_begin_pos, current_loop_end_pos);
+            std::tie(current_loop_begin_pos, current_loop_end_pos) = loop_manager->get_loop_bounds(linear_ir, current_loop_id);
 
             // We fuse upper Loops into the current till we can do it.
             // After that we fuse lower Loops into the current till we can do it.

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -126,18 +126,12 @@ LinearIR::constExprIt InsertBuffers::insertion_position(const LinearIR& linear_i
     // If upper expression is inside Loop, we should insert Buffer after this Loop
     if (loop_idx < up_loop_count) {
         const auto up_loop_id = up_loops[loop_idx];
-        const auto loop_info = loop_manager->get_loop_info(up_loop_id);
-        LinearIR::constExprIt loop_begin_pos, loop_end_pos;
-        loop_manager->get_loop_bounds(linear_ir, up_loop_id, loop_begin_pos, loop_end_pos);
-        return loop_end_pos;
+        return loop_manager->get_loop_bounds(linear_ir, up_loop_id).second;
     }
     // If lower expression is inside Loop, we should insert Buffer before this Loop
     if (loop_idx < down_loop_count) {
         const auto down_loop_id = down_loops[loop_idx];
-        const auto loop_info = loop_manager->get_loop_info(down_loop_id);
-        LinearIR::constExprIt loop_begin_pos, loop_end_pos;
-        loop_manager->get_loop_bounds(linear_ir, down_loop_id, loop_begin_pos, loop_end_pos);
-        return loop_begin_pos;
+        return loop_manager->get_loop_bounds(linear_ir, down_loop_id).first;
     }
     OPENVINO_THROW("Incorrect configuration for Buffer insertion!");
 }

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -34,8 +34,7 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr&
     const auto work_amount = loop_info->get_work_amount();
     const auto work_amount_increment = loop_info->get_increment();
 
-    LinearIR::constExprIt loop_begin_pos, loop_end_pos;
-    loop_manager->get_loop_bounds(linear_ir, loop_id, loop_begin_pos, loop_end_pos);
+    const auto loop_bounds = loop_manager->get_loop_bounds(linear_ir, loop_id);
 
     const auto in_out_num = loop_entries.size() + loop_exits.size();
     std::vector<bool> is_incremented;
@@ -59,10 +58,10 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr&
     init_params(loop_entries);
     init_params(loop_exits);
 
-    const auto outer_loop_ids = get_outer_loop_ids(*loop_begin_pos, loop_id);
+    const auto outer_loop_ids = get_outer_loop_ids(*loop_bounds.first, loop_id);
 
     const auto& loop_begin = std::make_shared<op::LoopBegin>();
-    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, std::vector<PortConnectorPtr>{}, outer_loop_ids, false, loop_begin_pos);
+    const auto loop_begin_expr = *linear_ir.insert_node(loop_begin, std::vector<PortConnectorPtr>{}, outer_loop_ids, false, loop_bounds.first);
 
     const auto& loop_end = std::make_shared<op::LoopEnd>(
             loop_begin->output(0), work_amount, work_amount_increment, is_incremented, ptr_increments,
@@ -70,7 +69,7 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr&
     loop_end->has_outer_loop = has_outer_loop;
     // Add LoopBegin port connector
     loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
-    linear_ir.insert_node(loop_end, loop_end_inputs, outer_loop_ids, false, loop_end_pos);
+    linear_ir.insert_node(loop_end, loop_end_inputs, outer_loop_ids, false, loop_bounds.second);
 }
 
 bool InsertLoops::run(LinearIR& linear_ir) {

--- a/src/common/snippets/src/lowered/pass/move_result_out_of_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/move_result_out_of_loop.cpp
@@ -51,8 +51,8 @@ bool MoveResultOutOfLoop::run(LinearIR& linear_ir) {
             continue;
         }
 
-        LinearIR::constExprIt loop_begin_pos, loop_end_pos;
-        loop_manager->get_loop_bounds(linear_ir, *(parent_loop_ids.cbegin()), loop_begin_pos, loop_end_pos);
+        const auto loop_bounds = loop_manager->get_loop_bounds(linear_ir, *(parent_loop_ids.cbegin()));
+        const auto loop_end_pos = loop_bounds.second;
         // If the Result isn't found after Outer LoopEnd, need to move it to there
         if (std::find(loop_end_pos, linear_ir.cend(), expr) == linear_ir.cend()) {
             expr_it = std::prev(expr_it);  // save iterator before moving

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -67,15 +67,11 @@ bool SplitLoops::run(LinearIR& linear_ir) {
                 const auto& loop_to_fuse = !split_parent ? parent_loop : loop;
                 loop_to_split->set_work_amount(loop_to_fuse->get_increment());
 
-                LinearIR::constExprIt loop_begin_pos, loop_end_pos;
-                LoopManager::get_loop_bounds(linear_ir,
-                                             loop_to_split->get_entry_points(),
-                                             loop_to_split->get_exit_points(),
-                                             loop_begin_pos,
-                                             loop_end_pos,
-                                             loop_to_split_id);
-                const auto split_loop_id = loop_manager->mark_loop(loop_begin_pos,
-                                                                   loop_end_pos,
+                const auto loop_bounds = LoopManager::get_loop_bounds(linear_ir, loop_to_split_id,
+                                                                      loop_to_split->get_entry_points(),
+                                                                      loop_to_split->get_exit_points());
+                const auto split_loop_id = loop_manager->mark_loop(loop_bounds.first,
+                                                                   loop_bounds.second,
                                                                    loop_to_fuse->get_work_amount(),
                                                                    loop_to_fuse->get_increment(),
                                                                    loop_to_split->get_dim_idx(),


### PR DESCRIPTION
### Details:
 - *On the master we [create](https://github.com/openvinotoolkit/openvino/blob/03a5be788a82e1b50736947fba88c3002074e13d/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp#L135) copy of subloop in `InsertTailLoop` and [compare](https://github.com/openvinotoolkit/openvino/blob/03a5be788a82e1b50736947fba88c3002074e13d/src/common/snippets/src/lowered/loop_manager.cpp#L367) with iterators of linear IR before copy [insertion](https://github.com/openvinotoolkit/openvino/blob/03a5be788a82e1b50736947fba88c3002074e13d/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp#L199) to this LinearIR. It leads to comparison of iterators from the different collections. The PR changes the order of these action*
 - *Adds brief descriptions to `LoopManager` interface*
 - *Added interface `LoopInfo::update_<>_points` to avoid many `get_points() -> changes them -> set_points()`*

### Tickets:
 - *N/A*

### Prerequisites:
- https://github.com/openvinotoolkit/openvino/pull/22161
