### PR TITLE
Fix `INFER_NOT_STARTED` infer status code

### DIFF
--- a/src/inference/dev_api/openvino/runtime/iasync_infer_request.hpp
+++ b/src/inference/dev_api/openvino/runtime/iasync_infer_request.hpp
@@ -20,6 +20,7 @@
 #include "openvino/runtime/threading/itask_executor.hpp"
 
 namespace ov {
+class IInferRequestInternalWrapper;
 
 /**
  * @brief Base class with default implementation of asynchronous multi staged inference request.
@@ -202,6 +203,7 @@ private:
     Futures m_futures;
     std::promise<void> m_promise;
 
+    friend class IInferRequestInternalWrapper;
     friend struct DisableCallbackGuard;
     struct DisableCallbackGuard {
         explicit DisableCallbackGuard(IAsyncInferRequest* this_) : _this{this_} {

--- a/src/tests/functional/plugin/shared/include/behavior/infer_request/callback.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/infer_request/callback.hpp
@@ -134,9 +134,10 @@ TEST_P(InferRequestCallbackTests, ReturnResultNotReadyFromWaitInAsyncModeForTooS
     // get timestamp taken AFTER return from the Wait(STATUS_ONLY)
     const auto afterWaitTimeStamp = std::chrono::system_clock::now();
     // IF the callback timestamp is larger than the afterWaitTimeStamp
-    // then we should observe RESULT_NOT_READY
+    // then we should observe RESULT_NOT_READY or INFER_NOT_STARTED
     if (afterWaitTimeStamp < callbackTimeStampFuture.get()) {
-        ASSERT_TRUE(sts == InferenceEngine::StatusCode::RESULT_NOT_READY);
+        ASSERT_TRUE(sts == InferenceEngine::StatusCode::RESULT_NOT_READY ||
+                    sts == InferenceEngine::StatusCode::INFER_NOT_STARTED);
     }
     ASSERT_NO_THROW(req.Wait(InferenceEngine::InferRequest::WaitMode::RESULT_READY));
 }

--- a/src/tests/functional/plugin/shared/include/behavior/infer_request/wait.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/infer_request/wait.hpp
@@ -76,8 +76,7 @@ TEST_P(InferRequestWaitTests, returnDeviceBusyOnSetBlobAfterAsyncInfer) {
     auto outputBlob = req.GetBlob(cnnNet.getInputsInfo().begin()->first);
     InferenceEngine::StatusCode sts;
     sts = req.Wait(InferenceEngine::InferRequest::WaitMode::STATUS_ONLY);
-    ASSERT_TRUE(InferenceEngine::StatusCode::INFER_NOT_STARTED == sts ||
-                sts == InferenceEngine::StatusCode::RESULT_NOT_READY);
+    ASSERT_TRUE(InferenceEngine::StatusCode::INFER_NOT_STARTED == sts);
     req.StartAsync();
     sts = req.Wait(InferenceEngine::InferRequest::WaitMode::RESULT_READY);
     ASSERT_EQ(InferenceEngine::StatusCode::OK, sts);

--- a/src/tests/functional/plugin/shared/include/behavior/infer_request/wait.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/infer_request/wait.hpp
@@ -36,7 +36,8 @@ TEST_P(InferRequestWaitTests, canStartAsyncInferWithGetInOutWithStatusOnlyWait) 
     req.StartAsync();
     InferenceEngine::StatusCode sts;
     sts = req.Wait(InferenceEngine::InferRequest::WaitMode::STATUS_ONLY);
-    ASSERT_TRUE(sts == InferenceEngine::StatusCode::OK || sts == InferenceEngine::StatusCode::RESULT_NOT_READY);
+    ASSERT_TRUE(sts == InferenceEngine::StatusCode::OK || sts == InferenceEngine::StatusCode::RESULT_NOT_READY ||
+                sts == InferenceEngine::StatusCode::INFER_NOT_STARTED);
 }
 
 // Plugin correct infer request with allocating input and result BlobMaps inside plugin


### PR DESCRIPTION
### Details:
 - After https://github.com/openvinotoolkit/openvino/pull/15096/files#diff-a90e98f27bb865c5cde6cf5589727b53d63595049b054c665fb7e0db44149788 InferenceEngine API uses OpenVINO API via converter. OpenVINO wait_for() returns only true/false, when InferenceEngine Wait() may return INFER_NOT_STARTED/RESULT_NOT_READY/OK. So the changes restore INFER_NOT_STARTED status returned by converter

### Tickets:
 - CVS-128850
