### PR TITLE
[CPU][Emitters] Add more informative exception messages in emitters

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_bf16_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_bf16_emitters.hpp
@@ -29,7 +29,7 @@ private:
         } else if (host_isa_ == dnnl::impl::cpu::x64::sse41) {
             emit_isa<dnnl::impl::cpu::x64::sse41>(in_vec_idxs, out_vec_idxs);
         } else {
-            OPENVINO_THROW("Unsupported ISA");
+            OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
         }
     }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_conversion_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_conversion_emitters.cpp
@@ -31,9 +31,9 @@ void jit_convert_emitter::validate_types() const {
     };
 
     if (!is_supported_type(input_type))
-        OPENVINO_THROW("Unsupported input type: ", input_type.get_type_name());
+        OV_CPU_JIT_EMITTER_THROW("Unsupported input type: ", input_type.get_type_name());
     if (!is_supported_type(output_type))
-        OPENVINO_THROW("Unsupported output type: ", output_type.get_type_name());
+        OV_CPU_JIT_EMITTER_THROW("Unsupported output type: ", output_type.get_type_name());
 }
 
 size_t jit_convert_emitter::get_inputs_num() const { return 1; }
@@ -50,7 +50,7 @@ void jit_convert_emitter::float2bfloat(const std::vector<size_t> &in_vec_idxs, c
     Vmm vmm_src = Vmm(in_vec_idxs[0]);
     Vmm vmm_dst  = Vmm(out_vec_idxs[0]);
     if (!uni_vcvtneps2bf16)
-        OPENVINO_THROW("Converter from float to bf16 isn't initialized!");
+        OV_CPU_JIT_EMITTER_THROW("Converter from float to bf16 isn't initialized!");
 
     uni_vcvtneps2bf16->emit_code({static_cast<size_t>(vmm_src.getIdx())}, {static_cast<size_t>(vmm_dst.getIdx())});
 }
@@ -75,7 +75,7 @@ void jit_convert_truncation_emitter::emit_impl(const std::vector<size_t> &in_vec
     } else if (host_isa_ == cpu::x64::avx512_core) {
         emit_isa<cpu::x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -120,7 +120,7 @@ void jit_convert_truncation_emitter::emit_isa(const std::vector<size_t> &in_vec_
             h->uni_vpmovzxbd(vmm_dst, vmm_src);
             break;
         default:
-            OPENVINO_THROW("Unsupported input data type");
+            OV_CPU_JIT_EMITTER_THROW("Unsupported input data type");
     }
 
     switch (output_type) {
@@ -159,7 +159,7 @@ void jit_convert_truncation_emitter::emit_isa(const std::vector<size_t> &in_vec_
             }
             break;
         default:
-           OPENVINO_THROW("Unsupported output data type");
+           OV_CPU_JIT_EMITTER_THROW("Unsupported output data type");
     }
 }
 
@@ -204,7 +204,7 @@ void jit_convert_saturation_emitter::emit_impl(const std::vector<size_t> &in_vec
     } else if (host_isa_ == cpu::x64::avx512_core) {
         emit_isa<cpu::x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -246,7 +246,7 @@ void jit_convert_saturation_emitter::emit_isa(const std::vector<size_t> &in_vec_
             h->uni_vpmovzxbd(vmm_dst, vmm_src);
             break;
         default:
-           OPENVINO_THROW("Unsupported input data type");
+           OV_CPU_JIT_EMITTER_THROW("Unsupported input data type");
     }
 
     switch (output_type) {
@@ -286,7 +286,7 @@ void jit_convert_saturation_emitter::emit_isa(const std::vector<size_t> &in_vec_
             }
             break;
         default:
-            OPENVINO_THROW("Unsupported output data type");
+            OV_CPU_JIT_EMITTER_THROW("Unsupported output data type");
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_dnnl_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_dnnl_emitters.cpp
@@ -46,7 +46,7 @@ void jit_dnnl_emitter::set_injector() {
         eltwise_injector_avx512_core = std::make_shared<jit_uni_eltwise_injector_f32<cpu::x64::avx512_core>>(
                 h, kind, alpha, beta, 1.f);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -67,7 +67,7 @@ void jit_dnnl_emitter::emit_code(const std::vector<size_t> &in_vec_idxs, const s
             h->uni_vmovups(Zmm(out_vec_idxs[0]), Zmm(in_vec_idxs[0]));
         eltwise_injector_avx512_core->compute_vector(out_vec_idxs[0]);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -79,7 +79,7 @@ void jit_dnnl_emitter::emit_data() const {
     } else if (host_isa_ == cpu::x64::avx512_core) {
         eltwise_injector_avx512_core->prepare_table();
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
@@ -22,9 +22,9 @@ ov::element::Type get_arithmetic_binary_exec_precision(const std::shared_ptr<ov:
         input_precisions.push_back(input.get_source_output().get_element_type());
     }
 
-    OPENVINO_ASSERT(std::all_of(input_precisions.cbegin(), input_precisions.cend(),
-                                [&input_precisions](const ov::element::Type& precision) { return precision == input_precisions[0]; }),
-                    "Arithmetic binary node has not equal input precisions");
+    OV_CPU_JIT_EMITTER_ASSERT(std::all_of(input_precisions.cbegin(), input_precisions.cend(),
+                                          [&input_precisions](const ov::element::Type& precision) { return precision == input_precisions[0]; }),
+                           "Arithmetic binary node has not equal input precisions");
 
     return input_precisions[0];
 }
@@ -46,7 +46,7 @@ void jit_add_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, const st
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -61,7 +61,7 @@ void jit_add_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const std
         switch (exec_prc_) {
             case ov::element::f32: h->uni_vaddps(vmm_dst, vmm_src0, vmm_src1); break;
             case ov::element::i32:  h->uni_vpaddd(vmm_dst, vmm_src0, vmm_src1); break;
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -93,7 +93,7 @@ void jit_mul_add_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, cons
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -117,7 +117,7 @@ void jit_mul_add_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const
                 h->uni_vpmulld(vmm_dst, vmm_dst, vmm_src1);
                 h->uni_vpaddd(vmm_dst, vmm_dst, vmm_src2);
             } break;
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -149,7 +149,7 @@ void jit_mul_add_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const
                 h->uni_vpmulld(vmm_dst, vmm_src0, vmm_src1);
                 h->uni_vpaddd(vmm_dst, vmm_dst, vmm_src2);
             } break;
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -184,7 +184,7 @@ void jit_subtract_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, con
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -199,7 +199,7 @@ void jit_subtract_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, cons
         switch (exec_prc_) {
             case ov::element::f32: h->uni_vsubps(vmm_dst, vmm_src0, vmm_src1); break;
             case ov::element::i32:  h->uni_vpsubd(vmm_dst, vmm_src0, vmm_src1); break;
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -231,7 +231,7 @@ void jit_multiply_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, con
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -246,7 +246,7 @@ void jit_multiply_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, cons
         switch (exec_prc_) {
             case ov::element::f32: h->uni_vmulps(vmm_dst, vmm_src0, vmm_src1); break;
             case ov::element::i32:  h->uni_vpmulld(vmm_dst, vmm_src0, vmm_src1); break;
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -278,7 +278,7 @@ void jit_divide_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, const
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -307,7 +307,7 @@ void jit_divide_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const 
                 h->uni_vcvtps2dq(vmm_dst, vmm_dst);
                 break;
             }
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -347,7 +347,7 @@ void jit_floor_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -380,7 +380,7 @@ void jit_ceiling_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs,
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -417,7 +417,7 @@ void jit_floor_mod_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, co
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -471,7 +471,7 @@ void jit_mod_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const st
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -521,7 +521,7 @@ void jit_maximum_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, cons
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -536,7 +536,7 @@ void jit_maximum_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const
         switch (exec_prc_) {
             case ov::element::f32: h->uni_vmaxps(vmm_dst, vmm_src0, vmm_src1); break;
             case ov::element::i32:  h->uni_vpmaxsd(vmm_dst, vmm_src0, vmm_src1); break;
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -569,7 +569,7 @@ void jit_minimum_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, cons
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -584,7 +584,7 @@ void jit_minimum_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const
         switch (exec_prc_) {
             case ov::element::f32: h->uni_vminps(vmm_dst, vmm_src0, vmm_src1); break;
             case ov::element::i32:  h->uni_vpminsd(vmm_dst, vmm_src0, vmm_src1); break;
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -618,7 +618,7 @@ void jit_squared_difference_emitter::emit_impl(const std::vector<size_t> &in_vec
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -639,7 +639,7 @@ void jit_squared_difference_emitter::emit_isa(const std::vector<size_t> &in_vec_
                 h->uni_vpsubd(vmm_dst, vmm_src0, vmm_src1);
                 h->uni_vpmulld(vmm_dst, vmm_dst, vmm_dst);
             } break;
-            default: OPENVINO_THROW("Unsupported precision");
+            default: OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
         }
     };
 
@@ -677,7 +677,7 @@ void jit_power_dynamic_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -792,7 +792,7 @@ void jit_equal_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -860,7 +860,7 @@ void jit_not_equal_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, co
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -923,7 +923,7 @@ void jit_greater_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, cons
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -987,7 +987,7 @@ void jit_greater_equal_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1050,7 +1050,7 @@ void jit_less_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const s
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1118,7 +1118,7 @@ void jit_less_equal_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, c
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1187,7 +1187,7 @@ void jit_logical_and_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1275,7 +1275,7 @@ void jit_logical_or_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, c
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1363,7 +1363,7 @@ void jit_logical_xor_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1451,7 +1451,7 @@ void jit_logical_not_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1497,7 +1497,7 @@ jit_power_static_emitter::jit_power_static_emitter(x64::jit_generator* host,
     : jit_emitter(host, host_isa, exec_prc) {
     auto powerStaticNode = ov::as_type_ptr<ov::snippets::op::PowerStatic>(node);
     if (powerStaticNode == nullptr) {
-        OPENVINO_THROW("Can't cast to snippets::op::PowerStatic");
+        OV_CPU_JIT_EMITTER_THROW("Can't cast to snippets::op::PowerStatic");
     }
 
     power = powerStaticNode->get_power();
@@ -1528,7 +1528,7 @@ void jit_power_static_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs,
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1709,7 +1709,7 @@ void jit_prelu_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1771,7 +1771,7 @@ void jit_sqrt_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const s
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1805,7 +1805,7 @@ void jit_negative_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, con
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -1848,7 +1848,7 @@ void jit_erf_emitter::emit_impl(
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2035,7 +2035,7 @@ void jit_soft_sign_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, co
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2097,7 +2097,7 @@ void jit_is_finite_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, co
     } else if (host_isa_ == x64::sse41) {
         emit_isa<x64::sse41>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("jit_is_finite_emitter doesn't support ISA ", host_isa_);
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2170,7 +2170,7 @@ void jit_is_inf_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, const
     } else if (host_isa_ == x64::sse41) {
         emit_isa<x64::sse41>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("jit_is_inf_emitter doesn't support ISA ", host_isa_);
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2220,7 +2220,7 @@ void jit_is_nan_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, const
     } else if (host_isa_ == x64::sse41) {
         emit_isa<x64::sse41>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("jit_is_nan_emitter doesn't support ISA ", host_isa_);
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2262,7 +2262,7 @@ void jit_select_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, const
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2325,7 +2325,7 @@ void jit_bitwise_and_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2344,7 +2344,7 @@ void jit_bitwise_and_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, c
     } else if ((host_isa_ == x64::avx2) || (host_isa_ == x64::avx512_core)) {
         h->vandps(vmm_dst, vmm_src0, vmm_src1);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2382,7 +2382,7 @@ void jit_bitwise_not_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2400,7 +2400,7 @@ void jit_bitwise_not_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, c
     } else if ((host_isa_ == x64::avx2) || (host_isa_ == x64::avx512_core)) {
         h->vandnps(vmm_dst, vmm_src, table_val("all_bits"));
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2436,7 +2436,7 @@ void jit_bitwise_or_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, c
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2455,7 +2455,7 @@ void jit_bitwise_or_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, co
     } else if ((host_isa_ == x64::avx2) || (host_isa_ == x64::avx512_core)) {
         h->vorps(vmm_dst, vmm_src0, vmm_src1);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -2487,7 +2487,7 @@ void jit_bitwise_xor_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, 
     } else if (host_isa_ == x64::avx512_core) {
         emit_isa<x64::avx512_core>(in_vec_idxs, out_vec_idxs);
     } else {
-        OPENVINO_THROW("Unsupported ISA");
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.cpp
@@ -72,9 +72,9 @@ void jit_emitter::emitter_preamble(const std::vector<size_t> &in_idxs, const std
     if (host_isa_ == cpu::x64::sse41 && aux_vecs_count() > 0) {
         size_t idx = 0;
         if (is_vec_input)
-            OPENVINO_ASSERT(std::find(in_idxs.begin(), in_idxs.end(), idx) == in_idxs.end(), "Xmm(0) cannot be input register in SSE41");
+            OV_CPU_JIT_EMITTER_ASSERT(std::find(in_idxs.begin(), in_idxs.end(), idx) == in_idxs.end(), "Xmm(0) cannot be input register in SSE41");
         if (is_vec_output)
-            OPENVINO_ASSERT(std::find(out_idxs.begin(), out_idxs.end(), idx) == out_idxs.end(), "Xmm(0) cannot be output register in SSE41");
+            OV_CPU_JIT_EMITTER_ASSERT(std::find(out_idxs.begin(), out_idxs.end(), idx) == out_idxs.end(), "Xmm(0) cannot be output register in SSE41");
         if (std::find(aux_vec_idxs.begin(), aux_vec_idxs.end(), idx) == aux_vec_idxs.end()) {
             aux_vec_idxs.push_back(idx);
             preserved_vec_idxs.push_back(idx);
@@ -107,7 +107,7 @@ void jit_emitter::emitter_preamble(const std::vector<size_t> &in_idxs, const std
         preserved_vec_idxs.push_back(idx);
     }
     if (aux_vec_idxs.size() < aux_vecs_count())
-        OPENVINO_THROW("Failed to allocate required number of vector registers");
+        OV_CPU_JIT_EMITTER_THROW("Failed to allocate required number of vector registers");
 
     // Same logic but to allocate gprs
     for (auto idx : pool_gpr_idxs)
@@ -131,7 +131,7 @@ void jit_emitter::emitter_preamble(const std::vector<size_t> &in_idxs, const std
         preserved_gpr_idxs.push_back(_idx);
     }
     if (aux_gpr_idxs.size() < aux_gprs_count())
-        OPENVINO_THROW("Failed to allocate required number of general-purpose registers");
+        OV_CPU_JIT_EMITTER_THROW("Failed to allocate required number of general-purpose registers");
 
     if (!entry_map_.empty()) {
         // last aux_gpr_idx is for p_table, we can use aux_gpr_idxs from idx 0 for other purpose

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
@@ -8,6 +8,7 @@
 
 #include "snippets/snippets_isa.hpp"
 #include "snippets/generator.hpp"
+#include "emitters/utils.hpp"
 #include <node.h>
 
 #include <set>
@@ -18,39 +19,6 @@
 
 namespace ov {
 namespace intel_cpu {
-
-inline std::string jit_emitter_pretty_name(const std::string &pretty_func) {
-    // Example:
-    //      pretty_func := void ov::intel_cpu::jit_load_memory_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const
-    //      begin := -----------|
-    //      end := ---------------------------------------------------|
-    //      result := ov::intel_cpu::jit_load_memory_emitter
-    // Signatures:
-    //      GCC:   void foo() [with T = {type}]
-    //      clang: void foo() [T = {type}]
-    //      MSVC:  void __cdecl foo<{type}>(void)
-    auto parenthesis = pretty_func.find("(");
-    if (pretty_func[parenthesis - 1] == '>') { // To cover template on MSVC
-        parenthesis--;
-        size_t counter = 1;
-        while (counter != 0 && parenthesis > 0) {
-            parenthesis--;
-            if (pretty_func[parenthesis] == '>') counter++;
-            if (pretty_func[parenthesis] == '<') counter--;
-        }
-    }
-    const auto end = pretty_func.substr(0, parenthesis).rfind("::");
-    const auto begin = pretty_func.substr(0, end).rfind(" ") + 1;
-    return pretty_func.substr(begin, end - begin);
-}
-
-#ifdef __GNUC__
-#define OV_CPU_JIT_EMITTER_NAME jit_emitter_pretty_name(__PRETTY_FUNCTION__)
-#else /* __GNUC__ */
-#define OV_CPU_JIT_EMITTER_NAME jit_emitter_pretty_name(__FUNCSIG__)
-#endif /* __GNUC__ */
-#define OV_CPU_JIT_EMITTER_THROW(...) OPENVINO_THROW(OV_CPU_JIT_EMITTER_NAME, ": ", __VA_ARGS__)
-#define OV_CPU_JIT_EMITTER_ASSERT(cond, ...) OPENVINO_ASSERT((cond), OV_CPU_JIT_EMITTER_NAME, ": ", __VA_ARGS__)
 
 enum emitter_in_out_map {
     vec_to_vec,

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.cpp
@@ -102,7 +102,7 @@ void jit_load_emitter::emit_impl(const std::vector<size_t> &in_idxs, const std::
     } else if (host_isa_ == cpu::x64::avx512_core) {
         emit_isa<cpu::x64::avx512_core>(Reg64(in_idxs[0]), static_cast<int>(out_idxs[0]), offset);
     } else {
-        OPENVINO_THROW("Load emitter in ", name_, " is performed on unsupported isa(at least x64::sse41).");
+        OV_CPU_JIT_EMITTER_THROW("is performed on unsupported isa(at least x64::sse41).");
     }
 }
 
@@ -110,12 +110,10 @@ template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 void jit_load_emitter::emit_isa(const Xbyak::Reg64 &reg_src, const int out_vec_idx, const int offset) const {
     bool matched_prc = (dst_prc_ == src_prc_) || (dst_prc_ == ov::element::f32) || (dst_prc_ == ov::element::i32);
     if (!matched_prc) {
-        OPENVINO_THROW("Load emitter in ",
-                       name_,
-                       " only support output precision of FP32 or I32 or the same precision as input.");
+        OV_CPU_JIT_EMITTER_THROW("only support output precision of FP32 or I32 or the same precision as input.");
     }
     if (load_num_ > static_cast<int>((get_vec_length() / dst_prc_.size()))) {
-        OPENVINO_THROW("Load emitter in ", name_, " have unexpected number of elements to load.");
+        OV_CPU_JIT_EMITTER_THROW("have unexpected number of elements to load.");
     }
 
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xmm, isa == cpu::x64::avx2, Ymm, Zmm>::type;
@@ -143,7 +141,7 @@ void jit_load_emitter::emit_isa(const Xbyak::Reg64 &reg_src, const int out_vec_i
                 load_words_to_dword_extension<Vmm>(Vmm(out_vec_idx), reg_src, offset, src_prc_, load_size_);
                 break;
             default:
-                OPENVINO_THROW("Load emitter in ", name_, " has unsupported src precision to load.");
+                OV_CPU_JIT_EMITTER_THROW("has unsupported src precision to load.");
         }
     }
 
@@ -194,12 +192,12 @@ void jit_load_emitter::load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int o
 
     // Ensure data fits completely inside the Xmm/Ymm/Zmm register
     if (load_size < 0 || load_size > 64)
-        OPENVINO_THROW("Load emitter in ", name_, " has unexpected number of values to load in load_byte.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load in load_byte.");
     // check if proper number bytes fit inside the Xmm/Ymm register
     if (is_ymm && load_size > 32)
-        OPENVINO_THROW("Load emitter in ", name_, " has unexpected number of values to load to ymm in load_byte.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load to ymm in load_byte.");
     if (is_xmm && load_size > 16)
-        OPENVINO_THROW("Load emitter in ", name_, " has unexpected number of values to load to xmm in load_byte.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load to xmm in load_byte.");
 
     auto xmm = Xbyak::Xmm(vmm.getIdx());
     auto ymm = Xbyak::Ymm(vmm.getIdx());
@@ -303,7 +301,7 @@ void jit_load_emitter::load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int o
                 break;
             case 16: break;
             default:
-                OPENVINO_THROW("Load emitter in ", name_, " has unexpected number of values to load in load_byte.");
+                OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load in load_byte.");
         }
 
         if (has_xmm_block) {
@@ -378,17 +376,11 @@ void jit_load_emitter::load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak
     // For Ymm register, load capacity is halved (32 * load_size <= 256)
     // For Xmm register, load capacity is halved further (32 * load_size <= 128)
     if (load_size < 0 || load_size > 16)
-        OPENVINO_THROW("Load emitter in ",
-                       name_,
-                       " has unexpected number of values to load in load_bytes_to_dword_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load in load_bytes_to_dword_extension.");
     if (is_ymm && load_size > 8)
-        OPENVINO_THROW("Load emitter in ",
-                       name_,
-                       " has unexpected number of values to load to ymm in load_bytes_to_dword_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load to ymm in load_bytes_to_dword_extension.");
     if (is_xmm && load_size > 4)
-        OPENVINO_THROW("Load emitter in ",
-                       name_,
-                       " has unexpected number of values to load to xmm in load_bytes_to_dword_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load to xmm in load_bytes_to_dword_extension.");
 
     // For load_size == 4/8/16, do load/extension in one go
     switch (load_size) {
@@ -475,23 +467,17 @@ void jit_load_emitter::load_words_to_dword_extension(const Vmm &vmm, const Xbyak
     bool is_signed = prc.is_signed();
 
     if (is_f16 && !mayiuse(cpu::x64::avx2))
-        OPENVINO_THROW("Load emitter in ", name_, " only support fp16 on platform with avx2 or above.");
+        OV_CPU_JIT_EMITTER_THROW("only support fp16 on platform with avx2 or above.");
 
     // Ensure extended double words fit inside Zmm (32/2(num) * 32 <= 512)
     // For Ymm register, load capacity is halved (16/2(num) * 32 <= 128)
     // For Xmm register, load capacity is halved again (8/2(num) * 32 <= 128)
     if (load_size < 0 || load_size > 32)
-        OPENVINO_THROW("Load emitter in ",
-                       name_,
-                       " has unexpected number of values to load in load_words_to_dword_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load in load_words_to_dword_extension.");
     if (is_ymm && load_size > 16)
-        OPENVINO_THROW("Load emitter in ",
-                       name_,
-                       " has unexpected number of values to load to ymm in load_words_to_dword_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load to ymm in load_words_to_dword_extension.");
     if (is_xmm && load_size > 8)
-        OPENVINO_THROW("Load emitter in ",
-                       name_,
-                       " has unexpected number of values to load to xmm in load_words_to_dword_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to load to xmm in load_words_to_dword_extension.");
 
     auto xmm = Xbyak::Xmm(vmm.getIdx());
     auto ymm = Xbyak::Ymm(vmm.getIdx());
@@ -678,7 +664,7 @@ void jit_store_emitter::emit_impl(const std::vector<size_t> &in_idxs, const std:
     } else if (host_isa_ == cpu::x64::avx512_core) {
         emit_isa<cpu::x64::avx512_core>(static_cast<int>(in_idxs[0]), Reg64(out_idxs[0]), offset);
     } else {
-        OPENVINO_THROW("Store emitter in ", name_, " is performed on unsupported isa(at least x64::sse41).");
+        OV_CPU_JIT_EMITTER_THROW("is performed on unsupported isa(at least x64::sse41).");
     }
 }
 
@@ -686,14 +672,12 @@ template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 void jit_store_emitter::emit_isa(const int in_vec_idx, const Xbyak::Reg64 &reg_dst, const int offset) const {
     bool matched_prc = (src_prc_ == dst_prc_) || (src_prc_ == ov::element::f32) || (src_prc_ == ov::element::i32);
     if (!matched_prc) {
-        OPENVINO_THROW("Store emitter in ",
-                       name_,
-                       " only support input precision of FP32 or I32 or the same precision as output.");
+        OV_CPU_JIT_EMITTER_THROW("only support input precision of FP32 or I32 or the same precision as output.");
     }
     if ((src_prc_ == ov::element::f32) || (src_prc_ == ov::element::i32)) {
         if ((isa == cpu::x64::sse41 && store_num_ > 4) || (isa == cpu::x64::avx2 && store_num_ > 8) ||
             (isa == cpu::x64::avx512_core && store_num_ > 16) || store_num_ < 0) {
-            OPENVINO_THROW("Store emitter in ", name_, " has unexpected number of values to store.");
+            OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store.");
         }
     }
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xmm, isa == cpu::x64::avx2, Ymm, Zmm>::type;
@@ -747,7 +731,7 @@ void jit_store_emitter::emit_isa(const int in_vec_idx, const Xbyak::Reg64 &reg_d
                 store_dword_to_word_extension<Vmm>(reg_dst, offset, dst_prc_, store_num_);
                 break;
             default:
-                OPENVINO_THROW("Store emitter in ", name_, " has unsupported dst precision to store.");
+                OV_CPU_JIT_EMITTER_THROW("has unsupported dst precision to store.");
         }
     }
 }
@@ -778,11 +762,11 @@ void jit_store_emitter::store_bytes(const Xbyak::Reg64 &reg, int offset, int sto
 
     // Ensure data fits completely inside the Xmm/Ymm/Zmm register
     if (store_size < 0 || store_size > 64)
-        OPENVINO_THROW("Store emitter in ", name_, " has unexpected number of values to store in store_bytes.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store in store_bytes.");
     if (is_ymm && store_size > 32)
-        OPENVINO_THROW("Store emitter in ", name_, " has unexpected number of values to store to ymm in store_bytes.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store to ymm in store_bytes.");
     if (is_xmm && store_size > 16)
-        OPENVINO_THROW("Store emitter in ", name_, " has unexpected number of values to store to xmm in store_bytes.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store to xmm in store_bytes.");
 
     auto xmm = Xbyak::Xmm(data_idx);
     auto ymm = Xbyak::Ymm(data_idx);
@@ -879,7 +863,7 @@ void jit_store_emitter::store_bytes(const Xbyak::Reg64 &reg, int offset, int sto
                 break;
             case 16: break;
             default:
-                OPENVINO_THROW("Store emitter in ", name_, " has unexpected number of values to store in store_bytes.");
+                OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store in store_bytes.");
         }
     };
 
@@ -926,17 +910,11 @@ void jit_store_emitter::store_dword_to_byte_extension(const Xbyak::Reg64 &reg, i
     // At most 8 dwords can fit inside the Ymm register
     // At most 4 dwords can fit inside the Xmm register
     if (store_num < 0 || store_num > 16)
-        OPENVINO_THROW("Store emitter in ",
-                       name_,
-                       " has unexpected number of values to store in store_dword_to_byte_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store in store_dword_to_byte_extension.");
     if (is_ymm && store_num > 8)
-        OPENVINO_THROW("Store emitter in ",
-                       name_,
-                       " has unexpected number of values to store to ymm in store_dword_to_byte_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store to ymm in store_dword_to_byte_extension.");
     if (is_xmm && store_num > 4)
-        OPENVINO_THROW("Store emitter in ",
-                       name_,
-                       " has unexpected number of values to store to xmm in store_dword_to_byte_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store to xmm in store_dword_to_byte_extension.");
 
     auto vmm = Vmm(data_idx);
     auto zmm = Xbyak::Zmm(data_idx);
@@ -1096,17 +1074,11 @@ void jit_store_emitter::store_dword_to_word_extension(const Xbyak::Reg64 &reg,
     // At most 4 dwords can fit inside the Xmm register
     // At most 8 dwords can fit inside the Ymm register
     if (store_num < 0 || store_num > 16)
-        OPENVINO_THROW("Store emitter in ",
-                       name_,
-                       " has unexpected number of values to store in store_dword_to_word_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store in store_dword_to_word_extension.");
     if (is_ymm && store_num > 8)
-        OPENVINO_THROW("Store emitter in ",
-                       name_,
-                       " has unexpected number of values to store to ymm in store_dword_to_word_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store to ymm in store_dword_to_word_extension.");
     if (is_xmm && store_num > 4)
-        OPENVINO_THROW("Store emitter in ",
-                       name_,
-                       " has unexpected number of values to store to xmm in store_dword_to_word_extension.");
+        OV_CPU_JIT_EMITTER_THROW("has unexpected number of values to store to xmm in store_dword_to_word_extension.");
 
     auto xmm = Xbyak::Xmm(data_idx);
     auto ymm = Xbyak::Ymm(data_idx);
@@ -1215,7 +1187,7 @@ void jit_store_emitter::store_dword_to_word_extension(const Xbyak::Reg64 &reg,
                 store_bytes<Vmm>(reg, offset, store_num * 2);
             }
         } else {
-            OPENVINO_THROW("Store emitter in ", name_, " only support fp16 on platform with avx512_core or avx2.");
+            OV_CPU_JIT_EMITTER_THROW("only support fp16 on platform with avx512_core or avx2.");
         }
     } else {
         switch (store_num) {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_copy_b_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_copy_b_emitter.cpp
@@ -29,7 +29,7 @@ jit_brgemm_copy_b_emitter::jit_brgemm_copy_b_emitter(jit_generator* h, cpu_isa_t
     in_out_type_ = emitter_in_out_map::gpr_to_gpr;
     const auto brgemm_repack = ov::as_type_ptr<ov::intel_cpu::BrgemmCopyB>(expr->get_node());
     if (!brgemm_repack)
-        OPENVINO_THROW("jit_brgemm_copy_b_emitters expects BrgemmCopyB node");
+        OV_CPU_JIT_EMITTER_THROW("expects BrgemmCopyB node");
 
     m_brgemm_prc_in0 = brgemm_repack->get_src_element_type();
     m_brgemm_prc_in1 = brgemm_repack->get_input_element_type(0);
@@ -102,7 +102,7 @@ void jit_brgemm_copy_b_emitter::init_brgemm_copy(std::unique_ptr<matmul::jit_brg
 
     auto status = matmul::create_brgemm_matmul_copy_b(kernel, &brgCopyKernelConf);
     if (status != dnnl_success)
-        OPENVINO_THROW("jit_brgemm_copy_b_emitter cannot create kernel due to invalid params");
+        OV_CPU_JIT_EMITTER_THROW("cannot create kernel due to invalid params");
 }
 
 void jit_brgemm_copy_b_emitter::emit_impl(const std::vector<size_t>& in,
@@ -113,7 +113,7 @@ void jit_brgemm_copy_b_emitter::emit_impl(const std::vector<size_t>& in,
         Xbyak::Reg64 comp(static_cast<int>(0));  // Compensations. Default reg idx is 0 if there aren't the compensations
         if (m_with_comp) {
             if (out.size() != 2) {
-                OPENVINO_THROW("jit_brgemm_copy_b_emitter with compensations requires separate register for them");
+                OV_CPU_JIT_EMITTER_THROW("with compensations requires separate register for them");
             }
             comp = Xbyak::Reg64(static_cast<int>(out[1]));
         }
@@ -130,7 +130,7 @@ void jit_brgemm_copy_b_emitter::emit_impl(const std::vector<size_t>& in,
             emit_kernel_call(m_kernel.get(), src, dst, comp, current_N_blk, m_K, offset_in, offset_out, offset_comp);
         }
     } else {
-        OPENVINO_THROW("jit_brgemm_copy_b_emitter requires at least avx512_core instruction set");
+        OV_CPU_JIT_EMITTER_THROW("requires at least avx512_core instruction set");
     }
 }
 
@@ -253,7 +253,7 @@ void jit_brgemm_copy_b_emitter::emit_kernel_call(const matmul::jit_brgemm_matmul
 void jit_brgemm_copy_b_emitter::execute(matmul::jit_brgemm_matmul_copy_b_t *kernel, const void *src,
                                  const void *dst, const void *comp, size_t N, size_t K) {
     if (!kernel)
-        OPENVINO_THROW("Kernel for jit_brgemm_copy_b_emitter hasn't been created");
+        OV_CPU_JIT_EMITTER_THROW("Kernel hasn't been created");
 
     auto ctx = dnnl::impl::cpu::x64::matmul::jit_brgemm_matmul_copy_b_t::ctx_t();
     ctx.current_N_blk = N;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_fill_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_fill_emitter.cpp
@@ -18,7 +18,7 @@ jit_fill_emitter::jit_fill_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl:
     : jit_emitter(h, isa, ov::element::f32, emitter_in_out_map::vec_to_vec) {
     const auto fill = ov::as_type_ptr<snippets::op::Fill>(expr->get_node());
     if (fill->get_element_type().size() != 4) {
-        OPENVINO_THROW("Fill emitter supports only 4 Byte element types but gets: ", fill->get_element_type());
+        OV_CPU_JIT_EMITTER_THROW("supports only 4 Byte element types but gets: ", fill->get_element_type());
     }
 
     offset = fill->get_offset();
@@ -47,7 +47,7 @@ void jit_fill_emitter::emit_impl(const std::vector<size_t>& in, const std::vecto
     } else if (host_isa_ == dnnl::impl::cpu::x64::avx512_core) {
         emit_isa<dnnl::impl::cpu::x64::avx512_core>(in, out);
     } else {
-        OPENVINO_THROW("Fill emitter doesn't support ", host_isa_);
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_horizon_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_horizon_emitter.cpp
@@ -20,7 +20,7 @@ jit_horizon_emitter::jit_horizon_emitter(dnnl::impl::cpu::x64::jit_generator* h,
     } else if (ov::is_type<const snippets::op::HorizonSum>(expr->get_node())) {
         m_op_type = OpType::sum;
     } else {
-        OPENVINO_THROW("jit_horizon_emitter exprects HorizonMax or HorizonSum ops");
+        OV_CPU_JIT_EMITTER_THROW("exprects HorizonMax or HorizonSum ops");
     }
 }
 
@@ -33,7 +33,7 @@ void jit_horizon_emitter::emit_impl(const std::vector<size_t>& in,
     } else if (host_isa_ == dnnl::impl::cpu::x64::avx512_core) {
         emit_isa<dnnl::impl::cpu::x64::avx512_core>(in, out);
     } else {
-        OPENVINO_THROW("HorizonMax emitter doesn't support ", host_isa_);
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -77,7 +77,7 @@ void jit_horizon_emitter::perform_op(const Vmm &vmm1, const Vmm &vmm2, const Vmm
             h->uni_vaddps(vmm1, vmm2, vmm3);
             break;
         default:
-            OPENVINO_THROW("Unsupported horizontal operation.");
+            OV_CPU_JIT_EMITTER_THROW("Unsupported horizontal operation.");
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
@@ -27,9 +27,9 @@ inline static std::vector<size_t> transform_snippets_regs_to_idxs(const std::vec
 jit_kernel_emitter::jit_kernel_emitter(jit_generator* h, cpu_isa_t isa, const ov::snippets::lowered::ExpressionPtr& expr)
     : jit_container_emitter(h, isa), reg_indexes_idx(abi_param1.getIdx()), reg_const_params_idx(abi_param2.getIdx()) {
     const auto kernel = ov::as_type_ptr<snippets::op::Kernel>(expr->get_node());
-    OPENVINO_ASSERT(kernel != nullptr, "jit_kernel_emitter invoked with invalid op argument");
-    OPENVINO_ASSERT(!kernel->region.empty(), "jit_kernel_emitter invoked with empty body");
-    OPENVINO_ASSERT(kernel->compile_params != nullptr, "jit_kernel_emitter invoked with op::Kernel that contains no compile_params");
+    OV_CPU_JIT_EMITTER_ASSERT(kernel != nullptr, "invoked with invalid op argument");
+    OV_CPU_JIT_EMITTER_ASSERT(!kernel->region.empty(), "invoked with empty body");
+    OV_CPU_JIT_EMITTER_ASSERT(kernel->compile_params != nullptr, "invoked with op::Kernel that contains no compile_params");
 
     body = kernel->region;
     jcp = *reinterpret_cast<const jit_snippets_compile_args*>(kernel->compile_params);
@@ -62,14 +62,14 @@ jit_kernel_emitter::jit_kernel_emitter(jit_generator* h, cpu_isa_t isa, const ov
                 etype = expr->get_node()->get_input_element_type(0);
                 break;
             } default : {
-                OPENVINO_THROW("Kernel detected unsupported io_type");
+                OV_CPU_JIT_EMITTER_THROW("detected unsupported io_type");
             }
         }
         const auto& shape = desc->get_shape();
         const auto& layout = desc->get_layout();
-        OPENVINO_ASSERT(shape.size() == layout.size(), "Shape and layout must have the same length");
+        OV_CPU_JIT_EMITTER_ASSERT(shape.size() == layout.size(), "Shape and layout must have the same length");
         const auto max_dim = *std::max_element(layout.begin(), layout.end());
-        OPENVINO_ASSERT(max_dim < shape.size(), "Max layout index can't be larger than the shape size");
+        OV_CPU_JIT_EMITTER_ASSERT(max_dim < shape.size(), "Max layout index can't be larger than the shape size");
         io_shapes.push_back(shape);
         io_data_layouts.push_back(layout);
         io_data_sizes.push_back(etype.size());
@@ -135,12 +135,12 @@ void jit_kernel_emitter::emit_code(const std::vector<size_t> &in, const std::vec
 }
 
 void jit_kernel_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
-    OPENVINO_ASSERT(in.empty(), "jit_kernel_emitter got invalid number of inputs. Expected 0, got ", in.size());
-    OPENVINO_ASSERT(out.empty(), "jit_kernel_emitter got invalid number of outputs. Expected 0, got ", out.size());
+    OV_CPU_JIT_EMITTER_ASSERT(in.empty(), "got invalid number of inputs. Expected 0, got ", in.size());
+    OV_CPU_JIT_EMITTER_ASSERT(out.empty(), "got invalid number of outputs. Expected 0, got ", out.size());
     const auto num_params = num_inputs + num_outputs + num_unique_buffers;
-    OPENVINO_ASSERT(data_ptr_regs_idx.size() == num_params,
-                    "jit_kernel_emitter: number of inputs and outputs is inconsistent with the number of allocated registers ", num_params,
-                    " data_ptr_regs_idx.size() = ", data_ptr_regs_idx.size());
+    OV_CPU_JIT_EMITTER_ASSERT(data_ptr_regs_idx.size() == num_params,
+                              "number of inputs and outputs is inconsistent with the number of allocated registers ", num_params,
+                              " data_ptr_regs_idx.size() = ", data_ptr_regs_idx.size());
 }
 
 void jit_kernel_emitter::init_data_pointers(const Xbyak::Reg64& reg_indexes, const Xbyak::Reg64& reg_const_params,

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
@@ -15,7 +15,7 @@ namespace intel_cpu {
 jit_loop_begin_emitter::jit_loop_begin_emitter(jit_generator* h, cpu_isa_t isa, const ov::snippets::lowered::ExpressionPtr& expr)
     : jit_emitter(h, isa) {
     loop_begin = ov::as_type_ptr<snippets::op::LoopBegin>(expr->get_node());
-    OPENVINO_ASSERT(loop_begin != nullptr, "jit_loop_begin_emitter invoked with invalid op argument");
+    OV_CPU_JIT_EMITTER_ASSERT(loop_begin != nullptr, "invoked with invalid op argument");
     const auto loop_end = get_loop_end(expr);
     work_amount = loop_end->get_work_amount();
     evaluate_once = loop_end->get_evaluate_once();
@@ -23,11 +23,11 @@ jit_loop_begin_emitter::jit_loop_begin_emitter(jit_generator* h, cpu_isa_t isa, 
 }
 
 std::shared_ptr<snippets::op::LoopEnd> jit_loop_begin_emitter::get_loop_end(const ov::snippets::lowered::ExpressionPtr& expr) {
-    OPENVINO_ASSERT(expr->get_output_port_connectors().size() == 1, "jit_loop_begin_emitter has invalid LoopBegin expression configuration");
+    OV_CPU_JIT_EMITTER_ASSERT(expr->get_output_port_connectors().size() == 1, "has invalid LoopBegin expression configuration");
     const auto& consumers = expr->get_output_port_connector(0)->get_consumers();
-    OPENVINO_ASSERT(consumers.size() == 1, "jit_loop_begin_emitter has invalid LoopBegin expression configuration");
+    OV_CPU_JIT_EMITTER_ASSERT(consumers.size() == 1, "has invalid LoopBegin expression configuration");
     const auto loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(consumers.cbegin()->get_expr()->get_node());
-    OPENVINO_ASSERT(loop_end != nullptr, "jit_loop_begin_emitter has invalid LoopBegin expression configuration");
+    OV_CPU_JIT_EMITTER_ASSERT(loop_end != nullptr, "has invalid LoopBegin expression configuration");
     return loop_end;
 }
 
@@ -38,8 +38,8 @@ void jit_loop_begin_emitter::emit_code(const std::vector<size_t> &in, const std:
 }
 
 void jit_loop_begin_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
-    OPENVINO_ASSERT(in.empty(), "Invalid inputs size: expected 0 got ", in.size());
-    OPENVINO_ASSERT(out.size() == 1, "Invalid outputs size: expected 1 got ", out.size());
+    OV_CPU_JIT_EMITTER_ASSERT(in.empty(), "Invalid inputs size: expected 0 got ", in.size());
+    OV_CPU_JIT_EMITTER_ASSERT(out.size() == 1, "Invalid outputs size: expected 1 got ", out.size());
 }
 
 void jit_loop_begin_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
@@ -59,7 +59,7 @@ void jit_loop_begin_emitter::emit_impl(const std::vector<size_t>& in, const std:
 jit_loop_end_emitter::jit_loop_end_emitter(jit_generator* h, cpu_isa_t isa, const ov::snippets::lowered::ExpressionPtr& expr)
     : jit_emitter(h, isa) {
     loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(expr->get_node());
-    OPENVINO_ASSERT(loop_end != nullptr, "jit_loop_end_emitter invoked with invalid op argument");
+    OV_CPU_JIT_EMITTER_ASSERT(loop_end != nullptr, "invoked with invalid op argument");
     loop_begin = loop_end->get_loop_begin();
     // Note that 1 edge connects LoopBegin and LoopEnd
     num_inputs = expr->get_input_count();
@@ -83,10 +83,11 @@ void jit_loop_end_emitter::emit_code(const std::vector<size_t> &in, const std::v
 
 void jit_loop_end_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
     const auto io_size = num_inputs - 1;
-    OPENVINO_ASSERT(in.size() == num_inputs, "Invalid number of in arguments: expected ", num_inputs , " got ", in.size());
-    OPENVINO_ASSERT(out.size() == num_outputs, "Invalid number of out arguments: expected ", num_outputs, " got ", out.size());
-    OPENVINO_ASSERT(ptr_increments.size() == io_size, "Invalid ptr_increments size: expected ", io_size, " got ", ptr_increments.size());
-    OPENVINO_ASSERT(finalization_offsets.size() == io_size, "Invalid finalization_offsets size: expected ", io_size, " got ", finalization_offsets.size());
+    OV_CPU_JIT_EMITTER_ASSERT(in.size() == num_inputs, "Invalid number of in arguments: expected ", num_inputs , " got ", in.size());
+    OV_CPU_JIT_EMITTER_ASSERT(out.size() == num_outputs, "Invalid number of out arguments: expected ", num_outputs, " got ", out.size());
+    OV_CPU_JIT_EMITTER_ASSERT(ptr_increments.size() == io_size, "Invalid ptr_increments size: expected ", io_size, " got ", ptr_increments.size());
+    OV_CPU_JIT_EMITTER_ASSERT(finalization_offsets.size() == io_size,
+                              "Invalid finalization_offsets size: expected ", io_size, " got ", finalization_offsets.size());
 }
 
 void jit_loop_end_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_snippets_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_snippets_emitters.cpp
@@ -32,10 +32,10 @@ jit_broadcast_move_emitter::jit_broadcast_move_emitter(jit_generator* h, cpu_isa
     : jit_emitter(h, isa) {
     const auto n = expr->get_node();
     if (n->get_input_element_type(0) != n->get_output_element_type(0))
-        OPENVINO_THROW("jit_broadcast_move_emitter supports only equal input and output types but gets: ",
-                       n->get_input_element_type(0),
-                       " and ",
-                       n->get_output_element_type(0));
+        OV_CPU_JIT_EMITTER_THROW("supports only equal input and output types but gets: ",
+                              n->get_input_element_type(0),
+                              " and ",
+                              n->get_output_element_type(0));
     byte_size = n->get_input_element_type(0).size();
 }
 
@@ -48,7 +48,7 @@ void jit_broadcast_move_emitter::emit_impl(const std::vector<size_t>& in,
     } else if (host_isa_ == dnnl::impl::cpu::x64::avx512_core) {
         emit_isa<dnnl::impl::cpu::x64::avx512_core>(in, out);
     } else {
-        OPENVINO_THROW("BroadcastMove emitter doesn't support ", host_isa_);
+        OV_CPU_JIT_EMITTER_THROW("Unsupported ISA ", host_isa_);
     }
 }
 
@@ -63,7 +63,7 @@ void jit_broadcast_move_emitter::emit_isa(const std::vector<size_t> &in, const s
         case 4: h->uni_vbroadcastss(vmm_dst, xmm_src0); break;
         case 2: h->vpbroadcastw(vmm_dst, xmm_src0); break;
         case 1: h->vpbroadcastb(vmm_dst, xmm_src0); break;
-        default: OPENVINO_THROW("unsupported data type");
+        default: OV_CPU_JIT_EMITTER_THROW("unsupported data type");
     }
 }
 
@@ -80,7 +80,7 @@ jit_scalar_emitter::jit_scalar_emitter(jit_generator* h, cpu_isa_t isa, const Ex
             break;
         }
         default: {
-            OPENVINO_THROW("Scalar emitter doesn't support ", precision);
+            OV_CPU_JIT_EMITTER_THROW("doesn't support ", precision);
         }
     }
     push_arg_entry_of("scalar", value, true);
@@ -95,7 +95,7 @@ void jit_scalar_emitter::emit_impl(const std::vector<size_t>& in, const std::vec
     } else if (host_isa_ == dnnl::impl::cpu::x64::avx512_core) {
         emit_isa<dnnl::impl::cpu::x64::avx512_core>(in, out);
     } else {
-        OPENVINO_THROW("Scalar emitter doesn't support ", host_isa_);
+        OV_CPU_JIT_EMITTER_THROW("Unsupported isa ", host_isa_);
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/utils.cpp
+++ b/src/plugins/intel_cpu/src/emitters/utils.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "utils.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+std::string jit_emitter_pretty_name(const std::string &pretty_func) {
+#define SAFE_SYMBOL_FINDING(idx, find) \
+    auto idx = (find); \
+    if (idx == std::string::npos || idx == 0) \
+        return pretty_func;
+    // Example:
+    //      pretty_func := void ov::intel_cpu::jit_load_memory_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const
+    //      begin := -----------|
+    //      end := ---------------------------------------------------|
+    //      result := ov::intel_cpu::jit_load_memory_emitter
+    // Signatures:
+    //      GCC:   void foo() [with T = {type}]
+    //      clang: void foo() [T = {type}]
+    //      MSVC:  void __cdecl foo<{type}>(void)
+    SAFE_SYMBOL_FINDING(parenthesis, pretty_func.find("("))
+    if (pretty_func[parenthesis - 1] == '>') { // To cover template on MSVC
+        parenthesis--;
+        size_t counter = 1;
+        while (counter != 0 && parenthesis > 0) {
+            parenthesis--;
+            if (pretty_func[parenthesis] == '>') counter++;
+            if (pretty_func[parenthesis] == '<') counter--;
+        }
+    }
+    SAFE_SYMBOL_FINDING(end, pretty_func.substr(0, parenthesis).rfind("::"))
+    SAFE_SYMBOL_FINDING(begin, pretty_func.substr(0, end).rfind(" "))
+    begin++;
+#undef SAFE_SYMBOL_FINDING
+    return end > begin ? pretty_func.substr(begin, end - begin) : pretty_func;
+}
+
+} // namespace intel_cpu
+} // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/utils.hpp
+++ b/src/plugins/intel_cpu/src/emitters/utils.hpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+
+namespace ov {
+namespace intel_cpu {
+
+std::string jit_emitter_pretty_name(const std::string &pretty_func);
+
+#ifdef __GNUC__
+#define OV_CPU_JIT_EMITTER_NAME jit_emitter_pretty_name(__PRETTY_FUNCTION__)
+#else /* __GNUC__ */
+#define OV_CPU_JIT_EMITTER_NAME jit_emitter_pretty_name(__FUNCSIG__)
+#endif /* __GNUC__ */
+
+#define OV_CPU_JIT_EMITTER_THROW(...) OPENVINO_THROW(OV_CPU_JIT_EMITTER_NAME, ": ", __VA_ARGS__)
+#define OV_CPU_JIT_EMITTER_ASSERT(cond, ...) OPENVINO_ASSERT((cond), OV_CPU_JIT_EMITTER_NAME, ": ", __VA_ARGS__)
+
+} // namespace intel_cpu
+} // namespace ov


### PR DESCRIPTION
### Details:
 - *Added new files `name_` to `jit_emitter` to make exception messages more informative: now each emitter throws exception with prefix `The emitter <name_> ...`.*

- *The example:*
 ```
./bin/intel64/Release/ov_cpu_func_tests --gtest_filter='*smoke_Snippets*'
[ RUN      ] smoke_Snippets_Eltwise/Add.CompareWithRefImpl/IS[0]=[]_TS[0]=((1.16.29.31))_IS[1]=[]_TS[1]=((1.16.29.1))_T=f32_#N=1_#S=1_targetDevice=CPU

MEM_USAGE=773124KB
src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp:90: Failure
Exception from src/inference/src/core.cpp:99:
[ GENERAL_ERROR ] Check 'false' failed at src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.cpp:182:
The emitter jit_nop_emitter throws test exception


unknown file: Failure
C++ exception with description "Exception from src/inference/src/compiled_model.cpp:35:
CompiledModel was not initialized.
" thrown in the test body.
[  FAILED  ] smoke_Snippets_Eltwise/Add.CompareWithRefImpl/IS[0]=[]_TS[0]=((1.16.29.31))_IS[1]=[]_TS[1]=((1.16.29.1))_T=f32_#N=1_#S=1_targetDevice=CPU, where GetParam() = (({}, { { 1, 16, 29, 31 } }), ({}, { { 1, 16, 29, 1 } }), f32, 1, 1, "CPU") (12 ms)
 ```
 
 #### Updated (17/01):
  - *Added macros `OV_CPU_JIT_EMITTER_THROW` and `OV_CPU_JIT_EMITTER_ASSERT` (that are declared in [emitter.hpp](https://github.com/a-sidorova/openvino/blob/81b19d76ed15a44876b08fc79d56a5a14b02cb0f/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp#L42)) - inserted name of jit emitter with namespaces (using `__PRETTY_FUNC__` with GNU and `__FUNCSIG__` without GNU) and text of exception.*
  - *The example of exception in Release build on Ubuntu:*
```
src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp:90: Failure
Exception from src/inference/src/core.cpp:99:
[ GENERAL_ERROR ] Exception from src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp:60:
ov::intel_cpu::jit_add_emitter: Test throw from jit_add_emitter
```
  - *The example of exception in Release build on Windows:*
```
src\tests\functional\shared_test_classes\src\base\ov_subgraph.cpp(90): error: Exception from src\inference\src\core.cpp:102:

src\inference\src\ie_common.cpp:71 [ GENERAL_ERROR ] Exception from src\plugins\intel_cpu\src\emitters\plugin\x64\jit_eltwise_emitters.cpp:60:
ov::intel_cpu::jit_add_emitter: Test assert from jit_add_emitter
```
  - *The example of assertion in Release build on Ubuntu:*
```
src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp:90: Failure
Exception from src/inference/src/core.cpp:99:
[ GENERAL_ERROR ] Check '(false)' failed at src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp:60:
ov::intel_cpu::jit_add_emitter: Test assert from jit_add_emitter
```
  - *The example of assertion in Release build on Windows:*
```
src\tests\functional\shared_test_classes\src\base\ov_subgraph.cpp(90): error: Exception from src\inference\src\core.cpp:102:

src\inference\src\ie_common.cpp:71 [ GENERAL_ERROR ] Check '(false)' failed at src\plugins\intel_cpu\src\emitters\plugin\x64\jit_eltwise_emitters.cpp:60:
ov::intel_cpu::jit_add_emitter: Test assert from jit_add_emitter
```

### Tickets:
 - *N/A*
