### PR TITLE
Add link to Intel DevHub Discord to GFI template and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -42,6 +42,7 @@ body:
           discussions, guides.
       value: |
           - [Contribution guide - start here!](https://github.com/openvinotoolkit/openvino/blob/master/CONTRIBUTING.md)
+          - [Intel DevHub Discord channel](https://discord.gg/wPuqAujS) - engage in discussions, ask questions and talk to OpenVINO developers
     validations:
       required: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ Choose the component your Good First Issue is related to. You can run tests to m
 
 ### 3. Start working on your Good First Issue
 
-Use the issue description and locally built OpenVINO to complete the task. Remember that you can always ask users tagged in the "Contact points" section for help! You can also visit [Intel DevHub Discord server](https://discord.gg/wPuqAujS) and ask questions in the channel dedicated for Good First Issue support.
+Use the issue description and locally built OpenVINO to complete the task. Remember that you can always ask users tagged in the "Contact points" section for help! You can also visit [Intel DevHub Discord server](https://discord.gg/wPuqAujS) and ask questions in the channel dedicated to Good First Issue support.
 
 ### 4. Submit a PR with your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ You can start with the following links:
 - [User documentation](https://docs.openvino.ai/)
 - [Blog post on contributing to OpenVINO](https://medium.com/openvino-toolkit/how-to-contribute-to-an-ai-open-source-project-c741f48e009e)
 - [Pick up a Good First Issue](https://github.com/orgs/openvinotoolkit/projects/3)
+- Check out [Intel DevHub Discord server](https://discord.gg/wPuqAujS) - engage in discussions, ask questions and talk to OpenVINO developers
 
 ### 2. Building the project
 
@@ -138,7 +139,7 @@ Choose the component your Good First Issue is related to. You can run tests to m
 
 ### 3. Start working on your Good First Issue
 
-Use the issue description and locally built OpenVINO to complete the task. Remember that you can always ask users tagged in the "Contact points" section for help!
+Use the issue description and locally built OpenVINO to complete the task. Remember that you can always ask users tagged in the "Contact points" section for help! You can also visit [Intel DevHub Discord server](https://discord.gg/wPuqAujS) and ask questions in the channel dedicated for Good First Issue support.
 
 ### 4. Submit a PR with your changes
 

--- a/README.md
+++ b/README.md
@@ -171,10 +171,13 @@ See [How to build OpenVINO](./docs/dev/build.md) to get more information about t
 See [Contributions Welcome](https://github.com/openvinotoolkit/openvino/issues/17502) for good first issues.
 
 See [CONTRIBUTING](./CONTRIBUTING.md) for contribution details. Thank you!
+
+Visit [Intel DevHub Discord server](https://discord.gg/wPuqAujS) if you need help or wish to talk to OpenVINO developers. You can go to the channel dedicated to Good First Issue support if you are working on a task.
+
 ## Take the issue
 If you wish to be assigned to an issue please add a comment with `.take` command.  
 
-## Get a support
+## Get support
 
 Report questions, issues and suggestions, using:
 


### PR DESCRIPTION
### Details:
 - Modify GFI template with link to Intel DevHub Discord server
 - Add the link to the docs as well

### Tickets:
 - N/A
