### PR TITLE
[CPU] Update Node constant type when adding or removing parent edges

### DIFF
--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -51,19 +51,6 @@ bool Edge::isDropped() const {
     return not_in_parent && not_in_child;
 }
 
-void Edge::drop() {
-    auto dropFrom = [] (const Edge* edge, std::vector<EdgeWeakPtr> &edges) {
-        edges.erase(std::remove_if(edges.begin(), edges.end(),
-                                   [&edge] (EdgeWeakPtr _edge) {
-                                       return _edge.lock().get() == edge;
-                                   }),
-                    edges.end());
-    };
-
-    dropFrom(this, getParent()->childEdges);
-    dropFrom(this, getChild()->parentEdges);
-}
-
 void Edge::collectConsumers(std::vector<NodePtr>& result) const {
     if (!this->getChild()->getChildEdges().empty() && this->inPlace(LOOK_DOWN)) {
         if (auto peerChildSPD = this->getChild()->getSelectedPrimitiveDescriptor()) {

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -56,7 +56,6 @@ public:
     void externalAllocate(WeightsSharing::Ptr weightsCache);
     void reuse(MemoryPtr ptr);
     void validate();
-    void drop();
 
     const std::shared_ptr<Node> getParent() const;
     const std::shared_ptr<Node> getChild() const;

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -1745,8 +1745,9 @@ void GraphOptimizer::FuseConvolutionSumAndConvolutionSumActivation(Graph &graph)
             }
         }
 
-        int peer_port = peerNode->getChildEdgeAt(childIdx)->getInputNum();
-        peerNode->getChildEdgeAt(childIdx)->drop();
+        auto peerEdge = peerNode->getChildEdgeAt(childIdx);
+        const int peer_port = peerEdge->getInputNum();
+        graph.RemoveEdge(peerEdge);
 
         int childPort = 1;
         auto* mergedConvNode = dynamic_cast<Convolution*>(mergedConv.get());

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -80,7 +80,7 @@ Node::Node(const std::shared_ptr<ov::Node>& op,
     : selectedPrimitiveDescriptorIndex(-1),
       permanent(false),
       temporary(false),
-      constant(ConstantType::Unknown),
+      constant(ConstantType::NoConst),
       context(ctx),
       algorithm(Algorithm::Default),
       fusingPort(-1),
@@ -186,7 +186,7 @@ Node::Node(const std::string& type, const std::string& name, const GraphContext:
     : selectedPrimitiveDescriptorIndex(-1),
       permanent(false),
       temporary(false),
-      constant(ConstantType::Unknown),
+      constant(ConstantType::NoConst),
       context(ctx),
       fusingPort(-1),
       engine(ctx->getEngine()),
@@ -197,17 +197,13 @@ Node::Node(const std::string& type, const std::string& name, const GraphContext:
     // TODO [NM]: What about filling inDims and outDims?
 }
 
-void Node::addEdge(const EdgeWeakPtr& edge) {
-    auto edgePtr = edge.lock();
-    if (!edgePtr)
-        return;
-    auto parentPtr = edgePtr->getParent();
-    auto childPtr = edgePtr->getChild();
-    if (!parentPtr || !childPtr)
-        return;
+void Node::addEdge(const EdgePtr& edge) {
+    auto parent = edge->getParent();
+    auto child = edge->getChild();
+    assert(parent && child);
 
-    parentPtr->addChildEdge(edge);
-    childPtr->addParentEdge(edge);
+    parent->addChildEdge(edge);
+    child->addParentEdge(edge);
 }
 
 void Node::remove() {
@@ -215,7 +211,8 @@ void Node::remove() {
         for (auto& edge : edges) {
             auto edgePtr = edge.lock();
             if (!edgePtr) continue;
-            edgePtr->drop();
+            edgePtr->getParent()->removeChildEdge(edgePtr);
+            edgePtr->getChild()->removeParentEdge(edgePtr);
         }
     };
 
@@ -955,26 +952,26 @@ Node::ConstantType Node::getConstantType() const {
 }
 
 bool Node::isConstant() {
-    if (getConstantType() == ConstantType::Unknown)
-        updateConstantType();
     return getConstantType() == ConstantType::Const;
 }
 
 void Node::updateConstantType() {
-    if (constant != ConstantType::StrictNoConst) {
-        bool isConst = true;
-        for (const auto& parentEdge : getParentEdges()) {
-            isConst &= parentEdge.lock()->getParent()->isConstant();
-        }
-        constant = isConst ? ConstantType::Const : ConstantType::NoConst;
+    if (constant == ConstantType::StrictNoConst)
+        return;
+
+    bool isConst = true;
+    for (const auto& parentEdge : getParentEdges()) {
+        isConst &= parentEdge.lock()->getParent()->isConstant();
     }
+
+    const auto prevConstantType = constant;
+    constant = isConst ? ConstantType::Const : ConstantType::NoConst;
+    if (constant == prevConstantType)
+        return; // state has not changed, no reason to continue
 
     for (const auto& childEdge : getChildEdges()) {
         const auto childNode = childEdge.lock()->getChild();
-        const auto childConstType = childNode->getConstantType();
-        if (!one_of(childConstType, ConstantType::Unknown, ConstantType::StrictNoConst, constant)) {
-            childNode->updateConstantType();
-        }
+        childNode->updateConstantType();
     }
 }
 

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -171,17 +171,27 @@ public:
 
     // @todo the method is used when graph is "preconstructed" before creation of the actual graph object
     // remove, as soon edges are added via Graph interface exclusively
-    static void addEdge(const EdgeWeakPtr& edge);
+    static void addEdge(const EdgePtr& edge);
 
     virtual void cleanup();
     void remove();
 
-    void addParentEdge(const EdgeWeakPtr& edge) {
+    void addParentEdge(const EdgePtr& edge) {
         parentEdges.push_back(edge);
+        updateConstantType();
     }
 
-    void addChildEdge(const EdgeWeakPtr& edge) {
+    void addChildEdge(const EdgePtr& edge) {
         childEdges.push_back(edge);
+    }
+
+    void removeParentEdge(const EdgePtr edge) {
+        removeEdge(edge, parentEdges);
+        updateConstantType();
+    }
+
+    void removeChildEdge(const EdgePtr edge) {
+        removeEdge(edge, childEdges);
     }
 
     const std::vector<EdgeWeakPtr> &getParentEdges() const noexcept {
@@ -217,7 +227,6 @@ public:
     }
 
     enum class ConstantType {
-        Unknown,        // Unknown ConstantType is used before the constancy determination procedure run
         Const,          // Node is placed in a constant subgraph
         NoConst,        // Node is placed in a non-constant subgraph
         StrictNoConst,  // Node produces non-constant subgraph: this type can't be changed and it does not depend on the parent nodes' ConstantType.
@@ -617,7 +626,7 @@ protected:
         NoInPlace
     };
     mutable InPlaceType inplace = InPlaceType::Unknown;
-    ConstantType constant = ConstantType::Unknown;
+    ConstantType constant = ConstantType::NoConst;
     std::vector<MemoryPtr> internalBlobs;
     std::vector<MemoryPtr> internalBlobMemory;
     std::vector<NodeDesc> supportedPrimitiveDescriptors;
@@ -711,6 +720,16 @@ protected:
     std::shared_ptr<IShapeInfer> shapeInference;
 
 private:
+    static void removeEdge(const EdgePtr edge, std::vector<EdgeWeakPtr> &edges) {
+        edges.erase(std::remove_if(edges.begin(), edges.end(),
+                                   [&edge] (EdgeWeakPtr _edge) {
+                                       return _edge.lock() == edge;
+                                   }),
+                    edges.end());
+    }
+
+    bool isEdgesEmpty(const std::vector<EdgeWeakPtr>& edges) const;
+
     std::vector<EdgeWeakPtr> parentEdges;
     std::vector<EdgeWeakPtr> childEdges;
 
@@ -732,8 +751,6 @@ private:
     PerfCounters profiling;
 
     MemoryPtr scratchpadMem;
-
-    bool isEdgesEmpty(const std::vector<EdgeWeakPtr>& edges) const;
 
     // Hold output scales
     std::vector<float> DQScales;

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -227,8 +227,7 @@ Input::Input(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr conte
                                        op->get_type_name(),
                                        " with name ",
                                        op->get_friendly_name());
-
-    constant = ConstantType::NoConst;
+    constant = ConstantType::StrictNoConst;
 
     constOp = ov::as_type_ptr<op::v0::Constant>(op);
     if (constOp) {

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -218,21 +218,21 @@ jit_has_subnormals_base::fn_t jit_has_subnormals_function() {
 Input::Input(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
         : Node(op, context, PassThroughShapeInferFactory()) {
     if (!one_of(op->get_type_info(),
-            op::v0::Parameter::get_type_info_static(),
-            op::v0::Constant::get_type_info_static(),
-            op::v0::Result::get_type_info_static(),
-            op::v3::ReadValue::get_type_info_static(),
-            op::v6::ReadValue::get_type_info_static()))
+                op::v0::Parameter::get_type_info_static(),
+                op::v0::Constant::get_type_info_static(),
+                op::v0::Result::get_type_info_static(),
+                op::v3::ReadValue::get_type_info_static(),
+                op::v6::ReadValue::get_type_info_static()))
         OPENVINO_THROW_NOT_IMPLEMENTED("CPU Input node doesn't support ngraph operation ",
                                        op->get_type_name(),
                                        " with name ",
                                        op->get_friendly_name());
-    constant = ConstantType::StrictNoConst;
-
     constOp = ov::as_type_ptr<op::v0::Constant>(op);
     if (constOp) {
         constant = ConstantType::Const;
         cloneBlobIfRequired();
+    } else {
+        constant = ConstantType::StrictNoConst;
     }
 }
 


### PR DESCRIPTION
### Details:
 - Change approach for updating node constant type (whether the Node is located on a constant path)
 - Remove Unknown constant type
 - Assign NoConst by default
 - Update a constant type of the current node and its childs when a parent edge is added / removed