### PR TITLE
[CPU]Reshape in place is not applicable when input is shared

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -104,8 +104,7 @@ void Reshape::initSupportedPrimitiveDescriptors() {
     bool canBeInPlace = true;
 
     // CVS-81059 : disable inPlace in following case since it won't be satisfied by framework
-    if ((!isConstant() && getParentEdgeAt(0)->getParent()->isConstant()) ||
-        (getParentEdgeAt(0)->getParent()->getChildEdges().size() != 1))
+    if (!isConstant() && getParentEdgeAt(0)->getParent()->isConstant())
         canBeInPlace = false;
 
     NodeConfig config;

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -104,7 +104,8 @@ void Reshape::initSupportedPrimitiveDescriptors() {
     bool canBeInPlace = true;
 
     // CVS-81059 : disable inPlace in following case since it won't be satisfied by framework
-    if (!isConstant() && getParentEdgeAt(0)->getParent()->isConstant())
+    if ((!isConstant() && getParentEdgeAt(0)->getParent()->isConstant()) ||
+        (getParentEdgeAt(0)->getParent()->getChildEdges().size() != 1))
         canBeInPlace = false;
 
     NodeConfig config;

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_inplace.cpp
@@ -99,8 +99,8 @@ TEST_F(InPlaceReshapeFromConstantCheck, smoke_CPU_InPlaceReshapeFromConstantChec
  *                   |
  *                result1
  *
- *  If parent of reshape is shared, reshape in place should be not applicable.
- *  This is becuase multiple branches could change data on the same port, then pollute result each other.
+ *  The same memory is shared between the `result2` input and `MVN` output. The CPU graph inplace memory conflict
+ *  resolution logic must prevent `result2` data being rewritten by the MVN node.
  */
 
 class InPlaceReshapeShareInputCheck : public SubgraphBaseTest {


### PR DESCRIPTION
### Details:
 - *Reshape in place is not applicable when input is shared*

### Tickets:
 - *CVS-128618*
