### PR TITLE
Revert setting stable=true

### DIFF
--- a/src/frontends/tensorflow_common/src/op/arg_min_max.cpp
+++ b/src/frontends/tensorflow_common/src/op/arg_min_max.cpp
@@ -36,7 +36,7 @@ OutputVector translate_arg_min_max(const NodeContext& node, std::string mode) {
     auto k = make_shared<v0::Constant>(element::i64, Shape{}, 1);
     auto top_k_mode = (mode == "max" ? v11::TopK::Mode::MAX : v11::TopK::Mode::MIN);
     auto sort_type = v11::TopK::SortType::SORT_VALUES;
-    auto top_k = make_shared<v11::TopK>(input, k, axis, top_k_mode, sort_type, output_type, true);
+    auto top_k = make_shared<v11::TopK>(input, k, axis, top_k_mode, sort_type, output_type);
 
     auto axis_to_remove = make_shared<v0::Constant>(element::i64, Shape{1}, vector<int64_t>({axis}));
     auto res = make_shared<v0::Squeeze>(top_k->output(1), axis_to_remove);

--- a/tests/layer_tests/tensorflow_tests/test_tf_ArgMinMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ArgMinMax.py
@@ -19,7 +19,8 @@ class TestArgMinMax(CommonTFLayerTest):
         input_shape = inputs_info['input']
         inputs_data = {}
         rng = np.random.default_rng()
-        inputs_data['input'] = rng.integers(-8, 8, input_shape).astype(self.input_type)
+        # Because unstable sorting is chosen by default, input tensor with unrepeated elements should be generated.
+        inputs_data['input'] = rng.choice(np.product(input_shape), size=input_shape, replace=False).astype(self.input_type)
         return inputs_data
 
     def create_argmin_max_net(self, input_shape, dimension, input_type, output_type, op_type):


### PR DESCRIPTION
### Details:
 - *Revert setting stable=true for topk node. Unstable sorting was chosen by default because generally it has better performance than stable sorting.*

### Tickets:
 - *[127202](https://jira.devtools.intel.com/browse/CVS-127202)*
