### PR TITLE
Cmake Python build option flags should be added to the command in ste…

### DIFF
--- a/docs/dev/build_windows.md
+++ b/docs/dev/build_windows.md
@@ -55,7 +55,7 @@ Supported configurations:
       ```sh
       pip install -r <path\to\openvino>\src\bindings\python\src\compatibility\openvino\requirements-dev.txt
       ```
-  2. Second, enable the `-DENABLE_PYTHON=ON` in the CMake (Step #4) option above. To specify an exact Python version, use the following options (requires cmake 3.16 and higher):
+  2. Second, enable the `-DENABLE_PYTHON=ON` in the CMake (Step #3) option above. To specify an exact Python version, use the following options (requires cmake 3.16 and higher):
      ```sh
      -DPython3_EXECUTABLE="C:\Program Files\Python11\python.exe"
      ```


### PR DESCRIPTION
CMake Python build optional flags should be added to the command in Step#3 and not Step#4 as written in the build instructions for Windows. I fixed this trivial typo
