### PR TITLE
[CPU] Rework accessing node's parent and child edges

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -176,6 +176,15 @@ public:
 
     virtual void* getData() const = 0; // pointer to the actual memory
 
+    template <typename T, typename datatype = typename std::decay<T>::type>
+    T* getDataAs() const {
+        /** @todo enabling this check requires all the nodes to follow this requirement
+         * OPENVINO_ASSERT(element::from<datatype>() == getPrecision(),
+         * "Memory data element type ", getPrecision(), " is not representable as ", element::from<datatype>());
+         */
+        return static_cast<T*>(getData());
+    }
+
     virtual size_t getSize() const = 0; // in bytes
     virtual const Shape& getShape() const = 0;
     virtual const VectorDims& getStaticDims() const = 0;
@@ -191,6 +200,11 @@ public:
 
     //oneDNN specifics for backward compatibility
     virtual dnnl::memory getPrimitive() const = 0;
+
+    ov::element::Type getPrecision() const {
+        return getDesc().getPrecision();
+    }
+
     dnnl::memory::data_type getDataType() const {
         return DnnlExtensionUtils::ElementTypeToDataType(getDesc().getPrecision());
     }

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -70,7 +70,7 @@ void Edge::collectConsumers(std::vector<NodePtr>& result) const {
         if (auto peerChildSPD = childNode->getSelectedPrimitiveDescriptor()) {
             auto peerOutputNum = this->getOutputNum();
             auto peerInPlacePort = peerChildSPD->getConfig().inConfs[peerOutputNum].inPlace();
-            auto& vecChildEdges = childNode->getChildEdgesAtPort(peerInPlacePort);
+            auto vecChildEdges = getChild()->getChildEdgesAtPort(peerInPlacePort);
             for (auto childEdge : vecChildEdges) {
                 childEdge->collectConsumers(result);
             }
@@ -510,7 +510,7 @@ EdgePtr Edge::getBaseEdge(int look) {
         }
         return next_ch_edge;
     } else if (parentInPlacePort >= 0 && (look & LOOK_UP)) {
-        return getParent()->getParentEdgesAtPort(parentInPlacePort)[0];
+        return getParent()->getParentEdgeAt(parentInPlacePort);
     }
 
     auto edgesForSamePort = getParent()->getChildEdgesAtPort(inputNum);

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -210,11 +210,9 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model> &model) {
     for (auto &output : outputNodesMap) {
         const auto& outputNode = output.second;
         const auto precToSet = outputNode->getOriginalInputPrecisionAtPort(0);
-        const auto parentEdges = outputNode->getParentEdgesAtPort(0);
-        for (size_t i = 0; i < parentEdges.size(); i++) {
-            const auto parent = parentEdges[i]->getParent();
-            parent->setOriginalOutputPrecisionAtPort(parentEdges[i]->getInputNum(), precToSet);
-        }
+        const auto parentEdge = outputNode->getParentEdgeAt(0);
+        const auto parent = parentEdge->getParent();
+        parent->setOriginalOutputPrecisionAtPort(parentEdge->getInputNum(), precToSet);
     }
 }
 
@@ -473,7 +471,7 @@ void Graph::ResolveEdgeConflicts() {
                                           inDesc.getPrecision().get_type_name() + "_" + outDesc.getPrecision().get_type_name();
 
                 auto convertNode = std::make_shared<node::Convert>(inDesc.getShape(), inDesc.getPrecision(), outDesc.getPrecision(),
-                                                                       convertName, context);
+                                                                   convertName, context);
                 convertNode->setDescs(inDesc, outDesc);
                 InsertNode(edge, convertNode, true);
 
@@ -1336,41 +1334,21 @@ void Graph::SortTopologically() {
     for (size_t i = 0; i < graphNodes.size(); i++)
         graphNodes[i]->execIndex = static_cast<int>(i);
 
-    // TODO: Sort in/out edges by port index because of backward compatibility
-    //       A lot of plugin logic are build on top of assumption that index in
-    //       vector childEdges/parentEdges is port number. But that is not
-    //       truth anymore. But to keep old logic correct need to simulate ordering.
-    //
-    // Make first N (N == port_num) edge indexes are matched with port index
+    // Sort in / out child edges by port index
+    // Make first N (N == port_num) edge indexes match with port index
     for (auto &node : graphNodes) {
-        {
-            int port_num = node->inputShapes.size();
-            std::vector<EdgePtr> res(port_num);
+        int port_num = node->outputShapes.size();
+        std::vector<EdgePtr> res(port_num);
 
-            for (size_t i = 0; i < node->parentEdges.size(); i++) {
-                auto edge = node->getParentEdgeAt(i);
-                int port = edge->getOutputNum();
-                if (port < port_num && !res[port])
-                    res[port] = edge;
-                else
-                    res.push_back(edge);
-            }
-            node->parentEdges = {res.begin(), res.end()};
+        for (size_t i = 0; i < node->childEdges.size(); i++) {
+            auto edge = node->getChildEdgeAt(i);
+            int port = edge->getInputNum();
+            if (port < port_num && !res[port])
+                res[port] = edge;
+            else
+                res.push_back(edge);
         }
-        {
-            int port_num = node->outputShapes.size();
-            std::vector<EdgePtr> res(port_num);
-
-            for (size_t i = 0; i < node->childEdges.size(); i++) {
-                auto edge = node->getChildEdgeAt(i);
-                int port = edge->getInputNum();
-                if (port < port_num && !res[port])
-                    res[port] = edge;
-                else
-                    res.push_back(edge);
-            }
-            node->childEdges = {res.begin(), res.end()};
-        }
+        node->childEdges = {res.begin(), res.end()};
     }
 }
 
@@ -1521,31 +1499,30 @@ void Graph::RemoveDroppedEdges() {
                      graphEdges.end());
 }
 
-NodePtr Graph::InsertReorder(EdgePtr edge, std::string layerName, const MemoryDesc& inDesc, const MemoryDesc& outDesc,
-                                         bool isOptimized, const std::vector<int> & src_perm) {
-    NodePtr newReorder(new node::Reorder(layerName, context));
-    auto *reorderPtr = dynamic_cast<node::Reorder *>(newReorder.get());
-    if (reorderPtr == nullptr) {
-        OPENVINO_THROW("Graph::InsertReorder: Cannot cast to Reorder");
-    }
-    reorderPtr->setDescs(inDesc, outDesc);
-    reorderPtr->setOptimized(isOptimized);
-    reorderPtr->setSrcPermutation(src_perm);
+NodePtr Graph::InsertReorder(EdgePtr edge,
+                             std::string layerName,
+                             const MemoryDesc& inDesc,
+                             const MemoryDesc& outDesc,
+                             bool isOptimized,
+                             const std::vector<int> & src_perm) {
+    auto reorder = std::make_shared<node::Reorder>(inDesc, outDesc, layerName, context);
+    reorder->setOptimized(isOptimized);
+    reorder->setSrcPermutation(src_perm);
 
-    DEBUG_LOG(reorderPtr->getName(), " edge=", edge->name(), " isOptimized=", isOptimized);
+    DEBUG_LOG(reorder->getName(), " edge=", edge->name(), " isOptimized=", isOptimized);
     DEBUG_LOG("    inDesc: ", inDesc.getShape().toString(), inDesc.getPrecision().get_type_name(), " ", inDesc.serializeFormat());
     DEBUG_LOG("   outDesc: ", outDesc.getShape().toString(), outDesc.getPrecision().get_type_name(), " ", outDesc.serializeFormat());
 
-    InsertNode(edge, newReorder, true);
+    InsertNode(edge, reorder, true);
 
     // Using the method Edge::getDesc() we can check that input and output tensor descriptors are equal.
     // Due to the specificity of GraphOptimizer::MergeTransposeAndReorder() that isOptimized flag uses, we shouldn't do these checks.
     if (!isOptimized) {
-        newReorder->getParentEdgeAt(0)->getDesc();
-        newReorder->getChildEdgeAt(0)->getDesc();
+        reorder->getParentEdgeAt(0)->getDesc();
+        reorder->getChildEdgeAt(0)->getDesc();
     }
 
-    return newReorder;
+    return reorder;
 }
 
 bool Graph::InsertNode(EdgePtr edge, NodePtr node, bool initNode) {
@@ -1662,7 +1639,7 @@ void Graph::EnforceInferencePrecision() {
                 if (node->getOriginalInputPrecisionAtPort(inPort) != ov::element::f32)
                     return true;
 
-                const auto &parent = node->getParentEdgesAtPort(inPort)[0]->getParent();
+                const auto &parent = node->getParentEdgeAt(inPort)->getParent();
                 /* Skip BF16 enforcement for nodes after Constant Inputs for maintaining precision for fusing.
                  * Element type conversion to bf16 is done automatically, if convolution follows up after Constant Inputs
                  * and activation is bf16 */
@@ -1705,7 +1682,7 @@ void Graph::EnforceInferencePrecision() {
 
             // exclude Convert before Range since it may cause precision loss when integter type to LP.
             // TODO: Incorrect subgraph is generated by ONNX FE + ticket 117861.
-            const auto &child = node->getChildEdgesAtPort(i)[0]->getChild();
+            const auto &child = node->getChildEdgeAt(i)->getChild();
             if (child->getType() == Type::Range && node->getType() == Type::Convert)
                 continue;
 
@@ -1818,7 +1795,7 @@ void Graph::resolveInPlaceDirection(const NodePtr& node) const {
                 // the parent node does not use inPlace memory, let's check children
                 std::function<InplaceDirectionType(const NodePtr& node, int portIdx)> searchNonCyclicDirection;
                 searchNonCyclicDirection = [&](const NodePtr& node, int portIdx) -> InplaceDirectionType {
-                    auto& childEdges = node->getChildEdgesAtPort(portIdx);
+                    auto childEdges = node->getChildEdgesAtPort(portIdx);
                     for (auto& edge : childEdges) {
                         auto pChild = edge->getChild();
                         auto result = inPlaceDirection(pChild, PortType::INPUT, edge->getOutputNum());

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1386,10 +1386,6 @@ void Graph::CreateEdge(const NodePtr& parent,
                        int parentPort,
                        int childPort) {
     assert(parentPort >= 0 && childPort >= 0);
-    assert(std::none_of(child->getParentEdges().begin(), child->getParentEdges().end(),
-                        [&childPort](const EdgeWeakPtr& edge){
-                            return edge.lock()->getOutputNum() == childPort;
-                        }));
 
     auto edge = std::make_shared<Edge>(parent, child, parentPort, childPort);
 

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -452,7 +452,7 @@ void SyncInferRequest::set_tensor(const ov::Output<const ov::Node>& in_port, con
                            " are different.");
         }
 
-        const auto& desc = m_graph->getOutputNodeByName(name)->getParentEdgesAtPort(0)[0]->getMemory().getDesc();
+        const auto& desc = m_graph->getOutputNodeByName(name)->getParentEdgeAt(0)->getMemory().getDesc();
         if (!isDynamic && mem_desc_ptr->isCompatible(desc)) {
             m_external_ptr[name] = tensor;
         } else if (m_external_ptr.find(name) != m_external_ptr.end()) {
@@ -513,7 +513,7 @@ void SyncInferRequest::init_tensor(const std::string& name) {
             if (!isDynamic) {
                 auto mem_desc_ptr = MemoryDescUtils::generateCpuBlockedMemoryDesc(tensor);
                 if (mem_desc_ptr->isCompatible(
-                        m_graph->getInputNodeByName(name)->getChildEdgesAtPort(0)[0]->getMemory().getDesc())) {
+                        m_graph->getInputNodeByName(name)->getChildEdgeAt(0)->getMemory().getDesc())) {
                     m_external_ptr[name] = tensor;
                 }
             }
@@ -560,7 +560,7 @@ void SyncInferRequest::init_tensor(const std::string& name) {
                         tensor = std::make_shared<Tensor>(memory);
                     } else {
                         const auto graph_prec =
-                            output->second->getParentEdgesAtPort(0)[0]->getMemory().getDesc().getPrecision();
+                            output->second->getParentEdgeAt(0)->getMemory().getDesc().getPrecision();
                         OutputControlBlock control_block{model_prec, Shape{shape}};
 
                         DEBUG_LOG(name,
@@ -614,7 +614,7 @@ void SyncInferRequest::init_tensor(const std::string& name) {
             m_outputs[name] = tensor;
             if (!port_shape.is_dynamic() && !m_external_ptr.count(name)) {
                 auto desc = MemoryDescUtils::generateCpuBlockedMemoryDesc(tensor);
-                if (desc->isCompatible(output->second->getParentEdgesAtPort(0)[0]->getMemory().getDesc())) {
+                if (desc->isCompatible(output->second->getParentEdgeAt(0)->getMemory().getDesc())) {
                     m_external_ptr[name] = tensor;
                 }
             }

--- a/src/plugins/intel_cpu/src/memory_state.cpp
+++ b/src/plugins/intel_cpu/src/memory_state.cpp
@@ -229,7 +229,7 @@ void VariableStateKVcache::set_state_impl(const ov::SoPtr<ov::ITensor>& state) {
         std::make_shared<CpuBlockedMemoryDesc>(ov::element::i32, Shape{size_B, size_L});
 
     m_hidden_state = std::make_shared<Memory>(get_engine(), mem_desc);
-    auto buff = reinterpret_cast<int*>(m_hidden_state->getData());
+    auto buff = m_hidden_state->getDataAs<int>();
     for (size_t i = 0; i < size_B; ++i) {
         for (size_t j = 0; j < size_L; ++j) {
             buff[i * size_L + j] = i;

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -525,16 +525,20 @@ EdgePtr Node::getChildEdgeAt(size_t idx) const {
     return childEdgePtr;
 }
 
-std::vector<EdgePtr> Node::getChildEdgesAtPort(size_t idx) const {
-    if (idx >= outputShapes.size())
-        OPENVINO_THROW("Node ", getName(), " contains less output ports than ", idx);
+std::vector<EdgePtr> Node::getChildEdgesAtPort(int inputNum) const {
+    if (inputNum < 0)
+        OPENVINO_THROW("Node ", getName(), ". negative input number is not supported ", inputNum);
+
+    if (static_cast<size_t>(inputNum) >= outputShapes.size())
+        OPENVINO_THROW("Node ", getName(), " contains less output ports than ", inputNum);
 
     std::vector<EdgePtr> res;
     for (auto &edge_w : childEdges) {
         auto edge = edge_w.lock();
         if (!edge)
             OPENVINO_THROW("Node ", getName(), " contains dead weak ptr");
-        if (edge->getInputNum() == static_cast<int>(idx)) res.push_back(edge);
+        if (edge->getInputNum() == inputNum)
+            res.push_back(edge);
     }
     return res;
 }

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -99,6 +99,8 @@ Node::Node(const std::shared_ptr<ov::Node>& op,
         originalInputPrecisions.emplace_back(op->get_input_element_type(i));
     }
 
+    parentEdges.reserve(inputShapes.size());
+
     if (typeStr != "Result" && typeStr != "Assign") {
         if (op->get_output_size() == 0) {
             OPENVINO_THROW("Node with type '", typeStr, "' and name '", name, "' does not have any outputs.");
@@ -116,6 +118,8 @@ Node::Node(const std::shared_ptr<ov::Node>& op,
             outputShapes.emplace_back(isScalar ? ov::PartialShape{1} : shape);
             originalOutputPrecisions.emplace_back(op->get_output_element_type(i));
         }
+
+        childEdges.reserve(outputShapes.size());
     }
 
     isDynamic = std::any_of(inputShapes.begin(), inputShapes.end(), [](const Shape& shape){ return shape.isDynamic(); }) ||
@@ -178,17 +182,28 @@ Node::Node(const std::shared_ptr<ov::Node>& op,
     }
 }
 
-Node::Node(const std::string& type, const std::string& name, const GraphContext::CPtr ctx)
-    : selectedPrimitiveDescriptorIndex(-1),
+Node::Node(const std::string& type,
+           std::vector<Shape> inShapes,
+           std::vector<Shape> outShapes,
+           std::vector<ov::element::Type> inputPrecisions,
+           std::vector<ov::element::Type> outputPrecisions,
+           const std::string& name,
+           const GraphContext::CPtr ctx)
+    : inputShapes(std::move(inShapes)),
+      outputShapes(std::move(outShapes)),
+      selectedPrimitiveDescriptorIndex(-1),
       constant(ConstantType::NoConst),
       context(ctx),
+      originalInputPrecisions(std::move(inputPrecisions)),
+      originalOutputPrecisions(std::move(outputPrecisions)),
       fusingPort(-1),
       engine(ctx->getEngine()),
       name(name),
       typeStr(type),
       type(TypeFromName(type)),
       profiling(name) {
-    // TODO [NM]: What about filling inDims and outDims?
+    parentEdges.reserve(inputShapes.size());
+    childEdges.reserve(outputShapes.size());
 }
 
 void Node::addEdge(const EdgePtr& edge) {
@@ -381,7 +396,7 @@ void Node::resolveInPlaceEdges(Edge::LOOK look) {
             if (inplaceInpIndx < 0)
                 continue;
 
-            auto baseMemMngr = getParentEdgesAtPort(inplaceInpIndx).front()->getMemory().getMemoryMngr();
+            auto baseMemMngr = getParentEdgeAt(inplaceInpIndx)->getMemory().getMemoryMngr();
             auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr);
             const auto& childEdges = getChildEdgesAtPort(i);
 
@@ -492,7 +507,7 @@ std::string Node::getPrimitiveDescriptorType() const {
     return str_type;
 }
 
-const EdgePtr Node::getParentEdgeAt(size_t idx) const {
+EdgePtr Node::getParentEdgeAt(size_t idx) const {
     if (idx >= parentEdges.size())
         OPENVINO_THROW("Node ", getName(), " contains less parent edges than ", idx);
     auto parentEdgePtr = parentEdges[idx].lock();
@@ -501,7 +516,7 @@ const EdgePtr Node::getParentEdgeAt(size_t idx) const {
     return parentEdgePtr;
 }
 
-const EdgePtr Node::getChildEdgeAt(size_t idx) const {
+EdgePtr Node::getChildEdgeAt(size_t idx) const {
     if (idx >= childEdges.size())
         OPENVINO_THROW("Node ", getName(), " contains less child edges than ", idx);
     auto childEdgePtr = childEdges[idx].lock();
@@ -510,21 +525,7 @@ const EdgePtr Node::getChildEdgeAt(size_t idx) const {
     return childEdgePtr;
 }
 
-const std::vector<EdgePtr> Node::getParentEdgesAtPort(size_t idx) const {
-    if (idx >= inputShapes.size())
-        OPENVINO_THROW("Node ", getName(), " contains less input ports than ", idx);
-
-    std::vector<EdgePtr> res;
-    for (auto &edge_w : parentEdges) {
-        auto edge = edge_w.lock();
-        if (!edge)
-            OPENVINO_THROW("Node ", getName(), " contains dead weak ptr");
-        if (edge->getOutputNum() == static_cast<int>(idx)) res.push_back(edge);
-    }
-    return res;
-}
-
-const std::vector<EdgePtr> Node::getChildEdgesAtPort(size_t idx) const {
+std::vector<EdgePtr> Node::getChildEdgesAtPort(size_t idx) const {
     if (idx >= outputShapes.size())
         OPENVINO_THROW("Node ", getName(), " contains less output ports than ", idx);
 
@@ -537,7 +538,6 @@ const std::vector<EdgePtr> Node::getChildEdgesAtPort(size_t idx) const {
     }
     return res;
 }
-
 
 std::vector<memory::format_tag> Node::getAvailableFormatsForDims(const Shape &dims) const {
     if (dims.getRank() == 0)
@@ -875,7 +875,7 @@ void Node::prepareMemory(dnnl::primitive_desc_iterator& itpd) {
 MemoryPtr Node::prepareWeightMemory(DnnlMemoryDescPtr dstWeightDesc, DnnlMemoryDescPtr srcWeightDesc) {
     if (!getParentEdgeAt(1)->getParent()->isConstant())
         OPENVINO_THROW("Weight input is not const for node ", getName(), ".");
-    auto edgeMem = getParentEdgeAt(1)->getMemoryPtr();
+    auto edgeMem = getSrcMemoryAtPort(1);
     if (!edgeMem)
         OPENVINO_THROW("Cannot get const weights edgeMem for node ", getName(), ".");
 
@@ -1340,7 +1340,7 @@ bool Node::canBePerformedAsScaleShift(const Node *parentNode) const {
     const auto channelAxis = parentNode->getFusingAxis();
 
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        Node *node = getParentEdgesAtPort(i)[0]->getParent().get();
+        Node *node = getParentEdgeAt(i)->getParent().get();
         if (node == nullptr) {
             OPENVINO_THROW("Cannot get parent node for ", getName(), " on ", i, " port");
         }
@@ -1359,7 +1359,7 @@ bool Node::canBePerformedAsScaleShift(const Node *parentNode) const {
             if (i == fusingPort)
                 continue;
             auto& weightShape = getInputShapeAtPort(i).getDims();
-            if (getParentEdgesAtPort(i)[0]->getParent()->getChildEdges().size() != 1 ||
+            if (getParentEdgeAt(i)->getParent()->getChildEdges().size() != 1 ||
                 !isPerTensorOrPerChannelBroadcastable(dataShape, weightShape, channelAxis, true))
                 return false;
         }
@@ -1411,15 +1411,15 @@ std::pair<std::vector<float>, std::vector<float>> Node::getScalesAndShifts(const
                     elementsCount);
     };
 
-    const auto constPort = getParentEdgesAtPort(0)[0]->getParent().get() == parentNode ? 1 : 0;
+    const auto constPort = getParentEdgeAt(0)->getParent().get() == parentNode ? 1 : 0;
 
     if (one_of(getAlgorithm(), Algorithm::EltwiseMultiply, Algorithm::EltwiseDivide, Algorithm::EltwisePrelu)) {
-        fillValuesFrom(getParentEdgesAtPort(constPort)[0]->getParent(), scales);
+        fillValuesFrom(getParentEdgeAt(constPort)->getParent(), scales);
     } else if (one_of(getAlgorithm(), Algorithm::EltwiseAdd, Algorithm::EltwiseSubtract)) {
-        fillValuesFrom(getParentEdgesAtPort(constPort)[0]->getParent(), shifts);
+        fillValuesFrom(getParentEdgeAt(constPort)->getParent(), shifts);
     } else if (one_of(getAlgorithm(), Algorithm::EltwiseMulAdd)) {
-        fillValuesFrom(getParentEdgesAtPort(1)[0]->getParent(), scales);
-        fillValuesFrom(getParentEdgesAtPort(2)[0]->getParent(), shifts);
+        fillValuesFrom(getParentEdgeAt(1)->getParent(), scales);
+        fillValuesFrom(getParentEdgeAt(2)->getParent(), shifts);
     } else if (one_of(getAlgorithm(), Algorithm::EltwisePowerStatic)) {
         const auto power = dynamic_cast<const Eltwise *>(this);
         if (!power) {
@@ -1464,7 +1464,7 @@ bool Node::isInputTensorAtPortEmpty(size_t port) const {
     if (inputShapes[port].hasZeroDims()) {
         return true;
     }
-    auto edge = getParentEdgesAtPort(port)[0];
+    auto edge = getParentEdgeAt(port);
     if (one_of(edge->getStatus(), Edge::Status::Allocated, Edge::Status::Validated)) {
         auto&& mem = edge->getMemory();
         if (mem.isAllocated()) {
@@ -1481,7 +1481,7 @@ bool Node::isOutputTensorAtPortEmpty(size_t port) const {
     if (outputShapes[port].isStatic()) {
         return outputShapes[port].hasZeroDims();
     }
-    auto&& mem = getChildEdgesAtPort(port)[0]->getMemory();
+    auto&& mem = getChildEdgeAt(port)->getMemory();
     if (mem.isAllocated()) {
         return mem.getShape().hasZeroDims();
     }
@@ -1506,7 +1506,7 @@ bool Node::hasEmptyOutputTensors() const {
 
 bool Node::inputShapesDefined() const {
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        if (!getParentEdgesAtPort(i)[0]->getMemory().getDesc().isDefined()) {
+        if (!getParentEdgeAt(i)->getMemory().getDesc().isDefined()) {
             return false;
         }
     }
@@ -1515,7 +1515,7 @@ bool Node::inputShapesDefined() const {
 
 bool Node::outputShapesDefined() const {
     for (size_t i = 0; i < outputShapes.size(); i++) {
-        if (!getChildEdgesAtPort(i)[0]->getMemory().getDesc().isDefined()) {
+        if (!getChildEdgeAt(i)->getMemory().getDesc().isDefined()) {
             return false;
         }
     }
@@ -1538,7 +1538,7 @@ bool Node::inputShapesModified() const {
     }
 
     for (size_t i = 0; i < lastInputDims.size(); i++) {
-        if (lastInputDims[i] != getParentEdgesAtPort(i)[0]->getMemory().getStaticDims())
+        if (lastInputDims[i] != getParentEdgeAt(i)->getMemory().getStaticDims())
             return true;
     }
     return false;
@@ -1561,7 +1561,7 @@ std::vector<VectorDims> Node::shapeInferGeneric(const std::vector<Shape>& shapes
         if (input_value_port_mask) {
             for (size_t port = 0; port < inputShapes.size(); ++port) {
                 if (input_value_port_mask & (1 << port)) {
-                    input_values[port] = getParentEdgesAtPort(port)[0]->getMemoryPtr();
+                    input_values[port] = getSrcMemoryAtPort(port);
                 }
             }
         }
@@ -1585,13 +1585,13 @@ IShapeInfer::Result Node::shapeInfer() const {
 
         input_shapes.reserve(inputShapes.size());
         for (size_t port = 0; port < inputShapes.size(); ++port)
-            input_shapes.emplace_back(std::ref(getParentEdgesAtPort(port)[0]->getMemory().getStaticDims()));
+            input_shapes.emplace_back(std::ref(getParentEdgeAt(port)->getMemory().getStaticDims()));
 
         std::unordered_map<size_t, MemoryPtr> input_values;
         if (input_value_port_mask) {
             for (size_t port = 0; port < inputShapes.size(); ++port) {
                 if (input_value_port_mask & (1 << port)) {
-                    input_values[port] = getParentEdgesAtPort(port)[0]->getMemoryPtr();
+                    input_values[port] = getSrcMemoryAtPort(port);
                 }
             }
         }
@@ -1611,14 +1611,14 @@ void Node::updateLastInputDims() {
     }
 
     for (size_t i = 0; i < lastInputDims.size(); i++)
-        lastInputDims[i] = getParentEdgesAtPort(i)[0]->getMemory().getDesc().getShape().getDims();
+        lastInputDims[i] = getParentEdgeAt(i)->getMemory().getDesc().getShape().getDims();
 }
 
 bool Node::canFuseSimpleOperation(const NodePtr& node) const {
     if (node->getType() == Type::FakeQuantize) {
         bool ret = node->getAlgorithm() != Algorithm::FQBinarization;
         for (size_t i = 1; i < node->getParentEdges().size(); i++) {
-            ret &= node->getParentEdgesAtPort(i)[0]->getParent()->getChildEdges().size() == 1;
+            ret &= node->getParentEdgeAt(i)->getParent()->getChildEdges().size() == 1;
         }
         return ret;
     } else if (node->getType() == Type::Eltwise) {

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -904,7 +904,7 @@ MemoryPtr Node::prepareWeightMemory(DnnlMemoryDescPtr dstWeightDesc, DnnlMemoryD
         if (weightCache != nullptr) {
             const std::string string_hash = getName() + "_" + format
                                             + "_" + std::to_string(edgeMem->getSize())
-                                            + "_" + std::to_string(reinterpret_cast<uint64_t>(edgeMem->getData()));
+                                            + "_" + std::to_string(*edgeMem->getDataAs<uint64_t>());
 
             ptr = *weightCache->findOrCreate(string_hash, create);
         } else {

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -206,6 +206,25 @@ public:
     }
 
     EdgePtr getParentEdgeAt(size_t idx) const;
+
+    /**
+     * Returns all the child edges by input port number.
+     *
+     * Safe way of getting all the child edges at port.
+     * Does not require a vector of the child edges to be sorted.
+     * Allocates a storage (vector) to collect the child edges.
+     */
+    std::vector<EdgePtr> getChildEdgesAtPort(int inputNum) const;
+
+    /**
+     * Returns a child edge by index.
+     *
+     * @attention !!! Can only be used after Graph::SortTopologically is performed !!!
+     * Optimized way of accessing a child edge at port.
+     * If node contains multiple child edges at port, a random one is returned.
+     * Has less overhead in comparison with calling getChildEdgesAtPort(idx)[0].
+     * The main use case is accessing Memory from edge with less overhead.
+     */
     EdgePtr getChildEdgeAt(size_t idx) const;
 
     MemoryPtr getSrcMemoryAtPort(size_t idx) const {
@@ -233,8 +252,6 @@ public:
     T* getDstDataAtPortAs(size_t idx) const {
         return getDstMemoryAtPort(idx)->getDataAs<T>();
     }
-
-    std::vector<EdgePtr> getChildEdgesAtPort(size_t idx) const;
 
     int inPlaceInputPort(int portIdx) const;
     int inPlaceOutPort(int portIdx) const;

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -172,6 +172,10 @@ public:
     void remove();
 
     void addParentEdge(const EdgePtr& edge) {
+        assert(std::none_of(parentEdges.begin(), parentEdges.end(),
+                            [&edge](const EdgeWeakPtr& _edge){
+                                return _edge.lock()->getOutputNum() == edge->getOutputNum();
+                            }));
         parentEdges.insert(std::upper_bound(parentEdges.begin(), parentEdges.end(), edge,
                                             [](const EdgeWeakPtr& lhs, const EdgeWeakPtr& rhs) {
                                                 return lhs.lock()->getOutputNum() < rhs.lock()->getOutputNum();

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
@@ -100,24 +100,24 @@ static std::vector<size_t> getShape5D(const VectorDims &shape) {
 
 template<typename T>
 void BatchToSpace::batchToSpaceKernel() {
-    const auto *srcData = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
-    size_t dataRank = getParentEdgesAtPort(0)[0]->getMemoryPtr()->getShape().getRank();
+    const auto *srcData = getSrcDataAtPortAs<const T>(0);
+    const auto *blockShapesPtr = getSrcDataAtPortAs<int>(1);
+    size_t dataRank = getSrcMemoryAtPort(0)->getShape().getRank();
     blockShapeIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         blockShapeIn.push_back(*(blockShapesPtr + i));
     }
 
-    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->getData());
+    const auto *padsBeginPtr = getSrcDataAtPortAs<int>(2);
     cropsBeginIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         cropsBeginIn.push_back(*(padsBeginPtr + i));
     }
 
-    auto *dstData = reinterpret_cast<T *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    auto *dstData = getDstDataAtPortAs<T>(0);
 
-    const auto &inDims = getParentEdgesAtPort(0)[0]->getMemory().getStaticDims();
-    const auto &outDims = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();
+    const auto &inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
+    const auto &outDims = getChildEdgeAt(0)->getMemory().getStaticDims();
 
     auto srcDesc = getParentEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
 

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -1021,9 +1021,9 @@ void BinaryConvolution::createPrimitive() {
     if (!selectedPrimitiveDescriptor)
         OPENVINO_THROW("CPU binary convolution with name '", getName(), "' doesn't have primitive descriptors.");
 
-    auto srcDims = getParentEdgesAtPort(0)[0]->getMemory().getStaticDims();
-    auto weiDims = getParentEdgesAtPort(1)[0]->getMemory().getStaticDims();
-    auto dstDims = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();
+    auto srcDims = getParentEdgeAt(0)->getMemory().getStaticDims();
+    auto weiDims = getParentEdgeAt(1)->getMemory().getStaticDims();
+    auto dstDims = getChildEdgeAt(0)->getMemory().getStaticDims();
 
     auto implType = selectedPrimitiveDescriptor->getImplementationType();
 
@@ -1116,7 +1116,7 @@ bool BinaryConvolution::canFuse(const NodePtr& node) const {
     if (node->getType() == Type::FakeQuantize) {
         bool ret = node->getAlgorithm() == Algorithm::FQBinarization;
         for (size_t i = 1; i < node->getParentEdges().size(); i++) {
-            ret &= node->getParentEdgesAtPort(i)[0]->getParent()->getChildEdges().size() == 1;
+            ret &= node->getParentEdgeAt(i)->getParent()->getChildEdges().size() == 1;
         }
         return ret;
     } else {
@@ -1302,13 +1302,13 @@ void BinaryConvolution::executeReference(const uint8_t* src, const uint8_t* weig
 }
 
 void BinaryConvolution::execute(dnnl::stream strm) {
-    auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    auto weightsMemory = getParentEdgeAt(1)->getMemoryPtr();
-    auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemory = getSrcMemoryAtPort(0);
+    auto weightsMemory = getSrcMemoryAtPort(1);
+    auto dstMemory = getDstMemoryAtPort(0);
 
-    auto src = reinterpret_cast<const uint8_t*>(srcMemory->getData());
-    auto weights = reinterpret_cast<const uint8_t*>(weightsMemory->getData());
-    auto dst = reinterpret_cast<uint8_t*>(dstMemory->getData());
+    auto src = srcMemory->getDataAs<const uint8_t>();
+    auto weights = weightsMemory->getDataAs<const uint8_t>();
+    auto dst = dstMemory->getDataAs<uint8_t>();
 
     auto srcDesc = getParentEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
     std::vector<size_t> srcStride(srcDesc->getStrides().size());

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -114,17 +114,17 @@ bool Broadcast::needPrepareParams() const {
 
 void Broadcast::prepareParams() {
     if (!constMap[TARGET_SHAPE_IDX]) {
-        const auto& targetShapeMem = getParentEdgesAtPort(TARGET_SHAPE_IDX)[0]->getMemory();
-        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(targetShapeMem.getData());
+        const auto& targetShapeMem = getParentEdgeAt(TARGET_SHAPE_IDX)->getMemory();
+        const int32_t* targetShapeData = targetShapeMem.getDataAs<const int32_t>();
         targetShape.assign(targetShapeData, targetShapeData + targetShapeMem.getStaticDims()[0]);
     }
     if (broadcastType == EXPLICIT && !constMap[AXES_MAPPING_IDX]) {
-        const auto& axesMapMem = getParentEdgesAtPort(AXES_MAPPING_IDX)[0]->getMemory();
-        const int32_t* axesMapData = reinterpret_cast<const int32_t *>(axesMapMem.getData());
+        const auto& axesMapMem = getParentEdgeAt(AXES_MAPPING_IDX)->getMemory();
+        const int32_t* axesMapData = axesMapMem.getDataAs<const int32_t>();
         axesMapping.assign(axesMapData, axesMapData + axesMapMem.getStaticDims()[0]);
     }
 
-    const auto& srcDims = getParentEdgesAtPort(INPUT_DATA_IDX)[0]->getMemory().getShape().getStaticDims();
+    const auto& srcDims = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().getShape().getStaticDims();
     repeats.assign(targetShape.begin(), targetShape.end());
     const auto ndims = repeats.size();
 
@@ -160,7 +160,7 @@ bool Broadcast::needShapeInfer() const {
         if (targetShape.empty()) {
             return true;
         }
-        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_IDX)[0]->getMemory().getData());
+        const int32_t* targetShapeData = getParentEdgeAt(TARGET_SHAPE_IDX)->getMemory().getDataAs<const int32_t>();
         for (size_t i = 0lu; i < targetShape.size(); i++) {
             if (targetShape[i] != targetShapeData[i]) {
                 return true;
@@ -171,7 +171,7 @@ bool Broadcast::needShapeInfer() const {
         if (axesMapping.empty()) {
             return true;
         }
-        const int32_t* axesMappingData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(AXES_MAPPING_IDX)[0]->getMemory().getData());
+        const int32_t* axesMappingData = getParentEdgeAt(AXES_MAPPING_IDX)->getMemory().getDataAs<const int32_t>();
         for (size_t i = 0lu; i < axesMapping.size(); i++) {
             if (axesMapping[i] != axesMappingData[i]) {
                 return true;
@@ -192,7 +192,7 @@ void Broadcast::executeDynamicImpl(dnnl::stream strm) {
 
 void Broadcast::execute(dnnl::stream strm) {
     if (optimizedCase) {
-        optimizedExecute(getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr(), getChildEdgeAt(0)->getMemoryPtr());
+        optimizedExecute(getSrcMemoryAtPort(INPUT_DATA_IDX), getDstMemoryAtPort(0));
     } else {
         plainExecute(strm);
     }
@@ -229,8 +229,8 @@ void Broadcast::plainExecute(dnnl::stream strm) {
     }
 
     const size_t workAmountDst = dstStrides[0] * dstDims[0];
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr()->getData());
-    auto *dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcData = getSrcDataAtPortAs<const uint8_t>(INPUT_DATA_IDX);
+    auto *dstData = getDstDataAtPortAs<uint8_t>(0);
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t i = 0lu, srcIdx = 0lu, start = 0lu, end = 0lu;

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -186,9 +186,9 @@ void Bucketize::execute(dnnl::stream strm) {
 }
 
 void Bucketize::prepareParams() {
-    auto inputTensorMemPtr = getParentEdgeAt(INPUT_TENSOR_PORT)->getMemoryPtr();
-    auto inputBinsMemPtr = getParentEdgeAt(INPUT_BINS_PORT)->getMemoryPtr();
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto inputTensorMemPtr = getSrcMemoryAtPort(INPUT_TENSOR_PORT);
+    auto inputBinsMemPtr = getSrcMemoryAtPort(INPUT_BINS_PORT);
+    auto dstMemPtr = getDstMemoryAtPort(0);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         OPENVINO_THROW("Destination memory didn't allocate.");
     if (!inputTensorMemPtr || !inputTensorMemPtr->isAllocated())
@@ -222,9 +222,9 @@ bool Bucketize::isExecutable() const {
 
 template <typename T, typename T_BOUNDARIES, typename T_IND>
 void Bucketize::bucketize() {
-    const auto *input_data = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    const auto *boundaries_data = reinterpret_cast<const T_BOUNDARIES *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
-    auto *output_data = reinterpret_cast<T_IND *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    const auto *input_data = getSrcDataAtPortAs<const T>(0);
+    const auto *boundaries_data = getSrcDataAtPortAs<const T_BOUNDARIES>(1);
+    auto *output_data = getDstDataAtPortAs<T_IND>(0);
 
     if (!with_bins) {
         memset(output_data, 0, num_values * sizeof(T_IND));

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -979,23 +979,23 @@ ColorConvert::Converter::Converter(Node *node, const ColorFormat & colorFormat)
 }
 
 ov::element::Type ColorConvert::Converter::inputPrecision(size_t idx) const {
-    return _node->getParentEdgesAtPort(idx)[0]->getMemory().getDesc().getPrecision();
+    return _node->getParentEdgeAt(idx)->getMemory().getDesc().getPrecision();
 }
 
 ov::element::Type ColorConvert::Converter::outputPrecision(size_t idx) const {
-    return _node->getChildEdgesAtPort(idx)[0]->getMemory().getDesc().getPrecision();
+    return _node->getChildEdgeAt(idx)->getMemory().getDesc().getPrecision();
 }
 
 const void * ColorConvert::Converter::input(size_t idx) const {
-    return _node->getParentEdgeAt(idx)->getMemoryPtr()->getData();
+    return _node->getSrcDataAtPort(idx);
 }
 
 void * ColorConvert::Converter::output(size_t idx) const {
-    return _node->getChildEdgeAt(idx)->getMemoryPtr()->getData();
+    return _node->getDstDataAtPort(idx);
 }
 
 const VectorDims & ColorConvert::Converter::inputDims(size_t idx) const {
-    return _node->getParentEdgesAtPort(idx)[0]->getMemory().getStaticDims();
+    return _node->getParentEdgeAt(idx)->getMemory().getStaticDims();
 }
 
 bool ColorConvert::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {

--- a/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
@@ -253,8 +253,8 @@ void TileBroadcastCommon::broadcastScalar(const char *srcData, char *dstData, si
 }
 
 void TileBroadcastCommon::optimizedExecute(const MemoryPtr& srcMemory, const MemoryPtr& dstMemory) {
-    auto srcData = reinterpret_cast<const char *>(srcMemory->getData());
-    auto dstData = reinterpret_cast<char *>(dstMemory->getData());
+    auto srcData = srcMemory->getDataAs<const char>();
+    auto dstData = dstMemory->getDataAs<char>();
 
     if (srcMemory->getStaticDims() == dstMemory->getStaticDims()) {
         const auto prc = dstMemory->getDesc().getPrecision();
@@ -266,7 +266,7 @@ void TileBroadcastCommon::optimizedExecute(const MemoryPtr& srcMemory, const Mem
         if (optimizedParams.dstStrides[0] == optimizedParams.dims[5] * optimizedParams.dstStrides[5]) {
             size_t data_size = optimizedParams.dstStrides[5];
             size_t elt_cnt = optimizedParams.dims[5];
-            auto srcData_i32 = reinterpret_cast<const int *>(srcMemory->getData());
+            auto srcData_i32 = srcMemory->getDataAs<const int>();
             if (data_size == 1) {
                 memset(dstData, srcData[0], elt_cnt);
             } else if (data_size == 4 && srcData_i32[0] == 0) {

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -349,7 +349,7 @@ void Concat::prepareParams() {
         // in this case, inputs are also small 1d vector and single thread naive impl is faster
         canOptimize1DCase = true;
         for (size_t i = 0; i < getParentEdges().size(); i++) {
-            const auto& srcMemPtr = getParentEdgesAtPort(i)[0]->getMemoryPtr();
+            const auto& srcMemPtr = getSrcMemoryAtPort(i);
             const auto srcMemDesc = srcMemPtr->getDescPtr()->as<BlockedMemoryDesc>();
             const auto& inputShape = srcMemDesc->getBlockDims();
             const auto& strides = srcMemDesc->getStrides();

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -318,7 +318,7 @@ void Concat::prepareParams() {
     if (canOptimizeNspc || isInPlace())
         return;
 
-    const auto& dstMemPtr = getChildEdgesAtPort(0)[0]->getMemoryPtr();
+    const auto& dstMemPtr = getDstMemoryAtPort(0);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         OPENVINO_THROW("Destination memory didn't allocate.");
     auto dstMemDesc = dstMemPtr->getDescWithType<BlockedMemoryDesc>();
@@ -328,7 +328,7 @@ void Concat::prepareParams() {
     const auto& outputStrides = dstMemDesc->getStrides();
     size_t curConcatOffset = 0;
     const size_t elemSize = DnnlExtensionUtils::sizeOfDataType(dstMemPtr->getDataType());
-    const auto& src0BlkMemDesc = getParentEdgesAtPort(0)[0]->getMemoryPtr()->getDescPtr()->as<BlockedMemoryDesc>();
+    const auto& src0BlkMemDesc = getSrcMemoryAtPort(0)->getDescPtr()->as<BlockedMemoryDesc>();
     const auto& outputOrder = src0BlkMemDesc->getOrder();
     for (size_t i = 0; i < outputOrder.size(); i++) {
         if (outputOrder[i] == axis) {
@@ -364,7 +364,7 @@ void Concat::prepareParams() {
 
     std::vector<memory::desc> srcs_d;
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        const auto& srcMemPtr = getParentEdgesAtPort(i)[0]->getMemoryPtr();
+        const auto& srcMemPtr = getSrcMemoryAtPort(i);
         if (!srcMemPtr || !srcMemPtr->isAllocated()) {
             auto parent = getParentEdgeAt(i)->getParent();
             OPENVINO_THROW("Source memory from ", parent->getName(), " didn't allocate for node ", getName(), ".");
@@ -489,7 +489,7 @@ void Concat::execute(dnnl::stream strm) {
         std::unordered_map<int, memory> mem_ags {{DNNL_ARG_DST, dst_memory.getPrimitive()}};
         size_t nonZeroInShapes = 0;
         for (size_t i = 0; i < num_src; i++) {
-            const auto& srcMem = getParentEdgesAtPort(i)[0]->getMemory();
+            const auto& srcMem = getParentEdgeAt(i)->getMemory();
             if (srcMem.getShape().hasZeroDims()) {
                 continue;
             }
@@ -520,7 +520,7 @@ void Concat::exec1DCase() {
 void Concat::execNspcSpecCase() {
     const auto& dst_memory = getChildEdgeAt(0)->getMemory();
     const size_t num_src = getParentEdges().size();
-    uint8_t* dst_ptr = reinterpret_cast<uint8_t*>(dst_memory.getData());
+    uint8_t* dst_ptr = dst_memory.getDataAs<uint8_t>();
     const size_t dataSize = DnnlExtensionUtils::sizeOfDataType(dst_memory.getDataType());
 
     std::vector<size_t> channelsDataSize;
@@ -531,14 +531,14 @@ void Concat::execNspcSpecCase() {
     size_t nonZeroInShapes = 0;
     int firstNonZeroEdge = -1;
     for (size_t i = 0; i < num_src; i++) {
-        const auto& src_mem = getParentEdgesAtPort(i)[0]->getMemory();
+        const auto& src_mem = getParentEdgeAt(i)->getMemory();
         if (src_mem.getShape().hasZeroDims()) {
             continue;
         }
         const size_t num_channels = src_mem.getStaticDims()[channelAxis];
 
         channelsDataSize.push_back(num_channels * dataSize);
-        src_ptrs.push_back(reinterpret_cast<const uint8_t*>(src_mem.getData()));
+        src_ptrs.push_back(src_mem.getDataAs<const uint8_t>());
         dst_ptrs.push_back(dst_ptr + channels_size);
         channels_size += num_channels * dataSize;
 
@@ -565,10 +565,10 @@ void Concat::execRef() {
     const size_t elemSize = DnnlExtensionUtils::sizeOfDataType(dstMemory.getDataType());
     const auto dstMemBlkDesc = dstMemory.getDescPtr()->as<BlockedMemoryDesc>();
     const auto& outputShape = dstMemBlkDesc->getBlockDims();
-    uint8_t* dstPtr = reinterpret_cast<uint8_t*>(dstMemory.getData());
+    uint8_t* dstPtr = dstMemory.getDataAs<uint8_t>();
     for (size_t i = 0; i < numSrc; i++) {
-        const auto& srcMem = getParentEdgesAtPort(i)[0]->getMemory();
-        srcPtrs[i] = reinterpret_cast<const uint8_t*>(srcMem.getData());
+        const auto& srcMem = getParentEdgeAt(i)->getMemory();
+        srcPtrs[i] = srcMem.getDataAs<const uint8_t>();
     }
 
     size_t outputStrides[MAX_RANK_REF] = {0};
@@ -679,7 +679,7 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
                     getName(),
                     " can't use inPlace memory with concatenation on dynamic dimension");
 
-    auto& edges = getChildEdgesAtPort(inplaceOutIndx);
+    auto edges = getChildEdgesAtPort(inplaceOutIndx);
     auto itr = std::find_if(edges.begin(), edges.end(), [](const EdgePtr& edge) { return edge->getStatus() == Edge::Status::Allocated; });
     OPENVINO_ASSERT(itr != edges.end(), " Could not find allocated child edge for concat node: " , getName());
 

--- a/src/plugins/intel_cpu/src/nodes/convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/convert.cpp
@@ -43,12 +43,8 @@ Convert::Convert(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
 
 Convert::Convert(const Shape &shape, const ov::element::Type &inPrc, const ov::element::Type &outPrc,
                  const std::string &nodeName, const GraphContext::CPtr context)
-        : Node("Convert", nodeName, context) {
+    : Node("Convert", {shape}, {shape}, {inPrc}, {outPrc}, nodeName, context) {
     convertParams.origPrc = outPrc;
-    inputShapes.push_back(shape);
-    addOriginalInputPrecision(inPrc);
-    outputShapes.push_back(shape);
-    addOriginalOutputPrecision(outPrc);
 
     isDynamic = shape.isDynamic();
     if (isDynamicNode()) {
@@ -154,8 +150,8 @@ void Convert::prepareParams() {
     convertParams.size = parentMem.getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
 
     auto selectedPD = getSelectedPrimitiveDescriptor();
-    MemoryDescPtr srcDesc = getParentEdgeAt(0)->getMemoryPtr()->getDescPtr();
-    MemoryDescPtr dstDesc = getChildEdgeAt(0)->getMemoryPtr()->getDescPtr();
+    MemoryDescPtr srcDesc = getSrcMemoryAtPort(0)->getDescPtr();
+    MemoryDescPtr dstDesc = getDstMemoryAtPort(0)->getDescPtr();
     execPtr = selectedPD->getExecutorFactoryAs<ConvertExecutorFactory>()->makeExecutor(convertParams,
                                                                                        srcDesc,
                                                                                        dstDesc,
@@ -177,8 +173,8 @@ void Convert::execute(dnnl::stream strm) {
     if (parentPaddElemCount != childPaddElemCount)
         OPENVINO_THROW(errorPrefix, " has different elements number in input and output buffers");
 
-    MemoryCPtr srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    MemoryPtr dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    MemoryCPtr srcMemory = getSrcMemoryAtPort(0);
+    MemoryPtr dstMemory = getDstMemoryAtPort(0);
     execPtr->exec(srcMemory, dstMemory);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/convert.h
+++ b/src/plugins/intel_cpu/src/nodes/convert.h
@@ -15,7 +15,7 @@ class Convert : public Node {
 public:
     Convert(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context);
     Convert(const Shape &shape, const ov::element::Type &inPrc, const ov::element::Type &outPrc,
-                      const std::string &nodeName, const GraphContext::CPtr context);
+            const std::string &nodeName, const GraphContext::CPtr context);
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
@@ -68,9 +68,9 @@ void CTCGreedyDecoder::initSupportedPrimitiveDescriptors() {
 }
 
 void CTCGreedyDecoder::execute(dnnl::stream strm) {
-    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->getData());
-    const float* sequenceMask = reinterpret_cast<const float *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->getData());
-    float* outputSequences = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    const float* probabilities = getSrcDataAtPortAs<const float>(DATA_INDEX);
+    const float* sequenceMask = getSrcDataAtPortAs<const float>(SEQUENCE_LENGTH_INDEX);
+    float* outputSequences = getDstDataAtPortAs<float>(0);
 
     const size_t T = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[0];
     const size_t B = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[1];

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.cpp
@@ -73,10 +73,10 @@ void CTCGreedyDecoderSeqLen::initSupportedPrimitiveDescriptors() {
 }
 
 void CTCGreedyDecoderSeqLen::execute(dnnl::stream strm) {
-    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->getData());
-    const int* sequenceLengths = reinterpret_cast<const int *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->getData());
-    int* decodedClasses =  reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_INDEX)[0]->getMemoryPtr()->getData());
-    int* decodedClassesLength = reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_LENGTH_INDEX)[0]->getMemoryPtr()->getData());
+    const float* probabilities = getSrcDataAtPortAs<const float>(DATA_INDEX);
+    const int* sequenceLengths = getSrcDataAtPortAs<const int>(SEQUENCE_LENGTH_INDEX);
+    int* decodedClasses =  getDstDataAtPortAs<int>(DECODED_CLASSES_INDEX);
+    int* decodedClassesLength = getDstDataAtPortAs<int>(DECODED_CLASSES_LENGTH_INDEX);
 
     const size_t B = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[0];;
     const size_t T = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[1];;
@@ -85,7 +85,7 @@ void CTCGreedyDecoderSeqLen::execute(dnnl::stream strm) {
 
     int blankIndex = C - 1;
     if (inputShapes.size() > BLANK_INDEX)
-        blankIndex = (reinterpret_cast<const int  *>(getParentEdgeAt(BLANK_INDEX)->getMemoryPtr()->getData()))[0];
+        blankIndex = (getSrcDataAtPortAs<const int >(BLANK_INDEX))[0];
 
     size_t workAmount = 0;
     for (size_t b = 0; b < B; b++) {
@@ -93,7 +93,7 @@ void CTCGreedyDecoderSeqLen::execute(dnnl::stream strm) {
             std::string errorMsg = errorPrefix
                                    + ". Sequence length " + std::to_string(sequenceLengths[b])
                                    + " cannot be greater than according decoded classes dimension size "
-                                   + std::to_string(getChildEdgesAtPort(DECODED_CLASSES_INDEX)[0]->getMemory().getStaticDims()[1]);
+                                   + std::to_string(getChildEdgeAt(DECODED_CLASSES_INDEX)->getMemory().getStaticDims()[1]);
             OPENVINO_THROW(errorMsg);
         }
         workAmount += sequenceLengths[b];

--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
@@ -65,11 +65,11 @@ void CTCLoss::executeDynamicImpl(dnnl::stream strm) {
 void CTCLoss::execute(dnnl::stream strm) {
     int32_t returnCode = 0;
 
-    const float* logits = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    const int* logitsLength = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
-    const int* labels = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->getData());
-    const int* labelsLength = reinterpret_cast<const int *>(getParentEdgeAt(3)->getMemoryPtr()->getData());
-    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    const float* logits = getSrcDataAtPortAs<const float>(0);
+    const int* logitsLength = getSrcDataAtPortAs<const int>(1);
+    const int* labels = getSrcDataAtPortAs<const int>(2);
+    const int* labelsLength = getSrcDataAtPortAs<const int>(3);
+    float* dstData = getDstDataAtPortAs<float>(0);
 
     const auto &inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
     const size_t batchNum = inDims[0];
@@ -78,7 +78,7 @@ void CTCLoss::execute(dnnl::stream strm) {
 
     int blankIndex = classesNum - 1;
     if (inputShapes.size() > 4) {
-        blankIndex = reinterpret_cast<const int *>(getParentEdgeAt(4)->getMemoryPtr()->getData())[0];
+        blankIndex = getSrcDataAtPortAs<const int>(4)[0];
     }
 
     std::vector<int> decodedTargetLenB(batchNum, 0);

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
@@ -109,8 +109,8 @@ void CumSum::execute(dnnl::stream strm) {
 
 template <typename dataType>
 void CumSum::exec() {
-    const auto *input = reinterpret_cast<const dataType *>(getParentEdgeAt(CUM_SUM_DATA)->getMemoryPtr()->getData());
-    auto *output = reinterpret_cast<dataType *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    const auto *input = getSrcDataAtPortAs<const dataType>(CUM_SUM_DATA);
+    auto *output = getDstDataAtPortAs<dataType>(0);
     const VectorDims strides = getParentEdgeAt(CUM_SUM_DATA)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
 
     if (reverse) {
@@ -132,7 +132,7 @@ template <bool reverse, bool exclusive, typename dataType>
 void CumSum::cumSum(const dataType *input, dataType *output, const VectorDims &strides) {
     VectorDims iterationRange(numOfDims - 1);
     size_t j = 0;
-    const auto &shape = getParentEdgesAtPort(CUM_SUM_DATA)[0]->getMemory().getStaticDims();
+    const auto &shape = getParentEdgeAt(CUM_SUM_DATA)->getMemory().getStaticDims();
     for (size_t i = 0; i < shape.size(); i++) {
         if (i == axis)
             continue;
@@ -232,12 +232,12 @@ size_t CumSum::getAxis(const IMemory& _axis, const IMemory& _data) const {
     int64_t axisValueFromBlob = 0;
     switch (axisPrecision) {
         case ov::element::i32 : {
-            const auto *axisPtr = reinterpret_cast<const int32_t *>(_axis.getData());
+            const auto *axisPtr = _axis.getDataAs<const int32_t>();
             axisValueFromBlob = static_cast<int64_t>(axisPtr[0]);
             break;
         }
         case ov::element::i64 : {
-            const auto *axisPtr = reinterpret_cast<const int64_t *>(_axis.getData());
+            const auto *axisPtr = _axis.getDataAs<const int64_t>();
             axisValueFromBlob = axisPtr[0];
             break;
         }

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -1176,10 +1176,10 @@ void DeformableConvolution::DefConvRefExecutor::exec(const float* src, const flo
 }
 
 void DeformableConvolution::prepareParams() {
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
-    auto offMemPtr = getParentEdgeAt(OFF_ID)->getMemoryPtr();
-    auto weiMemPtr = getParentEdgeAt(WEI_ID)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(0);
+    auto srcMemPtr = getSrcMemoryAtPort(DATA_ID);
+    auto offMemPtr = getSrcMemoryAtPort(OFF_ID);
+    auto weiMemPtr = getSrcMemoryAtPort(WEI_ID);
 
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         OPENVINO_THROW(errorPrefix, " did not allocate destination memory");
@@ -1191,7 +1191,7 @@ void DeformableConvolution::prepareParams() {
         OPENVINO_THROW(errorPrefix, " did not allocate weights memory");
 
     if (getOriginalInputsNumber() > 3) {
-        auto modMemPtr = getParentEdgeAt(MOD_ID)->getMemoryPtr();
+        auto modMemPtr = getSrcMemoryAtPort(MOD_ID);
         if (!modMemPtr || !modMemPtr->isAllocated())
             OPENVINO_THROW(errorPrefix, " did not allocate modulations memory");
     }
@@ -1214,7 +1214,7 @@ void DeformableConvolution::prepareParams() {
     if (withModulation) {
         descVector.push_back(getParentEdgeAt(MOD_ID)->getMemory().getDescWithType<BlockedMemoryDesc>());
     }
-    descVector.push_back(getChildEdgesAtPort(0)[0]->getMemory().getDescWithType<BlockedMemoryDesc>());
+    descVector.push_back(getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>());
 
     DefConvKey key = {
         descVector,
@@ -1223,8 +1223,8 @@ void DeformableConvolution::prepareParams() {
     };
 
     const int MB = getParentEdgeAt(DATA_ID)->getMemory().getStaticDims()[0];
-    const int OH = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims()[2];
-    const int OW = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims()[3];
+    const int OH = getChildEdgeAt(0)->getMemory().getStaticDims()[2];
+    const int OW = getChildEdgeAt(0)->getMemory().getStaticDims()[3];
 
     const int KH = getParentEdgeAt(WEI_ID)->getMemory().getStaticDims()[2];
     const int KW = getParentEdgeAt(WEI_ID)->getMemory().getStaticDims()[3];
@@ -1294,15 +1294,15 @@ void DeformableConvolution::execute(dnnl::stream strm) {
     auto &srcMemory2 = getParentEdgeAt(2)->getMemory();
     auto &dstMemory = getChildEdgeAt(0)->getMemory();
 
-    const auto *src = reinterpret_cast<const float *>(srcMemory0.getData());
-    const auto *offsets = reinterpret_cast<const float *>(srcMemory1.getData());
-    const auto *weights = reinterpret_cast<const float *>(srcMemory2.getData());
+    const auto *src = srcMemory0.getDataAs<const float>();
+    const auto *offsets = srcMemory1.getDataAs<const float>();
+    const auto *weights = srcMemory2.getDataAs<const float>();
     float* modulation = nullptr;
     if (inputsNumber > 3) {
-        modulation = reinterpret_cast<float *>(getParentEdgeAt(3)->getMemory().getData());
+        modulation = getParentEdgeAt(3)->getMemory().getDataAs<float>();
     }
 
-    float *dst = reinterpret_cast<float *>(dstMemory.getData());
+    float *dst = dstMemory.getDataAs<float>();
 
     auto selectedPrimitiveDescriptor = getSelectedPrimitiveDescriptor();
     if (!selectedPrimitiveDescriptor)

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -160,8 +160,8 @@ void DepthToSpace::initSupportedPrimitiveDescriptors() {
 }
 
 void DepthToSpace::createPrimitive() {
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(0);
+    auto srcMemPtr = getSrcMemoryAtPort(0);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_ERROR("has not allocated destination memory");
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -184,7 +184,7 @@ void DepthToSpace::createPrimitive() {
 }
 
 void DepthToSpace::prepareParams() {
-    attrs.srcBlockedDims = getParentEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
+    attrs.srcBlockedDims = getSrcMemoryAtPort(0)->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
     auto builder = [](const DepthToSpaceAttrs& key) -> std::shared_ptr<DepthToSpaceExecutor> {
         return std::make_shared<DepthToSpaceExecutor>(key);
     };
@@ -291,8 +291,8 @@ void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const 
     if (!permuteKernel)
         OPENVINO_THROW("Could not execute. Kernel for Transpose node was not compiled.");
 
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->getData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
+    const uint8_t* srcData = srcMemPtr->getDataAs<const uint8_t>();
+    uint8_t* dstData = dstMemPtr->getDataAs<uint8_t>();
 
     permuteKernel->execute(srcData, dstData, MB);
 }
@@ -302,8 +302,8 @@ void DepthToSpace::execute(dnnl::stream strm) {
         THROW_ERROR("doesn't have a compiled executor.");
     }
 
-    int MB = getParentEdgeAt(0)->getMemoryPtr()->getStaticDims()[0];
-    execPtr->exec(getParentEdgeAt(0)->getMemoryPtr(), getChildEdgeAt(0)->getMemoryPtr(), MB);
+    int MB = getSrcMemoryAtPort(0)->getStaticDims()[0];
+    execPtr->exec(getSrcMemoryAtPort(0), getDstMemoryAtPort(0), MB);
 }
 
 void DepthToSpace::executeDynamicImpl(dnnl::stream strm) {

--- a/src/plugins/intel_cpu/src/nodes/detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.cpp
@@ -171,15 +171,15 @@ void DetectionOutput::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void DetectionOutput::execute(dnnl::stream strm) {
-    float *dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    float *dstData = getDstDataAtPortAs<float>(0);
 
-    const float *locData     = reinterpret_cast<const float *>(getParentEdgeAt(ID_LOC)->getMemoryPtr()->getData());
-    const float *confData    = reinterpret_cast<const float *>(getParentEdgeAt(ID_CONF)->getMemoryPtr()->getData());
-    const float *priorData   = reinterpret_cast<const float *>(getParentEdgeAt(ID_PRIOR)->getMemoryPtr()->getData());
+    const float *locData     = getSrcDataAtPortAs<const float>(ID_LOC);
+    const float *confData    = getSrcDataAtPortAs<const float>(ID_CONF);
+    const float *priorData   = getSrcDataAtPortAs<const float>(ID_PRIOR);
     const float *ARMConfData = inputShapes.size() > 3 ?
-            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_CONF)->getMemoryPtr()->getData()) : nullptr;
+            getSrcDataAtPortAs<const float>(ID_ARM_CONF) : nullptr;
     const float *ARMLocData = inputShapes.size() > 4 ?
-            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_LOC)->getMemoryPtr()->getData()) : nullptr;
+            getSrcDataAtPortAs<const float>(ID_ARM_LOC) : nullptr;
 
     float *reorderedConfData = reorderedConf.data();
     int *reorderedConfDataIndices = reinterpret_cast<int*>(reorderedConf.data());
@@ -827,7 +827,7 @@ inline void DetectionOutput::NMSMX(int* indicesIn,
 
 inline void DetectionOutput::generateOutput(float* reorderedConfData, int* indicesData, int* detectionsData, float* decodedBboxesData,
     float* dstData) {
-    const auto& outDims = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();
+    const auto& outDims = getChildEdgeAt(0)->getMemory().getStaticDims();
     const int numResults = outDims[2];
     const int DETECTION_SIZE = outDims[3];
     if (DETECTION_SIZE != 7) {
@@ -842,7 +842,7 @@ inline void DetectionOutput::generateOutput(float* reorderedConfData, int* indic
     else
         dstDataSize = imgNum * classesNum * priorsNum * DETECTION_SIZE * sizeof(float);
 
-    if (static_cast<size_t>(dstDataSize) > getChildEdgesAtPort(0)[0]->getMemory().getSize()) {
+    if (static_cast<size_t>(dstDataSize) > getChildEdgeAt(0)->getMemory().getSize()) {
         OPENVINO_THROW(errorPrefix, ": OUT_OF_BOUNDS");
     }
     memset(dstData, 0, dstDataSize);

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -234,13 +234,13 @@ void copyDataToOutputWithSignalSize(const float* input, const std::vector<size_t
 } // namespace
 
 void DFT::execute(dnnl::stream strm) {
-    const auto& outputShape = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();
+    const auto& outputShape = getChildEdgeAt(0)->getMemory().getStaticDims();
 
     const auto inputDataEdge = getParentEdgeAt(DATA_INDEX);
     const auto outputDataEdge = getChildEdgeAt(0);
 
-    const auto src = reinterpret_cast<const float*>(inputDataEdge->getMemoryPtr()->getData());
-    auto dst = reinterpret_cast<float*>(outputDataEdge->getMemoryPtr()->getData());
+    const auto src = inputDataEdge->getMemoryPtr()->getDataAs<const float>();
+    auto dst = outputDataEdge->getMemoryPtr()->getDataAs<float>();
 
     const auto inputRank = inputDataEdge->getMemory().getShape().getRank();
 
@@ -525,7 +525,7 @@ void DFT::prepareParams() {
     bool hasFFT = false;
 
     axes = getAxes();
-    const auto outputShape = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();
+    const auto outputShape = getChildEdgeAt(0)->getMemory().getStaticDims();
 
     for (size_t axis : axes) {
         size_t nComplex = outputShape[axis];
@@ -542,7 +542,7 @@ void DFT::prepareParams() {
 
 std::vector<int32_t> DFT::getAxes() const {
     auto axesEdge = getParentEdgeAt(AXES_INDEX);
-    const auto* axesStartPtr = reinterpret_cast<const int32_t*>(axesEdge->getMemoryPtr()->getData());
+    const auto* axesStartPtr = axesEdge->getMemoryPtr()->getDataAs<const int32_t>();
     auto axes = std::vector<int32_t>(axesStartPtr, axesStartPtr + axesEdge->getMemory().getStaticDims()[0]);
     for (auto& axis : axes) {
         if (axis < 0) {

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offset_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offset_sum.cpp
@@ -75,17 +75,17 @@ void EmbeddingBagOffsetSum::initSupportedPrimitiveDescriptors() {
 }
 
 void EmbeddingBagOffsetSum::prepareParams() {
-    _indicesLen = getParentEdgesAtPort(INDICES_IDX)[0]->getMemory().getStaticDims()[0];
-    _offsetsLen = getParentEdgesAtPort(OFFSETS_IDX)[0]->getMemory().getStaticDims()[0];
-    EmbeddingBagSum::prepareParams(getParentEdgesAtPort(EMB_TABLE_IDX)[0]->getMemory().getStaticDims());
+    _indicesLen = getParentEdgeAt(INDICES_IDX)->getMemory().getStaticDims()[0];
+    _offsetsLen = getParentEdgeAt(OFFSETS_IDX)->getMemory().getStaticDims()[0];
+    EmbeddingBagSum::prepareParams(getParentEdgeAt(EMB_TABLE_IDX)->getMemory().getStaticDims());
 }
 
 void EmbeddingBagOffsetSum::initFromInputs() {
-    indicesData_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->getData());
-    offsetsData_ = reinterpret_cast<const int *>(getParentEdgeAt(OFFSETS_IDX)->getMemoryPtr()->getData());
+    indicesData_ = getSrcDataAtPortAs<const int>(INDICES_IDX);
+    offsetsData_ = getSrcDataAtPortAs<const int>(OFFSETS_IDX);
 
     if (getParentEdges().size() > DEFAULT_INDEX_IDX) {
-        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->getData());
+        defaultIndices_ = getSrcDataAtPortAs<const int>(DEFAULT_INDEX_IDX);
     }
 }
 
@@ -131,14 +131,14 @@ bool EmbeddingBagOffsetSum::isExecutable() const {
 }
 
 void EmbeddingBagOffsetSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcData = getSrcDataAtPortAs<const uint8_t>(0);
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->getData());
+        weightsData = getSrcDataAtPortAs<const uint8_t>(PER_SAMPLE_WEIGHTS_IDX);
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),
-                                       inputMem.getStaticDims(), getChildEdgesAtPort(0)[0]->getMemoryPtr());
+                                       inputMem.getStaticDims(), getDstMemoryAtPort(0));
 }
 
 bool EmbeddingBagOffsetSum::created() const {

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed_sum.cpp
@@ -67,13 +67,13 @@ void EmbeddingBagPackedSum::initSupportedPrimitiveDescriptors() {
 }
 
 void EmbeddingBagPackedSum::prepareParams() {
-    _batch = getParentEdgesAtPort(INDICES_IDX)[0]->getMemory().getStaticDims()[0];
-    _indicesPerBag = getParentEdgesAtPort(INDICES_IDX)[0]->getMemory().getStaticDims()[1];
-    EmbeddingBagSum::prepareParams(getParentEdgesAtPort(EMB_TABLE_IDX)[0]->getMemory().getStaticDims());
+    _batch = getParentEdgeAt(INDICES_IDX)->getMemory().getStaticDims()[0];
+    _indicesPerBag = getParentEdgeAt(INDICES_IDX)->getMemory().getStaticDims()[1];
+    EmbeddingBagSum::prepareParams(getParentEdgeAt(EMB_TABLE_IDX)->getMemory().getStaticDims());
 }
 
 void EmbeddingBagPackedSum::initFromInputs() {
-    _indices = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->getData());
+    _indices = getSrcDataAtPortAs<const int>(INDICES_IDX);
 }
 
 void EmbeddingBagPackedSum::getIndices(size_t embIndex, const int*& indices, size_t& size, int& weightsIdx, bool& withWeight) {
@@ -97,14 +97,14 @@ bool EmbeddingBagPackedSum::isExecutable() const {
 }
 
 void EmbeddingBagPackedSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcData = getSrcDataAtPortAs<const uint8_t>(0);
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->getData());
+        weightsData = getSrcDataAtPortAs<const uint8_t>(PER_SAMPLE_WEIGHTS_IDX);
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),
-                                       inputMem.getStaticDims(), getChildEdgesAtPort(0)[0]->getMemoryPtr());
+                                       inputMem.getStaticDims(), getDstMemoryAtPort(0));
 }
 
 bool EmbeddingBagPackedSum::created() const {

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_sum.cpp
@@ -52,7 +52,7 @@ void EmbeddingBagSum::processData(const T* srcData, const T* weightsData,
     initFromInputs();
 
     const size_t outputBagsNum = outMemory->getShape().getStaticDims()[0];
-    auto *dstData = reinterpret_cast<T *>(outMemory->getData());
+    auto *dstData = outMemory->getDataAs<T>();
 
     auto threadBody = [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
@@ -75,18 +75,18 @@ void EmbeddingSegmentsSum::initSupportedPrimitiveDescriptors() {
 }
 
 void EmbeddingSegmentsSum::prepareParams() {
-    EmbeddingBagSum::prepareParams(getParentEdgesAtPort(EMB_TABLE_IDX)[0]->getMemory().getStaticDims());
+    EmbeddingBagSum::prepareParams(getParentEdgeAt(EMB_TABLE_IDX)->getMemory().getStaticDims());
 }
 
 void EmbeddingSegmentsSum::initFromInputs() {
-    indices_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->getData());
+    indices_ = getSrcDataAtPortAs<const int>(INDICES_IDX);
     indicesSize_ = getParentEdgeAt(INDICES_IDX)->getMemory().getShape().getElementsCount();
 
-    segmentIds_ = reinterpret_cast<const int *>(getParentEdgeAt(SEGMENT_ID_IDX)->getMemoryPtr()->getData());
+    segmentIds_ = getSrcDataAtPortAs<const int>(SEGMENT_ID_IDX);
     lastNumSegments_ = getNumSegments();
 
     if (getParentEdges().size() > DEFAULT_INDEX_IDX) {
-        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->getData());
+        defaultIndices_ = getSrcDataAtPortAs<const int>(DEFAULT_INDEX_IDX);
     }
 }
 
@@ -119,7 +119,7 @@ void EmbeddingSegmentsSum::getIndices(size_t embIndex, const int*& indices, size
 }
 
 int32_t EmbeddingSegmentsSum::getNumSegments() const {
-    return reinterpret_cast<const int32_t *>(getParentEdgesAtPort(NUM_SEGMENTS_IDX)[0]->getMemory().getData())[0];
+    return getParentEdgeAt(NUM_SEGMENTS_IDX)->getMemory().getDataAs<const int32_t>()[0];
 }
 
 bool EmbeddingSegmentsSum::needShapeInfer() const {
@@ -143,14 +143,14 @@ bool EmbeddingSegmentsSum::isExecutable() const {
 }
 
 void EmbeddingSegmentsSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcData = getSrcDataAtPortAs<const uint8_t>(0);
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->getData());
+        weightsData = getSrcDataAtPortAs<const uint8_t>(PER_SAMPLE_WEIGHTS_IDX);
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),
-                                       inputMem.getStaticDims(), getChildEdgesAtPort(0)[0]->getMemoryPtr());
+                                       inputMem.getStaticDims(), getDstMemoryAtPort(0));
 }
 
 bool EmbeddingSegmentsSum::created() const {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
@@ -91,7 +91,7 @@ bool AclDeconvExecutor::init(const DeconvAttrs& deconvAttrs,
 }
 
 static void transpose_to_1023(const MemoryCPtr& srcMemPtr, std::vector<float>& dst_data) {
-    const auto src_data = reinterpret_cast<float*>(srcMemPtr->getData());
+    const auto src_data = srcMemPtr->getDataAs<float>();
 
     const int DIM0 = srcMemPtr->getStaticDims()[0];
     const int DIM1 = srcMemPtr->getStaticDims()[1];

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_opt_transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_opt_transpose.cpp
@@ -17,8 +17,8 @@ struct TransposeContext {
 
 template <typename T>
 void transpose_to_0312(const int MB, const MemoryCPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
-    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->getData());
-    auto dst_data = reinterpret_cast<T*>(dstMemPtr->getData());
+    const auto src_data = srcMemPtr->getDataAs<const T>();
+    auto dst_data = dstMemPtr->getDataAs<T>();
 
     const int DIM1 = srcMemPtr->getStaticDims()[1];
     const int DIM2 = srcMemPtr->getStaticDims()[2];
@@ -42,8 +42,8 @@ void transpose_to_0312(const int MB, const MemoryCPtr& srcMemPtr, MemoryPtr& dst
 
 template<typename T>
 void transpose_to_04123(const int MB, const MemoryCPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
-    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->getData());
-    auto dst_data = reinterpret_cast<T*>(dstMemPtr->getData());
+    const auto src_data = srcMemPtr->getDataAs<const T>();
+    auto dst_data = dstMemPtr->getDataAs<T>();
 
     const int DIM1 = srcMemPtr->getStaticDims()[1];
     const int DIM2 = srcMemPtr->getStaticDims()[2];
@@ -70,8 +70,8 @@ void transpose_to_04123(const int MB, const MemoryCPtr& srcMemPtr, MemoryPtr& ds
 
 template<typename T>
 void transpose_to_051234(const int MB, const MemoryCPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
-    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->getData());
-    auto dst_data = reinterpret_cast<T*>(dstMemPtr->getData());
+    const auto src_data = srcMemPtr->getDataAs<const T>();
+    auto dst_data = dstMemPtr->getDataAs<T>();
 
     const int DIM1 = srcMemPtr->getStaticDims()[1];
     const int DIM2 = srcMemPtr->getStaticDims()[2];

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_transpose.cpp
@@ -64,8 +64,8 @@ void RefTransposeExecutor::referenceExecute(const uint8_t* src_data, uint8_t* ds
 }
 
 void RefTransposeExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, const int MB) {
-    const uint8_t* src_data = reinterpret_cast<const uint8_t*>(src[0]->getData());
-    uint8_t* dst_data = reinterpret_cast<uint8_t*>(dst[0]->getData());
+    const uint8_t* src_data = src[0]->getDataAs<const uint8_t>();
+    uint8_t* dst_data = dst[0]->getDataAs<uint8_t>();
     referenceExecute(src_data, dst_data, jcp, MB);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -453,7 +453,7 @@ inline VectorDims getBlockND(const VectorDims& shape) {
 }
 
 const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) {
-    const uint8_t *src_data_origin = reinterpret_cast<uint8_t*>(src[0]->getData());
+    const uint8_t *src_data_origin = src[0]->getDataAs<uint8_t>();
 
     const auto &srcDim = src[0]->getStaticDims();
     const auto &dstDim = dst[0]->getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_transpose.cpp
@@ -153,8 +153,8 @@ void MlasTransposeExecutor::TransposeSingleAxisOutwards(const MemoryCPtr& input,
     const auto& input_dims = input_shape.getDims();
     const auto element_size = input->getDesc().getPrecision().size();
 
-    const auto* input_data = reinterpret_cast<const uint8_t*>(input->getData());
-    auto* output_data = reinterpret_cast<uint8_t*>(output->getData());
+    const auto* input_data = input->getDataAs<const uint8_t>();
+    auto* output_data = output->getDataAs<uint8_t>();
 
     auto num_loops = calcShapeSize(input_shape, 0, to);
     auto num_writers = input_dims[from];
@@ -215,8 +215,8 @@ void MlasTransposeExecutor::TransposeSingleAxisInwards(const MemoryCPtr& input, 
     const auto& input_dims = input_shape.getDims();
 
     const auto element_size = input->getDesc().getPrecision().size();
-    const auto* input_data = reinterpret_cast<const uint8_t*>(input->getData());
-    auto* output_data = reinterpret_cast<uint8_t*>(output->getData());
+    const auto* input_data = input->getDataAs<const uint8_t>();
+    auto* output_data = output->getDataAs<uint8_t>();
 
     auto num_loops = calcShapeSize(input_shape, 0, from);
     auto num_readers = input_dims[from];

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/jit_transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/jit_transpose.cpp
@@ -14,8 +14,8 @@ void JitTransposeExecutor::exec(const std::vector<MemoryCPtr>& src, const std::v
     if (!pKernel)
         OPENVINO_THROW("Could not execute. Kernel for Transpose node was not compiled.");
 
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(src[0]->getData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dst[0]->getData());
+    const uint8_t* srcData = src[0]->getDataAs<const uint8_t>();
+    uint8_t* dstData = dst[0]->getDataAs<uint8_t>();
 
     pKernel->execute(srcData, dstData, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
@@ -275,14 +275,14 @@ void ExperimentalDetectronDetectionOutput::execute(dnnl::stream strm) {
     assert(classes_num_ == static_cast<int>(getParentEdgeAt(INPUT_SCORES)->getMemory().getStaticDims()[1]));
     assert(4 * classes_num_ == static_cast<int>(getParentEdgeAt(INPUT_DELTAS)->getMemory().getStaticDims()[1]));
 
-    const auto* boxes = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->getData());
-    const auto* deltas = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->getData());
-    const auto* scores = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->getData());
-    const auto* im_info = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->getData());
+    const auto* boxes = getSrcDataAtPortAs<const float>(INPUT_ROIS);
+    const auto* deltas = getSrcDataAtPortAs<const float>(INPUT_DELTAS);
+    const auto* scores = getSrcDataAtPortAs<const float>(INPUT_SCORES);
+    const auto* im_info = getSrcDataAtPortAs<const float>(INPUT_IM_INFO);
 
-    auto* output_boxes = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_BOXES)[0]->getMemoryPtr()->getData());
-    auto* output_scores = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->getData());
-    auto* output_classes = reinterpret_cast<int32_t *>(getChildEdgesAtPort(OUTPUT_CLASSES)[0]->getMemoryPtr()->getData());
+    auto* output_boxes = getDstDataAtPortAs<float>(OUTPUT_BOXES);
+    auto* output_scores = getDstDataAtPortAs<float>(OUTPUT_SCORES);
+    auto* output_classes = getDstDataAtPortAs<int32_t>(OUTPUT_CLASSES);
 
     const float img_H = im_info[0];
     const float img_W = im_info[1];

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
@@ -347,13 +347,13 @@ void ExperimentalDetectronGenerateProposalsSingleImage::execute(dnnl::stream str
             OPENVINO_THROW("'Deltas' blob size for ONNXProposal is incompatible with 'scores' blob size!");
 
         // Prepare memory
-        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->getData());
-        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->getData());
-        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->getData());
-        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->getData());
+        const float *p_deltas_item  = getSrcDataAtPortAs<const float>(INPUT_DELTAS);
+        const float *p_scores_item  = getSrcDataAtPortAs<const float>(INPUT_SCORES);
+        const float *p_anchors_item = getSrcDataAtPortAs<const float>(INPUT_ANCHORS);
+        const float *p_img_info_cpu = getSrcDataAtPortAs<const float>(INPUT_IM_INFO);
 
-        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
-        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->getData());
+        float *p_roi_item       = getDstDataAtPortAs<float>(OUTPUT_ROIS);
+        float *p_roi_score_item = getDstDataAtPortAs<float>(OUTPUT_SCORES);
 
         const int anchors_num = scoreDims[0];
 

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
@@ -68,8 +68,8 @@ void ExperimentalDetectronPriorGridGenerator::execute(dnnl::stream strm) {
     const float step_w = stride_w_ ? stride_w_ : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[3]) / layer_width;
     const float step_h = stride_h_ ? stride_h_ : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[2]) / layer_height;
 
-    const auto *bottom_data_0 = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    auto *top_data_0 = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
+    const auto *bottom_data_0 = getSrcDataAtPortAs<const float>(0);
+    auto *top_data_0 = getDstDataAtPortAs<float>(OUTPUT_ROIS);
 
     for (int h = 0; h < layer_height; ++h) {
         for (int w = 0; w < layer_width; ++w) {

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
@@ -333,11 +333,11 @@ void ExperimentalDetectronROIFeatureExtractor::execute(dnnl::stream strm) {
     const int channels_num = getParentEdgeAt(INPUT_FEATURES_START)->getMemory().getStaticDims()[1];
     const int feaxels_per_roi = pooled_height_ * pooled_width_ * channels_num;
 
-    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->getData());
-    auto *output_rois_features = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROI_FEATURES)[0]->getMemoryPtr()->getData());
+    auto *input_rois = getSrcDataAtPortAs<const float>(INPUT_ROIS);
+    auto *output_rois_features = getDstDataAtPortAs<float>(OUTPUT_ROI_FEATURES);
     float *output_rois = nullptr;
     if (OUTPUT_ROIS < outputShapes.size()) {
-        output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
+        output_rois = getDstDataAtPortAs<float>(OUTPUT_ROIS);
     }
 
     std::vector<int> level_ids(num_rois, 0);
@@ -355,7 +355,7 @@ void ExperimentalDetectronROIFeatureExtractor::execute(dnnl::stream strm) {
         const int level_rois_offset = rois_per_level[i];
         const int level_rois_num = rois_per_level[i + 1] - level_rois_offset;
         if (level_rois_num > 0) {
-            auto *featuremap = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_FEATURES_START + i)->getMemoryPtr()->getData());
+            auto *featuremap = getSrcDataAtPortAs<const float>(INPUT_FEATURES_START + i);
             const int featuremap_height = getParentEdgeAt(INPUT_FEATURES_START + i)->getMemory().getStaticDims()[2];
             const int featuremap_width = getParentEdgeAt(INPUT_FEATURES_START + i)->getMemory().getStaticDims()[3];
             ROIAlignForward_cpu_kernel<float>(feaxels_per_roi * level_rois_num,

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
@@ -66,9 +66,9 @@ void ExperimentalDetectronTopKROIs::execute(dnnl::stream strm) {
     const int input_rois_num = getParentEdgeAt(INPUT_ROIS)->getMemory().getStaticDims()[0];
     const int top_rois_num = (std::min)(max_rois_num_, input_rois_num);
 
-    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->getData());
-    auto *input_probs = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_PROBS)->getMemoryPtr()->getData());
-    auto *output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
+    auto *input_rois = getSrcDataAtPortAs<const float>(INPUT_ROIS);
+    auto *input_probs = getSrcDataAtPortAs<const float>(INPUT_PROBS);
+    auto *output_rois = getDstDataAtPortAs<float>(OUTPUT_ROIS);
 
     std::vector<size_t> idx(input_rois_num);
     iota(idx.begin(), idx.end(), 0);

--- a/src/plugins/intel_cpu/src/nodes/eye.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eye.cpp
@@ -73,7 +73,7 @@ struct Eye::EyeExecute {
 };
 
 void Eye::execute(dnnl::stream strm) {
-    auto outputPrec = getChildEdgesAtPort(0)[0]->getMemory().getDesc().getPrecision();
+    auto outputPrec = getChildEdgeAt(0)->getMemory().getDesc().getPrecision();
     OV_SWITCH(intel_cpu, EyeExecute, this, outputPrec,
               OV_CASE(ov::element::f32, float),
               OV_CASE(ov::element::bf16, bfloat16_t),
@@ -102,10 +102,10 @@ void Eye::executeSpecified() {
     const size_t rowNum = getRowNum();
     const size_t colNum = getColNum();
     const int64_t shift = getDiagIndex();
-    auto outPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto outPtr = getDstMemoryAtPort(0);
     if (!outPtr || !outPtr ->isAllocated())
         THROW_ERROR(errorPrefix, "Destination memory didn't allocate.");
-    T *dst = reinterpret_cast<T *>(outPtr->getData());
+    T *dst = outPtr->getDataAs<T>();
 
     const size_t batchVolume = getBatchVolume(getBatchShape());
     const size_t spatialCount = colNum * rowNum;

--- a/src/plugins/intel_cpu/src/nodes/eye.h
+++ b/src/plugins/intel_cpu/src/nodes/eye.h
@@ -42,34 +42,34 @@ private:
     template<typename T>
     struct EyeExecute;
     inline const size_t getRowNum() const {
-        auto rowMem = getParentEdgeAt(ROWS_NUM)->getMemoryPtr();
+        auto rowMem = getSrcMemoryAtPort(ROWS_NUM);
         if (rowMem == nullptr)
             OPENVINO_THROW(errorPrefix, " doesn't contain row_count data");
-        const int *rowPtr = reinterpret_cast<const int *>(rowMem->getData());
+        const int *rowPtr = rowMem->getDataAs<const int>();
 
         return rowPtr[0];
     }
     inline const size_t getColNum() const {
-        auto colMem = getParentEdgeAt(COLS_NUM)->getMemoryPtr();
+        auto colMem = getSrcMemoryAtPort(COLS_NUM);
         if (colMem == nullptr)
             OPENVINO_THROW(errorPrefix, " doesn't contain col_count data");
-        const int *colPtr =  reinterpret_cast<const int *>(colMem->getData());
+        const int *colPtr =  colMem->getDataAs<const int>();
 
         return colPtr[0];
     }
     inline const int getDiagIndex() const {
-        auto diagIndMem = getParentEdgeAt(DIAGONAL_INDEX)->getMemoryPtr();
+        auto diagIndMem = getSrcMemoryAtPort(DIAGONAL_INDEX);
         if (diagIndMem == nullptr)
             OPENVINO_THROW(errorPrefix, " doesn't contain diag_index data");
-        const int *diagIndexPtr = reinterpret_cast<const int *>(diagIndMem->getData());
+        const int *diagIndexPtr = diagIndMem->getDataAs<const int>();
 
         return diagIndexPtr[0];
     }
     inline const std::vector<int> getBatchShape() const {
         if (withBatchShape) {
-            const int batchShapeSize = static_cast<const int>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->getShape().getElementsCount());
+            const int batchShapeSize = static_cast<const int>(getSrcMemoryAtPort(BATCH_SHAPE)->getShape().getElementsCount());
             std::vector<int> batchShape(batchShapeSize);
-            const int *batchShapePtr = reinterpret_cast<const int *>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->getData());
+            const int *batchShapePtr = getSrcDataAtPortAs<const int>(BATCH_SHAPE);
             batchShape.assign(batchShapePtr, batchShapePtr + batchShapeSize);
             return batchShape;
         } else {

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1298,11 +1298,6 @@ void FakeQuantize::getSupportedDescriptors() {
     if (getChildEdges().empty())
         OPENVINO_THROW(errorPrefix, "has incorrect number of output edges: ", getChildEdges().size());
 
-    for (size_t i = 0; i < getParentEdges().size(); i++) {
-        if (getParentEdgesAtPort(i).size() != 1)
-            OPENVINO_THROW(errorPrefix, "has unsupported number of parent edges at port ", i);
-    }
-
     if (getInputShapeAtPort(0).getRank() != getInputShapeAtPort(0).getRank()) {
         OPENVINO_THROW(errorPrefix, "has different ranks for input and output tensors");
     }
@@ -1390,7 +1385,7 @@ bool FakeQuantize::needPrepareParams() const {
             return true;
         }
 
-        const auto axisSize = getParentEdgesAtPort(0)[0]->getMemory().getStaticDims()[getAxis()];
+        const auto axisSize = getParentEdgeAt(0)->getMemory().getStaticDims()[getAxis()];
         const auto newPaddedSize = rnd_up(axisSize, 16);
         const auto currPaddedSize = rnd_up(currentAxisSize, 16);
 
@@ -1494,10 +1489,10 @@ void FakeQuantize::createPrimitive() {
 }
 
 void FakeQuantize::executeReference() {
-    auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemory = getSrcMemoryAtPort(0);
+    auto dstMemory = getDstMemoryAtPort(0);
 
-    auto src = reinterpret_cast<const float *>(srcMemory->getData());
+    auto src = srcMemory->getDataAs<const float>();
 
     auto srcDims = srcMemory->getStaticDims();
     auto dstDims = dstMemory->getStaticDims();
@@ -1524,13 +1519,13 @@ void FakeQuantize::executeReference() {
         }
         d_str[1] = tmp;
 
-        auto dst = reinterpret_cast<uint8_t *>(dstMemory->getData());
+        auto dst = dstMemory->getDataAs<uint8_t>();
 
         const int nbits = 8;
         const int CB = impl::utils::div_up(C, nbits);
 
-        auto thresholds = reinterpret_cast<const float*>(internalBlobMemory[0]->getData());
-        auto output_mask = reinterpret_cast<const uint32_t*>(internalBlobMemory[1]->getData());
+        auto thresholds = internalBlobMemory[0]->getDataAs<const float>();
+        auto output_mask = internalBlobMemory[1]->getDataAs<const uint32_t>();
 
         parallel_nd(N, CB, D, H, W, [&](dim_t n, dim_t cb, dim_t d, dim_t h, dim_t w) {
             uint8_t bin_val = 0x00;
@@ -1560,7 +1555,7 @@ void FakeQuantize::executeReference() {
             dst[dst_off / nbits] = bin_val;
         });
     } else {
-        auto dst = reinterpret_cast<float *>(dstMemory->getData());
+        auto dst = dstMemory->getDataAs<float>();
 
         parallel_nd(N, C, D, H, W, [&](dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
             size_t src_off = srcDims.size() == 5 ?
@@ -1604,14 +1599,14 @@ void FakeQuantize::executeReference() {
 }
 void FakeQuantize::executeBinarization(const std::unique_ptr<jit_uni_quantize_kernel> &pKernel) const {
 #if defined(OPENVINO_ARCH_X86_64)
-    auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemory = getSrcMemoryAtPort(0);
+    auto dstMemory = getDstMemoryAtPort(0);
 
-    auto src = reinterpret_cast<const uint8_t *>(srcMemory->getData());
-    auto dst = reinterpret_cast<uint8_t *>(dstMemory->getData());
+    auto src = srcMemory->getDataAs<const uint8_t>();
+    auto dst = dstMemory->getDataAs<uint8_t>();
 
-    auto thresholds = reinterpret_cast<const float*>(internalBlobMemory[0]->getData());
-    auto output_mask = reinterpret_cast<const float*>(internalBlobMemory[1]->getData());
+    auto thresholds = internalBlobMemory[0]->getDataAs<const float>();
+    auto output_mask = internalBlobMemory[1]->getDataAs<const float>();
 
     auto src_dims = srcMemory->getStaticDims();
 
@@ -1646,11 +1641,11 @@ void FakeQuantize::executeBinarization(const std::unique_ptr<jit_uni_quantize_ke
 
 void FakeQuantize::executeQuantization(const std::unique_ptr<jit_uni_quantize_kernel> &pKernel) const {
 #if defined(OPENVINO_ARCH_X86_64)
-    auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemory = getSrcMemoryAtPort(0);
+    auto dstMemory = getDstMemoryAtPort(0);
 
-    auto src = reinterpret_cast<const uint8_t *>(srcMemory->getData());
-    auto dst = reinterpret_cast<uint8_t *>(dstMemory->getData());
+    auto src = srcMemory->getDataAs<const uint8_t>();
+    auto dst = dstMemory->getDataAs<uint8_t>();
 
     auto& srcDesc = srcMemory->getDesc();
     auto srcDims = srcDesc.getShape().getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -304,7 +304,7 @@ void FullyConnected::prepackMLASWeight() {
         if (weightCache != nullptr) {
             std::string format = "gemm_mlas_" + std::to_string(N) + "_" + std::to_string(K);
             const std::string string_hash = getName() + "_" + format + "_" + std::to_string(weightsMem->getSize()) +
-                                            "_" + std::to_string(reinterpret_cast<uint64_t>(weightsMem->getData()));
+                                            "_" + std::to_string(*weightsMem->getDataAs<uint64_t>());
 
             ptr = *weightCache->findOrCreate(string_hash, create);
         } else {

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -284,18 +284,18 @@ void FullyConnected::prepackMLASWeight() {
     auto prepareMLASWeight = [&](const int64_t N, const int64_t K) {
         if (!getParentEdgeAt(WEIGHTS_ID)->getParent()->isConstant())
             OPENVINO_THROW("Weight input is not const for node ", getName(), ".");
-        auto weightsMem = getParentEdgeAt(WEIGHTS_ID)->getMemoryPtr();
+        auto weightsMem = getSrcMemoryAtPort(WEIGHTS_ID);
         if (!weightsMem)
             OPENVINO_THROW("Cannot get const weights edgeMem for node ", getName(), ".");
         auto packedBsize = mlas_sgemm_pack_get_size(N, K);
         MemoryPtr ptr;
         auto create = [&]() {
-            float* weightPtr = reinterpret_cast<float*>(weightsMem->getData());
+            float* weightPtr = weightsMem->getDataAs<float>();
             size_t ldb = weightsNonTransposed ? N : K;
             MemoryPtr _ptr =
                 std::make_shared<Memory>(getEngine(),
                                          intel_cpu::CpuBlockedMemoryDesc(ov::element::i8, intel_cpu::Shape{packedBsize}));
-            float* prepackedDst = reinterpret_cast<float*>(_ptr->getData());
+            float* prepackedDst = _ptr->getDataAs<float>();
             mlas_sgemm_pack(weightsNonTransposed ? "F" : "T", N, K, ldb, weightPtr, prepackedDst);
             return _ptr;
         };
@@ -312,7 +312,7 @@ void FullyConnected::prepackMLASWeight() {
         }
         return ptr;
     };
-    const auto& wgtDims = getParentEdgeAt(WEIGHTS_ID)->getMemoryPtr()->getStaticDims();
+    const auto& wgtDims = getSrcMemoryAtPort(WEIGHTS_ID)->getStaticDims();
     // Weights are transposed by MatMulConstTransposesExtraction
     // K is the IC of weight
     // the weight is reshaped to [-1, K] in ConvertMatMulToFC
@@ -502,15 +502,15 @@ void FullyConnected::createPrimitive() {
 }
 
 void FullyConnected::prepareParams() {
-    auto srcMemPtr = getParentEdgesAtPort(0)[0]->getMemoryPtr();
-    auto dstMemPtr = getChildEdgesAtPort(0)[0]->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(0);
+    auto dstMemPtr = getDstMemoryAtPort(0);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         OPENVINO_THROW("Destination memory hasn't been allocated.");
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         OPENVINO_THROW("Input memory hasn't been allocated.");
     MemoryPtr biasMemPtr = nullptr;
     if (withBiases) {
-        biasMemPtr = getParentEdgesAtPort(2)[0]->getMemoryPtr();
+        biasMemPtr = getSrcMemoryAtPort(2);
         if (!biasMemPtr || !biasMemPtr->isAllocated())
             OPENVINO_THROW("Input memory hasn't been allocated.");
     }
@@ -582,7 +582,7 @@ void FullyConnected::prepareParams() {
 #ifdef CPU_DEBUG_CAPS
             // execPtr expects different weight layout.
             if (prevExecPtr) {
-                const Shape weiShape{getParentEdgesAtPort(1)[0]->getMemoryPtr()->getStaticDims()};
+                const Shape weiShape{getSrcMemoryAtPort(1)->getStaticDims()};
                 DEBUG_LOG("##", getName(), " weight desc is not compatible with previous inner product execPtr!");
                 DEBUG_LOG("#", static_cast<float>(execPtr->getWeightDesc()->getMaxMemSize()) / static_cast<float>(1<<20),
                            "#", weiShape.toString(),
@@ -628,9 +628,9 @@ void FullyConnected::prepareParams() {
 
 #ifdef OV_CPU_WITH_MLAS
 void FullyConnected::executeMLAS() {
-    const auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    const auto src0MemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    const auto biasMemPtr = withBiases ? getParentEdgeAt(BIAS_ID)->getMemoryPtr() : nullptr;
+    const auto dstMemPtr = getDstMemoryAtPort(0);
+    const auto src0MemPtr = getSrcMemoryAtPort(0);
+    const auto biasMemPtr = withBiases ? getSrcMemoryAtPort(BIAS_ID) : nullptr;
     int64_t lda = K;
     int64_t ldb = K;
     int64_t ldc = N;
@@ -640,14 +640,14 @@ void FullyConnected::executeMLAS() {
                        N,
                        K,
                        1.0f,
-                       reinterpret_cast<float*>(src0MemPtr->getData()),
+                       src0MemPtr->getDataAs<float>(),
                        lda,
-                       reinterpret_cast<float*>(mlasPackedPtr->getData()),
+                       mlasPackedPtr->getDataAs<float>(),
                        ldb,
                        0.0f,
-                       reinterpret_cast<float*>(dstMemPtr->getData()),
+                       dstMemPtr->getDataAs<float>(),
                        ldc,
-                       withBiases ? reinterpret_cast<float*>(biasMemPtr->getData()) : nullptr);
+                       withBiases ? biasMemPtr->getDataAs<float>() : nullptr);
 }
 
 #endif
@@ -671,10 +671,10 @@ void FullyConnected::execute(dnnl::stream strm) {
         auto param = primArgs.find(argType);
         if (param != primArgs.end()) {
             if (argType == DNNL_ARG_SRC && (getInputShapeAtPort(DATA_ID).getRank() > 2 || useConv1x1)) {
-                primArgs.at(argType).set_data_handle(getParentEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+                primArgs.at(argType).set_data_handle(getSrcDataAtPort(0));
             }
             if (argType == DNNL_ARG_DST && (getOutputShapeAtPort(0).getRank() > 2 || useConv1x1)) {
-                primArgs.at(argType).set_data_handle(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+                primArgs.at(argType).set_data_handle(getDstDataAtPort(0));
             }
         }
     };
@@ -1026,7 +1026,7 @@ bool FullyConnected::canBeExecutedInConv1x1() const {
     if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) &&
         getOriginalInputPrecisionAtPort(DATA_ID) == ov::element::f32 &&
         one_of(inRank, 2u, 3u) && weightRank == 2) {
-        auto dstMemPtr = getChildEdgesAtPort(0)[0]->getMemoryPtr();
+        auto dstMemPtr = getDstMemoryAtPort(0);
         DnnlMemoryDescCPtr outDesc = dstMemPtr->getDescWithType<DnnlMemoryDesc>();
         // brg convolution does not support stride
         dnnl::impl::memory_desc_wrapper wrapped(outDesc->getDnnlDesc().get());
@@ -1035,9 +1035,9 @@ bool FullyConnected::canBeExecutedInConv1x1() const {
     }
 
     if (retVal) {
-        auto srcMemPtr = getParentEdgesAtPort(0)[0]->getMemoryPtr();
+        auto srcMemPtr = getSrcMemoryAtPort(0);
         const auto& srcDims = srcMemPtr->getStaticDims();
-        auto weightMemPtr = getParentEdgesAtPort(1)[0]->getMemoryPtr();
+        auto weightMemPtr = getSrcMemoryAtPort(1);
         const auto& weightDims = weightMemPtr->getStaticDims();
         // for original inner product semantics:
         //  when input is 2D tensor
@@ -1095,7 +1095,7 @@ bool FullyConnected::useSparseWeightsDecompression() {
     if (blb == nullptr)
         OPENVINO_THROW("Cannot get const blob for node ", getName(), ".");
 
-    auto weightsData = reinterpret_cast<const int8_t*>(blb->getData());
+    auto weightsData = blb->getDataAs<const int8_t>();
     auto elementsCount = blb->getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
     size_t zerosCounts = 0;
     for (size_t i = 0; i < elementsCount; i++) {
@@ -1146,7 +1146,7 @@ void FullyConnected::fuseDecompressionConstant(const MemoryCPtr& memory, MemoryC
 DnnlMemoryDescPtr FullyConnected::makeTransposedWeightDescriptor(DnnlMemoryDescPtr desc) {
     if (!getParentEdgeAt(1)->getParent()->isConstant())
         OPENVINO_THROW("Weight input is not const for node ", getName(), ".");
-    auto edgeMem = getParentEdgeAt(1)->getMemoryPtr();
+    auto edgeMem = getSrcMemoryAtPort(1);
     if (!edgeMem)
         OPENVINO_THROW("Cannot get const weights edgeMem for node ", getName(), ".");
 

--- a/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
@@ -56,8 +56,8 @@ GatherElements::GatherElements(const std::shared_ptr<ov::Node>& op, const GraphC
 }
 
 void GatherElements::prepareParams() {
-    const auto& dataDims = getParentEdgesAtPort(dataIndex_)[0]->getMemory().getStaticDims();
-    const auto& dstDims = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();
+    const auto& dataDims = getParentEdgeAt(dataIndex_)->getMemory().getStaticDims();
+    const auto& dstDims = getChildEdgeAt(0)->getMemory().getStaticDims();
     strideAxDst_ = 1;
     for (size_t i = dstDims.size() - 1; i > axis_; i--)
         strideAxDst_ *= dstDims[i];
@@ -101,11 +101,11 @@ void GatherElements::executeDynamicImpl(dnnl::stream strm) {
 
 template <typename dataType>
 void GatherElements::directExecution() {
-    const auto *srcData = reinterpret_cast<const dataType *>(getParentEdgeAt(dataIndex_)->getMemoryPtr()->getData());
-    const auto *indices = reinterpret_cast<const int *>(getParentEdgeAt(indicesIndex_)->getMemoryPtr()->getData());
-    auto *dstData = reinterpret_cast<dataType *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcData = getSrcDataAtPortAs<const dataType>(dataIndex_);
+    const auto *indices = getSrcDataAtPortAs<const int>(indicesIndex_);
+    auto *dstData = getDstDataAtPortAs<dataType>(0);
 
-    const int outSize = getChildEdgesAtPort(0)[0]->getMemory().getShape().getElementsCount();
+    const int outSize = getChildEdgeAt(0)->getMemory().getShape().getElementsCount();
     auto threadBody = [&](const int ithr, const int nthr) {
         int start(0lu), end(0lu);
         splitter(outSize, nthr, ithr, start, end);

--- a/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
@@ -82,9 +82,9 @@ void GatherND::initSupportedPrimitiveDescriptors() {
 }
 
 void GatherND::prepareParams() {
-    auto srcMemPtr = getParentEdgeAt(GATHERND_DATA)->getMemoryPtr();
-    auto idxMemPtr = getParentEdgeAt(GATHERND_INDEXES)->getMemoryPtr();
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(GATHERND_DATA);
+    auto idxMemPtr = getSrcMemoryAtPort(GATHERND_INDEXES);
+    auto dstMemPtr = getDstMemoryAtPort(0);
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         THROW_ERROR(" has not allocated input memory of 'data'.");
     if (!idxMemPtr || !idxMemPtr->isAllocated())
@@ -129,9 +129,9 @@ void GatherND::execute(dnnl::stream strm) {
     if (!execPtr)
         THROW_ERROR("has not compiled executor.");
 
-    execPtr->exec(getParentEdgeAt(GATHERND_DATA)->getMemoryPtr(),
-                  getParentEdgeAt(GATHERND_INDEXES)->getMemoryPtr(),
-                  getChildEdgeAt(0)->getMemoryPtr());
+    execPtr->exec(getSrcMemoryAtPort(GATHERND_DATA),
+                  getSrcMemoryAtPort(GATHERND_INDEXES),
+                  getDstMemoryAtPort(0));
 }
 
 void GatherND::GatherNDExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
@@ -148,9 +148,9 @@ void GatherND::GatherNDExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPt
 }
 
 void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->getData());
-    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->getData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
+    const uint8_t* srcData = srcMemPtr->getDataAs<const uint8_t>();
+    const int32_t* indices = idxMemPtr->getDataAs<const int32_t>();
+    uint8_t* dstData = dstMemPtr->getDataAs<uint8_t>();
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);
@@ -185,9 +185,9 @@ void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const 
 
 template <typename dataType>
 void GatherND::GatherNDExecutor::gatherElementwise(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
-    const dataType* srcData = reinterpret_cast<const dataType*>(srcMemPtr->getData());
-    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->getData());
-    dataType* dstData = reinterpret_cast<dataType*>(dstMemPtr->getData());
+    const dataType* srcData = srcMemPtr->getDataAs<const dataType>();
+    const int32_t* indices = idxMemPtr->getDataAs<const int32_t>();
+    dataType* dstData = dstMemPtr->getDataAs<dataType>();
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);

--- a/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
+++ b/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
@@ -360,10 +360,10 @@ void GenerateProposals::execute(dnnl::stream strm) {
         }
 
         // Prepare memory
-        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->getData());
-        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->getData());
-        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->getData());
-        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->getData());
+        const float *p_deltas_item  = getSrcDataAtPortAs<const float>(INPUT_DELTAS);
+        const float *p_scores_item  = getSrcDataAtPortAs<const float>(INPUT_SCORES);
+        const float *p_anchors_item = getSrcDataAtPortAs<const float>(INPUT_ANCHORS);
+        const float *p_img_info_cpu = getSrcDataAtPortAs<const float>(INPUT_IM_INFO);
 
         const int anchors_num = scoreDims[1];
 
@@ -451,12 +451,12 @@ void GenerateProposals::execute(dnnl::stream strm) {
         }
         // copy to out memory
         redefineOutputMemory({VectorDims{total_num_rois, 4}, VectorDims{total_num_rois}, VectorDims{batch_size}});
-        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
-        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->getData());
-        uint8_t* p_roi_num_item = reinterpret_cast<uint8_t *>(getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->getData());
+        float *p_roi_item       = getDstDataAtPortAs<float>(OUTPUT_ROIS);
+        float *p_roi_score_item = getDstDataAtPortAs<float>(OUTPUT_SCORES);
+        uint8_t* p_roi_num_item = getDstDataAtPortAs<uint8_t>(OUTPUT_ROI_NUM);
         memcpy(p_roi_item, &roi_item[0], roi_item.size() * sizeof(float));
         memcpy(p_roi_score_item, &score_item[0], score_item.size() * sizeof(float));
-        memcpy(p_roi_num_item, &roi_num[0], getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->getSize());
+        memcpy(p_roi_num_item, &roi_num[0], getDstMemoryAtPort(OUTPUT_ROI_NUM)->getSize());
     } catch (const std::exception &e) {
         std::string errorMsg = e.what();
         OPENVINO_THROW(errorMsg);

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
@@ -181,13 +181,13 @@ void GridSample::createPrimitive() {
 }
 
 void GridSample::prepareParams() {
-    auto dataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
+    auto dataMemPtr = getSrcMemoryAtPort(IN_DATA);
     if (!dataMemPtr || !dataMemPtr->isAllocated())
         THROW_CPU_NODE_ERR("has not allocated input data memory.");
-    auto gridMemPtr = getParentEdgeAt(IN_GRID)->getMemoryPtr();
+    auto gridMemPtr = getSrcMemoryAtPort(IN_GRID);
     if (!gridMemPtr || !gridMemPtr->isAllocated())
         THROW_CPU_NODE_ERR("has not allocated input grid memory.");
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(0);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_CPU_NODE_ERR("has not allocated output memory.");
     if (getSelectedPrimitiveDescriptor() == nullptr)
@@ -264,9 +264,9 @@ void GridSample::prepareParams() {
 }
 
 void GridSample::execute(dnnl::stream strm) {
-    const void*    srcData = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getData();
-    const uint8_t* gridData = reinterpret_cast<uint8_t*>(getParentEdgeAt(IN_GRID)->getMemoryPtr()->getData());
-    uint8_t*       dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const void*    srcData = getSrcDataAtPort(IN_DATA);
+    const uint8_t* gridData = getSrcDataAtPortAs<uint8_t>(IN_GRID);
+    uint8_t*       dstData = getDstDataAtPortAs<uint8_t>(0);
 
     auto threadBody = [&](const int ithr, const int nthr) {
         const auto& p = execParamsPerThread[ithr];

--- a/src/plugins/intel_cpu/src/nodes/grn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grn.cpp
@@ -58,8 +58,8 @@ void GRN::initSupportedPrimitiveDescriptors() {
 }
 
 void GRN::prepareParams() {
-    const auto& dataMemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    const auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    const auto& dataMemPtr = getSrcMemoryAtPort(0);
+    const auto& dstMemPtr = getDstMemoryAtPort(0);
 
     if (!dataMemPtr || !dataMemPtr->isAllocated())
         OPENVINO_THROW(errorPrefix, " has not allocated input memory");
@@ -91,8 +91,8 @@ void GRN::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void GRN::execute(dnnl::stream strm) {
-    const float* src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    float* dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    const float* src_data = getSrcDataAtPortAs<const float>(0);
+    float* dst_data = getDstDataAtPortAs<float>(0);
 
     parallel_for3d(N, H, W, [&](int b, int h, int w) {
         double variance = 0;

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -113,7 +113,7 @@ void If::getSupportedDescriptors() {
         const std::string inputID = ov::op::util::get_ie_output_name(prev);
         auto outNode = outMapThen.find(inputID);
         if (outNode != outMapThen.end()) {
-            auto outMem = outNode->second->getParentEdgeAt(0)->getMemoryPtr();
+            auto outMem = outNode->second->getSrcMemoryAtPort(0);
             outputMemThen.push_back(outMem);
         } else {
             OPENVINO_THROW("Then body of node If with name ", getName(), " does not have output with name: ", inputID);
@@ -126,7 +126,7 @@ void If::getSupportedDescriptors() {
         const std::string inputID = ov::op::util::get_ie_output_name(prev);
         auto outNode = outMapElse.find(inputID);
         if (outNode != outMapElse.end()) {
-            auto outMem = outNode->second->getParentEdgeAt(0)->getMemoryPtr();
+            auto outMem = outNode->second->getSrcMemoryAtPort(0);
             outputMemElse.push_back(outMem);
         } else {
             OPENVINO_THROW("Else body of node If with name ", getName(), " does not have output with name: ", inputID);
@@ -199,7 +199,7 @@ void If::prepareBeforeMappers(const bool isThen, const dnnl::engine& eng) {
     auto &inputMems = isThen ? inputMemThen : inputMemElse;
     auto &beforeMappers = isThen ? beforeThenMappers : beforeElseMappers;
     for (auto& map_rule : inputPortMap) {
-        auto fromMem = getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
+        auto fromMem = getSrcMemoryAtPort(map_rule.from);
         auto& toMems = inputMems[map_rule.to];
         // Check precision between If node input/output and it's subgrapsh input/output.
         for (const auto& toMem : toMems) {
@@ -244,7 +244,7 @@ std::deque<MemoryPtr> If::getToMemories(const Node* node, const size_t port) con
 }
 
 void If::execute(dnnl::stream strm) {
-    const bool condition = static_cast<const bool>((reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->getData()))[0]);
+    const bool condition = static_cast<const bool>((getSrcDataAtPortAs<const uint8_t>(0))[0]);
 
     auto& beforeMappers = condition ? beforeThenMappers : beforeElseMappers;
     auto& afterMappers = condition ? afterThenMappers : afterElseMappers;

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
@@ -63,7 +63,7 @@ void LogSoftmax::initSupportedPrimitiveDescriptors() {
 }
 
 void LogSoftmax::prepareParams() {
-    const auto &dims = getParentEdgesAtPort(0)[0]->getMemory().getStaticDims();
+    const auto &dims = getParentEdgeAt(0)->getMemory().getStaticDims();
     reducedAxisStride = 1;
     axisStep = 1;
     isLastDim = false;
@@ -86,8 +86,8 @@ void LogSoftmax::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void LogSoftmax::execute(dnnl::stream strm) {
-    const float *srcData = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    const float *srcData = getSrcDataAtPortAs<const float>(0);
+    float* dstData = getDstDataAtPortAs<float>(0);
 
     if (isLastDim) {
         parallel_for(axisStep, [&](size_t i) {

--- a/src/plugins/intel_cpu/src/nodes/lrn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lrn.cpp
@@ -161,8 +161,8 @@ std::shared_ptr<MemoryDesc> Lrn::getSrcMemDesc(const dnnl::primitive_desc &prim_
 }
 
 void Lrn::prepareParams() {
-    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(0);
+    auto dstMemPtr = getDstMemoryAtPort(0);
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         OPENVINO_THROW(errorPrefix, " input memory did not allocate");
     if (!dstMemPtr || !dstMemPtr->isAllocated())

--- a/src/plugins/intel_cpu/src/nodes/mathematics.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mathematics.cpp
@@ -68,9 +68,9 @@ void Math::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void Math::execute(dnnl::stream strm) {
-    size_t dataSize = getChildEdgesAtPort(0)[0]->getMemory().getShape().getElementsCount();
-    const float *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    float* dst_data = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    size_t dataSize = getChildEdgeAt(0)->getMemory().getShape().getElementsCount();
+    const float *src_data = getSrcDataAtPortAs<const float>(0);
+    float* dst_data = getDstDataAtPortAs<float>(0);
 
     switch (getAlgorithm()) {
         case Algorithm::MathAbs:

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -524,9 +524,9 @@ ov::element::Type MatMul::getRuntimePrecision() const {
 }
 
 void MatMul::prepareParams() {
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto src0MemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto src1MemPtr = getParentEdgeAt(1)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(0);
+    auto src0MemPtr = getSrcMemoryAtPort(0);
+    auto src1MemPtr = getSrcMemoryAtPort(1);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         OPENVINO_THROW(errorPrefix, " did not allocate destination memory");
     if (!src0MemPtr || !src0MemPtr->isAllocated() || !src1MemPtr || !src1MemPtr->isAllocated())
@@ -564,7 +564,7 @@ void MatMul::prepareParams() {
 
     DnnlMemoryDescPtr dnnlBiasMemDesc = nullptr;
     if (withBiases) {
-        auto biasMemory = getParentEdgeAt(2)->getMemoryPtr();
+        auto biasMemory = getSrcMemoryAtPort(2);
         if (!biasMemory || !biasMemory->isAllocated())
             OPENVINO_THROW(errorPrefix, " did not allocate bias memory");
         dnnlBiasMemDesc = biasMemory->getDescWithType<DnnlMemoryDesc>();
@@ -623,7 +623,7 @@ void MatMul::prepareParams() {
     primArgs[DNNL_ARG_WEIGHTS_0] = src1MemPtr->getPrimitive();
     primArgs[DNNL_ARG_DST] = dstMemPtr->getPrimitive();
     if (withBiases)
-        primArgs[DNNL_ARG_BIAS] = getParentEdgeAt(2)->getMemoryPtr()->getPrimitive();
+        primArgs[DNNL_ARG_BIAS] = getSrcMemoryAtPort(2)->getPrimitive();
 
     appendPostOpArgs(*attr, primArgs, postOpsArgs);
 #ifdef CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/nodes/mha.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mha.cpp
@@ -900,11 +900,11 @@ void MHA::prepareParams() {
         return new_vec;
     };
 
-    const auto memDescTranspose0In0 = getParentEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
-    const auto memDescTranspose1In0 = getParentEdgeAt(1)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
-    const auto memDescAddIn1 = getParentEdgeAt(2)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
-    const auto memDescTranspose2In0 = getParentEdgeAt(3)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
-    const auto memDescOut = getChildEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescTranspose0In0 = getSrcMemoryAtPort(0)->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescTranspose1In0 = getSrcMemoryAtPort(1)->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescAddIn1 = getSrcMemoryAtPort(2)->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescTranspose2In0 = getSrcMemoryAtPort(3)->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescOut = getDstMemoryAtPort(0)->getDescWithType<BlockedMemoryDesc>();
 
     dimsTranspose0In0 = memDescTranspose0In0->getBlockDims();
     dimsTranspose1In0 = memDescTranspose1In0->getBlockDims();
@@ -1213,11 +1213,11 @@ void MHA::callBrgemm(brgemmCtx& ctx, std::unique_ptr<brgemm_kernel_t>& brgKernel
 
 template <typename in1_type>
 void MHA::mhaImpl() {
-    const uint8_t* pTranspose0In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    const uint8_t* pTranspose1In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(1)->getMemoryPtr()->getData());
-    const float* pAddIn1 = reinterpret_cast<const float*>(getParentEdgeAt(2)->getMemoryPtr()->getData());
-    const uint8_t* pTranspose2In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(3)->getMemoryPtr()->getData());
-    uint8_t* pout = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const uint8_t* pTranspose0In0 = getSrcDataAtPortAs<const uint8_t>(0);
+    const uint8_t* pTranspose1In0 = getSrcDataAtPortAs<const uint8_t>(1);
+    const float* pAddIn1 = getSrcDataAtPortAs<const float>(2);
+    const uint8_t* pTranspose2In0 = getSrcDataAtPortAs<const uint8_t>(3);
+    uint8_t* pout = getDstDataAtPortAs<uint8_t>(0);
 
     auto outPrcSize = outputPrecision.size();
 

--- a/src/plugins/intel_cpu/src/nodes/multinomial.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.cpp
@@ -93,10 +93,10 @@ void Multinomial::prepareParams() {
 
     if (m_num_samples_precision == ov::element::i32) {
         m_samples_count =
-            reinterpret_cast<const int32_t*>(getParentEdgeAt(NUM_SAMPLES_PORT)->getMemoryPtr()->getData())[0];
+            getSrcDataAtPortAs<const int32_t>(NUM_SAMPLES_PORT)[0];
     } else {
         m_samples_count =
-            reinterpret_cast<const int64_t*>(getParentEdgeAt(NUM_SAMPLES_PORT)->getMemoryPtr()->getData())[0];
+            getSrcDataAtPortAs<const int64_t>(NUM_SAMPLES_PORT)[0];
     }
 
     m_batches_count = probs_shape[0];
@@ -144,8 +144,8 @@ void Multinomial::execute_probs_type() {
 
 template <typename P, typename O>
 void Multinomial::execute_convert_type() {
-    const auto* probs = reinterpret_cast<const P*>(getParentEdgeAt(PROBS_PORT)->getMemoryPtr()->getData());
-    auto* output = reinterpret_cast<O*>(getChildEdgeAt(OUTPUT_PORT)->getMemoryPtr()->getData());
+    const auto* probs = getSrcDataAtPortAs<const P>(PROBS_PORT);
+    auto* output = getDstDataAtPortAs<O>(OUTPUT_PORT);
 
     std::vector<P> m_cdf(m_input_elements_count);
     std::vector<P> m_max_per_batch(m_batches_count);

--- a/src/plugins/intel_cpu/src/nodes/ngram.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ngram.cpp
@@ -66,13 +66,13 @@ void Ngram::initSupportedPrimitiveDescriptors() {
 }
 
 void Ngram::prepareParams() {
-    const auto& srcDataDims = getParentEdgeAt(0)->getMemoryPtr()->getStaticDims();
-    const auto& srcIndicesDims = getParentEdgeAt(1)->getMemoryPtr()->getStaticDims();
-    const auto& outDims = getChildEdgeAt(0)->getMemoryPtr()->getStaticDims();;
+    const auto& srcDataDims = getSrcMemoryAtPort(0)->getStaticDims();
+    const auto& srcIndicesDims = getSrcMemoryAtPort(1)->getStaticDims();
+    const auto& outDims = getDstMemoryAtPort(0)->getStaticDims();;
 
     idcesShapeSize = std::accumulate(srcIndicesDims.begin(), srcIndicesDims.end(), 1, std::multiplies<size_t>());
     numOutElems = std::accumulate(outDims.begin(), outDims.end(), 1, std::multiplies<size_t>());
-    idcesStride = getParentEdgeAt(1)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
+    idcesStride = getSrcMemoryAtPort(1)->getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
     numIdces = srcIndicesDims[0];
 
     windowStride = srcDataDims[1];
@@ -83,7 +83,7 @@ void Ngram::prepareParams() {
 
 template <typename idces_type>
 std::vector<size_t> Ngram::computeBatchLenghts() {
-    auto* srcIndices = reinterpret_cast<const idces_type*>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    auto* srcIndices = getSrcDataAtPortAs<const idces_type>(1);
 
     std::vector<size_t> batchLenghts{0};
     batchLenghts.reserve(numIdces + 1);
@@ -98,8 +98,8 @@ std::vector<size_t> Ngram::computeBatchLenghts() {
 }
 
 void Ngram::execute(dnnl::stream strm) {
-    auto* srcData = reinterpret_cast<const float*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    auto* dstData = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    auto* srcData = getSrcDataAtPortAs<const float>(0);
+    auto* dstData = getDstDataAtPortAs<float>(0);
 
     std::vector<size_t> batchLenghts;
     if (idcesPrecision == ov::element::i32) {

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
@@ -168,9 +168,9 @@ void NonMaxSuppression::initSupportedPrimitiveDescriptors() {
 }
 
 void NonMaxSuppression::prepareParams() {
-    const auto& boxesDims = isDynamicNode() ? getParentEdgesAtPort(NMS_BOXES)[0]->getMemory().getStaticDims() :
+    const auto& boxesDims = isDynamicNode() ? getParentEdgeAt(NMS_BOXES)->getMemory().getStaticDims() :
                                                getInputShapeAtPort(NMS_BOXES).getStaticDims();
-    const auto& scoresDims = isDynamicNode() ? getParentEdgesAtPort(NMS_SCORES)[0]->getMemory().getStaticDims() :
+    const auto& scoresDims = isDynamicNode() ? getParentEdgeAt(NMS_SCORES)->getMemory().getStaticDims() :
                                                 getInputShapeAtPort(NMS_SCORES).getStaticDims();
 
     m_batches_num = boxesDims[0];
@@ -207,9 +207,9 @@ void NonMaxSuppression::createJitKernel() {
 
 void NonMaxSuppression::executeDynamicImpl(dnnl::stream strm) {
     if (hasEmptyInputTensors() || (inputShapes.size() > NMS_MAX_OUTPUT_BOXES_PER_CLASS &&
-            reinterpret_cast<int *>(getParentEdgeAt(NMS_MAX_OUTPUT_BOXES_PER_CLASS)->getMemoryPtr()->getData())[0] == 0)) {
+            getSrcDataAtPortAs<int>(NMS_MAX_OUTPUT_BOXES_PER_CLASS)[0] == 0)) {
         redefineOutputMemory({{0, 3}, {0, 3}, {1}});
-        *reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALID_OUTPUTS)[0]->getMemoryPtr()->getData()) = 0;
+        *getDstDataAtPortAs<int>(NMS_VALID_OUTPUTS) = 0;
         return;
     }
     execute(strm);
@@ -220,7 +220,7 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
 
     size_t max_number_of_boxes = m_output_boxes_per_class * m_batches_num * m_classes_num;
     if (inputs_num > NMS_MAX_OUTPUT_BOXES_PER_CLASS) {
-        auto val = reinterpret_cast<int32_t *>(getParentEdgeAt(NMS_MAX_OUTPUT_BOXES_PER_CLASS)->getMemoryPtr()->getData())[0];
+        auto val = getSrcDataAtPortAs<int32_t>(NMS_MAX_OUTPUT_BOXES_PER_CLASS)[0];
         m_max_output_boxes_per_class = val <= 0l ? 0lu : static_cast<size_t>(val);
         m_output_boxes_per_class = std::min(m_max_output_boxes_per_class, m_boxes_num);
         max_number_of_boxes = m_output_boxes_per_class * m_batches_num * m_classes_num;
@@ -231,21 +231,21 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
     }
 
     if (inputs_num > NMS_IOU_THRESHOLD) {
-        m_iou_threshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_IOU_THRESHOLD)->getMemoryPtr()->getData())[0];
+        m_iou_threshold = getSrcDataAtPortAs<float>(NMS_IOU_THRESHOLD)[0];
     }
     if (inputs_num > NMS_SCORE_THRESHOLD) {
-        m_score_threshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_SCORE_THRESHOLD)->getMemoryPtr()->getData())[0];
+        m_score_threshold = getSrcDataAtPortAs<float>(NMS_SCORE_THRESHOLD)[0];
     }
     if (inputs_num > NMS_SOFT_NMS_SIGMA) {
-        m_soft_nms_sigma = reinterpret_cast<float *>(getParentEdgeAt(NMS_SOFT_NMS_SIGMA)->getMemoryPtr()->getData())[0];
+        m_soft_nms_sigma = getSrcDataAtPortAs<float>(NMS_SOFT_NMS_SIGMA)[0];
         m_scale = (m_soft_nms_sigma > 0.f) ? (-0.5f / m_soft_nms_sigma) : 0.f;
     }
 
-    auto boxes_memory = getParentEdgeAt(NMS_BOXES)->getMemoryPtr();
-    auto scores_memory = getParentEdgeAt(NMS_SCORES)->getMemoryPtr();
+    auto boxes_memory = getSrcMemoryAtPort(NMS_BOXES);
+    auto scores_memory = getSrcMemoryAtPort(NMS_SCORES);
 
-    auto boxes = reinterpret_cast<const float *>(boxes_memory->getData());
-    auto scores = reinterpret_cast<const float *>(scores_memory->getData());
+    auto boxes = boxes_memory->getDataAs<const float>();
+    auto scores = scores_memory->getDataAs<const float>();
 
     const auto& boxes_strides = boxes_memory->getDescWithType<BlockedMemoryDesc>()->getStrides();
     const auto& scores_strides = scores_memory->getDescWithType<BlockedMemoryDesc>()->getStrides();
@@ -292,7 +292,7 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
     }
 
     if (m_defined_outputs[NMS_SELECTED_INDICES]) {
-        auto out_ptr = reinterpret_cast<int32_t *>(getChildEdgesAtPort(NMS_SELECTED_INDICES)[0]->getMemoryPtr()->getData());
+        auto out_ptr = getDstDataAtPortAs<int32_t>(NMS_SELECTED_INDICES);
         int32_t* boxes_ptr = &(m_filtered_boxes[0].batch_index);
 
         size_t idx = 0lu;
@@ -308,7 +308,7 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
     }
 
     if (m_defined_outputs[NMS_SELECTED_SCORES]) {
-        auto out_ptr = reinterpret_cast<float *>(getChildEdgesAtPort(NMS_SELECTED_SCORES)[0]->getMemoryPtr()->getData());
+        auto out_ptr = getDstDataAtPortAs<float>(NMS_SELECTED_SCORES);
 
         size_t idx = 0lu;
         for (; idx < valid_outputs; idx++) {
@@ -324,7 +324,7 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
     }
 
     if (m_defined_outputs[NMS_VALID_OUTPUTS]) {
-        auto out_ptr = reinterpret_cast<int32_t *>(getChildEdgesAtPort(NMS_VALID_OUTPUTS)[0]->getMemoryPtr()->getData());
+        auto out_ptr = getDstDataAtPortAs<int32_t>(NMS_VALID_OUTPUTS);
         *out_ptr = static_cast<int32_t>(valid_outputs);
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/non_zero.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.cpp
@@ -119,7 +119,7 @@ void NonZero::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void NonZero::execute(dnnl::stream strm) {
-    auto inputPrec = getParentEdgesAtPort(0)[0]->getMemory().getDesc().getPrecision();
+    auto inputPrec = getParentEdgeAt(0)->getMemory().getDesc().getPrecision();
     NonZeroContext ctx = {*this };
     OV_SWITCH(intel_cpu, NonZeroExecute, ctx, inputPrec,
               OV_CASE(ov::element::f32, float),
@@ -133,8 +133,8 @@ void NonZero::execute(dnnl::stream strm) {
 template <typename T>
 void NonZero::executeSpecified() {
     const T zero = 0;
-    const T *src = reinterpret_cast<T *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    const T *src = getSrcDataAtPortAs<T>(0);
+    auto dstMemPtr = getDstMemoryAtPort(0);
     Shape inShape = getParentEdgeAt(0)->getMemory().getShape();
     size_t inRank = inShape.getRank();
     std::vector<size_t> nonZeroCounts = getNonZeroElementsCount(src, inShape);
@@ -150,7 +150,7 @@ void NonZero::executeSpecified() {
         VectorDims newDims{inRank, totalNonZeroCount};
         redefineOutputMemory({newDims});
     }
-    int* dst = reinterpret_cast<int*>(dstMemPtr->getData());
+    int* dst = dstMemPtr->getDataAs<int>();
     if (totalNonZeroCount == 0)
         return;
 

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -882,8 +882,8 @@ void NormalizeL2::setPostOps(dnnl::primitive_attr& kernel_attrs, const VectorDim
 }
 
 void NormalizeL2::createPrimitive() {
-    auto dstMemPtr = getChildEdgeAt(DATA)->getMemoryPtr();
-    auto srcMemPtr = getParentEdgeAt(DATA)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(DATA);
+    auto srcMemPtr = getSrcMemoryAtPort(DATA);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_ERROR("can't get destination memory");
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -917,7 +917,7 @@ bool NormalizeL2::isExecutable() const {
 }
 
 void NormalizeL2::prepareParams() {
-    const auto& dims = getParentEdgeAt(DATA)->getMemoryPtr()->getStaticDims();
+    const auto& dims = getSrcMemoryAtPort(DATA)->getStaticDims();
 
     setPostOps(kernel_attrs, dims, true);
 
@@ -945,8 +945,8 @@ void NormalizeL2::execute(dnnl::stream strm) {
     if (!execPtr)
         THROW_ERROR("doesn't have a compiled executor.");
 
-    const uint8_t *src_ptr = reinterpret_cast<const uint8_t *>(getParentEdgeAt(DATA)->getMemoryPtr()->getData());
-    uint8_t *dst_ptr = reinterpret_cast<uint8_t *>(getChildEdgeAt(DATA)->getMemoryPtr()->getData());
+    const uint8_t *src_ptr = getSrcDataAtPortAs<const uint8_t>(DATA);
+    uint8_t *dst_ptr = getDstDataAtPortAs<uint8_t>(DATA);
     execPtr->exec(src_ptr, dst_ptr, postOpsDataPtrs.data());
 }
 

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -78,7 +78,7 @@ OneHot::OneHot(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
 }
 
 bool OneHot::needShapeInfer() const {
-    const auto depthNodePtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->getData());
+    const auto depthNodePtr = getSrcDataAtPortAs<int32_t>(1);
     if (depth != static_cast<size_t>(depthNodePtr[0])) {
         depth = depthNodePtr[0];
         return true;
@@ -108,11 +108,11 @@ void OneHot::initSupportedPrimitiveDescriptors() {
 
 template<typename out_type>
 void OneHot::one_hot(size_t prefix_size, size_t suffix_size) {
-    const auto *src_data = reinterpret_cast<const in_type *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    auto *dst_data = reinterpret_cast<out_type *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *src_data = getSrcDataAtPortAs<const in_type>(0);
+    auto *dst_data = getDstDataAtPortAs<out_type>(0);
 
-    const out_type on_value = reinterpret_cast<const out_type *>(getParentEdgeAt(2)->getMemoryPtr()->getData())[0];
-    const out_type off_value = reinterpret_cast<const out_type *>(getParentEdgeAt(3)->getMemoryPtr()->getData())[0];
+    const out_type on_value = getSrcDataAtPortAs<const out_type>(2)[0];
+    const out_type off_value = getSrcDataAtPortAs<const out_type>(3)[0];
 
     // fill the output with off_value
     std::size_t dst_size = prefix_size * depth * suffix_size;

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -400,8 +400,8 @@ void Pooling::prepareParams() {
         }
     }
     if (useACL) {
-        auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-        auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+        auto dstMemPtr = getDstMemoryAtPort(0);
+        auto srcMemPtr = getSrcMemoryAtPort(0);
         if (!dstMemPtr || !dstMemPtr->isAllocated())
             OPENVINO_THROW("Destination memory didn't allocate.");
         if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -409,11 +409,11 @@ void Pooling::prepareParams() {
 
         std::vector<MemoryDescPtr> srcMemoryDescs;
         for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
-            srcMemoryDescs.push_back(getParentEdgeAt(i)->getMemoryPtr()->getDescPtr());
+            srcMemoryDescs.push_back(getSrcMemoryAtPort(i)->getDescPtr());
         }
         std::vector<MemoryDescPtr> dstMemoryDescs;
         for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
-            dstMemoryDescs.push_back(getChildEdgeAt(i)->getMemoryPtr()->getDescPtr());
+            dstMemoryDescs.push_back(getDstMemoryAtPort(i)->getDescPtr());
         }
 
         execPtr = selected_pd->getExecutorFactoryAs<PoolingExecutorFactory>()->makeExecutor(poolingAttrs,
@@ -422,8 +422,8 @@ void Pooling::prepareParams() {
                                                                                             *attr);
         selected_pd->setImplementationType(execPtr->getImplType());
     } else {
-        auto inDesc = getParentEdgesAtPort(0)[0]->getMemory().getDescWithType<DnnlMemoryDesc>();
-        auto outDesc = getChildEdgesAtPort(0)[0]->getMemory().getDescWithType<DnnlMemoryDesc>();
+        auto inDesc = getParentEdgeAt(0)->getMemory().getDescWithType<DnnlMemoryDesc>();
+        auto outDesc = getChildEdgeAt(0)->getMemory().getDescWithType<DnnlMemoryDesc>();
 
         if (isDynamicNode()) {
             initEffectiveAttributes(inDesc->getShape(), outDesc->getShape());
@@ -477,8 +477,8 @@ void Pooling::prepareParams() {
 
         auto scratchpadMem = getScratchPadMem(dnnlExecPtr->getScratchPadDesc());
         primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->getPrimitive();
-        primArgs[DNNL_ARG_SRC] = getParentEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
-        primArgs[DNNL_ARG_DST] = getChildEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
+        primArgs[DNNL_ARG_SRC] = getSrcMemoryAtPort(0)->getPrimitive();
+        primArgs[DNNL_ARG_DST] = getDstMemoryAtPort(0)->getPrimitive();
 
         Node::appendPostOpArgs(*attr, primArgs, postOpsArgs);
 
@@ -497,11 +497,11 @@ void Pooling::execute(dnnl::stream strm) {
     } else if (execPtr) {
         std::vector<MemoryCPtr> srcMemory;
         for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
-            srcMemory.push_back(getParentEdgeAt(i)->getMemoryPtr());
+            srcMemory.push_back(getSrcMemoryAtPort(i));
         }
         std::vector<MemoryPtr> dstMemory;
         for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
-            dstMemory.push_back(getChildEdgeAt(i)->getMemoryPtr());
+            dstMemory.push_back(getDstMemoryAtPort(i));
         }
 
         execPtr->exec(srcMemory, dstMemory, postOpsArgs);

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -107,13 +107,13 @@ PriorBox::PriorBox(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
 }
 
 bool PriorBox::needShapeInfer() const {
-    auto memory = getChildEdgeAt(0)->getMemoryPtr();
+    auto memory = getDstMemoryAtPort(0);
     if (memory->getShape().isDynamic()) {
         return true;
     }
 
     const auto& outputShape = memory->getShape().getStaticDims();
-    const int* in_data = reinterpret_cast<int*>(memory->getData());
+    const int* in_data = memory->getDataAs<int>();
     const int h = in_data[0];
     const int w = in_data[1];
     const auto output = static_cast<size_t>(4 * h * w * number_of_priors);
@@ -144,18 +144,18 @@ void PriorBox::createPrimitive() {
 }
 
 void PriorBox::execute(dnnl::stream strm) {
-    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const int* in_data = getSrcDataAtPortAs<int>(0);
     const int H = in_data[0];
     const int W = in_data[1];
 
-    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    const int* in_image = getSrcDataAtPortAs<int>(1);
     const int IH = in_image[0];
     const int IW = in_image[1];
 
     const int OH = 4 * H * W * number_of_priors;
     const int OW = 1;
 
-    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    float* dst_data = getDstDataAtPortAs<float>(0);
 
     float step_ = step;
     auto min_size_ = min_size;

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -57,13 +57,13 @@ PriorBoxClustered::PriorBoxClustered(const std::shared_ptr<ov::Node>& op, const 
 }
 
 bool PriorBoxClustered::needShapeInfer() const {
-    auto memory = getChildEdgeAt(0)->getMemoryPtr();
+    auto memory = getDstMemoryAtPort(0);
     if (memory->getShape().isDynamic()) {
         return true;
     }
 
     const auto& outputShape = memory->getShape().getStaticDims();
-    const int* in_data = reinterpret_cast<int*>(memory->getData());
+    const int* in_data = memory->getDataAs<int>();
     const int h = in_data[0];
     const int w = in_data[1];
     const auto output = static_cast<size_t>(4 * h * w * number_of_priors);
@@ -94,11 +94,11 @@ void PriorBoxClustered::createPrimitive() {
 }
 
 void PriorBoxClustered::execute(dnnl::stream strm) {
-    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const int* in_data = getSrcDataAtPortAs<int>(0);
     const int layer_height = in_data[0];
     const int layer_width = in_data[1];
 
-    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    const int* in_image = getSrcDataAtPortAs<int>(1);
     int img_height = in_image[0];
     int img_width = in_image[1];
 
@@ -109,7 +109,7 @@ void PriorBoxClustered::execute(dnnl::stream strm) {
         step_h = static_cast<float>(img_height) / layer_height;
     }
 
-    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    float* dst_data = getDstDataAtPortAs<float>(0);
     const auto& out_shape = getChildEdgeAt(0)->getMemory().getShape().getStaticDims();
 
     size_t var_size = variances.size();

--- a/src/plugins/intel_cpu/src/nodes/proposal.cpp
+++ b/src/plugins/intel_cpu/src/nodes/proposal.cpp
@@ -162,13 +162,13 @@ void Proposal::executeDynamicImpl(dnnl::stream strm) {
 
 void Proposal::execute(dnnl::stream strm) {
     try {
-        const float* probabilitiesData = reinterpret_cast<const float *>(getParentEdgeAt(PROBABILITIES_IN_IDX)->getMemoryPtr()->getData());
-        const float* anchorsData = reinterpret_cast<const float *>(getParentEdgeAt(ANCHORS_IN_IDX)->getMemoryPtr()->getData());
-        const float* imgInfoData = reinterpret_cast<const float *>(getParentEdgeAt(IMG_INFO_IN_IDX)->getMemoryPtr()->getData());
-        float* outRoiData = reinterpret_cast <float *>(getChildEdgesAtPort(ROI_OUT_IDX)[0]->getMemoryPtr()->getData());
+        const float* probabilitiesData = getSrcDataAtPortAs<const float>(PROBABILITIES_IN_IDX);
+        const float* anchorsData = getSrcDataAtPortAs<const float>(ANCHORS_IN_IDX);
+        const float* imgInfoData = getSrcDataAtPortAs<const float>(IMG_INFO_IN_IDX);
+        float* outRoiData = reinterpret_cast <float *>(getDstDataAtPort(ROI_OUT_IDX));
         float* outProbData = nullptr;
         if (store_prob)
-            outProbData = reinterpret_cast <float *>(getChildEdgesAtPort(PROBABILITIES_OUT_IDX)[0]->getMemoryPtr()->getData());
+            outProbData = reinterpret_cast <float *>(getDstDataAtPort(PROBABILITIES_OUT_IDX));
 
         auto inProbDims = getParentEdgeAt(0)->getMemory().getStaticDims();
         const size_t imgInfoSize = getParentEdgeAt(2)->getMemory().getStaticDims()[0];

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -492,9 +492,9 @@ void PSROIPooling::executeBilinearDeformable(const inputType *srcData, outputTyp
 
 template <typename inputType, typename outputType>
 void PSROIPooling::executeSpecified() {
-    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    const auto *bottomRoisBeginning = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
-    auto *dstData = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcData = getSrcDataAtPortAs<const inputType>(0);
+    const auto *bottomRoisBeginning = getSrcDataAtPortAs<const float>(1);
+    auto *dstData = getDstDataAtPortAs<outputType>(0);
 
     auto srcDesc = getParentEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
     auto dstDesc = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
@@ -512,8 +512,8 @@ void PSROIPooling::executeSpecified() {
     int numClasses = 1;
     int channelsEachClass = outputDim;
     if (!noTrans) {
-        const auto mem = getParentEdgeAt(2)->getMemoryPtr();
-        bottomTrans = reinterpret_cast<const float *>(mem->getData());
+        const auto mem = getSrcMemoryAtPort(2);
+        bottomTrans = mem->getDataAs<const float>();
         numClasses = static_cast<int>(mem->getStaticDims()[1]) / 2;
         channelsEachClass /= numClasses;
     }
@@ -551,8 +551,8 @@ struct PSROIPooling::PSROIPoolingExecute {
 };
 
 void PSROIPooling::execute(dnnl::stream strm) {
-    auto inputPrec = getParentEdgesAtPort(0)[0]->getMemory().getDesc().getPrecision();
-    auto outputPrec = getChildEdgesAtPort(0)[0]->getMemory().getDesc().getPrecision();
+    auto inputPrec = getParentEdgeAt(0)->getMemory().getDesc().getPrecision();
+    auto outputPrec = getChildEdgeAt(0)->getMemory().getDesc().getPrecision();
 
     if (!((inputPrec == ov::element::bf16 && outputPrec == ov::element::bf16) ||
           (inputPrec == ov::element::f32 && outputPrec == ov::element::f32))) {

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
@@ -88,10 +88,10 @@ void RandomUniform::initSupportedPrimitiveDescriptors() {
 
 void RandomUniform::createPrimitive() {
     if (m_const_inputs[MIN_VAL]) {
-        initEdgeValues(m_min_val, getParentEdgeAt(MIN_VAL)->getMemoryPtr()->getData(), m_output_prc);
+        initEdgeValues(m_min_val, getSrcDataAtPort(MIN_VAL), m_output_prc);
     }
     if (m_const_inputs[MAX_VAL]) {
-        initEdgeValues(m_max_val, getParentEdgeAt(MAX_VAL)->getMemoryPtr()->getData(), m_output_prc);
+        initEdgeValues(m_max_val, getSrcDataAtPort(MAX_VAL), m_output_prc);
         evalRange();
     }
 
@@ -124,14 +124,14 @@ void RandomUniform::createPrimitive() {
 }
 
 bool RandomUniform::needPrepareParams() const {
-    if (m_out_shape != getChildEdgeAt(0)->getMemoryPtr()->getShape().getStaticDims()) {
+    if (m_out_shape != getDstMemoryAtPort(0)->getShape().getStaticDims()) {
         return true;
     }
     return false;
 }
 
 void RandomUniform::prepareParams() {
-    m_out_shape = getChildEdgeAt(0)->getMemoryPtr()->getShape().getStaticDims();
+    m_out_shape = getDstMemoryAtPort(0)->getShape().getStaticDims();
     m_out_el_num = std::accumulate(m_out_shape.begin(), m_out_shape.end(), 1lu, std::multiplies<Dim>());
 
     if (m_algo == PHILOX) {
@@ -182,17 +182,17 @@ void RandomUniform::prepareParams() {
 
 void RandomUniform::execute(dnnl::stream strm) {
     if (!m_const_inputs[MIN_VAL]) {
-        initEdgeValues(m_min_val, getParentEdgeAt(MIN_VAL)->getMemoryPtr()->getData(), m_output_prc);
+        initEdgeValues(m_min_val, getSrcDataAtPort(MIN_VAL), m_output_prc);
         if (m_const_inputs[MAX_VAL]) {
             evalRange();
         }
     }
     if (!m_const_inputs[MAX_VAL]) {
-        initEdgeValues(m_max_val, getParentEdgeAt(MAX_VAL)->getMemoryPtr()->getData(), m_output_prc);
+        initEdgeValues(m_max_val, getSrcDataAtPort(MAX_VAL), m_output_prc);
         evalRange();
     }
 
-    auto data = getChildEdgeAt(0)->getMemoryPtr()->getData();
+    auto data = getDstDataAtPort(0);
 
     if (m_algo == PHILOX) {
         m_state = computePhilox(data, m_out_el_num, m_state);

--- a/src/plugins/intel_cpu/src/nodes/range.cpp
+++ b/src/plugins/intel_cpu/src/nodes/range.cpp
@@ -116,9 +116,9 @@ size_t Range::getWorkAmount(data_t *startPtr, data_t *stopPtr, data_t *stepPtr) 
         stopPtr = &limit;
     if (stepPtr == nullptr)
         stepPtr = &delta;
-    *startPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_START)->getMemoryPtr()->getData())[0];
-    *stopPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_LIMIT)->getMemoryPtr()->getData())[0];
-    *stepPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_DELTA)->getMemoryPtr()->getData())[0];
+    *startPtr = getSrcDataAtPortAs<const data_t>(RANGE_START)[0];
+    *stopPtr = getSrcDataAtPortAs<const data_t>(RANGE_LIMIT)[0];
+    *stepPtr = getSrcDataAtPortAs<const data_t>(RANGE_DELTA)[0];
     const data_t span = *stopPtr - *startPtr;
     const data_t step = *stepPtr;
     if (std::is_same<data_t, int>::value) {
@@ -138,7 +138,7 @@ Range::StatusCode Range::rangeKernel() {
         VectorDims newOutputShape {work_amount_dst};
         redefineOutputMemory({newOutputShape});
     }
-    data_t* dst_data = reinterpret_cast<data_t *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    data_t* dst_data = getDstDataAtPortAs<data_t>(0);
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t iwork = 0, end = 0;
         splitter(work_amount_dst, nthr, ithr, iwork, end);

--- a/src/plugins/intel_cpu/src/nodes/rdft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rdft.cpp
@@ -155,8 +155,8 @@ void RDFT::execute(dnnl::stream strm) {
     const auto& inputShape = inputMem.getStaticDims();
     const auto& outputShape = outputMem.getStaticDims();
 
-    auto inputPtr = reinterpret_cast<float*>(inputMem.getData());
-    auto outputPtr = reinterpret_cast<float*>(outputMem.getData());
+    auto inputPtr = inputMem.getDataAs<float>();
+    auto outputPtr = outputMem.getDataAs<float>();
 
     auto rank = inputShape.size() - inverse;
 
@@ -180,12 +180,12 @@ bool RDFT::created() const {
 
 void RDFT::prepareParams() {
     if (axesChanged()) {
-        const auto& axesMem = getParentEdgeAt(AXES_INDEX)->getMemoryPtr();
+        const auto& axesMem = getSrcMemoryAtPort(AXES_INDEX);
         auto newAxesSize = axesMem->getStaticDims()[0];
         if (axes.size() != newAxesSize) {
             axes.resize(newAxesSize);
         }
-        auto axesPtr = reinterpret_cast<const int*>(axesMem->getData());
+        auto axesPtr = axesMem->getDataAs<const int>();
         auto inputRank = inputShapes[DATA_INDEX].getRank() - inverse;
         for (size_t i = 0; i < axes.size(); i++) {
             axes[i] = axesPtr[i] < 0 ? axesPtr[i] + inputRank : axesPtr[i];
@@ -206,12 +206,12 @@ void RDFT::prepareParams() {
                 signalSizes.back() = inputShape[axes.back()];
             }
         } else {
-            const auto& signalSizesMem = getParentEdgeAt(SIGNAL_SIZE_INDEX)->getMemoryPtr();
+            const auto& signalSizesMem = getSrcMemoryAtPort(SIGNAL_SIZE_INDEX);
             auto newSize = signalSizesMem->getStaticDims()[0];
             if (signalSizes.size() != newSize) {
                 signalSizes.resize(newSize);
             }
-            const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->getData());
+            const auto& signalSizesPtr = signalSizesMem->getDataAs<const int>();
             for (size_t i = 0; i < newSize; i++) {
                 signalSizes[i] = signalSizesPtr[i];
             }
@@ -226,11 +226,11 @@ bool RDFT::axesChanged() const {
     if (isAxesConstant) {
         return false;
     }
-    const auto& axesMem = getParentEdgeAt(AXES_INDEX)->getMemoryPtr();
+    const auto& axesMem = getSrcMemoryAtPort(AXES_INDEX);
     if (axes.size() != axesMem->getStaticDims()[0]) {
         return true;
     }
-    auto axesPtr = reinterpret_cast<const int*>(axesMem->getData());
+    auto axesPtr = axesMem->getDataAs<const int>();
     auto inputRank = inputShapes[DATA_INDEX].getRank() - inverse;
     for (size_t i = 0; i < axes.size(); i++) {
         auto newAxis = axesPtr[i] < 0 ? axesPtr[i] + inputRank : axesPtr[i];
@@ -260,12 +260,12 @@ bool RDFT::signalSizesChanged() const {
         return inverse ? static_cast<size_t>(signalSizes.back()) != 2 * (inputShape[axes.back()] - 1)
                        : static_cast<size_t>(signalSizes.back()) != inputShape[axes.back()];
     } else {
-        const auto& signalSizesMem = getParentEdgeAt(SIGNAL_SIZE_INDEX)->getMemoryPtr();
+        const auto& signalSizesMem = getSrcMemoryAtPort(SIGNAL_SIZE_INDEX);
         auto newSize = signalSizesMem->getStaticDims()[0];
         if (signalSizes.size() != newSize || signalSizes.size() != axes.size()) {
             return true;
         }
-        const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->getData());
+        const auto& signalSizesPtr = signalSizesMem->getDataAs<const int>();
         for (size_t i = 0; i < newSize; i++) {
             if (signalSizesPtr[i] != signalSizes[i]) {
                 return true;

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -402,17 +402,17 @@ void RegionYolo::execute(dnnl::stream strm) {
         output_size = B * IH * IW * mask_size * (classes + coords + 1);
     }
 
-    if (output_size != getChildEdgeAt(0)->getMemoryPtr()->getShape().getElementsCount())
+    if (output_size != getDstMemoryAtPort(0)->getShape().getElementsCount())
         OPENVINO_THROW("Incorrect layer configuration or output dimensions. ",
                        output_size,
                        " != ",
-                       getChildEdgeAt(0)->getMemoryPtr()->getShape().getElementsCount());
+                       getDstMemoryAtPort(0)->getShape().getElementsCount());
 
     size_t inputs_size = IH * IW * num_ * (classes + coords + 1);
     size_t total_size = 2 * IH * IW;
 
-    const auto *src_data = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    auto *dst_data = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *src_data = getSrcDataAtPortAs<const uint8_t>(0);
+    auto *dst_data = getDstDataAtPortAs<uint8_t>(0);
 
     cpu_convert(src_data, dst_data, getParentEdgeAt(0)->getMemory().getDesc().getPrecision(),
                 getChildEdgeAt(0)->getMemory().getDesc().getPrecision(), output_size);

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -33,16 +33,6 @@ public:
 
     void executeDynamicImpl(dnnl::stream strm) override;
 
-    // void setDescs(const MemoryDesc& input, const MemoryDesc& output) {
-    //     this->input = input.clone();
-    //     inputShapes.clear();
-    //     inputShapes.push_back(this->input->getShape());
-
-    //     this->output = output.clone();
-    //     outputShapes.clear();
-    //     outputShapes.push_back(this->output->getShape());
-    // }
-
     void setSrcPermutation(const std::vector<int> & src_perm) {
         this->src_permutation = src_perm;
     }

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -17,7 +17,7 @@ namespace node {
 class Reorder : public Node {
 public:
     Reorder(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context);
-    Reorder(const std::string& name, const GraphContext::CPtr context);
+    Reorder(const MemoryDesc& input, const MemoryDesc& output, const std::string& name, const GraphContext::CPtr context);
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
@@ -33,15 +33,15 @@ public:
 
     void executeDynamicImpl(dnnl::stream strm) override;
 
-    void setDescs(const MemoryDesc& input, const MemoryDesc& output) {
-        this->input = input.clone();
-        inputShapes.clear();
-        inputShapes.push_back(this->input->getShape());
+    // void setDescs(const MemoryDesc& input, const MemoryDesc& output) {
+    //     this->input = input.clone();
+    //     inputShapes.clear();
+    //     inputShapes.push_back(this->input->getShape());
 
-        this->output = output.clone();
-        outputShapes.clear();
-        outputShapes.push_back(this->output->getShape());
-    }
+    //     this->output = output.clone();
+    //     outputShapes.clear();
+    //     outputShapes.push_back(this->output->getShape());
+    // }
 
     void setSrcPermutation(const std::vector<int> & src_perm) {
         this->src_permutation = src_perm;

--- a/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
@@ -57,8 +57,8 @@ void ReorgYolo::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void ReorgYolo::execute(dnnl::stream strm) {
-    const auto *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    auto *dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    const auto *src_data = getSrcDataAtPortAs<const float>(0);
+    auto *dst_data = getDstDataAtPortAs<float>(0);
 
     const auto &inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
     int IW = (inDims.size() > 3) ? inDims[3] : 1;

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -62,11 +62,11 @@ Reshape::Reshape(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
 }
 
 bool Reshape::needShapeInfer() const {
-    const auto& mem = getParentEdgesAtPort(1)[0]->getMemory();
+    const auto& mem = getParentEdgeAt(1)->getMemory();
     if (lastSecondInputValues.empty()) {
         lastSecondInputValues.resize(mem.getStaticDims()[0], 0);
     }
-    const int32_t *sndInput = reinterpret_cast<const int32_t *>(mem.getData());
+    const int32_t *sndInput = mem.getDataAs<const int32_t>();
     for (size_t i = 0; i < lastSecondInputValues.size(); i++) {
         if (lastSecondInputValues[i] != sndInput[i]) {
             for (size_t i = 0; i < lastSecondInputValues.size(); i++) {
@@ -127,8 +127,8 @@ void Reshape::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void Reshape::execute(dnnl::stream strm) {
-    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(0);
+    auto dstMemPtr = getDstMemoryAtPort(0);
 
     auto srcPtr = static_cast<uint8_t*>(srcMemPtr->getData());
     auto dstPtr = static_cast<uint8_t*>(dstMemPtr->getData());

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
@@ -80,9 +80,9 @@ void ReverseSequence::initSupportedPrimitiveDescriptors() {
 }
 
 void ReverseSequence::prepareParams() {
-    const auto& dataMemPtr = getParentEdgeAt(REVERSESEQUENCE_DATA)->getMemoryPtr();
-    const auto& seqLengthsMemPtr = getParentEdgeAt(REVERSESEQUENCE_LENGTHS)->getMemoryPtr();
-    const auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    const auto& dataMemPtr = getSrcMemoryAtPort(REVERSESEQUENCE_DATA);
+    const auto& seqLengthsMemPtr = getSrcMemoryAtPort(REVERSESEQUENCE_LENGTHS);
+    const auto& dstMemPtr = getDstMemoryAtPort(0);
 
     if (!dataMemPtr || !dataMemPtr->isAllocated())
         OPENVINO_THROW(errorPrefix, " has not allocated input memory of 'data'");
@@ -128,9 +128,9 @@ ReverseSequence::ReverseSequenceExecutor::ReverseSequenceExecutor(const VectorDi
 template<typename T>
 void ReverseSequence::ReverseSequenceExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& seqLengthsMemPtr, const MemoryPtr& dstMemPtr) {
     const VectorDims& srcDims = dataMemPtr->getStaticDims();
-    const auto *srcData = reinterpret_cast<const float *>(dataMemPtr->getData());
-    auto *dstData = reinterpret_cast<float *>(dstMemPtr->getData());
-    auto *seqLengthsData = reinterpret_cast<T *>(seqLengthsMemPtr->getData());
+    const auto *srcData = dataMemPtr->getDataAs<const float>();
+    auto *dstData = dstMemPtr->getDataAs<float>();
+    auto *seqLengthsData = seqLengthsMemPtr->getDataAs<T>();
 
     for (size_t i = 0; i < srcDims[batchAxis]; ++i) {
         if (static_cast<int32_t>(seqLengthsData[i]) > static_cast<int>(srcDims[seqAxis])) {
@@ -174,13 +174,13 @@ void ReverseSequence::execute(dnnl::stream strm) {
         OPENVINO_THROW("ReverseSequence layer does not support ", precision , " precision");
 
     if (precision == ov::element::f32)
-        execPtr->exec<float>(getParentEdgeAt(REVERSESEQUENCE_DATA)->getMemoryPtr(),
-                             getParentEdgeAt(REVERSESEQUENCE_LENGTHS)->getMemoryPtr(),
-                             getChildEdgeAt(0)->getMemoryPtr());
+        execPtr->exec<float>(getSrcMemoryAtPort(REVERSESEQUENCE_DATA),
+                             getSrcMemoryAtPort(REVERSESEQUENCE_LENGTHS),
+                             getDstMemoryAtPort(0));
     else
-        execPtr->exec<int32_t>(getParentEdgeAt(REVERSESEQUENCE_DATA)->getMemoryPtr(),
-                               getParentEdgeAt(REVERSESEQUENCE_LENGTHS)->getMemoryPtr(),
-                               getChildEdgeAt(0)->getMemoryPtr());
+        execPtr->exec<int32_t>(getSrcMemoryAtPort(REVERSESEQUENCE_DATA),
+                               getSrcMemoryAtPort(REVERSESEQUENCE_LENGTHS),
+                               getDstMemoryAtPort(0));
 }
 
 bool ReverseSequence::created() const {

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -776,10 +776,10 @@ void RNN::fillWeights(const int *gate_map, const size_t wIdx, const size_t rIdx)
     const size_t ie_w_vec_size = getInputShapeAtPort(wIdx).getElementsCount();
     const size_t ie_r_vec_size = getInputShapeAtPort(rIdx).getElementsCount();
 
-    auto *wInputNode = dynamic_cast<Input *>(getParentEdgesAtPort(wIdx)[0]->getParent().get());
+    auto *wInputNode = dynamic_cast<Input *>(getParentEdgeAt(wIdx)->getParent().get());
     auto wConstBlob = wInputNode->getMemoryPtr();
 
-    auto *rInputNode = dynamic_cast<Input *>(getParentEdgesAtPort(rIdx)[0]->getParent().get());
+    auto *rInputNode = dynamic_cast<Input *>(getParentEdgeAt(rIdx)->getParent().get());
     auto rConstBlob = rInputNode->getMemoryPtr();
 
     std::vector<Prec> ie_w_vec(ie_w_vec_size), ie_r_vec(ie_r_vec_size);
@@ -830,7 +830,7 @@ void RNN::fillBiases(const int *gate_map) {
     if (b_ptr == nullptr)
         OPENVINO_THROW("NotAllocated: Internal blob was not allocated for node ", getName(), ".");
 
-    auto *constInputNode = dynamic_cast<Input *>(getParentEdgesAtPort(bIdx)[0]->getParent().get());
+    auto *constInputNode = dynamic_cast<Input *>(getParentEdgeAt(bIdx)->getParent().get());
     auto constBlob = constInputNode->getMemoryPtr();
     auto const elementsCount = constBlob->getSize() / constBlob->getDesc().getPrecision().size();
 
@@ -1099,15 +1099,15 @@ Node::AttrPtr RNN::initPrimitiveAttr() {
 
 void RNN::prepareParams() {
     for (size_t i = 0; i < wIdx; i++) {
-        auto memPtr = getParentEdgesAtPort(i).front()->getMemoryPtr();
+        auto memPtr = getSrcMemoryAtPort(i);
         if (!memPtr || !memPtr->isAllocated())
             THROW_ERROR("has uninitialized memory at port ", i);
     }
-    if ((is_cell && DC != getParentEdgesAtPort(0)[0]->getMemory().getDesc().getShape().getStaticDims()[1]) ||
-        (!is_cell && DC != getParentEdgesAtPort(0)[0]->getMemory().getDesc().getShape().getStaticDims()[2]))
+    if ((is_cell && DC != getParentEdgeAt(0)->getMemory().getDesc().getShape().getStaticDims()[1]) ||
+        (!is_cell && DC != getParentEdgeAt(0)->getMemory().getDesc().getShape().getStaticDims()[2]))
             THROW_ERROR("has incorrect input size value in the first input.");
 
-    auto dataMemPtr = getParentEdgesAtPort(0).front()->getMemoryPtr();
+    auto dataMemPtr = getSrcMemoryAtPort(0);
     const size_t B = dataMemPtr->getShape().getStaticDims()[0];
     const size_t SL = is_cell ? 1lu : dataMemPtr->getShape().getStaticDims()[1];
     const Shape shapeS_4D{L, D, B, SC};
@@ -1187,8 +1187,8 @@ void RNN::execute(dnnl::stream strm) {
     if (!execPtr)
         THROW_ERROR("does not have initialized primitive to execute.");
 
-    const auto src_data_mem = getParentEdgeAt(0)->getMemoryPtr();
-    const auto dst_data_mem = getChildEdgeAt(0)->getMemoryPtr();
+    const auto src_data_mem = getSrcMemoryAtPort(0);
+    const auto dst_data_mem = getDstMemoryAtPort(0);
 
     auto args = primArgs;
 
@@ -1198,22 +1198,22 @@ void RNN::execute(dnnl::stream strm) {
     int state_i_tags[] {DNNL_ARG_SRC_ITER, DNNL_ARG_SRC_ITER_C};
     int state_o_tags[] {DNNL_ARG_DST_ITER, DNNL_ARG_DST_ITER_C};
     for (size_t s = 0; s < S; s++) {
-        args[state_i_tags[s]] = getParentEdgeAt(s+1)->getMemoryPtr()->getPrimitive();
+        args[state_i_tags[s]] = getSrcMemoryAtPort(s+1)->getPrimitive();
     }
     if (is_augru) {
         const auto atten_port = is_cell ? 5 : 6;
-        args[DNNL_ARG_AUGRU_ATTENTION] = getParentEdgeAt(atten_port)->getMemoryPtr()->getPrimitive();
+        args[DNNL_ARG_AUGRU_ATTENTION] = getSrcMemoryAtPort(atten_port)->getPrimitive();
     }
 
     if (is_cell) {
         for (size_t s = 0; s < S; s++) {
-            args[state_o_tags[s]] = getChildEdgesAtPort(s)[0]->getMemoryPtr()->getPrimitive();
+            args[state_o_tags[s]] = getDstMemoryAtPort(s)->getPrimitive();
         }
     } else {
         size_t n_ports_with_init_states = outputShapes.size() - 1; // first is a sequence data
         for (size_t s = 0; s < std::min(S, n_ports_with_init_states); s++) {
             if (s < outputShapes.size()) {
-                args[state_o_tags[s]] = getChildEdgesAtPort(s+1)[0]->getMemoryPtr()->getPrimitive();
+                args[state_o_tags[s]] = getDstMemoryAtPort(s+1)->getPrimitive();
             }
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -814,8 +814,8 @@ void ROIAlign::initSupportedPrimitiveDescriptors() {
 }
 
 void ROIAlign::createPrimitive() {
-    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(0);
+    auto dstMemPtr = getDstMemoryAtPort(0);
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         OPENVINO_THROW(errorPrefix, " did not allocate input memory");
     if (!dstMemPtr || !dstMemPtr->isAllocated())
@@ -876,10 +876,10 @@ void ROIAlign::executeSpecified() {
 
     auto isPlainFmt = srcBlockDesc->hasLayoutType(LayoutType::ncsp);
 
-    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    const auto *srcRoi = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
-    const auto *srcRoiIdx = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->getData());
-    auto *dst = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcData = getSrcDataAtPortAs<const inputType>(0);
+    const auto *srcRoi = getSrcDataAtPortAs<const float>(1);
+    const auto *srcRoiIdx = getSrcDataAtPortAs<const int>(2);
+    auto *dst = getDstDataAtPortAs<outputType>(0);
 
     auto nominalRoiCount = static_cast<int>(srcMemory1.getStaticDims()[0]);
     int realRois = 0;

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -498,9 +498,9 @@ void ROIPooling::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void ROIPooling::prepareParams() {
-    const auto& srcMemPtr0 = getParentEdgeAt(0)->getMemoryPtr();
-    const auto& srcMemPtr1 = getParentEdgeAt(0)->getMemoryPtr();
-    const auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    const auto& srcMemPtr0 = getSrcMemoryAtPort(0);
+    const auto& srcMemPtr1 = getSrcMemoryAtPort(0);
+    const auto& dstMemPtr = getDstMemoryAtPort(0);
     if (!srcMemPtr0 || !srcMemPtr0->isAllocated())
         OPENVINO_THROW("Input memory has not been allocated.");
     if (!srcMemPtr1 || !srcMemPtr1->isAllocated())
@@ -511,7 +511,7 @@ void ROIPooling::prepareParams() {
         OPENVINO_THROW("Preferable primitive descriptor is not set.");
 
     const auto& inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
-    const auto& outDims = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();
+    const auto& outDims = getChildEdgeAt(0)->getMemory().getStaticDims();
 
     refParams.mb = outDims[0];
     refParams.c = rnd_up(inDims[1], refParams.c_block);
@@ -560,9 +560,9 @@ public:
         auto src_strides = srcData.getDescWithType<BlockedMemoryDesc>()->getStrides();
         auto src_roi_step = srcRoi.getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
         auto dst_strides = dst.getDescWithType<BlockedMemoryDesc>()->getStrides();
-        const auto* src_ptr = reinterpret_cast<const T*>(srcData.getData());
-        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.getData());
-        auto* dst_ptr = reinterpret_cast<T*>(dst.getData());
+        const auto* src_ptr = srcData.getDataAs<const T>();
+        const auto* roi_ptr = srcRoi.getDataAs<const T>();
+        auto* dst_ptr = dst.getDataAs<T>();
         executeOptimizedGeneric(src_ptr, roi_ptr, dst_ptr, src_strides, dst_strides, src_roi_step);
     }
 
@@ -680,9 +680,9 @@ public:
         auto src_strides = srcData.getDescWithType<BlockedMemoryDesc>()->getStrides();
         auto src_roi_step = srcRoi.getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
         auto dst_strides = dst.getDescWithType<BlockedMemoryDesc>()->getStrides();
-        const auto* src_ptr = reinterpret_cast<const T*>(srcData.getData());
-        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.getData());
-        auto* dst_ptr = reinterpret_cast<T*>(dst.getData());
+        const auto* src_ptr = srcData.getDataAs<const T>();
+        const auto* roi_ptr = srcRoi.getDataAs<const T>();
+        auto* dst_ptr = dst.getDataAs<T>();
         executeReference(src_ptr, roi_ptr, dst_ptr, src_strides, dst_strides, src_roi_step);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/roll.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roll.cpp
@@ -97,10 +97,10 @@ void Roll::initSupportedPrimitiveDescriptors() {
 }
 
 void Roll::prepareParams() {
-    const auto& dataMemPtr = getParentEdgeAt(DATA_INDEX)->getMemoryPtr();
-    const auto& shiftMemPtr = getParentEdgeAt(SHIFT_INDEX)->getMemoryPtr();
-    const auto& axesMemPtr = getParentEdgeAt(AXES_INDEX)->getMemoryPtr();
-    const auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    const auto& dataMemPtr = getSrcMemoryAtPort(DATA_INDEX);
+    const auto& shiftMemPtr = getSrcMemoryAtPort(SHIFT_INDEX);
+    const auto& axesMemPtr = getSrcMemoryAtPort(AXES_INDEX);
+    const auto& dstMemPtr = getDstMemoryAtPort(0);
 
     if (!dataMemPtr || !dataMemPtr->isAllocated())
         OPENVINO_THROW(layerErrorPrefix, " has not allocated input memory of 'data'");
@@ -133,24 +133,24 @@ void Roll::execute(dnnl::stream strm) {
     const auto& dataTypeSize = dataPrecision.size();
     switch (dataTypeSize) {
         case sizeof(element_type_traits<ov::element::i8>::value_type): {
-            execPtr->exec<element_type_traits<ov::element::i8>::value_type>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr(),
-                                                                     getParentEdgeAt(SHIFT_INDEX)->getMemoryPtr(),
-                                                                     getParentEdgeAt(AXES_INDEX)->getMemoryPtr(),
-                                                                     getChildEdgeAt(0)->getMemoryPtr());
+            execPtr->exec<element_type_traits<ov::element::i8>::value_type>(getSrcMemoryAtPort(DATA_INDEX),
+                                                                     getSrcMemoryAtPort(SHIFT_INDEX),
+                                                                     getSrcMemoryAtPort(AXES_INDEX),
+                                                                     getDstMemoryAtPort(0));
             break;
         }
         case sizeof(element_type_traits<ov::element::i16>::value_type): {
-            execPtr->exec<element_type_traits<ov::element::i16>::value_type>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr(),
-                                                                     getParentEdgeAt(SHIFT_INDEX)->getMemoryPtr(),
-                                                                     getParentEdgeAt(AXES_INDEX)->getMemoryPtr(),
-                                                                     getChildEdgeAt(0)->getMemoryPtr());
+            execPtr->exec<element_type_traits<ov::element::i16>::value_type>(getSrcMemoryAtPort(DATA_INDEX),
+                                                                     getSrcMemoryAtPort(SHIFT_INDEX),
+                                                                     getSrcMemoryAtPort(AXES_INDEX),
+                                                                     getDstMemoryAtPort(0));
             break;
         }
         case sizeof(element_type_traits<ov::element::i32>::value_type): {
-            execPtr->exec<element_type_traits<ov::element::i32>::value_type>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr(),
-                                                                     getParentEdgeAt(SHIFT_INDEX)->getMemoryPtr(),
-                                                                     getParentEdgeAt(AXES_INDEX)->getMemoryPtr(),
-                                                                     getChildEdgeAt(0)->getMemoryPtr());
+            execPtr->exec<element_type_traits<ov::element::i32>::value_type>(getSrcMemoryAtPort(DATA_INDEX),
+                                                                     getSrcMemoryAtPort(SHIFT_INDEX),
+                                                                     getSrcMemoryAtPort(AXES_INDEX),
+                                                                     getDstMemoryAtPort(0));
             break;
         }
         default:
@@ -176,10 +176,10 @@ Roll::RollExecutor::RollExecutor(const VectorDims& dataDims, const VectorDims& s
 template<typename T>
 void Roll::RollExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& shiftMemPtr, const MemoryPtr& axesMemPtr,
     const MemoryPtr& dstMemPtr) {
-    const auto *data = reinterpret_cast<const T *>(dataMemPtr->getData());
-    const auto *shift = reinterpret_cast<const int32_t *>(shiftMemPtr->getData());
-    const auto *axes = reinterpret_cast<const int32_t *>(axesMemPtr->getData());
-    auto *dst = reinterpret_cast<T *>(dstMemPtr->getData());
+    const auto *data = dataMemPtr->getDataAs<const T>();
+    const auto *shift = shiftMemPtr->getDataAs<const int32_t>();
+    const auto *axes = axesMemPtr->getDataAs<const int32_t>();
+    auto *dst = dstMemPtr->getDataAs<T>();
 
     std::vector<size_t> shiftsVector(numOfDims, 0ul);
     const VectorDims& dataDims = dataMemPtr->getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -279,10 +279,10 @@ void RoPE::initSupportedPrimitiveDescriptors() {
 void RoPE::execute(dnnl::stream strm) {
     std::vector<MemoryPtr> inputs(getParentEdges().size()), outputs(getChildEdges().size());
     for (size_t i = 0; i < inputs.size(); i++) {
-        inputs[i] = getParentEdgeAt(i)->getMemoryPtr();
+        inputs[i] = getSrcMemoryAtPort(i);
     }
     for (size_t i = 0; i < outputs.size(); i++) {
-        outputs[i] = getChildEdgeAt(i)->getMemoryPtr();
+        outputs[i] = getDstMemoryAtPort(i);
     }
     m_executor->execute(strm, m_config, inputs, outputs);
 }

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -519,7 +519,7 @@ struct ScaledDotProductAttention::AttentionExecutor : public ScaledDotProductAtt
 
     void prepare_attn_mask(MemoryPtr attn_input) {
         attn_buf.resize<float>(attn_input->getStaticDims());
-        auto p = reinterpret_cast<uint8_t*>(attn_input->getData());
+        auto p = attn_input->getDataAs<uint8_t>();
         for (size_t i = 0; i < attn_input->getSize(); i++)
             attn_buf.data<float>()[i] = p[i] ? 0.0f : -FLT_MAX;
     }
@@ -558,7 +558,7 @@ struct ScaledDotProductAttention::AttentionExecutor : public ScaledDotProductAtt
             }
             // if has scale, attn_mask must be present
             if (input_num > 4) {
-                scale_input = *reinterpret_cast<float*>(inputs[4]->getData());
+                scale_input = *inputs[4]->getDataAs<float>();
             }
         }
 
@@ -753,15 +753,15 @@ void ScaledDotProductAttention::createPrimitive() {
 void ScaledDotProductAttention::execute(dnnl::stream strm) {
     auto orginSDPInputNumber = getOriginalInputsNumber() - (m_config.config.fuse_concat ? 3 : 0);
     std::vector<MemoryPtr> inputs(orginSDPInputNumber);
-    auto output = getChildEdgeAt(0)->getMemoryPtr();
+    auto output = getDstMemoryAtPort(0);
     MemoryPtr presentk_input, presentv_input, beam_input;
     for (size_t i = 0; i < orginSDPInputNumber; i++) {
-        inputs[i] = getParentEdgeAt(i)->getMemoryPtr();
+        inputs[i] = getSrcMemoryAtPort(i);
     }
 
     if (m_config.config.fuse_concat) {
         // initialization will be also completed in this func
-        gatherConcatPastkv(inputs[1], inputs[2], getParentEdgeAt(orginSDPInputNumber)->getMemoryPtr());
+        gatherConcatPastkv(inputs[1], inputs[2], getSrcMemoryAtPort(orginSDPInputNumber));
 
         presentk_input = m_k_state->internal_state_mem();
         presentv_input = m_v_state->internal_state_mem();
@@ -1172,8 +1172,8 @@ void ScaledDotProductAttention::updatePastkv(const MemoryPtr& mem_cur_k, const M
     }
     if (L0 > 0 && is_reset) {
         auto inputNumber = getOriginalInputsNumber();
-        auto k_mem = getParentEdgeAt(inputNumber - 2)->getMemoryPtr();
-        auto v_mem = getParentEdgeAt(inputNumber - 1)->getMemoryPtr();
+        auto k_mem = getSrcMemoryAtPort(inputNumber - 2);
+        auto v_mem = getSrcMemoryAtPort(inputNumber - 1);
         auto&& k_shape = k_mem->getShape();
         auto&& v_shape = v_mem->getShape();
         if (!k_shape.hasZeroDims() && !v_shape.hasZeroDims()) {

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -264,15 +264,15 @@ static std::vector<size_t> getBlockND(const VectorDims& shape) {
 }
 
 void ScatterUpdate::execute(dnnl::stream strm) {
-    auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto indicesMemPtr = getParentEdgeAt(INDICES_ID)->getMemoryPtr();
-    auto updateMemPtr = getParentEdgeAt(UPDATE_ID)->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(DATA_ID);
+    auto dstMemPtr = getDstMemoryAtPort(0);
+    auto indicesMemPtr = getSrcMemoryAtPort(INDICES_ID);
+    auto updateMemPtr = getSrcMemoryAtPort(UPDATE_ID);
 
-    uint8_t *dstPtr = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
-    uint8_t *srcPtr = reinterpret_cast<uint8_t*>(srcMemPtr->getData());
-    uint8_t *indicesPtr = reinterpret_cast<uint8_t*>(indicesMemPtr->getData());
-    uint8_t *updatePtr = reinterpret_cast<uint8_t*>(updateMemPtr->getData());
+    uint8_t *dstPtr = dstMemPtr->getDataAs<uint8_t>();
+    uint8_t *srcPtr = srcMemPtr->getDataAs<uint8_t>();
+    uint8_t *indicesPtr = indicesMemPtr->getDataAs<uint8_t>();
+    uint8_t *updatePtr = updateMemPtr->getDataAs<uint8_t>();
 
     const auto& srcDataDim = getParentEdgeAt(DATA_ID)->getMemory().getStaticDims();
     const auto& indicesDim = getParentEdgeAt(INDICES_ID)->getMemory().getStaticDims();
@@ -302,8 +302,8 @@ void ScatterUpdate::execute(dnnl::stream strm) {
 
     int axis = 0;
     if (axisRelaxed) {
-        auto axisMemPtr = getParentEdgeAt(AXIS_ID)->getMemoryPtr();
-        uint8_t *axisPtr = reinterpret_cast<uint8_t*>(axisMemPtr->getData());
+        auto axisMemPtr = getSrcMemoryAtPort(AXIS_ID);
+        uint8_t *axisPtr = axisMemPtr->getDataAs<uint8_t>();
         if (axisSize == 4) {
             auto *axisPtr32 = reinterpret_cast<int32_t*>(axisPtr);
             axis = *axisPtr32;

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -84,14 +84,14 @@ bool ShapeOf::isExecutable() const {
 }
 
 void ShapeOf::execute(dnnl::stream strm) {
-    auto inPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto outPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto inPtr = getSrcMemoryAtPort(0);
+    auto outPtr = getDstMemoryAtPort(0);
     auto&& inDims = inPtr->getStaticDims();
     size_t dimsCount = inDims.size();
     if (outPtr->getStaticDims().size() != 1 || dimsCount != outPtr->getStaticDims()[0])
         OPENVINO_THROW(errorPrefix, "has inconsistent input shape and output size");
 
-    auto* dst = reinterpret_cast<int *>(outPtr->getData());
+    auto* dst = outPtr->getDataAs<int>();
 
     for (size_t i = 0; i < dimsCount; i++) {
         dst[i] = inDims[i];

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -125,8 +125,8 @@ void ShuffleChannels::initSupportedPrimitiveDescriptors() {
 }
 
 void ShuffleChannels::createPrimitive() {
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(0);
+    auto srcMemPtr = getSrcMemoryAtPort(0);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_SHCH_ERROR("has not allocated destination memory");
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -149,7 +149,7 @@ void ShuffleChannels::createPrimitive() {
 }
 
 void ShuffleChannels::prepareParams() {
-    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(0);
     auto builder = [](const ShuffleChannelsAttributes& key) -> std::shared_ptr<ShuffleChannelsExecutor> {
         return std::make_shared<ShuffleChannelsExecutor>(key);
     };
@@ -292,10 +292,10 @@ void ShuffleChannels::execute(dnnl::stream strm) {
     if (!execPtr)
         THROW_SHCH_ERROR("doesn't have a compiled executor.");
 
-    int MB = (attrs.axis != 0) ? getParentEdgeAt(0)->getMemoryPtr()->getStaticDims()[0] : -1;
+    int MB = (attrs.axis != 0) ? getSrcMemoryAtPort(0)->getStaticDims()[0] : -1;
 
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const uint8_t* srcData = getSrcDataAtPortAs<const uint8_t>(0);
+    uint8_t* dstData = getDstDataAtPortAs<uint8_t>(0);
     execPtr->exec(srcData, dstData, MB);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -217,8 +217,8 @@ void SoftMax::prepareParams() {
     auto scratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
 
     primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->getPrimitive();
-    primArgs[DNNL_ARG_SRC] = getParentEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
-    primArgs[DNNL_ARG_DST] = getChildEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
+    primArgs[DNNL_ARG_SRC] = getSrcMemoryAtPort(0)->getPrimitive();
+    primArgs[DNNL_ARG_DST] = getDstMemoryAtPort(0)->getPrimitive();
 #ifdef CPU_DEBUG_CAPS
     if (result.second == CacheEntryBase::LookUpStatus::Miss) {
         auto pd = execPtr->getPrimitiveDesc();

--- a/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
@@ -96,24 +96,24 @@ static std::vector<int64_t> getShape5D(const VectorDims &shape) {
 
 template<typename T>
 void SpaceToBatch::SpaceToBatchKernel() {
-    const auto& srcMem = getParentEdgesAtPort(0)[0]->getMemoryPtr();
-    const auto& dstMem = getChildEdgesAtPort(0)[0]->getMemoryPtr();
+    const auto& srcMem = getSrcMemoryAtPort(0);
+    const auto& dstMem = getDstMemoryAtPort(0);
 
-    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    const auto *blockShapesPtr = getSrcDataAtPortAs<int>(1);
     size_t dataRank = srcMem->getShape().getRank();
     blockShapeIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         blockShapeIn.push_back(*(blockShapesPtr + i));
     }
 
-    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->getData());
+    const auto *padsBeginPtr = getSrcDataAtPortAs<int>(2);
     padsBeginIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         padsBeginIn.push_back(*(padsBeginPtr + i));
     }
 
-    const auto *srcData = reinterpret_cast<const T *>(srcMem->getData());
-    auto *dstData = reinterpret_cast<T *>(dstMem->getData());
+    const auto *srcData = srcMem->getDataAs<const T>();
+    auto *dstData = dstMem->getDataAs<T>();
 
     const int64_t srcLen = srcMem->getSize() / sizeof(T);
     const int64_t dstLen = dstMem->getSize() / sizeof(T);

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -163,8 +163,8 @@ void SpaceToDepth::initSupportedPrimitiveDescriptors() {
 }
 
 void SpaceToDepth::createPrimitive() {
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(0);
+    auto srcMemPtr = getSrcMemoryAtPort(0);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_ERROR("has not allocated destination memory");
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -189,9 +189,9 @@ void SpaceToDepth::createPrimitive() {
 
 void SpaceToDepth::prepareParams() {
     attrs.srcBlockedDims =
-        getParentEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
+        getSrcMemoryAtPort(0)->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
     attrs.destBlockedDims =
-        getChildEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
+        getDstMemoryAtPort(0)->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
     auto builder = [](const SpaceToDepthAttrs& key) -> std::shared_ptr<SpaceToDepthExecutor> {
         return std::make_shared<SpaceToDepthExecutor>(key);
     };
@@ -312,9 +312,9 @@ void SpaceToDepth::execute(dnnl::stream strm) {
     if (!execPtr) {
         THROW_ERROR("doesn't have a compiled executor.");
     }
-    const uint8_t* srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-    uint8_t* dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
-    const int MB = getParentEdgeAt(0)->getMemoryPtr()->getStaticDims()[0];
+    const uint8_t* srcData = getSrcDataAtPortAs<const uint8_t>(0);
+    uint8_t* dstData = getDstDataAtPortAs<uint8_t>(0);
+    const int MB = getSrcMemoryAtPort(0)->getStaticDims()[0];
     execPtr->exec(srcData, dstData, MB);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -288,12 +288,12 @@ void StridedSlice::prepareParams() {
 
     if (srcMemory.empty()) {
         for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
-            srcMemory.push_back(getParentEdgeAt(i)->getMemoryPtr());
+            srcMemory.push_back(getSrcMemoryAtPort(i));
         }
     }
     if (dstMemory.empty()) {
         for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
-            dstMemory.push_back(getChildEdgeAt(i)->getMemoryPtr());
+            dstMemory.push_back(getDstMemoryAtPort(i));
         }
     }
     execPtr = std::make_shared<StridedSliceCommonExecutor>(attrs, srcMemory, dstMemory, errorPrefix);
@@ -390,7 +390,7 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
     const size_t nDims = std::max(inputRank, outputRank);
 
     auto fillingInParameters = [&](std::vector<int> &parameter, const size_t type, const size_t size, const int value) {
-        const int *ptr = reinterpret_cast<const int32_t *>(srcMemory[type]->getData());
+        const int *ptr = srcMemory[type]->getDataAs<const int32_t>();
         parameter.assign(ptr, ptr + size);
 
         if (type != AXES_ID && params.attrs.ellipsisMaskCounter == 0 && size < nDims) {
@@ -725,8 +725,8 @@ void StridedSlice::StridedSliceCommonExecutor::indicesCalculationForOptimized() 
 }
 
 void StridedSlice::StridedSliceCommonExecutor::exec(const std::vector<MemoryCPtr>& srcMemory, const std::vector<MemoryCPtr>& dstMemory) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemory[0]->getData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemory[0]->getData());
+    const uint8_t* srcData = srcMemory[0]->getDataAs<const uint8_t>();
+    uint8_t* dstData = dstMemory[0]->getDataAs<uint8_t>();
     const uint8_t* srcShiftedData = srcData + srcShift;
     parallel_nt(nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -310,8 +310,8 @@ void DynamicBuffer::move_buffer(const MemoryPtr& new_buffer) {
     const auto src_offset_in_byte = stride > 0 ? 0 : (src_stride - valid_size);
     chunk_offset_in_byte = stride > 0 ? 0 : (dst_stride - valid_size);  // reset chunk_offset_in_byte
 
-    copy(reinterpret_cast<uint8_t*>(mem_holder_buffer->getData()) + src_offset_in_byte,
-        reinterpret_cast<uint8_t*>(new_buffer->getData()) + chunk_offset_in_byte,
+    copy(mem_holder_buffer->getDataAs<uint8_t>() + src_offset_in_byte,
+        new_buffer->getDataAs<uint8_t>() + chunk_offset_in_byte,
         src_stride, dst_stride, count, valid_size);
 
     // assign mem_holder_buffer
@@ -330,7 +330,7 @@ void DynamicBuffer::move_data() {
     const auto src_stride = abs(map_rule.stride) * len;
     const auto dst_stride = chunk_stride_in_byte;
 
-    copy(reinterpret_cast<const uint8_t*>(from->getData()), reinterpret_cast<uint8_t*>(mem_holder_buffer->getData()) + chunk_offset_in_byte,
+    copy(from->getDataAs<const uint8_t>(), mem_holder_buffer->getDataAs<uint8_t>() + chunk_offset_in_byte,
          src_stride, dst_stride, count, chunk_unit_in_byte);
 
     // adjust for next execution
@@ -361,8 +361,10 @@ void DynamicBuffer::transfer(const Node* node) {
         const auto dst_stride = to.front()->getStaticDims()[axis] * len;
         const auto valid_size = chunk_unit_in_byte * num_execs;
         const auto src_offset_in_byte = stride > 0 ? 0 : (src_stride - valid_size);
-        copy(reinterpret_cast<uint8_t*>(mem_holder_buffer->getData()) + src_offset_in_byte, reinterpret_cast<uint8_t*>(to.front()->getData()),
-            src_stride, dst_stride, count, dst_stride);
+
+        copy(mem_holder_buffer->getDataAs<uint8_t>() + src_offset_in_byte,
+             to.front()->getDataAs<uint8_t>(),
+             src_stride, dst_stride, count, dst_stride);
     } else {
         VectorDims newDims = to.front()->getShape().getDims();
         nullifyUndefinedDims(newDims);
@@ -422,7 +424,7 @@ void TensorIterator::getSupportedDescriptors() {
         const auto inputID = ov::op::util::create_ie_output_name(prev);
         auto outNode = outMap.find(inputID);
         if (outNode != outMap.end()) {
-            auto outMem = outNode->second->getParentEdgeAt(0)->getMemoryPtr();
+            auto outMem = outNode->second->getSrcMemoryAtPort(0);
             output_mem.push_back(outMem);
         }
     }
@@ -519,8 +521,8 @@ void TensorIterator::createPrimitive() {
 
 bool TensorIterator::needPrepareParams() const {
     if (getAlgorithm() == Algorithm::TensorIteratorLoop) {
-        const auto tripCountPtr = reinterpret_cast<const uint32_t*>(getParentEdgesAtPort(loopTripCountIdx).front()->getMemoryPtr()->getData());
-        const auto condPtr = reinterpret_cast<const uint8_t*>(getParentEdgesAtPort(loopExecutionConditionIdx).front()->getMemoryPtr()->getData());
+        const auto tripCountPtr = getSrcDataAtPortAs<const uint32_t>(loopTripCountIdx);
+        const auto condPtr = getSrcDataAtPortAs<const uint8_t>(loopExecutionConditionIdx);
         if (tripCountPtr[0] != static_cast<size_t>(lastUsedTripCount) || static_cast<bool>(condPtr[0]) != lastUsedCond)
             return true;
     }
@@ -638,7 +640,7 @@ void TensorIterator::executeDynamicImpl(dnnl::stream strm) {
 void TensorIterator::prepareInputPorts() {
     const auto &eng = getEngine();
     for (auto map_rule : inputPortMap) {
-        auto from_mem = getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
+        auto from_mem = getSrcMemoryAtPort(map_rule.from);
         auto &to_mem = input_mems[map_rule.to].front();  // first memory is enough to access the shared underlying physical memory
 
         if (map_rule.axis == -1)
@@ -652,7 +654,7 @@ void TensorIterator::prepareInputPorts() {
 void TensorIterator::prepareOutputPorts() {
     const auto &eng = getEngine();
     for (auto map_rule : outputPortMap) {
-        auto to_mem = getChildEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
+        auto to_mem = getDstMemoryAtPort(map_rule.from);
         auto &from_mem = output_mem[map_rule.to];
 
         if (map_rule.axis == -1)
@@ -713,7 +715,7 @@ void TensorIterator::prepareContinueCond() {
 
 void TensorIterator::prepareInitialCond() {
     if (loopExecutionConditionIdx != -1 || !initial_cond_check) {
-        auto mem = getParentEdgesAtPort(loopExecutionConditionIdx)[0]->getMemoryPtr();
+        auto mem = getSrcMemoryAtPort(loopExecutionConditionIdx);
         initial_cond_check.reset(new asBoolCheck(mem));
         lastUsedCond = initial_cond_check->getStatus();
     }
@@ -723,7 +725,7 @@ void TensorIterator::prepareTripCount() {
     if (loopTripCountIdx == -1) {
         trip_count_check.reset(new staticValueCheck(getNumIteration(inputPortMap, outputPortMap)));
     } else {
-        auto mem = getParentEdgesAtPort(loopTripCountIdx)[0]->getMemoryPtr();
+        auto mem = getSrcMemoryAtPort(loopTripCountIdx);
         trip_count_check.reset(new asIntCheck(mem));
     }
     lastUsedTripCount = trip_count_check->getStatus();
@@ -740,7 +742,7 @@ inline VectorDims sliced_input_dims(const MemoryPtr& mem, const int axis, const 
 
 void TensorIterator::reshapeSubgraphInput() {
     for (auto map_rule : inputPortMap) {
-        auto new_dims = sliced_input_dims(getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr(), map_rule.axis, map_rule.stride);
+        auto new_dims = sliced_input_dims(getSrcMemoryAtPort(map_rule.from), map_rule.axis, map_rule.stride);
         auto &to_mems = input_mems[map_rule.to];
         const auto& body_inshape = to_mems.front()->getShape();
         if (body_inshape.isDynamic() || body_inshape.getDims() != new_dims) {
@@ -780,7 +782,7 @@ void TensorIterator::reshapeAndFillOutput(dnnl::stream strm) {
 
 bool TensorIterator::checkForInputAndBodyShapesInequality() const {
     for (auto map_rule : inputPortMap) {
-        auto original_dims = sliced_input_dims(getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr(), map_rule.axis, map_rule.stride);
+        auto original_dims = sliced_input_dims(getSrcMemoryAtPort(map_rule.from), map_rule.axis, map_rule.stride);
         auto &to_mems = input_mems[map_rule.to];
         const auto& body_inshape = to_mems.front()->getShape();
         if (body_inshape.isDynamic() || body_inshape.getDims() != original_dims) {
@@ -843,7 +845,7 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap, co
     int numIterations = 1;
     bool isDefault = true;
     for (const auto& rule : inputPortMap) {
-        const auto& dims = getParentEdgesAtPort(rule.from)[0]->getMemoryPtr()->getStaticDims();
+        const auto& dims = getSrcMemoryAtPort(rule.from)->getStaticDims();
         if (!isIterable(rule)) {
             continue;
         }

--- a/src/plugins/intel_cpu/src/nodes/tile.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tile.cpp
@@ -114,9 +114,9 @@ bool Tile::needPrepareParams() const {
 
 void Tile::prepareParams() {
     if (!constMap[TILE_REPEATS]) {
-        const auto& repeatsMem = getParentEdgesAtPort(TILE_REPEATS)[0]->getMemory();
+        const auto& repeatsMem = getParentEdgeAt(TILE_REPEATS)->getMemory();
 
-        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(repeatsMem.getData());
+        const int32_t* repeatsData = repeatsMem.getDataAs<const int32_t>();
         originRepeats.assign(repeatsData, repeatsData + repeatsMem.getStaticDims()[0]);
 
         repeats.assign(std::max(originRepeats.size(), getInputShapeAtPort(TILE_INPUT).getRank()), 1lu);
@@ -140,7 +140,7 @@ bool Tile::needShapeInfer() const {
     if (!constMap[TILE_REPEATS]) {
         if (originRepeats.empty())
             return true;
-        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TILE_REPEATS)[0]->getMemory().getData());
+        const int32_t* repeatsData = getParentEdgeAt(TILE_REPEATS)->getMemory().getDataAs<const int32_t>();
         for (size_t i = 0lu; i < originRepeats.size(); i++) {
             if (originRepeats[i] != static_cast<size_t>(repeatsData[i]))
                 return true;
@@ -156,7 +156,7 @@ void Tile::executeDynamicImpl(dnnl::stream strm) {
 
 void Tile::execute(dnnl::stream strm) {
     if (optimizedCase) {
-        optimizedExecute(getParentEdgeAt(TILE_INPUT)->getMemoryPtr(), getChildEdgeAt(0)->getMemoryPtr());
+        optimizedExecute(getSrcMemoryAtPort(TILE_INPUT), getDstMemoryAtPort(0));
     } else {
         plainExecute(strm);
     }
@@ -169,8 +169,8 @@ void Tile::plainExecute(dnnl::stream strm) {
 
     auto& srcMemory = getParentEdgeAt(TILE_INPUT)->getMemory();
 
-    const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(srcMemory.getData());
-    uint8_t* dst_ptr = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemory().getData());
+    const uint8_t* src_ptr = srcMemory.getDataAs<const uint8_t>();
+    uint8_t* dst_ptr = getChildEdgeAt(0)->getMemory().getDataAs<uint8_t>();
 
     int m_inner_dim = 1;
     int m_outer_dim = 1;

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -1941,12 +1941,12 @@ void TopK::initSupportedPrimitiveDescriptors() {
 }
 
 bool TopK::needShapeInfer() const {
-    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->getData())[0];
+    const int src_k = getSrcDataAtPortAs<int>(TOPK_K)[0];
     return inputShapesModified() || src_k != top_k;
 }
 
 bool TopK::needPrepareParams() const {
-    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->getData())[0];
+    const int src_k = getSrcDataAtPortAs<int>(TOPK_K)[0];
     return inputShapesModified() || top_k != src_k;
 }
 
@@ -1978,8 +1978,8 @@ void TopK::preset_params() {
 }
 
 void TopK::prepareParams() {
-    auto dstMemPtr = getChildEdgeAt(TOPK_DATA)->getMemoryPtr();
-    auto srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(TOPK_DATA);
+    auto srcMemPtr = getSrcMemoryAtPort(TOPK_DATA);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         OPENVINO_THROW(errorPrefix, " has not allocated destination memory.");
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -1991,14 +1991,14 @@ void TopK::prepareParams() {
     dst_dims = dstMemPtr->getDesc().getShape().getDims();
 
     if (isDynamicNode()) {
-        const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->getData())[0];
+        const int src_k = getSrcDataAtPortAs<int>(TOPK_K)[0];
         if (static_cast<size_t>(src_k) > src_dims[axis])
             OPENVINO_THROW(errorPrefix, " gets top_k out of range!");
         if (top_k != src_k) {
             top_k = src_k;
         }
     } else {
-        top_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->getData())[0];
+        top_k = getSrcDataAtPortAs<int>(TOPK_K)[0];
     }
 
     if (jit_mode) {
@@ -2061,7 +2061,7 @@ void TopK::prepareParams() {
 }
 
 void TopK::createPrimitive() {
-    auto srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(TOPK_DATA);
     if (srcMemPtr->getDesc().hasLayoutType(LayoutType::ncsp)) {
         layout = TopKLayoutType::topk_ncsp;
     } else if (srcMemPtr->getDesc().hasLayoutType(LayoutType::nspc)) {
@@ -2134,13 +2134,13 @@ void TopK::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void TopK::execute(dnnl::stream strm) {
-    auto srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
-    auto dstMemPtr = getChildEdgeAt(TOPK_DATA)->getMemoryPtr();
-    auto dstIndexesMemPtr = getChildEdgeAt(TOPK_INDEX)->getMemoryPtr();
+    auto srcMemPtr = getSrcMemoryAtPort(TOPK_DATA);
+    auto dstMemPtr = getDstMemoryAtPort(TOPK_DATA);
+    auto dstIndexesMemPtr = getDstMemoryAtPort(TOPK_INDEX);
 
-    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->getData());
-    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->getData());
-    uint8_t *dst_idx = reinterpret_cast<uint8_t *>(dstIndexesMemPtr->getData());
+    const uint8_t *src_data = srcMemPtr->getDataAs<const uint8_t>();
+    uint8_t *dst_data = dstMemPtr->getDataAs<uint8_t>();
+    uint8_t *dst_idx = dstIndexesMemPtr->getDataAs<uint8_t>();
 
     if (jit_mode) {
         topk_process(src_data, dst_data, dst_idx);

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -137,8 +137,8 @@ void Transpose::prepareParams() {
 
     if (performAsReorder) {
         //  Transpose(order={0,3,1,2}) can be performed as Reorder(acdb=>abcd)
-        auto srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
-        auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+        auto srcMemPtr = getSrcMemoryAtPort(INPUT_DATA_IDX);
+        auto dstMemPtr = getDstMemoryAtPort(0);
         auto dstDesc = dstMemPtr->getDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
         auto srcDesc = dnnl::memory::desc(dstDesc.get_dims(), dstDesc.get_data_type(), memory::format_tag::acdb);
         auto result = getReorderPrim(context->getParamsCache(), getEngine(), srcDesc, dstDesc);
@@ -166,8 +166,8 @@ void Transpose::prepareParams() {
     transposeParams.permuteParams.dst_block_dims = dstDesc->getBlockDims();
 
     if (!isInputOrderConst) {
-        auto orderPtr = reinterpret_cast<const int32_t*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
-        auto orderLen = getParentEdgeAt(0)->getMemoryPtr()->getSize();
+        auto orderPtr = getSrcDataAtPortAs<const int32_t>(0);
+        auto orderLen = getSrcMemoryAtPort(0)->getSize();
         transposeParams.permuteParams.order.assign(orderPtr, orderPtr + orderLen);
     }
 
@@ -196,8 +196,8 @@ void Transpose::createPrimitive() {
     if (isOptimized)
         return;
 
-    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
+    auto dstMemPtr = getDstMemoryAtPort(0);
+    auto srcMemPtr = getSrcMemoryAtPort(INPUT_DATA_IDX);
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         OPENVINO_THROW("Destination memory was not allocated.");
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -241,8 +241,8 @@ void Transpose::execute(dnnl::stream strm) {
     if (prim) {
         prim.execute(strm, primArgs);
     } else if (execPtr) {
-        auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-        auto srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
+        auto dstMemPtr = getDstMemoryAtPort(0);
+        auto srcMemPtr = getSrcMemoryAtPort(INPUT_DATA_IDX);
 
         int MB = srcMemPtr->getStaticDims()[0];
 

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -88,13 +88,13 @@ void Unique::createPrimitive() {
 }
 
 void Unique::prepareParams() {
-    auto dataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
+    auto dataMemPtr = getSrcMemoryAtPort(IN_DATA);
     if (!dataMemPtr || !dataMemPtr->isAllocated()) {
         THROW_ERROR(" has not allocated input data memory.");
     }
     for (int i = 0; i < 4; i++) {
         if (definedOutputs[i]) {
-            auto dstMemPtr = getChildEdgeAt(i)->getMemoryPtr();
+            auto dstMemPtr = getDstMemoryAtPort(i);
             if (!dstMemPtr || !dstMemPtr->isAllocated()) {
                 THROW_ERROR(" has not allocated output memory at port ", i);
             }
@@ -106,9 +106,9 @@ void Unique::prepareParams() {
 
     size_t srcLen = 1;
     if (flattened) {
-        srcLen = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getSize() / dataTypeSize;
+        srcLen = getSrcMemoryAtPort(IN_DATA)->getSize() / dataTypeSize;
     } else {
-        auto dstDataShape = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getStaticDims();
+        auto dstDataShape = getSrcMemoryAtPort(IN_DATA)->getStaticDims();
         srcLen = dstDataShape[axis];
     }
     firstUniTmp.resize(srcLen, 0);
@@ -147,7 +147,7 @@ void Unique::execute(dnnl::stream strm) {
 }
 
 void Unique::executeDynamicImpl(dnnl::stream strm) {
-    const auto& srcDataDims = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getStaticDims();
+    const auto& srcDataDims = getSrcMemoryAtPort(IN_DATA)->getStaticDims();
     VectorDims dstDataDims;
     Dim uniqLen = 1;
     if (flattened) {
@@ -164,8 +164,8 @@ void Unique::executeDynamicImpl(dnnl::stream strm) {
 
 template <typename T>
 void Unique::flattenTensorExec() {
-    const T* srcDataPtr = reinterpret_cast<const T*>(getParentEdgeAt(IN_DATA)->getMemoryPtr()->getData());
-    const size_t inputLen = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getSize() / sizeof(T);
+    const T* srcDataPtr = getSrcDataAtPortAs<const T>(IN_DATA);
+    const size_t inputLen = getSrcMemoryAtPort(IN_DATA)->getSize() / sizeof(T);
     std::vector<T> uniDataTmp(inputLen);
     auto uniDataTmpPtr = uniDataTmp.data();
     int *firstTmpPtr = nullptr, *inToOutTmpPtr = nullptr, *occurTmpPtr = nullptr;
@@ -263,26 +263,26 @@ void Unique::flattenTensorExec() {
 
     redefineOutputMemory({ {uniqueLen}, {uniqueLen}, {inputLen}, {uniqueLen}});
 
-    T* uniDataPtr = reinterpret_cast<T*>(getChildEdgesAtPort(UNIQUE_DATA)[0]->getMemoryPtr()->getData());
+    T* uniDataPtr = getDstDataAtPortAs<T>(UNIQUE_DATA);
     cpu_parallel_memcpy(uniDataPtr, uniDataTmpPtr, uniqueLen * sizeof(T));
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
-        int *firstPtr = reinterpret_cast<int*>(getChildEdgesAtPort(FIRST_UNIQUE_IDX)[0]->getMemoryPtr()->getData());
+        int *firstPtr = getDstDataAtPortAs<int>(FIRST_UNIQUE_IDX);
         cpu_parallel_memcpy(firstPtr, firstUniTmp.data(), uniqueLen * sizeof(int));
     }
     if (definedOutputs[INPUT_TO_UNIQ_IDX]) {
-        auto inToOutPtr = reinterpret_cast<int*>(getChildEdgesAtPort(INPUT_TO_UNIQ_IDX)[0]->getMemoryPtr()->getData());
+        auto inToOutPtr = getDstDataAtPortAs<int>(INPUT_TO_UNIQ_IDX);
         cpu_parallel_memcpy(inToOutPtr, inToOutTmp.data(), inputLen * sizeof(int));
     }
     if (definedOutputs[OCCURRENCES_NUM]) {
-        auto occurPtr = reinterpret_cast<int*>(getChildEdgesAtPort(OCCURRENCES_NUM)[0]->getMemoryPtr()->getData());
+        auto occurPtr = getDstDataAtPortAs<int>(OCCURRENCES_NUM);
         cpu_parallel_memcpy(occurPtr, occurTmp.data(), uniqueLen * sizeof(int));
     }
 }
 
 template <typename T>
 void Unique::slicedTensorExec() {
-    auto inDataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
-    auto srcDataPtr = reinterpret_cast<const T*>(inDataMemPtr->getData());
+    auto inDataMemPtr = getSrcMemoryAtPort(IN_DATA);
+    auto srcDataPtr = inDataMemPtr->getDataAs<const T>();
     int *firstTmpPtr = nullptr, *inToOutTmpPtr = nullptr, *occurTmpPtr = nullptr;
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
         firstTmpPtr = firstUniTmp.data();
@@ -367,16 +367,16 @@ void Unique::slicedTensorExec() {
 
     int *firstPtr = nullptr, *inToOutPtr = nullptr, *occurNPtr = nullptr;
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
-        firstPtr = reinterpret_cast<int*>(getChildEdgesAtPort(FIRST_UNIQUE_IDX)[0]->getMemoryPtr()->getData());
+        firstPtr = getDstDataAtPortAs<int>(FIRST_UNIQUE_IDX);
     }
     if (definedOutputs[INPUT_TO_UNIQ_IDX]) {
-        inToOutPtr = reinterpret_cast<int*>(getChildEdgesAtPort(INPUT_TO_UNIQ_IDX)[0]->getMemoryPtr()->getData());
+        inToOutPtr = getDstDataAtPortAs<int>(INPUT_TO_UNIQ_IDX);
     }
     if (definedOutputs[OCCURRENCES_NUM]) {
-        occurNPtr = reinterpret_cast<int*>(getChildEdgesAtPort(OCCURRENCES_NUM)[0]->getMemoryPtr()->getData());
+        occurNPtr = getDstDataAtPortAs<int>(OCCURRENCES_NUM);
     }
 
-    T* dstDataPtr = reinterpret_cast<T*>(getChildEdgesAtPort(UNIQUE_DATA)[0]->getMemoryPtr()->getData());
+    T* dstDataPtr = getDstDataAtPortAs<T>(UNIQUE_DATA);
     const auto dstOuterStep = innerLen * uniqueLen;
     // Filling of the first output if needed.
     if (sorted || definedOutputs[UNIQUE_DATA]) {

--- a/src/plugins/intel_cpu/src/shape_inference/custom/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/adaptive_pooling.cpp
@@ -26,7 +26,7 @@ Result AdaptivePoolingShapeInfer::infer(
     VectorDims outputDims(inputRank);
     outputDims[0] = inputDims[0];
     outputDims[1] = inputDims[1];
-    auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(data_dependency.at(1)->getData());
+    auto newSpatialDimsPtr = data_dependency.at(1)->getDataAs<int32_t>();
     for (size_t i = 0; i < spatialDimsSize; i++) {
         outputDims[i + 2] = newSpatialDimsPtr[i];
     }

--- a/src/plugins/intel_cpu/src/shape_inference/custom/gather.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/gather.cpp
@@ -22,7 +22,7 @@ Result GatherShapeInfer::infer(const std::vector<std::reference_wrapper<const Ve
                            data_dependency.at(GATHER_AXIS)->getDesc().getPrecision(),
                            " for axis tensor.");
         }
-        m_axis = reinterpret_cast<const int32_t*>(data_dependency.at(GATHER_AXIS)->getData())[0];
+        m_axis = data_dependency.at(GATHER_AXIS)->getDataAs<const int32_t>()[0];
     }
     if (m_axis < 0) {
         m_axis += input_shape.size();

--- a/src/plugins/intel_cpu/src/shape_inference/custom/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/one_hot.cpp
@@ -18,7 +18,7 @@ namespace node {
 Result OneHotShapeInfer::infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) {
-    auto depth = reinterpret_cast<int32_t *>(data_dependency.at(1)->getData())[0];
+    auto depth = data_dependency.at(1)->getDataAs<int32_t>()[0];
     if (depth < 0) {
         OPENVINO_THROW("OneHot depth value can't be negative.");
     }

--- a/src/plugins/intel_cpu/src/shape_inference/custom/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/priorbox.cpp
@@ -18,7 +18,7 @@ namespace node {
 Result PriorBoxShapeInfer::infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) {
-    const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->getData());
+    const int* in_data = data_dependency.at(0)->getDataAs<const int>();
     const int H = in_data[0];
     const int W = in_data[1];
     const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);

--- a/src/plugins/intel_cpu/src/shape_inference/custom/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/priorbox_clustered.cpp
@@ -19,7 +19,7 @@ namespace node {
 Result PriorBoxClusteredShapeInfer::infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) {
-    const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->getData());
+    const int* in_data = data_dependency.at(0)->getDataAs<const int>();
     const int H = in_data[0];
     const int W = in_data[1];
     const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);

--- a/src/plugins/intel_cpu/src/shape_inference/custom/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/strided_slice.cpp
@@ -34,9 +34,9 @@ Result StridedSliceShapeInfer::infer(
             data_dependency.at(STRIDE_ID)->getDesc().getPrecision() != ov::element::i32) {
         OPENVINO_THROW("The data type of begin/end/stride is NOT I32, which is unexpected!");
     }
-    auto beginPtr = reinterpret_cast<int32_t *>(data_dependency.at(BEGIN_ID)->getData());
-    auto endPtr = reinterpret_cast<int32_t *>(data_dependency.at(END_ID)->getData());
-    auto stridePtr = reinterpret_cast<int32_t *>(data_dependency.at(STRIDE_ID)->getData());
+    auto beginPtr = data_dependency.at(BEGIN_ID)->getDataAs<int32_t>();
+    auto endPtr = data_dependency.at(END_ID)->getDataAs<int32_t>();
+    auto stridePtr = data_dependency.at(STRIDE_ID)->getDataAs<int32_t>();
 
     for (size_t i = 0, new_idx = 0; i < shapeIn.size(); ++i) {
         if (m_new_axis_mask_set.count(i)) {

--- a/src/plugins/intel_cpu/src/utils/blob_dump.cpp
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.cpp
@@ -92,7 +92,7 @@ void BlobDumper::prepare_plain_data(const MemoryPtr &memory, std::vector<uint8_t
 
     // check if it already plain
     if (desc.hasLayoutType(LayoutType::ncsp)) {
-        cpu_memcpy(data.data(), reinterpret_cast<const uint8_t*>(memory->getData()), size);
+        cpu_memcpy(data.data(), memory->getDataAs<const uint8_t>(), size);
         return;
     }
 
@@ -166,7 +166,7 @@ void BlobDumper::dumpAsTxt(std::ostream &stream) const {
            << "shape: ";
     for (size_t d : dims) stream << d << " ";
     stream << "(" << data_size << ")" <<
-    " by address 0x" << std::hex << reinterpret_cast<const long long *>(memory->getData()) << std::dec <<std::endl;
+    " by address 0x" << std::hex << memory->getDataAs<const long long>() << std::dec <<std::endl;
 
     const void *ptr = memory->getData();
 

--- a/src/plugins/intel_cpu/tests/unit/graph/dummy_node.hpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/dummy_node.hpp
@@ -4,10 +4,11 @@
 
 #pragma once
 
+#include "cpu_shape.h"
 #include "node.h"
-#include "graph.h"
+#include "graph_context.h"
 #include "edge.h"
-
+#include "openvino/core/shape.hpp"
 
 namespace ov {
 namespace intel_cpu {
@@ -15,20 +16,25 @@ namespace cpu_unit_test {
 
 class DummyNode : public Node {
 public:
+    // dummy node of the same shape and precision to both input and output.
     DummyNode(const ov::Shape& shape,
-            const ov::element::Type_t& prc,
-            const std::string& name,
-            const std::string& type,
-            const GraphContext::CPtr context,
-            LayoutType layout = LayoutType::ncsp,
-            int in_place_direction = Edge::LOOK::LOOK_UP,
-            bool is_executable = false) :
-        Node(type, name, context), m_layout(layout), m_inplace(in_place_direction), m_is_executable(is_executable) {
-        // dummy node of the same shape and precision to both input and output.
-        outputShapes.emplace_back(shape);
-        inputShapes.emplace_back(shape);
-        addOriginalOutputPrecision(prc);
-        addOriginalInputPrecision(prc);
+              const ov::element::Type_t& prc,
+              const std::string& name,
+              const std::string& type,
+              const GraphContext::CPtr context,
+              LayoutType layout = LayoutType::ncsp,
+              int in_place_direction = Edge::LOOK::LOOK_UP,
+              bool is_executable = false) :
+        Node(type,
+             {ov::intel_cpu::Shape(shape)},
+             {ov::intel_cpu::Shape(shape)},
+             {prc},
+             {prc},
+             name,
+             context),
+        m_layout(layout),
+        m_inplace(in_place_direction),
+        m_is_executable(is_executable) {
     }
 
     void getSupportedDescriptors() override {

--- a/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
@@ -5,6 +5,7 @@
 
 #include "dummy_node.hpp"
 
+#include "graph.h"
 #include "nodes/memory.hpp"
 #include "nodes/softmax.h"
 #include "nodes/shapeof.h"
@@ -153,8 +154,8 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
 
         auto memory_output = find_node_type(graph, Type::MemoryOutput);
 
-        auto second_dummy_out_mem = second_dummy->getChildEdgeAt(0)->getMemoryPtr()->getData();
-        auto memory_output_inp_mem = memory_output->getParentEdgeAt(0)->getMemoryPtr()->getData();
+        auto second_dummy_out_mem = second_dummy->getDstDataAtPort(0);
+        auto memory_output_inp_mem = memory_output->getSrcDataAtPort(0);
         //otherwise the memory will be modified by the dummy_look_up
         ASSERT_NE(second_dummy_out_mem, memory_output_inp_mem);
 
@@ -185,8 +186,8 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
 
         auto memory_output = find_node_type(graph, Type::MemoryOutput);
 
-        auto second_dummy_out_mem = second_dummy->getChildEdgeAt(0)->getMemoryPtr()->getData();
-        auto memory_output_inp_mem = memory_output->getParentEdgeAt(0)->getMemoryPtr()->getData();
+        auto second_dummy_out_mem = second_dummy->getDstDataAtPort(0);
+        auto memory_output_inp_mem = memory_output->getSrcDataAtPort(0);
         //otherwise the memory will be modified by the dummy_look_up
         ASSERT_NE(second_dummy_out_mem, memory_output_inp_mem);
 

--- a/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "dummy_node.hpp"
+#include "graph.h"
 #include "nodes/reorder.h"
 #include "nodes/input.h"
 #include "nodes/transpose.h"

--- a/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
@@ -4,9 +4,9 @@
 #include <gtest/gtest.h>
 
 #include "dummy_node.hpp"
+#include "graph.h"
 #include "nodes/input.h"
 #include "nodes/concat.h"
-
 
 using namespace ov::intel_cpu;
 

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -135,7 +135,6 @@ public:
         parentEdge->reuse(parentMemory);
         childEdge->reuse(childMemory);
 
-        // reorderNode->setDescs(inputDesc, outputDesc);
         std::array<std::shared_ptr<ov::intel_cpu::Node>, 3> nodes{inputNode, reorderNode, outputNode};
         for (auto& n : nodes) {
             n->init();

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -104,7 +104,7 @@ struct ReorderCPUTestParamSet {
 class ReorderCPUTestGraph {
 public:
     void buildReorderGraph(const ov::intel_cpu::CpuBlockedMemoryDesc& inputDesc,
-                    const ov::intel_cpu::CpuBlockedMemoryDesc& outputDesc) {
+                           const ov::intel_cpu::CpuBlockedMemoryDesc& outputDesc) {
         Config conf;
         conf.rtCacheCapacity = 100;
         auto context = std::make_shared<GraphContext>(conf,
@@ -116,7 +116,7 @@ public:
                                                                       "Reorder_Input",
                                                                       "Parameter",
                                                                       context);
-        reorderNode = std::make_shared<ov::intel_cpu::node::Reorder>("Reorder", context);
+        reorderNode = std::make_shared<ov::intel_cpu::node::Reorder>(inputDesc, outputDesc, "Reorder", context);
         outputNode = std::make_shared<ov::intel_cpu::node::Input>(outputDesc.clone(),
                                                                        "Reorder_Output",
                                                                        "Result",
@@ -135,7 +135,7 @@ public:
         parentEdge->reuse(parentMemory);
         childEdge->reuse(childMemory);
 
-        reorderNode->setDescs(inputDesc, outputDesc);
+        // reorderNode->setDescs(inputDesc, outputDesc);
         std::array<std::shared_ptr<ov::intel_cpu::Node>, 3> nodes{inputNode, reorderNode, outputNode};
         for (auto& n : nodes) {
             n->init();


### PR DESCRIPTION
### Details:
 - The main goal is to align and reduce an overhead of accessing pointers to the Memory in scope of prepareParams / execute calls
 - Remove method getParentEdgesAtPort(), to avoid any confusion, since it is impossible to have multiple producers (parent edges) at port.
 - Maintain sorted parent edges (by port id). This will help with the access performance in scope of execute / prepareParams method. I.e. for parent edges it is now guaranteed that vector idx equals to port id.
   std::set is not used intentionally, since the access performance during the inference stage is more important than compile_model stage.
 - **Child edges are still sorted periodically, since maintaining sorted order would require major refactoring of the core code logic.**
 - Introduce helper methods for the Node class: `getSrcMemoryAtPort, getDstMemoryAtPort, getSrcDataAtPort, getSrcDataAtPortAs, getDstDataAtPort, getDstDataAtPortAs` with self-explaining names
 - Introduce `getDataAs` for cpu `Memory` interface with the idea to enable an assert check for correct data type
 
### Tickets:
- 129034
