### PR TITLE
[GPU] Fix debug config setup position prior to allocate memories.

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -107,11 +107,6 @@ SyncInferRequest::SyncInferRequest(const std::shared_ptr<const CompiledModel>& c
     , m_shape_predictor(new cldnn::ShapePredictor(&m_graph->get_engine(), m_graph->get_config().get_property(ov::intel_gpu::buffers_preallocation_ratio)))
     , m_enable_profiling(m_graph->get_config().get_property(ov::enable_profiling))
     , m_use_external_queue(m_graph->use_external_queue()) {
-    init_mappings();
-    allocate_inputs();
-    allocate_outputs();
-    allocate_states();
-
     GPU_DEBUG_GET_INSTANCE(debug_config);
     GPU_DEBUG_IF(debug_config->mem_preallocation_params.is_initialized) {
         auto& mem_preallocation_params = debug_config->mem_preallocation_params;
@@ -122,6 +117,11 @@ SyncInferRequest::SyncInferRequest(const std::shared_ptr<const CompiledModel>& c
                                       mem_preallocation_params.max_per_dim_diff,
                                       mem_preallocation_params.buffers_preallocation_ratio));
     }
+
+    init_mappings();
+    allocate_inputs();
+    allocate_outputs();
+    allocate_states();
 }
 
 void SyncInferRequest::infer() {


### PR DESCRIPTION
### Details:
- Previously prealloc for VariableState has been set prior to the reset preallocator which applied debug configs
- After this fix, debug config can be applied to VariableState too 

