### PR TITLE
[GPU] fix Crop (Gather) in case of negative indices

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -119,6 +119,8 @@ void CreateGatherOpBase(ProgramBuilder& p, const std::shared_ptr<T>& op, const i
         ov::Shape start_offset(input_shape.size());
         int32_t new_offset0 = static_cast<int32_t>(result);
         if (support_neg_ind && new_offset0 < 0) {
+            // According to Gather-8,
+            // Negative values of indices indicate reverse indexing from data.shape[axis]
             new_offset0 += static_cast<int32_t>(input_shape.get_shape()[axis]);
         }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -119,7 +119,7 @@ void CreateGatherOpBase(ProgramBuilder& p, const std::shared_ptr<T>& op, const i
         ov::Shape start_offset(input_shape.size());
         int32_t new_offset0 = static_cast<int32_t>(result);
         if (support_neg_ind && new_offset0 < 0) {
-            new_offset0 += static_cast<int32_t>(start_offset.size());
+            new_offset0 += static_cast<int32_t>(input_shape.get_shape()[axis]);
         }
 
         start_offset[0] = static_cast<size_t>(new_offset0);

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
@@ -548,14 +548,33 @@ gather7ParamsTuple dummyParams2 = {
         ov::test::utils::DEVICE_GPU,
 };
 
-const auto gatherWithNagativeIndicesParams = testing::Combine(
+const auto gatherWithNagativeIndicesParams1 = testing::Combine(
         testing::Values(dummyParams2),
         testing::ValuesIn(nagativeSingleindicesData)
 );
 
-INSTANTIATE_TEST_CASE_P(smoke_Gather8NagativeIndice,
+INSTANTIATE_TEST_CASE_P(smoke_Gather8NagativeIndice1,
         Gather8withIndicesDataLayerTest,
-        gatherWithNagativeIndicesParams,
+        gatherWithNagativeIndicesParams1,
+        Gather8withIndicesDataLayerTest::getTestCaseName
+);
+
+gather7ParamsTuple dummyParams3 = {
+        ov::test::static_shapes_to_test_representation(std::vector<ov::Shape>({{6, 8, 2, 2}})),
+        ov::Shape({}),
+        std::tuple<int, int>{0, 0},
+        ov::element::f32,
+        ov::test::utils::DEVICE_GPU,
+};
+
+const auto gatherWithNagativeIndicesParams2 = testing::Combine(
+        testing::Values(dummyParams3),
+        testing::ValuesIn(nagativeSingleindicesData)
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_Gather8NagativeIndice2,
+        Gather8withIndicesDataLayerTest,
+        gatherWithNagativeIndicesParams2,
         Gather8withIndicesDataLayerTest::getTestCaseName
 );
 


### PR DESCRIPTION

### Details:
 - *Negative values of indices should be indexing from data.shape[axis]*

### Tickets:
 - *126925*
