### PR TITLE
[Py] Removing an old API from tests

### DIFF
--- a/tests/layer_tests/common/layer_test_class.py
+++ b/tests/layer_tests/common/layer_test_class.py
@@ -34,7 +34,6 @@ class CommonLayerTest:
         """
         model_path = self.produce_model_path(framework_model=framework_model, save_path=temp_dir)
         self.use_new_frontend = use_new_frontend
-        self.use_old_api = use_old_api
         # TODO Pass environment variables via subprocess environment
         os.environ['MO_ENABLED_TRANSFORMS'] = enabled_transforms
         os.environ['MO_DISABLED_TRANSFORMS'] = disabled_transforms

--- a/tests/layer_tests/common/layer_test_class.py
+++ b/tests/layer_tests/common/layer_test_class.py
@@ -25,7 +25,7 @@ class CommonLayerTest:
         raise RuntimeError("This is base class, please implement get_framework_results function for"
                            " the specific framework")
 
-    def _test(self, framework_model, ref_net, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def _test(self, framework_model, ref_net, ie_device, precision, ir_version, temp_dir,
               use_new_frontend=True, infer_timeout=60, enabled_transforms='',
               disabled_transforms='', **kwargs):
         """
@@ -81,13 +81,10 @@ class CommonLayerTest:
         if ie_device == 'GPU' and precision == 'FP32':
             config = {'INFERENCE_PRECISION_HINT': 'f32'}
 
-        if self.use_old_api:
-            raise Exception("Python API 1.0 isn't available")
-        else:
-            ie_engine = InferAPI20(model=path_to_xml,
-                                   weights=path_to_bin,
-                                   device=ie_device,
-                                   use_new_frontend=use_new_frontend)
+        ie_engine = InferAPI20(model=path_to_xml,
+                               weights=path_to_bin,
+                               device=ie_device,
+                               use_new_frontend=use_new_frontend)
         # Prepare feed dict
         if 'kwargs_to_prepare_input' in kwargs and kwargs['kwargs_to_prepare_input']:
             inputs_dict = self._prepare_input(ie_engine.get_inputs_info(precision),

--- a/tests/layer_tests/common/layer_test_class.py
+++ b/tests/layer_tests/common/layer_test_class.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import numpy as np
 from common.constants import test_device, test_precision
-from common.layer_utils import InferAPI20
+from common.layer_utils import InferAPI
 from common.utils.common_utils import generate_ir_python_api
 
 
@@ -80,10 +80,10 @@ class CommonLayerTest:
         if ie_device == 'GPU' and precision == 'FP32':
             config = {'INFERENCE_PRECISION_HINT': 'f32'}
 
-        ie_engine = InferAPI20(model=path_to_xml,
-                               weights=path_to_bin,
-                               device=ie_device,
-                               use_new_frontend=use_new_frontend)
+        ie_engine = InferAPI(model=path_to_xml,
+                             weights=path_to_bin,
+                             device=ie_device,
+                             use_new_frontend=use_new_frontend)
         # Prepare feed dict
         if 'kwargs_to_prepare_input' in kwargs and kwargs['kwargs_to_prepare_input']:
             inputs_dict = self._prepare_input(ie_engine.get_inputs_info(precision),

--- a/tests/layer_tests/common/layer_test_class.py
+++ b/tests/layer_tests/common/layer_test_class.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import numpy as np
 from common.constants import test_device, test_precision
-from common.layer_utils import IEInfer, InferAPI20
+from common.layer_utils import InferAPI20
 from common.utils.common_utils import generate_ir_python_api
 
 
@@ -82,9 +82,7 @@ class CommonLayerTest:
             config = {'INFERENCE_PRECISION_HINT': 'f32'}
 
         if self.use_old_api:
-            ie_engine = IEInfer(model=path_to_xml,
-                                weights=path_to_bin,
-                                device=ie_device)
+            raise Exception("Python API 1.0 isn't available")
         else:
             ie_engine = InferAPI20(model=path_to_xml,
                                    weights=path_to_bin,

--- a/tests/layer_tests/common/layer_utils.py
+++ b/tests/layer_tests/common/layer_utils.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 
 from common.utils.multiprocessing_utils import multiprocessing_run
-from openvino.inference_engine import IECore, get_version as ie_get_version
 from openvino.runtime import Core, get_version as ie2_get_version
 
 
@@ -32,43 +31,6 @@ class BaseInfer:
     def infer(self, input_data, config=None, infer_timeout=10):
         self.res = multiprocessing_run(self.fw_infer, [input_data, config], self.name, infer_timeout)
         return self.res
-
-
-class IEInfer(BaseInfer):
-    def __init__(self, model, weights, device):
-        super().__init__('Inference Engine')
-        self.device = device
-        self.model = model
-        self.weights = weights
-
-    def fw_infer(self, input_data, config=None):
-
-        print("Inference Engine version: {}".format(ie_get_version()))
-        print("Creating IE Core Engine...")
-        ie = IECore()
-        print("Reading network files")
-        net = ie.read_network(self.model, self.weights)
-        print("Loading network")
-        exec_net = ie.load_network(net, self.device, config)
-        print("Starting inference")
-        result = exec_net.infer(input_data)
-
-        if "exec_net" in locals():
-            del exec_net
-        if "ie" in locals():
-            del ie
-
-        return result
-
-    def get_inputs_info(self, precision) -> dict:
-        core = IECore()
-        net = core.read_network(self.model, self.weights)
-        inputs_info = {}
-        for item in net.input_info.items():
-            inputs_info[item[0]] = item[1].tensor_desc.dims
-
-        return inputs_info
-
 
 class InferAPI20(BaseInfer):
     def __init__(self, model, weights, device, use_new_frontend):

--- a/tests/layer_tests/common/layer_utils.py
+++ b/tests/layer_tests/common/layer_utils.py
@@ -32,7 +32,7 @@ class BaseInfer:
         self.res = multiprocessing_run(self.fw_infer, [input_data, config], self.name, infer_timeout)
         return self.res
 
-class InferAPI20(BaseInfer):
+class InferAPI(BaseInfer):
     def __init__(self, model, weights, device, use_new_frontend):
         super().__init__('Inference Engine')
         self.device = device

--- a/tests/layer_tests/common/tf2_layer_test_class.py
+++ b/tests/layer_tests/common/tf2_layer_test_class.py
@@ -32,7 +32,7 @@ class CommonTF2LayerTest(CommonLayerTest):
             return self.get_tf2_keras_results(inputs_dict, model_path)
         else:
             # get results from tflite
-            return get_tflite_results(self.use_new_frontend, self.use_old_api, inputs_dict, model_path)
+            return get_tflite_results(self.use_new_frontend, inputs_dict, model_path)
 
     def get_tf2_keras_results(self, inputs_dict, model_path):
         import tensorflow as tf

--- a/tests/layer_tests/common/tf_layer_test_class.py
+++ b/tests/layer_tests/common/tf_layer_test_class.py
@@ -5,7 +5,7 @@ from common.layer_test_class import CommonLayerTest
 from common.utils.tf_utils import summarize_graph
 
 from common.utils.tflite_utils import get_tflite_results, save_pb_to_tflite
-from common.utils.tf_utils import save_to_pb, transpose_nhwc_to_nchw, transpose_nchw_to_nhwc
+from common.utils.tf_utils import save_to_pb
 
 
 class CommonTFLayerTest(CommonLayerTest):
@@ -15,7 +15,7 @@ class CommonTFLayerTest(CommonLayerTest):
             data = inputs_dict.get(key)
             if not ':' in key:
                 key += ':0'
-            input[key] = transpose_nchw_to_nhwc(data, self.use_new_frontend)
+            input[key] = data
 
         return input
 
@@ -47,7 +47,7 @@ class CommonTFLayerTest(CommonLayerTest):
                 result = dict()
                 for i, output in enumerate(outputs_list):
                     _tf_res = tf_res[i]
-                    result[output] = transpose_nhwc_to_nchw(_tf_res, self.use_new_frontend)
+                    result[output] = _tf_res
                 return result
 
     def get_framework_results(self, inputs_dict, model_path):

--- a/tests/layer_tests/common/tf_layer_test_class.py
+++ b/tests/layer_tests/common/tf_layer_test_class.py
@@ -15,7 +15,7 @@ class CommonTFLayerTest(CommonLayerTest):
             data = inputs_dict.get(key)
             if not ':' in key:
                 key += ':0'
-            input[key] = transpose_nchw_to_nhwc(data, self.use_new_frontend, self.use_old_api)
+            input[key] = transpose_nchw_to_nhwc(data, self.use_new_frontend)
 
         return input
 
@@ -47,8 +47,7 @@ class CommonTFLayerTest(CommonLayerTest):
                 result = dict()
                 for i, output in enumerate(outputs_list):
                     _tf_res = tf_res[i]
-                    result[output] = transpose_nhwc_to_nchw(_tf_res, self.use_new_frontend,
-                                                            self.use_old_api)
+                    result[output] = transpose_nhwc_to_nchw(_tf_res, self.use_new_frontend)
                 return result
 
     def get_framework_results(self, inputs_dict, model_path):
@@ -59,4 +58,4 @@ class CommonTFLayerTest(CommonLayerTest):
             return self.get_tf_results(inputs_dict, model_path)
         else:
             # get results from tflite
-            return get_tflite_results(self.use_new_frontend, self.use_old_api, inputs_dict, model_path)
+            return get_tflite_results(self.use_new_frontend, inputs_dict, model_path)

--- a/tests/layer_tests/common/tflite_layer_test_class.py
+++ b/tests/layer_tests/common/tflite_layer_test_class.py
@@ -44,7 +44,7 @@ class TFLiteLayerTest(CommonLayerTest):
         return self.model_path
 
     def get_framework_results(self, inputs_dict, model_path):
-        return get_tflite_results(self.use_new_frontend, self.use_old_api, inputs_dict, model_path)
+        return get_tflite_results(self.use_new_frontend, inputs_dict, model_path)
 
     def check_tflite_model_has_only_allowed_ops(self):
         if self.allowed_ops is None:

--- a/tests/layer_tests/common/tflite_layer_test_class.py
+++ b/tests/layer_tests/common/tflite_layer_test_class.py
@@ -77,4 +77,4 @@ class TFLiteLayerTest(CommonLayerTest):
         model = self.make_model(params)
         self.model_path = self.produce_tflite_model(model, temp_dir)
         self.check_tflite_model_has_only_allowed_ops()
-        super()._test(model, None, ie_device, precision, None, temp_dir, False, True, **params)
+        super()._test(model, None, ie_device, precision, None, temp_dir, True, **params)

--- a/tests/layer_tests/common/utils/tf_utils.py
+++ b/tests/layer_tests/common/utils/tf_utils.py
@@ -150,8 +150,8 @@ def permute_axis(axis, permutation_inv):
     return permutation_inv[axis]
 
 
-def transpose_nchw_to_nhwc(data, use_new_frontend, use_old_api):
-    if use_new_frontend or not use_old_api:
+def transpose_nchw_to_nhwc(data, use_new_frontend):
+    if use_new_frontend:
         return data
 
     if len(data.shape) == 4:  # reshaping for 4D tensors
@@ -162,8 +162,8 @@ def transpose_nchw_to_nhwc(data, use_new_frontend, use_old_api):
         return data
 
 
-def transpose_nhwc_to_nchw(data, use_new_frontend, use_old_api):
-    if use_new_frontend or not use_old_api:
+def transpose_nhwc_to_nchw(data, use_new_frontend):
+    if use_new_frontend:
         return data
 
     if len(data.shape) == 4:  # reshaping for 4D tensors

--- a/tests/layer_tests/common/utils/tf_utils.py
+++ b/tests/layer_tests/common/utils/tf_utils.py
@@ -150,30 +150,6 @@ def permute_axis(axis, permutation_inv):
     return permutation_inv[axis]
 
 
-def transpose_nchw_to_nhwc(data, use_new_frontend):
-    if use_new_frontend:
-        return data
-
-    if len(data.shape) == 4:  # reshaping for 4D tensors
-        return data.transpose(0, 2, 3, 1)
-    elif len(data.shape) == 5:  # reshaping for 5D tensors
-        return data.transpose(0, 2, 3, 4, 1)
-    else:
-        return data
-
-
-def transpose_nhwc_to_nchw(data, use_new_frontend):
-    if use_new_frontend:
-        return data
-
-    if len(data.shape) == 4:  # reshaping for 4D tensors
-        return data.transpose(0, 3, 1, 2)  # 2, 0, 1
-    elif len(data.shape) == 5:  # reshaping for 5D tensors
-        return data.transpose(0, 4, 1, 2, 3)  # 3, 0, 1, 2
-    else:
-        return data
-
-
 def save_to_pb(tf_model, path_to_saved_tf_model, model_name = 'model.pb'):
     tf.io.write_graph(tf_model, path_to_saved_tf_model, model_name, False)
     assert os.path.isfile(os.path.join(path_to_saved_tf_model, model_name)), "model.pb haven't been saved " \

--- a/tests/layer_tests/common/utils/tflite_utils.py
+++ b/tests/layer_tests/common/utils/tflite_utils.py
@@ -80,7 +80,7 @@ def save_pb_to_tflite(pb_model):
     return tflite_model_path
 
 
-def get_tflite_results(use_new_frontend, use_old_api, inputs_dict, model_path):
+def get_tflite_results(use_new_frontend, inputs_dict, model_path):
     interpreter = tf.compat.v1.lite.Interpreter(model_path=model_path)
     interpreter.allocate_tensors()
     input_details = interpreter.get_input_details()
@@ -108,8 +108,7 @@ def get_tflite_results(use_new_frontend, use_old_api, inputs_dict, model_path):
     result = dict()
     for out in tf_lite_result.keys():
         _tf_res = tf_lite_result[out]
-        result[out] = transpose_nhwc_to_nchw(_tf_res, use_new_frontend,
-                                             use_old_api)
+        result[out] = transpose_nhwc_to_nchw(_tf_res, use_new_frontend,)
 
     return tf_lite_result
 

--- a/tests/layer_tests/common/utils/tflite_utils.py
+++ b/tests/layer_tests/common/utils/tflite_utils.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 import tensorflow as tf
 
-from common.utils.tf_utils import summarize_graph, transpose_nhwc_to_nchw
+from common.utils.tf_utils import summarize_graph
 
 
 def make_positive_array(inputs_dict):
@@ -108,7 +108,7 @@ def get_tflite_results(use_new_frontend, inputs_dict, model_path):
     result = dict()
     for out in tf_lite_result.keys():
         _tf_res = tf_lite_result[out]
-        result[out] = transpose_nhwc_to_nchw(_tf_res, use_new_frontend,)
+        result[out] = _tf_res
 
     return tf_lite_result
 

--- a/tests/layer_tests/conftest.py
+++ b/tests/layer_tests/conftest.py
@@ -66,11 +66,6 @@ def pytest_addoption(parser):
         action="store_true",
         help="Use Model Optimizer with new FrontEnd")
     parser.addoption(
-        "--use_old_api",
-        action="store_true",
-        help="Use old API for model processing in Inference Engine",
-    )
-    parser.addoption(
         "--tflite",
         required=False,
         action="store_true",
@@ -90,21 +85,9 @@ def use_new_frontend(request):
 
 
 @pytest.fixture(scope="session")
-def use_old_api(request):
-    """Fixture function for command-line option."""
-    return request.config.getoption('use_old_api')
-
-
-@pytest.fixture(scope="session")
 def tflite(request):
     """Fixture function for command-line option."""
     return request.config.getoption('tflite')
-
-
-@pytest.fixture(scope="session", autouse=True)
-def checks_for_keys_usage(request):
-    if request.config.getoption('use_old_api') and request.config.getoption('use_new_frontend'):
-        pytest.fail("Old API and new FrontEnd usage detected. Old API doesn't support new FrontEnd")
 
 
 @pytest.fixture(scope="function")

--- a/tests/layer_tests/mo_python_api_tests/test_mo_convert_complex_params.py
+++ b/tests/layer_tests/mo_python_api_tests/test_mo_convert_complex_params.py
@@ -187,7 +187,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_mo_convert_tf_model(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend, use_old_api):
+                                 temp_dir, use_new_frontend):
         tf_net_path = self.create_tf_model(temp_dir)
 
         test_params = params['params_test']
@@ -221,7 +221,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_mo_convert_tf_model_no_concat(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend, use_old_api):
+                                 temp_dir, use_new_frontend):
         tf_net_path = self.create_tf_model_no_concat(temp_dir)
 
         test_params = params['params_test']
@@ -310,7 +310,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_tf_model_single_input_output(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_new_frontend, use_old_api):
+                                                     temp_dir, use_new_frontend):
         tf_net_path = self.create_tf_model_single_input_output(temp_dir)
 
         test_params = params['params_test']
@@ -323,7 +323,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_clearing_transformation_registry(self, ie_device, precision, ir_version,
-                                                         temp_dir, use_new_frontend, use_old_api):
+                                                         temp_dir, use_new_frontend):
         tf_net_path = self.create_tf_model_single_input_output(temp_dir)
         from openvino.tools.mo import convert_model
 

--- a/tests/layer_tests/mo_python_api_tests/test_mo_convert_extensions.py
+++ b/tests/layer_tests/mo_python_api_tests/test_mo_convert_extensions.py
@@ -113,7 +113,7 @@ class TestExtensions(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_extensions(self, params, ie_device, precision, ir_version,
-                                   temp_dir, use_new_frontend, use_old_api):
+                                   temp_dir, use_new_frontend):
         onnx_net_path = self.create_onnx_model(temp_dir)
 
         test_params = params['params_test']

--- a/tests/layer_tests/mo_python_api_tests/test_mo_convert_pytorch.py
+++ b/tests/layer_tests/mo_python_api_tests/test_mo_convert_pytorch.py
@@ -1011,7 +1011,7 @@ class TestMoConvertPyTorch(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_import_from_memory(self, create_model, ie_device, precision, ir_version,
-                                   temp_dir, use_new_frontend, use_old_api):
+                                   temp_dir, use_new_frontend):
         fw_model, graph_ref, mo_params = create_model(temp_dir)
 
         test_params = {'input_model': fw_model}
@@ -1240,7 +1240,7 @@ class TestPrecisionSensitive():
                                                                                                      'aarch64',
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 122714, 122710')
-    def test_precision_sensitive(self, create_model, ie_device, precision, ir_version, temp_dir, use_new_frontend, use_old_api):
+    def test_precision_sensitive(self, create_model, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         import numpy.testing as npt
         from pathlib import Path
 

--- a/tests/layer_tests/onnx_tests/test_abs.py
+++ b/tests/layer_tests/onnx_tests/test_abs.py
@@ -167,12 +167,12 @@ class TestAbs(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_abs(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_abs(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_abs_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_abs_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_add_sub_mul_div.py
+++ b/tests/layer_tests/onnx_tests/test_add_sub_mul_div.py
@@ -194,168 +194,168 @@ class TestOperations(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_add(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_add(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Add', precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_add_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_add_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, op='Add', precision=precision, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sub(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sub(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Sub', precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sub_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sub_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, op='Sub', precision=precision, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_mul(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_mul(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Mul', precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_mul_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_mul_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, op='Mul', precision=precision, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_div(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_div(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Div', precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_div_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_div_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, op='Div', precision=precision, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_add_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_add_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Add', precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_add_const_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_add_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, op='Add', precision=precision, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_sub_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sub_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Sub', precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_sub_const_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sub_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, op='Sub', precision=precision, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_mul_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_mul_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Mul', precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_mul_const_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_mul_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, op='Mul', precision=precision, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_div_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_div_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Div', precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_div_const_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_div_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, op='Div', precision=precision, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_add_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_add_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Add', precision=precision, opset=6,
                                     ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_add_const_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_add_const_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, op='Add', precision=precision, opset=6,
                                           ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_sub_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sub_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Sub', precision=precision, opset=6,
                                     ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_sub_const_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sub_const_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, op='Sub', precision=precision, opset=6,
                                           ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_mul_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_mul_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Mul', precision=precision, opset=6,
                                     ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_mul_const_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_mul_const_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, op='Mul', precision=precision, opset=6,
                                           ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_div_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_div_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, op='Div', precision=precision, opset=6,
                                     ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_div_const_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_div_const_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, op='Div', precision=precision, opset=6,
                                           ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_and.py
+++ b/tests/layer_tests/onnx_tests/test_and.py
@@ -251,21 +251,21 @@ class TestAnd(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_and(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_and(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_and_one_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_and_one_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_one_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_and_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_and_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_argmax.py
+++ b/tests/layer_tests/onnx_tests/test_argmax.py
@@ -150,8 +150,8 @@ class TestArgMax(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keepdims", [None, 0])
     @pytest.mark.nightly
-    def test_argmax(self, params, keepdims, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_argmax(self, params, keepdims, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'CPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net(**params, ir_version=ir_version, keepdims=keepdims),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_bn.py
+++ b/tests/layer_tests/onnx_tests/test_bn.py
@@ -116,19 +116,19 @@ class TestBatchNormalization(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_bn(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_bn(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_bn_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_bn_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, opset=6, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_bn_opset7(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_bn_opset7(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, opset=7, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_ceil.py
+++ b/tests/layer_tests/onnx_tests/test_ceil.py
@@ -171,26 +171,26 @@ class TestCeil(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_ceil_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_ceil_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_ceil_const_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_ceil_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_ceil(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_ceil(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_ceil_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_ceil_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_clip.py
+++ b/tests/layer_tests/onnx_tests/test_clip.py
@@ -160,14 +160,14 @@ class TestClip(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_clip_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_clip_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, opset=6), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_clip_opset11(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_clip_opset11(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, opset=11), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_concat.py
+++ b/tests/layer_tests/onnx_tests/test_concat.py
@@ -252,39 +252,37 @@ class TestConcat(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_concat_3D_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_concat_3D_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_concat_net_const(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D_precommit)
     @pytest.mark.precommit
-    def test_concat_4D_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api):
+    def test_concat_4D_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_concat_net_const(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_concat_4D_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_concat_4D_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_concat_net_const(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D_precommit)
     @pytest.mark.nightly
-    def test_concat_5D_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api):
+    def test_concat_5D_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_concat_net_const(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_concat_5D_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_concat_5D_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_concat_net_const(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_concat_inputs_order_params)
     @pytest.mark.nightly
-    def test_concat_inputs_order(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_concat_inputs_order(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_concat_net(**params, ir_version=ir_version), ie_device=ie_device,
                    precision=precision, ir_version=ir_version, temp_dir=temp_dir,
-                   input_names=params['input_names'], use_old_api=use_old_api)
+                   input_names=params['input_names'])

--- a/tests/layer_tests/onnx_tests/test_concat.py
+++ b/tests/layer_tests/onnx_tests/test_concat.py
@@ -258,7 +258,7 @@ class TestConcat(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D_precommit)
     @pytest.mark.precommit
-    def test_concat_4D_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_concat_4D_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_concat_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version, temp_dir=temp_dir)
 
@@ -270,7 +270,7 @@ class TestConcat(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D_precommit)
     @pytest.mark.nightly
-    def test_concat_5D_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_concat_5D_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_concat_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version, temp_dir=temp_dir)
 

--- a/tests/layer_tests/onnx_tests/test_conv.py
+++ b/tests/layer_tests/onnx_tests/test_conv.py
@@ -414,11 +414,11 @@ class TestConv(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("bias", [False, True])
     @pytest.mark.nightly
     def test_conv_3D(self, params, dilations, pads, strides, bias, ie_device, precision, ir_version,
-                     temp_dir, use_old_api):
+                     temp_dir):
         self._test(*self.create_net(**params, shape=[2, 3, 25], dilations=dilations, pads=pads,
                                     strides=strides,
                                     bias=bias, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D_autopad[:-1])
     @pytest.mark.parametrize("auto_pad", ['SAME_UPPER', 'SAME_LOWER'])
@@ -426,10 +426,10 @@ class TestConv(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_conv_3D_autopad(self, params, auto_pad, bias, ie_device, precision, ir_version,
-                             temp_dir, use_old_api):
+                             temp_dir):
         self._test(*self.create_net(**params, shape=[2, 3, 25], bias=bias, auto_pad=auto_pad,
                                     ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D_precommit)
     @pytest.mark.parametrize("dilations", [[3, 5]])
@@ -438,11 +438,11 @@ class TestConv(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("bias", [False, True])
     @pytest.mark.precommit
     def test_conv_4D_precommit(self, params, dilations, pads, strides, bias, ie_device, precision,
-                               ir_version, temp_dir, use_old_api):
+                               ir_version, temp_dir):
         self._test(*self.create_net(**params, shape=[2, 3, 25, 25], dilations=dilations, pads=pads,
                                     strides=strides,
                                     bias=bias, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.parametrize("dilations", [[1, 1], [2, 2], [3, 5]])
@@ -451,12 +451,12 @@ class TestConv(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("bias", [False, True])
     @pytest.mark.nightly
     def test_conv_4D(self, params, dilations, pads, strides, bias, ie_device, precision, ir_version,
-                     temp_dir, use_old_api):
+                     temp_dir):
         self._test(
             *self.create_net(**params, shape=[2, 3, 25, 25], dilations=dilations, pads=pads,
                              strides=strides, bias=bias,
                              ir_version=ir_version), ie_device, precision, ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D_autopad[:-1])
     @pytest.mark.parametrize("auto_pad", ['SAME_UPPER', 'SAME_LOWER'])
@@ -464,10 +464,10 @@ class TestConv(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_conv_4D_autopad(self, params, auto_pad, bias, ie_device, precision, ir_version,
-                             temp_dir, use_old_api):
+                             temp_dir):
         self._test(*self.create_net(**params, shape=[2, 3, 25, 25], bias=bias, auto_pad=auto_pad,
                                     ir_version=ir_version), ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D_precommit)
     @pytest.mark.parametrize("dilations", [[3, 4, 5]])
@@ -476,13 +476,13 @@ class TestConv(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("bias", [False, True])
     @pytest.mark.precommit
     def test_conv_5D_precommit(self, params, dilations, pads, strides, bias, ie_device, precision,
-                               ir_version, temp_dir, use_old_api):
+                               ir_version, temp_dir):
         custom_eps_value = 1e-1 if ie_device == 'GPU' and precision == 'FP16' else None
         self._test(
             *self.create_net(**params, shape=[2, 3, 25, 25, 25], dilations=dilations, pads=pads,
                              strides=strides,
                              bias=bias, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api, custom_eps=custom_eps_value)
+            ie_device, precision, ir_version, temp_dir=temp_dir, custom_eps=custom_eps_value)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.parametrize("dilations", [[1, 1, 1], [2, 2, 2], [3, 4, 5]])
@@ -492,12 +492,12 @@ class TestConv(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_conv_5D(self, params, dilations, pads, strides, bias, ie_device, precision, ir_version,
-                     temp_dir, use_old_api):
+                     temp_dir):
         self._test(
             *self.create_net(**params, shape=[2, 3, 25, 25, 25], dilations=dilations, pads=pads,
                              strides=strides,
                              bias=bias, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D_autopad[:-1])
     @pytest.mark.parametrize("auto_pad", ['SAME_UPPER', 'SAME_LOWER'])
@@ -505,8 +505,8 @@ class TestConv(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_conv_5D_autopad(self, params, auto_pad, bias, ie_device, precision, ir_version,
-                             temp_dir, use_old_api):
+                             temp_dir):
         self._test(
             *self.create_net(**params, shape=[2, 3, 25, 25, 25], bias=bias, auto_pad=auto_pad,
                              ir_version=ir_version), ie_device, precision, ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_conv_transpose.py
+++ b/tests/layer_tests/onnx_tests/test_conv_transpose.py
@@ -184,12 +184,12 @@ class TestConvTranspose(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("auto_pad", ["NOTSET"])
     @pytest.mark.precommit
     def test_conv_transpose_4D_precommit(self, params, bias, ie_device, precision, ir_version,
-                                         auto_pad, temp_dir, use_old_api):
+                                         auto_pad, temp_dir):
         if ie_device == 'GPU' and 'dilations' in params:
             pytest.xfail('dilations are not supported on GPU')
         self._test(*self.create_conv_transpose(**params, ir_version=ir_version, bias=bias,
                                                auto_pad=auto_pad),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", explicit_pads_tests_4D)
     @pytest.mark.parametrize("bias", [False, True])
@@ -197,12 +197,12 @@ class TestConvTranspose(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_conv_transpose_4D(self, params, bias, ie_device, precision, ir_version, auto_pad,
-                               temp_dir, use_old_api):
+                               temp_dir):
         if ie_device == 'GPU' and 'dilations' in params:
             pytest.xfail('dilations are not supported on GPU')
         self._test(*self.create_conv_transpose(**params, ir_version=ir_version, bias=bias,
                                                auto_pad=auto_pad),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", valid_auto_pad_tests_4D)
     @pytest.mark.parametrize("bias", [False, True])
@@ -210,12 +210,12 @@ class TestConvTranspose(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_conv_transpose_valid_auto_pad_4D(self, params, bias, ie_device, precision, ir_version,
-                                              auto_pad, temp_dir, use_old_api):
+                                              auto_pad, temp_dir):
         if ie_device == 'GPU' and 'dilations' in params:
             pytest.xfail('dilations are not supported on GPU')
         self._test(*self.create_conv_transpose(**params, ir_version=ir_version, bias=bias,
                                                auto_pad=auto_pad),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", same_auto_pad_tests_4D)
     @pytest.mark.parametrize("bias", [False, True])
@@ -223,9 +223,9 @@ class TestConvTranspose(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_conv_transpose_same_auto_pad_4D(self, params, bias, ie_device, precision, ir_version,
-                                             auto_pad, temp_dir, use_old_api):
+                                             auto_pad, temp_dir):
         if ie_device == 'GPU' and 'dilations' in params:
             pytest.xfail('dilations are not supported on GPU')
         self._test(*self.create_conv_transpose(**params, ir_version=ir_version, bias=bias,
                                                auto_pad=auto_pad),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_cumsum.py
+++ b/tests/layer_tests/onnx_tests/test_cumsum.py
@@ -252,7 +252,7 @@ class TestCumSum(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("reverse", [0, 1])
     @pytest.mark.parametrize("exclusive", [0, 1])
     @pytest.mark.nightly
-    def test_cumsum(self, params, reverse, exclusive, ie_device, precision, ir_version, temp_dir,:
+    def test_cumsum(self, params, reverse, exclusive, ie_device, precision, ir_version, temp_dir):
         if 'axis' not in params:
             pytest.skip('No axis cases fail in ONNX')
         elif 'axis' in params and params['axis'] == -2 and exclusive == 1:

--- a/tests/layer_tests/onnx_tests/test_cumsum.py
+++ b/tests/layer_tests/onnx_tests/test_cumsum.py
@@ -252,22 +252,21 @@ class TestCumSum(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("reverse", [0, 1])
     @pytest.mark.parametrize("exclusive", [0, 1])
     @pytest.mark.nightly
-    def test_cumsum(self, params, reverse, exclusive, ie_device, precision, ir_version, temp_dir,
-                    use_old_api):
+    def test_cumsum(self, params, reverse, exclusive, ie_device, precision, ir_version, temp_dir,:
         if 'axis' not in params:
             pytest.skip('No axis cases fail in ONNX')
         elif 'axis' in params and params['axis'] == -2 and exclusive == 1:
             pytest.skip('Disabled due to an exception thrown by ONNXRuntime for this use case')
         self._test(
             *self.create_net(**params, exclusive=exclusive, reverse=reverse, ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("reverse", [0, 1])
     @pytest.mark.parametrize("exclusive", [0, 1])
     @pytest.mark.nightly
     def test_cumsum_const(self, params, reverse, exclusive, ie_device, precision, ir_version,
-                          temp_dir, use_old_api):
+                          temp_dir):
         if 'axis' not in params:
             pytest.skip('No axis cases fail in ONNX')
         elif 'axis' in params and params['axis'] == -2 and exclusive == 1:
@@ -275,4 +274,4 @@ class TestCumSum(OnnxRuntimeLayerTest):
         self._test(*self.create_net_const(**params, precision=precision, exclusive=exclusive,
                                           reverse=reverse,
                                           ir_version=ir_version), ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_dequantize_linear.py
+++ b/tests/layer_tests/onnx_tests/test_dequantize_linear.py
@@ -194,31 +194,28 @@ class TestDequantizeLinear(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_def_zerop)
     @pytest.mark.nightly
     def test_quantize_linear_def_zerop_opset10(self, params, ie_device, precision, ir_version,
-                                               temp_dir, use_old_api):
+                                               temp_dir):
         self._test(*self.create_dequanize_linear(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_quantize_linear_opset10(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_old_api):
+    def test_quantize_linear_opset10(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_dequanize_linear(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data + test_data_def_zerop)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='DequantizeLinear-13 is unsupported in MO')
-    def test_quantize_linear_opset13(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_old_api):
+    def test_quantize_linear_opset13(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_dequanize_linear(**params, opset=13, ir_version=ir_version),
                    ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_axis)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='DequantizeLinear-13 is unsupported in MO')
-    def test_quantize_linear_axis_opset13(self, params, ie_device, precision, ir_version, temp_dir,
-                                          use_old_api):
+    def test_quantize_linear_axis_opset13(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_dequanize_linear(**params, opset=13, ir_version=ir_version),
                    ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_dequantize_linear.py
+++ b/tests/layer_tests/onnx_tests/test_dequantize_linear.py
@@ -200,14 +200,14 @@ class TestDequantizeLinear(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_quantize_linear_opset10(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_quantize_linear_opset10(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_dequanize_linear(**params, ir_version=ir_version), ie_device,
                    precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data + test_data_def_zerop)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='DequantizeLinear-13 is unsupported in MO')
-    def test_quantize_linear_opset13(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_quantize_linear_opset13(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_dequanize_linear(**params, opset=13, ir_version=ir_version),
                    ie_device, precision,
                    ir_version, temp_dir=temp_dir)
@@ -215,7 +215,7 @@ class TestDequantizeLinear(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_axis)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='DequantizeLinear-13 is unsupported in MO')
-    def test_quantize_linear_axis_opset13(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_quantize_linear_axis_opset13(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_dequanize_linear(**params, opset=13, ir_version=ir_version),
                    ie_device, precision,
                    ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_dropout.py
+++ b/tests/layer_tests/onnx_tests/test_dropout.py
@@ -147,30 +147,30 @@ class TestDropout(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_dropout_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_dropout_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, opset=6, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_dropout(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_dropout(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_dropout_const_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_dropout_const_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, opset=6, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_dropout_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_dropout_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_elu.py
+++ b/tests/layer_tests/onnx_tests/test_elu.py
@@ -175,13 +175,13 @@ class TestElu(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_elu(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_elu(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_elu_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_elu_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_embedding_bag.py
+++ b/tests/layer_tests/onnx_tests/test_embedding_bag.py
@@ -132,6 +132,5 @@ class TestPytorchEmbeddingBag(PytorchLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_pytorch_embedding_bag(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
-        self._test(*self.create_net(**params), ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_old_api=use_old_api)
+    def test_pytorch_embedding_bag(self, params, ie_device, precision, ir_version, temp_dir):
+        self._test(*self.create_net(**params), ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_flatten.py
+++ b/tests/layer_tests/onnx_tests/test_flatten.py
@@ -196,7 +196,7 @@ class TestFlatten(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_3D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,:
+    def test_flatten_3D_const(self, params, opset, ie_device, precision, ir_version, temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
@@ -220,7 +220,7 @@ class TestFlatten(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_4D_precommit)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.precommit
-    def test_flatten_4D_precommit(self, params, opset, ie_device, precision, ir_version, temp_dir,:
+    def test_flatten_4D_precommit(self, params, opset, ie_device, precision, ir_version, temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
@@ -245,7 +245,7 @@ class TestFlatten(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_4D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,:
+    def test_flatten_4D_const(self, params, opset, ie_device, precision, ir_version, temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
@@ -257,7 +257,7 @@ class TestFlatten(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_5D_precommit)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_5D_precommit(self, params, opset, ie_device, precision, ir_version, temp_dir,:
+    def test_flatten_5D_precommit(self, params, opset, ie_device, precision, ir_version, temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
@@ -294,7 +294,7 @@ class TestFlatten(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_5D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,:
+    def test_flatten_5D_const(self, params, opset, ie_device, precision, ir_version, temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True

--- a/tests/layer_tests/onnx_tests/test_flatten.py
+++ b/tests/layer_tests/onnx_tests/test_flatten.py
@@ -184,126 +184,121 @@ class TestFlatten(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_3D(self, params, opset, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_flatten_3D(self, params, opset, ie_device, precision, ir_version, temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_3D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,
-                              use_old_api):
+    def test_flatten_3D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,:
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net_const(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_4D(self, params, opset, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_flatten_4D(self, params, opset, ie_device, precision, ir_version, temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D_precommit)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.precommit
-    def test_flatten_4D_precommit(self, params, opset, ie_device, precision, ir_version, temp_dir,
-                                  use_old_api):
+    def test_flatten_4D_precommit(self, params, opset, ie_device, precision, ir_version, temp_dir,:
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D_precommit)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
     def test_flatten_4D_const_precommit(self, params, opset, ie_device, precision, ir_version,
-                                        temp_dir, use_old_api):
+                                        temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net_const(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_4D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,
-                              use_old_api):
+    def test_flatten_4D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,:
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net_const(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D_precommit)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_5D_precommit(self, params, opset, ie_device, precision, ir_version, temp_dir,
-                                  use_old_api):
+    def test_flatten_5D_precommit(self, params, opset, ie_device, precision, ir_version, temp_dir,:
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_5D(self, params, opset, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_flatten_5D(self, params, opset, ie_device, precision, ir_version, temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D_precommit)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
     def test_flatten_5D_const_precommit(self, params, opset, ie_device, precision, ir_version,
-                                        temp_dir, use_old_api):
+                                        temp_dir):
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net_const(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.parametrize("opset", [6, 9])
     @pytest.mark.nightly
-    def test_flatten_5D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,
-                              use_old_api):
+    def test_flatten_5D_const(self, params, opset, ie_device, precision, ir_version, temp_dir,:
         # negative axis not allowed by onnx spec for flatten-1 and flatten-9
         if params['axis'] < 0:
             self.skip_framework = True
         else:
             self.skip_framework = False
         self._test(*self.create_flatten_net_const(**params, ir_version=ir_version, opset=opset),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_floor.py
+++ b/tests/layer_tests/onnx_tests/test_floor.py
@@ -168,13 +168,13 @@ class TestFloor(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_floor(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_floor(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_floor_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_floor_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_fusedgemm.py
+++ b/tests/layer_tests/onnx_tests/test_fusedgemm.py
@@ -138,7 +138,7 @@ class TestFusedGemm(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_fusedgemm(self, params, alpha, beta, trans_a, trans_b,
-                       ie_device, precision, opset, ir_version, temp_dir, use_old_api):
+                       ie_device, precision, opset, ir_version, temp_dir):
         self._test(
             *self.create_net(params['shapeA'], params['shapeB'], params['shapeC'], alpha, beta,
                              trans_a, trans_b,
@@ -146,4 +146,4 @@ class TestFusedGemm(OnnxRuntimeLayerTest):
                              params['activation_beta'], params['activation_gamma'],
                              opset, ir_version), ie_device, precision,
             ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api, custom_eps=1e-2)
+            temp_dir=temp_dir, custom_eps=1e-2)

--- a/tests/layer_tests/onnx_tests/test_gather.py
+++ b/tests/layer_tests/onnx_tests/test_gather.py
@@ -247,24 +247,24 @@ class TestGather(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_gather(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_gather(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_gather(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_gather(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_gather_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_gather_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     test_data_negative_indices = [
         dict(shape=[10, 12], axis=0, indices=[3, -1, -4], output_shape=[3, 12]),
@@ -278,8 +278,8 @@ class TestGather(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_negative_indices)
     @pytest.mark.nightly
     def test_gather_nightly_negative_indices(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_old_api):
+                                             temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net(**params, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_gemm.py
+++ b/tests/layer_tests/onnx_tests/test_gemm.py
@@ -226,13 +226,13 @@ class TestGemm(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_gemm(self, params, alpha, beta, trans_a, trans_b, ie_device, precision, opset,
-                  ir_version, temp_dir, use_old_api):
+                  ir_version, temp_dir):
         self._test(
             *self.create_net(params['shapeA'], params['shapeB'], params['shapeC'], alpha, beta,
                              trans_a,
                              trans_b, precision, opset, ir_version), ie_device, precision,
             ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_bc)
     @pytest.mark.parametrize("alpha", [None, 0.1, 2.0])
@@ -243,13 +243,13 @@ class TestGemm(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_gemm_bc(self, params, alpha, beta, trans_a, trans_b, ie_device, precision, opset,
-                     ir_version, temp_dir, use_old_api):
+                     ir_version, temp_dir):
         self._test(
             *self.create_net(params['shapeA'], params['shapeB'], params['shapeC'], alpha, beta,
                              trans_a,
                              trans_b, precision, opset, ir_version), ie_device, precision,
             ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("alpha", [None, 0.1, 2.0])
@@ -259,13 +259,13 @@ class TestGemm(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_gemm_double(self, params, alpha, beta, trans_a, trans_b, ie_device, precision,
-                         ir_version, temp_dir, use_old_api):
+                         ir_version, temp_dir):
         self._test(
             *self.create_net_double(params['shapeA'], params['shapeB'], params['shapeC'], alpha,
                                     beta,
                                     trans_a, trans_b, precision, ir_version), ie_device, precision,
             ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_bc)
     @pytest.mark.parametrize("alpha", [None, 0.1, 2.0])
@@ -275,13 +275,13 @@ class TestGemm(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_gemm_double_bc(self, params, alpha, beta, trans_a, trans_b, ie_device, precision,
-                            ir_version, temp_dir, use_old_api):
+                            ir_version, temp_dir):
         self._test(
             *self.create_net_double(params['shapeA'], params['shapeB'], params['shapeC'], alpha,
                                     beta,
                                     trans_a, trans_b, precision, ir_version), ie_device, precision,
             ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)
 
 
 class PytorchLayerTest(CommonLayerTest):
@@ -335,7 +335,7 @@ class TestPytorchMM(PytorchLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_pytorch_mm(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_pytorch_mm(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(precision, **params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_hard_sigmoid.py
+++ b/tests/layer_tests/onnx_tests/test_hard_sigmoid.py
@@ -221,20 +221,19 @@ class TestHardSigmoid(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_hard_sigmoid(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_hard_sigmoid(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.nightly
-    def test_hard_sigmoid_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                          use_old_api):
+    def test_hard_sigmoid_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_hard_sigmoid_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_hard_sigmoid_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_hard_sigmoid.py
+++ b/tests/layer_tests/onnx_tests/test_hard_sigmoid.py
@@ -228,7 +228,7 @@ class TestHardSigmoid(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.nightly
-    def test_hard_sigmoid_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_hard_sigmoid_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 

--- a/tests/layer_tests/onnx_tests/test_identity.py
+++ b/tests/layer_tests/onnx_tests/test_identity.py
@@ -172,13 +172,13 @@ class TestIdentity(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_identity(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_identity(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_identity_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_identity_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_image_scaler.py
+++ b/tests/layer_tests/onnx_tests/test_image_scaler.py
@@ -139,7 +139,7 @@ class TestImageScaler(OnnxRuntimeLayerTest):
                  dict(shape=[6, 8, 10, 12], scale=4.5)]
 
     @pytest.mark.parametrize("params", test_data_precommit)
-    def test_image_scaler_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_image_scaler_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
                    temp_dir=temp_dir)
@@ -153,7 +153,7 @@ class TestImageScaler(OnnxRuntimeLayerTest):
                    temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
-    def test_image_scaler_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_image_scaler_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 

--- a/tests/layer_tests/onnx_tests/test_image_scaler.py
+++ b/tests/layer_tests/onnx_tests/test_image_scaler.py
@@ -139,29 +139,27 @@ class TestImageScaler(OnnxRuntimeLayerTest):
                  dict(shape=[6, 8, 10, 12], scale=4.5)]
 
     @pytest.mark.parametrize("params", test_data_precommit)
-    def test_image_scaler_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api):
+    def test_image_scaler_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_image_scaler(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_image_scaler(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
-    def test_image_scaler_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                          use_old_api):
+    def test_image_scaler_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_image_scaler_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_image_scaler_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_instance_normalization.py
+++ b/tests/layer_tests/onnx_tests/test_instance_normalization.py
@@ -100,12 +100,12 @@ class TestInstanceNormalization(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_instance_normalization(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_instance_normalization(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_instance_normalization(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_instance_normalization(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_instance_normalization.py
+++ b/tests/layer_tests/onnx_tests/test_instance_normalization.py
@@ -100,14 +100,12 @@ class TestInstanceNormalization(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_instance_normalization(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api):
+    def test_instance_normalization(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_instance_normalization(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api):
+    def test_instance_normalization(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_leaky_relu.py
+++ b/tests/layer_tests/onnx_tests/test_leaky_relu.py
@@ -195,7 +195,7 @@ class TestLeakyRelu(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_leaky_relu_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_leaky_relu_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 

--- a/tests/layer_tests/onnx_tests/test_leaky_relu.py
+++ b/tests/layer_tests/onnx_tests/test_leaky_relu.py
@@ -181,27 +181,26 @@ class TestLeakyRelu(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_leaky_relu_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_leaky_relu_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_leaky_relu(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_leaky_relu(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_leaky_relu_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                        use_old_api):
+    def test_leaky_relu_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_leaky_relu_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_leaky_relu_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_log.py
+++ b/tests/layer_tests/onnx_tests/test_log.py
@@ -171,26 +171,26 @@ class TestLog(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_log_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_log_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_log(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_log(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.nightly
-    def test_log_const_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_log_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_log_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_log_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_logsoftmax.py
+++ b/tests/layer_tests/onnx_tests/test_logsoftmax.py
@@ -248,9 +248,9 @@ class TestLog(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_log(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_log(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_loop.py
+++ b/tests/layer_tests/onnx_tests/test_loop.py
@@ -273,14 +273,14 @@ class TestLoop(OnnxRuntimeLayerTest):
 
     @pytest.mark.precommit
     @pytest.mark.timeout(250)
-    def test_loop_simple_precommit(self, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_loop_simple_precommit(self, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_loop(), ie_device, precision, ir_version, temp_dir=temp_dir,
-                   infer_timeout=150, use_old_api=use_old_api)
+                   infer_timeout=150)
 
     @pytest.mark.precommit
     @pytest.mark.timeout(250)
-    def test_loop_in_loop_simple_precommit(self, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_loop_in_loop_simple_precommit(self, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.xfail("Program doesn't contain primitive: constant:res/10/M_2 that is input to: loop")
         self._test(*self.create_loop_in_loop(), ie_device, precision, ir_version, temp_dir=temp_dir,
-                   infer_timeout=150, use_old_api=use_old_api)
+                   infer_timeout=150)

--- a/tests/layer_tests/onnx_tests/test_lrn.py
+++ b/tests/layer_tests/onnx_tests/test_lrn.py
@@ -111,29 +111,29 @@ class TestLRN(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_lrn_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_lrn_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         # onnxruntime only supports 4D tensors for LRN
         self.skip_framework = True
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_lrn(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_lrn(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         # onnxruntime only supports 4D tensors for LRN
         self.skip_framework = True
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_lrn_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_lrn_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self.skip_framework = False
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_lstm.py
+++ b/tests/layer_tests/onnx_tests/test_lstm.py
@@ -144,24 +144,23 @@ class TestLSTM(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize('direction', ["forward", "bidirectional", "reverse"])
     @pytest.mark.parametrize('cell_type', ["LSTM", "GRU", "RNN"])
     def test_lstm_simple_precommit(self, direction, cell_type, ie_device, precision, ir_version,
-                                   temp_dir, use_old_api):
+                                   temp_dir):
         self._test(*self.create_lstm(direction, cell_type), ie_device, precision, ir_version,
-                   temp_dir=temp_dir, infer_timeout=150, use_old_api=use_old_api)
+                   temp_dir=temp_dir, infer_timeout=150)
 
     # LSTM/RNN/GRU Sequence Generation
     @pytest.mark.parametrize('direction', ["forward", "bidirectional", "reverse"])
     @pytest.mark.parametrize('cell_type', ["LSTM", "GRU", "RNN"])
     def test_lstm_sequence_generate(self, direction, cell_type, ie_device, precision, ir_version,
-                                    temp_dir, use_old_api):
+                                    temp_dir):
         self._test(*self.create_lstm(direction, cell_type), ie_device, precision, ir_version,
                    disabled_transforms='lstm_to_tensor_iterator,gru_and_rnn_to_tensor_iterator',
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     # TODO: add more params for nightly
     @pytest.mark.nightly
     @pytest.mark.parametrize('direction', ["forward", "bidirectional", "reverse"])
     @pytest.mark.parametrize('cell_type', ["LSTM", "GRU", "RNN"])
-    def test_lstm_nightly(self, direction, cell_type, ie_device, precision, ir_version, temp_dir,
-                          use_old_api):
+    def test_lstm_nightly(self, direction, cell_type, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_lstm(direction, cell_type), ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_lstm.py
+++ b/tests/layer_tests/onnx_tests/test_lstm.py
@@ -161,6 +161,6 @@ class TestLSTM(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.parametrize('direction', ["forward", "bidirectional", "reverse"])
     @pytest.mark.parametrize('cell_type', ["LSTM", "GRU", "RNN"])
-    def test_lstm_nightly(self, direction, cell_type, ie_device, precision, ir_version, temp_dir,:
+    def test_lstm_nightly(self, direction, cell_type, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_lstm(direction, cell_type), ie_device, precision, ir_version,
                    temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_matmul.py
+++ b/tests/layer_tests/onnx_tests/test_matmul.py
@@ -167,30 +167,30 @@ class TestMatMul(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_matmul(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_matmul(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_broadcasting)
     @pytest.mark.nightly
-    def test_matmul_bc(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_matmul_bc(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_dual_matmul(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_dual_matmul(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_dual_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_broadcasting)
     @pytest.mark.nightly
-    def test_dual_matmul_bc(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_dual_matmul_bc(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_dual_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_mean_variance_normalization.py
+++ b/tests/layer_tests/onnx_tests/test_mean_variance_normalization.py
@@ -69,6 +69,6 @@ class TestMeanVarianceNormalization(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_mvn(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_mvn(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_neg.py
+++ b/tests/layer_tests/onnx_tests/test_neg.py
@@ -80,14 +80,14 @@ class TestNeg(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize('params', test_data_precommit)
     @pytest.mark.precommit
-    def test_neg_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_neg_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_neg(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize('params', test_data)
     @pytest.mark.nightly
-    def test_neg(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_neg(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_neg(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_non_zero.py
+++ b/tests/layer_tests/onnx_tests/test_non_zero.py
@@ -187,14 +187,14 @@ class TestNonZero(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_non_zero(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_non_zero(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_const_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_non_zero_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_non_zero_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_not.py
+++ b/tests/layer_tests/onnx_tests/test_not.py
@@ -173,21 +173,21 @@ class TestNot(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_not_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_not_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_not(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_not(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_not_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_not_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_or.py
+++ b/tests/layer_tests/onnx_tests/test_or.py
@@ -254,28 +254,28 @@ class TestOr(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_or_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_or_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_or(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_or(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_or_one_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_or_one_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_one_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_or_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_or_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_pad.py
+++ b/tests/layer_tests/onnx_tests/test_pad.py
@@ -181,12 +181,11 @@ class TestPad(OnnxRuntimeLayerTest):
                                             ('reflect', None),
                                             ('edge', None)])
     @pytest.mark.nightly
-    def test_pad_opset_9(self, params, mode_value, ie_device, precision, ir_version, temp_dir,
-                         use_old_api):
+    def test_pad_opset_9(self, params, mode_value, ie_device, precision, ir_version, temp_dir,:
         mode, value = mode_value
         self._test(
             *self.create_net(**params, mode=mode, value=value, ir_version=ir_version, opset=9),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.parametrize("mode_value", [(None, None),
@@ -197,10 +196,10 @@ class TestPad(OnnxRuntimeLayerTest):
                                             ('edge', None)])
     @pytest.mark.precommit
     def test_pad_opset_latest_precommit(self, params, mode_value, ie_device, precision, ir_version,
-                                        temp_dir, use_old_api):
+                                        temp_dir):
         mode, value = mode_value
         self._test(*self.create_net(**params, mode=mode, value=value, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("mode_value", [(None, None),
@@ -210,8 +209,7 @@ class TestPad(OnnxRuntimeLayerTest):
                                             ('reflect', None),
                                             ('edge', None)])
     @pytest.mark.nightly
-    def test_pad_opset_latest(self, params, mode_value, ie_device, precision, ir_version, temp_dir,
-                              use_old_api):
+    def test_pad_opset_latest(self, params, mode_value, ie_device, precision, ir_version, temp_dir,:
         mode, value = mode_value
         self._test(*self.create_net(**params, mode=mode, value=value, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_pad.py
+++ b/tests/layer_tests/onnx_tests/test_pad.py
@@ -181,7 +181,7 @@ class TestPad(OnnxRuntimeLayerTest):
                                             ('reflect', None),
                                             ('edge', None)])
     @pytest.mark.nightly
-    def test_pad_opset_9(self, params, mode_value, ie_device, precision, ir_version, temp_dir,:
+    def test_pad_opset_9(self, params, mode_value, ie_device, precision, ir_version, temp_dir):
         mode, value = mode_value
         self._test(
             *self.create_net(**params, mode=mode, value=value, ir_version=ir_version, opset=9),
@@ -209,7 +209,7 @@ class TestPad(OnnxRuntimeLayerTest):
                                             ('reflect', None),
                                             ('edge', None)])
     @pytest.mark.nightly
-    def test_pad_opset_latest(self, params, mode_value, ie_device, precision, ir_version, temp_dir,:
+    def test_pad_opset_latest(self, params, mode_value, ie_device, precision, ir_version, temp_dir):
         mode, value = mode_value
         self._test(*self.create_net(**params, mode=mode, value=value, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_pooling.py
+++ b/tests/layer_tests/onnx_tests/test_pooling.py
@@ -389,23 +389,21 @@ class TestPooling(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("incl_pad", [None, 1])
     @pytest.mark.nightly
-    def test_avgpool_opset7(self, params, incl_pad, ie_device, precision, ir_version, temp_dir,
-                            use_old_api):
+    def test_avgpool_opset7(self, params, incl_pad, ie_device, precision, ir_version, temp_dir,:
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(
             *self.create_net(**params, op='AveragePool', count_include_pad=incl_pad,
                              ir_version=ir_version, opset=7),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_autopad)
     @pytest.mark.nightly
-    def test_avgpool_opset7_autopad(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api):
+    def test_avgpool_opset7_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='AveragePool', ir_version=ir_version, opset=7),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("incl_pad", [None, 1])
@@ -413,88 +411,81 @@ class TestPooling(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_avgpool_opset10(self, params, incl_pad, ceil, ie_device, precision, ir_version,
-                             temp_dir, use_old_api):
+                             temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(
             *self.create_net(**params, op='AveragePool', count_include_pad=incl_pad, ceil=ceil,
                              ir_version=ir_version,
-                             opset=10), ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_old_api=use_old_api)
+                             opset=10), ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_autopad)
     @pytest.mark.nightly
-    def test_avgpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_old_api):
+    def test_avgpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='AveragePool', ir_version=ir_version, opset=10),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("st_order", [None, 1])
     @pytest.mark.nightly
-    def test_maxpool_opset8(self, params, st_order, ie_device, precision, ir_version, temp_dir,
-                            use_old_api):
+    def test_maxpool_opset8(self, params, st_order, ie_device, precision, ir_version, temp_dir,:
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(
             *self.create_net(**params, op='MaxPool', storage_order=st_order, ir_version=ir_version,
                              opset=8),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_autopad)
     @pytest.mark.nightly
-    def test_maxpool_opset8_autopad(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api):
+    def test_maxpool_opset8_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='MaxPool', ir_version=ir_version, opset=8),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("st_order", [None, 1])
     @pytest.mark.parametrize("ceil", [True, False])
     @pytest.mark.nightly
     def test_maxpool_opset10(self, params, st_order, ceil, ie_device, precision, ir_version,
-                             temp_dir, use_old_api):
+                             temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='MaxPool', storage_order=st_order, ceil=ceil,
                                     ir_version=ir_version,
-                                    opset=10), ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_old_api=use_old_api)
+                                    opset=10), ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_autopad_precommit)
     @pytest.mark.precommit
-    def test_maxpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_old_api):
+    def test_maxpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='MaxPool', ir_version=ir_version, opset=10),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_autopad)
     @pytest.mark.nightly
-    def test_maxpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_old_api):
+    def test_maxpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='MaxPool', ir_version=ir_version, opset=10),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", global_test_data)
     @pytest.mark.nightly
-    def test_global_avgpool(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_global_avgpool(self, params, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_global_net(**params, op='GlobalAveragePool', ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", global_test_data)
     @pytest.mark.nightly
-    def test_global_maxpool(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_global_maxpool(self, params, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_global_net(**params, op='GlobalMaxPool', ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_pooling.py
+++ b/tests/layer_tests/onnx_tests/test_pooling.py
@@ -389,7 +389,7 @@ class TestPooling(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("incl_pad", [None, 1])
     @pytest.mark.nightly
-    def test_avgpool_opset7(self, params, incl_pad, ie_device, precision, ir_version, temp_dir,:
+    def test_avgpool_opset7(self, params, incl_pad, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(
@@ -399,7 +399,7 @@ class TestPooling(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_autopad)
     @pytest.mark.nightly
-    def test_avgpool_opset7_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_avgpool_opset7_autopad(self, params, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='AveragePool', ir_version=ir_version, opset=7),
@@ -421,7 +421,7 @@ class TestPooling(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_autopad)
     @pytest.mark.nightly
-    def test_avgpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_avgpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='AveragePool', ir_version=ir_version, opset=10),
@@ -430,7 +430,7 @@ class TestPooling(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("st_order", [None, 1])
     @pytest.mark.nightly
-    def test_maxpool_opset8(self, params, st_order, ie_device, precision, ir_version, temp_dir,:
+    def test_maxpool_opset8(self, params, st_order, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(
@@ -440,7 +440,7 @@ class TestPooling(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_autopad)
     @pytest.mark.nightly
-    def test_maxpool_opset8_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_maxpool_opset8_autopad(self, params, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='MaxPool', ir_version=ir_version, opset=8),
@@ -460,7 +460,7 @@ class TestPooling(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_autopad_precommit)
     @pytest.mark.precommit
-    def test_maxpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_maxpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='MaxPool', ir_version=ir_version, opset=10),
@@ -468,7 +468,7 @@ class TestPooling(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_autopad)
     @pytest.mark.nightly
-    def test_maxpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_maxpool_opset10_autopad(self, params, ie_device, precision, ir_version, temp_dir):
         if not len(params['shape']) in [4, 5]:
             pytest.skip("Pooling layer support only 4D and 5D input tensors")
         self._test(*self.create_net(**params, op='MaxPool', ir_version=ir_version, opset=10),

--- a/tests/layer_tests/onnx_tests/test_prelu.py
+++ b/tests/layer_tests/onnx_tests/test_prelu.py
@@ -113,39 +113,37 @@ class TestPRelu(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_scalar)
     @pytest.mark.nightly
-    def test_prelu_opset7_scalar(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_prelu_opset7_scalar(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, opset=7, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_shared_channels)
     @pytest.mark.nightly
-    def test_prelu_opset7_shared_channels(self, params, ie_device, precision, ir_version, temp_dir,
-                                          use_old_api):
+    def test_prelu_opset7_shared_channels(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net(**params, precision=precision, opset=7, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
     def test_prelu_shared_channels_precommit(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_old_api):
+                                             temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_scalar_precommit)
     @pytest.mark.precommit
-    def test_prelu_scalar_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api):
+    def test_prelu_scalar_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_scalar)
     @pytest.mark.nightly
-    def test_prelu_scalar(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_prelu_scalar(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_shared_channels)
     @pytest.mark.nightly
-    def test_prelu_shared_channels(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_prelu_shared_channels(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_prelu.py
+++ b/tests/layer_tests/onnx_tests/test_prelu.py
@@ -119,7 +119,7 @@ class TestPRelu(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_shared_channels)
     @pytest.mark.nightly
-    def test_prelu_opset7_shared_channels(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_prelu_opset7_shared_channels(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, opset=7, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 
@@ -132,7 +132,7 @@ class TestPRelu(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_scalar_precommit)
     @pytest.mark.precommit
-    def test_prelu_scalar_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_prelu_scalar_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 

--- a/tests/layer_tests/onnx_tests/test_reciprocal.py
+++ b/tests/layer_tests/onnx_tests/test_reciprocal.py
@@ -148,27 +148,26 @@ class TestReciprocal(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_reciprocal_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reciprocal_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_reciprocal(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reciprocal(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_reciprocal_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                        use_old_api):
+    def test_reciprocal_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_reciprocal_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reciprocal_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_reciprocal.py
+++ b/tests/layer_tests/onnx_tests/test_reciprocal.py
@@ -162,7 +162,7 @@ class TestReciprocal(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_reciprocal_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_reciprocal_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 

--- a/tests/layer_tests/onnx_tests/test_reduce.py
+++ b/tests/layer_tests/onnx_tests/test_reduce.py
@@ -131,70 +131,68 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.precommit
     def test_reduce_max_precommit(self, params, keep_dims, ie_device, precision, ir_version,
-                                  temp_dir, use_old_api):
+                                  temp_dir):
         self._test(*self.create_reduce(**params, op='ReduceMax', keep_dims=keep_dims,
                                        ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
-    def test_reduce_max(self, params, keep_dims, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reduce_max(self, params, keep_dims, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reduce(**params, op='ReduceMax', keep_dims=keep_dims,
                                        ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_reduce_sum(self, params, keep_dims, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reduce_sum(self, params, keep_dims, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reduce(**params, op='ReduceSum', keep_dims=keep_dims,
                                        ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_reduce_prod(self, params, keep_dims, ie_device, precision, ir_version, temp_dir,
-                         use_old_api):
+    def test_reduce_prod(self, params, keep_dims, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_reduce(**params, op='ReduceProd', keep_dims=keep_dims,
                                        ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.precommit
     def test_reduce_mean_precommit(self, params, keep_dims, ie_device, precision, ir_version,
-                                   temp_dir, use_old_api):
+                                   temp_dir):
         self._test(*self.create_reduce(**params, op='ReduceMean', keep_dims=keep_dims,
                                        ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_reduce_mean(self, params, keep_dims, ie_device, precision, ir_version, temp_dir,
-                         use_old_api):
+    def test_reduce_mean(self, params, keep_dims, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_reduce(**params, op='ReduceMean', keep_dims=keep_dims,
                                        ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.precommit
     def test_reduce_min_precommit(self, params, keep_dims, ie_device, precision, ir_version,
-                                  temp_dir, use_old_api):
+                                  temp_dir):
         self._test(*self.create_reduce(**params, op='ReduceMin', keep_dims=keep_dims,
                                        ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
-    def test_reduce_min(self, params, keep_dims, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reduce_min(self, params, keep_dims, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reduce(**params, op='ReduceMin', keep_dims=keep_dims,
                                        ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_reduce.py
+++ b/tests/layer_tests/onnx_tests/test_reduce.py
@@ -157,7 +157,7 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_reduce_prod(self, params, keep_dims, ie_device, precision, ir_version, temp_dir,:
+    def test_reduce_prod(self, params, keep_dims, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reduce(**params, op='ReduceProd', keep_dims=keep_dims,
                                        ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
@@ -175,7 +175,7 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_reduce_mean(self, params, keep_dims, ie_device, precision, ir_version, temp_dir,:
+    def test_reduce_mean(self, params, keep_dims, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reduce(**params, op='ReduceMean', keep_dims=keep_dims,
                                        ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_reduce_lp.py
+++ b/tests/layer_tests/onnx_tests/test_reduce_lp.py
@@ -239,33 +239,33 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 122846, 122783, 126312')
     def test_reduce_lp_precommit(self, params, keep_dims, reduce_p, ie_device, precision,
-                                 ir_version, temp_dir, use_old_api):
+                                 ir_version, temp_dir):
         self._test(*self.create_reduce_lp(**params, keep_dims=keep_dims, reduce_p=reduce_p,
                                           ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.parametrize("reduce_p", [1, 2])
     @pytest.mark.nightly
     def test_reduce_lp(self, params, keep_dims, reduce_p, ie_device, precision, ir_version,
-                       temp_dir, use_old_api):
+                       temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_reduce_lp(**params, keep_dims=keep_dims, reduce_p=reduce_p,
                                           ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.parametrize("reduce_p", [1, 2])
     @pytest.mark.precommit
     def test_reduce_lp_const_precommit(self, params, keep_dims, reduce_p, ie_device, precision,
-                                       ir_version, temp_dir, use_old_api):
+                                       ir_version, temp_dir):
         self._test(
             *self.create_reduce_lp_const(**params, keep_dims=keep_dims, reduce_p=reduce_p,
                                          ir_version=ir_version),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
@@ -273,7 +273,7 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
     def test_reduce_lp_const(self, params, keep_dims, reduce_p, ie_device, precision, ir_version,
-                             temp_dir, use_old_api):
+                             temp_dir):
         self._test(*self.create_reduce_lp_const(**params, keep_dims=keep_dims, reduce_p=reduce_p,
                                                 ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_relu.py
+++ b/tests/layer_tests/onnx_tests/test_relu.py
@@ -172,13 +172,13 @@ class TestRelu(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_relu(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_relu(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_relu_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_relu_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_reshape.py
+++ b/tests/layer_tests/onnx_tests/test_reshape.py
@@ -231,64 +231,64 @@ class TestReshape(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D_precommit)
     @pytest.mark.precommit
-    def test_reshape_5D_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_5D_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D_precommit)
     @pytest.mark.precommit
-    def test_reshape_4D_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_4D_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D_precommit)
     @pytest.mark.precommit
-    def test_reshape_3D_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_3D_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_reshape_5D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_5D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_reshape_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_reshape_3D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_3D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_reshape_const_5D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_const_5D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_reshape_const_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_const_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_reshape_const_3D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reshape_const_3D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reshape_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_resize.py
+++ b/tests/layer_tests/onnx_tests/test_resize.py
@@ -203,10 +203,9 @@ class TestResize(OnnxRuntimeLayerTest):
     ]
 
     @pytest.mark.parametrize("params", test_data)
-    def test_resize(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_resize(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_resize_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, custom_eps=2.0e-4, temp_dir=temp_dir,
-                   use_old_api=use_old_api)
+                   ie_device, precision, ir_version, custom_eps=2.0e-4, temp_dir=temp_dir)
 
     test_data_cubic = [
         dict(input_shape=[1, 3, 100, 200], output_shape=[1, 3, 350, 150],
@@ -236,14 +235,13 @@ class TestResize(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("nearest_mode", ['round_prefer_floor'])
     def test_resize_combined_cubic(self, params, coordinate_transformation_mode, cubic_coeff_a,
                                    mode,
-                                   nearest_mode, ie_device, precision, ir_version, temp_dir, use_old_api):
+                                   nearest_mode, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
                                            nearest_mode=nearest_mode,
                                            precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, custom_eps=2.6e-2, temp_dir=temp_dir,
-                   use_old_api=use_old_api)
+                   ie_device, precision, ir_version, custom_eps=2.6e-2, temp_dir=temp_dir)
 
     test_data_nearest = [
         dict(input_shape=[1, 3, 100, 200], output_shape=[1, 3, 350, 150],
@@ -266,14 +264,13 @@ class TestResize(OnnxRuntimeLayerTest):
                                               'floor', 'ceil'])
     def test_resize_combined_nearest(self, params, coordinate_transformation_mode, cubic_coeff_a,
                                      mode,
-                                     nearest_mode, ie_device, precision, ir_version, temp_dir,
-                                     use_old_api):
+                                     nearest_mode, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
                                            nearest_mode=nearest_mode,
                                            precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     test_data_linear = [
         dict(input_shape=[1, 3, 100, 200], output_shape=[1, 3, 350, 150],
@@ -303,15 +300,13 @@ class TestResize(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("nearest_mode", ['round_prefer_floor'])
     def test_resize_combined_linear(self, params, coordinate_transformation_mode, cubic_coeff_a,
                                     mode,
-                                    nearest_mode, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api):
+                                    nearest_mode, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
                                            nearest_mode=nearest_mode,
                                            precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, custom_eps=2.0e-2, temp_dir=temp_dir,
-                   use_old_api=use_old_api)
+                   ie_device, precision, ir_version, custom_eps=2.0e-2, temp_dir=temp_dir)
 
     test_data_sizes = [
         dict(input_shape=[1, 1, 4, 4], output_shape=[1, 1, 3, 3],
@@ -357,9 +352,9 @@ class TestResize(OnnxRuntimeLayerTest):
     ]
 
     @pytest.mark.parametrize("params", test_data_sizes)
-    def test_resize_sizes(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_resize_sizes(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_resize_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     test_data_sizes_cubic = [
         dict(input_shape=[1, 3, 100, 200], output_shape=[1, 3, 350, 150],
@@ -389,15 +384,13 @@ class TestResize(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("nearest_mode", ['round_prefer_floor'])
     def test_resize_combined_sizes_cubic(self, params, coordinate_transformation_mode,
                                          cubic_coeff_a, mode,
-                                         nearest_mode, ie_device, precision, ir_version, temp_dir,
-                                         use_old_api):
+                                         nearest_mode, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
                                            nearest_mode=nearest_mode,
                                            precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, custom_eps=2.6e-2, temp_dir=temp_dir,
-                   use_old_api=use_old_api)
+                   ie_device, precision, ir_version, custom_eps=2.6e-2, temp_dir=temp_dir)
 
     test_data_sizes_nearest = [
         dict(input_shape=[1, 3, 100, 200], output_shape=[1, 3, 350, 150],
@@ -444,14 +437,13 @@ class TestResize(OnnxRuntimeLayerTest):
                                               'floor', 'ceil'])
     def test_resize_combined_sizes_nearest(self, params, coordinate_transformation_mode,
                                            cubic_coeff_a, mode,
-                                           nearest_mode, ie_device, precision, ir_version, temp_dir,
-                                           use_old_api):
+                                           nearest_mode, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
                                            nearest_mode=nearest_mode,
                                            precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     test_data_sizes_linear = [
         dict(input_shape=[1, 3, 100, 200], output_shape=[1, 3, 350, 150],
@@ -481,15 +473,13 @@ class TestResize(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("nearest_mode", ['round_prefer_floor'])
     def test_resize_combined_sizes_linear(self, params, coordinate_transformation_mode,
                                           cubic_coeff_a, mode,
-                                          nearest_mode, ie_device, precision, ir_version, temp_dir,
-                                          use_old_api):
+                                          nearest_mode, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
                                            nearest_mode=nearest_mode,
                                            precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, custom_eps=2.0e-2, temp_dir=temp_dir,
-                   use_old_api=use_old_api)
+                   ie_device, precision, ir_version, custom_eps=2.0e-2, temp_dir=temp_dir)
 
 
 def create_ref_net_in_sizes_mode(precision, input_shape, output_shape, sizes_value, scales_value,

--- a/tests/layer_tests/onnx_tests/test_resize.py
+++ b/tests/layer_tests/onnx_tests/test_resize.py
@@ -264,7 +264,7 @@ class TestResize(OnnxRuntimeLayerTest):
                                               'floor', 'ceil'])
     def test_resize_combined_nearest(self, params, coordinate_transformation_mode, cubic_coeff_a,
                                      mode,
-                                     nearest_mode, ie_device, precision, ir_version, temp_dir,:
+                                     nearest_mode, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
@@ -300,7 +300,7 @@ class TestResize(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("nearest_mode", ['round_prefer_floor'])
     def test_resize_combined_linear(self, params, coordinate_transformation_mode, cubic_coeff_a,
                                     mode,
-                                    nearest_mode, ie_device, precision, ir_version, temp_dir,:
+                                    nearest_mode, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
@@ -384,7 +384,7 @@ class TestResize(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("nearest_mode", ['round_prefer_floor'])
     def test_resize_combined_sizes_cubic(self, params, coordinate_transformation_mode,
                                          cubic_coeff_a, mode,
-                                         nearest_mode, ie_device, precision, ir_version, temp_dir,:
+                                         nearest_mode, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
@@ -437,7 +437,7 @@ class TestResize(OnnxRuntimeLayerTest):
                                               'floor', 'ceil'])
     def test_resize_combined_sizes_nearest(self, params, coordinate_transformation_mode,
                                            cubic_coeff_a, mode,
-                                           nearest_mode, ie_device, precision, ir_version, temp_dir,:
+                                           nearest_mode, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,
@@ -473,7 +473,7 @@ class TestResize(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("nearest_mode", ['round_prefer_floor'])
     def test_resize_combined_sizes_linear(self, params, coordinate_transformation_mode,
                                           cubic_coeff_a, mode,
-                                          nearest_mode, ie_device, precision, ir_version, temp_dir,:
+                                          nearest_mode, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_resize_net(**params,
                                            coordinate_transformation_mode=coordinate_transformation_mode,
                                            cubic_coeff_a=cubic_coeff_a, mode=mode,

--- a/tests/layer_tests/onnx_tests/test_roi_align.py
+++ b/tests/layer_tests/onnx_tests/test_roi_align.py
@@ -140,10 +140,10 @@ class TestROIAlign(OnnxRuntimeLayerTest):
                                                                                                      'aarch64',
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 122846, 122783, 126312')
-    def test_roi_alignv10(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_roi_alignv10(self, params, ie_device, precision, ir_version, temp_dir):
         # TODO: ticket for investigating GPU failures: CVS-86300
         if ie_device != "GPU":
             self._test(*self.create_net(**params, ir_version=ir_version, onnx_version=10), ie_device, precision,
                        ir_version,
-                       temp_dir=temp_dir, use_old_api=use_old_api,
+                       temp_dir=temp_dir,
                        use_legacy_frontend=True)

--- a/tests/layer_tests/onnx_tests/test_scale.py
+++ b/tests/layer_tests/onnx_tests/test_scale.py
@@ -134,14 +134,14 @@ class TestScale(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_scale(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_scale(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_scale_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_scale_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_scatter.py
+++ b/tests/layer_tests/onnx_tests/test_scatter.py
@@ -114,10 +114,10 @@ class TestScatter(TestScatters):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_scatter(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_scatter(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
 
 class TestScatterElements(TestScatters):
@@ -126,7 +126,7 @@ class TestScatterElements(TestScatters):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_scatter_elements(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_scatter_elements(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_sigmoid.py
+++ b/tests/layer_tests/onnx_tests/test_sigmoid.py
@@ -179,20 +179,20 @@ class TestSigmoid(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_sigmoid_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sigmoid_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sigmoid(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sigmoid(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sigmoid_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sigmoid_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_sign.py
+++ b/tests/layer_tests/onnx_tests/test_sign.py
@@ -166,13 +166,13 @@ class TestSign(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sign(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sign(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sign_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sign_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_slice.py
+++ b/tests/layer_tests/onnx_tests/test_slice.py
@@ -371,48 +371,48 @@ class TestSlice(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_no_steps)
     @pytest.mark.nightly
-    def test_slice_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_slice_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, opset=6, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_no_steps)
     @pytest.mark.nightly
-    def test_slice_const_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_slice_const_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, opset=6, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_no_steps + test_data_with_steps)
     @pytest.mark.nightly
-    def test_slice_opset10(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_slice_opset10(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(
             *self.create_net(**params, opset=10, ir_version=ir_version), ie_device, precision,
             ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_no_steps + test_data_with_steps)
     @pytest.mark.nightly
-    def test_slice_const_opset10(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_slice_const_opset10(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net_const(**params, opset=10, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_no_steps + test_data_with_steps)
     @pytest.mark.nightly
-    def test_slice_opset11(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_slice_opset11(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(
             *self.create_net(**params, opset=11, ir_version=ir_version), ie_device, precision,
             ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_no_steps + test_data_with_steps)
     @pytest.mark.nightly
-    def test_slice_const_opset11(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_slice_const_opset11(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, opset=11, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_softmax.py
+++ b/tests/layer_tests/onnx_tests/test_softmax.py
@@ -166,7 +166,7 @@ class TestSoftmax(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_softmax(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_softmax(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_softplus.py
+++ b/tests/layer_tests/onnx_tests/test_softplus.py
@@ -171,15 +171,15 @@ class TestSoftplus(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_softplus(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_softplus(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_softplus_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_softplus_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_softsign.py
+++ b/tests/layer_tests/onnx_tests/test_softsign.py
@@ -172,14 +172,14 @@ class TestSoftsign(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_softsign(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_softsign(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_softsign_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_softsign_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_split_concat.py
+++ b/tests/layer_tests/onnx_tests/test_split_concat.py
@@ -262,47 +262,47 @@ class TestSplitConcat(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_3D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_3D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_split_concat_net(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_split_concat_net(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_5D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_5D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_split_concat_net(**params, ir_version=ir_version), ie_device,
-                   precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_3D_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_3D_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_split_concat_net_const(**params, ir_version=ir_version), ie_device,
-            precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_4D_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_4D_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_split_concat_net_const(**params, ir_version=ir_version), ie_device,
-            precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_5D_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_5D_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_split_concat_net_const(**params, ir_version=ir_version), ie_device,
-            precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            precision, ir_version, temp_dir=temp_dir)
 
 
 class TestSplit(OnnxRuntimeLayerTest):
@@ -550,37 +550,37 @@ class TestSplit(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_3D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_3D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_split_net(**params, ir_version=ir_version), ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_split_net(**params, ir_version=ir_version), ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_split_5D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_5D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_split_net(**params, ir_version=ir_version), ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_multiple_out)
-    def test_split_outputs_order(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_split_outputs_order(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_split_net_ordered_outputs(**params, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   output_names=params['output_names'], use_old_api=use_old_api)
+                   output_names=params['output_names'])
 
     @pytest.mark.parametrize("params", test_multiple_out_with_add)
     def test_split_outputs_order_multiple_connection_before_result_case(self, params, ie_device,
                                                                         precision, ir_version,
-                                                                        temp_dir, use_old_api):
+                                                                        temp_dir):
         self._test(*self.create_split_net_ordered_outputs_with_add(**params, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   output_names=params['output_names'], use_old_api=use_old_api)
+                   output_names=params['output_names'])
 
     @pytest.mark.parametrize("params", test_multiple_out_with_identity)
     def test_split_outputs_order_multiple_tensors_before_result_case(self,
@@ -588,8 +588,8 @@ class TestSplit(OnnxRuntimeLayerTest):
                                                                      ie_device,
                                                                      precision,
                                                                      ir_version,
-                                                                     temp_dir, use_old_api):
+                                                                     temp_dir):
         self._test(*self.create_split_net_ordered_outputs_multiple_tensor_names(**params,
                                                                                 ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   output_names=params['output_names'], use_old_api=use_old_api)
+                   output_names=params['output_names'])

--- a/tests/layer_tests/onnx_tests/test_sqrt.py
+++ b/tests/layer_tests/onnx_tests/test_sqrt.py
@@ -176,13 +176,13 @@ class TestSqrt(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sqrt(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sqrt(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sqrt_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sqrt_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_squeeze.py
+++ b/tests/layer_tests/onnx_tests/test_squeeze.py
@@ -176,47 +176,47 @@ class TestSqueeze(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_squeeze_5D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_squeeze_5D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_squeeze_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_squeeze_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_squeeze_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_squeeze_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_squeeze_3D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_squeeze_3D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_squeeze_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_squeeze_const_5D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_squeeze_const_5D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_squeeze_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_squeeze_const_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_squeeze_const_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_squeeze_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_squeeze_const_3D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_squeeze_const_3D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_squeeze_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_sum.py
+++ b/tests/layer_tests/onnx_tests/test_sum.py
@@ -285,57 +285,56 @@ class TestSum(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sum_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sum_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, opset=6, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_sum_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sum_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, precision=precision, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sum(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sum(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net(**params, precision=precision, ir_version=ir_version), ie_device,
             precision, ir_version,
-            temp_dir=temp_dir, use_old_api=use_old_api)
+            temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", const_test_data)
     @pytest.mark.nightly
-    def test_sum_const_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sum_const_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_const_net(**params, opset=6, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", const_test_data_precommit)
     @pytest.mark.precommit
-    def test_sum_const_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sum_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_const_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", const_test_data)
     @pytest.mark.nightly
-    def test_sum_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sum_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_const_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", const_test_data_broadcasting_precommit)
     @pytest.mark.precommit
     def test_sum_const_broadcasting_precommit(self, params, ie_device, precision, ir_version,
-                                              temp_dir, use_old_api):
+                                              temp_dir):
         self._test(*self.create_const_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", const_test_data_broadcasting)
     @pytest.mark.nightly
-    def test_sum_const_broadcasting(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api):
+    def test_sum_const_broadcasting(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_const_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_sum.py
+++ b/tests/layer_tests/onnx_tests/test_sum.py
@@ -334,7 +334,7 @@ class TestSum(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", const_test_data_broadcasting)
     @pytest.mark.nightly
-    def test_sum_const_broadcasting(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_sum_const_broadcasting(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_const_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
                    temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_topk.py
+++ b/tests/layer_tests/onnx_tests/test_topk.py
@@ -167,7 +167,7 @@ class TestTopK(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("sorted", [1, 0, None])
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_topk_opset11(self, params, ie_device, precision, ir_version, largest, sorted, temp_dir,:
+    def test_topk_opset11(self, params, ie_device, precision, ir_version, largest, sorted, temp_dir):
         self._test(*self.create_net(**params, largest=largest, sorted=sorted,
                                     opset=11, ir_version=ir_version), ie_device, precision,
                    ir_version,

--- a/tests/layer_tests/onnx_tests/test_topk.py
+++ b/tests/layer_tests/onnx_tests/test_topk.py
@@ -148,28 +148,27 @@ class TestTopK(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_topk_opset6(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_topk_opset6(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, opset=6, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_topk_opset10(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_topk_opset10(self, params, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'CPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net(**params, opset=10, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("largest", [1, 0, None])
     @pytest.mark.parametrize("sorted", [1, 0, None])
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_topk_opset11(self, params, ie_device, precision, ir_version, largest, sorted, temp_dir,
-                          use_old_api):
+    def test_topk_opset11(self, params, ie_device, precision, ir_version, largest, sorted, temp_dir,:
         self._test(*self.create_net(**params, largest=largest, sorted=sorted,
                                     opset=11, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_transpose.py
+++ b/tests/layer_tests/onnx_tests/test_transpose.py
@@ -169,7 +169,7 @@ class TestTranspose(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.nightly
-    def test_transpose_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
+    def test_transpose_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
                    temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_transpose.py
+++ b/tests/layer_tests/onnx_tests/test_transpose.py
@@ -155,29 +155,28 @@ class TestTranspose(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_transpose_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_transpose_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_transpose(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_transpose(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.nightly
-    def test_transpose_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api):
+    def test_transpose_const_precommit(self, params, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_transpose_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_transpose_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_trigonometry.py
+++ b/tests/layer_tests/onnx_tests/test_trigonometry.py
@@ -179,140 +179,140 @@ class TestTrigonomery(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sin(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sin(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Sin'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sinh(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sinh(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Sinh'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_asin(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_asin(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Asin'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_cos_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_cos_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Cos'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_cos(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_cos(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Cos'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_cosh(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_cosh(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Cosh'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_acos(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_acos(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Acos'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_tan(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_tan(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Tan'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_tanh(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_tanh(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Tanh'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_atan(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_atan(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version, op='Atan'), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sin_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sin_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Sin'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_sinh_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_sinh_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Sinh'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_asin_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_asin_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Asin'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
-    def test_cos_const_precommit(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_cos_const_precommit(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Cos'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_cos_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_cos_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Cos'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_cosh_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_cosh_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Cosh'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_acos_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_acos_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Acos'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_tan_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_tan_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Tan'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_tanh_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_tanh_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Tanh'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_atan_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_atan_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(
             *self.create_net_const(**params, ir_version=ir_version, precision=precision, op='Atan'),
-            ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+            ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_unsqueeze.py
+++ b/tests/layer_tests/onnx_tests/test_unsqueeze.py
@@ -176,47 +176,47 @@ class TestUnsqueeze(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_unsqueeze_5D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_unsqueeze_5D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_unsqueeze_net(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_unsqueeze_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_unsqueeze_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_unsqueeze_net(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_unsqueeze_3D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_unsqueeze_3D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_unsqueeze_net(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_unsqueeze_const_5D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_unsqueeze_const_5D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_unsqueeze_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_unsqueeze_const_4D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_unsqueeze_const_4D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_unsqueeze_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_unsqueeze_const_3D(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_unsqueeze_const_3D(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_unsqueeze_net_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_upsample.py
+++ b/tests/layer_tests/onnx_tests/test_upsample.py
@@ -94,14 +94,14 @@ class TestUpsample(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("mode", [None, 'nearest'])
     @pytest.mark.parametrize("opset", [7, 9])
     @pytest.mark.nightly
-    def test_upsample_nearest(self, params, mode, opset, ie_device, precision, ir_version, temp_dir,:
+    def test_upsample_nearest(self, params, mode, opset, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, mode=mode, opset=opset, ir_version=ir_version),
                    ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("opset", [7, 9])
     @pytest.mark.nightly
-    def test_upsample_linear(self, params, opset, ie_device, precision, ir_version, temp_dir,:
+    def test_upsample_linear(self, params, opset, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net(**params, mode='linear', opset=opset, ir_version=ir_version),
@@ -185,7 +185,7 @@ class TestPytorchUpsample(PytorchLayerTest):
     @pytest.mark.parametrize("mode", [None, 'nearest', 'bilinear'])
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_pytorch_upsample(self, params, mode, ie_device, precision, ir_version, temp_dir,:
+    def test_pytorch_upsample(self, params, mode, ie_device, precision, ir_version, temp_dir):
         if ie_device == 'GPU' and mode == 'bilinear':
             pytest.skip('Linear upsampling not supported on GPU')
         self._test(*self.create_net(**params, mode=mode, ir_version=ir_version), ie_device,

--- a/tests/layer_tests/onnx_tests/test_upsample.py
+++ b/tests/layer_tests/onnx_tests/test_upsample.py
@@ -94,20 +94,18 @@ class TestUpsample(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("mode", [None, 'nearest'])
     @pytest.mark.parametrize("opset", [7, 9])
     @pytest.mark.nightly
-    def test_upsample_nearest(self, params, mode, opset, ie_device, precision, ir_version, temp_dir,
-                              use_old_api):
+    def test_upsample_nearest(self, params, mode, opset, ie_device, precision, ir_version, temp_dir,:
         self._test(*self.create_net(**params, mode=mode, opset=opset, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("opset", [7, 9])
     @pytest.mark.nightly
-    def test_upsample_linear(self, params, opset, ie_device, precision, ir_version, temp_dir,
-                             use_old_api):
+    def test_upsample_linear(self, params, opset, ie_device, precision, ir_version, temp_dir,:
         if ie_device == 'GPU':
             pytest.skip('GREEN_SUITE')
         self._test(*self.create_net(**params, mode='linear', opset=opset, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)
 
 
 class PytorchLayerTest(CommonLayerTest):
@@ -176,21 +174,20 @@ class TestPytorchUpsample(PytorchLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.parametrize("mode", [None, 'nearest'])
     def test_pytorch_upsample_precommit(self, params, mode, ie_device, precision, ir_version,
-                                        temp_dir, use_old_api):
+                                        temp_dir):
         if ie_device == 'GPU':
             pytest.skip('Linear upsampling not supported on GPU')
         self._test(*self.create_net(**params, mode=mode, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("mode", [None, 'nearest', 'bilinear'])
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_pytorch_upsample(self, params, mode, ie_device, precision, ir_version, temp_dir,
-                              use_old_api):
+    def test_pytorch_upsample(self, params, mode, ie_device, precision, ir_version, temp_dir,:
         if ie_device == 'GPU' and mode == 'bilinear':
             pytest.skip('Linear upsampling not supported on GPU')
         self._test(*self.create_net(**params, mode=mode, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_where.py
+++ b/tests/layer_tests/onnx_tests/test_where.py
@@ -95,7 +95,7 @@ class TestWhere(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.skip(reason='GREEN_SUITE')
-    def test_where(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_where(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/onnx_tests/test_xor.py
+++ b/tests/layer_tests/onnx_tests/test_xor.py
@@ -251,21 +251,21 @@ class TestXor(OnnxRuntimeLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_xor(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_xor(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_xor_one_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_xor_one_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_one_const(**params, ir_version=ir_version), ie_device,
                    precision, ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_xor_const(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_xor_const(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_net_const(**params, ir_version=ir_version), ie_device, precision,
                    ir_version,
-                   temp_dir=temp_dir, use_old_api=use_old_api)
+                   temp_dir=temp_dir)

--- a/tests/layer_tests/ovc_python_api_tests/test_complex_params.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_complex_params.py
@@ -110,7 +110,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_mo_convert_tf_model(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend, use_old_api):
+                                 temp_dir, use_new_frontend):
         tf_net_path = self.create_tf_model(temp_dir)
 
         test_params = params['params_test']
@@ -150,7 +150,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_tf_model_single_input_output(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_new_frontend, use_old_api):
+                                                     temp_dir, use_new_frontend):
         tf_net_path = self.create_tf_model_single_input_output(temp_dir)
 
         test_params = params['params_test']
@@ -259,7 +259,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_ovc_convert_model_with_comma_in_names(self, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend, use_old_api):
+                                                  temp_dir, use_new_frontend):
         onnx_net_path = self.create_onnx_model_with_comma_in_names(temp_dir)
         ref_model = self.create_ref_graph_with_comma_in_names()
         test_params = {'input_model': onnx_net_path, 'output': 'relu_1,relu_2'}
@@ -269,7 +269,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_ovc_convert_model_with_several_output(self, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend, use_old_api):
+                                                  temp_dir, use_new_frontend):
         onnx_net_path = self.create_onnx_model_with_several_outputs(temp_dir)
         convert_model_params = {'input_model': onnx_net_path, 'output': ['Relu_1_data', 'concat']}
         cli_tool_params = {'input_model': onnx_net_path, 'output': 'Relu_1_data,concat'}

--- a/tests/layer_tests/ovc_python_api_tests/test_extensions.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_extensions.py
@@ -113,7 +113,7 @@ class TestExtensions(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_extensions(self, params, ie_device, precision, ir_version,
-                                   temp_dir, use_new_frontend, use_old_api):
+                                   temp_dir, use_new_frontend):
         onnx_net_path = self.create_onnx_model(temp_dir)
 
         test_params = params['params_test']

--- a/tests/layer_tests/ovc_python_api_tests/test_paddle.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_paddle.py
@@ -126,7 +126,7 @@ class TestPaddleConversionParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conversion_params(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend, use_old_api):
+                                 temp_dir, use_new_frontend):
         fw_model = params['fw_model']
         test_params = params['params_test']
         ref_model = params['ref_model']

--- a/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
@@ -1055,7 +1055,7 @@ class TestMoConvertPyTorch(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_import_from_memory(self, create_model, ie_device, precision, ir_version,
-                                   temp_dir, use_new_frontend, use_old_api):
+                                   temp_dir, use_new_frontend):
         fw_model, graph_ref, mo_params = create_model(temp_dir)
 
         test_params = {'input_model': fw_model}
@@ -1209,7 +1209,7 @@ class TestPytorchConversionParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conversion_params(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend, use_old_api):
+                                 temp_dir, use_new_frontend):
         fw_model = params['fw_model']
         test_params = params['params_test']
         ref_model = params['ref_model']

--- a/tests/layer_tests/ovc_python_api_tests/test_tf.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_tf.py
@@ -1039,7 +1039,7 @@ class TestTFConversionParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_mo_convert_tf_model(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend, use_old_api):
+                                 temp_dir, use_new_frontend):
         fw_model = params['fw_model']
         test_params = params['params_test']
         ref_model = params['ref_model']

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
@@ -70,7 +70,7 @@ class TestKerasActivation(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_old_api, use_new_frontend):
+                                      use_new_frontend):
         self._test(*self.create_keras_activation_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
@@ -32,10 +32,10 @@ class TestKerasActivityRegularization(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activity_regularization_case1_float32(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, use_old_api,
+                                                         ir_version, temp_dir,
                                                          use_new_frontend):
         self._test(*self.create_keras_activity_regularization_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -56,7 +56,7 @@ class TestKerasActivityRegularization(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_activity_regularization_case_2_float32(self, params, ie_device, precision,
-                                                          ir_version, temp_dir, use_old_api):
+                                                          ir_version, temp_dir):
         self._test(*self.create_keras_activity_regularization_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
@@ -92,9 +92,9 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_add_float32_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_old_api, use_new_frontend):
+                                         use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -109,10 +109,10 @@ class TestKerasAdd(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_add_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_add_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
-                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, use_old_api=use_old_api,
+                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
@@ -123,10 +123,10 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_add_float32_several_inputs_precommit(self, params, ie_device, precision,
-                                                        ir_version, temp_dir, use_old_api,
+                                                        ir_version, temp_dir,
                                                         use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
-                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, use_old_api=use_old_api,
+                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
@@ -147,7 +147,7 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_add_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                              temp_dir, use_old_api, use_new_frontend):
+                                              temp_dir, use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
@@ -34,9 +34,9 @@ class TestKerasAdditiveAttention(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_additive_attention_float32_case1(self, params, ie_device, precision, ir_version,
-                                                    temp_dir, use_old_api, use_new_frontend):
+                                                    temp_dir, use_new_frontend):
         self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -69,7 +69,7 @@ class TestKerasAdditiveAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_additive_attention_float32_case2(self, params, ie_device, precision, ir_version,
-                                                    temp_dir, use_old_api, use_new_frontend):
+                                                    temp_dir, use_new_frontend):
         self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
@@ -29,9 +29,9 @@ class TestKerasAlphaDropout(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_keras_alpha_dropout_case1_float32(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_old_api, use_new_frontend):
+                                                     temp_dir, use_new_frontend):
         self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(rate=0.5, input_names=["x1"], input_shapes=[[1]],
@@ -48,7 +48,7 @@ class TestKerasAlphaDropout(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_keras_alpha_dropout_case2_float32(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_old_api, use_new_frontend):
+                                                     temp_dir, use_new_frontend):
         self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
@@ -32,9 +32,9 @@ class TestKerasAttention(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_attention_float32_case1(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_old_api, use_new_frontend):
+                                           use_new_frontend):
         self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -68,7 +68,7 @@ class TestKerasAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_attention_float32_case2(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_old_api, use_new_frontend):
+                                           use_new_frontend):
         self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
@@ -40,9 +40,9 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_average_case1_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_old_api, use_new_frontend):
+                                         use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[1], [1]],
@@ -59,9 +59,9 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_average_case2_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_old_api, use_new_frontend):
+                                         use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [
@@ -76,7 +76,7 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_average_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_old_api, use_new_frontend):
+                                                  temp_dir, use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
@@ -34,9 +34,9 @@ class TestKerasAveragePooling1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_1D_case1_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_old_api, use_new_frontend):
+                                             temp_dir, use_new_frontend):
         self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -50,7 +50,7 @@ class TestKerasAveragePooling1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_1D_case2_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_old_api, use_new_frontend):
+                                             temp_dir, use_new_frontend):
         self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
@@ -34,9 +34,9 @@ class TestKerasAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_2D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api, use_new_frontend):
+                                       use_new_frontend):
         self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -53,7 +53,7 @@ class TestKerasAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_2D_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_old_api, use_new_frontend):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
@@ -33,9 +33,9 @@ class TestKerasAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_3D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api, use_new_frontend):
+                                       use_new_frontend):
         self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -52,7 +52,7 @@ class TestKerasAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_3D_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_old_api, use_new_frontend):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
@@ -34,10 +34,10 @@ class TestKerasBatchNormalization(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_batch_normalization_float32(self, params, ie_device, precision, ir_version,
-                                               temp_dir, use_old_api, use_new_frontend):
+                                               temp_dir, use_new_frontend):
         self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(axis=1, momentum=0.5, epsilon=1e-4, center=True, scale=False,
@@ -58,7 +58,7 @@ class TestKerasBatchNormalization(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_batch_normalization_extended_float32(self, params, ie_device, precision,
-                                                        ir_version, temp_dir, use_old_api, use_new_frontend):
+                                                        ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
@@ -46,7 +46,7 @@ class TestKerasBidirectional(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_bidirectional_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_old_api, use_new_frontend):
+                                         use_new_frontend):
         self._test(*self.create_keras_bidirectional_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
@@ -33,10 +33,10 @@ class TestKerasConcatenate(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_concatenate_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api, use_new_frontend):
+                                       use_new_frontend):
         self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -58,8 +58,8 @@ class TestKerasConcatenate(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_concatenate_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_old_api, use_new_frontend):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
@@ -60,9 +60,9 @@ class TestKerasConv1D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_1d_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_conv_1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_conv1d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
@@ -67,8 +67,8 @@ class TestKerasConv1DTranspose(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(reason="Needs tensorflow 2.3.0.")
     def test_keras_conv_1d_case1_transpose_float32(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_old_api, use_new_frontend):
+                                                   temp_dir, use_new_frontend):
         self._test(*self.create_keras_conv1d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
@@ -59,9 +59,9 @@ class TestKerasConv2D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_2d_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_conv_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_conv2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
@@ -65,8 +65,8 @@ class TestKerasConv2DTranspose(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_2d_transpose_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_old_api, use_new_frontend):
+                                             temp_dir, use_new_frontend):
         self._test(*self.create_keras_conv_2d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
@@ -62,8 +62,8 @@ class TestKerasConv3D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_3d_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_conv_3d_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_conv3d_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
@@ -65,8 +65,8 @@ class TestKerasConv3DTranspose(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_3D_transpose_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_old_api, use_new_frontend):
+                                             temp_dir, use_new_frontend):
         self._test(*self.create_keras_conv_3d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
@@ -54,8 +54,8 @@ class TestKerasConvLSTM2D(CommonTF2LayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_keras_conv_lstm_2d_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_old_api, use_new_frontend):
+                                      use_new_frontend):
         self._test(*self.create_keras_conv_lstm_2d_net(**params), ie_device,
                    precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
@@ -34,7 +34,7 @@ class TestKerasCropping1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api, use_new_frontend):
+                                       use_new_frontend):
         self._test(*self.create_keras_cropping_1d_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
@@ -36,8 +36,8 @@ class TestKerasCropping2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api, use_new_frontend):
+                                       use_new_frontend):
         self._test(*self.create_keras_cropping_2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
@@ -36,8 +36,8 @@ class TestKerasCropping3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_3d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api, use_new_frontend):
+                                       use_new_frontend):
         self._test(*self.create_keras_cropping_3d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
@@ -42,10 +42,10 @@ class TestKerasDense(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_simple)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_dense_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_dense_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                  use_new_frontend):
         self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_activation = [
@@ -67,7 +67,7 @@ class TestKerasDense(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_old_api, use_new_frontend):
+                                      use_new_frontend):
         self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
@@ -51,10 +51,10 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_format_padding)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_dconv2D_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_dconv2D_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_use_bias_true = [
@@ -78,9 +78,9 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_use_bias_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_activations = [
@@ -104,7 +104,7 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activations_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_old_api, use_new_frontend):
+                                       use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
@@ -44,10 +44,10 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_normalize_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                         use_old_api, use_new_frontend):
+                                         use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_old_api=use_old_api, use_new_frontend=use_new_frontend, **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_difficult_axes_float32 = [
         dict(input_names=["x", "y"], input_shapes=[[5, 4, 4], [5, 4, 4]], input_type=tf.float32,
@@ -70,10 +70,10 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_difficult_axes_float32(self, params, ie_device, precision, temp_dir,
-                                              ir_version, use_old_api, use_new_frontend):
+                                              ir_version, use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_old_api=use_old_api, use_new_frontend=use_new_frontend, **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_normalize_higher_rank = [
         dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
@@ -99,7 +99,7 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_normalize_higher_rank(self, params, ie_device, precision, temp_dir,
-                                             ir_version, use_old_api, use_new_frontend):
+                                             ir_version, use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_old_api=use_old_api, use_new_frontend=use_new_frontend, **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
@@ -32,10 +32,10 @@ class TestKerasDropout(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
@@ -55,8 +55,8 @@ class TestKerasDropout(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
@@ -106,10 +106,10 @@ class TestKerasELU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
@@ -120,10 +120,10 @@ class TestKerasELU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_alpha2 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
@@ -140,7 +140,7 @@ class TestKerasELU(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="51109")
     def test_keras_elu_float32_alpha2(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_old_api, use_new_frontend):
+                                      use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -40,10 +40,10 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                use_new_frontend):
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_mask_zero_false = [
@@ -61,7 +61,7 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_emb_without_zero_mask_float32(self, params, ie_device, precision, ir_version,
-                                                 temp_dir, use_old_api, use_new_frontend):
+                                                 temp_dir, use_new_frontend):
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
@@ -34,8 +34,8 @@ class TestKerasFlatten(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_flatten_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_flatten_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_flatten_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
@@ -35,7 +35,7 @@ class TestKerasGlobalAvgPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling1D_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_old_api, use_new_frontend):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
@@ -34,7 +34,7 @@ class TestKerasGlobalAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling2D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, use_old_api, use_new_frontend):
+                                                ir_version, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
@@ -34,7 +34,7 @@ class TestKerasGlobalAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling3D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, use_old_api, use_new_frontend):
+                                                ir_version, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling3D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
@@ -35,7 +35,7 @@ class TestKerasGlobalMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_max_pooling1D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, use_old_api, use_new_frontend):
+                                                ir_version, use_new_frontend):
         self._test(*self.create_keras_global_max_pooling1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
@@ -35,7 +35,7 @@ class TestKerasGlobalMaxPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_max_pooling2D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, use_old_api, use_new_frontend):
+                                                ir_version, use_new_frontend):
         self._test(*self.create_keras_global_maxpool2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
@@ -34,7 +34,7 @@ class TestKerasGlobalMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_maxpool3D_float32(self, params, ie_device, precision, temp_dir,
-                                            ir_version, use_old_api, use_new_frontend):
+                                            ir_version, use_new_frontend):
         self._test(*self.create_keras_global_maxpool3D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
@@ -56,9 +56,9 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_gru_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                         use_old_api, use_new_frontend):
+                                         use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_without_bias = [
@@ -77,9 +77,9 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_without_bias_float32(self, params, ie_device, precision, temp_dir,
-                                            ir_version, use_old_api, use_new_frontend):
+                                            ir_version, use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_different_flags = [
@@ -104,9 +104,9 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                     use_old_api, use_new_frontend):
+                                     use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_zero_recurrent_dropout = [
@@ -129,8 +129,8 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="50176")
     def test_keras_gru_flags_zero_recurrent_dropout_float32(self, params, ie_device, precision,
-                                                            temp_dir, ir_version, use_old_api,
+                                                            temp_dir, ir_version,
                                                             use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
@@ -49,8 +49,8 @@ class TestKerasGRUCell(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49537")
-    def test_keras_grucell_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api,
+    def test_keras_grucell_float32(self, params, ie_device, precision, temp_dir, ir_version,
                                    use_new_frontend):
         self._test(*self.create_keras_grucell_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
@@ -79,8 +79,8 @@ class TestKerasLambda(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_lambda_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api,
+    def test_keras_lambda_float32(self, params, ie_device, precision, temp_dir, ir_version,
                                   use_new_frontend):
         self._test(*self.create_keras_lambda_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_old_api=use_old_api, use_new_frontend=use_new_frontend, **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
@@ -32,10 +32,10 @@ class TestKerasLayerNormalization(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api,
+    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version,
                                  use_new_frontend):
         self._test(*self.create_keras_lnorm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
@@ -53,7 +53,7 @@ class TestKerasLayerNormalization(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api):
+    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version):
         self._test(*self.create_keras_lnorm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
@@ -33,7 +33,7 @@ class TestKerasLeakyRelu(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_leaky_relu_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                      use_old_api, use_new_frontend):
+                                      use_new_frontend):
         self._test(*self.create_keras_leaky_relu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
@@ -49,9 +49,9 @@ class TestKerasLocallyConnected1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected1D_float32(self, params, ie_device, precision, temp_dir,
-                                               ir_version, use_old_api, use_new_frontend):
+                                               ir_version, use_new_frontend):
         self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_simple_channels_first = [
@@ -73,8 +73,8 @@ class TestKerasLocallyConnected1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected1D_channels_first_float32(self, params, ie_device, precision,
-                                                              temp_dir, ir_version, use_old_api,
+                                                              temp_dir, ir_version,
                                                               use_new_frontend):
         self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
@@ -49,9 +49,9 @@ class TestKerasLocallyConnected2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected2D_float32(self, params, ie_device, precision, temp_dir,
-                                               ir_version, use_old_api, use_new_frontend):
+                                               ir_version, use_new_frontend):
         self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_simple_channels_first = [
@@ -73,8 +73,8 @@ class TestKerasLocallyConnected2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected2D_channels_first_float32(self, params, ie_device, precision,
-                                                              temp_dir, ir_version, use_old_api,
+                                                              temp_dir, ir_version,
                                                               use_new_frontend):
         self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
@@ -56,9 +56,9 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_lstm_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                          use_old_api, use_new_frontend):
+                                          use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_without_bias = [
@@ -79,9 +79,9 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_without_bias_float32(self, params, ie_device, precision, temp_dir,
-                                             ir_version, use_old_api, use_new_frontend):
+                                             ir_version, use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_different_flags = [
@@ -100,7 +100,7 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                      use_old_api, use_new_frontend):
+                                      use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
@@ -54,7 +54,7 @@ class TestKerasLSTMCell(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49537")
     def test_keras_lstmcell_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_lstmcell_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
@@ -36,8 +36,8 @@ class TestKerasMasking(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49567")
-    def test_keras_masking_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api,
+    def test_keras_masking_float32(self, params, ie_device, precision, temp_dir, ir_version,
                                    use_new_frontend):
         self._test(*self.create_keras_masking_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
@@ -91,10 +91,10 @@ class TestKerasMaximum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -109,10 +109,10 @@ class TestKerasMaximum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
@@ -123,9 +123,9 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_old_api, use_new_frontend):
+                                                  temp_dir, use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [
@@ -145,7 +145,7 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_old_api, use_new_frontend):
+                                                  temp_dir, use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
@@ -44,9 +44,9 @@ class TestKerasMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool1D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, use_old_api, use_new_frontend):
+                                                  ir_version, use_new_frontend):
         self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_p_dformat_float32 = [
@@ -64,7 +64,7 @@ class TestKerasMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool1D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
-                                                     ir_version, use_old_api, use_new_frontend):
+                                                     ir_version, use_new_frontend):
         self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
@@ -49,7 +49,7 @@ class TestKerasMaxPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool2D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, use_old_api, use_new_frontend):
+                                                  ir_version, use_new_frontend):
         self._test(*self.create_keras_maxpool2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
@@ -45,9 +45,9 @@ class TestKerasMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool3D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, use_old_api, use_new_frontend):
+                                                  ir_version, use_new_frontend):
         self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_p_dformat_float32 = [
@@ -65,7 +65,7 @@ class TestKerasMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool3D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
-                                                     ir_version, use_old_api, use_new_frontend):
+                                                     ir_version, use_new_frontend):
         self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
@@ -91,10 +91,10 @@ class TestKerasMinimum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -109,10 +109,10 @@ class TestKerasMinimum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
@@ -123,9 +123,9 @@ class TestKerasMinimum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_minimum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_old_api):
+                                                  temp_dir):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    **params)
 
     test_data_float32_several_inputs = [
@@ -145,7 +145,7 @@ class TestKerasMinimum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_minimum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_old_api, use_new_frontend):
+                                                  temp_dir, use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
@@ -80,9 +80,9 @@ class TestKerasMultiHeadAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.precommit
     def test_keras_multiheadattention(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_old_api, use_new_frontend):
+                                      use_new_frontend):
         self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests to cover no bias cases
@@ -108,7 +108,7 @@ class TestKerasMultiHeadAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_no_bias)
     @pytest.mark.nightly
     def test_keras_multiheadattention_no_bias(self, params, ie_device, precision, ir_version,
-                                              temp_dir, use_old_api, use_new_frontend):
+                                              temp_dir, use_new_frontend):
         self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
@@ -92,9 +92,9 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -110,9 +110,9 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
@@ -123,9 +123,9 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_old_api, use_new_frontend):
+                                                   temp_dir, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
@@ -146,7 +146,7 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_old_api, use_new_frontend):
+                                                   temp_dir, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
@@ -30,8 +30,8 @@ class TestKerasPermute(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_permute_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_permute_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_permute_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
@@ -27,10 +27,10 @@ class TestKerasPReLU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                  use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
@@ -43,10 +43,10 @@ class TestKerasPReLU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                  use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_shared_axes = [
@@ -60,7 +60,7 @@ class TestKerasPReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_shared_axes)
     @pytest.mark.nightly
     def test_keras_prelu_float32_shared_axes(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_old_api, use_new_frontend):
+                                             temp_dir, use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
@@ -53,10 +53,10 @@ class TestKerasRelu(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                 use_new_frontend):
         self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
@@ -70,8 +70,8 @@ class TestKerasRelu(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                 use_new_frontend):
         self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
@@ -29,8 +29,8 @@ class TestKerasRepeatVector(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_repeatvector(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_repeatvector(self, params, ie_device, precision, ir_version, temp_dir,
                                 use_new_frontend):
         self._test(*self.create_keras_repeatvector_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
@@ -33,8 +33,8 @@ class TestKerasReshape(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_reshape(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_reshape(self, params, ie_device, precision, ir_version, temp_dir,
                            use_new_frontend):
         self._test(*self.create_keras_reshape_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
@@ -59,10 +59,10 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
-    def test_keras_rnn(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_rnn(self, params, ie_device, precision, ir_version, temp_dir,
                        use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for default parameter values
@@ -82,9 +82,9 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_multiple_outputs)
     @pytest.mark.nightly
     def test_keras_rnn_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir,
-                                        use_old_api, use_new_frontend):
+                                        use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for other attributes: go_backward and time_major
@@ -103,8 +103,8 @@ class TestKerasRNN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_others)
     @pytest.mark.nightly
-    def test_keras_rnn_others(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_rnn_others(self, params, ie_device, precision, ir_version, temp_dir,
                               use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
@@ -40,10 +40,10 @@ class TestKerasRoll(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_keras_roll(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_roll(self, params, ie_device, precision, ir_version, temp_dir,
                         use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_keras_roll_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
@@ -46,10 +46,10 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_separableconv1d(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_separableconv1d(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different activations
@@ -80,10 +80,10 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_activations)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_activations(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, use_old_api,
+                                                         ir_version, temp_dir,
                                                          use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different padding
@@ -102,9 +102,9 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_padding)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_padding(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_old_api, use_new_frontend):
+                                                     temp_dir, use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different bias
@@ -120,7 +120,7 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_bias)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_bias(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_old_api, use_new_frontend):
+                                                  temp_dir, use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
@@ -49,10 +49,10 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_separableconv2d(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_separableconv2d(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different activations
@@ -85,10 +85,10 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_activations)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_activations(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, use_old_api,
+                                                         ir_version, temp_dir,
                                                          use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different padding
@@ -104,9 +104,9 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_padding)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_padding(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_old_api, use_new_frontend):
+                                                     temp_dir, use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different bias
@@ -123,7 +123,7 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_bias)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_bias(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_old_api, use_new_frontend):
+                                                  temp_dir, use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
@@ -57,9 +57,9 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_simplernn_different_activations(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_old_api, use_new_frontend):
+                                                   temp_dir, use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with dropout
@@ -77,9 +77,9 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_dropout)
     @pytest.mark.nightly
     def test_keras_simplernn_dropout(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_old_api, use_new_frontend):
+                                     use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with other attributes
@@ -96,10 +96,10 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_other)
     @pytest.mark.nightly
-    def test_keras_simplernn_other(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_simplernn_other(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with multiple outputs
@@ -125,7 +125,7 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_multipleoutput)
     @pytest.mark.nightly
     def test_keras_simplernn_test_data_multipleoutput(self, params, ie_device, precision,
-                                                      ir_version, temp_dir, use_old_api, use_new_frontend):
+                                                      ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
@@ -53,10 +53,10 @@ class TestKerasSoftmax(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
@@ -70,8 +70,8 @@ class TestKerasSoftmax(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
@@ -55,9 +55,9 @@ class TestKerasSoftplus(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49516")
     def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
@@ -73,7 +73,7 @@ class TestKerasSoftplus(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49516")
     def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
@@ -31,7 +31,7 @@ class TestKerasSpatialDropout1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout1d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_spatialdropout1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
@@ -34,9 +34,9 @@ class TestKerasSpatialDropout2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout2d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -51,7 +51,7 @@ class TestKerasSpatialDropout2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_spatialdropout2d_channels_first(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_old_api, use_new_frontend):
+                                                   temp_dir, use_new_frontend):
         self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
@@ -34,9 +34,9 @@ class TestKerasSpatialDropout3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout3d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -51,7 +51,7 @@ class TestKerasSpatialDropout3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_spatialdropout3d_channels_first(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_old_api, use_new_frontend):
+                                                   temp_dir, use_new_frontend):
         self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
@@ -41,8 +41,8 @@ class TestKerasStackedRNNCells(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
-    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_stackedrnncells_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
@@ -62,9 +62,9 @@ class TestKerasSubtract(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -80,7 +80,7 @@ class TestKerasSubtract(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_old_api, use_new_frontend):
+                                    use_new_frontend):
         self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
@@ -53,10 +53,10 @@ class TestKerasSWish(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                  use_new_frontend):
         self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
@@ -69,8 +69,8 @@ class TestKerasSWish(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                  use_new_frontend):
         self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
@@ -28,9 +28,9 @@ class TestKerasThresholdedReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
     def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_old_api, use_new_frontend):
+                                           use_new_frontend):
         self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data = [
@@ -43,7 +43,7 @@ class TestKerasThresholdedReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_old_api, use_new_frontend):
+                                           use_new_frontend):
         self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
@@ -36,8 +36,8 @@ class TestKerasTimeDistributed(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_timedistributed(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_timedistributed(self, params, ie_device, precision, ir_version, temp_dir,
                                    use_new_frontend):
         self._test(*self.create_keras_timedistributed_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
@@ -32,7 +32,7 @@ class TestKerasUpSampling1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_upsampling1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                        use_old_api, use_new_frontend):
+                                        use_new_frontend):
         self._test(*self.create_keras_upsampling1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -53,8 +53,8 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     def test_keras_upsampling2d_nearest(self, params, input_type, data_format, interpolation,
                                         ie_device, precision, ir_version, temp_dir,
-                                        use_old_api, use_new_frontend):
+                                        use_new_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, input_type=input_type, data_format=data_format,
                                                        interpolation=interpolation, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
@@ -34,10 +34,10 @@ class TestKerasUpSampling3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_upsampling3(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_upsampling3(self, params, ie_device, precision, ir_version, temp_dir,
                                use_new_frontend):
         self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -54,7 +54,7 @@ class TestKerasUpSampling3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
-                                               temp_dir, use_old_api, use_new_frontend):
+                                               temp_dir, use_new_frontend):
         self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
@@ -30,8 +30,8 @@ class TestKerasZeroPadding1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_zeropadding1d(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
+    def test_keras_zeropadding1d(self, params, ie_device, precision, ir_version, temp_dir,
                                  use_new_frontend):
         self._test(*self.create_keras_zeropadding1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
@@ -34,9 +34,9 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_zeropadding2d_channels_last(self, params, ie_device, precision, ir_version,
-                                               temp_dir, use_old_api):
+                                               temp_dir):
         self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    **params)
 
     test_data_channels_first = [
@@ -51,7 +51,7 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_zeropadding2d_channels_first(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_old_api, use_new_frontend):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
@@ -34,9 +34,9 @@ class TestKerasZeroPadding3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_zeropadding3d_channels_last(self, params, ie_device, precision, ir_version,
-                                               temp_dir, use_old_api, use_new_frontend):
+                                               temp_dir, use_new_frontend):
         self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -51,7 +51,7 @@ class TestKerasZeroPadding3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_zeropadding3d_channels_first(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_old_api, use_new_frontend):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
@@ -53,9 +53,9 @@ class TestMapFN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_basic)
     @pytest.mark.precommit
     @pytest.mark.nightly
-    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, use_old_api, use_new_frontend):
+    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
                    **params)
 
     test_multiple_inputs = [
@@ -71,9 +71,9 @@ class TestMapFN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_multiple_inputs)
     @pytest.mark.nightly
-    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, use_old_api, use_new_frontend):
+    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
                    **params)
 
     test_multiple_outputs = [
@@ -91,9 +91,9 @@ class TestMapFN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_multiple_outputs)
     @pytest.mark.nightly
-    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, use_old_api, use_new_frontend):
+    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
                    **params)
 
     test_multiple_inputs_outputs_int32 = [
@@ -113,7 +113,7 @@ class TestMapFN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_multiple_inputs_outputs_int32)
     @pytest.mark.nightly
     def test_multiple_inputs_outputs_int32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_old_api, use_new_frontend):
+                                           use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
                    **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Add.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Add.py
@@ -64,11 +64,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
     def test_add_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_2D = [
         dict(x_shape=[1, 1], y_shape=[1, 1]),
@@ -81,11 +81,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_add_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1, 1, 1]),
@@ -101,11 +101,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_add_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1, 1, 1, 1]),
@@ -119,11 +119,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_add_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1, 1, 1, 1, 1]),
@@ -137,11 +137,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_add_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     ###############################################################################################
     #                                                                                             #
@@ -156,11 +156,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_1D)
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_1D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_broadcast_2D = [
         dict(x_shape=[1, 1], y_shape=[1]),
@@ -174,11 +174,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_2D)
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_2D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_broadcast_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1]),
@@ -199,11 +199,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_3D)
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_3D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_broadcast_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1]),
@@ -222,11 +222,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_add_placeholder_const_broadcast_4D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_broadcast_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1]),
@@ -244,10 +244,9 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_add_placeholder_const_broadcast_5D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         # we do not perform transpose in the test in case of new frontend
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision,
-                   ir_version=ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api)
+                   ir_version=ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_AddN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AddN.py
@@ -61,8 +61,8 @@ class TestAddN(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_addn_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_addn_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_AddTypes.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AddTypes.py
@@ -50,7 +50,7 @@ class TestAddTypes(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_add_types(self, const_shape, input_type, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend, use_old_api):
+                       use_new_frontend):
         self._test(*self.create_add_types_net(const_shape, input_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_AdjustContrastv2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AdjustContrastv2.py
@@ -43,7 +43,7 @@ class TestAdjustContrastv2(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_adjust_contrast_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend, use_old_api):
+                                   use_new_frontend):
         self._test(*self.create_adjust_contrast_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ArgMinMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ArgMinMax.py
@@ -57,8 +57,8 @@ class TestArgMinMax(CommonTFLayerTest):
                                                                                          'arm64', 'ARM64'],
                        reason='Ticket - 126314')
     def test_argmin_max_net(self, params, input_type, output_type, op_type, ie_device, precision, ir_version, temp_dir,
-                            use_new_frontend, use_old_api):
+                            use_new_frontend):
         self._test(*self.create_argmin_max_net(**params, input_type=input_type,
                                                output_type=output_type, op_type=op_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Atan2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Atan2.py
@@ -40,7 +40,7 @@ class TestAtan2(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_atan2_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_atan2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BatchToSpace.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BatchToSpace.py
@@ -33,10 +33,10 @@ class TestBatchToSpace(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_batch_to_space_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_batch_to_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(in_shape=[4, 1, 1, 3], block_shape_value=[2, 2], crops_value=[[0, 0], [0, 0]]),
@@ -48,10 +48,10 @@ class TestBatchToSpace(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_batch_to_space_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_batch_to_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(in_shape=[144, 2, 1, 4, 1], block_shape_value=[3, 4, 2, 2],
@@ -61,7 +61,7 @@ class TestBatchToSpace(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_batch_to_space_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_batch_to_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BatchToSpaceND.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BatchToSpaceND.py
@@ -29,7 +29,7 @@ class TestBatchToSpaceND(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_batch_to_space_nd_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend, use_old_api):
+                                     use_new_frontend):
         self._test(*self.create_batch_to_space_nd_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BiasAdd.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BiasAdd.py
@@ -98,20 +98,20 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_bias_add_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend, use_old_api):
+                                           use_new_frontend):
         self._test(*self.create_bias_add_placeholder_const_net(**params, ir_version=ir_version,
                                                                use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_bias_add_2_consts_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
                                                       use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_3D = [
         pytest.param(dict(shape=[1, 1, 224]), marks=pytest.mark.xfail(reason="*-19053")),
@@ -121,20 +121,20 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_bias_add_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend, use_old_api):
+                                           use_new_frontend):
         self._test(*self.create_bias_add_placeholder_const_net(**params, ir_version=ir_version,
                                                                use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_bias_add_2_consts_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
                                                       use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(shape=[1, 1, 100, 224]),
@@ -146,20 +146,20 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_bias_add_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend, use_old_api):
+                                           use_new_frontend):
         self._test(*self.create_bias_add_placeholder_const_net(**params, ir_version=ir_version,
                                                                use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_bias_add_2_consts_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
                                                       use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(shape=[1, 1, 50, 100, 224]),
@@ -170,17 +170,17 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_bias_add_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend, use_old_api):
+                                           use_new_frontend):
         self._test(*self.create_bias_add_placeholder_const_net(**params, ir_version=ir_version,
                                                                use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_bias_add_2_consts_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
                                                       use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
@@ -140,7 +140,7 @@ class TestBinaryOps(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_binary_op(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                       use_new_frontend, use_old_api):
+                       use_new_frontend):
         if not use_new_frontend and op_type in ['BitwiseAnd', 'BitwiseOr', 'BitwiseXor']:
             pytest.skip("Bitwise ops are supported only by new TF FE.")
         if precision == "FP16":
@@ -150,4 +150,4 @@ class TestBinaryOps(CommonTFLayerTest):
             *self.create_add_placeholder_const_net(**params, ir_version=ir_version, op_type=op_type,
                                                    use_new_frontend=use_new_frontend), ie_device,
             precision,
-            ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BroadcastArgs.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BroadcastArgs.py
@@ -56,8 +56,7 @@ class TestBroadcastArgs(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_broadcast_args_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                                  use_old_api):
+    def test_broadcast_args_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_broadcast_args_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BroadcastArgs.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BroadcastArgs.py
@@ -56,7 +56,7 @@ class TestBroadcastArgs(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_broadcast_args_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_broadcast_args_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_broadcast_args_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BroadcastTo.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BroadcastTo.py
@@ -48,8 +48,8 @@ class TestBroadcastTo(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_broadcastto_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_broadcastto_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Bucketize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Bucketize.py
@@ -45,7 +45,7 @@ class TestBucketize(CommonTFLayerTest):
     @pytest.mark.xfail(platform.machine() in ["aarch64", "arm64", "ARM64"],
                        reason='Ticket - 122716')
     def test_bucketize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         self._test(*self.create_bucketize_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CTCGreedyDecoder.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CTCGreedyDecoder.py
@@ -61,10 +61,10 @@ class TestCTCGreedyDecoder(CommonTFLayerTest):
     @pytest.mark.parametrize("merge_repeated", [False, True])
     @pytest.mark.nightly
     def test_ctcgreedydecoder_placeholder_const(self, params, merge_repeated, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104860')
         self._test(*self.create_ctcgreedydecoder_placeholder_const_net(**params, ir_version=ir_version,
                                                              use_new_frontend=use_new_frontend, merge_repeated=merge_repeated),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api, merge_repeated=merge_repeated)
+                   use_new_frontend=use_new_frontend, merge_repeated=merge_repeated)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CTCLoss.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CTCLoss.py
@@ -63,9 +63,9 @@ class TestCTCLoss(CommonTFLayerTest):
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_ctcloss_placeholder_const(self, params, preprocess_collapse_repeated, ctc_merge_repeated,
                                        ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend, use_old_api):
+                                       use_new_frontend):
         self._test(*self.create_ctcloss_placeholder_const_net(**params,
                                                               preprocess_collapse_repeated=preprocess_collapse_repeated,
                                                               ctc_merge_repeated=ctc_merge_repeated),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Cast.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Cast.py
@@ -65,9 +65,9 @@ class TestCastOp(CommonTFLayerTest):
     @pytest.mark.parametrize("truncate", [ False, True ])
     @pytest.mark.nightly
     def test_cast_op_placeholder_const(self, params, input_type, output_type, truncate, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_cast_op_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend, input_type=input_type,
                                                           output_type=output_type, truncate=truncate),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CheckNumerics.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CheckNumerics.py
@@ -41,7 +41,7 @@ class TestCheckNumerics(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_check_numerics_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_check_numerics_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ClipByValue.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ClipByValue.py
@@ -43,8 +43,8 @@ class TestClipByValue(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_clip_by_value_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend, use_old_api):
+                                 use_new_frontend):
         self._test(
             *self.create_clip_by_value_net(**params), ie_device,
             precision, temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-            use_old_api=use_old_api, **params)
+            **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ComplexFFT.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ComplexFFT.py
@@ -62,11 +62,11 @@ class TestComplexFFT(CommonTFLayerTest):
                        reason='Ticket - 126314')
     def test_complex_fft_basic(self, params, fft_op,
                                ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(
             *self.create_complex_fft_net(**params, fft_op=fft_op),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api, custom_eps=1e-2)
+            use_new_frontend=use_new_frontend, custom_eps=1e-2)
 
 
 class TestComplexAbs(CommonTFLayerTest):
@@ -106,11 +106,11 @@ class TestComplexAbs(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_abs_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(
             *self.create_complex_abs_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)
 
 
 class TestComplexRFFT(CommonTFLayerTest):
@@ -149,11 +149,11 @@ class TestComplexRFFT(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_rfft_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend, use_old_api):
+                                use_new_frontend):
         self._test(
             *self.create_complex_rfft_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)
 
 
 class TestComplexIRFFT(CommonTFLayerTest):
@@ -195,8 +195,8 @@ class TestComplexIRFFT(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_irfft_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend, use_old_api):
+                                 use_new_frontend):
         self._test(
             *self.create_complex_irfft_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Concat.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Concat.py
@@ -40,7 +40,7 @@ class TestConcat(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_concat_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_concat_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -52,7 +52,7 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_concat_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_concat_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -64,7 +64,7 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_concat_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_concat_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -77,7 +77,7 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_concat_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_concat_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -91,7 +91,7 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_concat_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_concat_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -103,7 +103,7 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_concat_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_concat_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Concat.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Concat.py
@@ -40,12 +40,11 @@ class TestConcat(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_concat_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                          use_old_api):
+    def test_concat_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_1D = [
         dict(input_shapes=[[1], [2]], axis=0, is_v2=False),
@@ -53,12 +52,11 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_concat_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                       use_old_api):
+    def test_concat_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_2D = [
         dict(input_shapes=[[1, 4], [1, 2]], axis=-1, is_v2=True)
@@ -66,12 +64,11 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_concat_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                       use_old_api):
+    def test_concat_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_3D = [
         dict(input_shapes=[[1, 3, 2], [1, 3, 5]], axis=-1, is_v2=True),
@@ -80,12 +77,11 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_concat_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                       use_old_api):
+    def test_concat_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(input_shapes=[[1, 3, 5, 7], [3, 3, 5, 7], [2, 3, 5, 7]], axis=0, is_v2=False),
@@ -95,12 +91,11 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_concat_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                       use_old_api):
+    def test_concat_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(input_shapes=[[1, 3, 5, 7, 8], [2, 3, 5, 7, 8]], axis=0, is_v2=True),
@@ -108,9 +103,8 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_concat_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                       use_old_api):
+    def test_concat_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ConjugateTranspose.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ConjugateTranspose.py
@@ -65,10 +65,10 @@ class TestComplexConjugateTranspose(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_conjugate_transpose(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend, use_old_api):
+                                 use_new_frontend):
         self._test(*self.create_complex_conjugate_transpose_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestConjugateTranspose(CommonTFLayerTest):
@@ -116,7 +116,7 @@ class TestConjugateTranspose(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_conjugate_transpose(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend, use_old_api):
+                                 use_new_frontend):
         self._test(*self.create_conjugate_transpose_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conv2D.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conv2D.py
@@ -82,10 +82,10 @@ class TestConv2D(CommonTFLayerTest):
     @pytest.mark.parametrize("padding", ['EXPLICIT', 'SAME', 'VALID'])
     @pytest.mark.nightly
     def test_conv2d_placeholder_const(self, params, padding, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104862')
         self._test(*self.create_conv2d_placeholder_const_net(**params, input_padding=padding, ir_version=ir_version,
                                                              use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, input_padding=padding, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conv2DBackprop.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conv2DBackprop.py
@@ -70,8 +70,8 @@ class TestConv2DBackprop(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conv2dbackprop_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_conv2dbackprop_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conv3D.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conv3D.py
@@ -76,8 +76,8 @@ class TestConv3D(CommonTFLayerTest):
     @pytest.mark.parametrize("padding", ['SAME', 'VALID'])
     @pytest.mark.nightly
     def test_conv3d_placeholder_const(self, params, padding, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_conv3d_placeholder_const_net(**params, input_padding=padding, ir_version=ir_version,
                                                              use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, input_padding=padding, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conv3DBackprop.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conv3DBackprop.py
@@ -72,8 +72,8 @@ class TestConv3DBackprop(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conv3dbackprop_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_conv3dbackprop_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CropAndResize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CropAndResize.py
@@ -58,7 +58,7 @@ class TestCropAndResize(CommonTFLayerTest):
     @pytest.mark.xfail(platform.machine() in ["aarch64", "arm64", "ARM64"],
                        reason='Ticket - 122716')
     def test_crop_and_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend, use_old_api):
+                                   use_new_frontend):
         self._test(*self.create_crop_and_resize_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Cumsum.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Cumsum.py
@@ -50,7 +50,7 @@ class TestCumsum(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_cumsum_basic(self, params, exclusive, reverse, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend, use_old_api):
+                          use_new_frontend):
         self._test(*self.create_cumsum_net(**params, exclusive=exclusive, reverse=reverse),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_DepthToSpace.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_DepthToSpace.py
@@ -29,7 +29,7 @@ class TestDepthToSpace(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_depth_to_space_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_depth_to_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Div.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Div.py
@@ -44,7 +44,7 @@ class TestDiv(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_div_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend, use_old_api):
+                       use_new_frontend):
         self._test(*self.create_div_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_DivNoNan.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_DivNoNan.py
@@ -46,7 +46,7 @@ class TestDivNoNan(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_div_no_nan_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend, use_old_api):
+                              use_new_frontend):
         self._test(*self.create_div_no_nan_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_DynamicPartition.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_DynamicPartition.py
@@ -45,14 +45,14 @@ class TestDynamicPartition(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_dynamic_partition_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend, use_old_api):
+                                     use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         if not use_new_frontend:
             pytest.skip("DynamicPartition operation is not supported via legacy frontend.")
         self._test(*self.create_dynamic_partition_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_other_types = [
         dict(data_shape=[10], partitions_shape=[10], num_partitions=10, data_type=tf.int32),
@@ -62,11 +62,11 @@ class TestDynamicPartition(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_other_types)
     @pytest.mark.nightly
     def test_dynamic_partition_other_types(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend, use_old_api):
+                                           use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         if not use_new_frontend:
             pytest.skip("DynamicPartition operation is not supported via legacy frontend.")
         self._test(*self.create_dynamic_partition_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Eltwise.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Eltwise.py
@@ -59,7 +59,7 @@ class TestEltwise(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_eltwise(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_eltwise(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_eltwise_net(**params, ir_version=ir_version,
                                             use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Eltwise.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Eltwise.py
@@ -59,12 +59,11 @@ class TestEltwise(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_eltwise(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_eltwise(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_eltwise_net(**params, ir_version=ir_version,
                                             use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = []
     for operation in ['sum', 'max', 'mul']:
@@ -74,10 +73,10 @@ class TestEltwise(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_eltwise_5D_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_eltwise_net(**params, ir_version=ir_version,
                                             use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_EnsureShape.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_EnsureShape.py
@@ -38,7 +38,7 @@ class TestEnsureShape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_ensure_shape_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend, use_old_api):
+                                use_new_frontend):
         self._test(*self.create_ensure_shape_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Equal.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Equal.py
@@ -111,13 +111,12 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_int32)
     @pytest.mark.nightly
-    def test_tf_equal_int32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                    use_old_api):
+    def test_tf_equal_int32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.int32),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api, **params)
+                   **params)
 
     test_data_int64 = [
         pytest.param(
@@ -134,13 +133,12 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_int64)
     @pytest.mark.nightly
-    def test_tf_equal_int64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                    use_old_api):
+    def test_tf_equal_int64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.int64),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api, **params)
+                   **params)
 
     # Values for checking important corner cases for float values
     # expect:   false   false   false    false   false   false    true    false    true
@@ -160,13 +158,12 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float16)
     @pytest.mark.nightly
-    def test_tf_equal_float16(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                    use_old_api):
+    def test_tf_equal_float16(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.float16),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api, **params)
+                   **params)
 
     test_data_float32 = [
         pytest.param(
@@ -181,13 +178,12 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_tf_equal_float32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                    use_old_api):
+    def test_tf_equal_float32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.float32),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api, **params)
+                   **params)
 
     test_data_float64 = [
         pytest.param(
@@ -202,10 +198,9 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float64)
     @pytest.mark.nightly
-    def test_tf_equal_float64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                    use_old_api):
+    def test_tf_equal_float64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.float64),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api, **params)
+                   **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Equal.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Equal.py
@@ -111,7 +111,7 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_int32)
     @pytest.mark.nightly
-    def test_tf_equal_int32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_tf_equal_int32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.int32),
                    ie_device, precision,
@@ -133,7 +133,7 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_int64)
     @pytest.mark.nightly
-    def test_tf_equal_int64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_tf_equal_int64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.int64),
                    ie_device, precision,
@@ -158,7 +158,7 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float16)
     @pytest.mark.nightly
-    def test_tf_equal_float16(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_tf_equal_float16(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.float16),
                    ie_device, precision,
@@ -178,7 +178,7 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_tf_equal_float32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_tf_equal_float32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.float32),
                    ie_device, precision,
@@ -198,7 +198,7 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float64)
     @pytest.mark.nightly
-    def test_tf_equal_float64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_tf_equal_float64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend, output_type=np.float64),
                    ie_device, precision,

--- a/tests/layer_tests/tensorflow_tests/test_tf_ExpandDims.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ExpandDims.py
@@ -36,7 +36,7 @@ class TestExpandDims(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_basic)
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
-    def test_expand_dims_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_expand_dims_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_expand_dims_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ExpandDims.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ExpandDims.py
@@ -36,8 +36,7 @@ class TestExpandDims(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_basic)
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
-    def test_expand_dims_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                               use_old_api):
+    def test_expand_dims_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_expand_dims_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ExtractImagePatches.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ExtractImagePatches.py
@@ -37,8 +37,7 @@ class TestExtractImagePatches(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
     def test_extract_image_patches_basic(self, params, padding, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend,
-                                         use_old_api):
+                                         use_new_frontend,:
         self._test(*self.create_extract_image_patches_net(**params, padding=padding),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ExtractImagePatches.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ExtractImagePatches.py
@@ -37,7 +37,7 @@ class TestExtractImagePatches(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
     def test_extract_image_patches_basic(self, params, padding, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend,:
+                                         use_new_frontend):
         self._test(*self.create_extract_image_patches_net(**params, padding=padding),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Eye.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Eye.py
@@ -53,8 +53,7 @@ class TestTFEye(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_tf_eye(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                    use_old_api=True):
+    def test_tf_eye(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_tf_eye_net(**params), ie_device,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Eye.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Eye.py
@@ -60,4 +60,4 @@ class TestTFEye(CommonTFLayerTest):
         self._test(*self.create_tf_eye_net(**params), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api, **params)
+                   **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantWithMinMaxVars.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantWithMinMaxVars.py
@@ -47,7 +47,7 @@ class TestFakeQuantWithMinMaxVars(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_fake_quant_with_min_max_vars_basic(self, params, fake_quant_op, ie_device, precision, ir_version, temp_dir,
-                                                use_new_frontend,:
+                                                use_new_frontend):
         self._test(*self.create_fake_quant_with_min_max_vars_net(**params, fake_quant_op=fake_quant_op),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)
@@ -63,7 +63,7 @@ class TestFakeQuantWithMinMaxVars(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail("104822")
     def test_fake_quant_with_min_max_vars_per_channel_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                                            use_new_frontend,:
+                                                            use_new_frontend):
         self._test(*self.create_fake_quant_with_min_max_vars_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantWithMinMaxVars.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantWithMinMaxVars.py
@@ -47,11 +47,10 @@ class TestFakeQuantWithMinMaxVars(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_fake_quant_with_min_max_vars_basic(self, params, fake_quant_op, ie_device, precision, ir_version, temp_dir,
-                                                use_new_frontend,
-                                                use_old_api):
+                                                use_new_frontend,:
         self._test(*self.create_fake_quant_with_min_max_vars_net(**params, fake_quant_op=fake_quant_op),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_per_channel_basic = [
         dict(inputs_shape=[2, 6, 4], min_value=[-4, -3, -5, -8], max_value=[4, 7, 9, 5], num_bits=None,
@@ -64,8 +63,7 @@ class TestFakeQuantWithMinMaxVars(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail("104822")
     def test_fake_quant_with_min_max_vars_per_channel_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                                            use_new_frontend,
-                                                            use_old_api):
+                                                            use_new_frontend,:
         self._test(*self.create_fake_quant_with_min_max_vars_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantize.py
@@ -140,9 +140,9 @@ class TestFakeQuantize(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_fake_quantize(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         self._test(*self.create_fake_quantize_net(**params, ir_version=ir_version,
                                                   use_new_frontend=use_new_frontend), ie_device,
                    precision, ir_version,
                    kwargs_to_prepare_input=params, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Fill.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Fill.py
@@ -52,8 +52,8 @@ class TestFillOps(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_fill_ops_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_fill_ops_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FloorDiv.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FloorDiv.py
@@ -44,8 +44,8 @@ class TestFloorDiv(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
     def test_add_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FusedBatchNorm.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FusedBatchNorm.py
@@ -106,7 +106,7 @@ class TestFusedBatchNorm(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_fused_batch_norm_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend, use_old_api):
+                                    use_new_frontend):
         self._test(*self.create_fused_batch_norm_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_GRUBlockCell.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_GRUBlockCell.py
@@ -61,9 +61,9 @@ class TestTFGRUBlockCell(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_tf_gru_block_cell(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("Skip TF GRUBlockCell test on GPU")
         self._test(*self.create_tf_gru_block_cell(**params),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api, custom_eps=1e-3, **params)
+                   use_new_frontend=use_new_frontend, custom_eps=1e-3, **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Gather.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Gather.py
@@ -69,8 +69,7 @@ class TestGather(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_gather(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                    use_old_api):
+    def test_gather(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_gather_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Gather.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Gather.py
@@ -69,7 +69,7 @@ class TestGather(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_gather(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_gather(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_gather_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_GatherNd.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_GatherNd.py
@@ -58,8 +58,7 @@ class TestGatherNd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_gather_nd_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                             use_old_api):
+    def test_gather_nd_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_gather_nd_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_GatherNd.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_GatherNd.py
@@ -58,7 +58,7 @@ class TestGatherNd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_gather_nd_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_gather_nd_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_gather_nd_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Identity.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Identity.py
@@ -32,7 +32,7 @@ class TestIdentity(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_identity_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                            use_new_frontend, use_old_api):
+                            use_new_frontend):
         self._test(*self.create_identity_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_IdentityN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_IdentityN.py
@@ -39,7 +39,7 @@ class TestIdentityN(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_split_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_identityn_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_If.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_If.py
@@ -72,12 +72,12 @@ class TestIfFloat(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend, use_old_api):
+                      use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         self._test(*self.create_if_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestIfInt(CommonTFLayerTest):
@@ -144,12 +144,12 @@ class TestIfInt(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend, use_old_api):
+                      use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         self._test(*self.create_if_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestNestedIf(CommonTFLayerTest):
@@ -224,12 +224,12 @@ class TestNestedIf(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend, use_old_api):
+                      use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         self._test(*self.create_if_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestSequantialIfs(CommonTFLayerTest):
@@ -316,9 +316,9 @@ class TestSequantialIfs(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend, use_old_api):
+                      use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         self._test(*self.create_sequential_ifs_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Inv.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Inv.py
@@ -38,7 +38,7 @@ class TestInv(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_inv_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend, use_old_api):
+                                         use_new_frontend):
         self._test(*self.create_inv_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_InvertPermutation.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_InvertPermutation.py
@@ -38,7 +38,7 @@ class TestInvertPermutation(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_invert_permutation_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_invert_permutation_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_IsFinite.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_IsFinite.py
@@ -40,11 +40,11 @@ class TestIsFinite(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_is_finite_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         if not use_new_frontend:
             pytest.skip("IsFinite operation is not supported via legacy frontend.")
         self._test(*self.create_is_finite_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_IsInf.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_IsInf.py
@@ -38,11 +38,11 @@ class TestIsInf(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_is_inf_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend, use_old_api):
+                          use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         if not use_new_frontend:
             pytest.skip("IsInf operation is not supported via legacy frontend.")
         self._test(*self.create_is_inf_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_IsNan.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_IsNan.py
@@ -40,11 +40,11 @@ class TestIsNan(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_is_nan_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend, use_old_api):
+                          use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         if not use_new_frontend:
             pytest.skip("IsNan operation is not supported via legacy frontend.")
         self._test(*self.create_is_nan_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_L2Loss.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_L2Loss.py
@@ -28,11 +28,11 @@ class TestL2Loss(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_l2_loss_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104863')
         if not use_new_frontend:
             pytest.skip("L2Loss is not supported by legacy FE.")
         self._test(*self.create_l2_loss_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LRN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LRN.py
@@ -29,7 +29,7 @@ class TestLRN(CommonTFLayerTest):
     #@pytest.mark.precommit_tf_fe - ticket 116032
     @pytest.mark.nightly
     def test_lrn_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend, use_old_api):
+                       use_new_frontend):
         self._test(*self.create_lrn_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LeakyRelu.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LeakyRelu.py
@@ -36,7 +36,7 @@ class TestLeakyRelu(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_leaky_relu_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend, use_old_api):
+                              use_new_frontend):
         self._test(*self.create_leaky_relu_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LinSpace.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LinSpace.py
@@ -33,7 +33,7 @@ class TestLinSpace(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_lin_space_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         self._test(*self.create_lin_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ListDiff.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ListDiff.py
@@ -42,7 +42,7 @@ class TestListDiff(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_list_diff_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         self._test(*self.create_list_diff_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Log1p.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Log1p.py
@@ -37,7 +37,7 @@ class TestLog1p(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_log1p_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_log1p_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LogSoftmax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LogSoftmax.py
@@ -44,7 +44,7 @@ class TestLogSoftmax(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_log_softmax_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_log_softmax_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MatMul.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MatMul.py
@@ -59,11 +59,11 @@ class TestMatMul(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_matmul_op_precommit(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                                 use_new_frontend, use_old_api):
+                                 use_new_frontend):
         self._test(*self.create_net_with_matmul_op(**params, ir_version=ir_version, op_type=op_type,
                                                   use_new_frontend=use_new_frontend, x_bool=False, y_bool=False),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data = test_data_precommit + [
         dict(x_shape=[2, 3, 4, 4], y_shape=[2, 3, 4, 4]),   #Tests 4D shapes
@@ -85,8 +85,8 @@ class TestMatMul(CommonTFLayerTest):
         ])
     @pytest.mark.nightly
     def test_matmul_op_nightly(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                                x_bool, y_bool, use_new_frontend, use_old_api):
+                                x_bool, y_bool, use_new_frontend):
         self._test(*self.create_net_with_matmul_op(**params, ir_version=ir_version, op_type=op_type,
                                                   use_new_frontend=use_new_frontend, x_bool=x_bool, y_bool=y_bool),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MatrixDiag.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MatrixDiag.py
@@ -38,7 +38,7 @@ class TestMatrixDiag(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_matrix_diag_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_matrix_diag_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MaxPoolWithArgmax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MaxPoolWithArgmax.py
@@ -68,10 +68,10 @@ class TestMaxPoolWithArgmax(CommonTFLayerTest):
     def test_max_pool_with_argmax_basic(self, params, input_type, padding, targmax,
                                         include_batch_in_index, with_second_output,
                                         ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend, use_old_api):
+                                        use_new_frontend):
         self._test(
             *self.create_max_pool_with_argmax_net(**params, input_type=input_type, padding=padding, targmax=targmax,
                                                   include_batch_in_index=include_batch_in_index,
                                                   with_second_output=with_second_output),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MinMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MinMax.py
@@ -59,8 +59,8 @@ class TestMinMaxOps(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_minmax_ops_placeholder_const(self, params, op_type, keep_dims, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_minmax_ops_placeholder_const_net(**params, op_type=op_type, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend, keep_dims=keep_dims),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Mul.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Mul.py
@@ -63,11 +63,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_2D = [
         dict(x_shape=[1, 1], y_shape=[1, 1]),
@@ -80,11 +80,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1, 1, 1]),
@@ -100,11 +100,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1, 1, 1, 1]),
@@ -117,11 +117,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1, 1, 1, 1, 1]),
@@ -135,11 +135,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     ###############################################################################################
     #                                                                                             #
@@ -154,11 +154,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_1D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_1D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_broadcast_2D = [
         dict(x_shape=[1, 1], y_shape=[1]),
@@ -172,11 +172,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_2D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_2D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_broadcast_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1]),
@@ -198,11 +198,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_3D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_3D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_broadcast_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1]),
@@ -221,11 +221,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mul_placeholder_const_broadcast_4D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_broadcast_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1]),
@@ -242,11 +242,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_5D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_5D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestComplexMul(CommonTFLayerTest):
@@ -297,8 +297,8 @@ class TestComplexMul(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_mul(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(
             *self.create_complex_mul_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MulNoNan.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MulNoNan.py
@@ -41,7 +41,7 @@ class TestMulNoNan(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_mul_no_nan_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend, use_old_api):
+                              use_new_frontend):
         self._test(*self.create_mul_no_nan_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Multinomial.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Multinomial.py
@@ -121,7 +121,6 @@ class TestMultinomial(CommonTFLayerTest):
         ir_version,
         temp_dir,
         use_new_frontend,
-        use_old_api,
     ):
         if ie_device == "GPU":
             pytest.skip("Multinomial is not supported on GPU")
@@ -139,6 +138,5 @@ class TestMultinomial(CommonTFLayerTest):
             temp_dir=temp_dir,
             ir_version=ir_version,
             use_new_frontend=use_new_frontend,
-            use_old_api=use_old_api,
             kwargs_to_prepare_input={"input": input, "num_samples": num_samples},
         )

--- a/tests/layer_tests/tensorflow_tests/test_tf_NestedWhile.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_NestedWhile.py
@@ -70,14 +70,12 @@ class TestNestedWhile(CommonTFLayerTest):
         return g, None
 
     @pytest.mark.nightly
-    def test_simple_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                          use_old_api):
+    def test_simple_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_simple_while(), ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_nested_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                          use_old_api):
+    def test_nested_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_nested_while(), ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_NestedWhile.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_NestedWhile.py
@@ -70,12 +70,12 @@ class TestNestedWhile(CommonTFLayerTest):
         return g, None
 
     @pytest.mark.nightly
-    def test_simple_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_simple_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_simple_while(), ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)
 
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_nested_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_nested_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_nested_while(), ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_NonMaxSupression.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_NonMaxSupression.py
@@ -88,23 +88,19 @@ class TestNonMaxSuppression(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_NonMaxSuppression(self, test_params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend, use_old_api):
+                              use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("Skip TF NonMaxSuppresion test on GPU")
-        self.use_old_api = use_old_api
         self._test(*self.create_nms_net(test_params), ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api)
+                   ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     @pytest.mark.parametrize("test_params", test_params)
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_NonMaxSuppressionWithScores(self, test_params, ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend, use_old_api):
+                                        use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("Skip TF NonMaxSuppresionWithScores test on GPU")
-        self.use_old_api = use_old_api
         self._test(*self.create_nms_net(test_params, with_scores=True), ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api)
+                   ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_NonMaxSupression.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_NonMaxSupression.py
@@ -14,7 +14,7 @@ class TestNonMaxSuppression(CommonTFLayerTest):
 
     # overload inputs generation to suit NMS use case
     def _prepare_input(self, inputs_dict):
-        channel = ':0' if self.use_old_api or not self.use_new_frontend else ''
+        channel = ':0' if not self.use_new_frontend else ''
         input_data = {}
         for input in inputs_dict.keys():
             input_data[input + channel] = np.random.uniform(low=0, high=1,

--- a/tests/layer_tests/tensorflow_tests/test_tf_NormalizeL2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_NormalizeL2.py
@@ -37,10 +37,10 @@ class TestNormalizeL2(CommonTFLayerTest):
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 126314, 122716')
     def test_normalize_l2_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend, use_old_api):
+                                use_new_frontend):
         self._test(*self.create_normalize_l2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_complex = [
         dict(shape=[2, 3, 5, 4], axes=[1, 2, 3]),
@@ -50,7 +50,7 @@ class TestNormalizeL2(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_complex)
     @pytest.mark.nightly
     def test_normalize_l2_complex(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_normalize_l2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_OneHot.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_OneHot.py
@@ -32,7 +32,7 @@ class TestOneHot(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_one_hot_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_one_hot_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_one_hot_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)
@@ -44,7 +44,7 @@ class TestOneHot(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.nightly
-    def test_one_hot_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_one_hot_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_one_hot_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_OneHot.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_OneHot.py
@@ -32,11 +32,10 @@ class TestOneHot(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_one_hot_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                           use_old_api):
+    def test_one_hot_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_one_hot_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_complex = [
         dict(shape=[3, 4], depth=1, on_value=1.0, off_value=-5.0, axis=-2),
@@ -45,8 +44,7 @@ class TestOneHot(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.nightly
-    def test_one_hot_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                             use_old_api):
+    def test_one_hot_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_one_hot_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_OnesLike.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_OnesLike.py
@@ -39,7 +39,7 @@ class TestOnesLike(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_ones_like(self, params, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend, use_old_api):
+                       use_new_frontend):
         self._test(*self.create_ones_like_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Pack.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Pack.py
@@ -47,7 +47,7 @@ class TestPack(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_pack_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend, use_old_api):
+                        use_new_frontend):
         self._test(*self.create_pack_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Pad.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Pad.py
@@ -39,7 +39,7 @@ class TestPad(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_pad_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_pad_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_pad_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)
@@ -83,7 +83,7 @@ class TestComplexPad(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_pad_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_pad_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_pad_complex_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Pad.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Pad.py
@@ -39,11 +39,10 @@ class TestPad(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_pad_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                       use_old_api):
+    def test_pad_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_pad_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestComplexPad(CommonTFLayerTest):
@@ -84,8 +83,7 @@ class TestComplexPad(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_pad_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                         use_old_api):
+    def test_pad_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_pad_complex_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ParallelDynamicStitch.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ParallelDynamicStitch.py
@@ -71,12 +71,12 @@ class TestParallelDynamicStitch(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_parallel_dynamic_stitch_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         if not use_new_frontend:
             pytest.skip("DynamicStitch operation is not supported via legacy frontend.")
         self._test(*self.create_parallel_dynamic_stitch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_different_types = [
         dict(data_input_cnt=4, shape_of_element=[3, 2], data_type=tf.float64),
@@ -87,9 +87,9 @@ class TestParallelDynamicStitch(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_different_types)
     @pytest.mark.nightly
     def test_parallel_dynamic_stitch_different_types(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         if not use_new_frontend:
             pytest.skip("DynamicStitch operation is not supported via legacy frontend.")
         self._test(*self.create_parallel_dynamic_stitch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Placeholder.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Placeholder.py
@@ -49,7 +49,7 @@ class TestPlaceholder(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_placeholder(self, input_shape, input_type, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_placeholder_net(input_shape, input_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Pooling.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Pooling.py
@@ -149,7 +149,7 @@ class TestPooling(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
-    def test_pool_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_pool_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_pooling_net(**params, ir_version=ir_version,
                                             use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -232,7 +232,7 @@ class TestPooling(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
-    def test_pool_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_pool_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_pooling_net(**params, ir_version=ir_version,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Pooling.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Pooling.py
@@ -149,12 +149,11 @@ class TestPooling(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
-    def test_pool_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_pool_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_pooling_net(**params, ir_version=ir_version,
                                             use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = []
     for method in ['max', 'avg']:
@@ -233,11 +232,10 @@ class TestPooling(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
-    def test_pool_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_pool_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_pooling_net(**params, ir_version=ir_version,
                                             use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
@@ -93,14 +93,14 @@ class TestRandomUniform(CommonTFLayerTest):
     @pytest.mark.xfail(platform.machine() in ["aarch64", "arm64", "ARM64"],
                        reason='Ticket - 122716')
     def test_random_uniform_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("RandomUniform is not supported on GPU")
         self._test(
             *self.create_tf_random_uniform_net(**params, precision=precision, ir_version=ir_version,
                                                use_new_frontend=use_new_frontend), ie_device,
             precision, temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-            use_old_api=use_old_api, **params)
+            **params)
 
     test_data_other = [
         dict(global_seed=None, op_seed=56197, min_val=-100, max_val=100, x_shape=[6],
@@ -115,11 +115,11 @@ class TestRandomUniform(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_other)
     @pytest.mark.nightly
     def test_random_uniform_other(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("RandomUniform is not supported on GPU")
         self._test(
             *self.create_tf_random_uniform_net(**params, precision=precision, ir_version=ir_version,
                                                use_new_frontend=use_new_frontend), ie_device,
             precision, temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-            use_old_api=use_old_api, **params)
+            **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Range.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Range.py
@@ -52,7 +52,7 @@ class TestRange(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_range_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_range_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Rank.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Rank.py
@@ -29,7 +29,7 @@ class TestRank(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_rank_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend, use_old_api):
+                        use_new_frontend):
         self._test(*self.create_rank_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReLU6.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReLU6.py
@@ -80,7 +80,7 @@ class TestReLU6(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_relu6(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_relu6(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_relu6_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReLU6.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReLU6.py
@@ -66,11 +66,11 @@ class TestReLU6(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_relu6_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         self._test(*self.create_relu6_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data = [dict(shape=[1]),
                  pytest.param(dict(shape=[1, 224]), marks=pytest.mark.precommit_tf_fe),
@@ -80,9 +80,8 @@ class TestReLU6(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_relu6(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                   use_old_api):
+    def test_relu6(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_relu6_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Reciprocal.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Reciprocal.py
@@ -37,7 +37,7 @@ class TestReciprocal(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_reciprocal_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend, use_old_api):
+                              use_new_frontend):
         self._test(*self.create_reciprocal_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReduceArithmeticOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReduceArithmeticOps.py
@@ -45,8 +45,8 @@ class TestReduceArithmeticOps(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
     def test_reduce(self, params, operation, keep_dims, ie_device, precision, ir_version, temp_dir,
-                    use_new_frontend, use_old_api):
+                    use_new_frontend):
         self._test(*self.create_reduce_net(**params, operation=operation, keep_dims=keep_dims, ir_version=ir_version,
                                            use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReduceLogicalOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReduceLogicalOps.py
@@ -65,8 +65,8 @@ class TestLogicalOps(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_logical_ops_placeholder_const(self, params, op_type, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_logical_ops_placeholder_const_net(**params, op_type=op_type, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Resample_pattern_new.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Resample_pattern_new.py
@@ -73,7 +73,7 @@ class TestResamplePattern(CommonTFLayerTest):
     # TODO mark as precommit (after successfully passing in nightly)
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_resample(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_resample(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_resample_net(params['shape'], params['factor'], use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Resample_pattern_new.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Resample_pattern_new.py
@@ -73,8 +73,7 @@ class TestResamplePattern(CommonTFLayerTest):
     # TODO mark as precommit (after successfully passing in nightly)
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_resample(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                      use_old_api):
+    def test_resample(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_resample_net(params['shape'], params['factor'], use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Reshape.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Reshape.py
@@ -45,10 +45,10 @@ class TestReshape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_reshape_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         self._test(*self.create_reshape_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 class TestComplexReshape(CommonTFLayerTest):
     def _prepare_input(self, inputs_info):
@@ -87,9 +87,9 @@ class TestComplexReshape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_reshape(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(
             *self.create_complex_transpose_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)
 

--- a/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
@@ -65,7 +65,7 @@ class TestResize(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend, use_old_api):
+                          use_new_frontend):
         self._test(*self.create_resize_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Reverse.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Reverse.py
@@ -27,6 +27,6 @@ class TestReverse(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_reverse_basic(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reverse_basic(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reverse_net(**params),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReverseSequence.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReverseSequence.py
@@ -47,7 +47,7 @@ class TestReverseSequence(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_reverse_sequence_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend, use_old_api):
+                                    use_new_frontend):
         self._test(*self.create_reverse_sequence_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReverseV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReverseV2.py
@@ -28,6 +28,6 @@ class TestReverseV2(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
-    def test_reverse_v2_basic(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
+    def test_reverse_v2_basic(self, params, ie_device, precision, ir_version, temp_dir):
         self._test(*self.create_reverse_v2_net(**params),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
+                   ie_device, precision, ir_version, temp_dir=temp_dir)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Roll.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Roll.py
@@ -41,12 +41,11 @@ class TestTFRoll(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_tf_roll(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_tf_roll(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_tf_roll_net(**params, ir_version=ir_version,
                                             use_new_frontend=use_new_frontend), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
-                   use_old_api=use_old_api, **params)
+                   **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Roll.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Roll.py
@@ -41,7 +41,7 @@ class TestTFRoll(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_tf_roll(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_tf_roll(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_tf_roll_net(**params, ir_version=ir_version,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Rsqrt.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Rsqrt.py
@@ -68,7 +68,7 @@ class TestRsqrt(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_rsqrt(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_rsqrt(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_rsqrt_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Rsqrt.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Rsqrt.py
@@ -54,11 +54,11 @@ class TestRsqrt(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_rsqrt_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         self._test(*self.create_rsqrt_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data = [dict(shape=[1]),
                  pytest.param(dict(shape=[1, 224]), marks=pytest.mark.precommit_tf_fe),
@@ -68,9 +68,8 @@ class TestRsqrt(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_rsqrt(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                   use_old_api):
+    def test_rsqrt(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_rsqrt_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ScatterND.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ScatterND.py
@@ -74,8 +74,8 @@ class TestTFScatterND(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_tf_scatter_nd(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         self._test(*self.create_tf_scatternd_placeholder_const_net(**params, ir_version=ir_version,
                                                                    use_new_frontend=use_new_frontend),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api, **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SegmentSum.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SegmentSum.py
@@ -46,12 +46,12 @@ class TestSegmentSum(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_segment_sum_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         if not use_new_frontend:
             pytest.skip("SegmentSum operation is not supported via legacy frontend.")
         self._test(*self.create_segment_sum_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_different_types = [
         dict(data_shape=[2, 3], segment_ids_shape=[2], data_type=tf.int32, segment_ids_type=tf.int32),
@@ -63,9 +63,9 @@ class TestSegmentSum(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_different_types)
     @pytest.mark.nightly
     def test_segment_sum_different_types(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend, use_old_api):
+                                         use_new_frontend):
         if not use_new_frontend:
             pytest.skip("SegmentSum operation is not supported via legacy frontend.")
         self._test(*self.create_segment_sum_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Select.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Select.py
@@ -46,9 +46,9 @@ class TestSelect(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_select_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend, use_old_api):
+                          use_new_frontend):
         if not use_new_frontend:
             pytest.skip("Select tests are not passing for the legacy frontend.")
         self._test(*self.create_select_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SelectV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SelectV2.py
@@ -45,9 +45,9 @@ class TestSelectV2(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_select_v2_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         if not use_new_frontend:
             pytest.skip("Select tests are not passing for the legacy frontend.")
         self._test(*self.create_select_v2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Shape.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Shape.py
@@ -51,12 +51,12 @@ class TestShape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_shape_basic(self, input_shape, input_type, out_type, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         if input_shape == [] and out_type == tf.int64:
             pytest.skip('129100 - Hangs or segfault')
         self._test(*self.create_shape_net(input_shape=input_shape, input_type=input_type, out_type=out_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestComplexShape(CommonTFLayerTest):
@@ -96,8 +96,8 @@ class TestComplexShape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_shape(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         self._test(
             *self.create_complex_shape_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ShapeN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ShapeN.py
@@ -32,7 +32,7 @@ class TestShapeN(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_shape_n_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         self._test(*self.create_shape_n_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Size.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Size.py
@@ -39,7 +39,7 @@ class TestSize(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_size_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend, use_old_api):
+                        use_new_frontend):
         self._test(*self.create_size_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Slice.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Slice.py
@@ -30,7 +30,7 @@ class TestSlice(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_slice_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_slice_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Slice.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Slice.py
@@ -30,8 +30,7 @@ class TestSlice(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_slice_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                         use_old_api):
+    def test_slice_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Softmax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Softmax.py
@@ -39,7 +39,7 @@ class TestSoftmax(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_softmax_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         self._test(*self.create_softmax_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Softsign.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Softsign.py
@@ -71,8 +71,8 @@ class TestSoftsign(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_softsign(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend, use_old_api):
+                      use_new_frontend):
         self._test(*self.create_softsign_net(**params, ir_version=ir_version,
                                              use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SpaceToBatch.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SpaceToBatch.py
@@ -38,10 +38,10 @@ class TestSpaceToBatch(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_space_to_batch_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_space_to_batch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(in_shape=[1, 2, 2, 3], block_shape_value=[2, 2], pads_value=[[0, 0], [0, 0]]),
@@ -51,10 +51,10 @@ class TestSpaceToBatch(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_space_to_batch_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_space_to_batch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(in_shape=[3, 3, 4, 5, 2], block_shape_value=[3, 4, 2],
@@ -66,7 +66,7 @@ class TestSpaceToBatch(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_space_to_batch_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_space_to_batch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SpaceToBatchND.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SpaceToBatchND.py
@@ -29,7 +29,7 @@ class TestSpaceToBatchND(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_space_to_batch_nd_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend, use_old_api):
+                                     use_new_frontend):
         self._test(*self.create_space_to_batch_nd_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SpaceToDepth.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SpaceToDepth.py
@@ -29,7 +29,7 @@ class TestSpaceToDepth(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_space_to_depth_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_space_to_depth_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Split.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Split.py
@@ -31,7 +31,7 @@ class TestSplit(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_split_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_split_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SplitV.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SplitV.py
@@ -36,7 +36,7 @@ class TestSplitV(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == 'true', reason="Ticket - 113359")
     def test_split_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_splitv_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Squeeze.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Squeeze.py
@@ -40,10 +40,10 @@ class TestSqueeze(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_squeeze_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_1D = [
         dict(input_shape=[1], axis=[], input_type=np.float32),
@@ -52,11 +52,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_squeeze_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                        use_old_api):
+    def test_squeeze_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_2D = [
         dict(input_shape=[1, 2], axis=[0], input_type=np.float32),
@@ -65,11 +64,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_squeeze_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                        use_old_api):
+    def test_squeeze_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_3D = [
         dict(input_shape=[2, 1, 3], axis=[], input_type=np.float32),
@@ -78,11 +76,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_squeeze_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                        use_old_api):
+    def test_squeeze_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(input_shape=[1, 1, 5, 10], axis=[], input_type=np.int32),
@@ -92,11 +89,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_squeeze_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                        use_old_api):
+    def test_squeeze_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(input_shape=[1, 1, 5, 10, 22], axis=[], input_type=np.float32),
@@ -109,11 +105,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_squeeze_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                        use_old_api):
+    def test_squeeze_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestComplexSqueeze(CommonTFLayerTest):
@@ -155,8 +150,8 @@ class TestComplexSqueeze(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_squeeze(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(
             *self.create_complex_squeeze_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Squeeze.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Squeeze.py
@@ -52,7 +52,7 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_squeeze_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_squeeze_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)
@@ -64,7 +64,7 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_squeeze_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_squeeze_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)
@@ -76,7 +76,7 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_squeeze_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_squeeze_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)
@@ -89,7 +89,7 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_squeeze_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_squeeze_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)
@@ -105,7 +105,7 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_squeeze_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_squeeze_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_StridedSlice.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_StridedSlice.py
@@ -45,10 +45,10 @@ class TestStridedSlice(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_strided_slice_basic(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend, use_old_api):
+                                 temp_dir, use_new_frontend):
         self._test(*self.create_strided_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_squeeze_data = [
         dict(input_shape=[1, 5], begin_value=[0, 0], end_value=[1, 5], strides_value=[1, 1], begin_mask=0,
@@ -84,10 +84,10 @@ class TestStridedSlice(CommonTFLayerTest):
     @pytest.mark.parametrize('params', test_squeeze_data)
     @pytest.mark.nightly
     def test_strided_slice_replace_with_squeeze(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_strided_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_unsqueeze_data = [
         dict(input_shape=[1, 5], begin_value=[0, 0], end_value=[1, 5], strides_value=[1, 1], begin_mask=0,
@@ -114,10 +114,10 @@ class TestStridedSlice(CommonTFLayerTest):
     @pytest.mark.parametrize('params', test_unsqueeze_data)
     @pytest.mark.nightly
     def test_strided_slice_replace_with_unsqueeze(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend, use_old_api):
+                                                  temp_dir, use_new_frontend):
         self._test(*self.create_strided_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 class TestComplexStridedSlice(CommonTFLayerTest):
     def _prepare_input(self, inputs_info):
@@ -222,8 +222,8 @@ class TestComplexStridedSlice(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_strided_slice(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(
             *self.create_complex_strided_slice_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Sub.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Sub.py
@@ -64,11 +64,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     test_data_2D = [
         dict(x_shape=[1, 1], y_shape=[1, 1]),
@@ -80,11 +80,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     test_data_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1, 1, 1]),
@@ -98,11 +98,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1, 1, 1, 1]),
@@ -115,11 +115,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1, 1, 1, 1, 1]),
@@ -132,11 +132,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     ###############################################################################################
     #                                                                                             #
@@ -151,11 +151,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_1D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_1D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     test_data_broadcast_2D = [
         dict(x_shape=[1, 1], y_shape=[1]),
@@ -168,11 +168,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_2D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_2D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     test_data_broadcast_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1]),
@@ -188,11 +188,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_3D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_3D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     test_data_broadcast_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1]),
@@ -211,11 +211,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_4D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_4D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
 
     test_data_broadcast_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1, 1, 1, 1, 1]),
@@ -233,8 +233,8 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_5D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_5D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend, use_old_api):
+                                                temp_dir, use_new_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
                                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Swish.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Swish.py
@@ -83,7 +83,7 @@ class TestSwish(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_swish(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_swish(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_swish_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Swish.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Swish.py
@@ -69,11 +69,11 @@ class TestSwish(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_swish_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         self._test(*self.create_swish_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data = [dict(shape=[1]),
                  dict(shape=[1, 224]),
@@ -83,9 +83,8 @@ class TestSwish(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_swish(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                   use_old_api):
+    def test_swish(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_swish_net(**params, ir_version=ir_version,
                                           use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SwitchMerge.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SwitchMerge.py
@@ -59,7 +59,7 @@ class TestSwitchMerge(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_merge_eliminating_several_cond_flows(self, params, cond_value, x_type, ie_device, precision, ir_version,
                                                   temp_dir,
-                                                  use_new_frontend, use_old_api):
+                                                  use_new_frontend):
         self._test(*self.merge_eliminating_several_cond_flows_net(**params, cond_value=cond_value, x_type=x_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorArrayOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorArrayOps.py
@@ -52,10 +52,10 @@ class TestTensorArraySizeV3(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tensor_array_size_v3(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_tensor_array_size_v3(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestTensorArrayReadV3(CommonTFLayerTest):
@@ -96,10 +96,10 @@ class TestTensorArrayReadV3(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tensor_array_read_v3(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend, use_old_api):
+                                  use_new_frontend):
         self._test(*self.create_tensor_array_read_v3(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestTensorArrayWriteGatherV3(CommonTFLayerTest):
@@ -162,10 +162,10 @@ class TestTensorArrayWriteGatherV3(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tensor_array_write_v3(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend, use_old_api):
+                                   use_new_frontend):
         self._test(*self.create_tensor_array_write_v3(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestTensorArrayConcatV3(CommonTFLayerTest):
@@ -205,7 +205,7 @@ class TestTensorArrayConcatV3(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tensor_array_concat_v3(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend, use_old_api):
+                                    use_new_frontend):
         self._test(*self.create_tensor_array_concat_v3(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListConcatV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListConcatV2.py
@@ -43,7 +43,7 @@ class TestTensorListConcatV2(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_tensor_list_resize(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListLength.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListLength.py
@@ -42,10 +42,10 @@ class TestTensorListLength(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_length_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_tensor_list_length(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestTensorListLengthEmptyList(CommonTFLayerTest):
@@ -81,7 +81,7 @@ class TestTensorListLengthEmptyList(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_length_empty_list(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend, use_old_api):
+                                           use_new_frontend):
         self._test(*self.create_tensor_list_length_empty_list(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListResize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListResize.py
@@ -46,7 +46,7 @@ class TestTensorListResize(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend, use_old_api):
+                                      use_new_frontend):
         self._test(*self.create_tensor_list_resize(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Tile.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Tile.py
@@ -40,7 +40,7 @@ class TestTile(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tile_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend, use_old_api):
+                        use_new_frontend):
         self._test(*self.create_tile_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ToBool.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ToBool.py
@@ -37,7 +37,7 @@ class TestToBool(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_to_bool_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend, use_old_api):
+                                         use_new_frontend):
         self._test(*self.create_tobool_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TopK.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopK.py
@@ -56,7 +56,7 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_TopK_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_TopK_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -69,7 +69,7 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_TopK_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_TopK_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -82,7 +82,7 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_TopK_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_TopK_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -95,7 +95,7 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_TopK_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_TopK_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
@@ -108,7 +108,7 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_TopK_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_TopK_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,

--- a/tests/layer_tests/tensorflow_tests/test_tf_TopK.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopK.py
@@ -56,12 +56,11 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_TopK_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_TopK_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_2D = [
         dict(shape=[14, 15], k=10),
@@ -70,12 +69,11 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_TopK_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_TopK_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_3D = [
         dict(shape=[13, 14, 15], k=10),
@@ -84,12 +82,11 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_TopK_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_TopK_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_4D = [
         dict(shape=[12, 13, 14, 15], k=10),
@@ -98,12 +95,11 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_TopK_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_TopK_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_5D = [
         dict(shape=[11, 12, 13, 14, 15], k=10),
@@ -112,9 +108,8 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_TopK_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                     use_old_api):
+    def test_TopK_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
@@ -52,7 +52,7 @@ class TestTopKV2(CommonTFLayerTest):
                                                                                                      'aarch64',
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 126314, 122716')
-    def test_topk_v2_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
+    def test_topk_v2_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
         self._test(*self.create_topk_v2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
@@ -52,8 +52,7 @@ class TestTopKV2(CommonTFLayerTest):
                                                                                                      'aarch64',
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 126314, 122716')
-    def test_topk_v2_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
-                           use_old_api):
+    def test_topk_v2_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,:
         self._test(*self.create_topk_v2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Transpose.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Transpose.py
@@ -28,10 +28,10 @@ class TestTranspose(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_transpose_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend, use_old_api):
+                             use_new_frontend):
         self._test(*self.create_transpose_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestComplexTranspose(CommonTFLayerTest):
@@ -72,8 +72,8 @@ class TestComplexTranspose(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_transpose(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(
             *self.create_complex_transpose_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TruncateDiv.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TruncateDiv.py
@@ -49,7 +49,7 @@ class TestTruncateDiv(CommonTFLayerTest):
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 126314, 122716')
     def test_truncate_div_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_truncate_div_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TruncateMod.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TruncateMod.py
@@ -43,7 +43,7 @@ class TestTruncateMod(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_truncate_mod_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend, use_old_api):
+                               use_new_frontend):
         self._test(*self.create_truncate_mod_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnaryOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnaryOps.py
@@ -163,7 +163,7 @@ class TestUnaryOps(CommonTFLayerTest):
                                          ])
     @pytest.mark.precommit
     def test_unary_op_precommit(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                                use_new_frontend, use_old_api):
+                                use_new_frontend):
         if not use_new_frontend and op_type in ['BitwiseNot']:
             pytest.skip("Bitwise ops are supported only by new TF FE.")
         if ie_device == 'GPU':
@@ -171,14 +171,14 @@ class TestUnaryOps(CommonTFLayerTest):
         self._test(*self.create_net_with_unary_op(**params, ir_version=ir_version, op_type=op_type,
                                                   use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     @pytest.mark.xfail(sys.version_info > (3, 10),
                        reason="tensorflow_addons package is not available for Python 3.11 and higher")
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
     def test_unary_op_mish_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend, use_old_api):
+                                     use_new_frontend):
         """
         TODO: Move to `test_unary_op_precommit()` once tensorflow_addons package is available for Python 3.11
         """
@@ -187,7 +187,7 @@ class TestUnaryOps(CommonTFLayerTest):
         self._test(*self.create_net_with_mish(**params, ir_version=ir_version,
                                               use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data = [pytest.param(dict(shape=[10, 12]), marks=pytest.mark.precommit_tf_fe),
                  dict(shape=[8, 10, 12]),
@@ -228,7 +228,7 @@ class TestUnaryOps(CommonTFLayerTest):
     @pytest.mark.skipif(sys.platform == 'darwin', reason="Ticket - 122182")
     @pytest.mark.xfail(platform.machine() in ["aarch64", "arm64", "ARM64"], reason='Ticket - 122716')
     def test_unary_op(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                      use_new_frontend, use_old_api):
+                      use_new_frontend):
         if not use_new_frontend and op_type in ['BitwiseNot']:
             pytest.skip("Bitwise ops are supported only by new TF FE.")
         if ie_device == 'GPU':
@@ -236,14 +236,14 @@ class TestUnaryOps(CommonTFLayerTest):
         self._test(*self.create_net_with_unary_op(**params, ir_version=ir_version, op_type=op_type,
                                                   use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     @pytest.mark.xfail(sys.version_info > (3, 10),
                        reason="tensorflow_addons package is not available for Python 3.11 and higher")
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_unary_op_mish(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                           use_new_frontend, use_old_api):
+                           use_new_frontend):
         """
         TODO: Move to `test_unary_op()` once tensorflow_addons package is available for Python 3.11
         """
@@ -252,4 +252,4 @@ class TestUnaryOps(CommonTFLayerTest):
         self._test(*self.create_net_with_mish(**params, ir_version=ir_version,
                                               use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Unique.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Unique.py
@@ -39,12 +39,12 @@ class TestUnique(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_unique_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend, use_old_api):
+                          use_new_frontend):
         if not use_new_frontend:
             pytest.skip("Unique operation is not supported via legacy frontend.")
         self._test(*self.create_unique_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
     test_data_other_types = [
         dict(x_shape=[10], data_type=tf.int32, out_idx=tf.int32),
@@ -54,9 +54,9 @@ class TestUnique(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_other_types)
     @pytest.mark.nightly
     def test_unique_other_types(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend, use_old_api):
+                                use_new_frontend):
         if not use_new_frontend:
             pytest.skip("Unique operation is not supported via legacy frontend.")
         self._test(*self.create_unique_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_UniqueWithCounts.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UniqueWithCounts.py
@@ -39,9 +39,9 @@ class TestUnique(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_unique_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend, use_old_api):
+                          use_new_frontend):
         if not use_new_frontend:
             pytest.skip("Unique operation is not supported via legacy frontend.")
         self._test(*self.create_unique_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Unpack.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Unpack.py
@@ -49,7 +49,7 @@ class TestUnpack(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_unpack_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend, use_old_api):
+                          use_new_frontend):
         self._test(*self.create_unpack_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnravelIndex.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnravelIndex.py
@@ -38,7 +38,7 @@ class TestUnravelIndex(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_unravel_index_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend, use_old_api):
+                                 use_new_frontend):
         self._test(*self.create_unravel_index_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentSum.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentSum.py
@@ -61,11 +61,11 @@ class TestUnsortedSegmentSum(CommonTFLayerTest):
                        reason='Ticket - 122716')
     def test_unsorted_segment_sum_basic(self, params, data_type, segment_ids_type, num_segments_type, ie_device,
                                         precision, ir_version, temp_dir,
-                                        use_new_frontend, use_old_api):
+                                        use_new_frontend):
         if not use_new_frontend:
             pytest.skip("UnsortedSegmentSum operation is not supported via legacy frontend.")
         self._test(
             *self.create_unsorted_segment_sum_net(**params, data_type=data_type, segment_ids_type=segment_ids_type,
                                                   num_segments_type=num_segments_type),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+            use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Where.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Where.py
@@ -37,7 +37,7 @@ class TestWhere(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_where_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_where_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_While.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_While.py
@@ -60,10 +60,10 @@ class TestWhile(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_while_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestWhileShapeVariant(CommonTFLayerTest):
@@ -120,10 +120,10 @@ class TestWhileShapeVariant(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_while_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)
 
 
 class TestWhileWithNestedIf(CommonTFLayerTest):
@@ -194,7 +194,7 @@ class TestWhileWithNestedIf(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_with_nested_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend, use_old_api):
+                                        use_new_frontend):
         self._test(*self.create_while_with_nested_if_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Xlog1py.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Xlog1py.py
@@ -47,7 +47,7 @@ class TestXlog1py(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_xlog1py_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_xlog1py_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Xlogy.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Xlogy.py
@@ -47,7 +47,7 @@ class TestXlogy(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_xlogy_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend, use_old_api):
+                         use_new_frontend):
         self._test(*self.create_xlogy_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ZerosLike.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ZerosLike.py
@@ -29,7 +29,7 @@ class TestZerosLike(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_zeros_like_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend, use_old_api):
+                              use_new_frontend):
         self._test(*self.create_zeros_like_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)
+                   use_new_frontend=use_new_frontend)


### PR DESCRIPTION
### Details:
 - Removed API 1.0 usage from python's layer tests

### Tickets:
 - 125181
