### PR TITLE
M_PI(math.h) using fix & dirent.h is existed in MinGW

### DIFF
--- a/samples/cpp/common/utils/src/args_helper.cpp
+++ b/samples/cpp/common/utils/src/args_helper.cpp
@@ -7,7 +7,7 @@
 
 #include <iostream>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #    include "samples/os/windows/w_dirent.h"
 #else
 #    include <dirent.h>

--- a/src/frontends/onnx/frontend/src/op/blackmanwindow.cpp
+++ b/src/frontends/onnx/frontend/src/op/blackmanwindow.cpp
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #define _USE_MATH_DEFINES
-#include <math.h>
 
 #include "op/blackmanwindow.hpp"
+
+#include <math.h>
 
 #include <memory>
 

--- a/src/frontends/onnx/frontend/src/op/blackmanwindow.cpp
+++ b/src/frontends/onnx/frontend/src/op/blackmanwindow.cpp
@@ -1,14 +1,15 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 #include "op/blackmanwindow.hpp"
 
 #include <memory>
 
 #include "default_opset.hpp"
 #include "utils/common.hpp"
-#define _USE_MATH_DEFINES
-#include <math.h>
 
 OPENVINO_SUPPRESS_DEPRECATED_START
 namespace ngraph {

--- a/src/frontends/onnx/frontend/src/op/hammingwindow.cpp
+++ b/src/frontends/onnx/frontend/src/op/hammingwindow.cpp
@@ -1,14 +1,16 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 #include "op/hammingwindow.hpp"
 
 #include <memory>
 
 #include "default_opset.hpp"
 #include "utils/common.hpp"
-#define _USE_MATH_DEFINES
-#include <math.h>
+
 
 OPENVINO_SUPPRESS_DEPRECATED_START
 namespace ngraph {

--- a/src/frontends/onnx/frontend/src/op/hammingwindow.cpp
+++ b/src/frontends/onnx/frontend/src/op/hammingwindow.cpp
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #define _USE_MATH_DEFINES
-#include <math.h>
 
 #include "op/hammingwindow.hpp"
+
+#include <math.h>
 
 #include <memory>
 
 #include "default_opset.hpp"
 #include "utils/common.hpp"
-
 
 OPENVINO_SUPPRESS_DEPRECATED_START
 namespace ngraph {

--- a/src/frontends/onnx/frontend/src/op/hannwindow.cpp
+++ b/src/frontends/onnx/frontend/src/op/hannwindow.cpp
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #define _USE_MATH_DEFINES
-#include <math.h>
 
 #include "op/hannwindow.hpp"
+
+#include <math.h>
 
 #include <memory>
 
 #include "default_opset.hpp"
 #include "utils/common.hpp"
-
 
 OPENVINO_SUPPRESS_DEPRECATED_START
 namespace ngraph {

--- a/src/frontends/onnx/frontend/src/op/hannwindow.cpp
+++ b/src/frontends/onnx/frontend/src/op/hannwindow.cpp
@@ -1,14 +1,16 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 #include "op/hannwindow.hpp"
 
 #include <memory>
 
 #include "default_opset.hpp"
 #include "utils/common.hpp"
-#define _USE_MATH_DEFINES
-#include <math.h>
+
 
 OPENVINO_SUPPRESS_DEPRECATED_START
 namespace ngraph {


### PR DESCRIPTION
M_PI using fix in MinGW
![image](https://github.com/openvinotoolkit/openvino/assets/68764729/1ec00f2a-df10-4082-9f18-4cc1627758e5)
![image](https://github.com/openvinotoolkit/openvino/assets/68764729/b8afb583-493e-41f7-a632-015e80588cca)
![image](https://github.com/openvinotoolkit/openvino/assets/68764729/7b6d81e4-57c3-4469-9784-4980b6509d6d)
&
'direct.h' header is existed in MinGW