### PR TITLE
[GPU] Optimization for kv cache op

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/variable_state.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/variable_state.hpp
@@ -40,6 +40,10 @@ public:
     bool is_set() const;
     void set();
     void set_layout(const cldnn::layout& new_layout);
+    void set_memory(const cldnn::memory::ptr& new_mem, const cldnn::layout& actual_layout);
+    size_t get_actual_mem_size() const {
+        return actual_size;
+    }
 
 private:
     cldnn::layout m_layout;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/shape_predictor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/shape_predictor.hpp
@@ -51,8 +51,14 @@ public:
     std::pair<bool, ov::Shape> predict_preallocation_shape(const std::string& id,
                                                            const ov::Shape& current_shape,
                                                            size_t dt_bitwidth,
-                                                           bool can_reuse_buffer);
+                                                           bool can_reuse_buffer,
+                                                           int32_t next_iters_prealloc_count = -1);
+
     bool can_preallocate(size_t desired_buffer_size);
+
+    void reset() {
+        _shapes_info.clear();
+    }
 
 private:
     void add_shape(const std::string& id, const ov::Shape& shape);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -79,10 +79,12 @@ struct kv_cache_impl : typed_primitive_impl_ocl<kv_cache> {
         variable.set();
 
         if (can_be_optimized) {
+            GPU_DEBUG_TRACE_DETAIL << desc->id  << " : Output is same as variable memory! Skip copying " << std::endl;
             // When primitive is optimized, concat kernel writes directly to variable memory
             return res_event;
         } else {
             // Othwerise, we need to copy result from out buffer to state memory
+            GPU_DEBUG_TRACE_DETAIL << desc->id  << " : Copying output to variable meomry" << std::endl;
             auto& stream = instance.get_network().get_stream();
 
             stream.enqueue_barrier();

--- a/src/plugins/intel_gpu/src/graph/include/kv_cache_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/kv_cache_inst.h
@@ -36,6 +36,50 @@ public:
 
     static std::string to_string(const kv_cache_node& node);
 
+    static int32_t get_prealloc_iter_num() {
+        return 128;
+    }
+
+    static void update_pad(layout& l, int64_t pad, int64_t sequence_axis_legacy) {
+        const auto& dyn_pad_dims = l.data_padding.get_dynamic_pad_dims();
+        const auto& lower_padd = l.data_padding.lower_size().sizes();
+        auto upper_padd = l.data_padding.upper_size().sizes();
+        upper_padd[sequence_axis_legacy] = pad;
+        l.data_padding = padding(lower_padd, upper_padd, 0.f, dyn_pad_dims);
+    }
+
+    static int64_t get_sequence_axis_legacy(int64_t sequence_axis, size_t past_layout_rank) {
+        auto sequence_axis_legacy = sequence_axis;
+        if (sequence_axis_legacy < 0)
+            sequence_axis_legacy = past_layout_rank + sequence_axis_legacy;
+        if (sequence_axis_legacy >= 2) {
+            auto spatial_axis = sequence_axis_legacy - 2;
+            // Default and minimum number of dimensions is 4
+            auto spatial_size = std::max<size_t>(past_layout_rank, 4) - 2;
+            sequence_axis_legacy = spatial_size - spatial_axis - 1 + 2;
+        }
+        return sequence_axis_legacy;
+    }
+
+    static int64_t get_max_pad(const layout& target_layout, size_t buffer_size, int64_t legacy_sequence_axis, std::string target_name = "") {
+        if (buffer_size == 0)
+            return 0;
+        const size_t total_elements = target_layout.count();
+        const int64_t concat_axis_size = target_layout.get_tensor().sizes()[legacy_sequence_axis];
+        const int64_t sequence_element_size = total_elements / concat_axis_size;
+        const int64_t max_sequence_elements = buffer_size / sequence_element_size;
+        auto max_pad = std::max<int64_t>(max_sequence_elements - concat_axis_size, 0);
+        auto target_layout_name = (target_name != "") ? target_name : "target_layout";
+        GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] " << target_name  << " : " << target_layout.to_string() << std::endl;
+        GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] buffer size " << buffer_size << std::endl;
+        GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] total_elements " << total_elements << std::endl;
+        GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] concat_axis_size = " << concat_axis_size << std::endl;
+        GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] sequence_element_size = " << sequence_element_size << std::endl;
+        GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] max_sequence_elements = " << max_sequence_elements << std::endl;
+        GPU_DEBUG_TRACE_DETAIL << "[get_max_pad] max_pad (max_sequence_elements - concat_axis_size) = " << max_pad << std::endl;
+        return max_pad;
+    }
+
     typed_primitive_inst(network& network, const kv_cache_node& desc);
     typed_primitive_inst(network& network) : parent(network), memory_state::variable("") {}
 };

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -229,6 +229,8 @@ public:
     void set_shape_change() { _shape_changed = true; }
 
     void build_deps();
+
+    void init_variable();
     void do_runtime_skip_reorder();
     void do_runtime_skip_gather();
     void do_runtime_skip_permute();

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -230,7 +230,7 @@ public:
 
     void build_deps();
 
-    void init_variable();
+    void update_paddings();
     void do_runtime_skip_reorder();
     void do_runtime_skip_gather();
     void do_runtime_skip_permute();

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -463,29 +463,44 @@ event::ptr primitive_inst::realloc_if_needed() {
     if (_node->is_type<input_layout>())
         return ev;
 
+    auto& sp = *get_network().get_shape_predictor();
+    auto dt_size = ov::element::Type(actual_layout.data_type).bitwidth();
     // read_value/assign nodes are supposed to always use variable memory
     if (auto stateful_prim = dynamic_cast<memory_state::variable*>(this)) {
         std::string variable_id = stateful_prim->variable_id();
         auto& variable = get_network().get_variable(variable_id);
-        GPU_DEBUG_TRACE_DETAIL << "realloc_if_needed: variable " << id() << " set layout" << _impl_params->get_output_layout().to_string() << std::endl;
         if (_node->is_type<kv_cache>()) {
             // Reuse state memory as output for kv cache if possible
             // otherwise clear _outputs for the cases when mem was reused previously
             if (_impl_params->can_be_optimized()) {
+                GPU_DEBUG_TRACE_DETAIL << id() << " : realloc_if_needed: Set kvcache output memmory as variable memory " << variable.get_memory()->buffer_ptr()
+                                    << " (ptr: " << variable.get_memory()->buffer_ptr()
+                                    << ", actual_size: " << variable.get_actual_mem_size()/8 << " bytes"
+                                    << ", variable layout " << variable.get_layout().to_short_string() << ")" << std::endl;
+
                 _outputs[0] = variable.get_memory();
+                // To record shape predictor
+                auto prealloc_info = sp.predict_preallocation_shape(id(), _impl_params->output_layouts[0].get_shape(), dt_size, true);
                 return ev;
             } else if (_outputs[0] && variable.get_memory() && get_network().get_engine().is_the_same_buffer(*_outputs[0], *variable.get_memory())) {
+                GPU_DEBUG_TRACE_DETAIL << id() << " : realloc_if_needed: Reset output mem" << std::endl;
                 _outputs[0] = nullptr;
                 _max_output_layout_count = 0;
+            } else {
+                GPU_DEBUG_TRACE_DETAIL << id() << " : realloc_if_needed: can_be_optimized = false and memories are not being shared" << std::endl;
             }
+        } else {
+            variable.set_layout(_impl_params->output_layouts[0]);
+            GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable (ptr: " << variable.get_memory()->buffer_ptr()
+                                   << ", actual_size:" << variable.get_actual_mem_size() << " bytes"
+                                   << ", variable layout:" << variable.get_layout().to_short_string() << ")" << std::endl;
         }
-        variable.set_layout(actual_layout);
-        GPU_DEBUG_TRACE_DETAIL << id() << ": use variable memory " << variable.get_memory()->buffer_ptr()
-                               << " (size=" << variable.get_memory()->size() << ")" << std::endl;
         // For nodes that can be optimized, variable memory is used as output memory
         // so there is no need for output memory reallocation
-        if (can_be_optimized())
+        if (can_be_optimized()) {
+            _max_output_layout_count = variable.get_actual_mem_size() / (dt_size / 8);
             return ev;
+        }
     }
 
     // Update output layout with respect to FC's fake alignment
@@ -507,14 +522,14 @@ event::ptr primitive_inst::realloc_if_needed() {
         }
     }
 
-    if (_node->is_type<gather>() || _node->is_type<permute>()) {
-        // For the nodes which can be optimized at runtime, input memory is used as output memory
-        // So there is no need to reallocate output memory
-        if (can_be_optimized())
+    // Clear out memory if if was previously reused, but now primitive can't be optimized
+    if (_node->is_type<gather>() || _node->is_type<permute>() || _node->is_type<reshape>() || _node->is_type<reorder>()) {
+        if (can_be_optimized()) {
+            _max_output_layout_count = _deps[0].first->_max_output_layout_count;
             return ev;
-        // Clear out memory if if was previously reused, but now primitive can't be optimized
-        if (!can_be_optimized() && _outputs[0] && dep_memory_ptr(0)
-            && _network.get_engine().is_the_same_buffer(dep_memory(0), output_memory(0))) {
+        } else if (_outputs[0] && dep_memory_ptr(0) &&
+                   _network.get_engine().is_the_same_buffer(dep_memory(0), output_memory(0))) {
+            // Clear out memory if if was previously reused, but now primitive can't be optimized
             _outputs[0] = nullptr;
             _max_output_layout_count = 0;
         }
@@ -522,16 +537,22 @@ event::ptr primitive_inst::realloc_if_needed() {
 
     // update layout to ensure that it repsects paddings for correct allocation size
     if (_node_output_layout.data_padding.get_dynamic_pad_dims() != tensor(0)) {
-        const auto current_buf_size = updated_layout.get_buffer_size().sizes();
-        updated_layout = layout(ov::Shape(current_buf_size.begin(), current_buf_size.end()), updated_layout.data_type, updated_layout.format);
+        //const auto current_buf_size = updated_layout.get_buffer_size().sizes();
+        size_t rank = updated_layout.get_shape().size();
+        auto current_buf_shape = updated_layout.get_buffer_size().get_partial_shape(rank, std::min(4UL, rank));
+        updated_layout = layout(current_buf_shape, updated_layout.data_type, updated_layout.format);
+    }
+
+
+    // If we allocated too large memory, reclaim the memory.
+    if (updated_layout.count() * 10 < _max_output_layout_count) {
+        GPU_DEBUG_TRACE_DETAIL << id() << ": Updated output size " << updated_layout.count()
+                               << " is much smaller than current memory size! " << _max_output_layout_count
+                               << "Reset memory" << std::endl;
+        _max_output_layout_count = 0;
     }
 
     bool can_reuse_buffer = _outputs[0] && updated_layout.count() <= _max_output_layout_count;
-
-    // If we allocated too large memory, reclaim the memory.
-    if (updated_layout.count() * 10 < _max_output_layout_count)
-        can_reuse_buffer = false;
-
     // Handle runtime dynamic concat optimization
     if (_node->is_type<concatenation>() && can_be_optimized() && allocation_done_by_other) {
         allocation_done_by_other = false;
@@ -539,16 +560,21 @@ event::ptr primitive_inst::realloc_if_needed() {
     }
 
     auto current_shape = updated_layout.get_shape();
-    auto& sp = *get_network().get_shape_predictor();
-    auto dt_size = ov::element::Type(updated_layout.data_type).bitwidth();
-    auto prealloc_info = sp.predict_preallocation_shape(id(), current_shape, dt_size, can_reuse_buffer);
+    std::pair<bool, ov::Shape> prealloc_info;
+    int32_t tmp_prealloc_count = _node->is_type<kv_cache>() ? kv_cache_inst::get_prealloc_iter_num() : -1;
+    GPU_DEBUG_IF(debug_config->mem_preallocation_params.is_initialized) {
+        // If debug config is set, repsect the config most
+        tmp_prealloc_count = -1;
+    }
+    prealloc_info = sp.predict_preallocation_shape(id(), current_shape, dt_size, can_reuse_buffer, tmp_prealloc_count);
+
     if (prealloc_info.first && sp.can_preallocate(ov::shape_size(prealloc_info.second) * dt_size)) {
         auto new_layout = updated_layout;
         new_layout.set_partial_shape(prealloc_info.second);
         updated_params.output_layouts[0] = new_layout;
     }
 
-    if (updated_params.output_layouts[0].count() < updated_layout.count())
+    if (updated_params.output_layouts[0].get_buffer_size().count() < updated_layout.get_buffer_size().count())
         updated_params.output_layouts[0] = updated_layout;
 
     if (can_reuse_buffer) {
@@ -567,8 +593,61 @@ event::ptr primitive_inst::realloc_if_needed() {
                                <<  " Requested buffer_size=" << updated_layout.count() << std::endl;
         _outputs = allocate_outputs(&updated_params, need_reset_output_memory(), true);
         // TODO : need to handle multiple outputs
-        _max_output_layout_count = updated_params.output_layouts[0].count();
+        _max_output_layout_count = updated_params.output_layouts[0].get_buffer_size().count();
     }
+    // Set variable memory same as output memory
+    if (_node->is_type<kv_cache>()) {
+        auto desc = _node->as<kv_cache>().get_primitive();
+        auto& variable = get_network().get_variable(desc->variable_info.variable_id);
+        auto present_layout = _impl_params->output_layouts[0];
+        const auto& sequence_axis = desc->concat_axis;
+        auto sequence_axis_legacy =
+            kv_cache_inst::get_sequence_axis_legacy(sequence_axis, present_layout.get_partial_shape().size());
+        GPU_DEBUG_TRACE_DETAIL << id() << " is kv_cache => set the variable with newly allocated output memory"
+                               << std::endl;
+        bool axis_is_outer_most = true;
+        for (int64_t dim = 0; dim < sequence_axis; ++dim) {
+            if (present_layout.get_shape()[dim] > 1) {
+                axis_is_outer_most = false;
+                break;
+            }
+        }
+        if (present_layout.data_padding.get_dynamic_pad_dims().sizes()[sequence_axis_legacy] == 1) {
+            // Apply padding of variable to make it be optimized in the next iteration
+            auto max_pad = kv_cache_inst::get_max_pad(present_layout,
+                                                      updated_params.output_layouts[0].get_buffer_size().count(),
+                                                      sequence_axis_legacy,
+                                                      "present_layout");
+            if (max_pad > 0) {
+                kv_cache_inst::update_pad(present_layout, max_pad, sequence_axis_legacy);
+                if (!axis_is_outer_most) {
+                    GPU_DEBUG_TRACE_DETAIL << id() << ": Update impl with new output padding" << std::endl;
+                    set_shape_change();
+                    _impl_params->output_layouts[0] = present_layout;
+                    update_impl();
+                }
+                GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable " << variable.get_name()
+                                       << "'s memory with allocated kv cache output: "
+                                       << present_layout.to_short_string() << " is_set  = " << variable.is_set()
+                                       << std::endl;
+                variable.set_memory(_outputs[0], present_layout);
+                _impl_params->_can_be_optimized = true;
+                // No need to copy, still it can be optimized
+                GPU_DEBUG_TRACE_DETAIL << id() << ": Set can_be_optimized = true " << std::endl;
+            } else {
+                GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable " << variable.get_name()
+                                       << "'s layout with allocated kv cache output: " << present_layout.to_short_string()
+                                       << " (is_set  = " << variable.is_set() << ") " << std::endl;
+                variable.set_layout(present_layout);
+            }
+        } else {
+            GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable " << variable.get_name()
+                                   << "'s layout with allocated kv cache output: " << present_layout.to_short_string()
+                                   << " (is_set  = " << variable.is_set() << ") " << std::endl;
+            variable.set_layout(present_layout);
+        }
+    }
+
     _mem_allocated = true;
     // intermediate memory allocation is required for primitives consisting of multiple kernels in dynamic case
     {
@@ -780,6 +859,30 @@ bool primitive_inst::update_impl() {
     return true;
 }
 
+void primitive_inst::init_variable() {
+    auto reset_pad = [](kernel_impl_params& params, const program_node* node) {
+        params.output_layouts[0].data_padding = node->get_output_layout(0).data_padding;
+    };
+    if (_node->is_type<read_value>()) {
+        auto& variable = get_network().get_variable(_node->as<read_value>().get_primitive()->variable_id);
+        // Reset paddings for read_value and users with dynamic pad when variable is reset
+        // to avoid wrong pad used for some nodes due to pad propagation logic (which uses previous iter pad values)
+        if (!variable.is_set()) {
+            primitive_inst* inst = this;
+            while (inst) {
+                reset_pad(*inst->_impl_params, inst->_node);
+                auto& users = inst->_node->get_users();
+                if (users.size() == 1 && users.front()->get_output_layout(0).data_padding.get_dynamic_pad_dims() != tensor(0)) {
+                    inst = inst->get_user_insts().front();
+                } else {
+                    inst = nullptr;
+                }
+            }
+        }
+        return;
+    }
+}
+
 void primitive_inst::do_runtime_skip_reorder() {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, openvino::itt::handle("do_runtime_skip_reorder: " + id()));
     GPU_DEBUG_GET_INSTANCE(debug_config);
@@ -843,24 +946,6 @@ void primitive_inst::do_runtime_in_place_kv_cache() {
     auto reset_pad = [](kernel_impl_params& params, const program_node* node) {
         params.output_layouts[0].data_padding = node->get_output_layout(0).data_padding;
     };
-    if (_node->is_type<read_value>()) {
-        auto& variable = get_network().get_variable(_node->as<read_value>().get_primitive()->variable_id);
-        // Reset paddings for read_value and users with dynamic pad when variable is reset
-        // to avoid wrong pad used for some nodes due to pad propagation logic (which uses previous iter pad values)
-        if (!variable.is_set()) {
-            primitive_inst* inst = this;
-            while (inst) {
-                reset_pad(*inst->_impl_params, inst->_node);
-                auto& users = inst->_node->get_users();
-                if (users.size() == 1 && users.front()->get_output_layout(0).data_padding.get_dynamic_pad_dims() != tensor(0)) {
-                    inst = inst->get_user_insts().front();
-                } else {
-                    inst = nullptr;
-                }
-            }
-        }
-        return;
-    }
 
     if (_node->is_type<gather>() && _impl_params->output_layouts[0].data_padding.get_dynamic_pad_dims() != tensor(0)) {
         if (can_be_optimized())
@@ -874,57 +959,37 @@ void primitive_inst::do_runtime_in_place_kv_cache() {
         return;
 
     _impl_params->_can_be_optimized = false;
+
     if (_impl_params->get_input_layout(0).count() == 0) {
         return;
     }
-
     auto desc = _node->as<kv_cache>().get_primitive();
     auto& past_layout = _impl_params->input_layouts[0];
     auto& present_layout = _impl_params->output_layouts[0];
     const auto& sequence_axis = desc->concat_axis;
 
-    auto sequence_axis_legacy = sequence_axis;
-    if (sequence_axis_legacy >= 2) {
-        auto spatial_axis = sequence_axis_legacy - 2;
-        // Default and minimum number of dimensions is 4
-        auto spatial_size = std::max<size_t>(past_layout.get_partial_shape().size(), 4) - 2;
-        sequence_axis_legacy = spatial_size - spatial_axis - 1 + 2;
-    }
-
+    auto sequence_axis_legacy = kv_cache_inst::get_sequence_axis_legacy(sequence_axis, past_layout.get_partial_shape().size());
     if (present_layout.data_padding.get_dynamic_pad_dims().sizes()[sequence_axis_legacy] != 1)
         return;
 
-    const size_t total_elements = past_layout.count();
-    const int64_t concat_axis_size = past_layout.get_partial_shape()[sequence_axis].get_length();
-    const int64_t sequence_element_size = total_elements / concat_axis_size;
-
-    const int64_t max_sequence_elements = _deps[0].first->_max_output_layout_count / sequence_element_size;
-    const int64_t max_pad = std::max<int64_t>(max_sequence_elements - concat_axis_size, 0);
+    GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] " << id() << " initial present_layout : " << present_layout.to_string() << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] " << id() << " initial past_layout : " << past_layout.to_string() << std::endl;
+    auto max_pad = kv_cache_inst::get_max_pad(past_layout, _deps[0].first->_max_output_layout_count, sequence_axis_legacy, "past_layout");
 
     if (max_pad > 0) {
-        auto update_pad = [&](layout& l, int64_t pad) {
-            const auto& dyn_pad_dims = l.data_padding.get_dynamic_pad_dims();
-            const auto& lower_padd = l.data_padding.lower_size().sizes();
-            auto upper_padd = l.data_padding.upper_size().sizes();
-            upper_padd[sequence_axis_legacy] = pad;
-            l.data_padding = padding(lower_padd, upper_padd, 0.f, dyn_pad_dims);
-        };
-
-        update_pad(present_layout, max_pad - 1);
+        kv_cache_inst::update_pad(present_layout, max_pad - 1, sequence_axis_legacy);
+        GPU_DEBUG_TRACE_DETAIL << "[do runtime_in_place_kv_cache] " << id() << " Updated present_layout's pad : " << present_layout.to_string() << std::endl;
         auto& variable = get_network().get_variable(desc->variable_info.variable_id);
-        GPU_DEBUG_TRACE_DETAIL << "do_runtime_in_place_kv_cache set_layout: " << present_layout.to_string() << " is_set  = " << variable.is_set() << std::endl;
         variable.set_layout(present_layout);
+        GPU_DEBUG_TRACE_DETAIL << "[do_runtime_in_place_kv_cache] " << id() << "Updated variable with present_layout"
+                               << variable.get_layout().to_string() << " is_set  = " << variable.is_set() << std::endl;
         if (past_layout.data_padding.upper_size().sizes()[sequence_axis_legacy] > 0 && variable.is_set()) {
-            update_pad(past_layout, max_pad);
+            kv_cache_inst::update_pad(past_layout, max_pad, sequence_axis_legacy);
             _impl_params->_can_be_optimized = true;
+            GPU_DEBUG_TRACE_DETAIL << "[do_runtime_in_place_kv_cache] " << id() << " Updated past layout's pad : " << past_layout.to_string() << std::endl;
         }
-        GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] concat_axis_size = " << concat_axis_size << std::endl;
-        GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] sequence_element_size = " << sequence_element_size << std::endl;
-        GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] max_sequence_elements = " << max_sequence_elements << std::endl;
-        GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] max_pad = " << max_pad << std::endl;
-        GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] can be optimized: " << _impl_params->_can_be_optimized << std::endl;
-        GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] " << present_layout.to_string() << std::endl;
     }
+    GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] " << id() << " can be optimized: " << _impl_params->_can_be_optimized << std::endl;
 }
 
 void primitive_inst::do_runtime_skip_gather() {
@@ -1117,7 +1182,6 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
         OPENVINO_ASSERT(_node != nullptr, "[GPU] Invalid primitive_inst object for dynamic shapes case: program_node can't be null");
         update_shape();
 
-        do_runtime_in_place_kv_cache();
 
         bool can_skip_execution = false;
         if (_impl_params->output_layouts[0].count() == 0) {
@@ -1148,8 +1212,10 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
         // Check successor reorder if layouts are same
         // Need to set can_be_optimized for user reorder at predecessor because
         // if the user is can_be_optimized and output node then current nodes' output should be allocated to host.
+        init_variable();
         do_runtime_skip_reorder();
         do_runtime_skip_gather();
+        do_runtime_in_place_kv_cache();
         do_runtime_skip_permute();
 
         if (!is_valid_fusion()) {

--- a/src/plugins/intel_gpu/src/graph/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/read_value.cpp
@@ -40,6 +40,10 @@ void read_value_inst::update_output_memory() {
         return;
 
     const auto& variable = get_network().get_variable(variable_id());
+    GPU_DEBUG_TRACE_DETAIL << id() << " Update output memory with variable " << variable_id() << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << " - ptr : " << variable.get_memory()->buffer_ptr() << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << " - layout " << variable.get_layout().to_string() << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << " - actual_size " << variable.get_actual_mem_size() << " bytes" << std::endl;
     set_output_memory(variable.get_memory(), false, 0);
 }
 } // namespace cldnn

--- a/src/plugins/intel_gpu/src/plugin/variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/variable_state.cpp
@@ -47,9 +47,20 @@ void VariableState::set() {
     m_is_set = true;
 }
 
+void VariableState::set_memory(const cldnn::memory::ptr& new_mem, const cldnn::layout& actual_layout) {
+    GPU_DEBUG_TRACE_DETAIL << m_name << " : Update memory (Ptr : " << new_mem->buffer_ptr()
+                           << ", layout : " << actual_layout.to_short_string() << ")" << std::endl;
+    m_memory = new_mem;
+    m_layout = actual_layout;
+    actual_size = m_memory->size();
+    update_device_buffer();
+}
+
 void VariableState::set_layout(const cldnn::layout& new_layout) {
+    if (m_layout == new_layout)
+        return;
     m_layout = new_layout;
-    GPU_DEBUG_TRACE_DETAIL << "Update state layout to " << new_layout.to_short_string() << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << m_name << " : " << "Update state layout to " << new_layout.to_short_string() << std::endl;
     update_device_buffer();
 }
 
@@ -61,8 +72,12 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
 }
 
 void VariableState::update_device_buffer() {
-    if (m_layout.is_dynamic() || m_layout.bytes_count() == 0)
+    if (m_layout.is_dynamic() || m_layout.bytes_count() == 0) {
+        m_shape_predictor->reset();
+        m_memory.reset();
+        actual_size = 0;
         return;
+    }
 
     if (actual_size < m_layout.bytes_count()) {
         const auto alloc_type = m_context->get_engine().use_unified_shared_memory() ? cldnn::allocation_type::usm_device : cldnn::allocation_type::cl_mem;


### PR DESCRIPTION
### Details:
 - Fixed wrong behavior w.r.t skipped primitives' max_output_layout_size
 - Increased can_be_optimized = true hit for kv cache ops 
 - Enabled more prealloc for kv cache opts 
 - Reduced peak memory required for stateful model by memory sharing b/w kv cache output and variable in the next iteration  


