### PR TITLE
[GPU] Fuse type conversion only reorders to the prev FC nodes

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -97,8 +97,8 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
     auto input_pshape = input_layout.get_partial_shape();
     auto weights_layout = *impl_param.weights_layout;
     auto weights_pshape = weights_layout.get_partial_shape();
-    auto output_type = input_layout.data_type;
-    if ((output_type == data_types::u8 || output_type == data_types::i8) && desc->output_data_types[0])
+    auto output_type = desc->output_data_types[0].value_or(input_layout.data_type);
+    if (data_type_traits::is_i8_u8(input_layout.data_type) && desc->output_data_types[0])
         output_type = *desc->output_data_types[0];
 
     if (impl_param.has_fused_primitives()) {
@@ -139,8 +139,8 @@ std::vector<layout> fully_connected_inst::calc_output_layouts(fully_connected_no
     auto input_layout = impl_param.get_input_layout();
     auto weights_layout = *impl_param.weights_layout;
 
-    auto output_type = input_layout.data_type;
-    if (data_type_traits::is_i8_u8(output_type) && desc->output_data_types[0])
+    auto output_type = desc->output_data_types[0].value_or(input_layout.data_type);
+    if (data_type_traits::is_i8_u8(input_layout.data_type) && desc->output_data_types[0])
         output_type = *desc->output_data_types[0];
 
     if (impl_param.has_fused_primitives()) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_convert_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_convert_fusion.cpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "fc_convert_fusion.hpp"
+
+#include "intel_gpu/op/fully_connected.hpp"
+#include "intel_gpu/op/fully_connected_compressed.hpp"
+
+#include "openvino/core/rt_info.hpp"
+#include "openvino/pass/pattern/op/or.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace ov {
+namespace intel_gpu {
+
+FullyConnectedConvertFusion::FullyConnectedConvertFusion() {
+    using namespace ov::pass::pattern;
+
+    auto data = any_input();
+    auto weights = any_input();
+    auto fully_connected = wrap_type<op::FullyConnected>({data, weights}, consumers_count(1));
+    auto fully_connected_compressed = wrap_type<op::FullyConnectedCompressed>({data, weights, any_input(), any_input()}, consumers_count(1));
+    auto fc = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{fully_connected, fully_connected_compressed});
+    auto convert = wrap_type<ov::op::v0::Convert>({fc}, type_matches(element::f32));
+
+    ov::matcher_pass_callback callback = [=](Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+
+        const auto& m_data = pattern_map.at(data).get_node_shared_ptr();
+        const auto& m_weights = pattern_map.at(weights).get_node_shared_ptr();
+        const auto& m_convert = pattern_map.at(convert).get_node_shared_ptr();
+        auto output_type = m_convert->get_output_element_type(0);
+
+        std::shared_ptr<Node> m_fc = nullptr;
+        std::shared_ptr<Node> new_fc = nullptr;
+        auto it = pattern_map.find(fully_connected);
+        if (it != pattern_map.end()) {
+            m_fc = it->second.get_node_shared_ptr();
+            new_fc = std::make_shared<op::FullyConnected>(m_data, m_weights, output_type);
+        } else {
+            m_fc = pattern_map.at(fully_connected_compressed).get_node_shared_ptr();
+            new_fc = std::make_shared<op::FullyConnectedCompressed>(m_data,
+                                                                    m_weights,
+                                                                    m_fc->input_value(2),
+                                                                    m_fc->input_value(3),
+                                                                    output_type);
+        }
+        new_fc->set_friendly_name(m_convert->get_friendly_name());
+        copy_runtime_info(m.get_matched_nodes(), new_fc);
+        replace_node(m_convert, new_fc);
+
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(convert, "FullyConnectedConvertFusion");
+    this->register_matcher(m, callback);
+}
+
+}  // namespace intel_gpu
+}  // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_convert_fusion.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_convert_fusion.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov {
+namespace intel_gpu {
+
+class FullyConnectedConvertFusion: public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("FullyConnectedConvertFusion", "0");
+    FullyConnectedConvertFusion();
+};
+
+}   // namespace intel_gpu
+}   // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -122,6 +122,7 @@
 #include "plugin/transformations/binary_conv_to_conv.hpp"
 #include "plugin/transformations/move_convert_after_gather.hpp"
 #include "plugin/transformations/kv_cache_fusion.hpp"
+#include "plugin/transformations/fc_convert_fusion.hpp"
 
 #include "transformations/low_precision/mark_dequantization_subgraph.hpp"
 #include "low_precision/pull_reshape_through_dequantization.hpp"
@@ -698,6 +699,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::ConvertGatherToGatherCompressed>();
         manager.register_pass<ov::intel_gpu::RMSFusion>();
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
+        manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
 
         // This is supposed to be the last pass to ensure that we don't have name collisions until
         // GPU plugin stops using friendly names for program creation

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/matmul_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/matmul_si_test.cpp
@@ -110,7 +110,7 @@ INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_test,
         {
             layout{ov::PartialShape{10, 1024}, data_types::f32, format::bfyx},
             layout{ov::PartialShape{1000, 1024}, data_types::f32, format::bfyx},
-            data_types::i32, false, false,
+            data_types::f32, false, false,
             layout{ov::PartialShape{10, 1000}, data_types::f32, format::bfyx}
         },
         {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1212,7 +1212,7 @@ public:
             input_layout("input", input_mem->get_layout()),
             data("weights", weights_mem),
             data("scale", scale_mem),
-            fully_connected("fc_prim", input_info("input"), "weights", "", "scale", "", data_types::f32, padding(), 2, 2)
+            fully_connected("fc_prim", input_info("input"), "weights", "", "scale", "", data_types::f16, padding(), 2, 2)
         );
 
         auto config = get_test_default_config(engine);

--- a/src/plugins/intel_gpu/tests/unit/transformations/fc_convert_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/fc_convert_fusion_test.cpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include <openvino/core/model.hpp>
+#include <openvino/pass/manager.hpp>
+#include "common_test_utils/ov_test_utils.hpp"
+#include <transformations/utils/utils.hpp>
+
+#include <plugin/transformations/fc_convert_fusion.hpp>
+
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/parameter.hpp"
+#include "intel_gpu/op/fully_connected.hpp"
+#include "intel_gpu/op/fully_connected_compressed.hpp"
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+TEST_F(TransformationTestsF, FullyConnectedConvertFusionTest1) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 16 }, { 1 });
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weights_const, scale_const, zp_const);
+        auto convert = std::make_shared<ov::op::v0::Convert>(fc_compressed, ov::element::f32);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{input});
+        manager.register_pass<FullyConnectedConvertFusion>();
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 16 }, { 1 });
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weights_const, scale_const, zp_const, ov::element::f32);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input });
+    }
+}
+
+TEST_F(TransformationTestsF, FullyConnectedConvertFusionTest2) {
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{3, 2, 2});
+        auto input2 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{2, 2}, {1});
+        auto matmul = std::make_shared<op::FullyConnected>(input1, input2);
+        auto convert = std::make_shared<ov::op::v0::Convert>(matmul, ov::element::f32);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{input1});
+        manager.register_pass<FullyConnectedConvertFusion>();
+    }
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{3, 2, 2});
+        auto input2 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{2, 2}, {1});
+        auto matmul = std::make_shared<op::FullyConnected>(input1, input2, ov::element::f32);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+    }
+}


### PR DESCRIPTION
### Details:
 - Added internal transformation which fuse `Convert` with `FC` or `FC compressed`
 - This is the initial work to finally optimize `FC->Convert->Reshape->Eltwise` pattern

### Tickets:
 - 128739
