### PR TITLE
[PyOV] Add optional string decoding for InferRequest and CompiledModel inference calls

### DIFF
--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -116,6 +116,14 @@ class InferRequest(_InferRequestWrapper):
 
                               Default value: False
         :type share_outputs: bool, optional
+        :param decode_strings: Controls decoding outputs of textual based data.
+
+                               If set to `True` string outputs will be returned as numpy arrays of `U` kind.
+
+                               If set to `False` string outputs will be returned as numpy arrays of `S` kind.
+
+                               Default value: False
+        :type decode_strings: bool, optional, keyword-only
 
         :return: Dictionary of results from output tensors with port/int/str keys.
         :rtype: OVDict
@@ -337,6 +345,14 @@ class CompiledModel(CompiledModelBase):
 
                               Default value: False
         :type share_outputs: bool, optional
+        :param decode_strings: Controls decoding outputs of textual based data.
+
+                               If set to `True` string outputs will be returned as numpy arrays of `U` kind.
+
+                               If set to `False` string outputs will be returned as numpy arrays of `S` kind.
+
+                               Default value: True
+        :type decode_strings: bool, optional, keyword-only
 
         :return: Dictionary of results from output tensors with port/int/str as keys.
         :rtype: OVDict

--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -57,6 +57,8 @@ class InferRequest(_InferRequestWrapper):
         inputs: Any = None,
         share_inputs: bool = False,
         share_outputs: bool = False,
+        *,
+        decode_strings: bool = False,
     ) -> OVDict:
         """Infers specified input(s) in synchronous mode.
 
@@ -122,7 +124,7 @@ class InferRequest(_InferRequestWrapper):
             self,
             inputs,
             is_shared=share_inputs,
-        ), share_outputs=share_outputs))
+        ), share_outputs=share_outputs, decode_strings=decode_strings))
 
     def start_async(
         self,
@@ -268,6 +270,8 @@ class CompiledModel(CompiledModelBase):
         inputs: Any = None,
         share_inputs: bool = True,
         share_outputs: bool = False,
+        *,
+        decode_strings: bool = True,
     ) -> OVDict:
         """Callable infer wrapper for CompiledModel.
 
@@ -344,6 +348,7 @@ class CompiledModel(CompiledModelBase):
             inputs,
             share_inputs=share_inputs,
             share_outputs=share_outputs,
+            decode_strings=decode_strings,
         )
 
 

--- a/src/bindings/python/src/pyopenvino/core/common.cpp
+++ b/src/bindings/python/src/pyopenvino/core/common.cpp
@@ -499,7 +499,7 @@ uint32_t get_optimal_number_of_requests(const ov::CompiledModel& actual) {
     }
 }
 
-py::dict outputs_to_dict(InferRequestWrapper& request, bool share_outputs) {
+py::dict outputs_to_dict(InferRequestWrapper& request, bool share_outputs, bool decode_strings) {
     py::dict res;
     for (const auto& out : request.m_outputs) {
         auto t = request.m_request.get_tensor(out);
@@ -507,7 +507,12 @@ py::dict outputs_to_dict(InferRequestWrapper& request, bool share_outputs) {
             if (share_outputs) {
                 PyErr_WarnEx(PyExc_RuntimeWarning, "Result of a string type will be copied to OVDict!", 1);
             }
-            res[py::cast(out)] = string_helpers::string_array_from_tensor(std::move(t));
+            if (decode_strings) {
+                res[py::cast(out)] = string_helpers::string_array_from_tensor(std::move(t));
+            }
+            else {
+                res[py::cast(out)] = string_helpers::bytes_array_from_tensor(std::move(t));
+            }
         } else {
             res[py::cast(out)] = array_helpers::array_from_tensor(std::move(t), share_outputs);
         }

--- a/src/bindings/python/src/pyopenvino/core/common.hpp
+++ b/src/bindings/python/src/pyopenvino/core/common.hpp
@@ -116,7 +116,7 @@ void set_request_tensors(ov::InferRequest& request, const py::dict& inputs);
 
 uint32_t get_optimal_number_of_requests(const ov::CompiledModel& actual);
 
-py::dict outputs_to_dict(InferRequestWrapper& request, bool share_outputs);
+py::dict outputs_to_dict(InferRequestWrapper& request, bool share_outputs, bool decode_strings);
 
 ov::pass::Serialize::Version convert_to_version(const std::string& version);
 

--- a/src/bindings/python/src/pyopenvino/core/infer_request.cpp
+++ b/src/bindings/python/src/pyopenvino/core/infer_request.cpp
@@ -14,14 +14,14 @@
 
 namespace py = pybind11;
 
-inline py::object run_sync_infer(InferRequestWrapper& self, bool share_outputs) {
+inline py::object run_sync_infer(InferRequestWrapper& self, bool share_outputs, bool decode_strings) {
     {
         py::gil_scoped_release release;
         *self.m_start_time = Time::now();
         self.m_request.infer();
         *self.m_end_time = Time::now();
     }
-    return Common::outputs_to_dict(self, share_outputs);
+    return Common::outputs_to_dict(self, share_outputs, decode_strings);
 }
 
 void regclass_InferRequest(py::module m) {
@@ -167,12 +167,13 @@ void regclass_InferRequest(py::module m) {
     // Overload for single input, it will throw error if a model has more than one input.
     cls.def(
         "infer",
-        [](InferRequestWrapper& self, const ov::Tensor& inputs, bool share_outputs) {
+        [](InferRequestWrapper& self, const ov::Tensor& inputs, bool share_outputs, bool decode_strings) {
             self.m_request.set_input_tensor(inputs);
-            return run_sync_infer(self, share_outputs);
+            return run_sync_infer(self, share_outputs, decode_strings);
         },
         py::arg("inputs"),
         py::arg("share_outputs"),
+        py::arg("decode_strings"),
         R"(
             Infers specified input(s) in synchronous mode.
             Blocks all methods of InferRequest while request is running.
@@ -194,14 +195,15 @@ void regclass_InferRequest(py::module m) {
     // and values are always of type: ov::Tensor.
     cls.def(
         "infer",
-        [](InferRequestWrapper& self, const py::dict& inputs, bool share_outputs) {
+        [](InferRequestWrapper& self, const py::dict& inputs, bool share_outputs, bool decode_strings) {
             // Update inputs if there are any
             Common::set_request_tensors(self.m_request, inputs);
             // Call Infer function
-            return run_sync_infer(self, share_outputs);
+            return run_sync_infer(self, share_outputs, decode_strings);
         },
         py::arg("inputs"),
         py::arg("share_outputs"),
+        py::arg("decode_strings"),
         R"(
             Infers specified input(s) in synchronous mode.
             Blocks all methods of InferRequest while request is running.
@@ -714,7 +716,7 @@ void regclass_InferRequest(py::module m) {
     cls.def_property_readonly(
         "results",
         [](InferRequestWrapper& self) {
-            return Common::outputs_to_dict(self, false);
+            return Common::outputs_to_dict(self, false, false);
         },
         R"(
             Gets all outputs tensors of this InferRequest.

--- a/src/bindings/python/tests/test_runtime/test_string_infer.py
+++ b/src/bindings/python/tests/test_runtime/test_string_infer.py
@@ -1,0 +1,107 @@
+import numpy as np
+import pytest
+
+import openvino.runtime.opset13 as ops
+from openvino import (
+    CompiledModel,
+    InferRequest,
+    Model,
+    Type,
+    compile_model,
+)
+
+
+def create_string_compiled_model(shape):
+    parameter = ops.parameter(shape, Type.string)
+    result = ops.result(parameter)
+ 
+    model = Model([result], [parameter])
+    compiled = compile_model(model)
+    return compiled
+
+
+def create_string_infer_request(shape):
+    return create_string_compiled_model(shape).create_infer_request()
+
+
+def as_bytes_array(data):
+    array = np.array(data)
+    return array if array.dtype.kind == "S" else np.char.encode(array)
+
+
+def as_string_array(data):
+    array = np.array(data)
+    return array if array.dtype.kind == "U" else np.char.decode(array)
+
+
+@pytest.mark.parametrize(
+    ("ov_func"),
+    [
+        create_string_compiled_model([-1]).__call__,
+        create_string_infer_request([-1]).infer,
+    ]
+)
+def test_keyword_only_decode_fails(ov_func):
+    print(ov_func)
+    with pytest.raises(TypeError) as error:
+        _ = ov_func([], False, False, False)
+    assert "takes from 1 to 4 positional arguments but 5 were given" in str(error.value)
+
+
+@pytest.mark.parametrize(
+    ("class_defaults", "expected_value"),
+    [
+        (CompiledModel.__call__.__kwdefaults__, True),
+        (InferRequest.infer.__kwdefaults__, False),
+    ],
+)
+def test_default_decode_flag(class_defaults, expected_value):
+    assert class_defaults["decode_strings"] == expected_value
+
+
+@pytest.mark.parametrize(
+    ("string_data", "data_shape"),
+    [
+        ([bytes("text", encoding="utf-8"), bytes("openvino", encoding="utf-8")], [-1]),
+        ([[b"xyz"], [b"abc"], [b"this is my last"]], [3, -1]),
+        (["text", "abc", "openvino"], [3]),
+        (["text", "больше текста", "jeszcze więcej słów", "효과가 있었어"], [-1]),
+        ([["text"], ["abc"], ["openvino"]], [3, 1]),
+        ([["jeszcze więcej słów", "효과가 있었어"]], [1, 2]),
+    ],
+)
+@pytest.mark.parametrize(
+    ("decode_strings"),
+    [
+        True,
+        False,
+    ],
+)
+def test_infer_request_infer(string_data, data_shape, decode_strings):
+    infer_request = create_string_infer_request(data_shape)
+    res = infer_request.infer(string_data, decode_strings=decode_strings)
+    assert np.array_equal(res[0], as_string_array(string_data) if decode_strings else as_bytes_array(string_data))
+
+
+@pytest.mark.parametrize(
+    ("string_data", "data_shape"),
+    [
+        ([bytes("text", encoding="utf-8"), bytes("openvino", encoding="utf-8")], [-1]),
+        ([[b"xyz"], [b"abc"], [b"this is my last"]], [3, -1]),
+        (["text", "abc", "openvino"], [3]),
+        (["text", "больше текста", "jeszcze więcej słów", "효과가 있었어"], [-1]),
+        ([["text"], ["abc"], ["openvino"]], [3, 1]),
+        ([["jeszcze więcej słów", "효과가 있었어"]], [1, 2]),
+    ],
+)
+@pytest.mark.parametrize(
+    ("decode_strings"),
+    [
+        True,
+        False,
+    ],
+)
+def test_compiled_model_infer(string_data, data_shape, decode_strings):
+    compiled_model = create_string_compiled_model(data_shape)
+    res = compiled_model(string_data, decode_strings=decode_strings)
+    assert np.array_equal(res[0], as_string_array(string_data) if decode_strings else as_bytes_array(string_data))

--- a/src/bindings/python/tests/test_runtime/test_string_infer.py
+++ b/src/bindings/python/tests/test_runtime/test_string_infer.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import pytest
 
@@ -14,7 +18,7 @@ from openvino import (
 def create_string_compiled_model(shape):
     parameter = ops.parameter(shape, Type.string)
     result = ops.result(parameter)
- 
+
     model = Model([result], [parameter])
     compiled = compile_model(model)
     return compiled
@@ -39,10 +43,9 @@ def as_string_array(data):
     [
         create_string_compiled_model([-1]).__call__,
         create_string_infer_request([-1]).infer,
-    ]
+    ],
 )
 def test_keyword_only_decode_fails(ov_func):
-    print(ov_func)
     with pytest.raises(TypeError) as error:
         _ = ov_func([], False, False, False)
     assert "takes from 1 to 4 positional arguments but 5 were given" in str(error.value)


### PR DESCRIPTION
### Details:
 - Add optional keyword-only flag `decode_strings` to determine if string-based outputs should be decoded to Python strings or kept as bytes. Decoding increases the time of the inference, with this change, it can be applied on demand by OV (advised approach) or using `np.char.decode`.
 - `CompiledModel.__call__`  **decodes by default**. Returns data as strings.
 - `InferRequest.infer` and `InferRequest.results` **do not decode by default**. Returns data as bytes.
 - Added testcases to cover the functionality.

### Tickets:
 - *128010*
