### PR TITLE
[GPU] Fixed mem alloc size and pad propagation for kv cache opt

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -521,10 +521,9 @@ event::ptr primitive_inst::realloc_if_needed() {
     }
 
     // update layout to ensure that it repsects paddings for correct allocation size
-    if (_node->is_type<kv_cache>() && !_impl_params->can_be_optimized()) {
+    if (_node_output_layout.data_padding.get_dynamic_pad_dims() != tensor(0)) {
         const auto current_buf_size = updated_layout.get_buffer_size().sizes();
-        ov::Shape current_shape(current_buf_size.begin(), current_buf_size.end());
-        updated_layout.set_partial_shape(current_shape);
+        updated_layout = layout(ov::Shape(current_buf_size.begin(), current_buf_size.end()), updated_layout.data_type, updated_layout.format);
     }
 
     bool can_reuse_buffer = _outputs[0] && updated_layout.count() <= max_output_layout_size;
@@ -535,12 +534,12 @@ event::ptr primitive_inst::realloc_if_needed() {
         return ev;
     }
 
-    auto current_shape = actual_layout.get_shape();
+    auto current_shape = updated_layout.get_shape();
     auto& sp = *get_network().get_shape_predictor();
-    auto dt_size = ov::element::Type(actual_layout.data_type).bitwidth();
+    auto dt_size = ov::element::Type(updated_layout.data_type).bitwidth();
     auto prealloc_info = sp.predict_preallocation_shape(id(), current_shape, dt_size, can_reuse_buffer);
     if (prealloc_info.first && sp.can_preallocate(ov::shape_size(prealloc_info.second) * dt_size)) {
-        auto new_layout = actual_layout;
+        auto new_layout = updated_layout;
         new_layout.set_partial_shape(prealloc_info.second);
         updated_params.output_layouts[0] = new_layout;
     }
@@ -559,7 +558,7 @@ event::ptr primitive_inst::realloc_if_needed() {
     } else {
         GPU_DEBUG_TRACE_DETAIL << id() << ": realloc output memory. "
                                <<  " Current buffer_size=" << max_output_layout_size
-                               <<  " Requested buffer_size=" << actual_layout.count() << std::endl;
+                               <<  " Requested buffer_size=" << updated_layout.count() << std::endl;
         _outputs = allocate_outputs(&updated_params, need_reset_output_memory(), true);
         // TODO : need to handle multiple outputs
         max_output_layout_size = updated_params.output_layouts[0].count();
@@ -974,11 +973,15 @@ void primitive_inst::do_runtime_skip_gather() {
         for (int64_t i = 0; i < static_cast<int32_t>(idx_shape[0]); ++i) {
             if (idx_data[i] != i) {
                 GPU_DEBUG_TRACE_DETAIL << "--- Cannot optimize because idx_data [" << i << "] (" << idx_data[i] << ") != " << i << std::endl;
+                if (_impl_params->output_layouts[0].data_padding.get_dynamic_pad_dims() != tensor(0))
+                    _impl_params->output_layouts[0].data_padding = padding();
                 set_can_be_optimized(false);
                 return;
             }
         }
     }
+    // propagate input layout including correct paddings.
+    _impl_params->output_layouts[0] = _impl_params->input_layouts[0];
     GPU_DEBUG_TRACE_DETAIL << "[do_runtime_skip_gather] " << id() << " : can_be_optimized" << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "            - Input layout : " << _impl_params->get_input_layout(0).to_short_string() << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "            - Indices layout : " << _impl_params->get_input_layout(1).to_short_string() << std::endl;

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/kv_cache.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/kv_cache.cpp
@@ -254,6 +254,7 @@ class KVCacheTests: public ::testing::Test {
     void test_smoke_multipleIterations_stateful(bool is_caching_test,
                                                 bool fuse_cache_reorder,
                                                 bool build_state_initializer,
+                                                size_t batch = 1,
                                                 ov::element::Type model_element_type = ov::element::f16) {
     #if defined(ANDROID)
         GTEST_SKIP();
@@ -277,7 +278,6 @@ class KVCacheTests: public ::testing::Test {
             properties.insert(ov::cache_dir(cacheDirName));
         }
 
-        const size_t batch = 1;
         const size_t n_heads = 32;
         const size_t n_features = 10;
         const size_t context_size = 20;
@@ -311,14 +311,23 @@ class KVCacheTests: public ::testing::Test {
         auto output0 = model->get_results().at(0);
 
         auto beam_idx_shape = ov::Shape{batch};
-        auto beam_idx_data = ov::Tensor(ov::element::i32, beam_idx_shape);
+
+        auto beam_idx_data_0 = ov::Tensor(ov::element::i32, beam_idx_shape);
+        auto beam_idx_data_1 = ov::Tensor(ov::element::i32, beam_idx_shape);
         for (size_t i = 0; i < batch; i++) {
-            beam_idx_data.data<int32_t>()[i] = i;
+            beam_idx_data_0.data<int32_t>()[i] = i;
+            beam_idx_data_1.data<int32_t>()[i] = batch - i - 1;
         }
 
-        auto get_ref_results = [&ref_model, fuse_cache_reorder, &beam_idx_shape, &beam_idx_data](const ov::Tensor& kv_cache,
-                                                                                                 const ov::Tensor& new_token_data,
-                                                                                                 const ov::Tensor& matmul_data) {
+        std::vector<ov::Tensor> beam_idx_data_array = {
+            beam_idx_data_0,
+            beam_idx_data_1,
+        };
+
+        auto get_ref_results = [&ref_model, fuse_cache_reorder, &beam_idx_shape](const ov::Tensor& kv_cache,
+                                                                                 const ov::Tensor& new_token_data,
+                                                                                 const ov::Tensor& matmul_data,
+                                                                                 const ov::Tensor& beam_idx_data) {
             auto input0 = ref_model->get_parameters().at(0);
             auto input1 = ref_model->get_parameters().at(1);
             auto input2 = ref_model->get_parameters().at(2);
@@ -367,9 +376,6 @@ class KVCacheTests: public ::testing::Test {
 
         infer_request.set_tensor(input0, new_token_input);
         infer_request.set_tensor(input1, matmul_input);
-        if (fuse_cache_reorder) {
-            infer_request.set_tensor(input2, beam_idx_data);
-        }
 
         for (size_t num_repeats = 0; num_repeats < 2; num_repeats++) {
             ov::Tensor ref_kv_cache;
@@ -388,9 +394,13 @@ class KVCacheTests: public ::testing::Test {
                 new_token_data.copy_to(new_token_input);
                 matmul_data.copy_to(matmul_input);
 
+                if (fuse_cache_reorder) {
+                    infer_request.set_tensor(input2, beam_idx_data_array[0]);
+                }
+
                 ref_kv_cache = ov::Tensor(element_type, kv_cache_size_initial);
 
-                auto ref_results = get_ref_results(ref_kv_cache, new_token_data, matmul_data);
+                auto ref_results = get_ref_results(ref_kv_cache, new_token_data, matmul_data, beam_idx_data_array[0]);
                 ref_kv_cache = ref_results[0];
 
                 infer_request.infer();
@@ -408,7 +418,11 @@ class KVCacheTests: public ::testing::Test {
                 ov::Shape matmul_in_size_loop = {batch, n_heads, input_tokens, context_length};
                 auto new_token_data = ov::test::utils::create_and_fill_tensor(element_type, new_token_size);
                 auto matmul_data = ov::test::utils::create_and_fill_tensor(element_type, matmul_in_size_loop);
-                auto ref_results = get_ref_results(ref_kv_cache, new_token_data, matmul_data);
+                if (fuse_cache_reorder) {
+                    infer_request.set_tensor(input2, beam_idx_data_array[i % beam_idx_data_array.size()]);
+                }
+
+                auto ref_results = get_ref_results(ref_kv_cache, new_token_data, matmul_data, beam_idx_data_array[i % beam_idx_data_array.size()]);
                 ref_kv_cache = ref_results[0];
 
                 new_token_input.set_shape(new_token_data.get_shape());
@@ -461,7 +475,10 @@ TEST_F(KVCacheTests, smoke_multipleIterations_stateful_gather_with_initializer_c
 }
 
 TEST_F(KVCacheTests, smoke_multipleIterations_stateful_gather_with_initializer_f32) {
-    this->test_smoke_multipleIterations_stateful(false, true, true, ov::element::f32);
+    this->test_smoke_multipleIterations_stateful(false, true, true, 1, ov::element::f32);
+}
+TEST_F(KVCacheTests, smoke_multipleIterations_stateful_gather_with_initializer_batch_3) {
+    this->test_smoke_multipleIterations_stateful(false, true, true, 3);
 }
 
 } // namespace


### PR DESCRIPTION
### Details:
 - Fixed dynamic pad handling in runtime gather opt. Before that fix pad could be lost in some cases which led to the wrong accuracy
 - Updated realloc_if_needed logic to merge paddings to updated_shape to ensure correct buffer size is used for allocation. It's needed to avoid an issue when shape predictor uses ration based approach for prealloc and squeeze all dimensions into 1 while padding is not modified. So we could have `[N, C, H, W] + [0, PAD, 0, 0]` case transformed to `[N*C*H*W*RATIO] + [0, PAD, 0, 0]` and final alloc size being `N*C*H*W*RATIO*PAD` while `N*(C+PAD)*H*W*RATIO` was expected

