### PR TITLE
[Snippets] Fixed access by expired reference

### DIFF
--- a/src/common/snippets/src/lowered/pass/allocate_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/allocate_buffers.cpp
@@ -67,18 +67,19 @@ void AllocateBuffers::set_buffer_offset(const ExpressionPtr& buffer_expr, const 
 bool AllocateBuffers::run(lowered::LinearIR& linear_ir) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::AllocateBuffers");
     m_buffer_scratchpad_size = 0;
-    PassPipeline pipeline;
+
     if (m_is_optimized_mode) {
         BufferClusters buffer_clusters;
+        PassPipeline pipeline;
         pipeline.register_pass<EnumerateExpressions>();
         pipeline.register_pass<IdentifyBuffers>();
         pipeline.register_pass<DefineBufferClusters>(buffer_clusters);
         pipeline.register_pass<SolveBufferMemory>(m_buffer_scratchpad_size, buffer_clusters);
         pipeline.register_pass<NormalizeBufferIDs>();
+        pipeline.run(linear_ir);
     } else {
-        pipeline.register_pass<InitBuffersDefault>(m_buffer_scratchpad_size);
+        InitBuffersDefault(m_buffer_scratchpad_size).run(linear_ir);
     }
-    pipeline.run(linear_ir);
 
     return m_buffer_scratchpad_size > 0;
 }


### PR DESCRIPTION
### Details:
 - *We inited the pass pipeline in `AllocateBuffers` in condition body `if (m_is_optimized_mode)` where some passes has reference on `BufferClusters buffer_clusters` as class field. After `if` body execution we run the pass pipeline with saved reference on the `buffer_clusters` that already destroyed. The PR suggests to create `buffer_clusters` and run the pass pipeline in the one code block.*

### Tickets:
 - *129379*
