### PR TITLE
[GPU] Add a config property for kernel cache capacity.

### DIFF
--- a/docs/articles_en/openvino_workflow/running_inference_with_openvino/Device_Plugins/GPU.rst
+++ b/docs/articles_en/openvino_workflow/running_inference_with_openvino/Device_Plugins/GPU.rst
@@ -421,6 +421,7 @@ All parameters must be set before calling ``ov::Core::compile_model()`` in order
 - ``ov::intel_gpu::hint::queue_throttle``
 - ``ov::intel_gpu::enable_loop_unrolling``
 - ``ov::intel_gpu::disable_winograd_convolution``
+- ``ov::intel_gpu::kernel_cache_capacity``
 
 Read-only Properties
 +++++++++++++++++++++++++++++++++++++++

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -108,6 +108,7 @@ void regmodule_properties(py::module m) {
 
     wrap_property_RW(m_intel_gpu, ov::intel_gpu::enable_loop_unrolling, "enable_loop_unrolling");
     wrap_property_RW(m_intel_gpu, ov::intel_gpu::disable_winograd_convolution, "disable_winograd_convolution");
+    wrap_property_RW(m_intel_gpu, ov::intel_gpu::kernel_cache_capacity, "kernel_cache_capacity");
 
     // Submodule hint (intel_gpu)
     py::module m_intel_gpu_hint = m_intel_gpu.def_submodule(

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -362,6 +362,11 @@ def test_properties_ro(ov_property_ro, expected_value):
             ((True, True),),
         ),
         (
+            intel_gpu.kernel_cache_capacity,
+            "GPU_KERNEL_CACHE_CAPACITY",
+            ((100, 100),),
+        ),
+        (
             intel_gpu_hint.queue_throttle,
             "GPU_QUEUE_THROTTLE",
             ((intel_gpu_hint.ThrottleLevel.LOW, hints.Priority.LOW),),

--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -71,6 +71,12 @@ static constexpr Property<bool> enable_loop_unrolling{"GPU_ENABLE_LOOP_UNROLLING
  */
 static constexpr Property<bool> disable_winograd_convolution{"GPU_DISABLE_WINOGRAD_CONVOLUTION"};
 
+/**
+ * @brief Set the capacity of ocl kernel cache.
+ * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
+ */
+static constexpr Property<int32_t> kernel_cache_capacity{"GPU_KERNEL_CACHE_CAPACITY"};
+
 namespace hint {
 /**
  * @brief This enum represents the possible value of ov::intel_gpu::hint::queue_throttle property:

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -229,8 +229,8 @@ void program::init_program() {
     if (!_compilation_context)
         _compilation_context = program::make_compilation_context(_config);
 
-
-    size_t impls_cache_capacity = _impls_cache_capacity;
+    size_t impls_cache_capacity = _config.get_property(ov::intel_gpu::kernel_cache_capacity);
+    GPU_DEBUG_INFO << " kernel cache capacity: " << impls_cache_capacity << '\n';
     GPU_DEBUG_IF(debug_config->impls_cache_capacity >= 0) {
         impls_cache_capacity = debug_config->impls_cache_capacity;
     }

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -263,6 +263,7 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
             ov::PropertyName{ov::intel_gpu::hint::queue_throttle.name(), PropertyMutability::RO},
             ov::PropertyName{ov::intel_gpu::enable_loop_unrolling.name(), PropertyMutability::RO},
             ov::PropertyName{ov::intel_gpu::disable_winograd_convolution.name(), PropertyMutability::RO},
+            ov::PropertyName{ov::intel_gpu::kernel_cache_capacity.name(), PropertyMutability::RO},
             ov::PropertyName{ov::cache_dir.name(), PropertyMutability::RO},
             ov::PropertyName{ov::cache_mode.name(), PropertyMutability::RO},
             ov::PropertyName{ov::hint::performance_mode.name(), PropertyMutability::RO},

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -537,6 +537,7 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::intel_gpu::hint::queue_throttle.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::enable_loop_unrolling.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::disable_winograd_convolution.name(), PropertyMutability::RW},
+        ov::PropertyName{ov::intel_gpu::kernel_cache_capacity.name(), PropertyMutability::RW},
         ov::PropertyName{ov::cache_dir.name(), PropertyMutability::RW},
         ov::PropertyName{ov::cache_mode.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::performance_mode.name(), PropertyMutability::RW},

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -52,6 +52,7 @@ void ExecutionConfig::set_default() {
         std::make_tuple(ov::intel_gpu::hint::queue_priority, ov::hint::Priority::MEDIUM),
         std::make_tuple(ov::intel_gpu::enable_loop_unrolling, true),
         std::make_tuple(ov::intel_gpu::disable_winograd_convolution, false),
+        std::make_tuple(ov::intel_gpu::kernel_cache_capacity, 10000),
         std::make_tuple(ov::internal::exclusive_async_requests, false),
         std::make_tuple(ov::cache_mode, ov::CacheMode::OPTIMIZE_SPEED),
 


### PR DESCRIPTION
### Details:
 - *Add "GPU_KERNEL_CACHE_CAPACITY" property to adjust the capacity of kernel cache.*
 - *Default value is 10000.*

### Tickets:
 - *129289*
