### PR TITLE
Fix TSUnary transformation

### DIFF
--- a/src/common/transformations/src/transformations/transpose_sinking/ts_general.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_general.cpp
@@ -53,7 +53,6 @@ TSGeneralForward::TSGeneralForward() {
 TSGeneralBackward::TSGeneralBackward() {
     MATCHER_SCOPE(TSGeneralBackward);
     ADD_MATCHER(this, TSUnaryBackward);
-    ADD_MATCHER(this, TSUnaryBackward);
     ADD_MATCHER(this, TSBinaryBackward);
     ADD_MATCHER(this, TSConcatBackward);
     ADD_MATCHER(this, TSSplitBackward);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
@@ -38,7 +38,7 @@ using NodePair = std::pair<NodePtr, NodePtr>;
 TSUnaryForward::TSUnaryForward() {
     MATCHER_SCOPE(TSUnaryForward);
 
-    // We consider HardSigmoid, LogSoftmax, ConvertLike as unary ops
+    // We consider HardSigmoid, Swish, Selu, ConvertLike as unary ops
     // and handle only 0th input of these ops.
     create_pattern<UnaryElementwiseArithmetic,
                    ov::op::v0::Clamp,

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
@@ -38,6 +38,8 @@ using NodePair = std::pair<NodePtr, NodePtr>;
 TSUnaryForward::TSUnaryForward() {
     MATCHER_SCOPE(TSUnaryForward);
 
+    // We consider HardSigmoid, LogSoftmax, ConvertLike as unary ops
+    // and handle only 0th input of these ops.
     create_pattern<UnaryElementwiseArithmetic,
                    ov::op::v0::Clamp,
                    ov::op::v0::Elu,
@@ -51,7 +53,7 @@ TSUnaryForward::TSUnaryForward() {
                    ov::op::v4::Swish,
                    ov::op::v0::HardSigmoid,
                    ov::op::v5::LogSoftmax,
-                   ov::op::v1::ConvertLike>(true);
+                   ov::op::v1::ConvertLike>(true, {0});
     auto ts_unary_sinking_function = [this](const std::shared_ptr<Node>& main_node,
                                             const utils::TransposeInputsInfo& transpose_info) -> bool {
         bool res = utils::sink_forward::UpdateInputTransposes(main_node, transpose_info, {0});
@@ -64,7 +66,7 @@ TSUnaryForward::TSUnaryForward() {
 }
 
 TSUnaryBackward::TSUnaryBackward() {
-    MATCHER_SCOPE(TSUnaryBackwardMultiConsumers);
+    MATCHER_SCOPE(TSUnaryBackward);
 
     auto unary_restrictions = [](const Output<Node>& output) -> bool {
         return CheckTransposeConsumers(output);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
@@ -147,9 +147,11 @@ bool HasDynamicRankInput(const NodePtr& node) {
     return false;
 }
 
-ov::Rank::value_type GetMaxInputRank(const NodePtr& node) {
+ov::Rank::value_type GetMaxInputRank(const NodePtr& node, const std::vector<size_t>& input_indexes) {
     ov::Rank::value_type max_input_rank = 0;
-    for (auto& input_node : node->input_values()) {
+
+    for (const auto& idx : input_indexes) {
+        const auto& input_node = node->get_input_source_output(idx);
         const ov::Rank output_rank = input_node.get_partial_shape().rank();
         if (output_rank.is_dynamic())
             return -1;
@@ -213,7 +215,7 @@ bool UpdateInputTransposes(const NodePtr& main_node,
     if (transpose_input_info.isEmpty() || HasDynamicRankInput(main_node))
         return false;
 
-    const auto max_input_rank = GetMaxInputRank(main_node);
+    const auto max_input_rank = GetMaxInputRank(main_node, input_indexes);
     if (max_input_rank < 0)
         return false;
 
@@ -303,7 +305,7 @@ NodeVector InsertTransposeBeforeNode(const NodePtr& main_node,
 
     NodeVector new_nodes;
 
-    const auto max_input_rank = GetMaxInputRank(main_node);
+    const auto max_input_rank = GetMaxInputRank(main_node, input_indexes);
     if (max_input_rank < 0)
         return {};
 

--- a/src/common/transformations/tests/transpose_sinking/ts_unary_test.cpp
+++ b/src/common/transformations/tests/transpose_sinking/ts_unary_test.cpp
@@ -112,7 +112,7 @@ NodePtr UnaryFactory<LogSoftmax>::create(const OutputVector& inputs) const {
 
 template <>
 NodePtr UnaryFactory<ConvertLike>::create(const OutputVector& inputs) const {
-    auto like = std::make_shared<Constant>(element::f64, Shape{}, 1);
+    auto like = std::make_shared<Constant>(element::f64, Shape{1, 2, 3, 2, 1, 1}, 1);
     return std::make_shared<ConvertLike>(inputs[0], like);
 }
 
@@ -158,6 +158,32 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(const FactoryPtr& unary_
     auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
     return std::make_shared<ov::Model>(transpose0, ov::ParameterVector{X});
+}
+
+// We consider HardSigmoid, LogSoftmax, ConvertLike as unary ops
+// and handle only 0th input of these ops.
+// Transpose on 2nd input should be ignored.
+namespace ignore_transpose_on_second_input {
+std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(const FactoryPtr& unary_factory,
+                                                         size_t num_unary_ops,
+                                                         const Shape& input_shape,
+                                                         element::Type input_type) {
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
+
+    NodePtr in_op = X;
+    for (size_t i = 0; i < num_unary_ops; ++i) {
+        in_op = unary_factory->create({in_op});
+
+        // Connect Transpose to 2nd input of the main node
+        std::vector<int> order(in_op->input(1).get_shape().size());
+        std::iota(order.rbegin(), order.rend(), 0);
+        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{order.size()}, order);
+        auto transpose0 = std::make_shared<Transpose>(in_op->input_value(1), ng_order0);
+        in_op->input(1).replace_source_output(transpose0);
+    }
+
+    return std::make_shared<ov::Model>(in_op, ov::ParameterVector{X});
+}
 }
 
 NodePtr CreateReshape(const NodePtr& parent_node, const Shape& input_shape) {
@@ -449,6 +475,19 @@ auto test_forward = []() {
     return wrapper(test_case);
 };
 
+auto test_forward_unary_with_multiple_inputs = []() {
+    TestCase test_case;
+    test_case.main_node = std::vector<FactoryPtr> {CREATE_UNARY_FACTORY(HardSigmoid), CREATE_UNARY_FACTORY(LogSoftmax),
+                                                   CREATE_UNARY_FACTORY(ConvertLike)};
+    test_case.transformation = CREATE_PASS_FACTORY(TSUnaryForward);
+    test_case.num_main_ops = {1, 10};
+    test_case.test_model = ignore_transpose_on_second_input::CreateFunctionTransposeBefore;
+    test_case.ref_model = ignore_transpose_on_second_input::CreateFunctionTransposeBefore;
+    test_case.input_shape = {1, 96, 55, 55};
+    test_case.type = element::f32;
+    return wrapper(test_case);
+};
+
 auto test_backward = []() {
     TestCase test_case;
     test_case.main_node = unary_factories;
@@ -549,6 +588,11 @@ auto test_forward_multiple_consumers_first_node = []() {
 INSTANTIATE_TEST_SUITE_P(TSUnaryForwardTestSuite,
                          TransposeSinkingUnaryTestFixture,
                          transpose_sinking::testing::unary::test_forward(),
+                         TransposeSinkingUnaryTestFixture::get_test_name);
+
+INSTANTIATE_TEST_SUITE_P(TSUnaryForwardMultipleInputsTestSuite,
+                         TransposeSinkingUnaryTestFixture,
+                         transpose_sinking::testing::unary::test_forward_unary_with_multiple_inputs(),
                          TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(TSUnaryBackwardTestSuite,

--- a/src/common/transformations/tests/transpose_sinking/ts_unary_test.cpp
+++ b/src/common/transformations/tests/transpose_sinking/ts_unary_test.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(const FactoryPtr& unary_
     return std::make_shared<ov::Model>(transpose0, ov::ParameterVector{X});
 }
 
-// We consider HardSigmoid, LogSoftmax, ConvertLike as unary ops
+// We consider HardSigmoid, Swish, Selu, ConvertLike as unary ops
 // and handle only 0th input of these ops.
 // Transpose on 2nd input should be ignored.
 namespace ignore_transpose_on_second_input {
@@ -478,8 +478,9 @@ auto test_forward = []() {
 auto test_forward_unary_with_multiple_inputs = []() {
     TestCase test_case;
     test_case.main_node = std::vector<FactoryPtr>{CREATE_UNARY_FACTORY(HardSigmoid),
-                                                  CREATE_UNARY_FACTORY(LogSoftmax),
-                                                  CREATE_UNARY_FACTORY(ConvertLike)};
+                                                  CREATE_UNARY_FACTORY(Selu),
+                                                  CREATE_UNARY_FACTORY(ConvertLike),
+                                                  CREATE_UNARY_FACTORY(Swish)};
     test_case.transformation = CREATE_PASS_FACTORY(TSUnaryForward);
     test_case.num_main_ops = {1, 10};
     test_case.test_model = ignore_transpose_on_second_input::CreateFunctionTransposeBefore;

--- a/src/common/transformations/tests/transpose_sinking/ts_unary_test.cpp
+++ b/src/common/transformations/tests/transpose_sinking/ts_unary_test.cpp
@@ -184,7 +184,7 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(const FactoryPtr& unary
 
     return std::make_shared<ov::Model>(in_op, ov::ParameterVector{X});
 }
-}
+}  // namespace ignore_transpose_on_second_input
 
 NodePtr CreateReshape(const NodePtr& parent_node, const Shape& input_shape) {
     const size_t mul = std::accumulate(input_shape.begin(), input_shape.end(), (size_t)1, std::multiplies<size_t>());
@@ -477,8 +477,9 @@ auto test_forward = []() {
 
 auto test_forward_unary_with_multiple_inputs = []() {
     TestCase test_case;
-    test_case.main_node = std::vector<FactoryPtr> {CREATE_UNARY_FACTORY(HardSigmoid), CREATE_UNARY_FACTORY(LogSoftmax),
-                                                   CREATE_UNARY_FACTORY(ConvertLike)};
+    test_case.main_node = std::vector<FactoryPtr>{CREATE_UNARY_FACTORY(HardSigmoid),
+                                                  CREATE_UNARY_FACTORY(LogSoftmax),
+                                                  CREATE_UNARY_FACTORY(ConvertLike)};
     test_case.transformation = CREATE_PASS_FACTORY(TSUnaryForward);
     test_case.num_main_ops = {1, 10};
     test_case.test_model = ignore_transpose_on_second_input::CreateFunctionTransposeBefore;


### PR DESCRIPTION
### Details:
We consider HardSigmoid, LogSoftmax and ConvertLike as Unary operation in TransposeSinking transformation and have to ignore other inputs except 0th.

### Tickets:
 - *CVS-126737*
