### PR TITLE
[Snippets] Added RegType as part of PortDescriptor

### DIFF
--- a/src/common/snippets/include/snippets/emitter.hpp
+++ b/src/common/snippets/include/snippets/emitter.hpp
@@ -12,7 +12,15 @@
 namespace ov {
 namespace snippets {
 
-using RegInfo = std::pair<std::vector<size_t>, std::vector<size_t>>;
+/**
+ * @interface RegType
+ * @brief Register type of input and output operations
+ */
+enum RegType { gpr, vec };
+using Reg = std::pair<RegType, size_t>;
+using RegInfo = std::pair<std::vector<Reg>, std::vector<Reg>>;
+
+std::string regTypeToStr(const RegType& type);
 
 /**
  * @interface Emitter

--- a/src/common/snippets/include/snippets/emitter.hpp
+++ b/src/common/snippets/include/snippets/emitter.hpp
@@ -16,8 +16,20 @@ namespace snippets {
  * @interface RegType
  * @brief Register type of input and output operations
  */
-enum RegType { gpr, vec };
-using Reg = std::pair<RegType, size_t>;
+enum class RegType { gpr, vec };
+/**
+ * @interface Reg
+ * @brief Register representation: type of register and index
+ */
+struct Reg {
+    Reg(RegType type_, size_t idx_) : type(type_), idx(idx_) {}
+
+    RegType type = RegType::gpr;
+    size_t idx = 0;
+
+    friend bool operator==(const Reg& lhs, const Reg& rhs);
+    friend bool operator!=(const Reg& lhs, const Reg& rhs);
+};
 using RegInfo = std::pair<std::vector<Reg>, std::vector<Reg>>;
 
 std::string regTypeToStr(const RegType& type);

--- a/src/common/snippets/include/snippets/generator.hpp
+++ b/src/common/snippets/include/snippets/generator.hpp
@@ -98,20 +98,11 @@ public:
     std::shared_ptr<const TargetMachine> get_target_machine() const;
 
     /**
-    * @interface opRegType
-    * @brief Register type of operations
-    *        Note that currently there are 4 types of ops:
-    *        gpr->gpr: (Parameter, Result, LoopBegin, LoopEnd etc)
-    *        gpr->vec: or vec->gpr Load/LoadConvert, Store/StoreConvert, BroadcastLoad etc.
-    *        vec->vec: all other "normal" operations that perform calculations on vector registers: Add, BroadcastMove, Power, etc.
-    */
-    enum opRegType {gpr2gpr, gpr2vec, vec2gpr, vec2vec};
-    /**
      * @brief gets register type by op type
      *        TODO: Should be static attribute of emitters
      * @return register type
      */
-    opRegType get_op_reg_type(const std::shared_ptr<Node>& op) const;
+    virtual RegType get_op_out_reg_type(const ov::Output<ov::Node>& out) const;
 
     virtual std::shared_ptr<Generator> clone() const = 0;
 
@@ -120,7 +111,7 @@ protected:
     * @brief gets register type by specific plugin op type
     * @return register type
     */
-    virtual opRegType get_specific_op_reg_type(const std::shared_ptr<ov::Node>& op) const;
+    virtual RegType get_specific_op_out_reg_type(const ov::Output<Node>& out) const;
     /**
     * @brief returns true if an emitter can use precompiled kernel.
     * @return bool

--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -32,7 +32,7 @@ public:
     std::shared_ptr<Emitter> get_emitter() const;
 
     RegInfo get_reg_info() const;
-    void set_reg_info(RegInfo rinfo);
+    void set_reg_info(const RegInfo& rinfo);
 
     const PortConnectorPtr& get_input_port_connector(size_t i) const;
     const PortConnectorPtr& get_output_port_connector(size_t i) const;

--- a/src/common/snippets/include/snippets/lowered/pass/assign_registers.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/assign_registers.hpp
@@ -21,11 +21,13 @@ namespace pass {
 class AssignRegisters : public Pass {
 public:
     OPENVINO_RTTI("AssignRegisters", "Pass")
-    explicit AssignRegisters(const std::function<Generator::opRegType(const std::shared_ptr<Node>& op)>& mapper) : m_reg_type_mapper(mapper) {}
+    explicit AssignRegisters(const std::function<RegType(const ov::Output<Node>& out)>& mapper) : m_reg_type_mapper(mapper) {}
     bool run(LinearIR& linear_ir) override;
 
 private:
-    std::function<Generator::opRegType(const std::shared_ptr<Node>& op)> m_reg_type_mapper;
+    void set_reg_types(LinearIR& linear_ir);
+
+    std::function<RegType(const ov::Output<Node>& out)> m_reg_type_mapper;
     static constexpr size_t reg_count = 16lu;
 };
 

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -25,6 +25,7 @@ public:
     bool run(LinearIR& linear_ir) override;
 
 private:
+    static void init_is_incremented(const LinearIR::LoopManager::LoopInfoPtr& loop_info);
     static void init_ptr_increments(const LinearIR::LoopManager::LoopInfoPtr& loop_info);
     static void init_finalization_offsets(const LinearIR::LoopManager::LoopInfoPtr& loop_info);
     static void init_element_type_sizes(const LinearIR::LoopManager::LoopInfoPtr& loop_info);

--- a/src/common/snippets/include/snippets/lowered/pass/insert_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_loops.hpp
@@ -25,7 +25,6 @@ public:
     bool run(LinearIR& linear_ir) override;
 private:
     static void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop);
-    static void filter_ports(std::vector<LinearIR::LoopManager::LoopPort>& loop_entries, std::vector<LinearIR::LoopManager::LoopPort>& loop_exits);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
+++ b/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
@@ -48,8 +48,8 @@ public:
     void set_layout(const std::vector<size_t>& layout) { m_layout = layout; }
     void set_subtensor(const VectorDims& subtensor) { m_subtensor_shape = subtensor; }
     void set_reg(Reg reg) { m_reg = std::move(reg); }
-    void set_reg_type(RegType type) { m_reg.first = type; }
-    void set_reg_num(size_t num) { m_reg.second = num; }
+    void set_reg_type(RegType type) { m_reg.type = type; }
+    void set_reg_idx(size_t idx) { m_reg.idx = idx; }
 
     std::string serialize() const;
     bool empty() const { return m_layout.empty() && m_subtensor_shape.empty();}
@@ -67,7 +67,7 @@ private:
     /// \brief Minimal tensor size that could be processed in one call
     VectorDims m_subtensor_shape{};
     /// \brief The corresponding abstract/physical register
-    Reg m_reg;
+    Reg m_reg { RegType::gpr, 0 };
 
     /// Notes:
     ///   - `m_tensor_shape` is dense shape which is controlled by expression outputs.

--- a/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
+++ b/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
@@ -7,6 +7,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/attribute_visitor.hpp"
 #include "snippets/shape_types.hpp"
+#include "snippets/emitter.hpp"
 
 
 namespace ov {
@@ -41,12 +42,14 @@ public:
     const VectorDims& get_shape() const {return m_tensor_shape;}
     const VectorDims& get_subtensor() const {return m_subtensor_shape;}
     const std::vector<size_t>& get_layout() const {return m_layout;}
-    size_t get_reg() const { return m_reg; }
+    const Reg& get_reg() const { return m_reg; }
 
     void set_shape(const VectorDims& tensor) { m_tensor_shape = tensor; }
     void set_layout(const std::vector<size_t>& layout) { m_layout = layout; }
     void set_subtensor(const VectorDims& subtensor) { m_subtensor_shape = subtensor; }
-    void set_reg(size_t reg) { m_reg = reg; }
+    void set_reg(Reg reg) { m_reg = std::move(reg); }
+    void set_reg_type(RegType type) { m_reg.first = type; }
+    void set_reg_num(size_t num) { m_reg.second = num; }
 
     std::string serialize() const;
     bool empty() const { return m_layout.empty() && m_subtensor_shape.empty();}
@@ -64,7 +67,7 @@ private:
     /// \brief Minimal tensor size that could be processed in one call
     VectorDims m_subtensor_shape{};
     /// \brief The corresponding abstract/physical register
-    size_t m_reg = 0;
+    Reg m_reg;
 
     /// Notes:
     ///   - `m_tensor_shape` is dense shape which is controlled by expression outputs.

--- a/src/common/snippets/src/emitter.cpp
+++ b/src/common/snippets/src/emitter.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/emitter.hpp"
+
+namespace ov {
+namespace snippets {
+
+std::string regTypeToStr(const RegType& type) {
+    switch (type) {
+        case RegType::vec:
+            return "vec";
+        case RegType::gpr:
+            return "gpr";
+    }
+    return "undefined";
+}
+
+}  // namespace snippets
+}  // namespace ov

--- a/src/common/snippets/src/emitter.cpp
+++ b/src/common/snippets/src/emitter.cpp
@@ -7,14 +7,22 @@
 namespace ov {
 namespace snippets {
 
+bool operator==(const Reg& lhs, const Reg& rhs) {
+    return lhs.type == rhs.type && lhs.idx == rhs.idx;
+}
+bool operator!=(const Reg& lhs, const Reg& rhs) {
+    return !(lhs == rhs);
+}
+
 std::string regTypeToStr(const RegType& type) {
     switch (type) {
         case RegType::vec:
             return "vec";
         case RegType::gpr:
             return "gpr";
+        default:
+            OPENVINO_THROW("Unexpected RegType");
     }
-    return "undefined";
 }
 
 }  // namespace snippets

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -87,7 +87,7 @@ RegType Generator::get_op_out_reg_type(const ov::Output<Node>& out) const {
         || std::dynamic_pointer_cast<op::PerfCountEndBase>(op)
 #endif
         )
-        return gpr;
+        return RegType::gpr;
     else if (std::dynamic_pointer_cast<snippets::op::Load>(op) ||
              std::dynamic_pointer_cast<snippets::op::BroadcastLoad>(op) ||
              ov::op::util::is_unary_elementwise_arithmetic(op) ||
@@ -104,7 +104,7 @@ RegType Generator::get_op_out_reg_type(const ov::Output<Node>& out) const {
              std::dynamic_pointer_cast<op::HorizonMax>(op) ||
              std::dynamic_pointer_cast<op::HorizonSum>(op) ||
              std::dynamic_pointer_cast<op::Fill>(op))
-        return vec;
+        return RegType::vec;
     else
         return get_specific_op_out_reg_type(op);
 }

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -23,8 +23,8 @@ void Generator::generate(lowered::LinearIR& linear_ir, LoweringResult& result, c
     if (!target->is_supported())
         OPENVINO_THROW("unsupported architecture for code generation");
 
-    std::function<opRegType(const std::shared_ptr<Node>& op)> reg_type_mapper = [&](const std::shared_ptr<Node>& op) -> opRegType {
-        return get_op_reg_type(op);
+    std::function<RegType(const ov::Output<Node>& out)> reg_type_mapper = [&](const ov::Output<Node>& out) -> RegType {
+        return get_op_out_reg_type(out);
     };
     lowered::pass::PassPipeline lowered_pipeline;
     // Note: the order of all passes in this pipeline must not be changed since they have hard dependencies
@@ -71,7 +71,8 @@ std::shared_ptr<const TargetMachine> Generator::get_target_machine() const {
     return target;
 }
 
-Generator::opRegType Generator::get_op_reg_type(const std::shared_ptr<Node>& op) const {
+RegType Generator::get_op_out_reg_type(const ov::Output<Node>& out) const {
+    const auto op = out.get_node_shared_ptr();
     if (std::dynamic_pointer_cast<ov::op::v0::Parameter>(op) ||
         std::dynamic_pointer_cast<ov::op::v0::Result>(op) ||
         std::dynamic_pointer_cast<op::LoopBegin>(op) ||
@@ -79,19 +80,17 @@ Generator::opRegType Generator::get_op_reg_type(const std::shared_ptr<Node>& op)
         std::dynamic_pointer_cast<op::Brgemm>(op) ||
         std::dynamic_pointer_cast<op::IntermediateMemoryBuffer>(op) ||
         std::dynamic_pointer_cast<op::NewMemoryBuffer>(op) ||
-        std::dynamic_pointer_cast<op::RankNormalization>(op)
+        std::dynamic_pointer_cast<op::RankNormalization>(op) ||
+        std::dynamic_pointer_cast<snippets::op::Store>(op)
 #ifdef SNIPPETS_DEBUG_CAPS
         || std::dynamic_pointer_cast<op::PerfCountBeginBase>(op)
         || std::dynamic_pointer_cast<op::PerfCountEndBase>(op)
 #endif
         )
-        return gpr2gpr;
+        return gpr;
     else if (std::dynamic_pointer_cast<snippets::op::Load>(op) ||
-             std::dynamic_pointer_cast<snippets::op::BroadcastLoad>(op))
-        return gpr2vec;
-    else if (std::dynamic_pointer_cast<snippets::op::Store>(op))
-        return vec2gpr;
-    else if (ov::op::util::is_unary_elementwise_arithmetic(op) ||
+             std::dynamic_pointer_cast<snippets::op::BroadcastLoad>(op) ||
+             ov::op::util::is_unary_elementwise_arithmetic(op) ||
              ov::op::util::is_binary_elementwise_arithmetic(op) ||
              ov::op::util::is_binary_elementwise_comparison(op) ||
              ov::op::util::is_binary_elementwise_logical(op) ||
@@ -105,13 +104,13 @@ Generator::opRegType Generator::get_op_reg_type(const std::shared_ptr<Node>& op)
              std::dynamic_pointer_cast<op::HorizonMax>(op) ||
              std::dynamic_pointer_cast<op::HorizonSum>(op) ||
              std::dynamic_pointer_cast<op::Fill>(op))
-        return vec2vec;
+        return vec;
     else
-        return get_specific_op_reg_type(op);
+        return get_specific_op_out_reg_type(op);
 }
 
-Generator::opRegType Generator::get_specific_op_reg_type(const std::shared_ptr<ov::Node>& op) const {
-    OPENVINO_THROW("Register type of the operation " + std::string(op->get_type_name()) + " isn't determined!");
+RegType Generator::get_specific_op_out_reg_type(const ov::Output<Node>& out) const {
+    OPENVINO_THROW("Register type of the operation " + std::string(out.get_node()->get_type_name()) + " isn't determined!");
 }
 
 }// namespace snippets

--- a/src/common/snippets/src/lowered/expression.cpp
+++ b/src/common/snippets/src/lowered/expression.cpp
@@ -82,7 +82,7 @@ RegInfo Expression::get_reg_info() const {
     return reg_info;
 }
 
-void Expression::set_reg_info(RegInfo rinfo) {
+void Expression::set_reg_info(const RegInfo& rinfo) {
     const auto& in = rinfo.first;
     const auto& out = rinfo.second;
     OPENVINO_ASSERT(m_input_port_descriptors.size() == in.size(), "Incorrect count of input physical registers");

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -133,10 +133,10 @@ void LinearIR::debug_print(bool tds_as_pointers) const {
     auto print_rinfo = [](const RegInfo& rinfo) {
         std::cerr << " : {";
         for (auto i : rinfo.first)
-            std::cerr << i.first << "[" << i.second << "] ";
+            std::cerr << regTypeToStr(i.type) << "[" << i.idx << "] ";
         std::cerr << " => ";
         for (auto i : rinfo.second)
-            std::cerr << i.first << "[" << i.second << "] ";
+            std::cerr << regTypeToStr(i.type) << "[" << i.idx << "] ";
         std::cerr << "}";
     };
     std::map<PortConnectorPtr, int> td2int;

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -133,10 +133,10 @@ void LinearIR::debug_print(bool tds_as_pointers) const {
     auto print_rinfo = [](const RegInfo& rinfo) {
         std::cerr << " : {";
         for (auto i : rinfo.first)
-            std::cerr << i << " ";
+            std::cerr << i.first << "[" << i.second << "] ";
         std::cerr << " => ";
         for (auto i : rinfo.second)
-            std::cerr << i << " ";
+            std::cerr << i.first << "[" << i.second << "] ";
         std::cerr << "}";
     };
     std::map<PortConnectorPtr, int> td2int;

--- a/src/common/snippets/src/lowered/pass/assign_registers.cpp
+++ b/src/common/snippets/src/lowered/pass/assign_registers.cpp
@@ -16,26 +16,56 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 
+void AssignRegisters::set_reg_types(LinearIR& linear_ir) {
+    for (const auto& expr : linear_ir) {
+        const auto op = expr->get_node();
+        if (ov::is_type<op::LoopEnd>(op) ||
+            ov::is_type<ov::op::v0::Result>(op)
+#ifdef SNIPPETS_DEBUG_CAPS
+        || ov::is_type<op::PerfCountBeginBase>(op)
+        || ov::is_type<op::PerfCountEndBase>(op)
+#endif
+        )
+        continue;
+
+        OPENVINO_ASSERT(expr->get_output_count() == op->get_output_size(), "Incorrect count of output port descriptors!");
+        for (size_t i = 0; i < expr->get_output_count(); ++i) {
+            const auto reg_type = m_reg_type_mapper(op->output(i));
+            expr->get_output_port_descriptor(i)->set_reg_type(reg_type);
+            // propogate to consumers
+            for (const auto& consumer : expr->get_output_port_connector(i)->get_consumers()) {
+                consumer.get_descriptor_ptr()->set_reg_type(reg_type);
+            }
+        }
+    }
+}
+
 bool AssignRegisters::run(LinearIR& linear_ir) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::AssignRegisters")
     using Reg = size_t;
     using tensor = PortConnectorPtr;
-    const auto& expressions = linear_ir.get_ops();
 
-    std::vector<std::pair<Generator::opRegType, ExpressionPtr>> typed_ops;
-    NodeVector ops;
+    set_reg_types(linear_ir);
+    const auto& exprs = linear_ir.get_ops();
+    const auto& io_exprs = linear_ir.get_IO_ops();
+    Reg num_expressions = exprs.size();
     Reg num_parameters = 0;
     Reg num_results = 0;
-    Reg num_expressions = 0;
-    for (auto& expr : expressions) {
-        auto op = expr->get_node();
-        auto reg_type = m_reg_type_mapper(op);
-        typed_ops.emplace_back(reg_type, expr);
-        num_parameters += is_type<ov::op::v0::Parameter>(op);
-        num_results += is_type<ov::op::v0::Result>(op);
-        ops.push_back(op);
-        num_expressions++;
+    for (const auto& expr : io_exprs) {
+        switch (expr->get_type()) {
+            case snippets::lowered::IOExpression::io_type::INPUT: {
+                num_parameters++;
+                break;
+            }
+            case snippets::lowered::IOExpression::io_type::OUTPUT: {
+                num_results++;
+                break;
+            } default : {
+                OPENVINO_THROW("Kernel detected unsupported io_type");
+            }
+        }
     }
+
     size_t counter_vec = 0;
     size_t counter_gpr = 0;
     std::map<tensor, Reg> regs_vec, regs_gpr;
@@ -43,7 +73,7 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
     std::map<tensor, Reg> manually_assigned_gprs, manually_assigned_vecs;
     const auto IS_MANUALLY_ALLOCATED_REG = SIZE_MAX;
     auto accumulator_reg = 0lu;
-    for (const auto& expr : expressions) {
+    for (const auto& expr : exprs) {
         auto op = expr->get_node();
         if (const auto io_expr = std::dynamic_pointer_cast<IOExpression>(expr)) {
             if (io_expr->get_type() == IOExpression::io_type::INPUT) {
@@ -112,35 +142,38 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
     // Note: have to specify default capture "=" due to MSVC bug (it doesn't capture const expressions implicitly)
     // Otherwise WIN build fails with "IS_MANUALLY_ALLOCATED_REG cannot be implicitly captured because no default capture mode has been specified"
     // the same problem with all the other lambdas in this file
-    auto enumerate_out_tensors = [=] (const ExpressionPtr& expr,
-                                      decltype(regs_vec)& reg_map,
-                                      const std::map<tensor, Reg>& manually_assigned_regs,
-                                      size_t& counter) {
-        for (const auto& out_tensor : expr->get_output_port_connectors()) {
-            // Note that some ops might have identical input&output tensors (Result and Tile* for ex.)
-            // so we have to check that the tensor has not been enumerated already
-            if (reg_map.count(out_tensor) == 0) {
-                reg_map[out_tensor] = manually_assigned_regs.count(out_tensor) == 0 ? counter++ : IS_MANUALLY_ALLOCATED_REG;
-            }
+    auto enumerate_out_tensor = [=] (const tensor& out_tensor,
+                                     decltype(regs_vec)& reg_map,
+                                     const std::map<tensor, Reg>& manually_assigned_regs,
+                                     size_t& counter) {
+        // Note that some ops might have identical input&output tensors (Result and Tile* for ex.)
+        // so we have to check that the tensor has not been enumerated already
+        if (reg_map.count(out_tensor) == 0) {
+            reg_map[out_tensor] = manually_assigned_regs.count(out_tensor) == 0 ? counter++ : IS_MANUALLY_ALLOCATED_REG;
         }
     };
-    for (const auto& t_op : typed_ops) {
-        switch (t_op.first) {
-            case Generator::opRegType::vec2vec:
-            case Generator::opRegType::gpr2vec:
-                enumerate_out_tensors(t_op.second, regs_vec, manually_assigned_vecs, counter_vec);
-                break;
-            case Generator::opRegType::gpr2gpr:
-            case Generator::opRegType::vec2gpr:
-                enumerate_out_tensors(t_op.second, regs_gpr, manually_assigned_gprs, counter_gpr);
-                break;
+    for (const auto& expr : exprs) {
+        for (size_t i = 0; i < expr->get_output_count(); ++i) {
+            const auto& out = expr->get_output_port(i);
+            switch (out.get_descriptor_ptr()->get_reg().first) {
+                case vec:
+                    enumerate_out_tensor(out.get_port_connector_ptr(), regs_vec, manually_assigned_vecs, counter_vec);
+                    break;
+                case gpr:
+                    enumerate_out_tensor(out.get_port_connector_ptr(), regs_gpr, manually_assigned_gprs, counter_gpr);
+                    break;
+                default:
+                    OPENVINO_THROW("Unsupported reg type detected");
+            }
         }
     }
     // todo: make one for gpr and one for vector
-    std::vector<std::set<Reg>> used_gpr(num_expressions, std::set<Reg>()); // used = used as an input
-    std::vector<std::set<Reg>> defined_gpr(num_expressions, std::set<Reg>()); // defined = used as output
-    std::vector<std::set<Reg>> used_vec(num_expressions, std::set<Reg>());
-    std::vector<std::set<Reg>> defined_vec(num_expressions, std::set<Reg>());
+    std::vector<std::set<Reg>> used_gpr, used_vec; // used = used as an input
+    std::vector<std::set<Reg>> defined_gpr, defined_vec; // defined = used as output
+    used_gpr.reserve(num_expressions);
+    used_vec.reserve(num_expressions);
+    defined_gpr.reserve(num_expressions);
+    defined_vec.reserve(num_expressions);
 
     auto tensor2reg = [=] (const std::vector<tensor>& tensors, const std::map<tensor, Reg>& reg_map) {
         std::set<Reg> result;
@@ -153,44 +186,52 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
         }
         return result;
     };
-    for (size_t i = 0; i < typed_ops.size(); i++) {
-        const auto& t_op = typed_ops[i];
-        std::vector<tensor> used_tensors, defined_tensors;
-        for (const auto& in : t_op.second->get_input_port_connectors())
-            used_tensors.push_back(in);
-        for (const auto& out : t_op.second->get_output_port_connectors())
-            defined_tensors.push_back(out);
-        switch (t_op.first) {
-            case Generator::opRegType::vec2vec:
-                used_vec[i] = tensor2reg(used_tensors, regs_vec);
-                defined_vec[i] = tensor2reg(defined_tensors, regs_vec);
-                break;
-            case Generator::opRegType::gpr2gpr:
-                used_gpr[i] = tensor2reg(used_tensors, regs_gpr);
-                defined_gpr[i] = tensor2reg(defined_tensors, regs_gpr);
-                break;
-            case Generator::opRegType::gpr2vec:
-                used_gpr[i] = tensor2reg(used_tensors, regs_gpr);
-                defined_vec[i] = tensor2reg(defined_tensors, regs_vec);
-                break;
-            case Generator::opRegType::vec2gpr:
-                used_vec[i] = tensor2reg(used_tensors, regs_vec);
-                defined_gpr[i] = tensor2reg(defined_tensors, regs_gpr);
-                break;
+
+    for (const auto& expr : exprs) {
+        std::vector<tensor> used_gpr_tensors, used_vec_tensors, defined_gpr_tensors, defined_vec_tensors;
+        for (size_t i = 0; i < expr->get_input_count(); ++i) {
+            const auto& in = expr->get_input_port(i);
+            switch (in.get_descriptor_ptr()->get_reg().first) {
+                case vec:
+                    used_vec_tensors.push_back(in.get_port_connector_ptr());
+                    break;
+                case gpr:
+                    used_gpr_tensors.push_back(in.get_port_connector_ptr());
+                    break;
+                default:
+                    OPENVINO_THROW("Unsupported reg type detected");
+            }
         }
+        for (size_t i = 0; i < expr->get_output_count(); ++i) {
+            const auto& out = expr->get_output_port(i);
+            switch (out.get_descriptor_ptr()->get_reg().first) {
+                case vec:
+                    defined_vec_tensors.push_back(out.get_port_connector_ptr());
+                    break;
+                case gpr:
+                    defined_gpr_tensors.push_back(out.get_port_connector_ptr());
+                    break;
+                default:
+                    OPENVINO_THROW("Unsupported reg type detected");
+            }
+        }
+        used_vec.emplace_back(tensor2reg(used_vec_tensors, regs_vec));
+        used_gpr.emplace_back(tensor2reg(used_gpr_tensors, regs_gpr));
+        defined_vec.emplace_back(tensor2reg(defined_vec_tensors, regs_vec));
+        defined_gpr.emplace_back(tensor2reg(defined_gpr_tensors, regs_gpr));
     }
 
     // define life intervals
     // liveOut[i] - regs that are live on exit from i-th (topologically ordered) operation
     // liveIn[i] - regs that are live on entering the i-th (topologically ordered) operation
-    std::vector<std::set<Reg>> life_in_vec(std::move(used_vec));
-    std::vector<std::set<Reg>> life_out_vec(typed_ops.size(), std::set<Reg>());
-    std::vector<std::set<Reg>> life_in_gpr(std::move(used_gpr));
-    std::vector<std::set<Reg>> life_out_gpr(typed_ops.size(), std::set<Reg>());
+    std::vector<std::set<Reg>> life_in_vec(std::move(used_vec)),
+                               life_in_gpr(std::move(used_gpr));
+    std::vector<std::set<Reg>> life_out_vec(num_expressions, std::set<Reg>()),
+                               life_out_gpr(num_expressions, std::set<Reg>());
 
     // todo: this part if O(N*N), so it's slow for large subgraphs. Can we simplify it? At least add an early stopping criteria
-    for (size_t i = 0; i < typed_ops.size(); i++) {
-        for (size_t n = 0; n < typed_ops.size(); n++) {
+    for (size_t i = 0; i < num_expressions; i++) {
+        for (size_t n = 0; n < num_expressions; n++) {
             // Regs that are live on entering the operation = regs used by the op + (all other regs alive - regs defined by the op)
             // copy regs from lifeOut to lifeIn while ignoring regs in def
             std::set_difference(life_out_gpr[n].begin(), life_out_gpr[n].end(),
@@ -200,9 +241,9 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
                                 defined_vec[n].begin(), defined_vec[n].end(),
                                 std::inserter(life_in_vec[n], life_in_vec[n].begin()));
         }
-        for (size_t n = 0; n < typed_ops.size(); n++) {
-            const auto& expr = typed_ops[n].second;
-            if (is_type<op::LoopEnd>(expr->get_node()) || is_type<ov::op::v0::Result>(expr->get_node()))
+        size_t n = 0;
+        for (const auto& expr : exprs) {
+            if (is_type<ov::op::v0::Result>(expr->get_node()))
                 continue;
             for (const auto& out : expr->get_output_port_connectors()) {
                 for (const auto& child_expr_input : out->get_consumers()) {
@@ -214,20 +255,13 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
                         child_it++;
                         k++;
                     }
-                    if (k == typed_ops.size())
+                    if (k == num_expressions)
                         OPENVINO_THROW("assign registers can't find target op in the body");
-                    switch (typed_ops[k].first) {
-                        case Generator::opRegType::vec2vec:
-                        case Generator::opRegType::vec2gpr:
-                            life_out_vec[n].insert(life_in_vec[k].begin(), life_in_vec[k].end());
-                            break;
-                        case Generator::opRegType::gpr2gpr:
-                        case Generator::opRegType::gpr2vec:
-                            life_out_gpr[n].insert(life_in_gpr[k].begin(), life_in_gpr[k].end());
-                            break;
-                    }
+                    life_out_vec[n].insert(life_in_vec[k].begin(), life_in_vec[k].end());
+                    life_out_gpr[n].insert(life_in_gpr[k].begin(), life_in_gpr[k].end());
                 }
             }
+            n++;
         }
     }
     struct by_starting {
@@ -257,7 +291,7 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
         }
         return i;
     };
-    for (int i = 0; i < static_cast<int>(typed_ops.size()); i++) {
+    for (int i = 0; i < static_cast<int>(num_expressions); i++) {
         for (const auto& def : defined_vec[i])
             live_intervals_vec[std::make_pair(i, find_last_use(life_in_vec, static_cast<int>(def)))] = def;
         for (const auto& def : defined_gpr[i])
@@ -329,16 +363,15 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
     register_assigned_regs(regs_vec, unique2reused_map_vec);
     register_assigned_regs(regs_gpr, unique2reused_map_gpr);
 
-    for (auto& t_op : typed_ops) {
-        RegInfo rinfo;
-        const auto& expr = t_op.second;
-        for (const auto& in : expr->get_input_port_connectors()) {
-            rinfo.first.push_back(assigned_regs[in]);
+    for (const auto& expr : exprs) {
+        RegInfo rinfo = expr->get_reg_info();
+        for (size_t i = 0; i < expr->get_input_count(); ++i) {
+            rinfo.first[i].second = assigned_regs[expr->get_input_port_connector(i)];
         }
-        for (const auto& out : expr->get_output_port_connectors()) {
-            rinfo.second.push_back(assigned_regs[out]);
+        for (size_t i = 0; i < expr->get_output_count(); ++i) {
+            rinfo.second[i].second = assigned_regs[expr->get_output_port_connector(i)];
         }
-        t_op.second->set_reg_info(rinfo);
+        expr->set_reg_info(rinfo);
     }
     return false;
 }

--- a/src/common/snippets/src/lowered/pass/assign_registers.cpp
+++ b/src/common/snippets/src/lowered/pass/assign_registers.cpp
@@ -136,11 +136,11 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
     for (const auto& expr : exprs) {
         for (size_t i = 0; i < expr->get_output_count(); ++i) {
             const auto& out = expr->get_output_port(i);
-            switch (out.get_descriptor_ptr()->get_reg().first) {
-                case vec:
+            switch (out.get_descriptor_ptr()->get_reg().type) {
+                case RegType::vec:
                     enumerate_out_tensor(out.get_port_connector_ptr(), regs_vec, manually_assigned_vecs, counter_vec);
                     break;
-                case gpr:
+                case RegType::gpr:
                     enumerate_out_tensor(out.get_port_connector_ptr(), regs_gpr, manually_assigned_gprs, counter_gpr);
                     break;
                 default:
@@ -172,11 +172,11 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
         std::vector<tensor> used_gpr_tensors, used_vec_tensors, defined_gpr_tensors, defined_vec_tensors;
         for (size_t i = 0; i < expr->get_input_count(); ++i) {
             const auto& in = expr->get_input_port(i);
-            switch (in.get_descriptor_ptr()->get_reg().first) {
-                case vec:
+            switch (in.get_descriptor_ptr()->get_reg().type) {
+                case RegType::vec:
                     used_vec_tensors.push_back(in.get_port_connector_ptr());
                     break;
-                case gpr:
+                case RegType::gpr:
                     used_gpr_tensors.push_back(in.get_port_connector_ptr());
                     break;
                 default:
@@ -185,11 +185,11 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
         }
         for (size_t i = 0; i < expr->get_output_count(); ++i) {
             const auto& out = expr->get_output_port(i);
-            switch (out.get_descriptor_ptr()->get_reg().first) {
-                case vec:
+            switch (out.get_descriptor_ptr()->get_reg().type) {
+                case RegType::vec:
                     defined_vec_tensors.push_back(out.get_port_connector_ptr());
                     break;
-                case gpr:
+                case RegType::gpr:
                     defined_gpr_tensors.push_back(out.get_port_connector_ptr());
                     break;
                 default:
@@ -345,14 +345,12 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
     register_assigned_regs(regs_gpr, unique2reused_map_gpr);
 
     for (const auto& expr : exprs) {
-        RegInfo rinfo = expr->get_reg_info();
         for (size_t i = 0; i < expr->get_input_count(); ++i) {
-            rinfo.first[i].second = assigned_regs[expr->get_input_port_connector(i)];
+            expr->get_input_port_descriptor(i)->set_reg_idx(assigned_regs[expr->get_input_port_connector(i)]);
         }
         for (size_t i = 0; i < expr->get_output_count(); ++i) {
-            rinfo.second[i].second = assigned_regs[expr->get_output_port_connector(i)];
+            expr->get_output_port_descriptor(i)->set_reg_idx(assigned_regs[expr->get_output_port_connector(i)]);
         }
-        expr->set_reg_info(rinfo);
     }
     return false;
 }

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -24,7 +24,7 @@ void InsertTailLoop::propagate_updated_subtensor_through_loop(const LinearIR& li
     // First step: set new dim value to the corresponding entry_points' dimensions
     if (new_dim_value != existing_subtensor_value) {
         for (const auto& port : loop_info->get_entry_points()) {
-            const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().first;
+            const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().type;
             if ((port.is_incremented && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
                 const auto& expr = port.expr_port->get_expr();
                 const auto node = expr->get_node();
@@ -49,7 +49,7 @@ void InsertTailLoop::propagate_updated_subtensor_through_loop(const LinearIR& li
     }
 
     auto update_only_dim_idx_with_subtensor_value = [&](const LinearIR::LoopManager::LoopPort& port) {
-        const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().first;
+        const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().type;
          if ((port.is_incremented && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
             auto desc = port.expr_port->get_descriptor_ptr();
             const auto expr = port.expr_port->get_expr();

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -24,7 +24,8 @@ void InsertTailLoop::propagate_updated_subtensor_through_loop(const LinearIR& li
     // First step: set new dim value to the corresponding entry_points' dimensions
     if (new_dim_value != existing_subtensor_value) {
         for (const auto& port : loop_info->get_entry_points()) {
-            if (port.is_incremented) {
+            const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().first;
+            if ((port.is_incremented && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
                 const auto& expr = port.expr_port->get_expr();
                 const auto node = expr->get_node();
                 auto desc = port.expr_port->get_descriptor_ptr();
@@ -48,7 +49,8 @@ void InsertTailLoop::propagate_updated_subtensor_through_loop(const LinearIR& li
     }
 
     auto update_only_dim_idx_with_subtensor_value = [&](const LinearIR::LoopManager::LoopPort& port) {
-        if (port.is_incremented) {
+        const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().first;
+         if ((port.is_incremented && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
             auto desc = port.expr_port->get_descriptor_ptr();
             const auto expr = port.expr_port->get_expr();
             const auto parent_desc = expr->get_input_port_connector(port.expr_port->get_index())->get_source().get_descriptor_ptr();

--- a/src/common/snippets/src/lowered/port_descriptor.cpp
+++ b/src/common/snippets/src/lowered/port_descriptor.cpp
@@ -54,7 +54,7 @@ std::string PortDescriptor::serialize() const {
     ss << m_layout.size() << " ";
     for (auto val : m_layout)
         ss << val << " ";
-    ss << regTypeToStr(m_reg.first) << "["<< m_reg.second << "]";
+    ss << regTypeToStr(m_reg.type) << "["<< m_reg.idx << "]";
     return ss.str();
 }
 bool operator==(const PortDescriptor& lhs, const PortDescriptor& rhs) {

--- a/src/common/snippets/src/lowered/port_descriptor.cpp
+++ b/src/common/snippets/src/lowered/port_descriptor.cpp
@@ -43,7 +43,7 @@ PortDescriptorPtr PortDescriptor::clone() const {
     return desc;
 }
 
-std::string  PortDescriptor::serialize() const {
+std::string PortDescriptor::serialize() const {
     std::stringstream ss;
     ss << m_tensor_shape.size() << " ";
     for (auto val : m_tensor_shape)
@@ -54,12 +54,14 @@ std::string  PortDescriptor::serialize() const {
     ss << m_layout.size() << " ";
     for (auto val : m_layout)
         ss << val << " ";
+    ss << regTypeToStr(m_reg.first) << "["<< m_reg.second << "]";
     return ss.str();
 }
 bool operator==(const PortDescriptor& lhs, const PortDescriptor& rhs) {
     return lhs.m_tensor_shape == rhs.m_tensor_shape &&
            lhs.m_layout == rhs.m_layout &&
-           lhs.m_subtensor_shape == rhs.m_subtensor_shape;
+           lhs.m_subtensor_shape == rhs.m_subtensor_shape &&
+           lhs.m_reg == rhs.m_reg;
 }
 
 void PortDescriptorUtils::init_default(std::vector<PortDescriptorPtr>& in_descs,

--- a/src/common/snippets/src/op/serialization_node.cpp
+++ b/src/common/snippets/src/op/serialization_node.cpp
@@ -48,16 +48,16 @@ bool SerializationNode::visit_attributes(AttributeVisitor &visitor) {
         const auto &shape = desc->get_shape();
         if (!shape.empty())
             shapes.emplace_back("in_shape_" + std::to_string(i), shape);
-        in_reg_types.emplace_back(regTypeToStr(desc->get_reg().first));
-        in_regs.emplace_back(desc->get_reg().second);
+        in_reg_types.emplace_back(regTypeToStr(desc->get_reg().type));
+        in_regs.emplace_back(desc->get_reg().idx);
     }
     for (size_t i = 0; i < m_expr->get_output_count(); i++) {
         const auto& desc = m_expr->get_output_port_descriptor(i);
         const auto &shape = desc->get_shape();
         if (!shape.empty())
             shapes.emplace_back("out_shape_" + std::to_string(i), shape);
-        out_reg_types.emplace_back(regTypeToStr(desc->get_reg().first));
-        out_regs.emplace_back(desc->get_reg().second);
+        out_reg_types.emplace_back(regTypeToStr(desc->get_reg().type));
+        out_regs.emplace_back(desc->get_reg().idx);
     }
 
     if (!in_regs.empty()) {

--- a/src/common/snippets/src/op/serialization_node.cpp
+++ b/src/common/snippets/src/op/serialization_node.cpp
@@ -40,27 +40,38 @@ std::shared_ptr<Node> SerializationNode::clone_with_new_inputs(const OutputVecto
 }
 
 bool SerializationNode::visit_attributes(AttributeVisitor &visitor) {
+    std::vector<size_t> in_regs, out_regs;
+    std::vector<std::string> in_reg_types, out_reg_types;
     std::vector<std::pair<std::string, std::vector<size_t>>> shapes;
     for (size_t i = 0; i < m_expr->get_input_count(); i++) {
-        const auto &shape = m_expr->get_input_port_descriptor(i)->get_shape();
+        const auto& desc = m_expr->get_input_port_descriptor(i);
+        const auto &shape = desc->get_shape();
         if (!shape.empty())
             shapes.emplace_back("in_shape_" + std::to_string(i), shape);
+        in_reg_types.emplace_back(regTypeToStr(desc->get_reg().first));
+        in_regs.emplace_back(desc->get_reg().second);
     }
     for (size_t i = 0; i < m_expr->get_output_count(); i++) {
-        const auto &shape = m_expr->get_output_port_descriptor(i)->get_shape();
+        const auto& desc = m_expr->get_output_port_descriptor(i);
+        const auto &shape = desc->get_shape();
         if (!shape.empty())
             shapes.emplace_back("out_shape_" + std::to_string(i), shape);
+        out_reg_types.emplace_back(regTypeToStr(desc->get_reg().first));
+        out_regs.emplace_back(desc->get_reg().second);
     }
 
-    auto loop_ids = m_expr->get_loop_ids();
-    auto rinfo = m_expr->get_reg_info();
-    if (!rinfo.first.empty())
-        visitor.on_attribute("in_regs", rinfo.first);
-    if (!rinfo.second.empty())
-        visitor.on_attribute("out_regs", rinfo.second);
+    if (!in_regs.empty()) {
+        visitor.on_attribute("in_regs", in_regs);
+        visitor.on_attribute("in_reg_types", in_reg_types);
+    }
+    if (!out_regs.empty()) {
+        visitor.on_attribute("out_regs", out_regs);
+        visitor.on_attribute("out_reg_types", out_reg_types);
+    }
     for (auto& s : shapes)
         visitor.on_attribute(s.first, s.second);
 
+    auto loop_ids = m_expr->get_loop_ids();
     visitor.on_attribute("loop_ids", loop_ids);
     m_expr->get_node()->visit_attributes(visitor);
     return true;

--- a/src/common/snippets/tests/include/lowering_utils.hpp
+++ b/src/common/snippets/tests/include/lowering_utils.hpp
@@ -46,7 +46,7 @@ public:
     std::shared_ptr<Generator> clone() const override { return std::make_shared<DummyGenerator>(target); }
 
 protected:
-    ov::snippets::RegType get_op_out_reg_type(const ov::Output<ov::Node>& out) const override { return ov::snippets::vec; };
+    ov::snippets::RegType get_op_out_reg_type(const ov::Output<ov::Node>& out) const override { return ov::snippets::RegType::vec; };
 };
 
 class LoweringTests : public TransformationTestsF {

--- a/src/common/snippets/tests/include/lowering_utils.hpp
+++ b/src/common/snippets/tests/include/lowering_utils.hpp
@@ -46,7 +46,7 @@ public:
     std::shared_ptr<Generator> clone() const override { return std::make_shared<DummyGenerator>(target); }
 
 protected:
-    opRegType get_specific_op_reg_type(const std::shared_ptr<ov::Node>& op) const override { return vec2vec; };
+    ov::snippets::RegType get_op_out_reg_type(const ov::Output<ov::Node>& out) const override { return ov::snippets::vec; };
 };
 
 class LoweringTests : public TransformationTestsF {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
@@ -216,11 +216,11 @@ ov::snippets::RegType intel_cpu::CPUGenerator::get_specific_op_out_reg_type(cons
     const auto op = out.get_node_shared_ptr();
     if (std::dynamic_pointer_cast<intel_cpu::BrgemmCPU>(op) ||
         std::dynamic_pointer_cast<intel_cpu::BrgemmCopyB>(op))
-        return ov::snippets::gpr;
+        return ov::snippets::RegType::gpr;
     else if (
         std::dynamic_pointer_cast<intel_cpu::FusedMulAdd>(op) ||
         std::dynamic_pointer_cast<intel_cpu::SwishNode>(op))
-        return ov::snippets::vec;
+        return ov::snippets::RegType::vec;
     else
         OPENVINO_THROW("Register type of the operation " + std::string(op->get_type_name()) + " isn't determined!");
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
@@ -212,17 +212,19 @@ std::shared_ptr<snippets::Generator> intel_cpu::CPUGenerator::clone() const {
     return std::make_shared<CPUGenerator>(cpu_target_machine->get_isa());
 }
 
-snippets::Generator::opRegType intel_cpu::CPUGenerator::get_specific_op_reg_type(const std::shared_ptr<ov::Node>& op) const {
+ov::snippets::RegType intel_cpu::CPUGenerator::get_specific_op_out_reg_type(const ov::Output<ov::Node>& out) const {
+    const auto op = out.get_node_shared_ptr();
     if (std::dynamic_pointer_cast<intel_cpu::BrgemmCPU>(op) ||
         std::dynamic_pointer_cast<intel_cpu::BrgemmCopyB>(op))
-        return gpr2gpr;
+        return ov::snippets::gpr;
     else if (
         std::dynamic_pointer_cast<intel_cpu::FusedMulAdd>(op) ||
         std::dynamic_pointer_cast<intel_cpu::SwishNode>(op))
-        return vec2vec;
+        return ov::snippets::vec;
     else
         OPENVINO_THROW("Register type of the operation " + std::string(op->get_type_name()) + " isn't determined!");
 }
+
 bool intel_cpu::CPUGenerator::uses_precompiled_kernel(const std::shared_ptr<snippets::Emitter>& e) const {
     bool need = std::dynamic_pointer_cast<intel_cpu::jit_brgemm_emitter>(e) ||
                 std::dynamic_pointer_cast<intel_cpu::jit_brgemm_copy_b_emitter>(e);

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
@@ -41,8 +41,8 @@ public:
     std::shared_ptr<Generator> clone() const override;
 
 protected:
+    ov::snippets::RegType get_specific_op_out_reg_type(const ov::Output<ov::Node>& out) const override;
     bool uses_precompiled_kernel(const std::shared_ptr<snippets::Emitter>& emitter) const override;
-    opRegType get_specific_op_reg_type(const std::shared_ptr<ov::Node>& op) const override;
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_container_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_container_emitter.cpp
@@ -46,7 +46,6 @@ void jit_container_emitter::map_abstract_registers(mapping_info& gpr_map_pool, m
     };
 
     for (const auto& expression : expressions) {
-        const auto& emitter = expression->get_emitter();
         std::vector<snippets::Reg> in_physical_regs, out_physical_regs;
         std::vector<snippets::Reg> in_abstract_regs, out_abstract_regs;
         std::tie(in_abstract_regs, out_abstract_regs) = expression->get_reg_info();

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_container_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_container_emitter.cpp
@@ -21,21 +21,25 @@ void jit_container_emitter::map_abstract_registers(mapping_info& gpr_map_pool, m
     if (expressions.empty())
         OPENVINO_THROW("Cannot map registers when there is no allocated_emitters provided");
 
-    auto map_regs = [](const std::vector<size_t>& abstract_regs, mapping_info& mapping) {
-        auto& abstract_to_physical = mapping.first;
-        auto& regs_pool = mapping.second;
-        std::vector<size_t> physical_regs(abstract_regs.size());
-        for (size_t i = 0; i < abstract_regs.size(); i++) {
-            const auto abstract = abstract_regs[i];
+    auto map_regs = [&](const std::vector<snippets::Reg>& abstract_regs) {
+        std::vector<snippets::Reg> physical_regs = abstract_regs;
+        for (size_t i = 0; i < abstract_regs.size(); ++i) {
+            const auto& abstract_reg = abstract_regs[i];
+            const auto& type = abstract_reg.first;
+            const auto& abstract = abstract_reg.second;
+            OPENVINO_ASSERT(one_of(type, snippets::RegType::gpr, snippets::RegType::vec), "Incorrect reg type detected!");
+            auto& mapping = type == snippets::RegType::gpr ? gpr_map_pool : vec_map_pool;
+            auto& abstract_to_physical = mapping.first;
+            auto& regs_pool = mapping.second;
             auto& physical = physical_regs[i];
             if (abstract_to_physical.count(abstract) == 0) {
                 if (regs_pool.empty())
                     OPENVINO_THROW("Cannot map registers for jit_container_emitter: not enough regs in the pool");
-                physical = regs_pool.back();
+                physical.second = regs_pool.back();
                 regs_pool.pop_back();
-                abstract_to_physical[abstract] = physical;
+                abstract_to_physical[abstract] = physical.second;
             } else {
-                physical = abstract_to_physical[abstract];
+                physical.second = abstract_to_physical[abstract];
             }
         }
         return physical_regs;
@@ -43,29 +47,11 @@ void jit_container_emitter::map_abstract_registers(mapping_info& gpr_map_pool, m
 
     for (const auto& expression : expressions) {
         const auto& emitter = expression->get_emitter();
-        std::vector<size_t> in_physical_regs, out_physical_regs;
-        std::vector<size_t> in_abstract_regs, out_abstract_regs;
+        std::vector<snippets::Reg> in_physical_regs, out_physical_regs;
+        std::vector<snippets::Reg> in_abstract_regs, out_abstract_regs;
         std::tie(in_abstract_regs, out_abstract_regs) = expression->get_reg_info();
-        switch (std::dynamic_pointer_cast<jit_emitter>(emitter)->get_in_out_type()) {
-            case gpr_to_gpr:
-                in_physical_regs = map_regs(in_abstract_regs, gpr_map_pool);
-                out_physical_regs = map_regs(out_abstract_regs, gpr_map_pool);
-                break;
-            case gpr_to_vec:
-                in_physical_regs = map_regs(in_abstract_regs, gpr_map_pool);
-                out_physical_regs = map_regs(out_abstract_regs, vec_map_pool);
-                break;
-            case vec_to_gpr:
-                in_physical_regs = map_regs(in_abstract_regs, vec_map_pool);
-                out_physical_regs = map_regs(out_abstract_regs, gpr_map_pool);
-                break;
-            case vec_to_vec:
-                in_physical_regs = map_regs(in_abstract_regs, vec_map_pool);
-                out_physical_regs = map_regs(out_abstract_regs, vec_map_pool);
-                break;
-            default:
-                OPENVINO_THROW("Unsupported type of jit emitter!");
-        }
+        in_physical_regs = map_regs(in_abstract_regs);
+        out_physical_regs = map_regs(out_abstract_regs);
         expression->set_reg_info({in_physical_regs, out_physical_regs});
         if (auto container = std::dynamic_pointer_cast<jit_container_emitter>(expression->get_emitter()))
             container->map_abstract_registers(gpr_map_pool, vec_map_pool, expressions);

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_container_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_container_emitter.cpp
@@ -25,8 +25,8 @@ void jit_container_emitter::map_abstract_registers(mapping_info& gpr_map_pool, m
         std::vector<snippets::Reg> physical_regs = abstract_regs;
         for (size_t i = 0; i < abstract_regs.size(); ++i) {
             const auto& abstract_reg = abstract_regs[i];
-            const auto& type = abstract_reg.first;
-            const auto& abstract = abstract_reg.second;
+            const auto& type = abstract_reg.type;
+            const auto& abstract = abstract_reg.idx;
             OPENVINO_ASSERT(one_of(type, snippets::RegType::gpr, snippets::RegType::vec), "Incorrect reg type detected!");
             auto& mapping = type == snippets::RegType::gpr ? gpr_map_pool : vec_map_pool;
             auto& abstract_to_physical = mapping.first;
@@ -35,11 +35,11 @@ void jit_container_emitter::map_abstract_registers(mapping_info& gpr_map_pool, m
             if (abstract_to_physical.count(abstract) == 0) {
                 if (regs_pool.empty())
                     OPENVINO_THROW("Cannot map registers for jit_container_emitter: not enough regs in the pool");
-                physical.second = regs_pool.back();
+                physical.idx = regs_pool.back();
                 regs_pool.pop_back();
-                abstract_to_physical[abstract] = physical.second;
+                abstract_to_physical[abstract] = physical.idx;
             } else {
-                physical.second = abstract_to_physical[abstract];
+                physical.idx = abstract_to_physical[abstract];
             }
         }
         return physical_regs;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
@@ -225,6 +225,18 @@ void jit_kernel_emitter::init_data_pointers(const Xbyak::Reg64& reg_indexes, con
     }
 }
 
+std::pair<std::vector<size_t>, std::vector<size_t>> jit_kernel_emitter::get_reg_idxs(const ov::snippets::RegInfo& reg_info) {
+    auto init_reg_idxs = [](const std::vector<snippets::Reg>& regs, std::vector<size_t>& idxs) {
+        idxs.reserve(regs.size());
+        for (const auto& reg : regs)
+            idxs.push_back(reg.second);
+    };
+    std::pair<std::vector<size_t>, std::vector<size_t>> idxs;
+    init_reg_idxs(reg_info.first, idxs.first);
+    init_reg_idxs(reg_info.second, idxs.second);
+    return idxs;
+}
+
 void jit_kernel_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     h->preamble();
 
@@ -237,7 +249,7 @@ void jit_kernel_emitter::emit_impl(const std::vector<size_t>& in, const std::vec
     for (const auto& expression : body) {
         const auto& emitter = expression->get_emitter();
         std::vector<size_t> in_regs, out_regs;
-        std::tie(in_regs, out_regs) = expression->get_reg_info();
+        std::tie(in_regs, out_regs) = get_reg_idxs(expression->get_reg_info());
         emitter->emit_code(in_regs, out_regs, vec_regs_pool, gp_regs_pool);
     }
     h->postamble();

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
@@ -12,9 +12,16 @@ using namespace dnnl::impl::cpu::x64;
 namespace ov {
 namespace intel_cpu {
 
-inline static void transform_idxs_to_regs(const std::vector<size_t>& idxs, std::vector<Reg64>& regs) {
-    regs.resize(idxs.size());
+inline static std::vector<Reg64> transform_idxs_to_regs(const std::vector<size_t>& idxs) {
+    std::vector<Reg64> regs(idxs.size());
     std::transform(idxs.begin(), idxs.end(), regs.begin(), [](size_t idx){return Reg64(static_cast<int>(idx));});
+    return regs;
+}
+
+inline static std::vector<size_t> transform_snippets_regs_to_idxs(const std::vector<snippets::Reg>& regs) {
+    std::vector<size_t> idxs(regs.size());
+    std::transform(regs.cbegin(), regs.cend(), idxs.begin(), [](const snippets::Reg& reg) { return reg.idx; });
+    return idxs;
 }
 
 jit_kernel_emitter::jit_kernel_emitter(jit_generator* h, cpu_isa_t isa, const ov::snippets::lowered::ExpressionPtr& expr)
@@ -225,31 +232,19 @@ void jit_kernel_emitter::init_data_pointers(const Xbyak::Reg64& reg_indexes, con
     }
 }
 
-std::pair<std::vector<size_t>, std::vector<size_t>> jit_kernel_emitter::get_reg_idxs(const ov::snippets::RegInfo& reg_info) {
-    auto init_reg_idxs = [](const std::vector<snippets::Reg>& regs, std::vector<size_t>& idxs) {
-        idxs.reserve(regs.size());
-        for (const auto& reg : regs)
-            idxs.push_back(reg.second);
-    };
-    std::pair<std::vector<size_t>, std::vector<size_t>> idxs;
-    init_reg_idxs(reg_info.first, idxs.first);
-    init_reg_idxs(reg_info.second, idxs.second);
-    return idxs;
-}
-
 void jit_kernel_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     h->preamble();
 
-    Reg64 reg_indexes = Reg64(static_cast<int>(reg_indexes_idx));
-    Reg64 reg_const_params = Reg64(static_cast<int>(reg_const_params_idx));
-    std::vector<Reg64> data_ptr_regs;
-    transform_idxs_to_regs(data_ptr_regs_idx, data_ptr_regs);
+    auto reg_indexes = Reg64(static_cast<int>(reg_indexes_idx));
+    auto reg_const_params = Reg64(static_cast<int>(reg_const_params_idx));
+    auto data_ptr_regs = transform_idxs_to_regs(data_ptr_regs_idx);
 
     init_data_pointers(reg_indexes, reg_const_params, data_ptr_regs);
     for (const auto& expression : body) {
+        const auto reg_info = expression->get_reg_info();
+        const auto in_regs = transform_snippets_regs_to_idxs(reg_info.first);
+        const auto out_regs = transform_snippets_regs_to_idxs(reg_info.second);
         const auto& emitter = expression->get_emitter();
-        std::vector<size_t> in_regs, out_regs;
-        std::tie(in_regs, out_regs) = get_reg_idxs(expression->get_reg_info());
         emitter->emit_code(in_regs, out_regs, vec_regs_pool, gp_regs_pool);
     }
     h->postamble();

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.hpp
@@ -57,6 +57,8 @@ private:
     void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
     void init_data_pointers(const Xbyak::Reg64&, const Xbyak::Reg64&, const std::vector<Xbyak::Reg64>&) const;
+    static std::pair<std::vector<size_t>, std::vector<size_t>> get_reg_idxs(const ov::snippets::RegInfo& reg_info);
+
 
     jit_snippets_compile_args jcp;
     std::vector<size_t> gp_regs_pool;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.hpp
@@ -57,8 +57,6 @@ private:
     void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
     void init_data_pointers(const Xbyak::Reg64&, const Xbyak::Reg64&, const std::vector<Xbyak::Reg64>&) const;
-    static std::pair<std::vector<size_t>, std::vector<size_t>> get_reg_idxs(const ov::snippets::RegInfo& reg_info);
-
 
     jit_snippets_compile_args jcp;
     std::vector<size_t> gp_regs_pool;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
@@ -55,6 +55,7 @@ private:
     int64_t wa_increment = 0;
     int64_t work_amount = 0;
     bool evaluate_once = false;
+    std::vector<bool> is_incremented;
     std::vector<int64_t> ptr_increments;
     std::vector<int64_t> finalization_offsets;
 };


### PR DESCRIPTION
### Details:
 - *Added `RegType` as part of PortDescriptor - description of expression ports. Now `RegType` is set by output ports and expressions can have different reg types on input and outputs.*
 - *Removed non-`MemoryAccess` input `PortConnectors` filtering from `InsertLoops`. Now `LoopEnd` might have inputs with different reg types*

### Tickets:
 - *N/A*
