### PR TITLE
[Snippets] Fix PerfCount infrastructure

### DIFF
--- a/src/common/snippets/include/snippets/lowered/expression_factory.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_factory.hpp
@@ -24,6 +24,10 @@ public:
             return create(loop_begin, params...);
         } else if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(n)) {
             return create(loop_end, params...);
+        } else if (const auto perf_counter = ov::as_type_ptr<op::PerfCountBeginBase>(n)) {
+            return create(perf_counter, params...);
+        } else if (const auto perf_counter = ov::as_type_ptr<op::PerfCountEndBase>(n)) {
+            return create(perf_counter, params...);
         }
         return create(n, params...);
     }
@@ -48,6 +52,15 @@ private:
     static ExpressionPtr create(const std::shared_ptr<op::LoopBegin>& n, const std::vector<PortConnectorPtr>& inputs, const LinearIR& linear_ir);
     static ExpressionPtr create(const std::shared_ptr<op::LoopEnd>& n, const std::vector<PortConnectorPtr>& inputs, const LinearIR& linear_ir);
     static ExpressionPtr create(const std::shared_ptr<ov::Node>& n, const std::vector<PortConnectorPtr>& inputs, const LinearIR& linear_ir);
+
+    // Note: PerfCountBegin nodes have a PerfCountEnd ov::Output, but corresponding expression should not have any outputs to avoid register allocation
+    static ExpressionPtr create(const std::shared_ptr<op::PerfCountBeginBase>& n,
+                                                   const std::vector<PortConnectorPtr>& inputs,
+                                                   const LinearIR& linear_ir);
+    static ExpressionPtr create(const std::shared_ptr<op::PerfCountEndBase>& n,
+                                                   const std::vector<PortConnectorPtr>& inputs,
+                                                   const LinearIR& linear_ir);
+    static ExpressionPtr create_without_connections(const std::shared_ptr<ov::Node>& n, const LinearIR& linear_ir);
 
     // Creates inputs for expression using parent output port connectors
     static void create_expression_inputs(const LinearIR& linear_ir, const ExpressionPtr& expr);

--- a/src/common/snippets/include/snippets/lowered/expression_factory.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_factory.hpp
@@ -24,10 +24,12 @@ public:
             return create(loop_begin, params...);
         } else if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(n)) {
             return create(loop_end, params...);
+#ifdef SNIPPETS_DEBUG_CAPS
         } else if (const auto perf_counter = ov::as_type_ptr<op::PerfCountBeginBase>(n)) {
             return create(perf_counter, params...);
         } else if (const auto perf_counter = ov::as_type_ptr<op::PerfCountEndBase>(n)) {
             return create(perf_counter, params...);
+#endif
         }
         return create(n, params...);
     }
@@ -54,6 +56,7 @@ private:
     static ExpressionPtr create(const std::shared_ptr<ov::Node>& n, const std::vector<PortConnectorPtr>& inputs, const LinearIR& linear_ir);
 
     // Note: PerfCountBegin nodes have a PerfCountEnd ov::Output, but corresponding expression should not have any outputs to avoid register allocation
+#ifdef SNIPPETS_DEBUG_CAPS
     static ExpressionPtr create(const std::shared_ptr<op::PerfCountBeginBase>& n,
                                                    const std::vector<PortConnectorPtr>& inputs,
                                                    const LinearIR& linear_ir);
@@ -61,6 +64,7 @@ private:
                                                    const std::vector<PortConnectorPtr>& inputs,
                                                    const LinearIR& linear_ir);
     static ExpressionPtr create_without_connections(const std::shared_ptr<ov::Node>& n, const LinearIR& linear_ir);
+#endif
 
     // Creates inputs for expression using parent output port connectors
     static void create_expression_inputs(const LinearIR& linear_ir, const ExpressionPtr& expr);

--- a/src/common/snippets/include/snippets/lowered/pass/insert_perf_count.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_perf_count.hpp
@@ -24,8 +24,11 @@ namespace pass {
 class InsertPerfCount: public Pass {
 public:
     OPENVINO_RTTI("InsertPerfCount", "Pass")
-    InsertPerfCount() = default;
+    InsertPerfCount(std::map<std::string, std::string> boundary_op_names);
     bool run(LinearIR& linear_ir) override;
+
+private:
+    std::map<std::string, std::string> m_boundary_op_names;
 };
 
 } // namespace pass

--- a/src/common/snippets/src/lowered/expression_factory.cpp
+++ b/src/common/snippets/src/lowered/expression_factory.cpp
@@ -117,6 +117,29 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::Loop
     return expr;
 }
 
+ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::PerfCountBeginBase>& n,
+                                                  const std::vector<PortConnectorPtr>& inputs,
+                                                  const LinearIR& linear_ir) {
+    OPENVINO_ASSERT(inputs.empty(), "PerfCountBegin factory do not accept any input connectors");
+    return create_without_connections(n, linear_ir);
+}
+
+ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::PerfCountEndBase>& n,
+                                                  const std::vector<PortConnectorPtr>& inputs,
+                                                  const LinearIR& linear_ir) {
+    OPENVINO_ASSERT(inputs.empty(), "PerfCountEnd factory do not accept any input connectors");
+    return create_without_connections(n, linear_ir);
+}
+
+ExpressionPtr LinearIR::ExpressionFactory::create_without_connections(const std::shared_ptr<ov::Node>& n,
+                                                                      const LinearIR& linear_ir) {
+    auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory));
+    expr->m_input_port_descriptors.clear();
+    expr->m_output_port_descriptors.clear();
+    expr->validate();
+    return expr;
+}
+
 ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::Node>& n,
                                                   const std::vector<PortConnectorPtr>& inputs,
                                                   const LinearIR& linear_ir) {

--- a/src/common/snippets/src/lowered/expression_factory.cpp
+++ b/src/common/snippets/src/lowered/expression_factory.cpp
@@ -117,6 +117,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::Loop
     return expr;
 }
 
+#ifdef SNIPPETS_DEBUG_CAPS
 ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::PerfCountBeginBase>& n,
                                                   const std::vector<PortConnectorPtr>& inputs,
                                                   const LinearIR& linear_ir) {
@@ -139,6 +140,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create_without_connections(const std:
     expr->validate();
     return expr;
 }
+#endif
 
 ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::Node>& n,
                                                   const std::vector<PortConnectorPtr>& inputs,

--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -5,7 +5,6 @@
 
 #include "snippets/lowered/pass/insert_perf_count.hpp"
 #include "snippets/lowered/linear_ir.hpp"
-#include "snippets/snippets_isa.hpp"
 #include "snippets/itt.hpp"
 
 namespace ov {
@@ -13,48 +12,47 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 
+InsertPerfCount::InsertPerfCount(std::map<std::string, std::string> boundary_op_names)
+    : Pass(), m_boundary_op_names(std::move(boundary_op_names)) {
+}
+
 bool InsertPerfCount::run(LinearIR& linear_ir) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::InsertPerfCount")
     if (linear_ir.empty())
         return false;
-
-    auto is_parameter = [](const std::shared_ptr<ov::Node>& node) {
-        return ov::is_type<ov::op::v0::Parameter>(node);
-    };
-    auto is_result = [](const std::shared_ptr<ov::Node>& node) {
-        return ov::is_type<ov::op::v0::Result>(node);
-    };
-
-    // mark perf_count_begin and perf_count_end position
-    auto perf_count_begin_pos = linear_ir.cbegin();
-    auto perf_count_end_pos = perf_count_begin_pos;
-    bool first_result_marked = false;
-    for (auto expr_it = linear_ir.cbegin(); expr_it != linear_ir.cend(); expr_it++) {
-        const auto expr = *expr_it;
-        const auto& node = expr->get_node();
-        if (is_parameter(node))
-            perf_count_begin_pos = expr_it;
-
-        if (is_result(node) && !first_result_marked) {
-            perf_count_end_pos = expr_it;
-            first_result_marked = true;
-        }
+    if (m_boundary_op_names.empty()) {
+        const auto& first_op_name = linear_ir.begin()->get()->get_node()->get_friendly_name();
+        const auto& last_op_name = linear_ir.rbegin()->get()->get_node()->get_friendly_name();
+        m_boundary_op_names.insert({first_op_name, last_op_name});
     }
 
-    // insert perf_count_begin after last parameter
-    // linear_ir.insert has insert before behavior, need move to next.
-    const auto empty_inputs = std::vector<PortConnectorPtr>{};
-    const auto last_param_it = perf_count_begin_pos;
-    perf_count_begin_pos = std::next(perf_count_begin_pos);
-    const auto& perf_count_begin = std::make_shared<op::PerfCountBegin>();
-    linear_ir.insert_node(perf_count_begin, empty_inputs, last_param_it->get()->get_loop_ids(), false, perf_count_begin_pos);
+    size_t seq_number = 0;
+    for (auto expr_it = linear_ir.cbegin(); expr_it != linear_ir.cend(); expr_it++) {
+        const auto& op_name = expr_it->get()->get_node()->get_friendly_name();
+        const auto& found = m_boundary_op_names.find(op_name);
+        if (found != m_boundary_op_names.end()) {
+            const auto perf_count_begin_pos = expr_it;
+            auto perf_count_end_pos = expr_it;
+            while (perf_count_end_pos->get()->get_node()->get_friendly_name() != found->second &&
+                   perf_count_end_pos != linear_ir.cend()) {
+                perf_count_end_pos++;
+            }
+            OPENVINO_ASSERT(perf_count_end_pos != linear_ir.cend(), "Failed to find requested op name to insert PerfCountEnd");
+            // insert perf_count_begin after last parameter
+            // linear_ir.insert has insert before behavior, need move to next.
+            perf_count_end_pos++;
+            const auto& perf_count_begin = std::make_shared<snippets::op::PerfCountBegin>();
+            perf_count_begin->set_friendly_name(std::string("PerfCount_Begin_") + std::to_string(seq_number));
+            const auto empty_inputs = std::vector<PortConnectorPtr>{};
+            linear_ir.insert_node(perf_count_begin, empty_inputs, perf_count_begin_pos->get()->get_loop_ids(), false, perf_count_begin_pos);
 
-    // insert perf_count_end before first result
-    const auto& perf_count_end = std::make_shared<op::PerfCountEnd>(perf_count_begin->output(0));
-    perf_count_end->set_friendly_name("last_parameter_to_first_result");
-    // PerfCountEnd doesn't need PortConnector to PerfCountBegin
-    linear_ir.insert_node(perf_count_end, empty_inputs, perf_count_end_pos->get()->get_loop_ids(), false, perf_count_end_pos);
-
+            // insert perf_count_end before first result
+            const auto& perf_count_end = std::make_shared<snippets::op::PerfCountEnd>(perf_count_begin->output(0));
+            perf_count_end->set_friendly_name(std::string("PerfCount_End_") + std::to_string(seq_number));
+            linear_ir.insert_node(perf_count_end, empty_inputs, perf_count_end_pos->get()->get_loop_ids(), false, perf_count_end_pos);
+            seq_number++;
+        }
+    }
     return true;
 }
 

--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -38,18 +38,15 @@ bool InsertPerfCount::run(LinearIR& linear_ir) {
                 perf_count_end_pos++;
             }
             OPENVINO_ASSERT(perf_count_end_pos != linear_ir.cend(), "Failed to find requested op name to insert PerfCountEnd");
-            // insert perf_count_begin after last parameter
-            // linear_ir.insert has insert before behavior, need move to next.
-            perf_count_end_pos++;
             const auto& perf_count_begin = std::make_shared<snippets::op::PerfCountBegin>();
             perf_count_begin->set_friendly_name(std::string("PerfCount_Begin_") + std::to_string(seq_number));
             const auto empty_inputs = std::vector<PortConnectorPtr>{};
             linear_ir.insert_node(perf_count_begin, empty_inputs, perf_count_begin_pos->get()->get_loop_ids(), false, perf_count_begin_pos);
 
-            // insert perf_count_end before first result
             const auto& perf_count_end = std::make_shared<snippets::op::PerfCountEnd>(perf_count_begin->output(0));
             perf_count_end->set_friendly_name(std::string("PerfCount_End_") + std::to_string(seq_number));
-            linear_ir.insert_node(perf_count_end, empty_inputs, perf_count_end_pos->get()->get_loop_ids(), false, perf_count_end_pos);
+            // linear_ir.insert has insert before behavior, need to increment perf_count_end_pos
+            linear_ir.insert_node(perf_count_end, empty_inputs, perf_count_end_pos->get()->get_loop_ids(), false, next(perf_count_end_pos));
             seq_number++;
         }
     }

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -475,8 +475,8 @@ snippets::Schedule Subgraph::generate_from_linear_ir(const std::shared_ptr<lower
     LoweringResult lowering_result;
     control_flow_transformations(linear_ir, lowering_result, lowered_pass_config, backed_passes);
 #ifdef SNIPPETS_DEBUG_CAPS
-    if (linear_ir.get_config().perf_count_mode == lowered::PerfCountMode::Chrono) {
-        lowered::pass::InsertPerfCount perf_count_pass;
+    if (linear_ir.get_config().perf_count_mode != lowered::PerfCountMode::Disabled) {
+        lowered::pass::InsertPerfCount perf_count_pass({});
         perf_count_pass.run(linear_ir);
     }
 #endif

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_perf_count_rdtsc_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_perf_count_rdtsc_emitters.cpp
@@ -73,9 +73,7 @@ void jit_perf_count_rdtsc_end_emitter::emit_impl(const std::vector<size_t> &in_i
 
     // iteration++
     h->mov(h->rax, reinterpret_cast<size_t>(&m_end_node->iteration));
-    h->mov(h->rdx, qword[h->rax]);
-    h->add(h->rdx, 0x01);
-    h->mov(qword[h->rax], h->rdx);
+    h->inc(qword[h->rax]);
 
     h->pop(h->rdx);
     h->pop(h->rax);

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
@@ -58,7 +58,7 @@ public:
     // in destructor of PerfCountRdtscEnd, output the perf info
     // accumulation is cycle count
     uint64_t accumulation = 0ul;
-    uint64_t iteration = 0;
+    uint64_t iteration = 0ul;
 };
 
 } // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
@@ -7,6 +7,7 @@
 
 #include "openvino/op/op.hpp"
 #include "snippets/op/perf_count.hpp"
+#include <iomanip>
 
 using namespace ov::snippets::op;
 
@@ -38,8 +39,16 @@ public:
     PerfCountRdtscEnd(const Output<Node>& pc_begin);
     PerfCountRdtscEnd() = default;
     ~PerfCountRdtscEnd() {
-        uint64_t avg = iteration == 0 ? 0 : accumulation / iteration;
-        std::cout << "accumulation:" << accumulation << " iteration:" << iteration << " avg:" << avg << std::endl;
+        double avg = 0;
+        if (iteration != 0) {
+            // Note: theoretically accumulation could be larger than 2^53, however
+            // iteration is unlikely to exceed this threshold. So here we derive an integral part first
+            // and cast only the remainder to double
+            const uint64_t integral = accumulation / iteration;
+            avg = integral + static_cast<double>(accumulation - integral * iteration) / iteration;
+        }
+        std::cerr << "name : " << get_friendly_name() << " : acc : " << accumulation << " : num_hit : " << iteration
+         << std::fixed << std::setprecision(4) << " : avg : " << avg << std::endl;
     }
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& inputs) const override;
 
@@ -49,7 +58,7 @@ public:
     // in destructor of PerfCountRdtscEnd, output the perf info
     // accumulation is cycle count
     uint64_t accumulation = 0ul;
-    uint32_t iteration = 0u;
+    uint64_t iteration = 0;
 };
 
 } // namespace intel_cpu


### PR DESCRIPTION
### Details:
 - *When PerfCounters are inserted, output descriptors and connectors are automatically created based on the node number of outputs*
 - *This leads to ShapeInfer exception "Check 'result.dims.size() == out_descriptors.size()' failed" and inability to use the PerfCounters feature*
 - *This PR fixes this behavior*

### Tickets:
 - *129627*
