### PR TITLE
[CAPI][TEST] fix cancel api test with infer finished before cancel call

### DIFF
--- a/src/bindings/c/tests/ov_infer_request_test.cpp
+++ b/src/bindings/c/tests/ov_infer_request_test.cpp
@@ -298,8 +298,13 @@ TEST_P(ov_infer_request_test, infer) {
 
 TEST_P(ov_infer_request_test, cancel) {
     OV_EXPECT_OK(ov_infer_request_set_tensor(infer_request, in_tensor_name, input_tensor));
-
+    OV_ASSERT_OK(ov_infer_request_start_async(infer_request));
     OV_EXPECT_OK(ov_infer_request_cancel(infer_request));
+    ov_status_e return_status = ov_infer_request_wait(infer_request);
+    if (return_status == ov_status_e::OK || return_status == ov_status_e::INFER_CANCELLED)
+        GTEST_SUCCEED();
+    else
+        GTEST_FAIL();
 }
 
 TEST_P(ov_infer_request_ppp, infer_ppp) {

--- a/src/bindings/c/tests/ov_infer_request_test.cpp
+++ b/src/bindings/c/tests/ov_infer_request_test.cpp
@@ -299,8 +299,7 @@ TEST_P(ov_infer_request_test, infer) {
 TEST_P(ov_infer_request_test, cancel) {
     OV_EXPECT_OK(ov_infer_request_set_tensor(infer_request, in_tensor_name, input_tensor));
     OV_ASSERT_OK(ov_infer_request_start_async(infer_request));
-    OV_EXPECT_OK(ov_infer_request_cancel(infer_request));
-    ov_status_e return_status = ov_infer_request_wait(infer_request);
+    ov_status_e return_status = ov_infer_request_cancel(infer_request);
     if (return_status == ov_status_e::OK || return_status == ov_status_e::INFER_CANCELLED)
         GTEST_SUCCEED();
     else


### PR DESCRIPTION
### Details:
 - handle cancel() call after async infer & the infer finished
 - Refer C++ API test
![image](https://github.com/openvinotoolkit/openvino/assets/52686861/4589b6a5-3a31-470f-9aca-4eb548e67617)

Ported https://github.com/openvinotoolkit/openvino/pull/22151

### Tickets:
 - [129394](https://jira.devtools.intel.com/browse/CVS-129394)
