### PR TITLE
[op conformance] Fix wrong rounding of passrate when it close to 100

### DIFF
--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/merge_xmls.py
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/merge_xmls.py
@@ -87,6 +87,7 @@ def aggregate_test_results(aggregated_results: SubElement, xml_reports: list,
                         if aggregated_device_results is None:
                             aggregated_results.append(xml_device_entry)
                             aggregated_device_results = aggregated_results.find(device_name)
+                            break
                         else:
                             aggregated_device_results.append(xml_results_entry)
                         continue

--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/utils/stat_update_utils.py
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/utils/stat_update_utils.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2018-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import xml.etree.ElementTree as ET
 
 from . import conformance_utils
@@ -43,9 +44,9 @@ def update_passrates(results: ET.SubElement, rel_weights={}):
             rel_all_tests = rel_all_tests_actual if rel_all_tests_expected is None else rel_all_tests_expected
             k = 1 if rel_all_tests_expected is None else round(rel_all_tests_actual / rel_all_tests_expected)
             rel_passrate = float(rel_passed_tests * 100 / (k * rel_all_tests)) if rel_all_tests != None and rel_all_tests != 0 else 0
-            op.set("passrate", "%.2f"%passrate)
+            op.set("passrate", f"{math.floor(passrate * 100) / 100}")
             if rel_all_tests != None and rel_passed_tests != None:
-                op.set("relative_passrate", "%.2f"%rel_passrate)
+                op.set("relative_passrate", f"{math.floor(rel_passrate * 100) / 100}")
 
 
 


### PR DESCRIPTION
### Details:
 - *Fix situation when op has several tests with different wights and some of wights much bigger(0.1 and 1.0(-14)) for some of IRs then other. For example tests with big weight IRs are passed , then fail or crash will slightly influence on relative passrate and passrate will be close to 100. Before such values rounded to 100.00 and op could has several crash, but 100 passrate, now it is fixed*
