### PR TITLE
[OP CONFORMANCE] Extend expected_failures_CPU by sporadic failure test

### DIFF
--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/github/skip_configs/CPU/expected_failures_OP.csv
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/github/skip_configs/CPU/expected_failures_OP.csv
@@ -209,3 +209,4 @@ conformance_Convolution/ReadIRTest.Inference/Op=Convolution.1_Type=f32_Shape=dyn
 conformance_Reshape/ReadIRTest.Inference/Op=Reshape.1_Type=f32_Shape=dynamic_IR=b7a53df966d640f075cea7421ca5989ca91ca638e7af16aff33bc275eb7dfe9c_Device=CPU_Config=(),0.000352708
 conformance_ScatterElementsUpdate/ReadIRTest.Inference/Op=ScatterElementsUpdate.12_Type=f32_Shape=static_IR=5b185120e46fc0a2238ff4de19e278888ecda5fbae130c62e1ec21b4883ee61d_Device=CPU_Config=(),6.62629e-06
 conformance_Unsqueeze/ReadIRTest.Inference/Op=Unsqueeze.1_Type=f32_Shape=dynamic_IR=bda73cc94d837df9fb535743febd300cf0baf7fdf48ff538c079a4a7ca291592_Device=CPU_Config=(),2.89071e-06
+conformance_Gather/ReadIRTest.Inference/Op=Gather.8_Type=i64_Shape=dynamic_IR=e255ef2321233444ce6e4fdeb513a9b271987457aa9bd456948b64f589de1e2b_Device=CPU_Config=(),9.4639279043362649e-05


### PR DESCRIPTION
### Details:
 - *conformance_Gather/ReadIRTest.Inference/Op=Gather.8_Type=i64_Shape=dynamic_IR=e255ef2321233444ce6e4fdeb513a9b271987457aa9bd456948b64f589de1e2b_Device=CPU_Config=(),9.4639279043362649e-05*

### Tickets:
 - *CVS-129831*
