### PR TITLE
[CPU][apiConformance] support EXECUTION_DEVICES in ov::intel_cpu::Engine

### DIFF
--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -857,7 +857,7 @@ ov::Any Engine::get_ro_property(const std::string& name, const ov::AnyMap& optio
     } else if (name == ov::intel_cpu::sparse_weights_decompression_rate) {
         return decltype(ov::intel_cpu::sparse_weights_decompression_rate)::value_type(engConfig.fcSparseWeiDecompressionRate);
     } else if (name == ov::execution_devices) {
-        return decltype(ov::execution_devices)::value_type{ov::IPlugin::get_device_name()};
+        return decltype(ov::execution_devices)::value_type{get_device_name()};
     }
     /* Internally legacy parameters are used with new API as part of migration procedure.
      * This fallback can be removed as soon as migration completed */

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -792,6 +792,7 @@ ov::Any Engine::get_ro_property(const std::string& name, const ov::AnyMap& optio
                                                     RO_property(ov::available_devices.name()),
                                                     RO_property(ov::range_for_async_infer_requests.name()),
                                                     RO_property(ov::range_for_streams.name()),
+                                                    RO_property(ov::execution_devices.name()),
                                                     RO_property(ov::device::full_name.name()),
                                                     RO_property(ov::device::capabilities.name()),
         };
@@ -855,6 +856,8 @@ ov::Any Engine::get_ro_property(const std::string& name, const ov::AnyMap& optio
         return decltype(ov::intel_cpu::denormals_optimization)::value_type(engConfig.denormalsOptMode == Config::DenormalsOptMode::DO_On);
     } else if (name == ov::intel_cpu::sparse_weights_decompression_rate) {
         return decltype(ov::intel_cpu::sparse_weights_decompression_rate)::value_type(engConfig.fcSparseWeiDecompressionRate);
+    } else if (name == ov::execution_devices) {
+        return decltype(ov::execution_devices)::value_type{ov::IPlugin::get_device_name()};
     }
     /* Internally legacy parameters are used with new API as part of migration procedure.
      * This fallback can be removed as soon as migration completed */

--- a/src/plugins/intel_cpu/tests/functional/behavior/ov_executable_network/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/ov_executable_network/properties.cpp
@@ -270,5 +270,14 @@ TEST_F(OVClassConfigTestCPU, smoke_CpuExecNetworkCheckLogLevel) {
     }
 }
 
+TEST_F(OVClassConfigTestCPU, smoke_CpuExecNetworkCheckCPUExecutionDevice) {
+    ov::Core ie;
+    ov::Any value;
+    ov::CompiledModel compiledModel;
+
+    ASSERT_NO_THROW(compiledModel = ie.compile_model(model, deviceName));
+    ASSERT_NO_THROW(value = compiledModel.get_property(ov::execution_devices));
+    ASSERT_EQ(value.as<std::string>(), "CPU");
+}
 
 } // namespace

--- a/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
@@ -318,4 +318,12 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginSetConfigLogLevel) {
             testing::HasSubstr(expect_message));
 }
 
+TEST_F(OVClassConfigTestCPU, smoke_PluginCheckCPUExecutionDevice) {
+    ov::Core ie;
+    ov::Any value;
+
+    ASSERT_NO_THROW(value = ie.get_property("CPU", ov::execution_devices));
+    ASSERT_EQ(value.as<std::string>(), "CPU");
+}
+
 } // namespace

--- a/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
@@ -31,6 +31,7 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginAllSupportedPropertiesAreAvailable) {
         RO_property(ov::available_devices.name()),
         RO_property(ov::range_for_async_infer_requests.name()),
         RO_property(ov::range_for_streams.name()),
+        RO_property(ov::execution_devices.name()),
         RO_property(ov::device::full_name.name()),
         RO_property(ov::device::capabilities.name()),
         // read write

--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/github/skip_configs/CPU/expected_failures_API.csv
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/github/skip_configs/CPU/expected_failures_API.csv
@@ -1,5 +1,4 @@
 Test Name,Fix Priority
-ov_plugin_mandatory/OVCheckGetSupportedROMetricsPropsTests.ChangeCorrectProperties/target_device=CPU_properties={EXECUTION_DEVICES:},1.0
 ov_plugin_mandatory/OVCheckGetSupportedROMetricsPropsTests.ChangeCorrectProperties/target_device=CPU_properties={DEVICE_TYPE:},1.0
 ov_plugin_mandatory/OVCheckGetSupportedROMetricsPropsTests.ChangeCorrectProperties/target_device=CPU_properties={DEVICE_ARCHITECTURE:},1.0
 ov_plugin_mandatory/OVCheckChangePropComplieModleGetPropTests_InferencePrecision.ChangeCorrectProperties/target_device=CPU_,1.0


### PR DESCRIPTION
### Details:
 - add ov::execution_devices property support for ov::intel_cpu::Engine

### Tickets:
 - Closes https://github.com/openvinotoolkit/openvino/issues/22153
 - CVS-111344