### PR TITLE
[TRANSFORMATIONS -> CONSTANT FOLDING] Add evaluate for SqDiff due to using by constant folding

### DIFF
--- a/src/core/include/openvino/op/squared_difference.hpp
+++ b/src/core/include/openvino/op/squared_difference.hpp
@@ -29,6 +29,8 @@ public:
                       const AutoBroadcastSpec& auto_broadcast = AutoBroadcastSpec(AutoBroadcastType::NUMPY));
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
+    bool has_evaluate() const override;
 };
 }  // namespace v0
 }  // namespace op

--- a/src/core/src/op/squared_difference.cpp
+++ b/src/core/src/op/squared_difference.cpp
@@ -3,8 +3,28 @@
 //
 
 #include "openvino/op/squared_difference.hpp"
+#include "openvino/reference/squared_difference.hpp"
 
 #include "itt.hpp"
+#include "utils.hpp"
+
+namespace squared_difference {
+struct Evaluate : ov::element::NoAction<bool> {
+    using ov::element::NoAction<bool>::visit;
+
+    template <ov::element::Type_t ET>
+    static result_type visit(const ov::Tensor& in0,
+                             const ov::Tensor& in1,
+                             ov::Tensor& out,
+                             const ov::Shape& shape0,
+                             const ov::Shape& shape1,
+                             const ov::op::AutoBroadcastSpec& broadcast_spec) {
+        using T = typename ov::element_type_traits<ET>::value_type;
+        ov::reference::squared_difference(in0.data<const T>(), in1.data<const T>(), out.data<T>(), shape0, shape1, broadcast_spec);
+        return true;
+    }
+};
+} // namespace squared_difference
 
 // ------------------------------ v0 -------------------------------------------
 
@@ -19,4 +39,37 @@ std::shared_ptr<ov::Node> ov::op::v0::SquaredDifference::clone_with_new_inputs(c
     OV_OP_SCOPE(v0_SquaredDifference_clone_with_new_inputs);
     check_new_args_count(this, new_args);
     return std::make_shared<ov::op::v0::SquaredDifference>(new_args.at(0), new_args.at(1), this->get_autob());
+}
+
+bool ov::op::v0::SquaredDifference::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
+    OV_OP_SCOPE(v0_SquaredDifference_evaluate);
+    OPENVINO_ASSERT(outputs.size() == 1);
+
+    outputs[0].set_shape(infer_broadcast_shape(this, inputs));
+    using namespace ov::element;
+    return IF_TYPE_OF(v0_SquaredDifference_evaluate,
+                      OV_PP_ET_LIST(f32, f16, i32, i64, u32, u64),
+                      squared_difference::Evaluate,
+                      inputs[0].get_element_type(),
+                      inputs[0],
+                      inputs[1],
+                      outputs[0],
+                      inputs[0].get_shape(),
+                      inputs[1].get_shape(),
+                      get_autob());
+}
+
+bool ov::op::v0::SquaredDifference::has_evaluate() const {
+    OV_OP_SCOPE(v0_SquaredDifference_has_evaluate);
+    switch (get_input_element_type(0)) {
+    case element::f32:
+    case element::f16:
+    case element::i32:
+    case element::i64:
+    case element::u32:
+    case element::u64:
+        return true;
+    default:
+        return false;
+    }
 }

--- a/src/core/src/op/squared_difference.cpp
+++ b/src/core/src/op/squared_difference.cpp
@@ -3,9 +3,9 @@
 //
 
 #include "openvino/op/squared_difference.hpp"
-#include "openvino/reference/squared_difference.hpp"
 
 #include "itt.hpp"
+#include "openvino/reference/squared_difference.hpp"
 #include "utils.hpp"
 
 namespace squared_difference {
@@ -20,11 +20,16 @@ struct Evaluate : ov::element::NoAction<bool> {
                              const ov::Shape& shape1,
                              const ov::op::AutoBroadcastSpec& broadcast_spec) {
         using T = typename ov::element_type_traits<ET>::value_type;
-        ov::reference::squared_difference(in0.data<const T>(), in1.data<const T>(), out.data<T>(), shape0, shape1, broadcast_spec);
+        ov::reference::squared_difference(in0.data<const T>(),
+                                          in1.data<const T>(),
+                                          out.data<T>(),
+                                          shape0,
+                                          shape1,
+                                          broadcast_spec);
         return true;
     }
 };
-} // namespace squared_difference
+}  // namespace squared_difference
 
 // ------------------------------ v0 -------------------------------------------
 

--- a/src/core/src/op/squared_difference.cpp
+++ b/src/core/src/op/squared_difference.cpp
@@ -48,7 +48,7 @@ bool ov::op::v0::SquaredDifference::evaluate(TensorVector& outputs, const Tensor
     outputs[0].set_shape(infer_broadcast_shape(this, inputs));
     using namespace ov::element;
     return IF_TYPE_OF(v0_SquaredDifference_evaluate,
-                      OV_PP_ET_LIST(f32, f16, i32, i64, u32, u64),
+                      OV_PP_ET_LIST(f32),
                       squared_difference::Evaluate,
                       inputs[0].get_element_type(),
                       inputs[0],
@@ -63,11 +63,6 @@ bool ov::op::v0::SquaredDifference::has_evaluate() const {
     OV_OP_SCOPE(v0_SquaredDifference_has_evaluate);
     switch (get_input_element_type(0)) {
     case element::f32:
-    case element::f16:
-    case element::i32:
-    case element::i64:
-    case element::u32:
-    case element::u64:
         return true;
     default:
         return false;


### PR DESCRIPTION
### Details:
 - *This pattern was not applied by `Constant folding transformation:`*
![image](https://github.com/openvinotoolkit/openvino/assets/22008923/94629416-5aa1-4bd6-abef-56f89f695155)
- The result after constant folding before fix:
![image](https://github.com/openvinotoolkit/openvino/assets/22008923/f25aeae1-fefe-44d4-b502-4ea534c78539)
- The result after constant folding after fix:
![image](https://github.com/openvinotoolkit/openvino/assets/22008923/0b621542-1d84-4554-91f7-83b0a30f6eac)

### Tickets:
 - *https://jira.devtools.intel.com/browse/CVS-129152*
