### PR TITLE
Decrease number of workers for ONNX Model tests to prevent OOM kills

### DIFF
--- a/.github/workflows/job_onnx_models_tests.yml
+++ b/.github/workflows/job_onnx_models_tests.yml
@@ -103,4 +103,4 @@ jobs:
           python3 -m pip install pytest-xdist[psutil] pytest-forked
 
       - name: ONNX Models Tests
-        run: python3 -m pytest --backend="CPU" --model_zoo_dir="${MODELS_SHARE_PATH}" ${INSTALL_TEST_DIR}/onnx/tests/tests_python/test_zoo_models.py -v -n 10 --forked -k 'not _cuda' --model_zoo_xfail
+        run: python3 -m pytest --backend="CPU" --model_zoo_dir="${MODELS_SHARE_PATH}" ${INSTALL_TEST_DIR}/onnx/tests/tests_python/test_zoo_models.py -v -n auto --forked -k 'not _cuda' --model_zoo_xfail

--- a/.github/workflows/job_onnx_models_tests.yml
+++ b/.github/workflows/job_onnx_models_tests.yml
@@ -103,4 +103,4 @@ jobs:
           python3 -m pip install pytest-xdist[psutil] pytest-forked
 
       - name: ONNX Models Tests
-        run: python3 -m pytest --backend="CPU" --model_zoo_dir="${MODELS_SHARE_PATH}" ${INSTALL_TEST_DIR}/onnx/tests/tests_python/test_zoo_models.py -v -n 12 --forked -k 'not _cuda' --model_zoo_xfail
+        run: python3 -m pytest --backend="CPU" --model_zoo_dir="${MODELS_SHARE_PATH}" ${INSTALL_TEST_DIR}/onnx/tests/tests_python/test_zoo_models.py -v -n 10 --forked -k 'not _cuda' --model_zoo_xfail


### PR DESCRIPTION
### Details:
ONNX Model tests are consuming all available RAM on the node assigned, let's reduce number of parallel workers and see if they become any slower

### Tickets:
- CVS-129447