### PR TITLE
[GPU] Extend gemm to fuse transpose layers

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/op/gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/gemm.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/core/node.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/op.hpp"
+
+namespace ov {
+namespace intel_gpu {
+namespace op {
+
+class Gemm : public ov::op::v0::MatMul {
+public:
+    OPENVINO_OP("Gemm", "gpu_opset");
+
+    Gemm() = default;
+
+    Gemm(const ov::Output<Node>& A,
+         const ov::Output<Node>& B,
+         const std::vector<int64_t>& order_a,
+         const std::vector<int64_t>& order_b,
+         const std::vector<int64_t>& order_c,
+         const ov::element::Type output_type = ov::element::undefined);
+
+    bool visit_attributes(ov::AttributeVisitor &visitor) override;
+
+    void validate_and_infer_types() override;
+
+    std::shared_ptr<Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
+
+    ov::element::Type get_output_type() const { return m_output_type; }
+
+protected:
+    std::vector<int64_t> m_order_a;
+    std::vector<int64_t> m_order_b;
+    std::vector<int64_t> m_order_c;
+    ov::element::Type m_output_type;
+};
+
+std::vector<ov::PartialShape> shape_infer(const Gemm* op,
+                                          std::vector<ov::PartialShape> input_shapes,
+                                          const std::vector<int64_t>& order_a,
+                                          const std::vector<int64_t>& order_b,
+                                          const std::vector<int64_t>& order_c);
+
+}   // namespace op
+}   // namespace intel_gpu
+}   // namespace ov

--- a/src/plugins/intel_gpu/include/intel_gpu/op/gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/gemm.hpp
@@ -32,6 +32,9 @@ public:
 
     std::shared_ptr<Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
 
+    std::vector<int64_t> get_input0_order() const { return m_order_a; }
+    std::vector<int64_t> get_input1_order() const { return m_order_b; }
+    std::vector<int64_t> get_output_order() const { return m_order_c; }
     ov::element::Type get_output_type() const { return m_output_type; }
 
 protected:

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/primitives_list.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/primitives_list.hpp
@@ -275,3 +275,4 @@ REGISTER_FACTORY(internal, RMS);
 REGISTER_FACTORY(internal, GatherCompressed);
 REGISTER_FACTORY(internal, KVCache);
 REGISTER_FACTORY(internal, ReadValue);
+REGISTER_FACTORY(internal, Gemm);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
@@ -38,7 +38,7 @@ struct gemm : public primitive_base<gemm> {
     gemm(const primitive_id& id,
          const std::vector<input_info>& inputs,
          const data_types data_type,
-         const bool transpose_input0 = false,
+         const bool transpose_input0,
          const bool transpose_input1 = false,
          const float alpha = 1.0f,
          const float beta = 0.0f,
@@ -55,25 +55,79 @@ struct gemm : public primitive_base<gemm> {
         if (inputs.size() != 2 && inputs.size() != 3) {
             throw std::invalid_argument("Invalid inputs count - gemm expects either two or three inputs");
         }
+
+        auto get_tranaposed_order = [] (size_t rank, bool transposed) {
+            std::vector<int64_t> order(rank);
+            std::iota(order.begin(), order.end(), 0);
+            if (transposed)
+                std::swap(order[rank - 1], order[rank - 2]);
+            return order;
+        };
+
+        input0_order = get_tranaposed_order(input_rank, transpose_input0);
+        input1_order = get_tranaposed_order(weight_rank, transpose_input1);
+        output_order = {};
+    }
+
+    /// @brief Constructs gemm layer.
+    /// @brief Primitive id containing first matrix
+    /// @brief Primitive id containing second matrix
+    /// @brief Transposed order of first input matrix
+    /// @brief Transposed order of second input matrix
+    /// @brief Transposed order of output matrix
+    /// @brief Variable containing ALPHA parameter
+    /// @brief Variable containing BETA parameter
+    gemm(const primitive_id& id,
+         const std::vector<input_info>& inputs,
+         const data_types data_type,
+         const std::vector<int64_t>& input0_order = {0, 1, 2, 3},
+         const std::vector<int64_t>& input1_order = {0, 1, 2, 3},
+         const std::vector<int64_t>& output_order = {},
+         const float alpha = 1.0f,
+         const float beta = 0.0f,
+         const padding& output_padding = padding())
+        : primitive_base(id, inputs, {output_padding}, {optional_data_type{ data_type }}),
+          input0_order(input0_order),
+          input1_order(input1_order),
+          output_order(output_order),
+          alpha(alpha),
+          beta(beta),
+          input_rank(input0_order.size()),
+          weight_rank(input1_order.size()) {
+        if (inputs.size() != 2 && inputs.size() != 3) {
+            throw std::invalid_argument("Invalid inputs count - gemm expects either two or three inputs");
+        }
     }
 
     /// @brief Flag for transposing first input matrix
     bool transpose_input0 = false;
     /// @brief Flag for transposing second input matrix
     bool transpose_input1 = false;
+    /// @brief order of input 0
+    std::vector<int64_t> input0_order;
+    /// @brief order of input 1
+    std::vector<int64_t> input1_order;
+    /// @brief order of output
+    std::vector<int64_t> output_order;
     /// @brief Variable containing ALPHA parameter
     float alpha = 1.0f;
     /// @brief Variable containing BETA parameter
     float beta = 1.0f;
     /// @brief First matrix rank
     size_t input_rank = 4;
-     /// @brief Second matrix rank
+    /// @brief Second matrix rank
     size_t weight_rank = 4;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, transpose_input0);
         seed = hash_combine(seed, transpose_input1);
+        for (auto order : input0_order)
+            seed = hash_combine(seed, order);
+        for (auto order : input1_order)
+            seed = hash_combine(seed, order);
+        for (auto order : output_order)
+            seed = hash_combine(seed, order);
         seed = hash_combine(seed, alpha);
         seed = hash_combine(seed, beta);
         return seed;
@@ -97,6 +151,9 @@ struct gemm : public primitive_base<gemm> {
         primitive_base<gemm>::save(ob);
         ob << transpose_input0;
         ob << transpose_input1;
+        ob << input0_order;
+        ob << input1_order;
+        ob << output_order;
         ob << alpha;
         ob << beta;
         ob << input_rank;
@@ -107,6 +164,9 @@ struct gemm : public primitive_base<gemm> {
         primitive_base<gemm>::load(ib);
         ib >> transpose_input0;
         ib >> transpose_input1;
+        ib >> input0_order;
+        ib >> input1_order;
+        ib >> output_order;
         ib >> alpha;
         ib >> beta;
         ib >> input_rank;

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -22,35 +22,40 @@ layout gemm_inst::calc_output_layout(gemm_node const& node, kernel_impl_params c
     auto input0_shape = input0_layout.get_shape();
     auto input1_shape = input1_layout.get_shape();
 
-    bool transpose_input0 = prim->transpose_input0;
-    bool transpose_input1 = prim->transpose_input1;
+    auto input0_order = prim->input0_order;
+    auto input1_order = prim->input1_order;
 
     bool reordered = prim->input_rank > 4 || prim->weight_rank > 4;
     size_t output_rank = std::max(prim->input_rank, prim->weight_rank);
     size_t input_rank = reordered ? output_rank : prim->input_rank;
     size_t weight_rank = reordered ? output_rank : prim->weight_rank;
 
-    auto update_input_shape = [&output_rank](const ov::Shape& input_shape, size_t rank, bool transpose, bool first_input) {
-        auto input_shape_update = ov::Shape(input_shape.begin(), input_shape.begin() + std::min(rank, input_shape.size()));
+    auto update_input_shape = [&output_rank](const ov::Shape& input_shape, size_t rank, std::vector<int64_t> input_order, bool first_input) {
+        auto input_shape_update = ov::Shape();
+        auto _input_shape_update = ov::Shape(input_shape.begin(), input_shape.begin() + std::min(rank, input_shape.size()));
+        if (_input_shape_update.size() == input_order.size() && input_order.size() > 1) {
+            for (auto idx : input_order) {
+                input_shape_update.push_back(_input_shape_update[idx]);
+            }
+        } else {
+            input_shape_update = _input_shape_update;
+        }
         if (input_shape_update.size() == 1) {
             first_input ? input_shape_update.insert(input_shape_update.begin(), 1)
                         : input_shape_update.insert(input_shape_update.end(), 1);
-            if (transpose) {
-                std::swap(input_shape_update[0], input_shape_update[1]);
-            }
             output_rank = std::max(output_rank, rank + 1);
         }
         input_shape_update.insert(input_shape_update.begin(), output_rank - input_shape_update.size(), 1);
         return input_shape_update;
     };
 
-    auto input0_shape_update = update_input_shape(input0_shape, input_rank, transpose_input0, true);
-    auto input1_shape_update = update_input_shape(input1_shape, weight_rank, transpose_input1, false);
+    auto input0_shape_update = update_input_shape(input0_shape, input_rank, input0_order, true);
+    auto input1_shape_update = update_input_shape(input1_shape, weight_rank, input1_order, false);
 
     ov::Shape bias_shape(output_rank);
     if (prim->input_size() == 3) {
         bias_shape = impl_param.get_input_layout(2).get_shape();
-        bias_shape = update_input_shape(bias_shape, weight_rank, transpose_input1, false);
+        bias_shape = update_input_shape(bias_shape, weight_rank, input1_order, false);
     }
 
     auto output_shape = input0_shape_update;
@@ -58,8 +63,8 @@ layout gemm_inst::calc_output_layout(gemm_node const& node, kernel_impl_params c
         output_shape[i] = std::max(std::max(input0_shape_update[i], input1_shape_update[i]), bias_shape[i]);
     }
 
-    size_t M = !transpose_input0 ? *(input0_shape_update.end() - 2) : input0_shape_update.back();
-    size_t N = !transpose_input1 ? input1_shape_update.back() : *(input1_shape_update.end() - 2);
+    size_t M = *(input0_shape_update.end() - 2);
+    size_t N = input1_shape_update.back();
 
     output_shape[output_rank - 2] = M;
     output_shape[output_rank - 1] = N;
@@ -187,8 +192,14 @@ layout gemm_inst::transform_output_layout(const std::shared_ptr<const gemm> prim
         auto input0_pshape = input_layouts[0].get_partial_shape();
         auto input1_pshape = input_layouts[1].get_partial_shape();
 
-        auto M = !primitive->transpose_input0 ? input0_pshape[input0_pshape.size() - 2] : input0_pshape[input0_pshape.size() - 1];
-        auto N = !primitive->transpose_input1 ? input1_pshape[input1_pshape.size() - 1] : input1_pshape[input1_pshape.size() - 2];
+        auto input0_order = primitive->input0_order;
+        auto input1_order = primitive->input1_order;
+
+        auto m_idx = ((input0_order.size() > 1) ? input0_order[input0_order.size() - 2] : input0_order[0])
+                    + input0_pshape.size() - input0_order.size();
+        auto n_idx = input1_order[input1_order.size() - 1] + input1_pshape.size() - input1_order.size();
+        auto M = input0_pshape[m_idx];
+        auto N = input1_pshape[n_idx];
 
         auto output_pshape = input_layouts[0].get_partial_shape();
         for (size_t i = 0; i != input_layouts.size(); ++i) {

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <algorithm>
 
-#include "matmul_shape_inference.hpp"
+#include "intel_gpu/op/gemm.hpp"
 
 namespace cldnn {
 GPU_DEFINE_PRIMITIVE_TYPE_ID(gemm)
@@ -97,16 +97,17 @@ std::vector<layout> gemm_inst::calc_output_layouts(gemm_node const& node, const 
         output_type = impl_param.get_fused_output_layout().data_type;
     }
 
-    ov::op::v0::MatMul op;
-    op.set_transpose_a(prim->transpose_input0);
-    op.set_transpose_b(prim->transpose_input1);
+    ov::intel_gpu::op::Gemm op;
+    op.set_transpose_a(false);
+    op.set_transpose_b(false);
 
     std::vector<ShapeType> input_shapes = {
         input0_layout.get<ShapeType>(),
         input1_layout.get<ShapeType>()
     };
 
-    std::vector<ShapeType> output_shapes = ov::op::v0::shape_infer(&op, input_shapes);
+    std::vector<ShapeType> output_shapes = ov::intel_gpu::op::shape_infer(&op, input_shapes,
+                                    prim->input0_order, prim->input1_order, prim->output_order);
 
     cldnn::format output_format = input0_layout.format;
     if (node.get_preferred_output_fmt() != format::any)

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -47,6 +47,9 @@ public:
         params.beta = primitive->beta;
         params.transpose_input0 = primitive->transpose_input0;
         params.transpose_input1 = primitive->transpose_input1;
+        params.input0_order = primitive->input0_order;
+        params.input1_order = primitive->input1_order;
+        params.output_order = primitive->output_order;
 
         bool is_quantized = true;
         for (auto& input : impl_param.input_layouts)

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -753,6 +753,13 @@ bool primitive_inst::update_impl() {
 
                         if (!can_be_optimized()) {
                             auto impl = _node->type()->choose_impl(*_node, updated_params_no_dyn_pad);
+                            // In the case of gemm, if current dynamic impl is not gemm_ref and newly chosen impl is gemm_ref,
+                            // the newly chosen impl is not added to the impl cache for beffer performance.
+                            if (_node->is_type<gemm>() &&
+                                _dynamic_impl->get_kernel_name().find("gemm_ref") == std::string::npos &&
+                                impl->get_kernel_name().find("gemm_ref") != std::string::npos) {
+                                return;
+                            }
                             if (impl->get_kernels_source().size() > 0) {
                                 auto kernels = _program->get_kernels_cache().compile(updated_params_no_dyn_pad, impl->get_kernels_source());
                                 impl->set_kernels(kernels);

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -636,7 +636,9 @@ bool primitive_inst::use_async_compilation() {
         return false;
     }
 
-    return (_node->is_type<convolution>() || _node->is_type<fully_connected>() || _node->is_type<gemm>() ||
+    return (_node->is_type<convolution>() || _node->is_type<fully_connected>() ||
+            (_node->is_type<gemm>() && _node->get_selected_impl() &&
+             _node->get_selected_impl()->get_kernel_name().find("gemm_ref") != std::string::npos) ||
             (_node->is_type<softmax>() && _node->get_selected_impl() &&
              _node->get_selected_impl()->get_kernel_name().find("softmax_gpu_ref") != std::string::npos));
 }
@@ -753,13 +755,6 @@ bool primitive_inst::update_impl() {
 
                         if (!can_be_optimized()) {
                             auto impl = _node->type()->choose_impl(*_node, updated_params_no_dyn_pad);
-                            // In the case of gemm, if current dynamic impl is not gemm_ref and newly chosen impl is gemm_ref,
-                            // the newly chosen impl is not added to the impl cache for beffer performance.
-                            if (_node->is_type<gemm>() &&
-                                _dynamic_impl->get_kernel_name().find("gemm_ref") == std::string::npos &&
-                                impl->get_kernel_name().find("gemm_ref") != std::string::npos) {
-                                return;
-                            }
                             if (impl->get_kernels_source().size() > 0) {
                                 auto kernels = _program->get_kernels_cache().compile(updated_params_no_dyn_pad, impl->get_kernels_source());
                                 impl->set_kernels(kernels);

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -636,9 +636,7 @@ bool primitive_inst::use_async_compilation() {
         return false;
     }
 
-    return (_node->is_type<convolution>() || _node->is_type<fully_connected>() ||
-            (_node->is_type<gemm>() && _node->get_selected_impl() &&
-             _node->get_selected_impl()->get_kernel_name().find("gemm_ref") != std::string::npos) ||
+    return (_node->is_type<convolution>() || _node->is_type<fully_connected>() || _node->is_type<gemm>() ||
             (_node->is_type<softmax>() && _node->get_selected_impl() &&
              _node->get_selected_impl()->get_kernel_name().find("softmax_gpu_ref") != std::string::npos));
 }
@@ -755,6 +753,13 @@ bool primitive_inst::update_impl() {
 
                         if (!can_be_optimized()) {
                             auto impl = _node->type()->choose_impl(*_node, updated_params_no_dyn_pad);
+                            // In the case of gemm, if current dynamic impl is not gemm_ref and newly chosen impl is gemm_ref,
+                            // the newly chosen impl is not added to the impl cache for beffer performance.
+                            if (_node->is_type<gemm>() &&
+                                _dynamic_impl->get_kernel_name().find("gemm_ref") == std::string::npos &&
+                                impl->get_kernel_name().find("gemm_ref") != std::string::npos) {
+                                return;
+                            }
                             if (impl->get_kernels_source().size() > 0) {
                                 auto kernels = _program->get_kernels_cache().compile(updated_params_no_dyn_pad, impl->get_kernels_source());
                                 impl->set_kernels(kernels);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_ref.cl
@@ -26,11 +26,7 @@ inline uint FUNC(get_input0_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, ui
 }
 
 inline uint FUNC(get_input0_index)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
-#if !TRANSPOSE_INPUT0
-    return FUNC_CALL(get_input0_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
-#else
-    return FUNC_CALL(get_input0_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, x, y);
-#endif
+    return FUNC_CALL(get_input0_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR INPUT0_DIMS_ORDER);
 }
 
 inline uint FUNC(get_input1_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
@@ -50,11 +46,7 @@ inline uint FUNC(get_input1_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, ui
 }
 
 inline uint FUNC(get_input1_index)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
-#if !TRANSPOSE_INPUT1
-    return FUNC_CALL(get_input1_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
-#else
-    return FUNC_CALL(get_input1_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, x, y);
-#endif
+    return FUNC_CALL(get_input1_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR INPUT1_DIMS_ORDER);
 }
 
 #ifdef INPUT2_TYPE
@@ -100,11 +92,7 @@ KERNEL(gemm_ref)(
     bidx /= OUTPUT_SIZE_Z;
     const uint w = bidx % OUTPUT_SIZE_W;
 
-#if !TRANSPOSE_INPUT0
-    const uint K = INPUT0_SIZE_X;
-#else
-    const uint K = INPUT0_SIZE_Y;
-#endif
+    const uint K = CAT(INPUT0_SIZE_, MATMUL_AXIS);
 
     ACCUMULATOR_TYPE acc = ACCUMULATOR_VAL_ZERO;
 
@@ -129,7 +117,7 @@ KERNEL(gemm_ref)(
     }
 #endif
 
-    const uint dst_index = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
+    const uint dst_index = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR TR_B, TR_F, TR_W, TR_Z, TR_Y, TR_X);
 
     ACTIVATION_TYPE dequantized = TO_ACTIVATION_TYPE(acc);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "include/fetch_utils.cl"
 #include "include/batch_headers/fetch_data.cl"
 #include "include/batch_headers/sub_group_block_read.cl"
 #include "include/batch_headers/sub_group_block_write.cl"
@@ -27,20 +28,28 @@
     #define BLOCK_WRITE_C(ptr, offset, data) BLOCK_WRITEN(OUTPUT_TYPE, 1, ptr, offset, data)
 #endif // TILE_N > SIMD_WIDTH
 
-inline uint FUNC(get_input0_batch_offset)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z) {
+inline uint FUNC(get_input0_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
 #if INPUT0_SIMPLE
-    return GET_DATA_INDEX_6D_SAFE(INPUT0, b, f, w, z, 0, 0);
-#else // INPUT0_SIMPLE
+    return GET_DATA_INDEX_6D_SAFE(INPUT0, b, f, w, z, y, x);
+#else
 #   error gemm_tiled_opt.cl : Unsupported input 0 format
-#endif // INPUT0_SIMPLE
+#endif
 }
 
-inline uint FUNC(get_input1_batch_offset)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z) {
+inline uint FUNC(get_input0_index)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
+    return FUNC_CALL(get_input0_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR INPUT0_DIMS_ORDER);
+}
+
+inline uint FUNC(get_input1_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
 #if INPUT1_SIMPLE
-    return GET_DATA_INDEX_6D_SAFE(INPUT1, b, f, w, z, 0, 0);
-#else // INPUT1_SIMPLE
+    return GET_DATA_INDEX_6D_SAFE(INPUT1, b, f, w, z, y, x);
+#else
 #   error gemm_tiled_opt.cl : Unsupported input 1 format
-#endif // INPUT1_SIMPLE
+#endif
+}
+
+inline uint FUNC(get_input1_index)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
+    return FUNC_CALL(get_input1_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR INPUT1_DIMS_ORDER);
 }
 
 #ifdef INPUT2_TYPE
@@ -53,13 +62,7 @@ inline uint FUNC(get_input2_batch_offset)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f
 }
 #endif // INPUT2_TYPE
 
-inline uint FUNC(get_output_batch_offset)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z) {
-#if OUTPUT_SIMPLE
-    return GET_DATA_INDEX_6D(OUTPUT, b, f, w, z, 0, 0);
-#else // OUTPUT_SIMPLE
-#   error gemm_tiled_opt.cl : Unsupported output format
-#endif // OUTPUT_SIMPLE
-}
+#define VLOAD CAT(vload, SIMD_WIDTH)
 
 // Optimized gemm kernel for fp16/fp32 inputs
 REQD_SUB_GROUP_SIZE(SIMD_WIDTH)
@@ -99,48 +102,78 @@ KERNEL(gemm_tiled_opt)(
     uint y = tile_m_offset;
 
     const uint tile_m_iterations = TILE_M_NOT_DIVISIBLE ? (tile_m_num == (tile_m_size - 1) ? TILE_M_LEFTOVER : TILE_M) : TILE_M;
-    const uint z = batch_number % OUTPUT_SIZE_Z;
-    batch_number /= OUTPUT_SIZE_Z;
-    const uint w = batch_number % OUTPUT_SIZE_W;
-    batch_number /= OUTPUT_SIZE_W;
-    const uint f = batch_number % OUTPUT_FEATURE_NUM;
-    batch_number /= OUTPUT_FEATURE_NUM;
-    const uint b = batch_number % OUTPUT_BATCH_NUM;
+    const uint z = batch_number % TR_OUTPUT_SIZE_Z;
+    batch_number /= TR_OUTPUT_SIZE_Z;
+    const uint w = batch_number % TR_OUTPUT_SIZE_W;
+    batch_number /= TR_OUTPUT_SIZE_W;
+    const uint f = batch_number % TR_OUTPUT_FEATURE_NUM;
+    batch_number /= TR_OUTPUT_FEATURE_NUM;
+    const uint b = batch_number % TR_OUTPUT_BATCH_NUM;
 
     // Batch offsets
-    const uint batch_offset_input0 = FUNC_CALL(get_input0_batch_offset)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z);
-    const uint batch_offset_input1 = FUNC_CALL(get_input1_batch_offset)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z);
+    const uint batch_offset_input0 = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, 0);
+    const uint batch_offset_input1 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, 0, tile_n_offset);
 #ifdef INPUT2_TYPE
     const uint batch_offset_input2 = FUNC_CALL(get_input2_batch_offset)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z);
 #endif // INPUT2_TYPE
-    const uint batch_offset_output = FUNC_CALL(get_output_batch_offset)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z);
+    uint write_id = 0;
+    const uint batch_offset_output = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR TR_B, TR_F, TR_W, TR_Z, TR_Y, TR_X);
+    write_id = 1;
+    const uint batch_offset_output_diff = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR TR_B, TR_F, TR_W, TR_Z, TR_Y, TR_X) - batch_offset_output;
 
     // Start pointers offsets
-#if !TRANSPOSE_INPUT0
-    const __global INPUT0_TYPE* a_ptr = input0 + batch_offset_input0 + tile_m_offset * K_PADDED_IN0;
-#else // !TRANSPOSE_INPUT0
-    const __global INPUT0_TYPE* a_ptr = input0 + batch_offset_input0 + tile_m_offset;
-#endif // !TRANSPOSE_INPUT0
-#if !TRANSPOSE_INPUT1
-    const __global INPUT1_TYPE* b_ptr = input1 + batch_offset_input1 + tile_n_offset;
-#else // !TRANSPOSE_INPUT1
-    const __global INPUT1_TYPE* b_ptr = input1 + batch_offset_input1 + tile_n_offset * K;
-#endif // !TRANSPOSE_INPUT1
+#if TRANSPOSE_INPUT0 == 0
+    const __global INPUT0_TYPE* a_ptr = input0 + batch_offset_input0;
+    #if HAS_DYNAMIC_K_PADDING
+        const uint input0_offset = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (y+1), 0) - batch_offset_input0;
+        const uint input0_offset1 = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, (TILE_K)) - batch_offset_input0;
+    #else
+        const uint input0_offset = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR 0, 0, 0, 0, 1, 0);
+        const uint input0_offset1 = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR 0, 0, 0, 0, 0, (TILE_K));
+    #endif
+#elif TRANSPOSE_INPUT0 == 1
+    const __global INPUT0_TYPE* a_ptr = input0 + batch_offset_input0;
+    #if HAS_DYNAMIC_K_PADDING
+        const uint input0_offset = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, 1) - batch_offset_input0;
+        const uint input0_offset1 = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, (TILE_K)) - batch_offset_input0;
+    #else
+        const uint input0_offset = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR 0, 0, 0, 0, 0, 1);
+        const uint input0_offset1 = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR 0, 0, 0, 0, 0, (TILE_K));
+    #endif
+#endif // TRANSPOSE_INPUT0
+#if TRANSPOSE_INPUT1 == 0
+    const __global INPUT1_TYPE* b_ptr = input1 + batch_offset_input1;
+    #if HAS_DYNAMIC_K_PADDING
+        const uint input1_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, 1, tile_n_offset) - batch_offset_input1;
+    #else
+        const uint input1_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR 0, 0, 0, 0, 1, 0);
+    #endif
+#elif TRANSPOSE_INPUT1 == 1
+    const __global INPUT1_TYPE* b_ptr = input1 + batch_offset_input1;
+    #if HAS_DYNAMIC_K_PADDING
+        const uint input1_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, 0, (tile_n_offset + 1)) - batch_offset_input1;
+        const uint input1_offset1 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (TILE_K), tile_n_offset) - batch_offset_input1;
+    #else
+        const uint input1_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR 0, 0, 0, 0, 0, 1);
+        const uint input1_offset1 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR 0, 0, 0, 0, (TILE_K), 0);
+    #endif
+    const uint input1_fetch_size = ((N - tile_n_offset) < TILE_K) ? (N - tile_n_offset) : TILE_K;
+#endif // TRANSPOSE_INPUT1
 #ifdef INPUT2_TYPE
     const __global INPUT2_TYPE* c_ptr = input2 + batch_offset_input2 + tile_m_offset * N + tile_n_offset;
 #endif // INPUT2_TYPE
-    __global OUTPUT_TYPE* d_ptr = output + batch_offset_output + tile_m_offset * N + tile_n_offset;
+    __global OUTPUT_TYPE* d_ptr = output + batch_offset_output;
 
     const uint b_raw_global_id = tile_n_offset + sglid;
 
-#if TRANSPOSE_INPUT0
+#if TRANSPOSE_INPUT0 == 1
     MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile;
-#endif // TRANSPOSE_INPUT0
-#if !TRANSPOSE_INPUT1
+#endif // TRANSPOSE_INPUT0 == 1
+#if TRANSPOSE_INPUT1 != 1
     B_FLOATN b_tile[TILE_K];
-#else // !TRANSPOSE_INPUT1
+#else // TRANSPOSE_INPUT1 != 1
     MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile;
-#endif // !TRANSPOSE_INPUT1
+#endif // TRANSPOSE_INPUT1 != 1
     B_FLOATN c_tile[TILE_M];
 
     unroll_for (uint i = 0; i < TILE_M; i++) {
@@ -153,76 +186,65 @@ KERNEL(gemm_tiled_opt)(
         // Loading B tile
         unroll_for (uint b_load_id = 0; b_load_id < TILE_K; b_load_id++) {
 #if IS_DYNAMIC
+#if TRANSPOSE_INPUT1 == 0
 #if HAS_DYNAMIC_N_PADDING
-            // In case of dynamic padding we can't guarantee memory access alignment for
-            // block reads (4 bytes), so use scattered read
             b_tile[b_load_id] = b_raw_global_id > N - 1 ? 0 : b_ptr[sglid];
 #else
             b_tile[b_load_id] = TILE_N_NOT_DIVISIBLE ? (b_raw_global_id > N - 1 ? 0 : b_ptr[sglid]) : BLOCK_READ_B(b_ptr, 0);
 #endif
+            b_ptr += input1_offset;
+#elif TRANSPOSE_INPUT1 == 2 // TRANSPOSE_INPUT1 == 0
+            if (b_raw_global_id > N - 1) {
+                b_tile[b_load_id] = 0;
+            } else {
+                uint b_idx = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (b_load_id + k * TILE_K), x);
+                b_tile[b_load_id] = input1[b_idx];
+            }
+#endif // TRANSPOSE_INPUT1 == 0
 #else // IS_DYNAMIC
+#if TRANSPOSE_INPUT1 == 0
 #if TILE_N_NOT_DIVISIBLE
             b_tile[b_load_id] = b_raw_global_id > N - 1 ? 0 : b_ptr[sglid];
 #else // TILE_N_NOT_DIVISIBLE
             b_tile[b_load_id] = BLOCK_READ_B(b_ptr, 0);
 #endif // TILE_N_NOT_DIVISIBLE
+            b_ptr += input1_offset;
+#elif TRANSPOSE_INPUT1 == 2 // TRANSPOSE_INPUT1 == 0
+            if (b_raw_global_id > N - 1) {
+                b_tile[b_load_id] = 0;
+            } else {
+                uint b_idx = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (b_load_id + k * TILE_K), x);
+                b_tile[b_load_id] = input1[b_idx];
+            }
+#endif // TRANSPOSE_INPUT1 == 0
 #endif // IS_DYNAMIC
-#if !TRANSPOSE_INPUT1
-            b_ptr += N_PADDED;
-#else // !TRANSPOSE_INPUT1
-            b_ptr += K;
-#endif // !TRANSPOSE_INPUT1
         } // Loading B tile end
-
-#if TRANSPOSE_INPUT1
-        b_ptr -= K * SIMD_WIDTH - SIMD_WIDTH;
-
-        // B tile shuffling for NT, TT cases
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col0 = BLOCK_SHUFFLE(b_tile, 0);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col1 = BLOCK_SHUFFLE(b_tile, 1);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col2 = BLOCK_SHUFFLE(b_tile, 2);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col3 = BLOCK_SHUFFLE(b_tile, 3);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col4 = BLOCK_SHUFFLE(b_tile, 4);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col5 = BLOCK_SHUFFLE(b_tile, 5);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col6 = BLOCK_SHUFFLE(b_tile, 6);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col7 = BLOCK_SHUFFLE(b_tile, 7);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col8 = BLOCK_SHUFFLE(b_tile, 8);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col9 = BLOCK_SHUFFLE(b_tile, 9);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col10 = BLOCK_SHUFFLE(b_tile, 10);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col11 = BLOCK_SHUFFLE(b_tile, 11);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col12 = BLOCK_SHUFFLE(b_tile, 12);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col13 = BLOCK_SHUFFLE(b_tile, 13);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col14 = BLOCK_SHUFFLE(b_tile, 14);
-        MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile_col15 = BLOCK_SHUFFLE(b_tile, 15);
-
-        b_tile.s0 = b_tile_col0[sglid]; b_tile.s1 = b_tile_col1[sglid];
-        b_tile.s2 = b_tile_col2[sglid]; b_tile.s3 = b_tile_col3[sglid];
-        b_tile.s4 = b_tile_col4[sglid]; b_tile.s5 = b_tile_col5[sglid];
-        b_tile.s6 = b_tile_col6[sglid]; b_tile.s7 = b_tile_col7[sglid];
-        b_tile.s8 = b_tile_col8[sglid]; b_tile.s9 = b_tile_col9[sglid];
-        b_tile.sa = b_tile_col10[sglid]; b_tile.sb = b_tile_col11[sglid];
-        b_tile.sc = b_tile_col12[sglid]; b_tile.sd = b_tile_col13[sglid];
-        b_tile.se = b_tile_col14[sglid]; b_tile.sf = b_tile_col15[sglid];
+#if TRANSPOSE_INPUT1 == 1
+        b_ptr = b_ptr + (input1_offset * sglid);
+        b_tile = (N > b_raw_global_id) ? VLOAD(0, b_ptr) : 0;
+        b_ptr = b_ptr + input1_offset1 - (input1_offset * sglid);
 #endif // TRANSPOSE_INPUT1
 
         // Loading A tile and tile C calculation
         unroll_for (uint dot_id = 0; dot_id < tile_m_iterations; dot_id++) {
-#if !TRANSPOSE_INPUT0
+#if TRANSPOSE_INPUT0 == 0
 #if IS_DYNAMIC
 #if HAS_DYNAMIC_K_PADDING
             // In case of dynamic padding we can't guarantee memory access alignment for
             // block reads (4 bytes), so use scattered read
-            A_FLOATN a_read = a_ptr[dot_id * K_PADDED_IN0 + sglid];
+            uint a_idx = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (y + dot_id), (k * TILE_K + sglid));
+            A_FLOATN a_read = input0[a_idx];
 #else
-            A_FLOATN a_read = TILE_K_NOT_DIVISIBLE ? a_ptr[dot_id * K_PADDED_IN0 + sglid] : BLOCK_READ_A(a_ptr, dot_id * K);
+            A_FLOATN a_read = TILE_K_NOT_DIVISIBLE ? a_ptr[sglid] : BLOCK_READ_A(a_ptr, 0);
 #endif
 #else // IS_DYNAMIC
 #if TILE_K_NOT_DIVISIBLE
-            A_FLOATN a_read = a_ptr[dot_id * K + sglid];
+            A_FLOATN a_read = a_ptr[sglid];
 #else // TILE_K_NOT_DIVISIBLE
-            A_FLOATN a_read = BLOCK_READ_A(a_ptr, dot_id * K);
+            A_FLOATN a_read = BLOCK_READ_A(a_ptr, 0);
 #endif // TILE_K_NOT_DIVISIBLE
 #endif // IS_DYNAMIC
+            a_ptr += input0_offset;
 
             unroll_for (uint subtile_k_id = 0; subtile_k_id < TILE_K / SIMD_WIDTH; subtile_k_id++) {
                 unroll_for (uint simd_local_id = 0; simd_local_id < SIMD_WIDTH; simd_local_id++) {
@@ -234,42 +256,20 @@ KERNEL(gemm_tiled_opt)(
 #endif // TILE_K > SIMD_WIDTH
                 }
             }
-#else // !TRANSPOSE_INPUT0
-            a_tile[dot_id] = BLOCK_READ_A(a_ptr, dot_id * M);
-#endif // !TRANSPOSE_INPUT0
+#elif TRANSPOSE_INPUT0 == 2 // TRANSPOSE_INPUT0
+            uint a_idx = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (y + dot_id), (k * TILE_K + sglid));
+            a_tile[dot_id] = input0[a_idx];
+#endif // TRANSPOSE_INPUT0
         } // Loading A tile and tile C calculation end
 
-#if !TRANSPOSE_INPUT0
-        a_ptr += TILE_K;
-#else // !TRANSPOSE_INPUT0
-        a_ptr += TILE_K * M;
-
-        // A tile shuffling for TN, TT cases
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col0 = BLOCK_SHUFFLE(a_tile, 0);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col1 = BLOCK_SHUFFLE(a_tile, 1);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col2 = BLOCK_SHUFFLE(a_tile, 2);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col3 = BLOCK_SHUFFLE(a_tile, 3);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col4 = BLOCK_SHUFFLE(a_tile, 4);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col5 = BLOCK_SHUFFLE(a_tile, 5);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col6 = BLOCK_SHUFFLE(a_tile, 6);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col7 = BLOCK_SHUFFLE(a_tile, 7);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col8 = BLOCK_SHUFFLE(a_tile, 8);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col9 = BLOCK_SHUFFLE(a_tile, 9);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col10 = BLOCK_SHUFFLE(a_tile, 10);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col11 = BLOCK_SHUFFLE(a_tile, 11);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col12 = BLOCK_SHUFFLE(a_tile, 12);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col13 = BLOCK_SHUFFLE(a_tile, 13);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col14 = BLOCK_SHUFFLE(a_tile, 14);
-        MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile_col15 = BLOCK_SHUFFLE(a_tile, 15);
-
-        a_tile.s0 = a_tile_col0[sglid]; a_tile.s1 = a_tile_col1[sglid];
-        a_tile.s2 = a_tile_col2[sglid]; a_tile.s3 = a_tile_col3[sglid];
-        a_tile.s4 = a_tile_col4[sglid]; a_tile.s5 = a_tile_col5[sglid];
-        a_tile.s6 = a_tile_col6[sglid]; a_tile.s7 = a_tile_col7[sglid];
-        a_tile.s8 = a_tile_col8[sglid]; a_tile.s9 = a_tile_col9[sglid];
-        a_tile.sa = a_tile_col10[sglid]; a_tile.sb = a_tile_col11[sglid];
-        a_tile.sc = a_tile_col12[sglid]; a_tile.sd = a_tile_col13[sglid];
-        a_tile.se = a_tile_col14[sglid]; a_tile.sf = a_tile_col15[sglid];
+#if TRANSPOSE_INPUT0 == 0
+        a_ptr = a_ptr + input0_offset1 - (input0_offset * tile_m_iterations);
+#else // TRANSPOSE_INPUT0
+    #if TRANSPOSE_INPUT0 == 1
+        a_ptr = a_ptr + (input0_offset * sglid);
+        a_tile = VLOAD(0, a_ptr);
+        a_ptr = a_ptr + input0_offset1 - (input0_offset * sglid);
+    #endif
 
         // Tile C calculation for TN, TT cases
         unroll_for (uint dot_id = 0; dot_id < tile_m_iterations; dot_id++) {
@@ -290,12 +290,13 @@ KERNEL(gemm_tiled_opt)(
 #else
             b_tile[b_load_id] = TILE_N_NOT_DIVISIBLE ? (b_raw_global_id > N - 1 ? 0 : b_ptr[sglid]) : BLOCK_READ_B(b_ptr, 0);
 #endif
-            b_ptr += N_PADDED;
+            b_ptr += input1_offset;
         } // Loading leftovers of the matrix B end
 
         // Loading leftovers of the matrix A and tile C calculation
         unroll_for (uint dot_id = 0; dot_id < tile_m_iterations; dot_id++) {
-            INPUT0_TYPE a_read = a_ptr[dot_id * K_PADDED_IN0 + sglid];
+            uint a_idx = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (y + dot_id), (K_FULL_ITERATIONS * TILE_K + sglid));
+            INPUT0_TYPE a_read = input0[a_idx];
 
             unroll_for (uint simd_id = 0; simd_id < TILE_K_LEFTOVER; simd_id++) {
                 c_tile[dot_id] = mad((INPUT0_TYPE)(sub_group_broadcast(a_read, simd_id)), b_tile[simd_id], c_tile[dot_id]);
@@ -311,12 +312,13 @@ KERNEL(gemm_tiled_opt)(
 #else // TILE_N_NOT_DIVISIBLE
         b_tile[b_load_id] = BLOCK_READ_B(b_ptr, 0);
 #endif // TILE_N_NOT_DIVISIBLE
-        b_ptr += N;
+        b_ptr += input1_offset;
     } // Loading leftovers of the matrix B end
 
     // Loading leftovers of the matrix A and tile C calculation
     unroll_for (uint dot_id = 0; dot_id < tile_m_iterations; dot_id++) {
-        INPUT0_TYPE a_read = a_ptr[dot_id * K + sglid];
+        uint a_idx = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (y + dot_id), (K_FULL_ITERATIONS * TILE_K + sglid));
+        INPUT0_TYPE a_read = input0[a_idx];
 
         unroll_for (uint simd_id = 0; simd_id < TILE_K_LEFTOVER; simd_id++) {
             c_tile[dot_id] = mad((INPUT0_TYPE)(sub_group_broadcast(a_read, simd_id)), b_tile[simd_id], c_tile[dot_id]);
@@ -354,9 +356,9 @@ KERNEL(gemm_tiled_opt)(
             FUSED_OPS_SCALAR;
 #endif // FUSED_OPS_CAN_USE_PRELOAD
             OUTPUT_TYPE res = FUSED_OPS_RESULT_SCALAR;
-            d_ptr[sglid] = res;
+            *d_ptr = res;
 #else // HAS_FUSED_OPS
-            d_ptr[sglid] = dequantized;
+            *d_ptr = dequantized;
 #endif // HAS_FUSED_OPS
         }
 #else // IS_DYNAMIC
@@ -375,9 +377,9 @@ KERNEL(gemm_tiled_opt)(
             FUSED_OPS_SCALAR;
 #endif // FUSED_OPS_CAN_USE_PRELOAD
             OUTPUT_TYPE res = FUSED_OPS_RESULT_SCALAR;
-            d_ptr[sglid] = res;
+            *d_ptr = res;
 #else // HAS_FUSED_OPS
-            d_ptr[sglid] = dequantized;
+            *d_ptr = dequantized;
 #endif // HAS_FUSED_OPS
         }
 
@@ -404,7 +406,7 @@ KERNEL(gemm_tiled_opt)(
 
 #endif // TILE_N_NOT_DIVISIBLE || B_VEC_SIZE == 1
 #endif // IS_DYNAMIC
-        d_ptr += N;
+        d_ptr += batch_offset_output_diff;
 #ifdef INPUT2_TYPE
         c_ptr += N;
 #endif // INPUT2_TYPE
@@ -415,3 +417,4 @@ KERNEL(gemm_tiled_opt)(
 #undef BLOCK_READ_A
 #undef BLOCK_READ_B
 #undef BLOCK_WRITE_C
+#undef VLOAD

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
@@ -39,14 +39,14 @@ std::vector<int64_t> GemmKernelBase::ConvTo8dims(const std::vector<int64_t>& ord
         dims_order.push_back(order_idx[0] + 6);
         dims_order.push_back(order_idx[1] + 6);
     } else if (order_idx.size() == 3) {
-        dims_order.push_back(order_idx[0] == 0 ? 0 : order_idx[0] + 5);
-        dims_order.push_back(1);
+        dims_order.push_back(0);
+        dims_order.push_back(order_idx[0] == 0 ? 1 : order_idx[0] + 5);
         dims_order.push_back(2);
         dims_order.push_back(3);
         dims_order.push_back(4);
         dims_order.push_back(5);
-        dims_order.push_back(order_idx[1] == 0 ? 0 : order_idx[1] + 5);
-        dims_order.push_back(order_idx[2] == 0 ? 0 : order_idx[2] + 5);
+        dims_order.push_back(order_idx[1] == 0 ? 1 : order_idx[1] + 5);
+        dims_order.push_back(order_idx[2] == 0 ? 1 : order_idx[2] + 5);
     } else if (order_idx.size() == 4) {
         dims_order.push_back(order_idx[0] < 2 ? order_idx[0] : order_idx[0] + 4);
         dims_order.push_back(order_idx[1] < 2 ? order_idx[1] : order_idx[1] + 4);
@@ -146,8 +146,8 @@ std::string GemmKernelBase::GetDimsOrder(const std::vector<int64_t>& order_idx) 
         dims_order = "b,f,w,z,"
                     + dims2[get_order_idx(order_idx, 0)] + "," + dims2[get_order_idx(order_idx, 1)];
     } else if (order_idx.size() == 3) {
-        const std::vector<std::string> dims3 = {"b", "y", "x"};
-        dims_order = dims3[get_order_idx(order_idx, 0)] + ",f,w,z,"
+        const std::vector<std::string> dims3 = {"f", "y", "x"};
+        dims_order = "b," + dims3[get_order_idx(order_idx, 0)] + ",w,z,"
                     + dims3[get_order_idx(order_idx, 1)] + "," + dims3[get_order_idx(order_idx, 2)];
     } else if (order_idx.size() == 4) {
         const std::vector<std::string> dims4 = {"b", "f", "y", "x"};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
@@ -172,26 +172,11 @@ std::string GemmKernelBase::GetDimsOrder(const std::vector<int64_t>& order_idx) 
 JitConstants GemmKernelBase::GetJitConstants(const gemm_params& params) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
 
-    auto get_transpose_mode = [](const std::vector<int64_t>& order_idx) {
-        int64_t rank = order_idx.size() - 1;
-
-        if (rank == order_idx[rank]) {
-            // normal
-            return 0;
-        } else if (rank == order_idx[rank - 1]) {
-            // the second last dim is moved to the last
-            return 1;
-        } else {
-            // randomly transposed
-            return 2;
-        }
-    };
-
     jit.AddConstants({
         MakeJitConstant("ALPHA", params.alpha),
         MakeJitConstant("BETA", params.beta),
-        MakeJitConstant("TRANSPOSE_INPUT0", get_transpose_mode(params.input0_order)),
-        MakeJitConstant("TRANSPOSE_INPUT1", get_transpose_mode(params.input1_order)),
+        MakeJitConstant("TRANSPOSE_INPUT0", params.transpose_input0),
+        MakeJitConstant("TRANSPOSE_INPUT1", params.transpose_input1),
         MakeJitConstant("QUANTIZATION_TERM", params.quantization != QuantizationType::NONE),
     });
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
@@ -7,15 +7,198 @@
 #include "kernel_selector_utils.h"
 
 namespace kernel_selector {
+
+size_t GemmKernelBase::GetOuputSize(const std::vector<int64_t>& output_order, const kernel_selector::DataTensor &output,
+                                    char target_dim) const {
+    OPENVINO_ASSERT(target_dim == 'X' || target_dim == 'Y');
+
+    auto output_dims_order = GetDimsOrder(output_order);
+    int dim_idx = (target_dim == 'X') ? 10 : 8;
+    switch (output_dims_order[dim_idx]) {
+        case 'b':
+            return output.Batch().v;
+        case 'f':
+            return output.Feature().v;
+        case 'w':
+            return output.W().v;
+        case 'z':
+            return output.Z().v;
+        case 'y':
+            return output.Y().v;
+        case 'x':
+            return output.X().v;
+        default:
+            OPENVINO_THROW("Unsupported dimension: ", output_dims_order[dim_idx]);
+    }
+}
+
+std::vector<int64_t> GemmKernelBase::ConvTo8dims(const std::vector<int64_t>& order_idx) const {
+    std::vector<int64_t> dims_order;
+    if (order_idx.size() == 2) {
+        dims_order = {0, 1, 2, 3, 4, 5};
+        dims_order.push_back(order_idx[0] + 6);
+        dims_order.push_back(order_idx[1] + 6);
+    } else if (order_idx.size() == 3) {
+        dims_order.push_back(order_idx[0] == 0 ? 0 : order_idx[0] + 5);
+        dims_order.push_back(1);
+        dims_order.push_back(2);
+        dims_order.push_back(3);
+        dims_order.push_back(4);
+        dims_order.push_back(5);
+        dims_order.push_back(order_idx[1] == 0 ? 0 : order_idx[1] + 5);
+        dims_order.push_back(order_idx[2] == 0 ? 0 : order_idx[2] + 5);
+    } else if (order_idx.size() == 4) {
+        dims_order.push_back(order_idx[0] < 2 ? order_idx[0] : order_idx[0] + 4);
+        dims_order.push_back(order_idx[1] < 2 ? order_idx[1] : order_idx[1] + 4);
+        dims_order.push_back(2);
+        dims_order.push_back(3);
+        dims_order.push_back(4);
+        dims_order.push_back(5);
+        dims_order.push_back(order_idx[2] < 2 ? order_idx[2] : order_idx[2] + 4);
+        dims_order.push_back(order_idx[3] < 2 ? order_idx[3] : order_idx[3] + 4);
+    } else if (order_idx.size() == 5) {
+        dims_order.push_back(order_idx[0] < 2 ? order_idx[0] : order_idx[0] + 3);
+        dims_order.push_back(order_idx[1] < 2 ? order_idx[1] : order_idx[1] + 3);
+        dims_order.push_back(2);
+        dims_order.push_back(3);
+        dims_order.push_back(4);
+        dims_order.push_back(order_idx[2] < 2 ? order_idx[2] : order_idx[2] + 3);
+        dims_order.push_back(order_idx[3] < 2 ? order_idx[3] : order_idx[3] + 3);
+        dims_order.push_back(order_idx[4] < 2 ? order_idx[4] : order_idx[4] + 3);
+    } else if (order_idx.size() == 6) {
+        dims_order.push_back(order_idx[0] < 2 ? order_idx[0] : order_idx[0] + 2);
+        dims_order.push_back(order_idx[1] < 2 ? order_idx[1] : order_idx[1] + 2);
+        dims_order.push_back(2);
+        dims_order.push_back(3);
+        dims_order.push_back(order_idx[2] < 2 ? order_idx[2] : order_idx[2] + 2);
+        dims_order.push_back(order_idx[3] < 2 ? order_idx[3] : order_idx[3] + 2);
+        dims_order.push_back(order_idx[4] < 2 ? order_idx[4] : order_idx[4] + 2);
+        dims_order.push_back(order_idx[5] < 2 ? order_idx[5] : order_idx[5] + 2);
+    } else if (order_idx.size() == 7) {
+        dims_order.push_back(order_idx[0] < 2 ? order_idx[0] : order_idx[0] + 1);
+        dims_order.push_back(order_idx[1] < 2 ? order_idx[1] : order_idx[1] + 1);
+        dims_order.push_back(2);
+        dims_order.push_back(order_idx[2] < 2 ? order_idx[2] : order_idx[2] + 1);
+        dims_order.push_back(order_idx[3] < 2 ? order_idx[3] : order_idx[3] + 1);
+        dims_order.push_back(order_idx[4] < 2 ? order_idx[4] : order_idx[4] + 1);
+        dims_order.push_back(order_idx[5] < 2 ? order_idx[5] : order_idx[5] + 1);
+        dims_order.push_back(order_idx[6] < 2 ? order_idx[6] : order_idx[6] + 1);
+    } else {
+        dims_order = {0, 1, 2, 3, 4, 5, 6, 7};
+    }
+    return dims_order;
+}
+
+std::vector<std::string> GemmKernelBase::GetTransposedDims(const std::vector<int64_t>& order_idx, bool is_tiled_opt) const {
+    auto converted_dims = ConvTo8dims(order_idx);
+    std::vector<std::string> dim_ids;
+    for (auto dim : converted_dims) {
+        switch (dim) {
+        case 0:
+            dim_ids.push_back("b");
+            break;
+        case 1:
+            dim_ids.push_back("f");
+            break;
+        case 2:
+            dim_ids.push_back("u");
+            break;
+        case 3:
+            dim_ids.push_back("v");
+            break;
+        case 4:
+            dim_ids.push_back("w");
+            break;
+        case 5:
+            dim_ids.push_back("z");
+            break;
+        case 6:
+            if (is_tiled_opt) {
+                dim_ids.push_back("(y+write_id)");
+            } else {
+                dim_ids.push_back("y");
+            }
+            break;
+        case 7:
+            dim_ids.push_back("x");
+            break;
+        default:
+            break;
+        }
+    }
+    return dim_ids;
+}
+
+std::string GemmKernelBase::GetDimsOrder(const std::vector<int64_t>& order_idx) const {
+    auto get_order_idx = [](std::vector<int64_t> order_idx, int64_t dim_idx) {
+        int loc = 0;
+        for (auto idx : order_idx) {
+            if (idx == dim_idx)
+                break;
+            loc += 1;
+        }
+        return loc;
+    };
+
+    std::string dims_order = "";
+    if (order_idx.size() == 2) {
+        const std::vector<std::string> dims2 = {"y", "x"};
+        dims_order = "b,f,w,z,"
+                    + dims2[get_order_idx(order_idx, 0)] + "," + dims2[get_order_idx(order_idx, 1)];
+    } else if (order_idx.size() == 3) {
+        const std::vector<std::string> dims3 = {"b", "y", "x"};
+        dims_order = dims3[get_order_idx(order_idx, 0)] + ",f,w,z,"
+                    + dims3[get_order_idx(order_idx, 1)] + "," + dims3[get_order_idx(order_idx, 2)];
+    } else if (order_idx.size() == 4) {
+        const std::vector<std::string> dims4 = {"b", "f", "y", "x"};
+        dims_order = dims4[get_order_idx(order_idx, 0)] + "," + dims4[get_order_idx(order_idx, 1)] + ",w,z,"
+                    + dims4[get_order_idx(order_idx, 2)] + "," + dims4[get_order_idx(order_idx, 3)];
+    } else if (order_idx.size() == 5) {
+        const std::vector<std::string> dims5 = {"b", "f", "z", "y", "x"};
+        dims_order = dims5[get_order_idx(order_idx, 0)] + "," + dims5[get_order_idx(order_idx, 1)] + ",w,"
+                    + dims5[get_order_idx(order_idx, 2)] + "," + dims5[get_order_idx(order_idx, 3)] + ","
+                    + dims5[get_order_idx(order_idx, 4)];
+    } else if (order_idx.size() == 6) {
+        const std::vector<std::string> dims6 = {"b", "f", "w", "z", "y", "x"};
+        dims_order = dims6[get_order_idx(order_idx, 0)] + "," + dims6[get_order_idx(order_idx, 1)] + ","
+                    + dims6[get_order_idx(order_idx, 2)] + "," + dims6[get_order_idx(order_idx, 3)] + ","
+                    + dims6[get_order_idx(order_idx, 4)] + "," + dims6[get_order_idx(order_idx, 5)];
+    } else {
+        dims_order = "b,f,w,z,y,x";
+    }
+    return dims_order;
+}
+
 JitConstants GemmKernelBase::GetJitConstants(const gemm_params& params) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
+
+    auto get_transpose_mode = [](const std::vector<int64_t>& order_idx) {
+        int64_t rank = order_idx.size() - 1;
+
+        if (rank == order_idx[rank]) {
+            // normal
+            return 0;
+        } else if (rank == order_idx[rank - 1]) {
+            // the second last dim is moved to the last
+            return 1;
+        } else {
+            // randomly transposed
+            return 2;
+        }
+    };
 
     jit.AddConstants({
         MakeJitConstant("ALPHA", params.alpha),
         MakeJitConstant("BETA", params.beta),
-        MakeJitConstant("TRANSPOSE_INPUT0", params.transpose_input0),
-        MakeJitConstant("TRANSPOSE_INPUT1", params.transpose_input1),
+        MakeJitConstant("TRANSPOSE_INPUT0", get_transpose_mode(params.input0_order)),
+        MakeJitConstant("TRANSPOSE_INPUT1", get_transpose_mode(params.input1_order)),
         MakeJitConstant("QUANTIZATION_TERM", params.quantization != QuantizationType::NONE),
+    });
+
+    jit.AddConstants({
+        MakeJitConstant("INPUT0_DIMS_ORDER", GetDimsOrder(params.input0_order)),
+        MakeJitConstant("INPUT1_DIMS_ORDER", GetDimsOrder(params.input1_order)),
+        MakeJitConstant("MATMUL_AXIS", static_cast<char>(std::toupper(GetDimsOrder(params.input0_order).at(10)))),
     });
 
     return jit;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
@@ -181,6 +181,9 @@ JitConstants GemmKernelBase::GetJitConstants(const gemm_params& params) const {
     });
 
     jit.AddConstants({
+        MakeJitConstant("TRANSPOSE_X_LAST", 0),
+        MakeJitConstant("TRANSPOSE_Y_LAST", 1),
+        MakeJitConstant("TRANSPOSE_OTHER", 2),
         MakeJitConstant("INPUT0_DIMS_ORDER", GetDimsOrder(params.input0_order)),
         MakeJitConstant("INPUT1_DIMS_ORDER", GetDimsOrder(params.input1_order)),
         MakeJitConstant("MATMUL_AXIS", static_cast<char>(std::toupper(GetDimsOrder(params.input0_order).at(10)))),

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.h
@@ -17,8 +17,8 @@ struct gemm_params : public base_params {
 
     float alpha;
     float beta;
-    bool transpose_input0;
-    bool transpose_input1;
+    uint32_t transpose_input0;
+    uint32_t transpose_input1;
     std::vector<int64_t> input0_order;
     std::vector<int64_t> input1_order;
     std::vector<int64_t> output_order;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.h
@@ -19,6 +19,9 @@ struct gemm_params : public base_params {
     float beta;
     bool transpose_input0;
     bool transpose_input1;
+    std::vector<int64_t> input0_order;
+    std::vector<int64_t> input1_order;
+    std::vector<int64_t> output_order;
     QuantizationType quantization = QuantizationType::NONE;
 
     ParamsKey GetParamsKey() const override {
@@ -49,6 +52,12 @@ protected:
     virtual JitConstants GetJitConstants(const gemm_params& params) const;
     virtual DispatchData SetDefault(const gemm_params& params) const;
     KernelsData GetCommonKernelsData(const Params& params, const optional_params&) const;
+
+    std::string GetDimsOrder(const std::vector<int64_t>& order_idx) const;
+    size_t GetOuputSize(const std::vector<int64_t>& output_order, const kernel_selector::DataTensor &output, char target_dim) const;
+    std::vector<int64_t> ConvTo8dims(const std::vector<int64_t>& order_idx) const;
+    std::vector<std::string> GetTransposedDims(const std::vector<int64_t>& order_idx, bool is_tiled_opt = false) const;
+
     // Fused ops
     virtual JitConstants GetFusedPrimitivesJitConstants(const gemm_params& params, const DispatchData& dispatchData) const;
     Datatype GetActivationType(const gemm_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_ref.h
@@ -24,6 +24,7 @@ protected:
                  FusedOpType::ELTWISE };
     }
     bool Validate(const Params& params, const optional_params& options) const override;
+    DispatchData SetDefault(const gemm_params& params) const override;
     JitConstants GetJitConstants(const gemm_params& params) const override;
     DeviceFeaturesKey get_required_device_features_key(const Params& params, const optional_params& /*options*/) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -362,13 +362,6 @@ bool GemmKernelTiledOpt::Validate(const Params& params, const optional_params& o
             return false;
     }
 
-    bool gemm_leftovers = gmm_params.inputs[0].X().v % 16 || gmm_params.inputs[0].Y().v % 16 ||
-                          gmm_params.inputs[1].X().v % 16 || gmm_params.inputs[1].Y().v % 16;
-    // If gmm_params has dynamic inputs, the correct dimension value cannot be obtained
-    // and leftovers cannot be calculated, so it returns false
-    if ((gmm_params.transpose_input0 || gmm_params.transpose_input1) && (gemm_leftovers || gmm_params.has_dynamic_inputs()))
-        return false;
-
     for (size_t i = 1; i < gmm_params.inputs.size(); i++)
         if (gmm_params.inputs[0].GetDType() != gmm_params.inputs[i].GetDType())
             return false;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -46,8 +46,10 @@ GemmKernelBase::DispatchData GemmKernelTiledOpt::SetDefault(const gemm_params& p
     if (!params.has_dynamic_tensors()) {
         GemmTuningData td = SetTuningParams(params);
 
-        auto total_batches = output.LogicalSize() / (output.X().v * output.Y().v);
-        std::vector<size_t> global = { output.X().v, output.Y().v, total_batches };
+        auto total_batches = output.LogicalSize() /
+                            (GetOuputSize(params.output_order, output, 'X') * GetOuputSize(params.output_order, output, 'Y'));
+        std::vector<size_t> global = { GetOuputSize(params.output_order, output, 'X'), GetOuputSize(params.output_order, output, 'Y'),
+                                       total_batches };
 
         dispatchData.gws[0] = Align(global[0], td.tile_n_size) / (td.tile_n_size / td.simd_size);
         dispatchData.gws[1] = Align(global[1], td.tile_m_size) / td.tile_m_size;
@@ -109,6 +111,27 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
     GemmTuningData tuning_data = SetTuningParams(params);
     auto b_vec_size = tuning_data.tile_n_size / tuning_data.simd_size;
 
+    auto get_output_size = [this](const std::vector<int64_t>& output_order_idx, const int target_idx) {
+        auto output_dims_order = Parent::GetDimsOrder(output_order_idx);
+
+        switch (output_dims_order.at(target_idx)) {
+            case 'b':
+                return "OUTPUT_BATCH_NUM";
+            case 'f':
+                return "OUTPUT_FEATURE_NUM";
+            case 'w':
+                return "OUTPUT_SIZE_W";
+            case 'z':
+                return "OUTPUT_SIZE_Z";
+            case 'y':
+                return "OUTPUT_SIZE_Y";
+            case 'x':
+                return "OUTPUT_SIZE_X";
+            default:
+                return "";
+        }
+    };
+
     jit.Merge(MakeTypeJitConstants(params.inputs[0].GetDType(), "ACCUMULATOR"));
     if (params.has_dynamic_tensors()) {
         DimensionAccessHelper dims0(params.inputs[0]);
@@ -117,13 +140,13 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
         DimensionAccessHelper dims1_padded(params.inputs[1], true);
         // Note: Actually currently this kernel is not being selected if it is shape agnostic impl && transposed inputs
         // Because we cannot get the original rank
-        auto m_size = params.transpose_input0 ? dims0.x() : dims0.y();
-        auto n_size = params.transpose_input1 ? dims1.y() : dims1.x();
-        auto n_padded_size = params.transpose_input1 ? "(" + dims1_padded.y() + ")"
-                                                     : "(" + dims1_padded.x() + ")";
-        auto k_size = params.transpose_input0 ? dims0.y() : dims0.x();
-        auto k_padded_size_in0 = params.transpose_input0 ? "(" + dims0_padded.y() + ")"
-                                                         : "(" + dims0_padded.x() + ")";
+        auto input0_dims = ConvTo8dims(params.input0_order);
+        auto input1_dims = ConvTo8dims(params.input1_order);
+        auto m_size = dims0.dims_sizes[input0_dims[6]];
+        auto n_size = dims1.dims_sizes[input1_dims[7]];
+        auto n_padded_size = "(" + dims1_padded.dims_sizes[input1_dims[7]] + ")";
+        auto k_size = dims0.dims_sizes[input0_dims[7]];
+        auto k_padded_size_in0 = "(" + dims0_padded.dims_sizes[input0_dims[7]] + ")";
         const std::string leftover_m = "(" + m_size + "%" + std::to_string(tuning_data.tile_m_size) + ")";
         const std::string leftover_n = "(" + n_size + "%" + std::to_string(tuning_data.tile_n_size) + ")";
         const std::string leftover_k = "(" + k_size + "%" + std::to_string(tuning_data.tile_k_size) + ")";
@@ -149,6 +172,16 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
             MakeJitConstant("TILE_M_LEFTOVER", leftover_m),
             MakeJitConstant("TILE_K_LEFTOVER", leftover_k),
             MakeJitConstant("TILE_N_LEFTOVER", leftover_n),
+            MakeJitConstant("TR_B", GetTransposedDims(params.output_order, true).at(0)),
+            MakeJitConstant("TR_F", GetTransposedDims(params.output_order, true).at(1)),
+            MakeJitConstant("TR_W", GetTransposedDims(params.output_order, true).at(4)),
+            MakeJitConstant("TR_Z", GetTransposedDims(params.output_order, true).at(5)),
+            MakeJitConstant("TR_Y", GetTransposedDims(params.output_order, true).at(6)),
+            MakeJitConstant("TR_X", GetTransposedDims(params.output_order, true).at(7)),
+            MakeJitConstant("TR_OUTPUT_SIZE_Z", get_output_size(params.output_order, 6)),
+            MakeJitConstant("TR_OUTPUT_SIZE_W", get_output_size(params.output_order, 4)),
+            MakeJitConstant("TR_OUTPUT_FEATURE_NUM", get_output_size(params.output_order, 2)),
+            MakeJitConstant("TR_OUTPUT_BATCH_NUM", get_output_size(params.output_order, 0)),
         });
 
         bool has_dynamic_k_padding = params.transpose_input0 ? params.inputs[0].Y().pad.is_dynamic
@@ -160,9 +193,48 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
         if (has_dynamic_n_padding)
             jit.AddConstant(MakeJitConstant("HAS_DYNAMIC_N_PADDING", 1));
     } else {
-        auto m_size = output.Y().v;
-        auto n_size = output.X().v;
-        auto k_size = params.transpose_input0 ? params.inputs[0].Y().v : params.inputs[0].X().v;
+        auto get_untransposed_dim_size = [](const kernel_selector::DataTensor &data_tensor,
+                                            const std::vector<int64_t>& dims_order, const std::string dim) {
+            int64_t target_dim_idx;
+            size_t rank = data_tensor.GetDims().size();
+            if (dim.compare("Y") == 0) {
+                target_dim_idx = rank - 2;
+            } else if (dim.compare("X") == 0) {
+                target_dim_idx = rank - 1;
+            } else {
+                OPENVINO_THROW("Unsupported dimension: ", dim);
+            }
+
+            size_t loc = 0;
+            if (dims_order.size() == 0) {
+                loc = static_cast<size_t>(target_dim_idx);
+            } else {
+                for (auto dim_idx : dims_order) {
+                    if (dim_idx == target_dim_idx)
+                        break;
+                    loc += 1;
+                }
+            }
+
+            if (loc == 0) {
+                return data_tensor.Batch().v;
+            } else if (loc == 1) {
+                return data_tensor.Feature().v;
+            } else if (loc == (rank - 1) && rank >= 3) {
+                return data_tensor.X().v;
+            } else if (loc == (rank - 2) && rank >= 4) {
+                return data_tensor.Y().v;
+            } else if (loc == (rank - 3) && rank >= 5) {
+                return data_tensor.Z().v;
+            } else if (loc == (rank - 4) && rank >= 6) {
+                return data_tensor.W().v;
+            }
+            OPENVINO_THROW("Target dimension is not found.");
+        };
+
+        auto m_size = get_untransposed_dim_size(output, params.output_order, "Y");
+        auto n_size = get_untransposed_dim_size(output, params.output_order, "X");
+        auto k_size = get_untransposed_dim_size(params.inputs[0], params.input0_order, "X");
         auto leftover_m = m_size % tuning_data.tile_m_size;
         auto leftover_n = n_size % tuning_data.tile_n_size;
         auto leftover_k = k_size % tuning_data.tile_k_size;
@@ -184,6 +256,16 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
             MakeJitConstant("TILE_M_LEFTOVER", leftover_m),
             MakeJitConstant("TILE_K_LEFTOVER", leftover_k),
             MakeJitConstant("TILE_N_LEFTOVER", leftover_n),
+            MakeJitConstant("TR_B", GetTransposedDims(params.output_order, true).at(0)),
+            MakeJitConstant("TR_F", GetTransposedDims(params.output_order, true).at(1)),
+            MakeJitConstant("TR_W", GetTransposedDims(params.output_order, true).at(4)),
+            MakeJitConstant("TR_Z", GetTransposedDims(params.output_order, true).at(5)),
+            MakeJitConstant("TR_Y", GetTransposedDims(params.output_order, true).at(6)),
+            MakeJitConstant("TR_X", GetTransposedDims(params.output_order, true).at(7)),
+            MakeJitConstant("TR_OUTPUT_SIZE_Z", get_output_size(params.output_order, 6)),
+            MakeJitConstant("TR_OUTPUT_SIZE_W", get_output_size(params.output_order, 4)),
+            MakeJitConstant("TR_OUTPUT_FEATURE_NUM", get_output_size(params.output_order, 2)),
+            MakeJitConstant("TR_OUTPUT_BATCH_NUM", get_output_size(params.output_order, 0)),
         });
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -362,6 +362,14 @@ bool GemmKernelTiledOpt::Validate(const Params& params, const optional_params& o
             return false;
     }
 
+    bool gemm_leftovers = gmm_params.inputs[0].X().v % 16 || gmm_params.inputs[0].Y().v % 16 ||
+                          gmm_params.inputs[1].X().v % 16 || gmm_params.inputs[1].Y().v % 16;
+    // If gmm_params has dynamic inputs, the correct dimension value cannot be obtained
+    // and leftovers cannot be calculated, so it returns false
+    if ((gmm_params.transpose_input0 || gmm_params.transpose_input1) && (gemm_leftovers || gmm_params.has_dynamic_inputs()) &&
+        !gmm_params.is_shape_agnostic)
+        return false;
+
     for (size_t i = 1; i < gmm_params.inputs.size(); i++)
         if (gmm_params.inputs[0].GetDType() != gmm_params.inputs[i].GetDType())
             return false;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -196,7 +196,7 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
         auto get_untransposed_dim_size = [](const kernel_selector::DataTensor &data_tensor,
                                             const std::vector<int64_t>& dims_order, const std::string dim) {
             int64_t target_dim_idx;
-            size_t rank = data_tensor.GetDims().size();
+            const size_t rank = data_tensor.GetDims().size();
             if (dim.compare("Y") == 0) {
                 target_dim_idx = rank - 2;
             } else if (dim.compare("X") == 0) {
@@ -205,10 +205,11 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
                 OPENVINO_THROW("Unsupported dimension: ", dim);
             }
 
-            size_t loc = 0;
+            size_t loc = (dims_order.size() < rank) ? (rank - dims_order.size()) : 0;
             if (dims_order.size() == 0) {
                 loc = static_cast<size_t>(target_dim_idx);
             } else {
+                target_dim_idx = (dims_order.size() < rank) ? (target_dim_idx + dims_order.size() - rank) : target_dim_idx;
                 for (auto dim_idx : dims_order) {
                     if (dim_idx == target_dim_idx)
                         break;

--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -10,12 +10,21 @@
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/fake_quantize.hpp"
+#include "intel_gpu/op/gemm.hpp"
 
 #include "intel_gpu/primitives/gemm.hpp"
 #include "intel_gpu/primitives/fully_connected.hpp"
 #include "intel_gpu/primitives/reshape.hpp"
 #include "intel_gpu/primitives/reorder.hpp"
 #include "intel_gpu/primitives/permute.hpp"
+
+namespace ov {
+namespace op {
+namespace internal {
+using Gemm = ov::intel_gpu::op::Gemm;
+}  // namespace internal
+}  // namespace op
+}  // namespace ov
 
 namespace ov {
 namespace intel_gpu {
@@ -133,7 +142,52 @@ static void CreateMatMulOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::
     }
 }
 
+static void CreateGemmOp(ProgramBuilder& p, const std::shared_ptr<ov::op::internal::Gemm>& op) {
+    validate_inputs_count(op, {2});
+    auto inputs = p.GetInputInfo(op);
+    std::string layerName = layer_type_name_ID(op);
+
+    auto alpha = 1.0f;
+    auto beta = 0.0f;
+
+    auto shape_a = op->get_input_partial_shape(0);
+    auto shape_b = op->get_input_partial_shape(1);
+    auto out_shape = op->get_output_partial_shape(0);
+
+    size_t rank_a = shape_a.rank().get_length();
+    size_t rank_b = shape_b.rank().get_length();
+    size_t output_rank = out_shape.rank().get_length();
+
+    OPENVINO_ASSERT(rank_a == op->get_input0_order().size(), "[GPU] Length of input0_order is not same as rank of input0");
+    OPENVINO_ASSERT(rank_b == op->get_input1_order().size(), "[GPU] Length of input1_order is not same as rank of input1");
+    OPENVINO_ASSERT(output_rank == op->get_output_order().size(), "[GPU] Length of output_order is not same as rank of output");
+
+    auto gemmPrim = cldnn::gemm(layerName,
+                                inputs,
+                                cldnn::element_type_to_data_type(op->get_output_element_type(0)),
+                                op->get_input0_order(),
+                                op->get_input1_order(),
+                                op->get_output_order(),
+                                alpha,
+                                beta);
+
+    p.add_primitive(*op, gemmPrim);
+
+    if (!p.use_new_shape_infer()) {
+        auto outDims = op->get_output_shape(0);
+        auto outDimsN = outDims.size();
+        // Reshape output if gemm specific shape does not match default one
+        if (outDimsN < 4) {
+            auto outputShape = tensor_from_dims(outDims);
+            auto outReshapeName = layerName + "_cldnn_out_reshape";
+            auto outReshapePrim = cldnn::reshape(outReshapeName, cldnn::input_info(layerName), outputShape);
+            p.add_primitive(*op, outReshapePrim);
+        }
+    }
+}
+
 REGISTER_FACTORY_IMPL(v0, MatMul);
+REGISTER_FACTORY_IMPL(internal, Gemm);
 
 }  // namespace intel_gpu
 }  // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
@@ -72,8 +72,8 @@ std::vector<ov::PartialShape> shape_infer(const Gemm* op,
     auto shape_a = input_shapes[0];
     auto shape_b = input_shapes[1];
 
-    auto shape_a_t = transpose_shape(shape_a, order_a);
-    auto shape_b_t = transpose_shape(shape_b, order_b);
+    auto shape_a_t = (order_a.size() > 1) ? transpose_shape(shape_a, order_a) : shape_a;
+    auto shape_b_t = (order_b.size() > 1) ? transpose_shape(shape_b, order_b) : shape_b;
     auto out_shapes = ov::op::v0::shape_infer(dynamic_cast<const ov::op::v0::MatMul*>(op), std::vector<ov::PartialShape>{shape_a_t, shape_b_t});
 
     if (order_c.size() > 0) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
@@ -17,11 +17,14 @@ Gemm::Gemm(const ov::Output<Node>& A,
            const std::vector<int64_t>& order_b,
            const std::vector<int64_t>& order_c,
            const ov::element::Type output_type)
-    : ov::op::v0::MatMul(A, B, false, false)
+    : ov::op::v0::MatMul()
     , m_order_a(order_a)
     , m_order_b(order_b)
     , m_order_c(order_c)
     , m_output_type(output_type) {
+    set_arguments({A, B});
+    set_transpose_a(false);
+    set_transpose_b(false);
     validate_and_infer_types();
 }
 
@@ -73,7 +76,11 @@ std::vector<ov::PartialShape> shape_infer(const Gemm* op,
     auto shape_b_t = transpose_shape(shape_b, order_b);
     auto out_shapes = ov::op::v0::shape_infer(dynamic_cast<const ov::op::v0::MatMul*>(op), std::vector<ov::PartialShape>{shape_a_t, shape_b_t});
 
-    return { transpose_shape(out_shapes[0], order_c) };
+    if (order_c.size() > 0) {
+        return { transpose_shape(out_shapes[0], order_c) };
+    } else {
+        return { out_shapes[0] };
+    }
 }
 
 }  // namespace op

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "intel_gpu/op/gemm.hpp"
+#include "matmul_shape_inference.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/op/matmul.hpp"
+
+namespace ov {
+namespace intel_gpu {
+namespace op {
+
+Gemm::Gemm(const ov::Output<Node>& A,
+           const ov::Output<Node>& B,
+           const std::vector<int64_t>& order_a,
+           const std::vector<int64_t>& order_b,
+           const std::vector<int64_t>& order_c,
+           const ov::element::Type output_type)
+    : ov::op::v0::MatMul(A, B, false, false)
+    , m_order_a(order_a)
+    , m_order_b(order_b)
+    , m_order_c(order_c)
+    , m_output_type(output_type) {
+    validate_and_infer_types();
+}
+
+std::shared_ptr<ov::Node> Gemm::clone_with_new_inputs(const ov::OutputVector& new_args) const {
+    check_new_args_count(this, new_args);
+
+    return std::make_shared<Gemm>(new_args.at(0), new_args.at(1), m_order_a, m_order_b, m_order_c, m_output_type);
+}
+
+void Gemm::validate_and_infer_types() {
+    const auto input_size = get_input_size();
+    NODE_VALIDATION_CHECK(this,
+        input_size == 2,
+        "Number of inputs is incorrect. Current value is: ",
+        input_size,
+        ", expected 2.");
+
+    auto out_shapes = shape_infer(this, std::vector<ov::PartialShape>{get_input_partial_shape(0), get_input_partial_shape(1)}, m_order_a, m_order_b, m_order_c);
+
+    auto output_type = m_output_type == ov::element::undefined ? get_input_element_type(0) : m_output_type;
+    set_output_type(0, output_type, out_shapes[0]);
+}
+
+bool Gemm::visit_attributes(ov::AttributeVisitor &visitor) {
+    visitor.on_attribute("order_a", m_order_a);
+    visitor.on_attribute("order_b", m_order_b);
+    visitor.on_attribute("order_c", m_order_c);
+    visitor.on_attribute("output_type", m_output_type);
+    return true;
+}
+
+std::vector<ov::PartialShape> shape_infer(const Gemm* op,
+                                          std::vector<ov::PartialShape> input_shapes,
+                                          const std::vector<int64_t>& order_a,
+                                          const std::vector<int64_t>& order_b,
+                                          const std::vector<int64_t>& order_c) {
+    auto transpose_shape = [](const ov::PartialShape shape, const std::vector<int64_t>& order) {
+        auto shape_transposed = ov::PartialShape::dynamic(shape.rank());
+        for (size_t i = 0; i < order.size(); i++) {
+            shape_transposed[i] = shape[order[i]];
+        }
+
+        return shape_transposed;
+    };
+    auto shape_a = input_shapes[0];
+    auto shape_b = input_shapes[1];
+
+    auto shape_a_t = transpose_shape(shape_a, order_a);
+    auto shape_b_t = transpose_shape(shape_b, order_b);
+    auto out_shapes = ov::op::v0::shape_infer(dynamic_cast<const ov::op::v0::MatMul*>(op), std::vector<ov::PartialShape>{shape_a_t, shape_b_t});
+
+    return { transpose_shape(out_shapes[0], order_c) };
+}
+
+}  // namespace op
+}  // namespace intel_gpu
+}  // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_matmul_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_matmul_fusion.cpp
@@ -1,0 +1,165 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "intel_gpu/op/gemm.hpp"
+#include "openvino/core/node_vector.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/pass/pattern/op/label.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "transpose_matmul_fusion.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/pass/pattern/op/or.hpp"
+#include "openvino/pass/pattern/op/any.hpp"
+#include "transformations/utils/utils.hpp"
+
+using namespace ov::pass::pattern;
+using ov::pass::pattern::op::Or;
+
+namespace ov {
+namespace intel_gpu {
+
+namespace {
+std::vector<int64_t> default_order(size_t rank) {
+    std::vector<int64_t> order(rank);
+    std::iota(order.begin(), order.end(), 0);
+    return order;
+}
+}  // namespace
+
+class TransposeMatMulMatcher : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("TransposeMatMulMatcher", "0");
+    TransposeMatMulMatcher();
+};
+
+class TransposeMatMulTransposeMatcher : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("TransposeMatMulTransposeMatcher", "0");
+    TransposeMatMulTransposeMatcher();
+};
+
+TransposeMatMulFusion::TransposeMatMulFusion() {
+    add_matcher<TransposeMatMulTransposeMatcher>();
+    add_matcher<TransposeMatMulMatcher>();
+}
+
+
+TransposeMatMulMatcher::TransposeMatMulMatcher() {
+    auto not_transpose = [](const ov::Output<ov::Node>& output) -> bool {
+        return std::dynamic_pointer_cast<ov::op::v1::Transpose>(output.get_node_shared_ptr()) == nullptr;
+    };
+    auto input_a_m = any_input(not_transpose);
+    auto input_b_m = any_input(not_transpose);
+    auto transpose_a_order_m = wrap_type<ov::op::v0::Constant>(consumers_count(1));
+    auto transpose_b_order_m = wrap_type<ov::op::v0::Constant>(consumers_count(1));
+    auto transpose_a_m = wrap_type<ov::op::v1::Transpose>({input_a_m, transpose_a_order_m});
+    auto transpose_b_m = wrap_type<ov::op::v1::Transpose>({input_b_m, transpose_b_order_m});
+
+    auto matmul_in_a = std::make_shared<Or>(OutputVector{input_a_m, transpose_a_m});
+    auto matmul_in_b = std::make_shared<Or>(OutputVector{input_b_m, transpose_b_m});
+
+    auto matmul_m = wrap_type<ov::op::v0::MatMul>({ matmul_in_a, matmul_in_b });
+
+    ov::matcher_pass_callback callback = [=](Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+
+        auto matmul = std::dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_map.at(matmul_m).get_node_shared_ptr());
+        if (!matmul || transformation_callback(matmul)) {
+            return false;
+        }
+
+        auto users = matmul->get_output_target_inputs(0);
+        if (users.size() == 1 && dynamic_cast<ov::op::v1::Transpose*>(users.begin()->get_node()) != nullptr) {
+            return false;
+        }
+
+        auto order_a = default_order(matmul->get_input_partial_shape(0).size());
+        auto order_b = default_order(matmul->get_input_partial_shape(1).size());
+        auto order_c = default_order(matmul->get_output_partial_shape(0).size());
+
+        if (pattern_map.count(transpose_a_m) > 0) {
+            auto tranpose_a_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_a_order_m).get_node_shared_ptr());
+            order_a = tranpose_a_order->cast_vector<int64_t>();
+        }
+        if (pattern_map.count(transpose_b_m) > 0) {
+            auto tranpose_b_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_b_order_m).get_node_shared_ptr());
+            order_b = tranpose_b_order->cast_vector<int64_t>();
+        }
+
+        auto input_a = pattern_map.at(input_a_m).get_node_shared_ptr();
+        auto input_b = pattern_map.at(input_b_m).get_node_shared_ptr();
+
+        auto gemm = std::make_shared<op::Gemm>(input_a, input_b, order_a, order_b, order_c);
+        gemm->set_friendly_name(matmul->get_friendly_name());
+        ov::copy_runtime_info(m.get_matched_nodes(), gemm);
+        ov::replace_node(matmul, gemm);
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(matmul_m, "TransposeMatMulMatcher");
+    this->register_matcher(m, callback);
+}
+
+TransposeMatMulTransposeMatcher::TransposeMatMulTransposeMatcher() {
+    auto not_transpose = [](const ov::Output<ov::Node>& output) -> bool {
+        return std::dynamic_pointer_cast<ov::op::v1::Transpose>(output.get_node_shared_ptr()) == nullptr;
+    };
+    auto input_a_m = any_input(not_transpose);
+    auto input_b_m = any_input(not_transpose);
+    auto transpose_a_order_m = wrap_type<ov::op::v0::Constant>(consumers_count(1));
+    auto transpose_b_order_m = wrap_type<ov::op::v0::Constant>(consumers_count(1));
+    auto transpose_a_m = wrap_type<ov::op::v1::Transpose>({input_a_m, transpose_a_order_m});
+    auto transpose_b_m = wrap_type<ov::op::v1::Transpose>({input_b_m, transpose_b_order_m});
+
+    auto matmul_in_a = std::make_shared<Or>(OutputVector{input_a_m, transpose_a_m});
+    auto matmul_in_b = std::make_shared<Or>(OutputVector{input_b_m, transpose_b_m});
+
+    auto matmul_m = wrap_type<ov::op::v0::MatMul>({ matmul_in_a, matmul_in_b });
+    auto transpose_c_order_m = wrap_type<ov::op::v0::Constant>(consumers_count(1));
+    auto transpose_c_m = wrap_type<ov::op::v1::Transpose>({matmul_m, transpose_c_order_m});
+
+    ov::matcher_pass_callback callback = [=](Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+
+        auto matmul = std::dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_map.at(matmul_m).get_node_shared_ptr());
+        if (!matmul || transformation_callback(matmul)) {
+            return false;
+        }
+
+        auto tranpose_c_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_c_order_m).get_node_shared_ptr());
+        auto order_a = default_order(matmul->get_input_partial_shape(0).size());
+        auto order_b = default_order(matmul->get_input_partial_shape(1).size());
+        auto order_c = tranpose_c_order->cast_vector<int64_t>();
+
+        if (pattern_map.count(transpose_a_m) > 0) {
+            auto tranpose_a_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_a_order_m).get_node_shared_ptr());
+            order_a = tranpose_a_order->cast_vector<int64_t>();
+        }
+        if (pattern_map.count(transpose_b_m) > 0) {
+            auto tranpose_b_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_b_order_m).get_node_shared_ptr());
+            order_b = tranpose_b_order->cast_vector<int64_t>();
+        }
+
+        auto input_a = pattern_map.at(input_a_m).get_node_shared_ptr();
+        auto input_b = pattern_map.at(input_b_m).get_node_shared_ptr();
+
+        auto gemm = std::make_shared<op::Gemm>(input_a, input_b, order_a, order_b, order_c);
+        gemm->set_friendly_name(m.get_match_root()->get_friendly_name());
+        ov::copy_runtime_info(m.get_matched_nodes(), gemm);
+        ov::replace_node(m.get_match_root(), gemm);
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(transpose_c_m, "TransposeMatMulTransposeMatcher");
+    this->register_matcher(m, callback);
+}
+
+}  // namespace intel_gpu
+}  // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_matmul_fusion.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_matmul_fusion.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov {
+namespace intel_gpu {
+
+class TransposeMatMulFusion: public ov::pass::GraphRewrite {
+public:
+    OPENVINO_RTTI("TransposeMatMulFusion", "0");
+    TransposeMatMulFusion();
+};
+
+}   // namespace intel_gpu
+}   // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -703,7 +703,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::RMSFusion>();
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
-        manager.register_pass<ov::intel_gpu::TransposeMatMulFusion>();
+        if (!device_info.supports_immad)
+            manager.register_pass<ov::intel_gpu::TransposeMatMulFusion>();
 
         // This is supposed to be the last pass to ensure that we don't have name collisions until
         // GPU plugin stops using friendly names for program creation

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -124,6 +124,7 @@
 #include "plugin/transformations/kv_cache_fusion.hpp"
 #include "plugin/transformations/fc_convert_fusion.hpp"
 #include "plugin/transformations/clamp_fp16_output.hpp"
+#include "plugin/transformations/transpose_matmul_fusion.hpp"
 
 #include "transformations/low_precision/mark_dequantization_subgraph.hpp"
 #include "low_precision/pull_reshape_through_dequantization.hpp"
@@ -702,6 +703,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::RMSFusion>();
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
+        manager.register_pass<ov::intel_gpu::TransposeMatMulFusion>();
 
         // This is supposed to be the last pass to ensure that we don't have name collisions until
         // GPU plugin stops using friendly names for program creation

--- a/src/plugins/intel_gpu/tests/unit/module_tests/primitive_comparison_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/primitive_comparison_test.cpp
@@ -69,7 +69,7 @@ TEST(primitive_comparison, gemm) {
     auto gemm_prim_eq = gemm("gemm_eq", {input_info("input0_eq"), input_info("input1_eq")}, data_types::f32);
     auto gemm_prim_rank = gemm("gemm", def_inputs, data_types::f32, false, false, 1.0f, 0.0f, 2, 2);
     auto gemm_prim_alpha = gemm("gemm", def_inputs, data_types::f32, false, false, 1.5f);
-    auto gemm_prim_transpose = gemm("gemm", def_inputs, data_types::f32, true);
+    auto gemm_prim_transpose = gemm("gemm", def_inputs, data_types::f32, true, false);
 
     ASSERT_EQ(gemm_prim, gemm_prim_eq);
     ASSERT_NE(gemm_prim, gemm_prim_rank);

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/matmul_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/matmul_si_test.cpp
@@ -42,7 +42,9 @@ TEST_P(gemm_test, shape_infer) {
     auto matrix_a_layout_prim = std::make_shared<input_layout>("matrix_a", p.matrix_a_layout);
     auto matrix_b_layout_prim = std::make_shared<input_layout>("matrix_b", p.matrix_b_layout);
     auto gemm_prim = std::make_shared<gemm>("output", std::vector<input_info>{ input_info("matrix_a"), input_info("matrix_b") },
-                                            p.data_type, p.transpose_a, p.transpose_b);
+                                            p.data_type, p.transpose_a, p.transpose_b, 1.0f, 0.0f,
+                                            p.matrix_a_layout.get_partial_shape().rank().get_length(),
+                                            p.matrix_b_layout.get_partial_shape().rank().get_length());
 
     cldnn::program prog(engine);
 
@@ -166,7 +168,9 @@ TEST_P(gemm_test_preferred_output_format, shape_infer) {
     auto matrix_a_layout_prim = std::make_shared<input_layout>("matrix_a", p.matrix_a_layout);
     auto matrix_b_layout_prim = std::make_shared<input_layout>("matrix_b", p.matrix_b_layout);
     auto gemm_prim = std::make_shared<gemm>("output", std::vector<input_info>{ input_info("matrix_a"), input_info("matrix_b") },
-                                            p.data_type, p.transpose_a, p.transpose_b);
+                                            p.data_type, p.transpose_a, p.transpose_b, 1.0f, 0.0f,
+                                            p.matrix_a_layout.get_partial_shape().rank().get_length(),
+                                            p.matrix_b_layout.get_partial_shape().rank().get_length());
 
     cldnn::program prog(engine, {ov::intel_gpu::allow_new_shape_infer(true)});
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -127,8 +127,8 @@ public:
 
         const auto primitive_hash = primitve->hash();
         const auto params_hash = prim_inst->get_impl_params()->hash();
-        ASSERT_EQ(primitive_hash, 8009877756431655269UL);
-        ASSERT_EQ(params_hash, 12585836190897043350UL);
+        ASSERT_EQ(primitive_hash, 6333308204192016515UL);
+        ASSERT_EQ(params_hash, 5512364123521496254UL);
     }
 
     void test_permute_basic(bool is_caching_test) {

--- a/src/plugins/intel_gpu/tests/unit/transformations/transpose_matmul_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/transpose_matmul_fusion_test.cpp
@@ -1,0 +1,129 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/ov_test_utils.hpp"
+
+#include "openvino/core/model.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/pass/manager.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/result.hpp"
+#include "intel_gpu/op/gemm.hpp"
+
+#include "plugin/transformations/transpose_matmul_fusion.hpp"
+
+#include <memory>
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+namespace ov {
+namespace test {
+namespace intel_gpu {
+
+TEST_F(TransformationTestsF, TranposeMatmulFusion1) {
+    {
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input_a, input_b });
+        manager.register_pass<TransposeMatMulFusion>();
+    }
+    {
+        std::vector<int64_t> order_a = {0, 1, 2, 3};
+        std::vector<int64_t> order_b = {0, 1, 2, 3};
+        std::vector<int64_t> order_c = {0, 1, 2, 3};
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto gemm = std::make_shared<ov::intel_gpu::op::Gemm>(input_a, input_b, order_a, order_b, order_c, ov::element::undefined);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
+TEST_F(TransformationTestsF, TranposeMatmulFusion2) {
+    {
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto tranpose_a_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
+        auto tranpose_a = std::make_shared<ov::op::v1::Transpose>(input_a, tranpose_a_const);
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(tranpose_a, input_b);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input_a, input_b });
+        manager.register_pass<TransposeMatMulFusion>();
+    }
+    {
+        std::vector<int64_t> order_a = {0, 2, 1, 3};
+        std::vector<int64_t> order_b = {0, 1, 2, 3};
+        std::vector<int64_t> order_c = {0, 1, 2, 3};
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto gemm = std::make_shared<ov::intel_gpu::op::Gemm>(input_a, input_b, order_a, order_b, order_c, ov::element::undefined);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
+TEST_F(TransformationTestsF, TranposeMatmulFusion3) {
+    {
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto tranpose_a_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
+        auto tranpose_a = std::make_shared<ov::op::v1::Transpose>(input_a, tranpose_a_const);
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto tranpose_b_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 1, 3, 2});
+        auto tranpose_b = std::make_shared<ov::op::v1::Transpose>(input_b, tranpose_b_const);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(tranpose_a, tranpose_b);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input_a, input_b });
+        manager.register_pass<TransposeMatMulFusion>();
+    }
+    {
+        std::vector<int64_t> order_a = {0, 2, 1, 3};
+        std::vector<int64_t> order_b = {0, 1, 3, 2};
+        std::vector<int64_t> order_c = {0, 1, 2, 3};
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto gemm = std::make_shared<ov::intel_gpu::op::Gemm>(input_a, input_b, order_a, order_b, order_c, ov::element::undefined);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
+TEST_F(TransformationTestsF, TranposeMatmulFusion4) {
+    {
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto tranpose_a_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
+        auto tranpose_a = std::make_shared<ov::op::v1::Transpose>(input_a, tranpose_a_const);
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto tranpose_b_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
+        auto tranpose_b = std::make_shared<ov::op::v1::Transpose>(input_b, tranpose_b_const);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(tranpose_a, tranpose_b);
+        auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
+        auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{ tranpose_c }, ov::ParameterVector{ input_a, input_b });
+        manager.register_pass<TransposeMatMulFusion>();
+    }
+    {
+        std::vector<int64_t> order_a = {0, 2, 1, 3};
+        std::vector<int64_t> order_b = {0, 2, 1, 3};
+        std::vector<int64_t> order_c = {0, 2, 1, 3};
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
+        auto gemm = std::make_shared<ov::intel_gpu::op::Gemm>(input_a, input_b, order_a, order_b, order_c, ov::element::undefined);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
+}  // namespace intel_gpu
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - To fuse `transpose` layers into a `gemm` layer for faster LLM inference
   - before: [`transpose`] --> `gemm` --> [`transpose`]
   - after: `gemm`
 - `gemm` is extended to have `input0_order`, `input1_order` and `output_order` from `transpose` layers

### Tickets:
 - 127590
