### PR TITLE
[GPU] Remove internal swish fusion pass

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/pass_manager.h
+++ b/src/plugins/intel_gpu/src/graph/include/pass_manager.h
@@ -177,7 +177,6 @@ public:
 
 private:
     void run(program& p) override;
-    void fuse_sigmoid_mul_to_swish(program &p);
     void fuse_bias(program &p);
     void fuse_reorders(program& p);
     void fuse_simple_primitives(program &p);


### PR DESCRIPTION
### Details:
 - We have [similar transformation](https://github.com/openvinotoolkit/openvino/blob/master/src/common/transformations/src/transformations/common_optimizations/swish_fusion.cpp#L42) in ngraph so that pass seem to be redundant 