### PR TITLE
[TESTS] BenchmarkLayerTest base class fix

### DIFF
--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/benchmark.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/benchmark.hpp
@@ -199,7 +199,7 @@ namespace test {
 template <typename BaseLayerTest>
 class BenchmarkLayerTest : public BaseLayerTest {
     static_assert(std::is_base_of<SubgraphBaseTest, BaseLayerTest>::value,
-                  "BaseLayerTest should inherit from LayerTestsUtils::LayerTestsCommon");
+                  "BaseLayerTest should inherit from ov::test::SubgraphBaseTest");
 
  public:
     static constexpr int kDefaultNumberOfAttempts = 100;
@@ -226,6 +226,7 @@ class BenchmarkLayerTest : public BaseLayerTest {
     }
 
     void validate() override {
+        infer();
         for (const auto& res : curr_bench_results_) {
             const auto& node_type_name = res.first;
             const auto curr_time = static_cast<int64_t>(res.second);


### PR DESCRIPTION
### Details:
Currently, infer() is not called during `BenchmarkLayerTest` execution. This PR fixes this behavior by adding `infer()` call at the beginning of the overridden `validate()` method (as it is done in base `SubgraphBaseTest` class).
