### PR TITLE
LP Transformation tests move from ngraph to ov namespace

### DIFF
--- a/src/common/low_precision_transformations/tests/add_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/add_transformation.cpp
@@ -22,36 +22,36 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class AddTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type precision1;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
         ov::element::Type precision2;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
         std::vector<float> constValues;
     };
 
     class Expected {
     public:
         ov::element::Type precision1;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
         ov::element::Type precision2;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
         std::vector<float> constValues;
         std::string operationType;
 
         Expected() = default;
 
         Expected(const ov::element::Type& precision1,
-                 ngraph::builder::subgraph::DequantizationOperations dequantization1,
+                 ov::builder::subgraph::DequantizationOperations dequantization1,
                  const ov::element::Type& precision2,
-                 ngraph::builder::subgraph::DequantizationOperations dequantization2,
-                 ngraph::builder::subgraph::DequantizationOperations dequantizationAfter,
+                 ov::builder::subgraph::DequantizationOperations dequantization2,
+                 ov::builder::subgraph::DequantizationOperations dequantizationAfter,
                  std::vector<float> constValues,
                  std::string operationType = "Add")
             : precision1(precision1),

--- a/src/common/low_precision_transformations/tests/align_concat_quantization_parameters_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/align_concat_quantization_parameters_transformation.cpp
@@ -28,15 +28,15 @@ public:
     class Actual {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -63,7 +63,7 @@ public:
         AlignConcatQuantizationParametersTransformationTestValues testValues;
         std::tie(precision, shape, addFakeQuantize, additionalLayer, testValues) = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::AlignConcatQuantizationParametersFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::AlignConcatQuantizationParametersFunction::getOriginal(
             precision,
             testValues.actual.inputPrecision,
             shape,
@@ -89,7 +89,7 @@ public:
         transform.add<ov::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::AlignConcatQuantizationParametersFunction::getReference(
+        referenceFunction = ov::builder::subgraph::AlignConcatQuantizationParametersFunction::getReference(
             precision,
             testValues.expected.inputPrecision,
             shape,

--- a/src/common/low_precision_transformations/tests/assign_and_read_value_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/assign_and_read_value_transformation.cpp
@@ -28,14 +28,14 @@ public:
     class Actual {
     public:
         std::vector<float> constantValue;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         std::vector<float> constantValue;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -64,7 +64,7 @@ public:
         const auto params = TestTransformationParams(testValues.params)
             .setDefaultPrecisions(defaultPrecisions);
 
-        actualFunction = ngraph::builder::subgraph::AssignAndReadValueFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::AssignAndReadValueFunction::getOriginal(
             inputShape,
             precision,
             precisionBeforeDequantization,
@@ -77,7 +77,7 @@ public:
         transformer.add<ov::pass::low_precision::AssignAndReadValueTransformation, ov::op::v6::Assign>(actualFunction, params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::AssignAndReadValueFunction::getReference(
+        referenceFunction = ov::builder::subgraph::AssignAndReadValueFunction::getReference(
                 inputShape,
                 precision,
                 precisionBeforeDequantization,

--- a/src/common/low_precision_transformations/tests/avg_pool_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/avg_pool_transformation.cpp
@@ -26,15 +26,15 @@ public:
     class Actual {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -59,7 +59,7 @@ public:
         std::string additionalLayer;
         AvgPoolTransformationTestValues testValues;
         std::tie(precision, shape, addFakeQuantize, additionalLayer, testValues) = GetParam();
-        actualFunction = ngraph::builder::subgraph::AvgPoolFunction::getOriginal(precision,
+        actualFunction = ov::builder::subgraph::AvgPoolFunction::getOriginal(precision,
                                                                                  testValues.actual.inputPrecision,
                                                                                  shape,
                                                                                  addFakeQuantize,
@@ -72,7 +72,7 @@ public:
         transform.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::AvgPoolFunction::getReference(precision,
+            ov::builder::subgraph::AvgPoolFunction::getReference(precision,
                                                                      testValues.expected.inputPrecision,
                                                                      shape,
                                                                      addFakeQuantize,

--- a/src/common/low_precision_transformations/tests/avg_pool_with_child_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/avg_pool_with_child_transformation.cpp
@@ -25,16 +25,16 @@ public:
     class Actual {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationEnd;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationEnd;
     };
 
     TestTransformationParams params;
@@ -55,7 +55,7 @@ public:
         std::string additionalLayer;
         AvgPoolWithChildTransformationTestValues testValues;
         std::tie(precision, shape, testValues) = GetParam();
-        actualFunction = ngraph::builder::subgraph::AvgPoolFunction::getOriginal(precision,
+        actualFunction = ov::builder::subgraph::AvgPoolFunction::getOriginal(precision,
                                                                                  testValues.actual.inputPrecision,
                                                                                  shape,
                                                                                  false,
@@ -69,7 +69,7 @@ public:
         transform.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::AvgPoolFunction::getReference(precision,
+            ov::builder::subgraph::AvgPoolFunction::getReference(precision,
                                                                      testValues.expected.inputPrecision,
                                                                      shape,
                                                                      false,

--- a/src/common/low_precision_transformations/tests/batch_to_space_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/batch_to_space_transformation.cpp
@@ -28,17 +28,17 @@ public:
     class Actual {
     public:
         ov::element::Type input_type;
-        ngraph::builder::subgraph::DequantizationOperations dequantization_before;
+        ov::builder::subgraph::DequantizationOperations dequantization_before;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantization_after;
+        ov::builder::subgraph::DequantizationOperations dequantization_after;
     };
 
     class Expected {
     public:
         ov::element::Type input_type;
-        ngraph::builder::subgraph::DequantizationOperations dequantization_before;
+        ov::builder::subgraph::DequantizationOperations dequantization_before;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantization_after;
+        ov::builder::subgraph::DequantizationOperations dequantization_after;
     };
 
     TestTransformationParams params;
@@ -60,7 +60,7 @@ public:
         const ov::PartialShape input_shape = std::get<0>(GetParam());
         const BatchToSpaceTransformationTestValues test_values = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::BatchToSpaceFunction::get(
+        actualFunction = ov::builder::subgraph::BatchToSpaceFunction::get(
             input_shape,
             test_values.actual.input_type,
             test_values.actual.dequantization_before,
@@ -73,7 +73,7 @@ public:
         transform.add<ov::pass::low_precision::BatchToSpaceTransformation>(test_values.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::BatchToSpaceFunction::get(
+        referenceFunction = ov::builder::subgraph::BatchToSpaceFunction::get(
             input_shape,
             test_values.expected.input_type,
             test_values.expected.dequantization_before,

--- a/src/common/low_precision_transformations/tests/clamp_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/clamp_transformation.cpp
@@ -25,15 +25,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -52,10 +52,10 @@ public:
 
         actualFunction =
             testValues.nonDequantizationMultiply
-                ? ngraph::builder::subgraph::ClampFunction::getWithNonDequantizationMultiply(
+                ? ov::builder::subgraph::ClampFunction::getWithNonDequantizationMultiply(
                       inputShape,
                       testValues.actual.precisionBeforeDequantization)
-                : ngraph::builder::subgraph::ClampFunction::getOriginal(inputShape,
+                : ov::builder::subgraph::ClampFunction::getOriginal(inputShape,
                                                                         testValues.actual.precisionBeforeDequantization,
                                                                         testValues.actual.dequantization);
 
@@ -64,10 +64,10 @@ public:
         transformer.transform(actualFunction);
 
         referenceFunction = testValues.nonDequantizationMultiply
-                                ? ngraph::builder::subgraph::ClampFunction::getWithNonDequantizationMultiply(
+                                ? ov::builder::subgraph::ClampFunction::getWithNonDequantizationMultiply(
                                       inputShape,
                                       testValues.actual.precisionBeforeDequantization)
-                                : ngraph::builder::subgraph::ClampFunction::getReference(
+                                : ov::builder::subgraph::ClampFunction::getReference(
                                       inputShape,
                                       testValues.expected.precisionBeforeDequantization,
                                       testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/compose_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/compose_fake_quantize_transformation.cpp
@@ -21,15 +21,15 @@
 
 using namespace testing;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class ComposeFakeQuantizeTransformationParams {
 public:
     class Values {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
     };
 
     ov::element::Type originalPrecision;
@@ -48,7 +48,7 @@ public:
     void SetUp() override {
         const auto inputShape = std::get<0>(GetParam());
         const auto testValues = std::get<1>(GetParam());
-        actualFunction = ngraph::builder::subgraph::ComposeFakeQuantizeFunction::get(
+        actualFunction = ov::builder::subgraph::ComposeFakeQuantizeFunction::get(
             testValues.originalPrecision,
             inputShape,
             testValues.actual.fakeQuantize,
@@ -61,7 +61,7 @@ public:
         const auto fakeQuantize = ov::as_type_ptr<ov::op::v0::FakeQuantize>(it->get_node()->shared_from_this());
         ov::pass::low_precision::NetworkHelper::composeFakeQuantize(fakeQuantize);
 
-        referenceFunction = ngraph::builder::subgraph::ComposeFakeQuantizeFunction::get(
+        referenceFunction = ov::builder::subgraph::ComposeFakeQuantizeFunction::get(
             testValues.originalPrecision,
             inputShape,
             testValues.expected.fakeQuantize,

--- a/src/common/low_precision_transformations/tests/concat_selection_with_intermediate_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_selection_with_intermediate_transformation.cpp
@@ -29,8 +29,8 @@ namespace {
 
 class ActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ActualValues& values) {
@@ -39,14 +39,14 @@ inline std::ostream& operator<<(std::ostream& out, const ActualValues& values) {
 
 class ResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
     ov::element::Type precisionBeforeOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore2;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore1;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore2;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter2;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter1;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ResultValues& values) {
@@ -78,7 +78,7 @@ public:
         const ov::element::Type precision = std::get<0>(GetParam());
         TestValues testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalSelectionWithIntermediate(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalSelectionWithIntermediate(
             precision,
             testValues.inputShape,
             testValues.transparentIntermediate,
@@ -97,7 +97,7 @@ public:
         transform.add<ov::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceSelectionWithIntermediate(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceSelectionWithIntermediate(
             precision,
             testValues.inputShape,
             testValues.transparentIntermediate,

--- a/src/common/low_precision_transformations/tests/concat_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_transformation.cpp
@@ -19,7 +19,7 @@
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 namespace {
 class ConcatTransformationTestValues {

--- a/src/common/low_precision_transformations/tests/concat_with_different_precision_on_children.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_different_precision_on_children.cpp
@@ -30,8 +30,8 @@ namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -40,14 +40,14 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
     ov::element::Type precisionBeforeOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore2;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore1;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore2;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter2;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter1;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationResultValues& values) {
@@ -84,7 +84,7 @@ public:
         const ov::PartialShape inputShape = std::get<1>(GetParam());
         ConcatTransformationTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithDifferentPrecisionOnChildren(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithDifferentPrecisionOnChildren(
             precision,
             inputShape,
             testValues.axis,
@@ -103,7 +103,7 @@ public:
         transform.add<ov::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithDifferentPrecisionOnChildren(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithDifferentPrecisionOnChildren(
             precision,
             inputShape,
             testValues.multiChannels,

--- a/src/common/low_precision_transformations/tests/concat_with_fq_tranformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_fq_tranformation.cpp
@@ -27,18 +27,18 @@
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert1;
-    ngraph::builder::subgraph::DequantizationOperations dequantization1;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert2;
-    ngraph::builder::subgraph::DequantizationOperations dequantization2;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
+    ov::builder::subgraph::DequantizationOperations::Convert convert1;
+    ov::builder::subgraph::DequantizationOperations dequantization1;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
+    ov::builder::subgraph::DequantizationOperations::Convert convert2;
+    ov::builder::subgraph::DequantizationOperations dequantization2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -48,14 +48,14 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert1;
-    ngraph::builder::subgraph::DequantizationOperations dequantization1;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert2;
-    ngraph::builder::subgraph::DequantizationOperations dequantization2;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
+    ov::builder::subgraph::DequantizationOperations::Convert convert1;
+    ov::builder::subgraph::DequantizationOperations dequantization1;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
+    ov::builder::subgraph::DequantizationOperations::Convert convert2;
+    ov::builder::subgraph::DequantizationOperations dequantization2;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationResultValues& values) {
@@ -117,7 +117,7 @@ public:
             testValues.actual.dequantization2.multiply.outPrecision = precision;
         }
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::get(precision,
+        actualFunction = ov::builder::subgraph::ConcatFunction::get(precision,
                                                                         shape,
                                                                         testValues.actual.fakeQuantize1,
                                                                         testValues.actual.convert1,
@@ -175,7 +175,7 @@ public:
         ov::IntervalsAlignmentSharedValue::Interval interval{-1.28f, 2.55f};
 
         referenceFunction =
-            ngraph::builder::subgraph::ConcatFunction::get(precision,
+            ov::builder::subgraph::ConcatFunction::get(precision,
                                                            shape,
                                                            testValues.result.fakeQuantize1,
                                                            testValues.result.convert1,

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_precision_selection_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_precision_selection_transformation.cpp
@@ -30,8 +30,8 @@ namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -40,14 +40,14 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
     ov::element::Type precisionBeforeOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore2;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore1;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore2;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter2;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter1;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationResultValues& values) {
@@ -83,7 +83,7 @@ public:
         const ov::PartialShape shape = std::get<1>(GetParam());
         ConcatTransformationTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithIntermediateAvgPool(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithIntermediateAvgPool(
             precision,
             shape,
             testValues.actual.fakeQuantize1,
@@ -106,7 +106,7 @@ public:
         transform.add<ov::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithIntermediateAvgPool(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithIntermediateAvgPool(
             precision,
             shape,
             testValues.result.fakeQuantize1,

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_reshape_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_reshape_transformation.cpp
@@ -27,8 +27,8 @@ using namespace ov::pass;
 namespace {
 class ActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ActualValues& values) {
@@ -37,9 +37,9 @@ inline std::ostream& operator<<(std::ostream& out, const ActualValues& values) {
 
 class ResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ResultValues& values) {
@@ -70,7 +70,7 @@ public:
         const ov::element::Type precision = std::get<0>(GetParam());
         TestValues testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithIntermediateReshape(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithIntermediateReshape(
             precision,
             testValues.inputShape,
             testValues.reshapeOutputShape,
@@ -83,7 +83,7 @@ public:
         transform.add<ov::pass::low_precision::ReshapeTransformation, ov::op::v1::Reshape>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithIntermediateReshape(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithIntermediateReshape(
             precision,
             testValues.inputShape,
             testValues.reshapeOutputShape,

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_transformation.cpp
@@ -29,8 +29,8 @@ namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -39,14 +39,14 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
     ov::element::Type precisionBeforeOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore2;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore1;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore2;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter2;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter1;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationResultValues& values) {
@@ -83,7 +83,7 @@ public:
         const ov::PartialShape shape = std::get<1>(GetParam());
         ConcatTransformationTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithIntermediate(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithIntermediate(
             precision,
             shape,
             testValues.transparentIntermediate,
@@ -102,7 +102,7 @@ public:
         transform.add<ov::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithIntermediate(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithIntermediate(
             precision,
             shape,
             testValues.transparentIntermediate,

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_with_constant_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_with_constant_transformation.cpp
@@ -30,8 +30,8 @@ namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -40,12 +40,12 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOperations1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::DequantizationOperations dequantizationOperations1;
     ov::element::Type precisionBeforeOp;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOperations2;
+    ov::builder::subgraph::DequantizationOperations dequantizationOperations2;
     ov::element::Type precisionAfterDequantization;
 };
 
@@ -84,7 +84,7 @@ public:
         const ov::PartialShape shape = std::get<1>(GetParam());
         ConcatTransformationTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithIntermediateWithConstant(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithIntermediateWithConstant(
             precision,
             shape,
             testValues.transparentIntermediate,
@@ -104,7 +104,7 @@ public:
         transform.add<ov::pass::low_precision::InterpolateTransformation, ov::op::v0::Interpolate>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithIntermediateWithConstant(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithIntermediateWithConstant(
             precision,
             shape,
             testValues.transparentIntermediate,

--- a/src/common/low_precision_transformations/tests/concat_with_neighbors_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_neighbors_transformation.cpp
@@ -36,9 +36,9 @@ namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize3;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize3;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -47,14 +47,14 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize3;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize3;
     ov::element::Type precisionBeforeOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
     ov::element::Type precisionAfterOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter2;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter1;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationResultValues& values) {
@@ -93,7 +93,7 @@ public:
         const ov::PartialShape shape = std::get<1>(GetParam());
         ConcatTransformationTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithNeighbors(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithNeighbors(
             precision,
             shape,
             testValues.actual.fakeQuantize1,
@@ -121,7 +121,7 @@ public:
         transform.add<ov::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithNeighbors(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithNeighbors(
             precision,
             shape,
             testValues.result.fakeQuantize1,

--- a/src/common/low_precision_transformations/tests/concat_with_neighbors_transformation_with_convolution.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_neighbors_transformation_with_convolution.cpp
@@ -22,21 +22,21 @@
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 namespace {
 
 class ConcatWithNeighborsWithConvolutionActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert1;
-    ngraph::builder::subgraph::DequantizationOperations dequantization1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert2;
-    ngraph::builder::subgraph::DequantizationOperations dequantization2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize3;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert3;
-    ngraph::builder::subgraph::DequantizationOperations dequantization3;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::DequantizationOperations::Convert convert1;
+    ov::builder::subgraph::DequantizationOperations dequantization1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::DequantizationOperations::Convert convert2;
+    ov::builder::subgraph::DequantizationOperations dequantization2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize3;
+    ov::builder::subgraph::DequantizationOperations::Convert convert3;
+    ov::builder::subgraph::DequantizationOperations dequantization3;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatWithNeighborsWithConvolutionActualValues& values) {
@@ -45,14 +45,14 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatWithNeighborsWith
 
 class ConcatWithNeighborsWithConvolutionResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize3;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize3;
     ov::element::Type precisionBeforeOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
     ov::element::Type precisionAfterOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter2;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter1;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatWithNeighborsWithConvolutionResultValues& values) {
@@ -91,7 +91,7 @@ public:
         const ov::Shape shape = std::get<1>(GetParam());
         ConcatWithNeighborsWithConvolutionTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::PrecisionPropagationFunction::getOriginalWithNeighbors(
+        actualFunction = ov::builder::subgraph::PrecisionPropagationFunction::getOriginalWithNeighbors(
             precision,
             shape,
             testValues.actual.fakeQuantize1,
@@ -124,7 +124,7 @@ public:
         transform.add<ov::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::PrecisionPropagationFunction::getReferenceWithNeighbors(
+        referenceFunction = ov::builder::subgraph::PrecisionPropagationFunction::getReferenceWithNeighbors(
             precision,
             shape,
             testValues.result.fakeQuantize1,

--- a/src/common/low_precision_transformations/tests/concat_with_not_quantized_parent_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_not_quantized_parent_transformation.cpp
@@ -32,18 +32,18 @@
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 namespace {
 
 class ConcatWithNotQuantizedParentTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert1;
-    ngraph::builder::subgraph::DequantizationOperations dequantization1;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert2;
-    ngraph::builder::subgraph::DequantizationOperations dequantization2;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
+    ov::builder::subgraph::DequantizationOperations::Convert convert1;
+    ov::builder::subgraph::DequantizationOperations dequantization1;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
+    ov::builder::subgraph::DequantizationOperations::Convert convert2;
+    ov::builder::subgraph::DequantizationOperations dequantization2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatWithNotQuantizedParentTransformationActualValues& values) {
@@ -58,14 +58,14 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatWithNotQuantizedP
 
 class ConcatWithNotQuantizedParentTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert1;
-    ngraph::builder::subgraph::DequantizationOperations dequantization1;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert2;
-    ngraph::builder::subgraph::DequantizationOperations dequantization2;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
+    ov::builder::subgraph::DequantizationOperations::Convert convert1;
+    ov::builder::subgraph::DequantizationOperations dequantization1;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
+    ov::builder::subgraph::DequantizationOperations::Convert convert2;
+    ov::builder::subgraph::DequantizationOperations dequantization2;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatWithNotQuantizedParentTransformationResultValues& values) {
@@ -137,7 +137,7 @@ public:
             testValues.actual.dequantization2.multiply.outPrecision = precision;
         }
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::get(
+        actualFunction = ov::builder::subgraph::ConcatFunction::get(
             precision,
             shapes.first,
             testValues.actual.fakeQuantize1,
@@ -205,7 +205,7 @@ public:
             testValues.result.dequantizationAfter.convert = {};
         }
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::get(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::get(
             precision,
             shapes.first,
             testValues.result.fakeQuantize1,

--- a/src/common/low_precision_transformations/tests/concat_with_reshape_at_the_end_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_reshape_at_the_end_transformation.cpp
@@ -30,9 +30,9 @@ namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize3;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize3;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -41,12 +41,12 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize3;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize3;
     ov::element::Type precisionBeforeOp;
     ov::element::Type precisionAfterOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOperations;
+    ov::builder::subgraph::DequantizationOperations dequantizationOperations;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationResultValues& values) {
@@ -77,7 +77,7 @@ public:
         const ov::Shape shape = std::get<1>(GetParam());
         ConcatTransformationTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithReshapeAtTheEndTransformation(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithReshapeAtTheEndTransformation(
             precision,
             shape,
             testValues.actual.fakeQuantize1,
@@ -91,7 +91,7 @@ public:
         transform.add<ov::pass::low_precision::ReshapeTransformation, ov::op::v1::Reshape>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithReshapeAtTheEndTransformation(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithReshapeAtTheEndTransformation(
             precision,
             shape,
             testValues.result.fakeQuantize1,

--- a/src/common/low_precision_transformations/tests/concat_with_split_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_split_transformation.cpp
@@ -37,8 +37,8 @@ namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -47,14 +47,14 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
     ov::element::Type precisionBeforeOp;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore2;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore1;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore2;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOperations1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOperations2;
+    ov::builder::subgraph::DequantizationOperations dequantizationOperations1;
+    ov::builder::subgraph::DequantizationOperations dequantizationOperations2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationResultValues& values) {
@@ -92,7 +92,7 @@ public:
         const ConcatTransformationTestValues testValues = std::get<2>(GetParam());
         const bool addConvolution = std::get<3>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithSplitedIntermediate(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithSplitedIntermediate(
             precision,
             shape,
             testValues.actual.fakeQuantize1,
@@ -118,7 +118,7 @@ public:
         transform.add<ov::pass::low_precision::SplitTransformation, ov::op::v1::Split>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithSplitedIntermediate(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithSplitedIntermediate(
             precision,
             shape,
             testValues.result.fakeQuantize1,

--- a/src/common/low_precision_transformations/tests/concat_with_strided_slice_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_strided_slice_transformation.cpp
@@ -30,8 +30,8 @@ namespace {
 
 class ConcatTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationActualValues& values) {
@@ -40,13 +40,13 @@ inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationAct
 
 class ConcatTransformationResultValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
     ov::element::Type precisionBeforeConcat;
     ov::element::Type precisionAfterConcat;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter1;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter2;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter1;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter2;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ConcatTransformationResultValues& values) {
@@ -84,7 +84,7 @@ public:
         const ov::PartialShape shape = std::get<1>(GetParam());
         ConcatTransformationTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConcatFunction::getOriginalWithStridedSlice(
+        actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithStridedSlice(
             precision,
             shape,
             testValues.actual.fakeQuantize1,
@@ -112,7 +112,7 @@ public:
         transform.add<ov::pass::low_precision::StridedSliceTransformation, ov::op::v1::StridedSlice>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConcatFunction::getReferenceWithStridedSlice(
+        referenceFunction = ov::builder::subgraph::ConcatFunction::getReferenceWithStridedSlice(
             precision,
             shape,
             testValues.result.fakeQuantize1,

--- a/src/common/low_precision_transformations/tests/convert_subtract_constant_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convert_subtract_constant_transformation.cpp
@@ -26,12 +26,12 @@ public:
     class Values {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
-        ngraph::builder::subgraph::Constant weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::Constant weights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -49,7 +49,7 @@ public:
         const auto inputShape = std::get<0>(GetParam());
         const auto testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        actualFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
             {},
@@ -65,7 +65,7 @@ public:
         manager.register_pass<ov::pass::low_precision::ConvertSubtractConstant>();
         manager.run_passes(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        referenceFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
             {},

--- a/src/common/low_precision_transformations/tests/convolution_backprop_data_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_backprop_data_transformation.cpp
@@ -23,7 +23,7 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
 using callback_function_type = std::function<bool(const_node_ptr&)>;
@@ -37,9 +37,9 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
         std::shared_ptr<ov::op::v0::Constant> weights;
         callback_function_type callback;
 
@@ -59,8 +59,8 @@ public:
                 callback(callback) {}
         Actual(
             const ov::element::Type& precisionBeforeDequantization,
-            const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
-            const ngraph::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+            const ov::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
+            const ov::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
             const std::shared_ptr<ov::op::v0::Constant>& weights,
             const callback_function_type& callback = empty_callback) :
                 precisionBeforeDequantization(precisionBeforeDequantization),
@@ -70,8 +70,8 @@ public:
                 callback(callback) {}
         Actual(
             const ov::element::Type& precisionBeforeDequantization,
-            const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
-            const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
+            const ov::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
+            const ov::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
             const std::shared_ptr<ov::op::v0::Constant>& weights,
             const callback_function_type& callback = empty_callback) :
                 precisionBeforeDequantization(precisionBeforeDequantization),
@@ -84,9 +84,9 @@ public:
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
         std::shared_ptr<ov::op::v0::Constant> weights;
         bool transformed;
     };
@@ -135,20 +135,20 @@ public:
                     testValues.actual.dequantizationOnWeights,
                     ov::as_type_ptr<ov::op::v0::Constant>(actualWeights));
         } else if (!testValues.actual.fakeQuantizeOnWeights.empty()) {
-            actualWeights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
+            actualWeights = ov::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
                     outputShape,
                     netPrecision,
                     testValues.actual.fakeQuantizeOnWeights,
                     ov::as_type_ptr<ov::op::v0::Constant>(actualWeights));
         } else {
-            actualWeights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
+            actualWeights = ov::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
                     outputShape,
                     netPrecision,
                     testValues.actual.dequantizationOnWeights,
                     ov::as_type_ptr<ov::op::v0::Constant>(actualWeights));
         }
 
-        actualFunction = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::ConvolutionBackpropDataFunction::getOriginal(
                 testValues.actual.precisionBeforeDequantization,
                 netPrecision,
                 inputShape,
@@ -169,21 +169,21 @@ public:
                         Shape{ inputChannels, outputShape[1], 1, 1 }));
 
         if (!testValues.expected.transformed) {
-            refWeights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
+            refWeights = ov::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
                 outputShape,
                 netPrecision,
                 testValues.actual.fakeQuantizeOnWeights,
                 testValues.actual.dequantizationOnWeights,
                 ov::as_type_ptr<ov::op::v0::Constant>(refWeights));
         } else {
-            refWeights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
+            refWeights = ov::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
                 outputShape,
                 netPrecision,
                 testValues.expected.dequantizationOnWeights,
                 ov::as_type_ptr<ov::op::v0::Constant>(refWeights));
         }
 
-        referenceFunction = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getReference(
+        referenceFunction = ov::builder::subgraph::ConvolutionBackpropDataFunction::getReference(
                 testValues.expected.precisionBeforeDequantization,
                 netPrecision,
                 inputShape,

--- a/src/common/low_precision_transformations/tests/convolution_qdq_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_qdq_transformation.cpp
@@ -27,12 +27,12 @@ public:
     class Values {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
-        ngraph::builder::subgraph::Constant weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::Constant weights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -50,7 +50,7 @@ public:
         const auto inputShape = std::get<0>(GetParam());
         const auto testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        actualFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
             {},
@@ -66,7 +66,7 @@ public:
         transform.add<ov::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        referenceFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
             {},

--- a/src/common/low_precision_transformations/tests/convolution_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_transformation.cpp
@@ -27,19 +27,19 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
         std::shared_ptr<ov::op::v0::Constant> weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         std::shared_ptr<ov::op::v0::Constant> weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
         ov::element::Type precisionAfterDequantization;
     };
 
@@ -60,7 +60,7 @@ public:
         const auto inputShape = std::get<1>(GetParam());
         auto testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConvolutionFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::ConvolutionFunction::getOriginal(
             netPrecision,
             testValues.actual.precisionBeforeDequantization,
             inputShape,
@@ -86,7 +86,7 @@ public:
             testValues.expected.weights = ov::as_type_ptr<ov::op::v0::Constant>(convertedWeights);
         }
 
-        referenceFunction = ngraph::builder::subgraph::ConvolutionFunction::getReference(
+        referenceFunction = ov::builder::subgraph::ConvolutionFunction::getReference(
             netPrecision,
             testValues.expected.precisionBeforeDequantization,
             inputShape,

--- a/src/common/low_precision_transformations/tests/convolution_with_incorrect_weights.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_with_incorrect_weights.cpp
@@ -25,16 +25,16 @@ class ConvolutionWithIncorrectWeightsTestValues {
 public:
     class Actual {
     public:
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     };
 
     class Expected {
     public:
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type weightsPrecision;
         std::vector<float> weightsValues;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     ov::element::Type inputPrecision;
@@ -52,7 +52,7 @@ public:
     void SetUp() override {
         const ConvolutionWithIncorrectWeightsTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::ConvolutionFunction::getOriginalWithIncorrectWeights(
+        actualFunction = ov::builder::subgraph::ConvolutionFunction::getOriginalWithIncorrectWeights(
             testValues.inputShape,
             testValues.inputPrecision,
             testValues.actual.fakeQuantizeOnWeights,
@@ -71,7 +71,7 @@ public:
         cleanupManager.register_pass<ov::pass::ConstantFolding>();
         cleanupManager.run_passes(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConvolutionFunction::getReferenceWithIncorrectWeights(
+        referenceFunction = ov::builder::subgraph::ConvolutionFunction::getReferenceWithIncorrectWeights(
             testValues.inputShape,
             testValues.inputPrecision,
             testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/depth_to_space_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/depth_to_space_transformation.cpp
@@ -20,7 +20,7 @@
 
 namespace {
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 using namespace ov::opset1;
 using namespace ov;
 
@@ -29,15 +29,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     DepthToSpace::DepthToSpaceMode mode;

--- a/src/common/low_precision_transformations/tests/elementwise_with_multi_parent_dequantization_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/elementwise_with_multi_parent_dequantization_transformation.cpp
@@ -23,24 +23,24 @@
 
 using namespace testing;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class ElementwiseWithMultiParentDequantizationTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type precision1;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
         ov::element::Type precision2;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
     };
 
     class Expected {
     public:
         ov::element::Type precision1;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
         ov::element::Type precision2;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
     };
 
     ov::element::Type precision;

--- a/src/common/low_precision_transformations/tests/eliminate_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/eliminate_fake_quantize_transformation.cpp
@@ -26,16 +26,16 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBefore;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData1;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData2;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData1;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData2;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBefore;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData1;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData2;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOperations2;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData1;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData2;
+        ov::builder::subgraph::DequantizationOperations dequantizationOperations2;
     };
 
     ov::PartialShape inputShape;
@@ -50,7 +50,7 @@ public:
     void SetUp() override {
         const TransformationTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::FuseFakeQuantizeFunction::get(testValues.inputShape,
+        actualFunction = ov::builder::subgraph::FuseFakeQuantizeFunction::get(testValues.inputShape,
                                                                                   testValues.actual.precisionBefore,
                                                                                   testValues.actual.fakeQuantizeOnData1,
                                                                                   testValues.actual.fakeQuantizeOnData2,
@@ -66,7 +66,7 @@ public:
         transformer.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::FuseFakeQuantizeFunction::get(testValues.inputShape,
+            ov::builder::subgraph::FuseFakeQuantizeFunction::get(testValues.inputShape,
                                                                      testValues.expected.precisionBefore,
                                                                      testValues.expected.fakeQuantizeOnData1,
                                                                      testValues.expected.fakeQuantizeOnData2,

--- a/src/common/low_precision_transformations/tests/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -31,21 +31,21 @@ class FakeQuantizeAndTwoOutputBranchesWithConvolutionTestValues {
 public:
     class ActualValues {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnData fqOnData;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights1;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights2;
+        ov::builder::subgraph::FakeQuantizeOnData fqOnData;
+        ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights1;
+        ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights2;
     };
 
     class ExpectedValues {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnData fqOnData;
+        ov::builder::subgraph::FakeQuantizeOnData fqOnData;
         ov::element::Type precisionBeforeOp;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOp;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights1;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter1;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights2;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter2;
+        ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights1;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter1;
+        ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights2;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter2;
     };
 
     TestTransformationParams params;
@@ -67,7 +67,7 @@ public:
         const ov::Shape shape = std::get<1>(GetParam());
         const FakeQuantizeAndTwoOutputBranchesWithConvolutionTestValues testValues = std::get<2>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndTwoOutputBranchesWithConvolutionFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::FakeQuantizeAndTwoOutputBranchesWithConvolutionFunction::getOriginal(
             precision,
             shape,
             testValues.actual.fqOnData,
@@ -79,7 +79,7 @@ public:
         transform.add<ov::pass::low_precision::ConvolutionTransformation, ov::op::v1::Convolution>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndTwoOutputBranchesWithConvolutionFunction::getReference(
+        referenceFunction = ov::builder::subgraph::FakeQuantizeAndTwoOutputBranchesWithConvolutionFunction::getReference(
             precision,
             shape,
             TestTransformationParams::toParams(testValues.params),

--- a/src/common/low_precision_transformations/tests/fake_quantize_on_weights_with_unsupported_child.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_on_weights_with_unsupported_child.cpp
@@ -28,13 +28,13 @@ public:
     class Actual {
     public:
         std::shared_ptr<ov::op::v0::Constant> weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     };
 
     class Expected {
     public:
         std::shared_ptr<ov::op::v0::Constant> weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     };
 
     TestTransformationParams params;
@@ -55,7 +55,7 @@ public:
         const auto inputShape = std::get<0>(GetParam());
         const auto testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizeOnWeightsAndUnsupportedChildFunction::get(
+        actualFunction = ov::builder::subgraph::FakeQuantizeOnWeightsAndUnsupportedChildFunction::get(
             inputShape,
             testValues.precision,
             testValues.actual.weights,
@@ -71,7 +71,7 @@ public:
         cleanupManager.run_passes(actualFunction);
 
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizeOnWeightsAndUnsupportedChildFunction::get(
+        referenceFunction = ov::builder::subgraph::FakeQuantizeOnWeightsAndUnsupportedChildFunction::get(
             inputShape,
             testValues.precision,
             testValues.expected.weights,

--- a/src/common/low_precision_transformations/tests/fake_quantize_precision_selection_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_precision_selection_transformation.cpp
@@ -26,15 +26,15 @@ using namespace ov::pass;
 namespace {
 class ActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
 };
 
 class ExpectedValues {
 public:
     element::Type fakeQuantizeOnDataOutPrecision;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
 };
 
 class FakeQuantizePrecisionSelectionTransformationTestValues {
@@ -80,7 +80,7 @@ public:
         auto precisionLimitedOperationParams(params);
         precisionLimitedOperationParams.setPrecisionsOnActivations(testValues.precisionsOnActivationForLimitedOperation);
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizePrecisionSelectionFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::FakeQuantizePrecisionSelectionFunction::getOriginal(
             precision,
             shape,
             {
@@ -103,7 +103,7 @@ public:
         transform.add<ov::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizePrecisionSelectionFunction::getReference(
+        referenceFunction = ov::builder::subgraph::FakeQuantizePrecisionSelectionFunction::getReference(
             precision,
             shape,
             {

--- a/src/common/low_precision_transformations/tests/fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_transformation.cpp
@@ -29,10 +29,10 @@ public:
 
     FakeQuantizeTransformationTestValues(
         const TestTransformationParams& params,
-        const ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant& actual,
-        const ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant& expected,
+        const ov::builder::subgraph::FakeQuantizeOnDataWithConstant& actual,
+        const ov::builder::subgraph::FakeQuantizeOnDataWithConstant& expected,
         const ov::element::Type expectedFakeQuantizeOnDataPrecision,
-        const std::map<ov::element::Type, ngraph::builder::subgraph::DequantizationOperations>& expectedValues,
+        const std::map<ov::element::Type, ov::builder::subgraph::DequantizationOperations>& expectedValues,
         const bool addNotPrecisionPreservedOperation = false)
         : params(params),
           actual(actual),
@@ -42,10 +42,10 @@ public:
           addNotPrecisionPreservedOperation(addNotPrecisionPreservedOperation) {}
 
     TestTransformationParams params;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant actual;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant expected;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant actual;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant expected;
     ov::element::Type expectedFakeQuantizeOnDataPrecision;
-    std::map<ov::element::Type, ngraph::builder::subgraph::DequantizationOperations> expectedValues;
+    std::map<ov::element::Type, ov::builder::subgraph::DequantizationOperations> expectedValues;
     // add not precision preserved operation to set output precision for FakeQuantize
     // don't set to 'true' by default to keep test cases with tested operation as output
     bool addNotPrecisionPreservedOperation;
@@ -76,7 +76,7 @@ public:
                                 .setUpdatePrecisions(updatePrecision)
                                 .setDefaultPrecisions(defaultPrecisions);
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizeFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::FakeQuantizeFunction::getOriginal(
             TestTransformationParams::toParams(fakeQuantizeOnData.params),
             precision,
             shape,
@@ -93,7 +93,7 @@ public:
         transform.add<ov::pass::low_precision::AvgPoolTransformation, ov::op::v1::AvgPool>(params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizeFunction::getReference(
+        referenceFunction = ov::builder::subgraph::FakeQuantizeFunction::getReference(
             TestTransformationParams::toParams(fakeQuantizeOnData.params),
             precision,
             shape,

--- a/src/common/low_precision_transformations/tests/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -31,13 +31,13 @@ class FakeQuantizeWithNotOptimalTransformationTestValues {
 public:
     class Values {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnData;
-        ngraph::builder::subgraph::DequantizationOperations::Convert convertOnData;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnData;
-        ngraph::builder::subgraph::Constant constantOnWeights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnData;
+        ov::builder::subgraph::DequantizationOperations::Convert convertOnData;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnData;
+        ov::builder::subgraph::Constant constantOnWeights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
     TestTransformationParams params;
     Values actual;
@@ -68,7 +68,7 @@ public:
 
         const auto params = TestTransformationParams(testValues.params).setUpdatePrecisions(updatePrecision);
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        actualFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             precision,
             shape,
             testValues.actual.fqOnData,
@@ -97,7 +97,7 @@ public:
         transformer.add<ov::pass::low_precision::FakeQuantizeDecompositionTransformation, ov::op::v0::FakeQuantize>(params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        referenceFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             precision,
             shape,
             testValues.expected.fqOnData,

--- a/src/common/low_precision_transformations/tests/fold_convert_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fold_convert_transformation.cpp
@@ -25,14 +25,14 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class FoldConvertTransformationTestValues {
 public:
     TestTransformationParams params;
     ov::element::Type precision;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationActual;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationExpected;
+    ov::builder::subgraph::DequantizationOperations dequantizationActual;
+    ov::builder::subgraph::DequantizationOperations dequantizationExpected;
 };
 
 typedef std::tuple<
@@ -48,7 +48,7 @@ public:
         const auto createFunction = [](
             const ov::element::Type precision,
             const ov::PartialShape& inputShape,
-            const ngraph::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ov::Model> {
+            const ov::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ov::Model> {
             auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
             std::shared_ptr<ov::Node> output = makeDequantization(input, dequantization);
             output->set_friendly_name("output");

--- a/src/common/low_precision_transformations/tests/fold_fake_quantize_in_transformations.cpp
+++ b/src/common/low_precision_transformations/tests/fold_fake_quantize_in_transformations.cpp
@@ -28,7 +28,7 @@ public:
     public:
         std::vector<float> constValues;
         ov::element::Type constPrecision;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
         ov::element::Type fqOutPrecision;
     };
 
@@ -83,7 +83,7 @@ public:
         }
 
         std::shared_ptr<Node> fq =
-            ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(dataSource,
+            ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(dataSource,
                                                                    element::f32,
                                                                    testValues.actual.fakeQuantize);
         ov::pass::low_precision::NetworkHelper::setOutDataPrecision(as_type_ptr<ov::op::v0::FakeQuantize>(fq),
@@ -97,7 +97,7 @@ public:
             "FoldFakeQuantizeFunction");
 
         referenceFunction =
-            ngraph::builder::subgraph::FoldFakeQuantizeFunction::getReference(testValues.expected.constPrecision,
+            ov::builder::subgraph::FoldFakeQuantizeFunction::getReference(testValues.expected.constPrecision,
                                                                               testValues.constShape,
                                                                               testValues.expected.constValues);
     }

--- a/src/common/low_precision_transformations/tests/fuse_convert_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_convert_transformation.cpp
@@ -22,22 +22,22 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class FuseConvertTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+        ov::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+        ov::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     };
 
     bool constInput;
@@ -56,7 +56,7 @@ public:
         const ov::PartialShape inputShape = std::get<0>(GetParam());
         const FuseConvertTransformationTestValues testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::FuseConvertFunction::get(
+        actualFunction = ov::builder::subgraph::FuseConvertFunction::get(
                 inputShape,
                 testValues.actual.inputPrecision,
                 testValues.actual.dequantization,
@@ -67,7 +67,7 @@ public:
         transformer.add<ov::pass::low_precision::FuseConvertTransformation, ov::op::v0::Convert>(testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FuseConvertFunction::get(
+        referenceFunction = ov::builder::subgraph::FuseConvertFunction::get(
                 inputShape,
                 testValues.expected.inputPrecision,
                 testValues.expected.dequantization,

--- a/src/common/low_precision_transformations/tests/fuse_dequantize_to_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_dequantize_to_fake_quantize_transformation.cpp
@@ -31,22 +31,22 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeAdd;
-        ngraph::builder::subgraph::Add add;
+        ov::builder::subgraph::Add add;
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
         ov::element::Type precisionAfterDequantization;
-        ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+        ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeAdd;
-        ngraph::builder::subgraph::Add add;
+        ov::builder::subgraph::Add add;
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
         ov::element::Type precisionAfterDequantization;
         ov::element::Type precisionFakeQuantizeOnData;
-        ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+        ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
     };
 
     ov::PartialShape inputShape;
@@ -62,7 +62,7 @@ public:
     void SetUp() override {
         const FuseDequantizeToFakeQuantizeTransformationTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::FuseFakeQuantizeFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::FuseFakeQuantizeFunction::getOriginal(
             testValues.inputShape,
             testValues.actual.precisionBeforeAdd,
             testValues.actual.add,
@@ -81,7 +81,7 @@ public:
             testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FuseFakeQuantizeFunction::getReference(
+        referenceFunction = ov::builder::subgraph::FuseFakeQuantizeFunction::getReference(
             testValues.inputShape,
             testValues.expected.precisionBeforeAdd,
             testValues.expected.add,

--- a/src/common/low_precision_transformations/tests/fuse_fake_quantize_with_multi_inputs_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_fake_quantize_with_multi_inputs_transformation.cpp
@@ -31,17 +31,17 @@ class FuseFakeQuantizeTransformationTestValues {
 public:
     class Actual {
     public:
-        std::vector<ngraph::builder::subgraph::FuseFakeQuantizeFunction::Branch> branches;
+        std::vector<ov::builder::subgraph::FuseFakeQuantizeFunction::Branch> branches;
         ov::element::Type precisionFakeQuantizeOnData;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
     };
 
     class Expected {
     public:
-        std::vector<ngraph::builder::subgraph::FuseFakeQuantizeFunction::Branch> branches;
+        std::vector<ov::builder::subgraph::FuseFakeQuantizeFunction::Branch> branches;
         ov::element::Type precisionFakeQuantizeOnData;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     ov::Shape inputShape;
@@ -55,7 +55,7 @@ public:
     void SetUp() override {
         const FuseFakeQuantizeTransformationTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::FuseFakeQuantizeFunction::get(
+        actualFunction = ov::builder::subgraph::FuseFakeQuantizeFunction::get(
             testValues.inputShape,
             testValues.actual.branches,
             testValues.actual.precisionFakeQuantizeOnData,
@@ -65,7 +65,7 @@ public:
         transformer.add<ov::pass::low_precision::FakeQuantizeTransformation, ov::op::v0::FakeQuantize>(testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FuseFakeQuantizeFunction::get(
+        referenceFunction = ov::builder::subgraph::FuseFakeQuantizeFunction::get(
             testValues.inputShape,
             testValues.expected.branches,
             testValues.expected.precisionFakeQuantizeOnData,

--- a/src/common/low_precision_transformations/tests/fuse_multiply_to_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_multiply_to_fake_quantize_transformation.cpp
@@ -27,14 +27,14 @@ class FuseMultiplyToFakeQuantizeTransformationTestValues {
 public:
     class Actual {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     TestTransformationParams params;
@@ -62,7 +62,7 @@ public:
             testValues.expected.fakeQuantizeOnData.quantizationLevel = quantizationLevel;
         }
 
-        actualFunction = ngraph::builder::subgraph::FuseMultiplyToFakeQuantizeFunction::get(
+        actualFunction = ov::builder::subgraph::FuseMultiplyToFakeQuantizeFunction::get(
             inputShape,
             testValues.actual.fakeQuantizeOnData,
             testValues.actual.dequantization);
@@ -71,7 +71,7 @@ public:
         transformer.add<ov::pass::low_precision::FuseMultiplyToFakeQuantizeTransformation, ov::op::v1::Multiply>(testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FuseMultiplyToFakeQuantizeFunction::get(
+        referenceFunction = ov::builder::subgraph::FuseMultiplyToFakeQuantizeFunction::get(
             inputShape,
             testValues.expected.fakeQuantizeOnData,
             testValues.expected.dequantization);

--- a/src/common/low_precision_transformations/tests/fuse_subtract_to_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/fuse_subtract_to_fake_quantize_transformation.cpp
@@ -22,7 +22,7 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class FuseSubtractToFakeQuantizeTransformationTestValues {
 public:
@@ -74,11 +74,11 @@ public:
         }
 
         actualFunction = testValues.actual.fakeQuantizeOnData2.empty() ?
-            ngraph::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
+            ov::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
                 inputShape,
                 testValues.actual.fakeQuantizeOnData,
                 testValues.actual.dequantization) :
-            ngraph::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
+            ov::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
                 inputShape,
                 testValues.actual.fakeQuantizeOnData,
                 testValues.actual.dequantization,
@@ -90,11 +90,11 @@ public:
         transformer.transform(actualFunction);
 
         referenceFunction = testValues.expected.fakeQuantizeOnData2.empty() ?
-            ngraph::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
+            ov::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
                 inputShape,
                 testValues.expected.fakeQuantizeOnData,
                 testValues.expected.dequantization) :
-            ngraph::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
+            ov::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
                 inputShape,
                 testValues.expected.fakeQuantizeOnData,
                 testValues.expected.dequantization,

--- a/src/common/low_precision_transformations/tests/gather_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/gather_transformation.cpp
@@ -27,15 +27,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     std::vector<size_t> gatherIndicesShape;
@@ -58,7 +58,7 @@ public:
         const int opset_version = std::get<2>(GetParam());
 
         actualFunction =
-            ngraph::builder::subgraph::GatherFunction::getOriginal(inputShape,
+            ov::builder::subgraph::GatherFunction::getOriginal(inputShape,
                                                                    testValues.gatherIndicesShape,
                                                                    testValues.gatherIndicesValues,
                                                                    testValues.axis,
@@ -72,7 +72,7 @@ public:
         transformer.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::GatherFunction::getReference(inputShape,
+            ov::builder::subgraph::GatherFunction::getReference(inputShape,
                                                                     testValues.gatherIndicesShape,
                                                                     testValues.gatherIndicesValues,
                                                                     testValues.axis,

--- a/src/common/low_precision_transformations/tests/get_dequantization_below_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/get_dequantization_below_transformation.cpp
@@ -24,8 +24,8 @@ using namespace ov::pass;
 
 class GetDequantizationBelowTestValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
-    ngraph::builder::subgraph::DequantizationOperations dequantization;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::DequantizationOperations dequantization;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const std::vector<float>& values) {
@@ -56,7 +56,7 @@ public:
         const ov::Shape shape = std::get<1>(GetParam());
         const GetDequantizationBelowTestValues testValues = std::get<2>(GetParam());
 
-        auto const model = ngraph::builder::subgraph::GetDequantizationFunction::get(
+        auto const model = ov::builder::subgraph::GetDequantizationFunction::get(
             precision,
             shape,
             testValues.fakeQuantize,
@@ -65,13 +65,13 @@ public:
         auto const fakeQuantize = model->get_parameters()[0]->output(0).get_target_inputs().begin()->get_node()->shared_from_this();
         auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantizationBelow(fakeQuantize);
 
-        actualFunction = ngraph::builder::subgraph::GetDequantizationFunction::get(
+        actualFunction = ov::builder::subgraph::GetDequantizationFunction::get(
             precision,
             shape,
             testValues.fakeQuantize,
             dequantization);
 
-        referenceFunction = ngraph::builder::subgraph::GetDequantizationFunction::get(
+        referenceFunction = ov::builder::subgraph::GetDequantizationFunction::get(
             precision,
             shape,
             testValues.fakeQuantize,

--- a/src/common/low_precision_transformations/tests/get_dequantization_test.cpp
+++ b/src/common/low_precision_transformations/tests/get_dequantization_test.cpp
@@ -36,13 +36,13 @@ public:
         size_t mulDataInput;
         std::tie(isConvert, isSubtract, subDataInput, mulDataInput) = this->GetParam();
 
-        actualFunction = ngraph::builder::subgraph::GetDequantizationFunction::getOriginal(isConvert,
+        actualFunction = ov::builder::subgraph::GetDequantizationFunction::getOriginal(isConvert,
                                                                                            isSubtract,
                                                                                            subDataInput,
                                                                                            mulDataInput);
         auto dequantization =
             ov::pass::low_precision::NetworkHelper::getDequantization(actualFunction->get_result());
-        referenceFunction = ngraph::builder::subgraph::GetDequantizationFunction::getReference(dequantization);
+        referenceFunction = ov::builder::subgraph::GetDequantizationFunction::getReference(dequantization);
     }
 
     static std::string getTestCaseName(testing::TestParamInfo<GetDequantizationTestValues> obj) {

--- a/src/common/low_precision_transformations/tests/get_dequantization_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/get_dequantization_transformation.cpp
@@ -21,7 +21,7 @@
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class GetDequantizationTestValues {
 public:

--- a/src/common/low_precision_transformations/tests/group_convolution_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/group_convolution_transformation.cpp
@@ -27,21 +27,21 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
         std::shared_ptr<ov::op::v0::Constant> weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         std::shared_ptr<ov::op::v0::Constant> weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
         ov::element::Type precisionAfterDequantization;
     };
 
@@ -66,7 +66,7 @@ public:
         const GroupConvolutionTestValues testValues = std::get<1>(GetParam());
 
         actualFunction =
-            ngraph::builder::subgraph::GroupConvolutionFunction::get(testValues.actual.precisionBeforeDequantization,
+            ov::builder::subgraph::GroupConvolutionFunction::get(testValues.actual.precisionBeforeDequantization,
                                                                      inputShape,
                                                                      outputShape,
                                                                      testValues.group,
@@ -92,7 +92,7 @@ public:
         transform.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::GroupConvolutionFunction::get(testValues.expected.precisionBeforeDequantization,
+            ov::builder::subgraph::GroupConvolutionFunction::get(testValues.expected.precisionBeforeDequantization,
                                                                      inputShape,
                                                                      outputShape,
                                                                      testValues.group,

--- a/src/common/low_precision_transformations/tests/interpolate_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/interpolate_transformation.cpp
@@ -23,7 +23,7 @@
 using namespace testing;
 using namespace ov::pass;
 using namespace ov;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class interpAttributes {
 public:
@@ -68,15 +68,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     ov::PartialShape inputShape;
@@ -104,7 +104,7 @@ public:
             interpAttrs.pads_begin = testValues.interpAttrs.pads_begin;
             interpAttrs.pads_end = testValues.interpAttrs.pads_end;
 
-            actualFunction = ngraph::builder::subgraph::InterpolateFunction::getOriginal(
+            actualFunction = ov::builder::subgraph::InterpolateFunction::getOriginal(
                 testValues.inputShape,
                 testValues.outputShape,
                 interpAttrs,
@@ -115,7 +115,7 @@ public:
             transformer.add<ov::pass::low_precision::InterpolateTransformation, ov::op::v0::Interpolate>(testValues.params);
             transformer.transform(actualFunction);
 
-            referenceFunction = ngraph::builder::subgraph::InterpolateFunction::getReference(
+            referenceFunction = ov::builder::subgraph::InterpolateFunction::getReference(
                 testValues.inputShape,
                 testValues.outputShape,
                 interpAttrs,
@@ -130,7 +130,7 @@ public:
             interp4Attrs.pads_begin = testValues.interp4Attrs.pads_begin;
             interp4Attrs.pads_end = testValues.interp4Attrs.pads_end;
 
-            actualFunction = ngraph::builder::subgraph::InterpolateFunction::getOriginal(
+            actualFunction = ov::builder::subgraph::InterpolateFunction::getOriginal(
                 testValues.inputShape,
                 testValues.outputShape,
                 testValues.scalesShape,
@@ -142,7 +142,7 @@ public:
             transformer.add<ov::pass::low_precision::InterpolateTransformation, ov::opset4::Interpolate>(testValues.params);
             transformer.transform(actualFunction);
 
-            referenceFunction = ngraph::builder::subgraph::InterpolateFunction::getReference(
+            referenceFunction = ov::builder::subgraph::InterpolateFunction::getReference(
                 testValues.inputShape,
                 testValues.outputShape,
                 testValues.scalesShape,

--- a/src/common/low_precision_transformations/tests/is_asymmetric_on_weights_dequantization.cpp
+++ b/src/common/low_precision_transformations/tests/is_asymmetric_on_weights_dequantization.cpp
@@ -22,9 +22,9 @@ class IsAsymmetricOnWeightsDequantizationTestValues {
 public:
     TestTransformationParams params;
     ov::element::Type precisionBeforeDequantization;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
     std::shared_ptr<ov::op::v0::Constant> weights;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
     bool isAsymmetricOnWeights;
 };
 
@@ -41,7 +41,7 @@ public:
         auto testValues = std::get<2>(GetParam());
 
         actualFunction =
-            ngraph::builder::subgraph::ConvolutionFunction::getOriginal(netPrecision,
+            ov::builder::subgraph::ConvolutionFunction::getOriginal(netPrecision,
                                                                         testValues.precisionBeforeDequantization,
                                                                         inputShape,
                                                                         testValues.dequantizationOnActivations,

--- a/src/common/low_precision_transformations/tests/is_asymmetric_on_weights_fq.cpp
+++ b/src/common/low_precision_transformations/tests/is_asymmetric_on_weights_fq.cpp
@@ -23,9 +23,9 @@ class IsAsymmetricOnWeightsFakeQuantizeTestValues {
 public:
     TestTransformationParams params;
     ov::element::Type precisionBeforeDequantization;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
     std::shared_ptr<ov::op::v0::Constant> weights;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
 };
 
 typedef std::tuple<
@@ -44,7 +44,7 @@ public:
         auto testValues = std::get<2>(GetParam());
         std::pair<std::vector<bool>, bool> transposeAndIsAsymmetricOnWeights = std::get<3>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ConvolutionFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::ConvolutionFunction::getOriginal(
             netPrecision,
             testValues.precisionBeforeDequantization,
             inputShape,

--- a/src/common/low_precision_transformations/tests/is_constant_path_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/is_constant_path_transformation.cpp
@@ -15,7 +15,7 @@
 
 using namespace testing;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 TEST(LPT, isConstantPathFQAfterInputTransformation) {
     const auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 16, 16 });

--- a/src/common/low_precision_transformations/tests/is_function_quantized_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/is_function_quantized_transformation.cpp
@@ -21,7 +21,7 @@ class IsFunctionQuantizedTransformationValues {
 public:
     ov::Shape shape;
     ov::element::Type precision;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize;
     bool constantSubgraphOnParameters;
     bool inputOnParameters;
 
@@ -34,7 +34,7 @@ public:
         const auto testValues = GetParam();
 
         const auto input = std::make_shared<ov::op::v0::Parameter>(testValues.precision, ov::Shape(testValues.shape));
-        const auto fakeQuantize = ngraph::builder::subgraph::makeFakeQuantize(
+        const auto fakeQuantize = ov::builder::subgraph::makeFakeQuantize(
             input,
             testValues.precision,
             testValues.fakeQuantize,

--- a/src/common/low_precision_transformations/tests/layer_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/layer_transformation.cpp
@@ -108,13 +108,13 @@ std::string LayerTransformation::getTestCaseNameByParams(
     return result.str();
 }
 
-ngraph::builder::subgraph::DequantizationOperations LayerTransformation::toDequantizationOperations(
+ov::builder::subgraph::DequantizationOperations LayerTransformation::toDequantizationOperations(
     const ov::pass::low_precision::FakeQuantizeDequantization& dequantization) {
     const auto convert = dequantization.convert != nullptr ?
-        ngraph::builder::subgraph::DequantizationOperations::Convert(dequantization.convert->output(0).get_element_type()) :
-        ngraph::builder::subgraph::DequantizationOperations::Convert();
+        ov::builder::subgraph::DequantizationOperations::Convert(dequantization.convert->output(0).get_element_type()) :
+        ov::builder::subgraph::DequantizationOperations::Convert();
 
-    ngraph::builder::subgraph::DequantizationOperations::Subtract subtract;
+    ov::builder::subgraph::DequantizationOperations::Subtract subtract;
     {
         const bool addDequantizationAttribute = dequantization.subtract != nullptr ?
             dequantization.subtract->get_rt_info().count("DEQUANTIZATION") != 0 :
@@ -127,7 +127,7 @@ ngraph::builder::subgraph::DequantizationOperations LayerTransformation::toDequa
             0ul;
 
         subtract = dequantization.subtractConstant != nullptr ?
-            ngraph::builder::subgraph::DequantizationOperations::Subtract(
+            ov::builder::subgraph::DequantizationOperations::Subtract(
                 dequantization.subtractConstant->cast_vector<float>(),
                 dequantization.subtract->output(0).get_element_type(),
                 dequantization.subtractConstant->output(0).get_shape(),
@@ -135,26 +135,26 @@ ngraph::builder::subgraph::DequantizationOperations LayerTransformation::toDequa
                 constantIndex,
                 dequantization.subtractConstant->output(0).get_element_type(),
                 dequantization.subtractConvert != nullptr) :
-            ngraph::builder::subgraph::DequantizationOperations::Subtract();
+            ov::builder::subgraph::DequantizationOperations::Subtract();
     }
 
-    ngraph::builder::subgraph::DequantizationOperations::Multiply multiply;
+    ov::builder::subgraph::DequantizationOperations::Multiply multiply;
     {
         const size_t constantIndex = dequantization.multiplyConstant && dequantization.multiply ?
             ov::pass::low_precision::NetworkHelper::getChildInputIndex(dequantization.multiplyConstant, dequantization.multiply) :
             0ul;
 
         multiply = dequantization.multiplyConstant != nullptr ?
-            ngraph::builder::subgraph::DequantizationOperations::Multiply(
+            ov::builder::subgraph::DequantizationOperations::Multiply(
                 dequantization.multiplyConstant->cast_vector<float>(),
                 dequantization.multiplyConstant->output(0).get_element_type(),
                 dequantization.multiplyConstant->output(0).get_shape(),
                 false,
                 constantIndex) :
-            ngraph::builder::subgraph::DequantizationOperations::Multiply();
+            ov::builder::subgraph::DequantizationOperations::Multiply();
     }
 
-    return ngraph::builder::subgraph::DequantizationOperations(convert, subtract, multiply);
+    return ov::builder::subgraph::DequantizationOperations(convert, subtract, multiply);
 }
 
 bool LayerTransformation::allNamesAreUnique(const std::shared_ptr<ov::Model>& model) {

--- a/src/common/low_precision_transformations/tests/layer_transformation.hpp
+++ b/src/common/low_precision_transformations/tests/layer_transformation.hpp
@@ -61,7 +61,7 @@ public:
         const ov::PartialShape& shape,
         const TestTransformationParams& params);
 
-    static ngraph::builder::subgraph::DequantizationOperations toDequantizationOperations(
+    static ov::builder::subgraph::DequantizationOperations toDequantizationOperations(
         const ov::pass::low_precision::FakeQuantizeDequantization& dequantization);
 
     static bool allNamesAreUnique(const std::shared_ptr<ov::Model>& model);

--- a/src/common/low_precision_transformations/tests/lpt_avoid_shapeof_propagation_test.cpp
+++ b/src/common/low_precision_transformations/tests/lpt_avoid_shapeof_propagation_test.cpp
@@ -221,8 +221,8 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationDepthToSpaceTransformation) {
 TEST(LPT, AvoidDequantizationToShapeOfPropagationFakeQuantizeDecompositionTransformation) {
     auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{1, 3, 16, 16});
 
-    ngraph::builder::subgraph::FakeQuantizeOnData fqValues{256ul, {}, {0.f}, {2.55f}, {0.f}, {2.55f}};
-    auto fakeQuantize = ngraph::builder::subgraph::makeFakeQuantize(input, element::f32, fqValues);
+    ov::builder::subgraph::FakeQuantizeOnData fqValues{256ul, {}, {0.f}, {2.55f}, {0.f}, {2.55f}};
+    auto fakeQuantize = ov::builder::subgraph::makeFakeQuantize(input, element::f32, fqValues);
     auto shapeOf = std::make_shared<ov::op::v0::ShapeOf>(fakeQuantize);
 
     auto& outInfo = fakeQuantize->output(0).get_rt_info();

--- a/src/common/low_precision_transformations/tests/markup_avg_pool_precisions_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/markup_avg_pool_precisions_transformation.cpp
@@ -34,15 +34,15 @@ public:
     class Actual {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -70,7 +70,7 @@ public:
         std::tie(precision, shape, addFakeQuantize, additionalLayer, testValues) = GetParam();
 
         actualFunction =
-            ngraph::builder::subgraph::MarkupAvgPoolPrecisionsFunction::getOriginal(precision,
+            ov::builder::subgraph::MarkupAvgPoolPrecisionsFunction::getOriginal(precision,
                                                                                     testValues.actual.inputPrecision,
                                                                                     shape,
                                                                                     addFakeQuantize,
@@ -97,7 +97,7 @@ public:
         transform.cleanup->add_matcher<ov::pass::low_precision::FuseMultiplyToFakeQuantizeTransformation>();
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::MarkupAvgPoolPrecisionsFunction::getReference(
+        referenceFunction = ov::builder::subgraph::MarkupAvgPoolPrecisionsFunction::getReference(
             precision,
             testValues.expected.inputPrecision,
             shape,

--- a/src/common/low_precision_transformations/tests/markup_bias_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/markup_bias_transformation.cpp
@@ -46,7 +46,7 @@ protected:
         std::string layer_type;
         std::tie(precision, test_values, layer_type) = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::MarkupBiasFunction::get(precision,
+        actualFunction = ov::builder::subgraph::MarkupBiasFunction::get(precision,
                                                                             test_values.input_shape,
                                                                             test_values.bias_shape,
                                                                             layer_type,

--- a/src/common/low_precision_transformations/tests/mat_mul_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mat_mul_transformation.cpp
@@ -28,20 +28,20 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization1;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
         ov::element::Type precisionBeforeDequantization2;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization1;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
         ov::element::Type precisionBeforeDequantization2;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
         ov::element::Type precisionBeforeOperation1;
         ov::element::Type precisionBeforeOperation2;
-        ngraph::builder::subgraph::DequantizationOperations result;
+        ov::builder::subgraph::DequantizationOperations result;
     };
 
     TestTransformationParams params;
@@ -78,7 +78,7 @@ public:
         const MatMullTransformationTestValues testValues = std::get<2>(GetParam());
 
         actualFunction =
-            ngraph::builder::subgraph::MatMulFunction::getOriginal(precision,
+            ov::builder::subgraph::MatMulFunction::getOriginal(precision,
                                                                    shapes.first,
                                                                    testValues.actual.precisionBeforeDequantization1,
                                                                    testValues.actual.dequantization1,
@@ -92,7 +92,7 @@ public:
 
         referenceFunction =
             (testValues.expected.precisionBeforeOperation1 == ov::element::f32) && testValues.expected.result.empty()
-                ? ngraph::builder::subgraph::MatMulFunction::getOriginal(
+                ? ov::builder::subgraph::MatMulFunction::getOriginal(
                       precision,
                       shapes.first,
                       testValues.actual.precisionBeforeDequantization1,
@@ -100,7 +100,7 @@ public:
                       shapes.second,
                       testValues.actual.precisionBeforeDequantization2,
                       testValues.actual.dequantization2)
-                : ngraph::builder::subgraph::MatMulFunction::getReference(
+                : ov::builder::subgraph::MatMulFunction::getReference(
                       precision,
                       shapes.first,
                       testValues.expected.precisionBeforeDequantization1,

--- a/src/common/low_precision_transformations/tests/mat_mul_with_constant_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mat_mul_with_constant_transformation.cpp
@@ -28,24 +28,24 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnData;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnData;
 
-        ngraph::builder::subgraph::Constant weights;
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::Constant weights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnData;
-        ngraph::builder::subgraph::Constant weights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnData;
+        ov::builder::subgraph::Constant weights;
 
         ov::element::Type precisionBeforeOperation;
-        ngraph::builder::subgraph::DequantizationOperations resultDequantization;
+        ov::builder::subgraph::DequantizationOperations resultDequantization;
 
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
     };
 
     TestTransformationParams params;
@@ -80,7 +80,7 @@ public:
         MatMullTransformationTestValues testValues = std::get<2>(GetParam());
 
         actualFunction =
-            ngraph::builder::subgraph::MatMulFunction::getOriginal(precision,
+            ov::builder::subgraph::MatMulFunction::getOriginal(precision,
                                                                    inputShape,
                                                                    testValues.actual.precisionBeforeDequantization,
                                                                    testValues.actual.dequantizationOnData,
@@ -94,14 +94,14 @@ public:
 
         referenceFunction =
             (testValues.expected.fqOnWeights.empty() && testValues.expected.dequantizationOnWeights.empty())
-                ? ngraph::builder::subgraph::MatMulFunction::getReference(
+                ? ov::builder::subgraph::MatMulFunction::getReference(
                       precision,
                       inputShape,
                       testValues.expected.precisionBeforeDequantization,
                       testValues.expected.dequantizationOnData,
                       testValues.expected.weights,
                       testValues.expected.resultDequantization)
-                : ngraph::builder::subgraph::MatMulFunction::getOriginal(
+                : ov::builder::subgraph::MatMulFunction::getOriginal(
                       precision,
                       inputShape,
                       testValues.expected.precisionBeforeDequantization,

--- a/src/common/low_precision_transformations/tests/max_pool_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/max_pool_transformation.cpp
@@ -28,17 +28,17 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization1;
+        ov::builder::subgraph::DequantizationOperations dequantization1;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantization2;
+        ov::builder::subgraph::DequantizationOperations dequantization2;
     };
 
     TestTransformationParams params;
@@ -56,7 +56,7 @@ public:
         const ov::PartialShape shape = std::get<0>(GetParam());
         const MaxPoolTransformationTestValues testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::MaxPoolFunction::get(
+        actualFunction = ov::builder::subgraph::MaxPoolFunction::get(
             shape,
             testValues.actual.precisionBeforeDequantization,
             testValues.actual.dequantization1,
@@ -67,7 +67,7 @@ public:
         transform.add<ov::pass::low_precision::MaxPoolTransformation, ov::op::v1::MaxPool>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::MaxPoolFunction::get(
+        referenceFunction = ov::builder::subgraph::MaxPoolFunction::get(
             shape,
             testValues.expected.precisionBeforeDequantization,
             testValues.expected.dequantization1,

--- a/src/common/low_precision_transformations/tests/move_dequantization_after_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/move_dequantization_after_transformation.cpp
@@ -21,20 +21,20 @@
 
 using namespace testing;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class MoveDequantizationAfterTransformationParams {
 public:
     class Actual {
     public:
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     ov::element::Type originalPrecision;
@@ -56,7 +56,7 @@ public:
     void SetUp() override {
         const auto inputShape = std::get<0>(GetParam());
         const auto testValues = std::get<1>(GetParam());
-        actualFunction = ngraph::builder::subgraph::MoveDequantizationAfterFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::MoveDequantizationAfterFunction::getOriginal(
             testValues.originalPrecision,
             inputShape,
             testValues.actual.dequantization);
@@ -69,7 +69,7 @@ public:
             testValues.updatePrecision,
             testValues.moveSubtract);
 
-        referenceFunction = ngraph::builder::subgraph::MoveDequantizationAfterFunction::getReference(
+        referenceFunction = ov::builder::subgraph::MoveDequantizationAfterFunction::getReference(
             testValues.originalPrecision,
             inputShape,
             testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/move_fake_quantize_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/move_fake_quantize_transformation.cpp
@@ -33,13 +33,13 @@ namespace {
 class MoveFakeQuantizeTransformationActualValues {
 public:
     size_t number_of_operations;
-    std::vector<ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant> fakeQuantizeBefore;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertBefore;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+    std::vector<ov::builder::subgraph::FakeQuantizeOnDataWithConstant> fakeQuantizeBefore;
+    ov::builder::subgraph::DequantizationOperations::Convert convertBefore;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
     std::string operation;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeAfter;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertAfter;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeAfter;
+    ov::builder::subgraph::DequantizationOperations::Convert convertAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const MoveFakeQuantizeTransformationActualValues& values) {
@@ -51,13 +51,13 @@ inline std::ostream& operator<<(std::ostream& out, const MoveFakeQuantizeTransfo
 class MoveFakeQuantizeTransformationResultValues {
 public:
     size_t number_of_operations;
-    std::vector<ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant> fakeQuantizeBefore;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertBefore;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+    std::vector<ov::builder::subgraph::FakeQuantizeOnDataWithConstant> fakeQuantizeBefore;
+    ov::builder::subgraph::DequantizationOperations::Convert convertBefore;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
     std::string operation;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeAfter;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertAfter;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeAfter;
+    ov::builder::subgraph::DequantizationOperations::Convert convertAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     ov::element::Type precisionAfterOperation;
 };
 
@@ -117,7 +117,7 @@ public:
 
         ov::IntervalsAlignmentSharedValue::Interval interval{-1.28f, 2.55f};
 
-        actualFunction = ngraph::builder::subgraph::MoveFakeQuantize::get(precision,
+        actualFunction = ov::builder::subgraph::MoveFakeQuantize::get(precision,
                                                                           inputShapes,
                                                                           testValues.actual.number_of_operations,
                                                                           testValues.actual.fakeQuantizeBefore,
@@ -161,7 +161,7 @@ public:
         }
 
         referenceFunction =
-            ngraph::builder::subgraph::MoveFakeQuantize::get(precision,
+            ov::builder::subgraph::MoveFakeQuantize::get(precision,
                                                              inputShapes,
                                                              testValues.result.number_of_operations,
                                                              testValues.result.fakeQuantizeBefore,

--- a/src/common/low_precision_transformations/tests/multiply_partial_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/multiply_partial_transformation.cpp
@@ -24,7 +24,7 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class MultiplyPartialTransformationTestValues {
 public:

--- a/src/common/low_precision_transformations/tests/multiply_to_group_convolution_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/multiply_to_group_convolution_transformation.cpp
@@ -22,14 +22,14 @@
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class MultiplyToGroupConvolutionTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
@@ -37,7 +37,7 @@ public:
         ov::element::Type inputPrecision;
         std::shared_ptr<ov::op::v0::Constant> weights;
         std::shared_ptr<ov::op::v0::Constant> biases;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     ov::PartialShape inputShape;
@@ -55,7 +55,7 @@ public:
     void SetUp() override {
         const MultiplyToGroupConvolutionTransformationTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::MultiplyToGroupConvolutionFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::MultiplyToGroupConvolutionFunction::getOriginal(
             testValues.inputShape,
             testValues.actual.precisionBeforeDequantization,
             testValues.actual.dequantization,
@@ -73,14 +73,14 @@ public:
         transformer.transform(actualFunction);
 
         if (testValues.transformed) {
-            referenceFunction = ngraph::builder::subgraph::MultiplyToGroupConvolutionFunction::getReference(
+            referenceFunction = ov::builder::subgraph::MultiplyToGroupConvolutionFunction::getReference(
                 testValues.inputShape,
                 testValues.expected.inputPrecision,
                 testValues.expected.weights,
                 testValues.expected.biases,
                 testValues.expected.dequantization);
         } else {
-            referenceFunction = ngraph::builder::subgraph::MultiplyToGroupConvolutionFunction::getOriginal(
+            referenceFunction = ov::builder::subgraph::MultiplyToGroupConvolutionFunction::getOriginal(
                 testValues.inputShape,
                 testValues.actual.precisionBeforeDequantization,
                 testValues.actual.dequantization,

--- a/src/common/low_precision_transformations/tests/multiply_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/multiply_transformation.cpp
@@ -23,14 +23,14 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class MultiplyBranch {
 public:
-    ngraph::builder::subgraph::Constant constant;
+    ov::builder::subgraph::Constant constant;
     ov::element::Type input_precision;
-    ngraph::builder::subgraph::DequantizationOperations dequantization;
-    ngraph::builder::subgraph::FakeQuantizeOnData fake_quantize;
+    ov::builder::subgraph::DequantizationOperations dequantization;
+    ov::builder::subgraph::FakeQuantizeOnData fake_quantize;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const MultiplyBranch& branch) {
@@ -53,7 +53,7 @@ class MultiplyValues {
 public:
     MultiplyBranch branch1;
     MultiplyBranch branch2;
-    ngraph::builder::subgraph::DequantizationOperations after_dequantization;
+    ov::builder::subgraph::DequantizationOperations after_dequantization;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const MultiplyValues& values) {
@@ -109,12 +109,12 @@ public:
         }
 
         const auto to_multiply_values = [&input_shapes, &input_precisions](const MultiplyValues& values) {
-            return ngraph::builder::subgraph::MultiplyValues(
-                ngraph::builder::subgraph::MultiplyBranch(
+            return ov::builder::subgraph::MultiplyValues(
+                ov::builder::subgraph::MultiplyBranch(
                     input_shapes.first, values.branch1.constant, input_precisions.first, values.branch1.dequantization, values.branch1.fake_quantize),
-                ngraph::builder::subgraph::MultiplyBranch(
+                ov::builder::subgraph::MultiplyBranch(
                     input_shapes.second, values.branch2.constant, input_precisions.second, values.branch2.dequantization, values.branch2.fake_quantize),
-                ngraph::builder::subgraph::DequantizationOperations(values.after_dequantization));
+                ov::builder::subgraph::DequantizationOperations(values.after_dequantization));
         };
 
         actualFunction = MultiplyFunction::get(model_precision, to_multiply_values(testParams.actual));

--- a/src/common/low_precision_transformations/tests/mvn_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mvn_transformation.cpp
@@ -23,22 +23,22 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class MVNTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     ov::AxisSet reductionAxes;
@@ -63,7 +63,7 @@ public:
         const MVNTransformationTestValues testValues = std::get<2>(GetParam());
         const int opset_version = std::get<3>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::MVNFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::MVNFunction::getOriginal(
             precision,
             inputShape,
             testValues.reductionAxes,
@@ -76,7 +76,7 @@ public:
         transformer.add<ov::pass::low_precision::MVNTransformation, ov::op::v0::Interpolate>(testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::MVNFunction::getReference(
+        referenceFunction = ov::builder::subgraph::MVNFunction::getReference(
             precision,
             inputShape,
             testValues.reductionAxes,

--- a/src/common/low_precision_transformations/tests/normalize_dequantization_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/normalize_dequantization_transformation.cpp
@@ -26,13 +26,13 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
     TestTransformationParams params;
     ov::Shape inputShape;
@@ -45,7 +45,7 @@ public:
     void SetUp() override {
         const NormalizeDequantizationTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::NormalizeDequantizationFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::NormalizeDequantizationFunction::getOriginal(
             testValues.actual.precisionBeforeDequantization,
             testValues.inputShape,
             testValues.actual.dequantization);
@@ -54,7 +54,7 @@ public:
         const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(targetNode);
         ov::pass::low_precision::NetworkHelper::normalizeDequantization(dequantization);
 
-        referenceFunction = ngraph::builder::subgraph::NormalizeDequantizationFunction::getOriginal(
+        referenceFunction = ov::builder::subgraph::NormalizeDequantizationFunction::getOriginal(
             testValues.expected.precisionBeforeDequantization,
             testValues.inputShape,
             testValues.expected.dequantization);

--- a/src/common/low_precision_transformations/tests/normalize_l2_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/normalize_l2_transformation.cpp
@@ -23,7 +23,7 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class NormalizeL2TransformationTestValues {
 public:
@@ -61,7 +61,7 @@ public:
         NormalizeL2TransformationTestValues params;
         std::tie(precision, shape, epsMode, axes, params) = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::NormalizeL2Function::getOriginal(
+        actualFunction = ov::builder::subgraph::NormalizeL2Function::getOriginal(
             precision,
             params.actual.inputPrecision,
             shape,
@@ -73,7 +73,7 @@ public:
         transform.add<ov::pass::low_precision::NormalizeL2Transformation, ov::op::v0::NormalizeL2>(params.transformationParams);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::NormalizeL2Function::getReference(
+        referenceFunction = ov::builder::subgraph::NormalizeL2Function::getReference(
             precision,
             params.expected.inputPrecision,
             shape,

--- a/src/common/low_precision_transformations/tests/pad_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/pad_transformation.cpp
@@ -26,15 +26,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -61,7 +61,7 @@ public:
         const auto precisionAfterActualOp = testValues.actual.dequantization.convert.empty() ?
             testValues.actual.precisionBeforeDequantization : testValues.actual.dequantization.convert.outPrecision;
 
-        actualFunction = ngraph::builder::subgraph::PadFunction::get(
+        actualFunction = ov::builder::subgraph::PadFunction::get(
             inputShape,
             testValues.actual.precisionBeforeDequantization,
             testValues.actual.dequantization,
@@ -76,7 +76,7 @@ public:
         transformer.add<ov::pass::low_precision::PadTransformation, ov::op::v1::Pad>(testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::PadFunction::get(
+        referenceFunction = ov::builder::subgraph::PadFunction::get(
             inputShape,
             testValues.expected.precisionBeforeDequantization,
             testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/prelu_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/prelu_transformation.cpp
@@ -28,15 +28,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -53,7 +53,7 @@ public:
         const auto testValues = std::get<1>(GetParam());
 
         actualFunction =
-            ngraph::builder::subgraph::PReluFunction::getOriginal(inputShape,
+            ov::builder::subgraph::PReluFunction::getOriginal(inputShape,
                                                                   testValues.actual.precisionBeforeDequantization,
                                                                   testValues.actual.dequantization);
 
@@ -62,7 +62,7 @@ public:
         transformer.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::PReluFunction::getReference(inputShape,
+            ov::builder::subgraph::PReluFunction::getReference(inputShape,
                                                                    testValues.expected.precisionBeforeDequantization,
                                                                    testValues.expected.dequantizationBefore,
                                                                    testValues.expected.precisionAfterOperation,

--- a/src/common/low_precision_transformations/tests/pull_reshape_through_dequantization_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/pull_reshape_through_dequantization_transformation.cpp
@@ -27,15 +27,15 @@ public:
     class Values {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-        ngraph::builder::subgraph::Constant weights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
-        ngraph::builder::subgraph::Reshape reshape1;
-        ngraph::builder::subgraph::DequantizationOperations::Multiply multiply;
-        ngraph::builder::subgraph::Transpose transpose;
-        ngraph::builder::subgraph::Reshape reshape2;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ov::builder::subgraph::Constant weights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::Reshape reshape1;
+        ov::builder::subgraph::DequantizationOperations::Multiply multiply;
+        ov::builder::subgraph::Transpose transpose;
+        ov::builder::subgraph::Reshape reshape2;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -69,7 +69,7 @@ public:
         testValues.expected.dequantizationOnWeights.subtract.constantShape = dequantizationElementwiseShape.second;
         testValues.expected.dequantizationOnWeights.multiply.constantShape = dequantizationElementwiseShape.second;
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        actualFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
             {},
@@ -94,7 +94,7 @@ public:
         decomp->add_matcher<ov::pass::LinOpSequenceFusion>();
         manager.run_passes(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        referenceFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
             {},

--- a/src/common/low_precision_transformations/tests/pull_transpose_through_dequantization_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/pull_transpose_through_dequantization_transformation.cpp
@@ -27,15 +27,15 @@ public:
     class Values {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-        ngraph::builder::subgraph::Constant weights;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
-        ngraph::builder::subgraph::Reshape reshape1;
-        ngraph::builder::subgraph::DequantizationOperations::Multiply multiply;
-        ngraph::builder::subgraph::Transpose transpose;
-        ngraph::builder::subgraph::Reshape reshape2;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+        ov::builder::subgraph::Constant weights;
+        ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+        ov::builder::subgraph::Reshape reshape1;
+        ov::builder::subgraph::DequantizationOperations::Multiply multiply;
+        ov::builder::subgraph::Transpose transpose;
+        ov::builder::subgraph::Reshape reshape2;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -62,7 +62,7 @@ public:
         testValues.expected.dequantizationOnWeights.subtract.constantShape = dequantizationElementwiseShape.second;
         testValues.expected.dequantizationOnWeights.multiply.constantShape = dequantizationElementwiseShape.second;
 
-        actualFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        actualFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
             {},
@@ -87,7 +87,7 @@ public:
         decomp->add_matcher<ov::pass::LinOpSequenceFusion>();
         manager.run_passes(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+        referenceFunction = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
             testValues.actual.precisionBeforeDequantization,
             inputShape,
             {},

--- a/src/common/low_precision_transformations/tests/quantization_granularity_restriction_test.cpp
+++ b/src/common/low_precision_transformations/tests/quantization_granularity_restriction_test.cpp
@@ -44,7 +44,7 @@ public:
             }
         }
 
-        actualFunction = ngraph::builder::subgraph::ConvolutionFunction::get(
+        actualFunction = ov::builder::subgraph::ConvolutionFunction::get(
             Shape({ 1, 3, 16, 16 }),
             element::f32,
             { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } },
@@ -60,7 +60,7 @@ public:
         manager.register_pass<ov::pass::low_precision::MarkupQuantizationGranularity>(quantizationRestrictions);
         manager.run_passes(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ConvolutionFunction::get(
+        referenceFunction = ov::builder::subgraph::ConvolutionFunction::get(
             Shape({ 1, 3, 16, 16 }),
             element::f32,
             { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } },

--- a/src/common/low_precision_transformations/tests/recurrent_cell_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/recurrent_cell_transformation.cpp
@@ -28,26 +28,26 @@
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 namespace {
 
 class RecurrentCellTransformationValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_X;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert_X;
-    ngraph::builder::subgraph::DequantizationOperations dequantization_X;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_H;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert_H;
-    ngraph::builder::subgraph::DequantizationOperations dequantization_H;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_W;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert_W;
-    ngraph::builder::subgraph::DequantizationOperations dequantization_W;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_R;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert_R;
-    ngraph::builder::subgraph::DequantizationOperations dequantization_R;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_X;
+    ov::builder::subgraph::DequantizationOperations::Convert convert_X;
+    ov::builder::subgraph::DequantizationOperations dequantization_X;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_H;
+    ov::builder::subgraph::DequantizationOperations::Convert convert_H;
+    ov::builder::subgraph::DequantizationOperations dequantization_H;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_W;
+    ov::builder::subgraph::DequantizationOperations::Convert convert_W;
+    ov::builder::subgraph::DequantizationOperations dequantization_W;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_R;
+    ov::builder::subgraph::DequantizationOperations::Convert convert_R;
+    ov::builder::subgraph::DequantizationOperations dequantization_R;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const RecurrentCellTransformationValues& values) {
@@ -92,7 +92,7 @@ public:
         const std::vector<ov::Shape> weights_shapes = std::get<2>(GetParam());
         RecurrentCellTransformationTestValues testValues = std::get<3>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::RecurrentCellFunction::get(precision,
+        actualFunction = ov::builder::subgraph::RecurrentCellFunction::get(precision,
                                                                       activations_shapes,
                                                                       weights_shapes,
                                                                       testValues.type,
@@ -135,7 +135,7 @@ public:
         }
 
         referenceFunction =
-            ngraph::builder::subgraph::RecurrentCellFunction::get(precision,
+            ov::builder::subgraph::RecurrentCellFunction::get(precision,
                                                                          activations_shapes,
                                                                          weights_shapes,
                                                                          testValues.type,

--- a/src/common/low_precision_transformations/tests/reduce_max_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reduce_max_transformation.cpp
@@ -25,7 +25,7 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class ReduceMaxTransformation : public ReduceTransformation<ov::op::v1::ReduceMax> {
     void SetUp() override {

--- a/src/common/low_precision_transformations/tests/reduce_mean_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reduce_mean_transformation.cpp
@@ -25,7 +25,7 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class ReduceMeanTransformation : public ReduceTransformation<ov::op::v1::ReduceMean> {
     void SetUp() override {

--- a/src/common/low_precision_transformations/tests/reduce_min_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reduce_min_transformation.cpp
@@ -25,7 +25,7 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class ReduceMinTransformation : public ReduceTransformation<ov::op::v1::ReduceMin> {
     void SetUp() override {

--- a/src/common/low_precision_transformations/tests/reduce_sum_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reduce_sum_transformation.cpp
@@ -25,7 +25,7 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class ReduceSumTransformation : public ReduceTransformation<ov::op::v1::ReduceSum> {
     void SetUp() override {

--- a/src/common/low_precision_transformations/tests/reduce_transformation.hpp
+++ b/src/common/low_precision_transformations/tests/reduce_transformation.hpp
@@ -21,22 +21,22 @@
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class ReduceTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -58,14 +58,14 @@ public:
         const ov::PartialShape inputShape = std::get<0>(GetParam());
         const ReduceTransformationTestValues testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ReduceFunction::getOriginal<ReduceType>(
+        actualFunction = ov::builder::subgraph::ReduceFunction::getOriginal<ReduceType>(
             testValues.actual.inputPrecision,
             inputShape,
             testValues.actual.dequantization,
             testValues.constantValues,
             testValues.keepDims);
 
-        referenceFunction = ngraph::builder::subgraph::ReduceFunction::getReference<ReduceType>(
+        referenceFunction = ov::builder::subgraph::ReduceFunction::getReference<ReduceType>(
             testValues.expected.inputPrecision,
             inputShape,
             testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/relu_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/relu_transformation.cpp
@@ -30,15 +30,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -56,7 +56,7 @@ public:
         const auto inputShape = std::get<0>(GetParam());
         const auto testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ReluFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::ReluFunction::getOriginal(
             inputShape,
             testValues.actual.precisionBeforeDequantization,
             testValues.actual.dequantization);
@@ -65,7 +65,7 @@ public:
         transformer.add<ov::pass::low_precision::ReluTransformation, ov::op::v0::PRelu>(testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ReluFunction::getReference(
+        referenceFunction = ov::builder::subgraph::ReluFunction::getReference(
             inputShape,
             testValues.expected.precisionBeforeDequantization,
             testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/reshape_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/reshape_transformation.cpp
@@ -28,15 +28,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     ov::PartialShape inputShape;
@@ -53,7 +53,7 @@ public:
         const ReshapeTransformationTestValues testValues = GetParam();
 
         actualFunction =
-            ngraph::builder::subgraph::ReshapeFunction::getOriginal(testValues.inputShape,
+            ov::builder::subgraph::ReshapeFunction::getOriginal(testValues.inputShape,
                                                                     testValues.reshapeConstValues,
                                                                     testValues.actual.precisionBeforeDequantization,
                                                                     testValues.actual.dequantization);
@@ -63,7 +63,7 @@ public:
         transformer.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::ReshapeFunction::getReference(testValues.inputShape,
+            ov::builder::subgraph::ReshapeFunction::getReference(testValues.inputShape,
                                                                      testValues.reshapeConstValues,
                                                                      testValues.expected.precisionBeforeDequantization,
                                                                      testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/round_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/round_transformation.cpp
@@ -22,8 +22,8 @@ class RoundTestValues {
 public:
     ov::element::Type inputPrecision;
     ov::Shape inputShape;
-    ngraph::builder::subgraph::DequantizationOperations actualDequantization;
-    ngraph::builder::subgraph::DequantizationOperations referenceDequantization;
+    ov::builder::subgraph::DequantizationOperations actualDequantization;
+    ov::builder::subgraph::DequantizationOperations referenceDequantization;
 };
 
 class RoundTransformation : public LayerTransformation, public testing::WithParamInterface<RoundTestValues> {
@@ -32,7 +32,7 @@ public:
         const auto testValues = this->GetParam();
 
         actualFunction =
-            ngraph::builder::subgraph::RoundWithToleranceFunction::getOriginal(testValues.inputPrecision,
+            ov::builder::subgraph::RoundWithToleranceFunction::getOriginal(testValues.inputPrecision,
                                                                                testValues.inputShape,
                                                                                testValues.actualDequantization);
         const auto lastNode = actualFunction->get_output_op(0)->get_input_node_shared_ptr(0);
@@ -52,7 +52,7 @@ public:
         }
 
         referenceFunction =
-            ngraph::builder::subgraph::RoundWithToleranceFunction::getReference(testValues.inputPrecision,
+            ov::builder::subgraph::RoundWithToleranceFunction::getReference(testValues.inputPrecision,
                                                                                 testValues.inputShape,
                                                                                 testValues.referenceDequantization);
     }

--- a/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
@@ -32,7 +32,7 @@ class SeparateInStandaloneBranchTransformationTestValues {
 public:
     TestTransformationParams params;
     ov::element::Type precisionBefore;
-    ngraph::builder::subgraph::DequantizationOperations dequantization;
+    ov::builder::subgraph::DequantizationOperations dequantization;
 };
 
 inline std::ostream& operator << (std::ostream& out, const SeparateInStandaloneBranchTransformationTestValues& testValues) {
@@ -54,10 +54,10 @@ public:
         const auto createActualFunction = [](
             const ov::element::Type precision,
             const ov::Shape& inputShape,
-            const ngraph::builder::subgraph::DequantizationOperations& dequantizations) -> std::shared_ptr<ov::Model> {
+            const ov::builder::subgraph::DequantizationOperations& dequantizations) -> std::shared_ptr<ov::Model> {
             const std::shared_ptr<ov::op::v0::Parameter> input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
             const auto relu = std::make_shared<ov::op::v0::Relu>(input);
-            const auto dequantizationsNode = ngraph::builder::subgraph::makeDequantization(relu, dequantizations);
+            const auto dequantizationsNode = ov::builder::subgraph::makeDequantization(relu, dequantizations);
 
             const std::shared_ptr<ov::Node> reshape1 = std::make_shared<ov::op::v1::Reshape>(
                 dequantizationsNode,
@@ -86,18 +86,18 @@ public:
         const auto createReferenceFunction = [](
             const ov::element::Type precision,
             const ov::Shape& inputShape,
-            const ngraph::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ov::Model> {
+            const ov::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ov::Model> {
             const std::shared_ptr<ov::op::v0::Parameter> input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
             const auto relu = std::make_shared<ov::op::v0::Relu>(input);
 
             const std::shared_ptr<ov::Node> reshape1 = std::make_shared<ov::op::v1::Reshape>(
-                ngraph::builder::subgraph::makeDequantization(relu, dequantization),
+                ov::builder::subgraph::makeDequantization(relu, dequantization),
                 std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{ 2 }, std::vector<double>({0, -1})),
                 true);
             reshape1->set_friendly_name("reshape1");
 
             const std::shared_ptr<ov::Node> reshape2 = std::make_shared<ov::op::v1::Reshape>(
-                ngraph::builder::subgraph::makeDequantization(relu, dequantization),
+                ov::builder::subgraph::makeDequantization(relu, dequantization),
                 std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{ 2 }, std::vector<double>({0, -1})),
                 true);
             reshape2->set_friendly_name("reshape2");

--- a/src/common/low_precision_transformations/tests/shuffle_channels_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/shuffle_channels_transformation.cpp
@@ -28,15 +28,15 @@ public:
     class Actual {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     TestTransformationParams params;
@@ -56,7 +56,7 @@ public:
         ov::PartialShape inputShape = std::get<0>(GetParam());
         ShuffleChannelsTransformationTestValues testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::ShuffleChannelsFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::ShuffleChannelsFunction::getOriginal(
             testValues.actual.inputPrecision,
             inputShape,
             testValues.actual.dequantization,
@@ -67,7 +67,7 @@ public:
         transform.add<ov::pass::low_precision::ShuffleChannelsTransformation, ov::op::v0::ShuffleChannels>(testValues.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::ShuffleChannelsFunction::getReference(
+        referenceFunction = ov::builder::subgraph::ShuffleChannelsFunction::getReference(
             testValues.expected.inputPrecision,
             inputShape,
             testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/space_to_batch_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/space_to_batch_transformation.cpp
@@ -28,17 +28,17 @@ public:
     class Actual {
     public:
         ov::element::Type input_type;
-        ngraph::builder::subgraph::DequantizationOperations dequantization_before;
+        ov::builder::subgraph::DequantizationOperations dequantization_before;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantization_after;
+        ov::builder::subgraph::DequantizationOperations dequantization_after;
     };
 
     class Expected {
     public:
         ov::element::Type input_type;
-        ngraph::builder::subgraph::DequantizationOperations dequantization_before;
+        ov::builder::subgraph::DequantizationOperations dequantization_before;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantization_after;
+        ov::builder::subgraph::DequantizationOperations dequantization_after;
     };
 
     TestTransformationParams params;
@@ -59,7 +59,7 @@ public:
         const ov::PartialShape input_shape = std::get<0>(GetParam());
         const SpaceToBatchTransformationTestValues test_values = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::SpaceToBatchFunction::get(
+        actualFunction = ov::builder::subgraph::SpaceToBatchFunction::get(
             input_shape,
             test_values.actual.input_type,
             test_values.actual.dequantization_before,
@@ -72,7 +72,7 @@ public:
         transform.add<ov::pass::low_precision::SpaceToBatchTransformation>(test_values.params);
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::SpaceToBatchFunction::get(
+        referenceFunction = ov::builder::subgraph::SpaceToBatchFunction::get(
             input_shape,
             test_values.expected.input_type,
             test_values.expected.dequantization_before,

--- a/src/common/low_precision_transformations/tests/split_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/split_transformation.cpp
@@ -25,15 +25,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        std::vector<ngraph::builder::subgraph::DequantizationOperations> dequantizationAfter;
+        std::vector<ov::builder::subgraph::DequantizationOperations> dequantizationAfter;
     };
 
     ov::PartialShape inputShape;
@@ -53,7 +53,7 @@ public:
         SplitTransformationTestValues testValues = std::get<1>(GetParam());
 
         actualFunction =
-            ngraph::builder::subgraph::SplitFunction::getOriginal(precision,
+            ov::builder::subgraph::SplitFunction::getOriginal(precision,
                                                                   testValues.inputShape,
                                                                   testValues.actual.precisionBeforeDequantization,
                                                                   testValues.actual.dequantization,
@@ -65,7 +65,7 @@ public:
         transformer.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::SplitFunction::getReference(precision,
+            ov::builder::subgraph::SplitFunction::getReference(precision,
                                                                    testValues.inputShape,
                                                                    testValues.expected.inputPrecision,
                                                                    testValues.expected.dequantizationBefore,

--- a/src/common/low_precision_transformations/tests/squeeze_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/squeeze_transformation.cpp
@@ -22,22 +22,22 @@ using namespace testing;
 using namespace ov;
 using namespace ov::pass;
 
-using ngraph::builder::subgraph::SqueezeFunction;
+using ov::builder::subgraph::SqueezeFunction;
 
 class SqueezeTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     ov::PartialShape inputShape;
@@ -52,7 +52,7 @@ public:
     void SetUp() override {
         const SqueezeTransformationTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::SqueezeFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::SqueezeFunction::getOriginal(
             testValues.inputShape,
             testValues.axes,
             testValues.actual.precisionBeforeDequantization,
@@ -63,7 +63,7 @@ public:
 
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::SqueezeFunction::getReference(
+        referenceFunction = ov::builder::subgraph::SqueezeFunction::getReference(
             testValues.inputShape,
             testValues.axes,
             testValues.expected.precisionBeforeDequantization,

--- a/src/common/low_precision_transformations/tests/strided_slice_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/strided_slice_transformation.cpp
@@ -24,22 +24,22 @@ namespace {
 using namespace testing;
 using namespace ov;
 using namespace ov::pass;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class StridedSliceTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type preicsionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     struct LayerParams {
@@ -69,7 +69,7 @@ public:
         const ov::PartialShape inputShape = std::get<0>(GetParam());
         const StridedSliceTransformationTestValues testValues = std::get<1>(GetParam());
 
-        actualFunction = ngraph::builder::subgraph::StridedSliceFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::StridedSliceFunction::getOriginal(
             testValues.actual.inputPrecision,
             inputShape,
             testValues.actual.dequantization,
@@ -86,7 +86,7 @@ public:
         transformer.add<ov::pass::low_precision::StridedSliceTransformation, ov::op::v1::StridedSlice>(testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::StridedSliceFunction::getReference(
+        referenceFunction = ov::builder::subgraph::StridedSliceFunction::getReference(
             testValues.expected.inputPrecision,
             inputShape,
             testValues.layerParams.begin,

--- a/src/common/low_precision_transformations/tests/subgraph/src/fq_decomposition_with_shared_constants.cpp
+++ b/src/common/low_precision_transformations/tests/subgraph/src/fq_decomposition_with_shared_constants.cpp
@@ -20,7 +20,7 @@
 
 using namespace testing;
 using namespace ov;
-using namespace ngraph::builder::subgraph;
+using namespace ov::builder::subgraph;
 
 class FQDecompositionWithSharedConstants : public LayerTransformation, public WithParamInterface<bool> {
 public:

--- a/src/common/low_precision_transformations/tests/transformations_after_split_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/transformations_after_split_transformation.cpp
@@ -154,7 +154,7 @@ class TransformationsAfterSplitTransformation : public LayerTransformation, publ
 public:
     void SetUp() override {
         const auto layerName = GetParam();
-        model = ngraph::builder::subgraph::TransformationsAfterSplitFunction::get(layerName);
+        model = ov::builder::subgraph::TransformationsAfterSplitFunction::get(layerName);
         model->validate_nodes_and_infer_types();
     }
 

--- a/src/common/low_precision_transformations/tests/transformer_is_function_quantized.cpp
+++ b/src/common/low_precision_transformations/tests/transformer_is_function_quantized.cpp
@@ -27,8 +27,8 @@ namespace {
 
 class TestValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const TestValues& testValue) {
@@ -39,7 +39,7 @@ class TransformerIsFunctionQuantized : public LayerTransformation, public testin
 public:
     void SetUp() override {
         const TestValues testValues = GetParam();
-        actualFunction = ngraph::builder::subgraph::ConvolutionFunction::get(
+        actualFunction = ov::builder::subgraph::ConvolutionFunction::get(
             Shape({ 1, 3, 16, 16 }),
             element::f32,
             testValues.fqOnData,

--- a/src/common/low_precision_transformations/tests/transpose_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/transpose_transformation.cpp
@@ -27,15 +27,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     std::vector<int> transposeConstValues;
@@ -54,7 +54,7 @@ public:
         const TransposeTransformationTestValues testValues = std::get<1>(GetParam());
 
         actualFunction =
-            ngraph::builder::subgraph::TransposeFunction::getOriginal(inputShape,
+            ov::builder::subgraph::TransposeFunction::getOriginal(inputShape,
                                                                       testValues.transposeConstValues,
                                                                       testValues.actual.precisionBeforeDequantization,
                                                                       testValues.actual.dequantization);
@@ -63,7 +63,7 @@ public:
         transformer.add<ov::pass::low_precision::TransposeTransformation, ov::op::v1::Transpose>(testValues.params);
         transformer.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::TransposeFunction::getReference(
+        referenceFunction = ov::builder::subgraph::TransposeFunction::getReference(
             inputShape,
             testValues.transposeConstValues,
             testValues.expected.precisionBeforeDequantization,

--- a/src/common/low_precision_transformations/tests/unsqueeze_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/unsqueeze_transformation.cpp
@@ -22,22 +22,22 @@ using namespace testing;
 using namespace ov;
 using namespace ov::pass;
 
-using ngraph::builder::subgraph::UnsqueezeFunction;
+using ov::builder::subgraph::UnsqueezeFunction;
 
 class UnsqueezeTransformationTestValues {
 public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     };
 
     ov::PartialShape inputShape;
@@ -52,7 +52,7 @@ public:
     void SetUp() override {
         const UnsqueezeTransformationTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::UnsqueezeFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::UnsqueezeFunction::getOriginal(
             testValues.inputShape,
             testValues.axes,
             testValues.actual.precisionBeforeDequantization,
@@ -63,7 +63,7 @@ public:
 
         transform.transform(actualFunction);
 
-        referenceFunction = ngraph::builder::subgraph::UnsqueezeFunction::getReference(
+        referenceFunction = ov::builder::subgraph::UnsqueezeFunction::getReference(
             testValues.inputShape,
             testValues.axes,
             testValues.expected.precisionBeforeDequantization,

--- a/src/common/low_precision_transformations/tests/variadic_split_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/variadic_split_transformation.cpp
@@ -25,15 +25,15 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     class Expected {
     public:
         ov::element::Type inputPrecision;
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore;
         ov::element::Type precisionAfterOperation;
-        std::vector<ngraph::builder::subgraph::DequantizationOperations> dequantizationAfter;
+        std::vector<ov::builder::subgraph::DequantizationOperations> dequantizationAfter;
     };
 
     ov::PartialShape inputShape;
@@ -50,7 +50,7 @@ public:
     void SetUp() override {
         const VariadicSplitTransformationTestValues testValues = GetParam();
 
-        actualFunction = ngraph::builder::subgraph::VariadicSplitFunction::getOriginal(
+        actualFunction = ov::builder::subgraph::VariadicSplitFunction::getOriginal(
             testValues.inputShape,
             testValues.actual.precisionBeforeDequantization,
             testValues.actual.dequantization,
@@ -63,7 +63,7 @@ public:
         transformer.transform(actualFunction);
 
         referenceFunction =
-            ngraph::builder::subgraph::VariadicSplitFunction::getReference(testValues.inputShape,
+            ov::builder::subgraph::VariadicSplitFunction::getReference(testValues.inputShape,
                                                                            testValues.expected.inputPrecision,
                                                                            testValues.expected.dequantizationBefore,
                                                                            testValues.expected.precisionAfterOperation,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/fq_and_avg_pool_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/fq_and_avg_pool_transformation.cpp
@@ -19,7 +19,7 @@ const std::vector<ov::pass::low_precision::LayerTransformation::Params> trasform
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8()
 };
 
-const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizes = {
+const std::vector<ov::builder::subgraph::FakeQuantizeOnData> fakeQuantizes = {
     { 256ul, {}, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
 };
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/fq_and_max_pool_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/fq_and_max_pool_transformation.cpp
@@ -19,7 +19,7 @@ const std::vector<ov::pass::low_precision::LayerTransformation::Params> trasform
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8()
 };
 
-const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizes = {
+const std::vector<ov::builder::subgraph::FakeQuantizeOnData> fakeQuantizes = {
     { 256ul, {}, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
 };
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/fuse_convert_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/fuse_convert_transformation.cpp
@@ -15,7 +15,7 @@ const std::vector< ov::PartialShape > inputAndQuantizationShapes = {
         { 1, 4, 16, 16 },
 };
 
-const std::vector<ngraph::builder::subgraph::DequantizationOperations> deqOperations = {
+const std::vector<ov::builder::subgraph::DequantizationOperations> deqOperations = {
         {
                 { ov::element::f32 },
                 {1.f},

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/fuse_fq_and_scale_shift_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/fuse_fq_and_scale_shift_transformation.cpp
@@ -20,7 +20,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8()
 };
 
-const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizeOnDataValues = {
+const std::vector<ov::builder::subgraph::FakeQuantizeOnData> fakeQuantizeOnDataValues = {
     { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
 // TODO: Issue 39810
 //    {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/recurrent_cell_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/recurrent_cell_transformation.cpp
@@ -46,7 +46,7 @@ const std::vector<LayerTestsDefinitions::RecurrentCellTransformationParam> param
         {255ul, {}, {-1.27f}, {1.27f}, {-1.27f}, {1.27f}},
         {},
         {{}, {}, {}},
-        ngraph::builder::subgraph::RecurrentCellFunction::RNNType::LSTMSequence,
+        ov::builder::subgraph::RecurrentCellFunction::RNNType::LSTMSequence,
         "RNNSeq",
         "u8"
     },
@@ -76,7 +76,7 @@ const std::vector<LayerTestsDefinitions::RecurrentCellTransformationParam> param
         {256ul, {}, {-1.27f}, {1.27f}, {-1.27f}, {1.27f}},
         {},
         {{}, {}, {}},
-        ngraph::builder::subgraph::RecurrentCellFunction::RNNType::LSTMSequence,
+        ov::builder::subgraph::RecurrentCellFunction::RNNType::LSTMSequence,
         "RNNSeq",
         "f32"
     }
@@ -125,7 +125,7 @@ const std::vector<LayerTestsDefinitions::RecurrentCellTransformationParam> param
         {255ul, {}, {-1.27f}, {1.27f}, {-1.27f}, {1.27f}},
         {},
         {{}, {}, {}},
-        ngraph::builder::subgraph::RecurrentCellFunction::RNNType::GRUSequence,
+        ov::builder::subgraph::RecurrentCellFunction::RNNType::GRUSequence,
         "RNNSeq",
         "u8"
     },
@@ -155,7 +155,7 @@ const std::vector<LayerTestsDefinitions::RecurrentCellTransformationParam> param
         {256ul, {}, {-1.27f}, {1.27f}, {-1.27f}, {1.27f}},
         {},
         {{}, {}, {}},
-        ngraph::builder::subgraph::RecurrentCellFunction::RNNType::GRUSequence,
+        ov::builder::subgraph::RecurrentCellFunction::RNNType::GRUSequence,
         "RNNSeq",
         "f32"
     }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/instances/x64/reduce.cpp
@@ -118,8 +118,8 @@ const auto fusingFakeQuantizeTranspose = fusingSpecificParams{std::make_shared<p
             auto last = order[order.size() - 1];
             order.pop_back();
             order.insert(order.begin(), last);
-            const auto transpose = ngraph::builder::subgraph::Transpose(order);
-            return ngraph::builder::subgraph::makeTranspose(fakeQuantize, transpose);
+            const auto transpose = ov::builder::subgraph::Transpose(order);
+            return ov::builder::subgraph::makeTranspose(fakeQuantize, transpose);
         }, "FakeQuantize(PerTensor)"}}), {"FakeQuantize"}};
 
 const std::vector<fusingSpecificParams> fusingParamsSet {

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fq_layer_dq_bias.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fq_layer_dq_bias.cpp
@@ -71,7 +71,7 @@ protected:
         const auto shapes = layer_type == "MatMul" ? std::vector<InputShape>{input_shape, input_shape}
                                                    : std::vector<InputShape>{input_shape};
         init_input_shapes(shapes);
-        function = ngraph::builder::subgraph::MarkupBiasFunction::get(ov::element::f32,
+        function = ov::builder::subgraph::MarkupBiasFunction::get(ov::element::f32,
                                                                       inputDynamicShapes[0],
                                                                       {},
                                                                       layer_type,

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/fq_and_avg_pool_transformation.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/fq_and_avg_pool_transformation.cpp
@@ -20,7 +20,7 @@ const std::vector<ov::pass::low_precision::LayerTransformation::Params> trasform
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8()
 };
 
-const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizes = {
+const std::vector<ov::builder::subgraph::FakeQuantizeOnData> fakeQuantizes = {
     { 256ul, {}, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
 };
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/fq_and_max_pool_transformation.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/fq_and_max_pool_transformation.cpp
@@ -20,7 +20,7 @@ const std::vector<ov::pass::low_precision::LayerTransformation::Params> trasform
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8()
 };
 
-const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizes = {
+const std::vector<ov::builder::subgraph::FakeQuantizeOnData> fakeQuantizes = {
     { 256ul, {}, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
 };
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/fuse_convert_transformation.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/fuse_convert_transformation.cpp
@@ -16,7 +16,7 @@ const std::vector<ov::PartialShape>inputAndQuantizationShapes = {
         { 1, 4, 16, 16 },
 };
 
-const std::vector<ngraph::builder::subgraph::DequantizationOperations> deqOperations = {
+const std::vector<ov::builder::subgraph::DequantizationOperations> deqOperations = {
         {
                 { ov::element::f32 },
                 {1.f},

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/fuse_fq_and_scale_shift_transformation.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/fuse_fq_and_scale_shift_transformation.cpp
@@ -21,7 +21,7 @@ const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8()
 };
 
-const std::vector<ngraph::builder::subgraph::FakeQuantizeOnData> fakeQuantizeOnDataValues = {
+const std::vector<ov::builder::subgraph::FakeQuantizeOnData> fakeQuantizeOnDataValues = {
     { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } },
 // TODO: Issue 39810
 //    {

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/recurrent_cell_transformation.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/recurrent_cell_transformation.cpp
@@ -47,7 +47,7 @@ const std::vector<LayerTestsDefinitions::RecurrentCellTransformationParam> param
         {255ul, {}, {-1.27f}, {1.27f}, {-1.27f}, {1.27f}},
         {},
         {{}, {}, {}},
-        ngraph::builder::subgraph::RecurrentCellFunction::RNNType::LSTMSequence,
+        ov::builder::subgraph::RecurrentCellFunction::RNNType::LSTMSequence,
         "RNNCell",
         "U8"
     },
@@ -77,7 +77,7 @@ const std::vector<LayerTestsDefinitions::RecurrentCellTransformationParam> param
         {256ul, {}, {-1.27f}, {1.27f}, {-1.27f}, {1.27f}},
         {},
         {{}, {}, {}},
-        ngraph::builder::subgraph::RecurrentCellFunction::RNNType::LSTMSequence,
+        ov::builder::subgraph::RecurrentCellFunction::RNNType::LSTMSequence,
         "RNNCell",
         "FP32"
     }
@@ -127,7 +127,7 @@ const std::vector<LayerTestsDefinitions::RecurrentCellTransformationParam> param
         {255ul, {}, {-1.27f}, {1.27f}, {-1.27f}, {1.27f}},
         {},
         {{}, {}, {}},
-        ngraph::builder::subgraph::RecurrentCellFunction::RNNType::GRUSequence,
+        ov::builder::subgraph::RecurrentCellFunction::RNNType::GRUSequence,
         "RNNCell",
         "U8"
     },
@@ -157,7 +157,7 @@ const std::vector<LayerTestsDefinitions::RecurrentCellTransformationParam> param
         {256ul, {}, {-1.27f}, {1.27f}, {-1.27f}, {1.27f}},
         {},
         {{}, {}, {}},
-        ngraph::builder::subgraph::RecurrentCellFunction::RNNType::GRUSequence,
+        ov::builder::subgraph::RecurrentCellFunction::RNNType::GRUSequence,
         "RNNCell",
         "FP32"
     }

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/add_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/add_transformation.hpp
@@ -13,8 +13,8 @@ namespace LayerTestsDefinitions {
 
 class AddTestValues{
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
     bool broadcast;
     std::vector<ov::element::Type> precisionOnActivations;
     std::vector<ov::element::Type> expectedPrecisions;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/assign_and_read_value_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/assign_and_read_value_transformation.hpp
@@ -11,7 +11,7 @@
 namespace LayerTestsDefinitions {
 class AssignAndReadValueTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
 };
 
 typedef std::tuple <

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/batch_to_space_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/batch_to_space_transformation.hpp
@@ -18,7 +18,7 @@ public:
     std::vector<size_t> block_shape;
     std::vector<size_t> crops_begin;
     std::vector<size_t> crops_end;
-    ngraph::builder::subgraph::FakeQuantizeOnData fake_quantize;
+    ov::builder::subgraph::FakeQuantizeOnData fake_quantize;
     std::string layer_type;
     std::string expected_kernel_type;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/clamp_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/clamp_transformation.hpp
@@ -11,8 +11,8 @@
 namespace LayerTestsDefinitions {
 class ClampTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     double clampLowConst;
     double clampHighConst;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/concat_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/concat_transformation.hpp
@@ -16,11 +16,11 @@ namespace LayerTestsDefinitions {
 class ConcatTransformationTestValues {
 public:
     std::shared_ptr<ov::op::v0::Constant> input_constant1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData1;
-    ngraph::builder::subgraph::DequantizationOperations dequantization1;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData1;
+    ov::builder::subgraph::DequantizationOperations dequantization1;
     std::shared_ptr<ov::op::v0::Constant> input_constant2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData2;
-    ngraph::builder::subgraph::DequantizationOperations dequantization2;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData2;
+    ov::builder::subgraph::DequantizationOperations dequantization2;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/concat_with_child_and_output.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/concat_with_child_and_output.hpp
@@ -13,8 +13,8 @@
 namespace LayerTestsDefinitions {
 class ConcatWithChildAndOutputTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData2;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData1;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData2;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/concat_with_different_precision_on_children.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/concat_with_different_precision_on_children.hpp
@@ -14,8 +14,8 @@ namespace LayerTestsDefinitions {
 class ConcatWithDifferentChildrenTransformationParam {
 public:
     std::int64_t axis;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData2;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData1;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData2;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/concat_with_split_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/concat_with_split_transformation.hpp
@@ -13,8 +13,8 @@
 namespace LayerTestsDefinitions {
 class ConcatWithSplitTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData2;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData1;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData2;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_backprop_data_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_backprop_data_transformation.hpp
@@ -18,23 +18,23 @@ namespace LayerTestsDefinitions {
 
 class ConvolutionBackpropDataTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
     std::string layerName;
     std::string expectedKernelType;
 
     ConvolutionBackpropDataTransformationParam() = default;
     ConvolutionBackpropDataTransformationParam(
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
-        const ngraph::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+        const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
+        const ov::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
         std::string layerName,
         std::string expectedKernelType) :
         fakeQuantizeOnData(fakeQuantizeOnData), fakeQuantizeOnWeights(fakeQuantizeOnWeights),
         layerName(std::move(layerName)), expectedKernelType(std::move(expectedKernelType)) {}
     ConvolutionBackpropDataTransformationParam(
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
-        ngraph::builder::subgraph::DequantizationOperations  dequantizationOnWeights,
+        const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
+        ov::builder::subgraph::DequantizationOperations  dequantizationOnWeights,
         std::string layerName,
         std::string expectedKernelType) :
         fakeQuantizeOnData(fakeQuantizeOnData), dequantizationOnWeights(std::move(dequantizationOnWeights)),

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_qdq_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_qdq_transformation.hpp
@@ -17,14 +17,14 @@ namespace LayerTestsDefinitions {
 
 class ConvolutionQDqTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnData;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnData;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+    ov::builder::subgraph::DequantizationOperations::Convert convertOnData;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnData;
 
-    ngraph::builder::subgraph::Constant constantOnWeights;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnWeights;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+    ov::builder::subgraph::Constant constantOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::DequantizationOperations::Convert convertOnWeights;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
 
     std::string layerName;
     std::string expectedKernelType;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_transformation.hpp
@@ -15,9 +15,9 @@ namespace LayerTestsDefinitions {
 
 class ConvolutionTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
     bool asymmetricQuantizationOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     bool asymmetricQuantizationOnWeights;
     std::string layerName;
     std::string expectedKernelType;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_with_incorrect_weights.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/convolution_with_incorrect_weights.hpp
@@ -15,8 +15,8 @@ namespace LayerTestsDefinitions {
 
 class ConvolutionWIthIncorrectWeightsParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     bool isCorrect;
 };
 

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/elementwise_branch_selection_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/elementwise_branch_selection_transformation.hpp
@@ -16,14 +16,14 @@ class ElementwiseBranchSelectionTestValues{
 public:
     class Branch {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeBefore;
-        ngraph::builder::subgraph::Convolution convolution;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeAfter;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeBefore;
+        ov::builder::subgraph::Convolution convolution;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeAfter;
     };
 
     Branch branch1;
     Branch branch2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeAfter;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeAfter;
     std::vector<std::pair<std::string, std::string>> expectedReorders;
     // expected operation name + expected operation precision
     std::vector<std::pair<std::string, std::string>> expectedPrecisions;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/eliminate_fake_quantize_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/eliminate_fake_quantize_transformation.hpp
@@ -19,8 +19,8 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBefore;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData1;
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData2;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData1;
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData2;
     };
 
     class Expected {

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_and_avg_pool_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_and_avg_pool_transformation.hpp
@@ -17,7 +17,7 @@ typedef std::tuple<
     ov::PartialShape,
     std::string,
     ov::pass::low_precision::LayerTransformation::Params,
-    ngraph::builder::subgraph::FakeQuantizeOnData> FakeQuantizeAndAvgPoolTransformationParams;
+    ov::builder::subgraph::FakeQuantizeOnData> FakeQuantizeAndAvgPoolTransformationParams;
 
 class FakeQuantizeAndAvgPoolTransformation :
     public testing::WithParamInterface<FakeQuantizeAndAvgPoolTransformationParams>,

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_and_max_pool_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_and_max_pool_transformation.hpp
@@ -17,7 +17,7 @@ typedef std::tuple<
     ov::PartialShape,
     std::string,
     ov::pass::low_precision::LayerTransformation::Params,
-    ngraph::builder::subgraph::FakeQuantizeOnData> FakeQuantizeAndMaxPoolTransformationParams;
+    ov::builder::subgraph::FakeQuantizeOnData> FakeQuantizeAndMaxPoolTransformationParams;
 
 class FakeQuantizeAndMaxPoolTransformation :
     public testing::WithParamInterface<FakeQuantizeAndMaxPoolTransformationParams>,

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_and_two_output_branches_with_convolution.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_and_two_output_branches_with_convolution.hpp
@@ -15,9 +15,9 @@
 namespace LayerTestsDefinitions {
 class FakeQuantizeAndTwoOutputBranchesWithConvolution {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights1;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights2;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights1;
+    ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights2;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_precision_selection_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_precision_selection_transformation.hpp
@@ -16,8 +16,8 @@ namespace LayerTestsDefinitions {
 
 class FakeQuantizePrecisionSelectionTransformationActualValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const FakeQuantizePrecisionSelectionTransformationActualValues& values) {
@@ -27,8 +27,8 @@ inline std::ostream& operator<<(std::ostream& out, const FakeQuantizePrecisionSe
 class FakeQuantizePrecisionSelectionTransformationExpectedValues {
 public:
     ov::element::Type fakeQuantizeOnDataOutPrecision;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const FakeQuantizePrecisionSelectionTransformationExpectedValues& values) {

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_transformation.hpp
@@ -12,7 +12,7 @@
 namespace LayerTestsDefinitions {
 class FakeQuantizeTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakequantize;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakequantize;
 
     std::string layerName;
     std::string expectedKernelType;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.hpp
@@ -19,16 +19,16 @@ namespace LayerTestsDefinitions {
 
 class FakeQuantizeWithNotOptimalTransformationTestValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnData;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnData;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnData;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnData;
+    ov::builder::subgraph::DequantizationOperations::Convert convertOnData;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnData;
 
-    ngraph::builder::subgraph::Constant constantOnWeights;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnWeights;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+    ov::builder::subgraph::Constant constantOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights;
+    ov::builder::subgraph::DequantizationOperations::Convert convertOnWeights;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
 
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     std::string expectedPrecision;
 };
 
@@ -47,7 +47,7 @@ inline std::ostream& operator<<(std::ostream& out, const FakeQuantizeWithNotOpti
         data.expectedPrecision;
 }
 
-// ngraph::builder::subgraph::FakeQuantizeOnData
+// ov::builder::subgraph::FakeQuantizeOnData
 typedef std::tuple<
     ov::element::Type,
     ov::PartialShape,

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_convert_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_convert_transformation.hpp
@@ -19,7 +19,7 @@ typedef std::tuple <
     element::Type,
     PartialShape,
     std::string,
-    ngraph::builder::subgraph::DequantizationOperations,
+    ov::builder::subgraph::DequantizationOperations,
     bool> FuseConvertTransformationParams;
 
 class FuseConvertTransformation :

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_dequantize_to_fake_quantize_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_dequantize_to_fake_quantize_transformation.hpp
@@ -18,11 +18,11 @@ public:
     class Actual {
     public:
         ov::element::Type precisionBeforeAdd;
-        ngraph::builder::subgraph::Add add;
+        ov::builder::subgraph::Add add;
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
         ov::element::Type precisionAfterDequantization;
-        ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+        ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
     };
 
     ov::PartialShape inputShape;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_fake_quantize_and_scale_shift_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_fake_quantize_and_scale_shift_transformation.hpp
@@ -16,7 +16,7 @@ typedef std::tuple<
     ov::PartialShape,
     std::string,
     ov::pass::low_precision::LayerTransformation::Params,
-    ngraph::builder::subgraph::FakeQuantizeOnData> FuseFakeQuantizeAndScaleShiftTransformationParams;
+    ov::builder::subgraph::FakeQuantizeOnData> FuseFakeQuantizeAndScaleShiftTransformationParams;
 
 class FuseFakeQuantizeAndScaleShiftTransformation :
     public testing::WithParamInterface<FuseFakeQuantizeAndScaleShiftTransformationParams>,

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_multiply_to_fake_quantize_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_multiply_to_fake_quantize_transformation.hpp
@@ -17,8 +17,8 @@ class FuseMultiplyToFakeQuantizeTransformationTestValues {
 public:
     class Actual {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     ov::PartialShape inputShape;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_subtract_to_fake_quantize_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/fuse_subtract_to_fake_quantize_transformation.hpp
@@ -17,8 +17,8 @@ class FuseSubtractToFakeQuantizeTransformationTestValues {
 public:
     class Actual {
     public:
-        ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+        ov::builder::subgraph::DequantizationOperations dequantization;
     };
 
     ov::PartialShape inputShape;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/gather_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/gather_transformation.hpp
@@ -21,7 +21,7 @@ public:
     int64_t batch_dims;
     ov::pass::low_precision::LayerTransformation::Params params;
     ov::element::Type precisionBeforeFq;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/group_convolution_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/group_convolution_transformation.hpp
@@ -18,8 +18,8 @@ public:
     GroupConvolutionTransformationParam() = default;
     GroupConvolutionTransformationParam(const size_t group,
                                         const int groupCalculationDimention,
-                                        const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
-                                        const ngraph::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+                                        const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
+                                        const ov::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
                                         const bool addReshape = true,
                                         const std::string& layerName = "",
                                         const std::string& expectedKernelType = "")
@@ -33,8 +33,8 @@ public:
 
     size_t group;
     int groupCalculationDimention;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
     bool addReshape;
     std::string layerName;
     std::string expectedKernelType;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/groupconvolution_qdq_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/groupconvolution_qdq_transformation.hpp
@@ -18,15 +18,15 @@ namespace LayerTestsDefinitions {
 
 class GroupConvolutionQDqTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnData;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnData;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+    ov::builder::subgraph::DequantizationOperations::Convert convertOnData;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnData;
 
-    ngraph::builder::subgraph::Constant constantOnWeights;
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertOnWeights;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
-    ngraph::builder::subgraph::Reshape reshape;
+    ov::builder::subgraph::Constant constantOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights;
+    ov::builder::subgraph::DequantizationOperations::Convert convertOnWeights;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+    ov::builder::subgraph::Reshape reshape;
 
     std::string layerName;
     std::string expectedKernelType;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_transformation.hpp
@@ -16,9 +16,9 @@ namespace LayerTestsDefinitions {
 class MatMulTransformationTestValues {
 public:
     ov::Shape inputShape1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData1;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData1;
     ov::Shape inputShape2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData2;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData2;
     std::string expectedKernelName;
     std::string expectedRuntimePrecision;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_with_constant_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_with_constant_transformation.hpp
@@ -20,11 +20,11 @@ namespace LayerTestsDefinitions {
 class MatMulWithConstantTransformationTestValues {
 public:
     ov::PartialShape inputShape;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnData;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnData;
 
-    ngraph::builder::subgraph::Constant weights;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnWeights;
-    ngraph::builder::subgraph::DequantizationOperations deqOnWeights;
+    ov::builder::subgraph::Constant weights;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fqOnWeights;
+    ov::builder::subgraph::DequantizationOperations deqOnWeights;
 
     std::string layerName;
     std::string expectedKernelType;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_with_optimized_constant_fq.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/mat_mul_with_optimized_constant_fq.hpp
@@ -14,8 +14,8 @@ namespace LayerTestsDefinitions {
 
 class MatMulWithOptimizedConstantFakeQuantizeTransformationTestValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnWeights;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnWeights;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/move_fake_quantize_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/move_fake_quantize_transformation.hpp
@@ -21,9 +21,9 @@ class MoveFakeQuantizeTransformationParam {
 public:
     size_t concatInputsCount;
     std::string operation;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeAfter;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convertAfter;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeAfter;
+    ov::builder::subgraph::DequantizationOperations::Convert convertAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     std::string layerName;
     std::string expectedKernelType;
     std::int64_t axis;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_to_group_convolution_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_to_group_convolution_transformation.hpp
@@ -12,7 +12,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-using namespace ngraph;
+using namespace ov;
 
 namespace LayerTestsDefinitions {
 

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_transformation.hpp
@@ -15,10 +15,10 @@ namespace LayerTestsDefinitions {
 class MultiplyTestValues {
 public:
     bool broadcast1;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize1;
     bool broadcast2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeAfter;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize2;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeAfter;
     ov::element::Type expectedPrecisions;
     bool secondInputIsConstant;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_with_one_parent_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/multiply_with_one_parent_transformation.hpp
@@ -14,7 +14,7 @@ namespace LayerTestsDefinitions {
 
 class MultiplyWithOneParentTransformationValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/pad_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/pad_transformation.hpp
@@ -10,7 +10,7 @@
 namespace LayerTestsDefinitions {
 class PadTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::vector<int64_t> padsBegin;
     std::vector<int64_t> padsEnd;
     float padValue;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/prelu_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/prelu_transformation.hpp
@@ -13,7 +13,7 @@ namespace LayerTestsDefinitions {
 
 class PReluTestValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     bool isSubtract;
 };
 

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/pull_reshape_through_dequantization_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/pull_reshape_through_dequantization_transformation.hpp
@@ -20,16 +20,16 @@ namespace LayerTestsDefinitions {
 class PullReshapeThroughDequantizationTestValues {
 public:
     ov::element::Type precisionBeforeDequantization;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnActivations;
-    ngraph::builder::subgraph::Constant weights;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationOnWeights;
-    ngraph::builder::subgraph::Reshape reshape1;
-    ngraph::builder::subgraph::DequantizationOperations::Multiply multiply;
-    ngraph::builder::subgraph::Transpose transpose;
-    ngraph::builder::subgraph::Reshape reshape2;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantizeOnData;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnActivations;
+    ov::builder::subgraph::Constant weights;
+    ov::builder::subgraph::DequantizationOperations dequantizationOnWeights;
+    ov::builder::subgraph::Reshape reshape1;
+    ov::builder::subgraph::DequantizationOperations::Multiply multiply;
+    ov::builder::subgraph::Transpose transpose;
+    ov::builder::subgraph::Reshape reshape2;
     ov::element::Type precisionAfterOperation;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     std::string operationName;
     std::string expectedKernelType;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/recurrent_cell_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/recurrent_cell_transformation.hpp
@@ -19,19 +19,19 @@ namespace LayerTestsDefinitions {
 
 class RecurrentCellTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_X;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert_X;
-    ngraph::builder::subgraph::DequantizationOperations dequantization_X;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_H;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert_H;
-    ngraph::builder::subgraph::DequantizationOperations dequantization_H;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_W;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert_W;
-    ngraph::builder::subgraph::DequantizationOperations dequantization_W;
-    ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_R;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert_R;
-    ngraph::builder::subgraph::DequantizationOperations dequantization_R;
-    ngraph::builder::subgraph::RecurrentCellFunction::RNNType RNNType;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_X;
+    ov::builder::subgraph::DequantizationOperations::Convert convert_X;
+    ov::builder::subgraph::DequantizationOperations dequantization_X;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_H;
+    ov::builder::subgraph::DequantizationOperations::Convert convert_H;
+    ov::builder::subgraph::DequantizationOperations dequantization_H;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_W;
+    ov::builder::subgraph::DequantizationOperations::Convert convert_W;
+    ov::builder::subgraph::DequantizationOperations dequantization_W;
+    ov::builder::subgraph::FakeQuantizeOnDataWithConstant fakeQuantize_R;
+    ov::builder::subgraph::DequantizationOperations::Convert convert_R;
+    ov::builder::subgraph::DequantizationOperations dequantization_R;
+    ov::builder::subgraph::RecurrentCellFunction::RNNType RNNType;
     std::string layerName;
     std::string expectedKernelType;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_max_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_max_transformation.hpp
@@ -11,7 +11,7 @@
 namespace LayerTestsDefinitions {
 class ReduceMaxTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::vector<int64_t> constantValues;
     bool keepDims;
     std::string layerName;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_mean_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_mean_transformation.hpp
@@ -21,11 +21,11 @@ public:
 
 class ReduceMeanTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::DequantizationOperations::Convert convert;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
     ReduceMeanOperation reduceMean;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
     std::string layerName;
     std::string expectedKernelType;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_min_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_min_transformation.hpp
@@ -11,7 +11,7 @@
 namespace LayerTestsDefinitions {
 class ReduceMinTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::vector<int64_t> constantValues;
     bool keepDims;
     std::string layerName;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_sum_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reduce_sum_transformation.hpp
@@ -11,7 +11,7 @@
 namespace LayerTestsDefinitions {
 class ReduceSumTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::vector<int64_t> constantValues;
     bool keepDims;
     std::string layerName;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/relu_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/relu_transformation.hpp
@@ -13,7 +13,7 @@ namespace LayerTestsDefinitions {
 
 class ReluTestValues {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     bool isSubtract;
 };
 

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/reshape_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/reshape_transformation.hpp
@@ -16,7 +16,7 @@ class ReshapeTransformationParam {
 public:
     ov::PartialShape inputShape;
     std::vector<int> reshapeConstValues;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::string layerType;
     std::string expectedKernelType;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/shuffle_channels_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/shuffle_channels_transformation.hpp
@@ -14,7 +14,7 @@ namespace LayerTestsDefinitions {
 
 class ShuffleChannelsTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
     std::int64_t axis;
     std::int64_t group;
     std::string layerName;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/space_to_batch_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/space_to_batch_transformation.hpp
@@ -18,7 +18,7 @@ public:
     std::vector<size_t> block_shape;
     std::vector<size_t> pads_begin;
     std::vector<size_t> pads_end;
-    ngraph::builder::subgraph::FakeQuantizeOnData fake_quantize;
+    ov::builder::subgraph::FakeQuantizeOnData fake_quantize;
     std::string layer_type;
     std::string expected_kernel_type;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/split_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/split_transformation.hpp
@@ -10,7 +10,7 @@
 namespace LayerTestsDefinitions {
 class SplitTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     int64_t splitedAxis;
     size_t numSplit;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/squeeze_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/squeeze_transformation.hpp
@@ -14,7 +14,7 @@ namespace LayerTestsDefinitions {
 
 class SqueezeTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::vector<float> squeezeAxes;
     ov::PartialShape shape;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/strided_slice_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/strided_slice_transformation.hpp
@@ -11,7 +11,7 @@
 namespace LayerTestsDefinitions {
 class StridedSliceTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::vector<int64_t> begin;
     std::vector<int64_t> end;
     std::vector<int64_t> strides;

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/subtract_multiply_to_multiply_add_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/subtract_multiply_to_multiply_add_transformation.hpp
@@ -16,7 +16,7 @@ class SubtractMultiplyToMultiplyAddTransformationTestValues {
 public:
     ov::PartialShape inputShape;
     ov::element::Type precision;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/transpose_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/transpose_transformation.hpp
@@ -18,7 +18,7 @@ public:
     std::vector<int> transposeConstValues;
     ov::pass::low_precision::LayerTransformation::Params params;
     ov::element::Type precisionBeforeFq;
-    ngraph::builder::subgraph::FakeQuantizeOnData fqOnData;
+    ov::builder::subgraph::FakeQuantizeOnData fqOnData;
 };
 
 typedef std::tuple<

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/unsqueeze_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/unsqueeze_transformation.hpp
@@ -14,7 +14,7 @@ namespace LayerTestsDefinitions {
 
 class UnsqueezeTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::vector<float> unsqueezeAxes;
     ov::PartialShape shape;
 };

--- a/src/tests/functional/plugin/shared/include/low_precision_transformations/variadic_split_transformation.hpp
+++ b/src/tests/functional/plugin/shared/include/low_precision_transformations/variadic_split_transformation.hpp
@@ -10,7 +10,7 @@
 namespace LayerTestsDefinitions {
 class VariadicSplitTransformationParam {
 public:
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     int64_t splitedAxis;
     std::vector<size_t> splitLengths;
 };

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/add_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/add_transformation.cpp
@@ -66,7 +66,7 @@ void AddTransformation::SetUp() {
     }
     init_input_shapes({ inputShape, inputShape2 });
 
-    function = ngraph::builder::subgraph::AddFunction::getOriginal(
+    function = ov::builder::subgraph::AddFunction::getOriginal(
         precision, inputShape, param.broadcast,
         param.fakeQuantize1, param.fakeQuantize2);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/assign_and_read_value_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/assign_and_read_value_transformation.cpp
@@ -36,7 +36,7 @@ void AssignAndReadValueTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::AssignAndReadValueFunction::getOriginal(
+    function = ov::builder::subgraph::AssignAndReadValueFunction::getOriginal(
         netPrecision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/batch_to_space_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/batch_to_space_transformation.cpp
@@ -32,7 +32,7 @@ void BatchToSpaceTransformation::SetUp() {
 
     init_input_shapes(param.input_shape);
 
-    function = ngraph::builder::subgraph::BatchToSpaceFunction::get(
+    function = ov::builder::subgraph::BatchToSpaceFunction::get(
         param.input_shape,
         input_type,
         param.fake_quantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/clamp_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/clamp_transformation.cpp
@@ -38,7 +38,7 @@ void ClampTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::ClampFunction::getOriginal(
+    function = ov::builder::subgraph::ClampFunction::getOriginal(
         netPrecision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_transformation.cpp
@@ -51,7 +51,7 @@ void ConcatTransformation::SetUp() {
     }
     init_input_shapes(inputs);
 
-    function = ngraph::builder::subgraph::ConcatFunction::getOriginal(
+    function = ov::builder::subgraph::ConcatFunction::getOriginal(
         precision,
         inputShape,
         testValues.input_constant1,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_child_and_output.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_child_and_output.cpp
@@ -53,7 +53,7 @@ void ConcatWithChildAndOutputTransformation::SetUp() {
 
     init_input_shapes({ inputShapes, inputShapes });
 
-    function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithChildAndOutput(
+    function = ov::builder::subgraph::ConcatFunction::getOriginalWithChildAndOutput(
         netPrecision, inputShapes, param.fqOnData1, param.fqOnData2);
 }
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_different_precision_on_children.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_different_precision_on_children.cpp
@@ -42,7 +42,7 @@ void ConcatWithDifferentChildrenTransformation::SetUp() {
 
     init_input_shapes({ inputShapes, inputShapes });
 
-    function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithDifferentPrecisionOnChildren(
+    function = ov::builder::subgraph::ConcatFunction::getOriginalWithDifferentPrecisionOnChildren(
         netPrecision, inputShapes, param.axis, param.fqOnData1, param.fqOnData2);
 }
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_intermediate_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_intermediate_transformation.cpp
@@ -63,7 +63,7 @@ void ConcatWithIntermediateTransformation::SetUp() {
 
     init_input_shapes({ inputShape1, inputShape });
 
-    function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithIntermediate(
+    function = ov::builder::subgraph::ConcatFunction::getOriginalWithIntermediate(
         ngPrecision,
         inputShape,
         transparentIntermediate,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_neighbors_graph_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_neighbors_graph_transformation.cpp
@@ -36,7 +36,7 @@ void ConcatWithNeighborsGraphTransformation::SetUp() {
 
     init_input_shapes({ inputShape, inputShape, inputShape });
 
-    function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithNeighbors(
+    function = ov::builder::subgraph::ConcatFunction::getOriginalWithNeighbors(
         ngPrecision,
         inputShape,
         { 256ul, ov::Shape({}), {0.f}, {2.55f}, {0.f}, {2.55f} },

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_split_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_split_transformation.cpp
@@ -52,7 +52,7 @@ void ConcatWithSplitTransformation::SetUp() {
     inputShape1[1] = inputShape1[1].get_length() / numSplit;
     init_input_shapes({ inputShape1, inputShapes });
 
-    function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithSplitedIntermediate(
+    function = ov::builder::subgraph::ConcatFunction::getOriginalWithSplitedIntermediate(
         netPrecision,
         inputShapes,
         param.fqOnData1,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_backprop_data_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_backprop_data_transformation.cpp
@@ -53,18 +53,18 @@ void ConvolutionBackpropDataTransformation::SetUp() {
     weightsShape[1] = inputShape[1].get_length() / 2;
 
     if (!param.fakeQuantizeOnWeights.empty()) {
-        weights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
+        weights = ov::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
             weightsShape,
             netPrecision,
             param.fakeQuantizeOnWeights);
     } else {
-        weights = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
+        weights = ov::builder::subgraph::ConvolutionBackpropDataFunction::getWeights(
             weightsShape,
             netPrecision,
             param.dequantizationOnWeights);
     }
 
-    function = ngraph::builder::subgraph::ConvolutionBackpropDataFunction::get(
+    function = ov::builder::subgraph::ConvolutionBackpropDataFunction::get(
         netPrecision,
         inputShape,
         outputShape,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_qdq_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_qdq_transformation.cpp
@@ -44,7 +44,7 @@ void ConvolutionQDqTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+    function = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
         netPrecision,
         inputShape,
         param.fakeQuantizeOnData,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_transformation.cpp
@@ -47,7 +47,7 @@ void ConvolutionTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+    function = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
         netPrecision,
         inputShape,
         // TODO: pass from test parameters

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_with_incorrect_weights.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_with_incorrect_weights.cpp
@@ -47,7 +47,7 @@ void ConvolutionWIthIncorrectWeightsTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::ConvolutionFunction::getOriginalWithIncorrectWeights(
+    function = ov::builder::subgraph::ConvolutionFunction::getOriginalWithIncorrectWeights(
         inputShape,
         netPrecision,
         param.fakeQuantizeOnWeights,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/depth_to_space_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/depth_to_space_transformation.cpp
@@ -57,7 +57,7 @@ void DepthToSpaceTransformation::SetUp() {
         IE_THROW() << "not supported input shape size " << inputShape.rank();
     }
 
-    function = ngraph::builder::subgraph::DepthToSpaceFunction::getOriginal(precision, inputShape, mode, blockSize);
+    function = ov::builder::subgraph::DepthToSpaceFunction::getOriginal(precision, inputShape, mode, blockSize);
 }
 
 TEST_P(DepthToSpaceTransformation, CompareWithRefImpl) {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/elementwise_branch_selection_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/elementwise_branch_selection_transformation.cpp
@@ -25,7 +25,7 @@ std::string ElementwiseBranchSelectionTransformation::getTestCaseName(const test
     result << get_test_case_name_by_params(netPrecision, inputShapes, targetDevice, params) <<
            "_elementwiseType_" << elementwiseType;
 
-    auto toString = [](const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData) -> std::string {
+    auto toString = [](const ov::builder::subgraph::FakeQuantizeOnData& fqOnData) -> std::string {
         if (fqOnData.empty()) {
             return "";
         }
@@ -56,7 +56,7 @@ void ElementwiseBranchSelectionTransformation::SetUp() {
 
     init_input_shapes({ inputShape, inputShape });
 
-    function = ngraph::builder::subgraph::AddFunction::getOriginalSubgraphWithConvolutions(
+    function = ov::builder::subgraph::AddFunction::getOriginalSubgraphWithConvolutions(
         precision,
         inputShape,
         false,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/eliminate_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/eliminate_fake_quantize_transformation.cpp
@@ -37,7 +37,7 @@ void EliminateFakeQuantizeTransformation::SetUp() {
     // Convolution is used in a model as operation with specific precision requirements on data branch
     // to test the transformation place in LPT pipeline:
     // markup transformations and FakeQuantize operation decomposition transformation have to handle FakeQuantize as usual
-    function = ngraph::builder::subgraph::FuseFakeQuantizeFunction::get(
+    function = ov::builder::subgraph::FuseFakeQuantizeFunction::get(
         testValues.inputShape,
         testValues.actual.precisionBefore,
         testValues.actual.fakeQuantizeOnData1,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_and_avg_pool_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_and_avg_pool_transformation.cpp
@@ -20,7 +20,7 @@ std::string FakeQuantizeAndAvgPoolTransformation::getTestCaseName(const testing:
     ov::PartialShape inputShapes;
     std::string targetDevice;
     ov::pass::low_precision::LayerTransformation::Params params;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::tie(precision, inputShapes, targetDevice, params, fakeQuantize) = obj.param;
 
     return get_test_case_name_by_params(precision, inputShapes, targetDevice, params);
@@ -32,12 +32,12 @@ void FakeQuantizeAndAvgPoolTransformation::SetUp() {
     ov::element::Type precision;
     ov::PartialShape inputShape;
     ov::pass::low_precision::LayerTransformation::Params params;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::tie(precision, inputShape, targetDevice, params, fakeQuantize) = this->GetParam();
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::AvgPoolFunction::getOriginal(
+    function = ov::builder::subgraph::AvgPoolFunction::getOriginal(
         precision,
         inputShape,
         fakeQuantize);

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_and_max_pool_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_and_max_pool_transformation.cpp
@@ -20,7 +20,7 @@ std::string FakeQuantizeAndMaxPoolTransformation::getTestCaseName(const testing:
     ov::PartialShape inputShapes;
     std::string targetDevice;
     ov::pass::low_precision::LayerTransformation::Params params;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::tie(precision, inputShapes, targetDevice, params, fakeQuantize) = obj.param;
 
     return get_test_case_name_by_params(precision, inputShapes, targetDevice, params);
@@ -31,12 +31,12 @@ void FakeQuantizeAndMaxPoolTransformation::SetUp() {
     ov::element::Type precision;
     ov::PartialShape inputShape;
     ov::pass::low_precision::LayerTransformation::Params params;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantize;
     std::tie(precision, inputShape, targetDevice, params, fakeQuantize) = this->GetParam();
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::MaxPoolFunction::getOriginal(
+    function = ov::builder::subgraph::MaxPoolFunction::getOriginal(
         precision,
         inputShape,
         fakeQuantize);

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -46,7 +46,7 @@ void FakeQuantizeAndTwoOutputBranchesWithConvolutionTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::FakeQuantizeAndTwoOutputBranchesWithConvolutionFunction::getOriginal(
+    function = ov::builder::subgraph::FakeQuantizeAndTwoOutputBranchesWithConvolutionFunction::getOriginal(
         netPrecision,
         inputShape,
         testValues.fqOnData,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_precision_selection_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_precision_selection_transformation.cpp
@@ -38,7 +38,7 @@ void FakeQuantizePrecisionSelectionTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::FakeQuantizePrecisionSelectionFunction::getOriginal(
+    function = ov::builder::subgraph::FakeQuantizePrecisionSelectionFunction::getOriginal(
         netPrecision,
         inputShape,
         {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_transformation.cpp
@@ -45,7 +45,7 @@ void FakeQuantizeTransformation::SetUp() {
 
     testParams.fakequantize.addConverts = isConvertOnConstants;
 
-    function = ngraph::builder::subgraph::FakeQuantizeFunction::getOriginal(
+    function = ov::builder::subgraph::FakeQuantizeFunction::getOriginal(
         params,
         netPrecision,
         inputShape,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fake_quantize_with_dq_not_optimal_transformation.cpp
@@ -39,7 +39,7 @@ void FakeQuantizeWithNotOptimalTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+    function = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
         netPrecision,
         inputShape,
         testValues.fqOnData,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fully_connected_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fully_connected_transformation.cpp
@@ -47,7 +47,7 @@ void FullyConnectedTransformation::SetUp() {
 
     init_input_shapes({ shapes.inputA, shapes.inputB });
 
-    function = ngraph::builder::subgraph::MatMulFunction::getOriginal(
+    function = ov::builder::subgraph::MatMulFunction::getOriginal(
         precision,
         shapes.inputA,
         shapes.inputB,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_convert_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_convert_transformation.cpp
@@ -25,7 +25,7 @@ std::string FuseConvertTransformation::getTestCaseName(const testing::TestParamI
     ov::PartialShape shape;
     ov::element::Type precision;
     auto params = LayerTestsUtils::LayerTransformationParamsNGraphFactory::createParamsU8I8();
-    ngraph::builder::subgraph::DequantizationOperations deqOperations;
+    ov::builder::subgraph::DequantizationOperations deqOperations;
     bool constInput;
     std::tie(precision, shape, targetDevice, deqOperations, constInput) = obj.param;
 
@@ -39,13 +39,13 @@ void FuseConvertTransformation::SetUp() {
     abs_threshold = 0.01;
     ov::PartialShape shape;
     ov::element::Type precision;
-    ngraph::builder::subgraph::DequantizationOperations deqOperations;
+    ov::builder::subgraph::DequantizationOperations deqOperations;
     bool constInput;
     std::tie(precision, shape, targetDevice, deqOperations, constInput) = this->GetParam();
 
     init_input_shapes(constInput ? std::vector<ov::PartialShape>{ shape } : std::vector<ov::PartialShape>{ shape, shape });
 
-    function = ngraph::builder::subgraph::FuseConvertFunction::getWithFQ(
+    function = ov::builder::subgraph::FuseConvertFunction::getWithFQ(
         shape,
         precision,
         deqOperations,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_dequantize_to_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_dequantize_to_fake_quantize_transformation.cpp
@@ -40,7 +40,7 @@ void FuseDequantizeToFakeQuantizeTransformation::SetUp() {
 
     init_input_shapes(testValues.inputShape);
 
-    function = ngraph::builder::subgraph::FuseFakeQuantizeFunction::getOriginal(
+    function = ov::builder::subgraph::FuseFakeQuantizeFunction::getOriginal(
         testValues.inputShape,
         testValues.actual.precisionBeforeAdd,
         testValues.actual.add,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_fake_quantize_and_scale_shift_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_fake_quantize_and_scale_shift_transformation.cpp
@@ -18,7 +18,7 @@ std::string FuseFakeQuantizeAndScaleShiftTransformation::getTestCaseName(const t
     ov::PartialShape inputShape;
     std::string targetDevice;
     ov::pass::low_precision::LayerTransformation::Params params;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
     std::tie(netPrecision, inputShape, targetDevice, params, fakeQuantizeOnData) = obj.param;
 
     std::ostringstream result;
@@ -31,12 +31,12 @@ void FuseFakeQuantizeAndScaleShiftTransformation::SetUp() {
     ov::element::Type netPrecision;
     ov::PartialShape inputShape;
     ov::pass::low_precision::LayerTransformation::Params params;
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData;
     std::tie(netPrecision, inputShape, targetDevice, params, fakeQuantizeOnData) = this->GetParam();
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::FuseFakeQuantizeAndScaleShiftFunction::getOriginal(
+    function = ov::builder::subgraph::FuseFakeQuantizeAndScaleShiftFunction::getOriginal(
         netPrecision,
         inputShape,
         fakeQuantizeOnData);

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_multiply_to_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_multiply_to_fake_quantize_transformation.cpp
@@ -32,7 +32,7 @@ void FuseMultiplyToFakeQuantizeTransformation::SetUp() {
 
     init_input_shapes(testValues.inputShape);
 
-    function = ngraph::builder::subgraph::FuseMultiplyToFakeQuantizeFunction::get(
+    function = ov::builder::subgraph::FuseMultiplyToFakeQuantizeFunction::get(
         testValues.inputShape,
         testValues.actual.fakeQuantizeOnData,
         testValues.actual.dequantization);

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_subtract_to_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_subtract_to_fake_quantize_transformation.cpp
@@ -32,7 +32,7 @@ void FuseSubtractToFakeQuantizeTransformation::SetUp() {
 
     init_input_shapes(testValues.inputShape);
 
-    function = ngraph::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
+    function = ov::builder::subgraph::FuseSubtractToFakeQuantizeFunction::get(
         testValues.inputShape,
         testValues.actual.fakeQuantizeOnData,
         testValues.actual.dequantization);

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/gather_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/gather_transformation.cpp
@@ -39,7 +39,7 @@ void GatherTransformation::SetUp() {
 
     init_input_shapes(testValues.inputShape);
 
-    function = ngraph::builder::subgraph::GatherFunction::getOriginal(
+    function = ov::builder::subgraph::GatherFunction::getOriginal(
         testValues.inputShape,
         testValues.gatherIndicesShape,
         testValues.gatherIndicesValues,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/gemm_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/gemm_transformation.cpp
@@ -43,7 +43,7 @@ void GemmTransformation::SetUp() {
     const float low = 0.f; // params.precisionsOnActivations[0] == ov::element::u8 ? 0.f : -128.f;
     const float high = 255.f; // params.precisionsOnActivations[0] == ov::element::u8 ? 255.f : 127.f;
 
-    function = ngraph::builder::subgraph::MatMulFunction::getOriginal(
+    function = ov::builder::subgraph::MatMulFunction::getOriginal(
         netPrecision,
         inputShape,
         low,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/group_convolution_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/group_convolution_transformation.cpp
@@ -58,7 +58,7 @@ void GroupConvolutionTransformation::SetUp() {
     while (param.fakeQuantizeOnData.constantShape.size() > inputShapes.first.size()) {
         param.fakeQuantizeOnData.constantShape.pop_back();
     }
-    function = ngraph::builder::subgraph::GroupConvolutionFunction::getOriginal(
+    function = ov::builder::subgraph::GroupConvolutionFunction::getOriginal(
         netPrecision,
         inputShapes.first,
         inputShapes.second,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/groupconvolution_qdq_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/groupconvolution_qdq_transformation.cpp
@@ -44,7 +44,7 @@ void GroupConvolutionQDqTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+    function = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
         netPrecision,
         inputShape,
         param.fakeQuantizeOnData,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/interpolate_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/interpolate_transformation.cpp
@@ -63,7 +63,7 @@ void InterpolateTransformation::SetUp() {
     interpAttrs.pads_begin = attributes.pads_begin;
     interpAttrs.pads_end = attributes.pads_end;
 
-    function = ngraph::builder::subgraph::InterpolateFunction::getOriginal(precision, shapes.first, shapes.second, interpAttrs);
+    function = ov::builder::subgraph::InterpolateFunction::getOriginal(precision, shapes.first, shapes.second, interpAttrs);
 }
 
 TEST_P(InterpolateTransformation, CompareWithRefImpl) {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_transformation.cpp
@@ -48,7 +48,7 @@ void MatMulTransformation::SetUp() {
 
     init_input_shapes({ testValues.inputShape1, testValues.inputShape2 });
 
-    function = ngraph::builder::subgraph::MatMulFunction::getOriginal(
+    function = ov::builder::subgraph::MatMulFunction::getOriginal(
         precision,
         testValues.inputShape1,
         testValues.fqOnData1,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
@@ -47,7 +47,7 @@ void MatMulWithConstantTransformation::SetUp() {
 
     init_input_shapes(testValues.inputShape);
 
-    function = ngraph::builder::subgraph::MatMulFunction::getOriginal(
+    function = ov::builder::subgraph::MatMulFunction::getOriginal(
         precision,
         testValues.inputShape,
         testValues.fqOnData,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_optimized_constant_fq.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_optimized_constant_fq.cpp
@@ -50,7 +50,7 @@ void MatMulWithOptimizedConstantFq::SetUp() {
 
     init_input_shapes({ shapes.first, shapes.second });
 
-    function = ngraph::builder::subgraph::MatMulWithOptimizedConstantFakeQuantizeFunction::getOriginal(
+    function = ov::builder::subgraph::MatMulWithOptimizedConstantFakeQuantizeFunction::getOriginal(
         precision,
         shapes.first,
         shapes.second,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/move_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/move_fake_quantize_transformation.cpp
@@ -64,7 +64,7 @@ void MoveFakeQuantizeTransformation::SetUp() {
         init_input_shapes(inputShapes);
     }
 
-    function = ngraph::builder::subgraph::MoveFakeQuantize::get(
+    function = ov::builder::subgraph::MoveFakeQuantize::get(
         netPrecision,
         inputShapes,
         param.concatInputsCount,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_to_group_convolution_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_to_group_convolution_transformation.cpp
@@ -46,7 +46,7 @@ void MultiplyToGroupConvolutionTransformation::SetUp() {
 
     init_input_shapes(shape);
 
-    function = ngraph::builder::subgraph::MultiplyToGroupConvolutionFunction::getOriginal(
+    function = ov::builder::subgraph::MultiplyToGroupConvolutionFunction::getOriginal(
         precision,
         shape,
         param.fqOnData,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_transformation.cpp
@@ -78,7 +78,7 @@ void MultiplyTransformation::SetUp() {
             std::vector<ov::PartialShape>{ inputShape1 } :
             std::vector<ov::PartialShape>{ inputShape1, inputShape2 });
 
-    function = ngraph::builder::subgraph::MultiplyPartialFunction::get(
+    function = ov::builder::subgraph::MultiplyPartialFunction::get(
         precision,
         inputShape,
         param.broadcast1,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_with_one_parent_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_with_one_parent_transformation.cpp
@@ -38,7 +38,7 @@ void MultiplyWithOneParentTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::MultiplyWithOneParentFunction::getOriginal(netPrecision, inputShape, values.fakeQuantize);
+    function = ov::builder::subgraph::MultiplyWithOneParentFunction::getOriginal(netPrecision, inputShape, values.fakeQuantize);
 }
 
 TEST_P(MultiplyWithOneParentTransformation, CompareWithRefImpl) {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mvn_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mvn_transformation.cpp
@@ -45,7 +45,7 @@ void MVNTransformation::SetUp() {
 
     init_input_shapes(shape);
 
-    function = ngraph::builder::subgraph::MVNFunction::getOriginal(
+    function = ov::builder::subgraph::MVNFunction::getOriginal(
         precision,
         shape,
         reductionAxes,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/normalize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/normalize_transformation.cpp
@@ -55,7 +55,7 @@ void NormalizeL2Transformation::SetUp() {
 
     init_input_shapes(shapes.first);
 
-    function = ngraph::builder::subgraph::NormalizeL2Function::getOriginal(
+    function = ov::builder::subgraph::NormalizeL2Function::getOriginal(
         precision,
         shapes,
         ov::element::u8,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/pad_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/pad_transformation.cpp
@@ -39,7 +39,7 @@ void PadTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::PadFunction::get(
+    function = ov::builder::subgraph::PadFunction::get(
         inputShape,
         netPrecision,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/prelu_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/prelu_transformation.cpp
@@ -39,7 +39,7 @@ void PReluTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::PReluFunction::getOriginal(inputShape, precision, testValues.fakeQuantize);
+    function = ov::builder::subgraph::PReluFunction::getOriginal(inputShape, precision, testValues.fakeQuantize);
 
     ov::pass::InitNodeInfo().run_on_model(function);
 }

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/pull_reshape_through_dequantization_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/pull_reshape_through_dequantization_transformation.cpp
@@ -62,7 +62,7 @@ void PullReshapeThroughDequantizationTransformation::SetUp() {
         testValues.dequantizationOnWeights.multiply.constantShape = elementwiseConstantShapes;
     }
 
-    function = ngraph::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
+    function = ov::builder::subgraph::FakeQuantizeAndConvolutionFunction::get(
         testValues.precisionBeforeDequantization,
         inputShape,
         testValues.fakeQuantizeOnData,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/recurrent_cell_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/recurrent_cell_transformation.cpp
@@ -48,7 +48,7 @@ void RecurrentCellTransformation::SetUp() {
 
     init_input_shapes(activations_shapes);
 
-    function = ngraph::builder::subgraph::RecurrentCellFunction::get(precision,
+    function = ov::builder::subgraph::RecurrentCellFunction::get(precision,
                                                                       activations_shapes,
                                                                       weights_shapes,
                                                                       param.RNNType,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_max_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_max_transformation.cpp
@@ -39,11 +39,11 @@ void ReduceMaxTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations::Convert convert;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
 
-    function = ngraph::builder::subgraph::ReduceFunction::get<ov::op::v1::ReduceMax>(
+    function = ov::builder::subgraph::ReduceFunction::get<ov::op::v1::ReduceMax>(
         netPrecision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_mean_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_mean_transformation.cpp
@@ -51,7 +51,7 @@ void ReduceMeanTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::ReduceFunction::get<ov::op::v1::ReduceMean>(
+    function = ov::builder::subgraph::ReduceFunction::get<ov::op::v1::ReduceMean>(
         netPrecision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_min_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_min_transformation.cpp
@@ -39,11 +39,11 @@ void ReduceMinTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations::Convert convert;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
 
-    function = ngraph::builder::subgraph::ReduceFunction::get<ov::op::v1::ReduceMin>(
+    function = ov::builder::subgraph::ReduceFunction::get<ov::op::v1::ReduceMin>(
         netPrecision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_sum_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reduce_sum_transformation.cpp
@@ -40,11 +40,11 @@ void ReduceSumTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    ngraph::builder::subgraph::DequantizationOperations::Convert convert;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore;
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+    ov::builder::subgraph::DequantizationOperations::Convert convert;
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore;
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter;
 
-    function = ngraph::builder::subgraph::ReduceFunction::get<ov::op::v1::ReduceSum>(
+    function = ov::builder::subgraph::ReduceFunction::get<ov::op::v1::ReduceSum>(
         netPrecision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/relu_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/relu_transformation.cpp
@@ -40,7 +40,7 @@ void ReluTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::ReluFunction::getOriginal(inputShape, precision, testValues.fakeQuantize);
+    function = ov::builder::subgraph::ReluFunction::getOriginal(inputShape, precision, testValues.fakeQuantize);
 
     ov::pass::InitNodeInfo().run_on_model(function);
 }

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/reshape_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/reshape_transformation.cpp
@@ -40,7 +40,7 @@ void ReshapeTransformation::SetUp() {
 
     init_input_shapes(param.inputShape);
 
-    function = ngraph::builder::subgraph::ReshapeFunction::getOriginal(
+    function = ov::builder::subgraph::ReshapeFunction::getOriginal(
         param.inputShape,
         param.reshapeConstValues,
         netPrecision,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/shuffle_channels_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/shuffle_channels_transformation.cpp
@@ -41,7 +41,7 @@ void ShuffleChannelsTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::ShuffleChannelsFunction::getOriginal(
+    function = ov::builder::subgraph::ShuffleChannelsFunction::getOriginal(
         netPrecision,
         inputShape,
         param.fakeQuantizeOnData,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/space_to_batch_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/space_to_batch_transformation.cpp
@@ -31,7 +31,7 @@ void SpaceToBatchTransformation::SetUp() {
 
     init_input_shapes(param.input_shape);
 
-    function = ngraph::builder::subgraph::SpaceToBatchFunction::get(
+    function = ov::builder::subgraph::SpaceToBatchFunction::get(
         param.input_shape,
         input_type,
         param.fake_quantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/split_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/split_transformation.cpp
@@ -39,7 +39,7 @@ void SplitTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::SplitFunction::getOriginal(
+    function = ov::builder::subgraph::SplitFunction::getOriginal(
         precision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/squeeze_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/squeeze_transformation.cpp
@@ -57,7 +57,7 @@ void SqueezeTransformation::SetUp() {
 
     init_input_shapes(squeezeParam.shape);
 
-    function = ngraph::builder::subgraph::SqueezeFunction::getOriginal(
+    function = ov::builder::subgraph::SqueezeFunction::getOriginal(
         netPrecision,
         squeezeParam.shape,
         squeezeParam.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/strided_slice_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/strided_slice_transformation.cpp
@@ -49,7 +49,7 @@ void StridedSliceTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::StridedSliceFunction::getOriginal(
+    function = ov::builder::subgraph::StridedSliceFunction::getOriginal(
         netPrecision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/subtract_multiply_to_multiply_add_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/subtract_multiply_to_multiply_add_transformation.cpp
@@ -34,7 +34,7 @@ void SubtractMultiplyToMultiplyAddTransformation::SetUp() {
 
     init_input_shapes(testValues.inputShape);
 
-    function = ngraph::builder::subgraph::SubtractMultiplyToMultiplyAddFunction::getOriginal(
+    function = ov::builder::subgraph::SubtractMultiplyToMultiplyAddFunction::getOriginal(
         testValues.inputShape,
         testValues.precision,
         testValues.fqOnData);

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/subtract_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/subtract_transformation.cpp
@@ -35,7 +35,7 @@ void SubtractTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::SubtractFunction::getOriginal(netPrecision, inputShape);
+    function = ov::builder::subgraph::SubtractFunction::getOriginal(netPrecision, inputShape);
 }
 
 TEST_P(SubtractTransformation, CompareWithRefImpl) {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/transpose_after_matmul_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/transpose_after_matmul_transformation.cpp
@@ -47,7 +47,7 @@ void TransposeAfterMatMulTransformation::SetUp() {
 
     init_input_shapes({ inputShape, inputShape });
 
-    function = ngraph::builder::subgraph::TransposeAfterMatMulFunction::getOriginal(precision, inputShape);
+    function = ov::builder::subgraph::TransposeAfterMatMulFunction::getOriginal(precision, inputShape);
 }
 
 TEST_P(TransposeAfterMatMulTransformation, CompareWithRefImpl) {

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/transpose_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/transpose_transformation.cpp
@@ -36,7 +36,7 @@ void TransposeTransformation::SetUp() {
 
     init_input_shapes(testValues.inputShape);
 
-    function = ngraph::builder::subgraph::TransposeFunction::getOriginal(
+    function = ov::builder::subgraph::TransposeFunction::getOriginal(
         testValues.inputShape,
         testValues.transposeConstValues,
         testValues.precisionBeforeFq,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/unsqueeze_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/unsqueeze_transformation.cpp
@@ -58,7 +58,7 @@ void UnsqueezeTransformation::SetUp() {
 
     init_input_shapes(unsqueezeParam.shape);
 
-    function = ngraph::builder::subgraph::UnsqueezeFunction::getOriginal(
+    function = ov::builder::subgraph::UnsqueezeFunction::getOriginal(
         netPrecision,
         unsqueezeParam.shape,
         unsqueezeParam.fakeQuantize,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/variadic_split_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/variadic_split_transformation.cpp
@@ -46,7 +46,7 @@ void VariadicSplitTransformation::SetUp() {
 
     init_input_shapes(inputShape);
 
-    function = ngraph::builder::subgraph::VariadicSplitFunction::getOriginal(
+    function = ov::builder::subgraph::VariadicSplitFunction::getOriginal(
         precision,
         inputShape,
         param.fakeQuantize,

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/add.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/add.hpp
@@ -14,7 +14,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -65,9 +65,9 @@ public:
         const bool broadcast,
         const ov::pass::low_precision::LayerTransformation::Params& params,
         const ov::element::Type& precision1,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
+        const ov::builder::subgraph::DequantizationOperations& dequantization1,
         const ov::element::Type& precision2,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization2,
+        const ov::builder::subgraph::DequantizationOperations& dequantization2,
         const int constInput,
         const std::vector<float>& constValues,
         const std::string& additionalLayer,
@@ -77,8 +77,8 @@ public:
         const ov::element::Type precision,
         const ov::PartialShape& inputShape,
         const bool broadcast,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData1,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData2);
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnData1,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnData2);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type precision,
@@ -87,10 +87,10 @@ public:
         const bool broadcast,
         const ov::pass::low_precision::LayerTransformation::Params& params,
         const ov::element::Type& precision1,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
+        const ov::builder::subgraph::DequantizationOperations& dequantization1,
         const ov::element::Type& precision2,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization2,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+        const ov::builder::subgraph::DequantizationOperations& dequantization2,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
         const int constInput,
         const std::vector<float>& constValues,
         const std::string& additionalLayer,
@@ -100,4 +100,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/align_concat_quantization_parameters.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/align_concat_quantization_parameters.hpp
@@ -10,7 +10,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,7 +22,7 @@ public:
         const ov::Shape& inputShape,
         const bool addFQ,
         const std::string additionalLayer,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type precision,
@@ -30,11 +30,11 @@ public:
         const ov::Shape& inputShape,
         const bool addFQ,
         const std::string additionalLayer,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/assign_and_read_value.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/assign_and_read_value.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,12 +22,12 @@ public:
         const size_t opsetVersion,
         const bool FQAfterReadValue,
         const std::vector<float>& constantValue,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type originalFunctionPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize,
+        const ov::builder::subgraph::FakeQuantizeOnData fakeQuantize,
         const size_t opsetVersion);
 
     static std::shared_ptr<ov::Model> getReference(
@@ -37,9 +37,9 @@ public:
         const size_t opsetVersion,
         const bool FQAfterReadValue,
         const std::vector<float>& constantValue,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/avg_pool.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/avg_pool.hpp
@@ -10,7 +10,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,7 +22,7 @@ public:
         const ov::PartialShape& inputShape,
         const bool addFQ,
         const std::vector<std::string>& additionalLayers,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type originalFunctionPrecision,
@@ -35,12 +35,12 @@ public:
         const ov::PartialShape& inputShape,
         const bool addFQ,
         const std::vector<std::string>& additionalLayers,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationEnd);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationEnd);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/batch_to_space.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/batch_to_space.hpp
@@ -8,7 +8,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,13 +23,13 @@ public:
 
     static std::shared_ptr<ov::Model> get(const ov::PartialShape& input_shape,
                                                  const ov::element::Type input_type,
-                                                 const ngraph::builder::subgraph::DequantizationOperations& dequantization_before,
+                                                 const ov::builder::subgraph::DequantizationOperations& dequantization_before,
                                                  const std::vector<size_t>& block_shape,
                                                  const std::vector<size_t>& crops_begin,
                                                  const std::vector<size_t>& crops_end,
-                                                 const ngraph::builder::subgraph::DequantizationOperations& dequantization_after = {});
+                                                 const ov::builder::subgraph::DequantizationOperations& dequantization_after = {});
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/clamp.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/clamp.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -18,7 +18,7 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getWithNonDequantizationMultiply(
         const ov::PartialShape& inputShape,
@@ -27,17 +27,17 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type originalFunctionPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize,
+        const ov::builder::subgraph::FakeQuantizeOnData fakeQuantize,
         const double clampLowConst,
         const double clampHighConst);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/add.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/add.hpp
@@ -9,7 +9,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -32,4 +32,4 @@ private:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/builders.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/builders.hpp
@@ -20,7 +20,7 @@
 #include "ov_lpt_models/common/reshape.hpp"
 #include "ov_lpt_models/common/transpose.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -106,4 +106,4 @@ std::shared_ptr<Node> makeConvolution(
 
 } // namespace subgraph
 } // namespace builder
-} // namespace ngraph
+} // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/constant.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/constant.hpp
@@ -11,7 +11,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -53,4 +53,4 @@ inline std::ostream& operator<<(std::ostream& out, const Constant& constant) {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/convolution.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/convolution.hpp
@@ -10,7 +10,7 @@
 #include "constant.hpp"
 #include "dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -32,4 +32,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/dequantization_operations.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/dequantization_operations.hpp
@@ -7,7 +7,7 @@
 #include "fake_quantize_on_data.hpp"
 #include "openvino/core/node.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -159,4 +159,4 @@ inline std::ostream& operator<<(std::ostream& out, const DequantizationOperation
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/fake_quantize_on_data.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/fake_quantize_on_data.hpp
@@ -11,7 +11,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -113,4 +113,4 @@ inline std::ostream& operator<<(std::ostream& out, const FakeQuantizeOnDataWithC
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/fake_quantize_on_weights.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/fake_quantize_on_weights.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 #include "fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -37,4 +37,4 @@ inline std::ostream& operator<<(std::ostream& out, const FakeQuantizeOnWeights& 
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/multiply.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/multiply.hpp
@@ -9,7 +9,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -32,4 +32,4 @@ private:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/reshape.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/reshape.hpp
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -25,4 +25,4 @@ private:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/transpose.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/transpose.hpp
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -24,4 +24,4 @@ private:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/compose_fake_quantize.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/compose_fake_quantize.hpp
@@ -8,7 +8,7 @@
 
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -17,11 +17,11 @@ public:
     static std::shared_ptr<ov::Model> get(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization2);
+        const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
+        const ov::builder::subgraph::DequantizationOperations& dequantization1,
+        const ov::builder::subgraph::DequantizationOperations& dequantization2);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/concat.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/concat.hpp
@@ -10,7 +10,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -297,4 +297,4 @@ private:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/convolution.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/convolution.hpp
@@ -12,7 +12,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,10 +22,10 @@ public:
         const ov::element::Type netPrecision,
         const ov::element::Type inputPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
         std::shared_ptr<ov::opset1::Constant> weights,
-        const ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnWeights = DequantizationOperations(),
+        const ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationOnWeights = DequantizationOperations(),
         const bool fqOnWeightsTransposeOnData = false,
         const bool fqOnWeightsTransposeOnInputLow = false,
         const bool fqOnWeightsTransposeOnInputHigh = false,
@@ -35,44 +35,44 @@ public:
     static std::shared_ptr<ov::Model> getOriginalWithIncorrectWeights(
         const ov::Shape& inputShape,
         ov::element::Type precision,
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
-        ngraph::builder::subgraph::DequantizationOperations dequantization,
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
+        ov::builder::subgraph::DequantizationOperations dequantization,
         bool isCrorrect);
 
     static std::shared_ptr<ov::Model> getOriginalWithIncorrectWeights(
         const ov::PartialShape& inputShape,
         ov::element::Type precision,
-        ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
-        ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData,
+        ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
+        ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData,
         bool isCorrect);
 
     static std::shared_ptr<ov::Model> getReferenceWithIncorrectWeights(
         const ov::Shape& inputShape,
         ov::element::Type inputPrecision,
-        ngraph::builder::subgraph::DequantizationOperations dequantizationBefore,
+        ov::builder::subgraph::DequantizationOperations dequantizationBefore,
         ov::element::Type weightsPrecision,
         std::vector<float> weightsValues,
-        ngraph::builder::subgraph::DequantizationOperations dequantizationAfter);
+        ov::builder::subgraph::DequantizationOperations dequantizationAfter);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type netPrecision,
         const ov::element::Type inputPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         std::shared_ptr<ov::opset1::Constant> weights,
-        const ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
+        const ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
         const ov::element::Type precisionAfterDequantization);
 
     static std::shared_ptr<ov::Model> get(
         const ov::Shape& inputShape,
         const ov::element::Type precision,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
+        const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
         const std::vector<float>& weightsValues,
-        const ngraph::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+        const ov::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
         const std::vector<ov::pass::low_precision::QuantizationGranularityRestriction>& restrictions = {});
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/convolution_backprop_data.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/convolution_backprop_data.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -55,4 +55,4 @@ public:
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/depth_to_space.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/depth_to_space.hpp
@@ -12,7 +12,7 @@
 #include "openvino/op/depth_to_space.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -29,18 +29,18 @@ public:
         const ov::op::v0::DepthToSpace::DepthToSpaceMode mode,
         const size_t blockSize,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::PartialShape& inputShape,
         const ov::op::v0::DepthToSpace::DepthToSpaceMode mode,
         const size_t blockSize,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/elementwise.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/elementwise.hpp
@@ -12,7 +12,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,15 +23,15 @@ public:
         const ov::PartialShape& inputShape,
         const bool broadcast,
         const std::string& elementWiseType,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore1,
-        const ngraph::builder::subgraph::Convolution& convolution1,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter1,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore2,
-        const ngraph::builder::subgraph::Convolution& convolution2,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter2,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter);
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore1,
+        const ov::builder::subgraph::Convolution& convolution1,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter1,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore2,
+        const ov::builder::subgraph::Convolution& convolution2,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter2,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/elementwise_with_multi_parent_dequantization.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/elementwise_with_multi_parent_dequantization.hpp
@@ -11,7 +11,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -60,11 +60,11 @@ public:
         const ov::Shape& inputShape,
         const ov::pass::low_precision::LayerTransformation::Params& params,
         const ov::element::Type& precision1,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
+        const ov::builder::subgraph::DequantizationOperations& dequantization1,
         const ov::element::Type& precision2,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization2);
+        const ov::builder::subgraph::DequantizationOperations& dequantization2);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize.hpp
@@ -11,7 +11,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -36,10 +36,10 @@ public:
         const bool updatePrecisions,
         const FakeQuantizeOnDataWithConstant& fakeQuantizeOnData,
         const ov::element::Type fakeQuantizeOutputPrecision,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const bool addNotPrecisionPreservedOperation);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_and_convolution.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_and_convolution.hpp
@@ -15,7 +15,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -62,4 +62,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_and_two_output_branches_with_convolution.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_and_two_output_branches_with_convolution.hpp
@@ -11,7 +11,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -28,14 +28,14 @@ public:
         const ov::element::Type precision,
         const ov::Shape& inputShape,
         const ov::pass::low_precision::LayerTransformation::Params& params,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnData,
         const ov::element::Type precisionBeforeOp,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOp,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter1,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter2);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter1,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter2);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_on_weights_and_unsupported_child.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_on_weights_and_unsupported_child.hpp
@@ -9,7 +9,7 @@
 #include <low_precision/layer_transformation.hpp>
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -19,9 +19,9 @@ static std::shared_ptr<ov::Model> get(
     const ov::Shape& inputShape,
     const ov::element::Type inputPrecision,
     const std::shared_ptr<ov::op::v0::Constant> weights,
-    const ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights);
+    const ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_precision_selection.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fake_quantize_precision_selection.hpp
@@ -11,7 +11,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -53,4 +53,4 @@ inline std::ostream& operator<<(std::ostream& out, const FakeQuantizePrecisionSe
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fold_fake_quantize.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fold_fake_quantize.hpp
@@ -9,7 +9,7 @@
 #include "low_precision/layer_transformation.hpp"
 #include "common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -29,4 +29,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_convert.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_convert.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -18,17 +18,17 @@ public:
     static std::shared_ptr<ov::Model> get(
             const ov::PartialShape& inputShape,
             const ov::element::Type inputPrecision,
-            const ngraph::builder::subgraph::DequantizationOperations& dequantization,
-            const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantize,
+            const ov::builder::subgraph::DequantizationOperations& dequantization,
+            const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantize,
             const bool constInput);
 
     static std::shared_ptr<ov::Model> getWithFQ(
             const ov::PartialShape& inputShape,
             const ov::element::Type inputPrecision,
-            const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+            const ov::builder::subgraph::DequantizationOperations& dequantization,
             const bool constInput);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_fake_quantize.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_fake_quantize.hpp
@@ -11,7 +11,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -20,7 +20,7 @@ public:
     class Branch {
     public:
         ov::element::Type precisionBeforeDequantization;
-        ngraph::builder::subgraph::DequantizationOperations dequantization;
+        ov::builder::subgraph::DequantizationOperations dequantization;
         ov::element::Type precisionAfterDequantization;
     };
 
@@ -60,4 +60,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_fake_quantize_and_scale_shift.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_fake_quantize_and_scale_shift.hpp
@@ -9,7 +9,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "openvino/core/partial_shape.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,4 +23,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_multiply_to_fake_quantize.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_multiply_to_fake_quantize.hpp
@@ -11,7 +11,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -25,4 +25,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_subtract_to_fake_quantize.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/fuse_subtract_to_fake_quantize.hpp
@@ -11,7 +11,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -32,4 +32,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/gather.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/gather.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,7 +22,7 @@ public:
         const std::vector<int>& axis,
         const int64_t batch_dims,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const int opset_version);
 
     static std::shared_ptr<ov::Model> getOriginal(
@@ -42,12 +42,12 @@ public:
         const std::vector<int>& axis,
         const int64_t batch_dims,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
         const int opset_version);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/get_dequantization.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/get_dequantization.hpp
@@ -10,7 +10,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -20,7 +20,7 @@ public:
         const ov::element::Type& precision,
         const Shape& shape,
         const FakeQuantizeOnData& fakeQuantize,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore);
 
     static std::shared_ptr<ov::Model> get(
         const ov::element::Type& precision,
@@ -36,4 +36,4 @@ public:
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/group_convolution.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/group_convolution.hpp
@@ -10,7 +10,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,9 +22,9 @@ public:
         const ov::Shape& outputShape,
         const size_t groupCount,
         const int groupCalculationDimention,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         std::shared_ptr<ov::op::v0::Constant> weightsConst,
-        const ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights);
+        const ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type precision,
@@ -43,16 +43,16 @@ public:
         const ov::PartialShape& outputShape,
         const size_t groupCount,
         const int calculatedDimention,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         std::shared_ptr<ov::op::v0::Constant> weightsConst,
-        const ngraph::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
+        const ov::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
         const ov::element::Type precisionAfterDequantization,
         const bool addReshape);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/interpolate.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/interpolate.hpp
@@ -10,7 +10,7 @@
 #include "openvino/core/model.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -21,7 +21,7 @@ public:
         const ov::Shape& outputShape,
         const ov::op::v0::Interpolate::Attributes& interpAttrs,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type precision,
@@ -34,9 +34,9 @@ public:
         const ov::Shape& outputShape,
         const ov::op::v0::Interpolate::Attributes& interpAttrs,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 
     // v4::Interpolate
     static std::shared_ptr<ov::Model> getOriginal(
@@ -45,7 +45,7 @@ public:
         const ov::Shape& scalesShape,
         const ov::op::v4::Interpolate::InterpolateAttrs& interp4Attrs,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type precision,
@@ -60,11 +60,11 @@ public:
         const ov::Shape& scalesShape,
         const ov::op::v4::Interpolate::InterpolateAttrs& interp4Attrs,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/markup_avg_pool_precisions.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/markup_avg_pool_precisions.hpp
@@ -10,7 +10,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,7 +22,7 @@ public:
         const ov::Shape& inputShape,
         const bool addFQ,
         const std::string additionalLayer,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         // -1 - no Convolution
         const int convoutionBranch,
         // -1 - no FakeQuantize
@@ -39,11 +39,11 @@ public:
         const ov::Shape& inputShape,
         const bool addFQ,
         const std::string additionalLayer,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/markup_bias.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/markup_bias.hpp
@@ -9,7 +9,7 @@
 
 #include "common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,4 +23,4 @@ public:
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/mat_mul.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/mat_mul.hpp
@@ -10,7 +10,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 #include "ov_lpt_models/common/constant.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -82,4 +82,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/mat_mul_with_optimized_constant_fake_quantize.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/mat_mul_with_optimized_constant_fake_quantize.hpp
@@ -9,7 +9,7 @@
 #include "openvino/core/partial_shape.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -25,4 +25,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/max_pool.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/max_pool.hpp
@@ -9,7 +9,7 @@
 #include "low_precision/layer_transformation.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,11 +23,11 @@ public:
     static std::shared_ptr<ov::Model> get(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/move_dequantization_after.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/move_dequantization_after.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_models/subgraph_builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -18,16 +18,16 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantization);
+        const ov::builder::subgraph::DequantizationOperations dequantization);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/move_fake_quantize.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/move_fake_quantize.hpp
@@ -10,7 +10,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -35,4 +35,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/mul_add_to_scaleshift_or_power.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/mul_add_to_scaleshift_or_power.hpp
@@ -10,7 +10,7 @@
 #include "common/dequantization_operations.hpp"
 #include "common/add.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -20,18 +20,18 @@ public:
         const ov::element::Type precision,
         const ov::Shape& inputShape,
         bool isDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations::Multiply& mulValues,
-        const ngraph::builder::subgraph::Add& addValues);
+        const ov::builder::subgraph::DequantizationOperations::Multiply& mulValues,
+        const ov::builder::subgraph::Add& addValues);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
         bool isDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations::Multiply& weightsValues,
-        const ngraph::builder::subgraph::Add& biasesValues,
+        const ov::builder::subgraph::DequantizationOperations::Multiply& weightsValues,
+        const ov::builder::subgraph::Add& biasesValues,
         const ov::element::Type precisionAfterOperation);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/multiply.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/multiply.hpp
@@ -10,17 +10,17 @@
 #include "ov_lpt_models/common/constant.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 class MultiplyBranch {
 public:
     MultiplyBranch(const PartialShape& inputShape,
-                   const ngraph::builder::subgraph::Constant& constant,
+                   const ov::builder::subgraph::Constant& constant,
                    const ov::element::Type& input_precision,
-                   const ngraph::builder::subgraph::DequantizationOperations& dequantization,
-                   const ngraph::builder::subgraph::FakeQuantizeOnData& fake_quantize)
+                   const ov::builder::subgraph::DequantizationOperations& dequantization,
+                   const ov::builder::subgraph::FakeQuantizeOnData& fake_quantize)
                    : inputShape(inputShape),
                      constant(constant),
                      input_precision(input_precision),
@@ -28,22 +28,22 @@ public:
                      fake_quantize(fake_quantize) {}
 
     PartialShape inputShape;
-    ngraph::builder::subgraph::Constant constant;
+    ov::builder::subgraph::Constant constant;
     ov::element::Type input_precision;
-    ngraph::builder::subgraph::DequantizationOperations dequantization;
-    ngraph::builder::subgraph::FakeQuantizeOnData fake_quantize;
+    ov::builder::subgraph::DequantizationOperations dequantization;
+    ov::builder::subgraph::FakeQuantizeOnData fake_quantize;
 };
 
 class MultiplyValues {
 public:
     MultiplyValues(const MultiplyBranch& branch1,
                    const MultiplyBranch& branch2,
-                   const ngraph::builder::subgraph::DequantizationOperations& after_dequantization)
+                   const ov::builder::subgraph::DequantizationOperations& after_dequantization)
                    : branch1(branch1), branch2(branch2), after_dequantization(after_dequantization) {}
 
     MultiplyBranch branch1;
     MultiplyBranch branch2;
-    ngraph::builder::subgraph::DequantizationOperations after_dequantization;
+    ov::builder::subgraph::DequantizationOperations after_dequantization;
 };
 
 class MultiplyFunction : public ElementwiseFunction {
@@ -53,4 +53,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/multiply_partial_function.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/multiply_partial_function.hpp
@@ -10,16 +10,16 @@
 #include "ov_lpt_models/common/constant.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 class MultiplyPartialBranch {
 public:
     PartialShape inputShape;
-    ngraph::builder::subgraph::Constant constant;
+    ov::builder::subgraph::Constant constant;
     ov::element::Type precisionBeforeDequantization;
-    ngraph::builder::subgraph::DequantizationOperations dequantization;
+    ov::builder::subgraph::DequantizationOperations dequantization;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const MultiplyPartialBranch& branch) {
@@ -47,13 +47,13 @@ public:
         const ov::element::Type precision,
         const ov::PartialShape& inputShape,
         const bool broadcast1,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fq1,
+        const ov::builder::subgraph::FakeQuantizeOnData& fq1,
         const bool broadcast2,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fq2,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqAfter,
+        const ov::builder::subgraph::FakeQuantizeOnData& fq2,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqAfter,
         const bool secondInputIsConstant = false);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/multiply_to_group_convolution.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/multiply_to_group_convolution.hpp
@@ -11,7 +11,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -20,7 +20,7 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
         const ov::element::Type& precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const bool haveMultiplyWithNoConstBeforeDequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
@@ -35,9 +35,9 @@ public:
         const ov::element::Type& precision,
         const std::shared_ptr<ov::op::v0::Constant>& weights,
         const std::shared_ptr<ov::op::v0::Constant>& biases,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/multiply_with_one_parent.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/multiply_with_one_parent.hpp
@@ -9,7 +9,7 @@
 #include "openvino/core/partial_shape.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,4 +23,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/mvn.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/mvn.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -19,7 +19,7 @@ public:
         const ov::AxisSet& reductionAxes,
         const bool& normalizeVariance,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const int opset_version);
 
     static std::shared_ptr<ov::Model> getOriginal(
@@ -34,12 +34,12 @@ public:
         const ov::AxisSet& reductionAxes,
         const bool& normalizeVariance,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
         const int opset_version);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/normalize_dequantization.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/normalize_dequantization.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -16,9 +16,9 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantization);
+        const ov::builder::subgraph::DequantizationOperations dequantization);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/normalize_l2.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/normalize_l2.hpp
@@ -12,7 +12,7 @@
 
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -32,7 +32,7 @@ public:
         const ov::PartialShape& shape,
         const ov::op::EpsMode& epsMode,
         const std::vector<size_t>& axes,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type precision,
@@ -40,11 +40,11 @@ public:
         const ov::PartialShape& shape,
         const ov::op::EpsMode& epsMode,
         const std::vector<size_t>& axes,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/pad.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/pad.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -37,4 +37,4 @@ static std::shared_ptr<ov::Model> get(
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/precision_propagation.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/precision_propagation.hpp
@@ -10,7 +10,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -47,4 +47,4 @@ private:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/prelu.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/prelu.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -16,7 +16,7 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
@@ -26,11 +26,11 @@ public:
     static std::shared_ptr<ov::Model> getReference(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/recurrent_cell.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/recurrent_cell.hpp
@@ -10,7 +10,7 @@
 #include "common/fake_quantize_on_data.hpp"
 #include "common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -36,4 +36,4 @@ std::shared_ptr<Node> makeQuantizationAndDequantization(const std::shared_ptr<No
                                                         const DequantizationOperations& dequantization);
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/reduce.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/reduce.hpp
@@ -11,7 +11,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_lpt_models/common/constant.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -21,7 +21,7 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type precision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const std::vector<int64_t>& constantValues,
         const bool keepDims) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
@@ -54,12 +54,12 @@ public:
     static std::shared_ptr<ov::Model> get(
         const ov::element::Type precision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData,
-        const ngraph::builder::subgraph::DequantizationOperations::Convert& convert,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnData,
+        const ov::builder::subgraph::DequantizationOperations::Convert& convert,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const std::vector<int64_t>& constantValues,
         const bool keepDims,
-        ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+        ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
         std::shared_ptr<ov::Node> parent = input;
 
@@ -100,11 +100,11 @@ public:
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type precision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const std::vector<int64_t>& constantValues,
         const bool keepDims,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
         const auto dequantization = makeDequantization(input, dequantizationBefore);
 
@@ -134,4 +134,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/relu.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/relu.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -16,7 +16,7 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
@@ -26,11 +26,11 @@ public:
     static std::shared_ptr<ov::Model> getReference(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/reshape.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/reshape.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -19,7 +19,7 @@ public:
         const ov::PartialShape& inputShape,
         const std::vector<int>& reshapeConstValues,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
@@ -31,11 +31,11 @@ public:
         const ov::PartialShape& inputShape,
         const std::vector<int>& reshapeConstValues,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/round.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/round.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_models/subgraph_builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -18,14 +18,14 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantization);
+        const ov::builder::subgraph::DequantizationOperations dequantization);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantization);
+        const ov::builder::subgraph::DequantizationOperations dequantization);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/shuffle_channels.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/shuffle_channels.hpp
@@ -10,7 +10,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -19,27 +19,27 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type inputPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations& deqBefore,
+        const ov::builder::subgraph::DequantizationOperations& deqBefore,
         const std::int64_t axis,
         const std::int64_t group);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type inputPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnData,
         const std::int64_t axis,
         const std::int64_t group);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::element::Type inputPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations& deqBefore,
+        const ov::builder::subgraph::DequantizationOperations& deqBefore,
         const std::int64_t axis,
         const std::int64_t group,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& deqAfter);
+        const ov::builder::subgraph::DequantizationOperations& deqAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/space_to_batch.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/space_to_batch.hpp
@@ -8,7 +8,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,13 +23,13 @@ public:
 
     static std::shared_ptr<ov::Model> get(const ov::PartialShape& input_shape,
                                                  const ov::element::Type input_type,
-                                                 const ngraph::builder::subgraph::DequantizationOperations& dequantization_before,
+                                                 const ov::builder::subgraph::DequantizationOperations& dequantization_before,
                                                  const std::vector<size_t>& block_shape,
                                                  const std::vector<size_t>& pads_begin,
                                                  const std::vector<size_t>& pads_end,
-                                                 const ngraph::builder::subgraph::DequantizationOperations& dequantization_after);
+                                                 const ov::builder::subgraph::DequantizationOperations& dequantization_after);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/split.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/split.hpp
@@ -12,7 +12,7 @@
 
 
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,14 +22,14 @@ public:
         const ov::element::Type& precision,
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const int64_t splitedAxis,
         const size_t numSplits);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type originalFunctionPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize,
+        const ov::builder::subgraph::FakeQuantizeOnData fakeQuantize,
         const int64_t splitedAxis,
         const size_t numSplit);
 
@@ -37,12 +37,12 @@ public:
         const ov::element::Type& precision,
         const ov::PartialShape& inputShape,
         const ov::element::Type inputPrecision,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const std::vector<ngraph::builder::subgraph::DequantizationOperations>& dequantizationAfter,
+        const std::vector<ov::builder::subgraph::DequantizationOperations>& dequantizationAfter,
         const int64_t splitedAxis,
         const size_t numSplits);
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/squeeze.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/squeeze.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -17,7 +17,7 @@ public:
         const ov::PartialShape& inputShape,
         const std::vector<float>& axes,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type originalFunctionPrecision,
@@ -29,11 +29,11 @@ public:
         const ov::PartialShape& inputShape,
         const std::vector<float>& axes,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/strided_slice.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/strided_slice.hpp
@@ -10,7 +10,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -19,7 +19,7 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type inputPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const std::vector<int64_t>& begin,
         const std::vector<int64_t>& end,
         const std::vector<int64_t>& strides,
@@ -32,7 +32,7 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type inputPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantize,
+        const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantize,
         const std::vector<int64_t>& begin,
         const std::vector<int64_t>& end,
         const std::vector<int64_t>& strides,
@@ -53,11 +53,11 @@ public:
         const std::vector<int64_t>& newAxisMask,
         const std::vector<int64_t>& shrinkAxisMask,
         const std::vector<int64_t>& elipsisMask,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/subtract.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/subtract.hpp
@@ -10,7 +10,7 @@
 #include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,4 +23,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/subtract_multiply_to_multiply_add.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/subtract_multiply_to_multiply_add.hpp
@@ -12,7 +12,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/multiply.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -21,23 +21,23 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const ov::element::Type precisionAfterDequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
         const ov::element::Type precision,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData);
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnData);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const ov::element::Type precisionAfterDequantization,
-        const ngraph::builder::subgraph::Multiply& multiply,
-        const ngraph::builder::subgraph::Add& add);
+        const ov::builder::subgraph::Multiply& multiply,
+        const ov::builder::subgraph::Add& add);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/transformations_after_split.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/transformations_after_split.hpp
@@ -9,7 +9,7 @@
 
 #include "openvino/core/model.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,4 +23,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/transpose.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/transpose.hpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -19,7 +19,7 @@ public:
         const ov::PartialShape& inputShape,
         const std::vector<int>& transposeConstValues,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
@@ -31,11 +31,11 @@ public:
         const ov::PartialShape& inputShape,
         const std::vector<int>& transposeConstValues,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/transpose_after_mat_mul.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/transpose_after_mat_mul.hpp
@@ -10,7 +10,7 @@
 #include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,4 +23,4 @@ public:
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/unsqueeze.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/unsqueeze.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -17,7 +17,7 @@ public:
         const ov::PartialShape& inputShape,
         const std::vector<float>& axes,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization);
+        const ov::builder::subgraph::DequantizationOperations& dequantization);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type originalFunctionPrecision,
@@ -29,11 +29,11 @@ public:
         const ov::PartialShape& inputShape,
         const std::vector<float>& axes,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter);
+        const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/variadic_split.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/variadic_split.hpp
@@ -12,7 +12,7 @@
 
 
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -21,26 +21,26 @@ public:
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const int64_t splitedAxis,
         const std::vector<size_t>& splitLengths);
 
     static std::shared_ptr<ov::Model> getOriginal(
         const ov::element::Type originalFunctionPrecision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize,
+        const ov::builder::subgraph::FakeQuantizeOnData fakeQuantize,
         const int64_t splitedAxis,
         const std::vector<size_t>& splitLengths);
 
     static std::shared_ptr<ov::Model> getReference(
         const ov::PartialShape& inputShape,
         const ov::element::Type inputPrecision,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const std::vector<ngraph::builder::subgraph::DequantizationOperations>& dequantizationAfter,
+        const std::vector<ov::builder::subgraph::DequantizationOperations>& dequantizationAfter,
         const int64_t splitedAxis,
         const std::vector<size_t>& splitLengths);
 };
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/add.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/add.cpp
@@ -15,7 +15,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -34,7 +34,7 @@ std::shared_ptr<Node> configure_postops(const std::shared_ptr<Node>& parent,
         return parent;
     }
 
-    return ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(
+    return ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(
            res,
            precision,
            {256, Shape{}, { 0 }, { 255 }, { 0 }, { 255 }, element::u8});
@@ -48,9 +48,9 @@ std::shared_ptr<ov::Model> AddFunction::getOriginal(
     const bool broadcast,
     const ov::pass::low_precision::LayerTransformation::Params& params,
     const ov::element::Type& precision1,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
+    const ov::builder::subgraph::DequantizationOperations& dequantization1,
     const ov::element::Type& precision2,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization2,
+    const ov::builder::subgraph::DequantizationOperations& dequantization2,
     const int constInput,
     const std::vector<float>& constValues,
     const std::string& additionalLayer,
@@ -67,7 +67,7 @@ std::shared_ptr<ov::Model> AddFunction::getOriginal(
             additionalLayer != "" ? precision : (precision1.is_real() ? precision : precision1),
             broadcast ? ov::PartialShape({inputShape1[0], inputShape1[1], 1, 1}) : inputShape1);
         if (additionalLayer != "") {
-            parent1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(
+            parent1 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(
                 input1,
                 precision,
                 {256, Shape{}, {0}, {255}, {0}, {255}, precision1});
@@ -173,8 +173,8 @@ std::shared_ptr<ov::Model> AddFunction::getOriginal(
     const ov::element::Type precision,
     const ov::PartialShape& inputShape,
     const bool broadcast,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData1,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData2) {
+    const ov::builder::subgraph::FakeQuantizeOnData& fqOnData1,
+    const ov::builder::subgraph::FakeQuantizeOnData& fqOnData2) {
     ov::PartialShape inputShape2 = inputShape;
 
     if (broadcast) {
@@ -214,10 +214,10 @@ std::shared_ptr<ov::Model> AddFunction::getReference(
     const bool broadcast,
     const ov::pass::low_precision::LayerTransformation::Params& params,
     const ov::element::Type& precision1,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
+    const ov::builder::subgraph::DequantizationOperations& dequantization1,
     const ov::element::Type& precision2,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization2,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+    const ov::builder::subgraph::DequantizationOperations& dequantization2,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
     const int constInputIndex,
     const std::vector<float>& constValues,
     const std::string& additionalLayer,
@@ -235,7 +235,7 @@ std::shared_ptr<ov::Model> AddFunction::getReference(
             additionalLayer != "" ? precision : (precision1.is_real() ? precision : precision1),
             broadcast ? ov::PartialShape({inputShape1[0], inputShape1[1], 1, 1}) : inputShape1);
         if (additionalLayer != "") {
-            parent1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(
+            parent1 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(
                     input1,
                     precision,
                     {256, Shape{}, {0}, {255}, {0}, {255}, precision1});
@@ -352,4 +352,4 @@ std::shared_ptr<ov::Model> AddFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/align_concat_quantization_parameters.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/align_concat_quantization_parameters.cpp
@@ -12,7 +12,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_models/subgraph_builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,7 +22,7 @@ std::shared_ptr<ov::Model> AlignConcatQuantizationParametersFunction::getOrigina
     const ov::Shape& inputShape,
     const bool addFQ,
     const std::string additionalLayer,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore) {
     const auto input1 = std::make_shared<ov::opset1::Parameter>(inputPrecision, ov::Shape(inputShape));
     std::shared_ptr<ov::Node> parent1 = input1;
     {
@@ -129,9 +129,9 @@ std::shared_ptr<ov::Model> AlignConcatQuantizationParametersFunction::getReferen
     const ov::Shape& inputShape,
     const bool addFQ,
     const std::string additionalLayer,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input1 = std::make_shared<ov::opset1::Parameter>(inputPrecision, ov::Shape(inputShape));
     std::shared_ptr<ov::Node> parent1 = input1;
     {
@@ -240,4 +240,4 @@ std::shared_ptr<ov::Model> AlignConcatQuantizationParametersFunction::getReferen
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/assign_and_read_value.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/assign_and_read_value.cpp
@@ -18,7 +18,7 @@
 #include "low_precision/network_helper.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -32,7 +32,7 @@ std::shared_ptr<ov::Model> AssignAndReadValueFunction::getOriginal(
         const size_t opsetVersion,
         const bool FQAfterReadValue,
         const std::vector<float>& constantValue,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+        const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
     const auto defaultConstant = std::make_shared<ov::opset1::Constant>(inputPrecision, inputShape.get_shape(), constantValue);
     const auto variable = std::make_shared<Variable>(VariableInfo{inputShape.get_shape(), inputPrecision, "id"});
@@ -76,7 +76,7 @@ std::shared_ptr<ov::Model> AssignAndReadValueFunction::getOriginal(
 std::shared_ptr<ov::Model> AssignAndReadValueFunction::getOriginal(
         const ov::element::Type precision,
         const ov::PartialShape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize,
+        const ov::builder::subgraph::FakeQuantizeOnData fakeQuantize,
         const size_t opsetVersion) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, inputShape);
     const auto defaultConstant = std::make_shared<ov::opset1::Constant>(precision, inputShape.get_shape(), std::vector<float>{0});
@@ -126,8 +126,8 @@ std::shared_ptr<ov::Model> AssignAndReadValueFunction::getReference(
     const size_t opsetVersion,
     const bool FQAfterReadValue,
     const std::vector<float>& constantValue,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
     auto constantPrecision = precisionBeforeDequantization;
     if (constantValue != std::vector<float>{0}) {
@@ -187,4 +187,4 @@ std::shared_ptr<ov::Model> AssignAndReadValueFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/avg_pool.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/avg_pool.cpp
@@ -12,7 +12,7 @@
 #include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,7 +22,7 @@ std::shared_ptr<ov::Model> AvgPoolFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const bool addFQ,
     const std::vector<std::string>& additionalLayers,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
     std::shared_ptr<ov::Node> parent = input;
 
@@ -98,10 +98,10 @@ std::shared_ptr<ov::Model> AvgPoolFunction::getReference(
     const ov::PartialShape& inputShape,
     const bool addFQ,
     const std::vector<std::string>& additionalLayers,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationEnd) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationEnd) {
     auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
 
     const auto deqBefore = makeDequantization(input, dequantizationBefore);
@@ -158,4 +158,4 @@ std::shared_ptr<ov::Model> AvgPoolFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/batch_to_space.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/batch_to_space.cpp
@@ -7,7 +7,7 @@
 #include "openvino/opsets/opset2.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -35,11 +35,11 @@ std::shared_ptr<ov::Model> BatchToSpaceFunction::get(const ov::PartialShape& inp
 
 std::shared_ptr<ov::Model> BatchToSpaceFunction::get(const ov::PartialShape& input_shape,
                                                             const ov::element::Type input_type,
-                                                            const ngraph::builder::subgraph::DequantizationOperations& dequantization_before,
+                                                            const ov::builder::subgraph::DequantizationOperations& dequantization_before,
                                                             const std::vector<size_t>& block_shape,
                                                             const std::vector<size_t>& crops_begin,
                                                             const std::vector<size_t>& crops_end,
-                                                            const ngraph::builder::subgraph::DequantizationOperations& dequantization_after) {
+                                                            const ov::builder::subgraph::DequantizationOperations& dequantization_after) {
     const auto input = std::make_shared<ov::opset1::Parameter>(input_type, input_shape);
 
     std::shared_ptr<Node> parent = dequantization_before.empty() ?
@@ -60,4 +60,4 @@ std::shared_ptr<ov::Model> BatchToSpaceFunction::get(const ov::PartialShape& inp
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/clamp.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/clamp.cpp
@@ -13,14 +13,14 @@
 #include "low_precision/network_helper.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 std::shared_ptr<ov::Model> ClampFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> dequantizationOp = makeDequantization(input, dequantization);
@@ -34,7 +34,7 @@ std::shared_ptr<ov::Model> ClampFunction::getOriginal(
 std::shared_ptr<ov::Model> ClampFunction::getOriginal(
     const ov::element::Type precision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize,
+    const ov::builder::subgraph::FakeQuantizeOnData fakeQuantize,
     const double clampLowConst,
     const double clampHighConst) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, inputShape);
@@ -76,9 +76,9 @@ std::shared_ptr<ov::Model> ClampFunction::getWithNonDequantizationMultiply(
 std::shared_ptr<ov::Model> ClampFunction::getReference(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     std::shared_ptr<Node> quantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -94,4 +94,4 @@ std::shared_ptr<ov::Model> ClampFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/add.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/add.cpp
@@ -4,7 +4,7 @@
 
 #include "ov_lpt_models/common/add.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -52,4 +52,4 @@ bool Add::empty() const noexcept {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/builders.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/builders.cpp
@@ -14,7 +14,7 @@
 #include "common_test_utils/node_builders/constant.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -396,4 +396,4 @@ std::shared_ptr<Node> makeConvolution(
 
 } // namespace subgraph
 } // namespace builder
-} // namespace ngraph
+} // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/constant.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/constant.cpp
@@ -4,7 +4,7 @@
 
 #include "ov_lpt_models/common/constant.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -52,4 +52,4 @@ bool Constant::empty() const noexcept {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/convolution.cpp
@@ -4,7 +4,7 @@
 
 #include "ov_lpt_models/common/convolution.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -26,4 +26,4 @@ bool Convolution::empty() const {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/dequantization_operations.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/dequantization_operations.cpp
@@ -5,7 +5,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "openvino/opsets/opset1.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -191,4 +191,4 @@ bool DequantizationOperations::empty() const noexcept {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/fake_quantize_on_data.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/fake_quantize_on_data.cpp
@@ -5,7 +5,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "openvino/opsets/opset1.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -84,4 +84,4 @@ bool FakeQuantizeOnDataWithConstant::empty() const {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/fake_quantize_on_weights.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/fake_quantize_on_weights.cpp
@@ -5,7 +5,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_weights.hpp"
 #include "openvino/opsets/opset1.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -29,4 +29,4 @@ bool FakeQuantizeOnWeights::empty() const {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/multiply.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/multiply.cpp
@@ -5,7 +5,7 @@
 #include "ov_lpt_models/common/multiply.hpp"
 #include "openvino/opsets/opset1.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -53,4 +53,4 @@ bool Multiply::empty() const noexcept {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/reshape.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/reshape.cpp
@@ -4,7 +4,7 @@
 
 #include "ov_lpt_models/common/reshape.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -23,4 +23,4 @@ bool Reshape::empty() const noexcept {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/transpose.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/transpose.cpp
@@ -4,7 +4,7 @@
 
 #include "ov_lpt_models/common/transpose.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,4 +22,4 @@ bool Transpose::empty() const noexcept {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/compose_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/compose_fake_quantize.cpp
@@ -11,16 +11,16 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
     std::shared_ptr<ov::Model> ComposeFakeQuantizeFunction::get(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization2) {
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnData,
+        const ov::builder::subgraph::DequantizationOperations& dequantization1,
+        const ov::builder::subgraph::DequantizationOperations& dequantization2) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
 
         auto fakeQuantize = makeFakeQuantize(input, precision, fqOnData);
@@ -44,4 +44,4 @@ namespace subgraph {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/concat.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/concat.cpp
@@ -16,7 +16,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -900,12 +900,12 @@ std::shared_ptr<ov::Model> ConcatFunction::getReference(
     const DequantizationOperations& dequantizationOperations) {
     const auto input1 = std::make_shared<ov::opset1::Parameter>(precision, inputShape);
     input1->set_friendly_name("input1");
-    const auto fakeQuantize1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(input1, precision, fqOnData1);
+    const auto fakeQuantize1 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(input1, precision, fqOnData1);
 
     const std::vector<size_t> inputShape2 = inputShape;
     const auto input2 = std::make_shared<ov::opset1::Parameter>(precision, ov::Shape(inputShape2));
     input2->set_friendly_name("input2");
-    const auto fakeQuantize2 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(input2, precision, fqOnData2);
+    const auto fakeQuantize2 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(input2, precision, fqOnData2);
 
     const std::shared_ptr<ov::opset1::Concat> concat = std::make_shared<ov::op::TypeRelaxed<ov::opset1::Concat>>(
         ov::OutputVector{ fakeQuantize1->output(0), fakeQuantize2->output(0) }, 1);
@@ -2047,4 +2047,4 @@ std::shared_ptr<Node> ConcatFunction::makeMaxPool(const Output<Node>& parent, co
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/convolution.cpp
@@ -20,7 +20,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -28,10 +28,10 @@ std::shared_ptr<ov::Model> ConvolutionFunction::getOriginal(
     const ov::element::Type netPrecision,
     const ov::element::Type inputPrecision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationOnActivations,
     std::shared_ptr<ov::opset1::Constant> weights,
-    const ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
+    const ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
     const bool transposeOnData,
     const bool transposeOnInputLow,
     const bool transposeOnInputHigh,
@@ -127,8 +127,8 @@ std::shared_ptr<ov::Model> ConvolutionFunction::getOriginal(
 std::shared_ptr<ov::Model> ConvolutionFunction::getOriginalWithIncorrectWeights(
     const ov::Shape& inputShape,
     ov::element::Type precision,
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
-    ngraph::builder::subgraph::DequantizationOperations dequantization,
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
+    ov::builder::subgraph::DequantizationOperations dequantization,
     bool isCorrect) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, ov::Shape(inputShape));
     const auto deq = makeDequantization(input, dequantization);
@@ -165,8 +165,8 @@ std::shared_ptr<ov::Model> ConvolutionFunction::getOriginalWithIncorrectWeights(
 std::shared_ptr<ov::Model> ConvolutionFunction::getOriginalWithIncorrectWeights(
     const ov::PartialShape& inputShape,
     ov::element::Type precision,
-    ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
-    ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData,
+    ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
+    ov::builder::subgraph::FakeQuantizeOnData fakeQuantizeOnData,
     bool isCorrect) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, inputShape);
     const auto fqOnData = fakeQuantizeOnData.empty() ?
@@ -207,10 +207,10 @@ std::shared_ptr<ov::Model> ConvolutionFunction::getOriginalWithIncorrectWeights(
 std::shared_ptr<ov::Model> ConvolutionFunction::getReferenceWithIncorrectWeights(
     const ov::Shape& inputShape,
     ov::element::Type inputPrecision,
-    ngraph::builder::subgraph::DequantizationOperations dequantizationBefore,
+    ov::builder::subgraph::DequantizationOperations dequantizationBefore,
     ov::element::Type weightsPrecision,
     std::vector<float> weightsValues,
-    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter) {
+    ov::builder::subgraph::DequantizationOperations dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, ov::Shape(inputShape));
     input->set_friendly_name("input");
 
@@ -253,11 +253,11 @@ std::shared_ptr<ov::Model> ConvolutionFunction::getReference(
     const ov::element::Type netPrecision,
     const ov::element::Type inputPrecision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     std::shared_ptr<ov::opset1::Constant> weights,
-    const ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
+    const ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
     const ov::element::Type precisionAfterDequantization) {
     auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
     auto dequantizationBeforeStructure = dequantizationBefore;
@@ -330,9 +330,9 @@ std::shared_ptr<ov::Model> ConvolutionFunction::getReference(
 std::shared_ptr<ov::Model> ConvolutionFunction::get(
     const ov::Shape& inputShape,
     const ov::element::Type precision,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
+    const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantizeOnData,
     const std::vector<float>& weightsValues,
-    const ngraph::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+    const ov::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
     const std::vector<ov::pass::low_precision::QuantizationGranularityRestriction>& restrictions) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, ov::Shape(inputShape));
     input->set_friendly_name("input");
@@ -396,4 +396,4 @@ std::shared_ptr<ov::Model> ConvolutionFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/convolution_backprop_data.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/convolution_backprop_data.cpp
@@ -17,7 +17,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -167,4 +167,4 @@ std::shared_ptr<ov::Model>  ConvolutionBackpropDataFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/depth_to_space.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/depth_to_space.cpp
@@ -8,7 +8,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -42,7 +42,7 @@ std::shared_ptr<ov::Model> DepthToSpaceFunction::getOriginal(
     const ov::opset1::DepthToSpace::DepthToSpaceMode mode,
     const size_t blockSize,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const auto dequantizationOp = makeDequantization(input, dequantization);
@@ -60,9 +60,9 @@ std::shared_ptr<ov::Model> DepthToSpaceFunction::getReference(
     const ov::opset1::DepthToSpace::DepthToSpaceMode mode,
     const size_t blockSize,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> dequantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -79,4 +79,4 @@ std::shared_ptr<ov::Model> DepthToSpaceFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/elementwise.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/elementwise.cpp
@@ -10,7 +10,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -19,9 +19,9 @@ namespace {
 std::shared_ptr<ov::opset1::FakeQuantize> makeFakeQuantizeWithNames(
         const Output<Node>& parent,
         const ov::element::Type precision,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnData,
         const std::string name) {
-    auto fq = ngraph::builder::subgraph::makeFakeQuantize(parent, precision, fqOnData);
+    auto fq = ov::builder::subgraph::makeFakeQuantize(parent, precision, fqOnData);
     fq->set_friendly_name(name);
     fq->get_input_node_ptr(1)->set_friendly_name(name + "/inputLow");
     fq->get_input_node_ptr(2)->set_friendly_name(name + "/inputHigh");
@@ -37,13 +37,13 @@ std::shared_ptr<ov::Model> ElementwiseFunction::getOriginalSubgraphWithConvoluti
         const ov::PartialShape& inputShape,
         const bool broadcast,
         const std::string& elementWiseType,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore1,
-        const ngraph::builder::subgraph::Convolution& convolution1,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter1,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore2,
-        const ngraph::builder::subgraph::Convolution& convolution2,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter2,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter) {
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore1,
+        const ov::builder::subgraph::Convolution& convolution1,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter1,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore2,
+        const ov::builder::subgraph::Convolution& convolution2,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter2,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter) {
     ov::PartialShape inputShape2 = inputShape;
 
     if (broadcast) {
@@ -55,9 +55,9 @@ std::shared_ptr<ov::Model> ElementwiseFunction::getOriginalSubgraphWithConvoluti
         const ov::element::Type precision,
         const ov::PartialShape& inputShape,
         const size_t index,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore,
-        const ngraph::builder::subgraph::Convolution& convolution,
-        const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter) ->
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataBefore,
+        const ov::builder::subgraph::Convolution& convolution,
+        const ov::builder::subgraph::FakeQuantizeOnData& fqOnDataAfter) ->
             std::pair<std::shared_ptr<ov::opset1::Parameter>, std::shared_ptr<ov::Node>> {
         const auto input = std::make_shared<ov::opset1::Parameter>(precision, inputShape);
         input->set_friendly_name("input" + std::to_string(index));
@@ -116,4 +116,4 @@ std::shared_ptr<ov::Model> ElementwiseFunction::getOriginalSubgraphWithConvoluti
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/elementwise_with_multi_parent_dequantization.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/elementwise_with_multi_parent_dequantization.cpp
@@ -11,7 +11,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -20,9 +20,9 @@ std::shared_ptr<ov::Model> ElementwiseWithMultiParentDequantizationFunction::get
     const ov::Shape& inputShape,
     const ov::pass::low_precision::LayerTransformation::Params& params,
     const ov::element::Type& precision1,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization1,
+    const ov::builder::subgraph::DequantizationOperations& dequantization1,
     const ov::element::Type& precision2,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization2) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization2) {
     const auto input1_1 = std::make_shared<ov::opset1::Parameter>(precision1, inputShape);
     const auto input1_2 = std::make_shared<ov::opset1::Parameter>(precision1, ov::Shape({ inputShape[0], inputShape[1], 1, 1 }));
     const std::shared_ptr<ov::Node> multiply1 = std::make_shared<ov::op::TypeRelaxed<ov::opset1::Multiply>>(
@@ -57,4 +57,4 @@ std::shared_ptr<ov::Model> ElementwiseWithMultiParentDequantizationFunction::get
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize.cpp
@@ -13,7 +13,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -82,7 +82,7 @@ std::shared_ptr<ov::Model> FakeQuantizeFunction::getReference(
     const bool updatePrecisions,
     const FakeQuantizeOnDataWithConstant& fakeQuantizeOnData,
     const ov::element::Type fakeQuantizeOutputPrecision,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const bool addNotPrecisionPreservedOperation) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, inputShape);
     input->set_friendly_name("input");
@@ -134,4 +134,4 @@ std::shared_ptr<ov::Model> FakeQuantizeFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_convolution.cpp
@@ -9,7 +9,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -120,8 +120,8 @@ std::shared_ptr<ov::Model> FakeQuantizeAndConvolutionFunction::get(
     {
         if (!fqOnData.empty()) {
             parentOnActivation = fqOnData.outputPrecision == element::undefined ?
-                ngraph::builder::subgraph::makeFakeQuantize(input, precision, fqOnData) :
-                ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(input, precision, fqOnData);
+                ov::builder::subgraph::makeFakeQuantize(input, precision, fqOnData) :
+                ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(input, precision, fqOnData);
         }
 
         if (!convertOnData.empty()) {
@@ -155,8 +155,8 @@ std::shared_ptr<ov::Model> FakeQuantizeAndConvolutionFunction::get(
 
         if (!fqOnWeights.empty()) {
             parentOnWeights = fqOnWeights.outputPrecision == element::undefined ?
-                ngraph::builder::subgraph::makeFakeQuantize(parentOnWeights, parentOnWeights->output(0).get_element_type(), fqOnWeights) :
-                ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(parentOnWeights, parentOnWeights->output(0).get_element_type(), fqOnWeights);
+                ov::builder::subgraph::makeFakeQuantize(parentOnWeights, parentOnWeights->output(0).get_element_type(), fqOnWeights) :
+                ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(parentOnWeights, parentOnWeights->output(0).get_element_type(), fqOnWeights);
         }
 
         if (!convertOnWeights.empty()) {
@@ -231,4 +231,4 @@ std::shared_ptr<ov::Model> FakeQuantizeAndConvolutionFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -10,7 +10,7 @@
 #include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -96,12 +96,12 @@ std::shared_ptr<ov::Model> FakeQuantizeAndTwoOutputBranchesWithConvolutionFuncti
     const ov::element::Type precision,
     const ov::Shape& inputShape,
     const ov::pass::low_precision::LayerTransformation::Params& params,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData,
+    const ov::builder::subgraph::FakeQuantizeOnData& fqOnData,
     const ov::element::Type precisionBeforeOp,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOp,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter1,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter2) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter1,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter2) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, ov::Shape(inputShape));
     const auto fakeQuantizeOnActivations = fqOnData.empty() ?
         nullptr :
@@ -145,4 +145,4 @@ std::shared_ptr<ov::Model> FakeQuantizeAndTwoOutputBranchesWithConvolutionFuncti
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_on_weights_and_unsupported_child.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_on_weights_and_unsupported_child.cpp
@@ -10,14 +10,14 @@
 #include "ov_models/builders.hpp"
 
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 std::shared_ptr<ov::Model> FakeQuantizeOnWeightsAndUnsupportedChildFunction::get(
     const ov::Shape& inputShape,
     const ov::element::Type inputPrecision,
     const std::shared_ptr<ov::opset1::Constant> weights,
-    const ngraph::builder::subgraph::FakeQuantizeOnWeights fqOnWeights) {
+    const ov::builder::subgraph::FakeQuantizeOnWeights fqOnWeights) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
     input->set_friendly_name("Input");
     weights->set_friendly_name("Weights");
@@ -47,4 +47,4 @@ std::shared_ptr<ov::Model> FakeQuantizeOnWeightsAndUnsupportedChildFunction::get
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_precision_selection.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_precision_selection.cpp
@@ -11,7 +11,7 @@
 #include "low_precision/network_helper.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -103,7 +103,7 @@ std::shared_ptr<ov::Model> FakeQuantizePrecisionSelectionFunction::getReference(
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, ov::Shape(inputShape));
     input->set_friendly_name("input");
 
-    const auto fakeQuantize = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(
+    const auto fakeQuantize = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(
         input,
         precision,
         values.fakeQuantizeOnData);
@@ -196,4 +196,4 @@ std::shared_ptr<ov::Model> FakeQuantizePrecisionSelectionFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fold_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fold_fake_quantize.cpp
@@ -9,7 +9,7 @@
 #include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -43,4 +43,4 @@ std::shared_ptr<ov::Model> FoldFakeQuantizeFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_convert.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_convert.cpp
@@ -9,18 +9,18 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 std::shared_ptr<ov::Model> FuseConvertFunction::get(
     const ov::PartialShape& inputShape,
     const ov::element::Type inputPrecision,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantize,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantize,
     const bool constInput) {
     std::shared_ptr<Node> parent;
-    std::shared_ptr<op::Parameter> input;
+    std::shared_ptr<ov::op::v0::Parameter> input;
     if (constInput) {
         parent = std::make_shared<ov::opset1::Constant>(inputPrecision, inputShape.to_shape(), std::vector<float>{ 128.f });
     } else {
@@ -49,10 +49,10 @@ std::shared_ptr<ov::Model> FuseConvertFunction::get(
 std::shared_ptr<ov::Model> FuseConvertFunction::getWithFQ(
     const ov::PartialShape& inputShape,
     const ov::element::Type inputPrecision,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const bool constInput) {
     std::shared_ptr<Node> parent;
-    std::shared_ptr<op::Parameter> input1;
+    std::shared_ptr<ov::op::v0::Parameter> input1;
     if (constInput) {
         parent = std::make_shared<ov::opset1::Constant>(inputPrecision, inputShape.to_shape(), std::vector<float>{ 128.f });
     } else {
@@ -65,7 +65,7 @@ std::shared_ptr<ov::Model> FuseConvertFunction::getWithFQ(
     deqStructure.multiply.outPrecision = inputPrecision;
     const std::shared_ptr<Node> dequantizationOp = makeDequantization(parent, deqStructure);
 
-    std::shared_ptr<op::Parameter> input2 = std::make_shared<ov::opset1::Parameter>(
+    std::shared_ptr<ov::op::v0::Parameter> input2 = std::make_shared<ov::opset1::Parameter>(
             inputPrecision,
             inputShape);
 
@@ -95,4 +95,4 @@ std::shared_ptr<ov::Model> FuseConvertFunction::getWithFQ(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_fake_quantize.cpp
@@ -13,7 +13,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -206,4 +206,4 @@ std::shared_ptr<ov::Model> FuseFakeQuantizeFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_fake_quantize_and_scale_shift.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_fake_quantize_and_scale_shift.cpp
@@ -8,7 +8,7 @@
 #include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -41,4 +41,4 @@ std::shared_ptr<ov::Model> FuseFakeQuantizeAndScaleShiftFunction::getOriginal(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_multiply_to_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_multiply_to_fake_quantize.cpp
@@ -13,7 +13,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -35,4 +35,4 @@ std::shared_ptr<ov::Model> FuseMultiplyToFakeQuantizeFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/fuse_subtract_to_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fuse_subtract_to_fake_quantize.cpp
@@ -13,7 +13,7 @@
 #include "ov_lpt_models/common/fake_quantize_on_data.hpp"
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -63,4 +63,4 @@ std::shared_ptr<ov::Model> FuseSubtractToFakeQuantizeFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/gather.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/gather.cpp
@@ -9,7 +9,7 @@
 #include "openvino/opsets/opset8.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -20,7 +20,7 @@ std::shared_ptr<ov::Model> GatherFunction::getOriginal(
     const std::vector<int>& axis,
     const int64_t batch_dims,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const int opset_version) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
     const std::shared_ptr<Node> dequantizationOp = makeDequantization(input, dequantization);
@@ -89,9 +89,9 @@ std::shared_ptr<ov::Model> GatherFunction::getReference(
     const std::vector<int>& axis,
     const int64_t batch_dims,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
     const int opset_version) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
@@ -130,4 +130,4 @@ std::shared_ptr<ov::Model> GatherFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/get_dequantization.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/get_dequantization.cpp
@@ -14,7 +14,7 @@
 #include "ov_models/subgraph_builders.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -22,14 +22,14 @@ std::shared_ptr<ov::Model> GetDequantizationFunction::get(
     const ov::element::Type& precision,
     const Shape& shape,
     const FakeQuantizeOnData& fakeQuantize,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const std::shared_ptr<ov::Node> input = std::make_shared<ov::opset1::Parameter>(
         ov::element::f32,
         shape);
 
     std::shared_ptr<ov::Node> parent = input;
     if (!fakeQuantize.empty()) {
-        parent = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(parent, precision, fakeQuantize);
+        parent = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(parent, precision, fakeQuantize);
     }
 
     if (!dequantization.empty()) {
@@ -54,7 +54,7 @@ std::shared_ptr<ov::Model> GetDequantizationFunction::get(
 
     std::shared_ptr<ov::Node> parent = input;
     if (!fakeQuantize.empty()) {
-        parent = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(parent, precision, fakeQuantize);
+        parent = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(parent, precision, fakeQuantize);
     }
 
     if (dequantization.convert != nullptr) {
@@ -126,4 +126,4 @@ std::shared_ptr<ov::Model> GetDequantizationFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/group_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/group_convolution.cpp
@@ -18,7 +18,7 @@
 using namespace ov::opset1;
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -32,7 +32,7 @@ std::shared_ptr<Node> createWeightsOriginal(
     const size_t kernelSize,
     const std::vector<float>& weightsValues,
     const FakeQuantizeOnWeights& fakeQuantizeOnWeights,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
     const bool addReshape = true) {
     std::shared_ptr<Node> weights;
     if (fakeQuantizeOnWeights.empty() && dequantizationOnWeights.empty()) {
@@ -96,7 +96,7 @@ std::shared_ptr<Node> createWeightsOriginal(
         }
 
         if (!dequantizationOnWeights.empty()) {
-            weights = ngraph::builder::subgraph::makeDequantization(weights, dequantizationOnWeights);
+            weights = ov::builder::subgraph::makeDequantization(weights, dequantizationOnWeights);
         }
 
         if (addReshape) {
@@ -143,9 +143,9 @@ std::shared_ptr<ov::Model> GroupConvolutionFunction::getOriginal(
     const ov::Shape& outputShape,
     const size_t groupCount,
     const int groupCalculationDimention,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     std::shared_ptr<ov::opset1::Constant> weightsConst,
-    const ngraph::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights) {
+    const ov::builder::subgraph::FakeQuantizeOnWeights fakeQuantizeOnWeights) {
     const auto rankLength = inputShape.size();
     OPENVINO_ASSERT(rankLength == 3 || rankLength == 4, "not supported input shape rank: ", rankLength);
 
@@ -286,12 +286,12 @@ std::shared_ptr<ov::Model> GroupConvolutionFunction::get(
     const ov::PartialShape& outputShape,
     const size_t groupCount,
     const int calculatedDimention,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     std::shared_ptr<ov::opset1::Constant> weightsConst,
-    const ngraph::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
+    const ov::builder::subgraph::FakeQuantizeOnWeights& fakeQuantizeOnWeights,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationOnWeights,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
     const ov::element::Type precisionAfterDequantization,
     const bool addReshape) {
     const auto rankLength = inputShape.rank().is_dynamic() ? 4 : inputShape.rank().get_length();
@@ -357,4 +357,4 @@ std::shared_ptr<ov::Model> GroupConvolutionFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/interpolate.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/interpolate.cpp
@@ -8,7 +8,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -17,7 +17,7 @@ std::shared_ptr<ov::Model> InterpolateFunction::getOriginal(
     const ov::Shape& outputShape,
     const ov::op::v0::Interpolate::Attributes& interpAttrs,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const auto dequantizationOp = makeDequantization(input, dequantization);
@@ -52,9 +52,9 @@ std::shared_ptr<ov::Model> InterpolateFunction::getReference(
     const ov::Shape& outputShape,
     const ov::op::v0::Interpolate::Attributes& interpAttrs,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> quantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -74,7 +74,7 @@ std::shared_ptr<ov::Model> InterpolateFunction::getOriginal(
     const ov::Shape& scalesShape,
     const ov::op::v4::Interpolate::InterpolateAttrs& interpAttrs,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const auto dequantizationOp = makeDequantization(input, dequantization);
@@ -113,9 +113,9 @@ std::shared_ptr<ov::Model> InterpolateFunction::getReference(
     const ov::Shape& scalesShape,
     const ov::op::v4::Interpolate::InterpolateAttrs& interpAttrs,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> quantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -131,4 +131,4 @@ std::shared_ptr<ov::Model> InterpolateFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/markup_avg_pool_precisions.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/markup_avg_pool_precisions.cpp
@@ -12,7 +12,7 @@
 #include "ov_models/subgraph_builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -54,7 +54,7 @@ std::shared_ptr<ov::Model> MarkupAvgPoolPrecisionsFunction::getOriginal(
     const ov::Shape& inputShape,
     const bool addFQ,
     const std::string additionalLayer,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     // -1 - no Convolution, 2 - on both branches
     const int convoutionBranch,
     // -1 - no FakeQuantize, 2 - on both branches
@@ -187,9 +187,9 @@ std::shared_ptr<ov::Model> MarkupAvgPoolPrecisionsFunction::getReference(
     const ov::Shape& inputShape,
     const bool addFQ,
     const std::string additionalLayer,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, ov::Shape(inputShape));
 
     const auto deqBefore = makeDequantization(input, dequantizationBefore);
@@ -232,4 +232,4 @@ std::shared_ptr<ov::Model> MarkupAvgPoolPrecisionsFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/markup_bias.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/markup_bias.cpp
@@ -8,7 +8,7 @@
 #include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 std::shared_ptr<ov::Model> MarkupBiasFunction::get(const ov::element::Type& precision,
@@ -126,4 +126,4 @@ std::shared_ptr<ov::Model> MarkupBiasFunction::get(const ov::element::Type& prec
 }
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/mat_mul.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/mat_mul.cpp
@@ -14,7 +14,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -340,4 +340,4 @@ std::shared_ptr<ov::Model> MatMulFunction::getOriginal(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/mat_mul_with_optimized_constant_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/mat_mul_with_optimized_constant_fake_quantize.cpp
@@ -7,7 +7,7 @@
 #include "openvino/opsets/opset1.hpp"
 #include "ov_models/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -55,4 +55,4 @@ std::shared_ptr<ov::Model> MatMulWithOptimizedConstantFakeQuantizeFunction::getO
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/max_pool.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/max_pool.cpp
@@ -11,7 +11,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -40,9 +40,9 @@ std::shared_ptr<ov::Model> MaxPoolFunction::getOriginal(
 std::shared_ptr<ov::Model> MaxPoolFunction::get(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
     std::shared_ptr<ov::Node> parent = input;
 
@@ -72,4 +72,4 @@ std::shared_ptr<ov::Model> MaxPoolFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/move_dequantization_after.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/move_dequantization_after.cpp
@@ -11,13 +11,13 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
     std::shared_ptr<ov::Model> MoveDequantizationAfterFunction::getOriginal(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantization) {
+        const ov::builder::subgraph::DequantizationOperations dequantization) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
 
         const auto deq = makeDequantization(input, dequantization);
@@ -44,9 +44,9 @@ namespace subgraph {
     std::shared_ptr<ov::Model> MoveDequantizationAfterFunction::getReference(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantizationBefore,
+        const ov::builder::subgraph::DequantizationOperations dequantizationBefore,
         const ov::element::Type precisionAfterOperation,
-        const ngraph::builder::subgraph::DequantizationOperations dequantizationAfter) {
+        const ov::builder::subgraph::DequantizationOperations dequantizationAfter) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
 
         const auto deqBefore = makeDequantization(input, dequantizationBefore);
@@ -75,4 +75,4 @@ namespace subgraph {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/move_fake_quantize.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/move_fake_quantize.cpp
@@ -13,7 +13,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -131,4 +131,4 @@ std::shared_ptr<ov::Model> MoveFakeQuantize::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/multiply.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/multiply.cpp
@@ -16,7 +16,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -80,4 +80,4 @@ std::shared_ptr<ov::Model> MultiplyFunction::get(const element::Type model_preci
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/multiply_partial_function.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/multiply_partial_function.cpp
@@ -18,7 +18,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -83,10 +83,10 @@ std::shared_ptr<ov::Model> MultiplyPartialFunction::get(
     const ov::element::Type precision,
     const ov::PartialShape& inputShape,
     const bool broadcast1,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fq1,
+    const ov::builder::subgraph::FakeQuantizeOnData& fq1,
     const bool broadcast2,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fq2,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fqAfter,
+    const ov::builder::subgraph::FakeQuantizeOnData& fq2,
+    const ov::builder::subgraph::FakeQuantizeOnData& fqAfter,
     const bool secondInputIsConstant) {
     auto inputShape1 = inputShape;
     if (broadcast1) {
@@ -153,4 +153,4 @@ std::shared_ptr<ov::Model> MultiplyPartialFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/multiply_to_group_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/multiply_to_group_convolution.cpp
@@ -8,14 +8,14 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_ops/type_relaxed.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 std::shared_ptr<ov::Model> MultiplyToGroupConvolutionFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const ov::element::Type& precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const bool haveMultiplyWithNoConstBeforeDequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
     std::shared_ptr<ov::op::Op> parent = input;
@@ -70,7 +70,7 @@ std::shared_ptr<ov::Model> MultiplyToGroupConvolutionFunction::getReference(
     const ov::element::Type& inputPrecision,
     const std::shared_ptr<ov::opset1::Constant>& weights,
     const std::shared_ptr<ov::opset1::Constant>& biases,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
 
     const size_t spatialDimsSize = inputShape.rank().get_length() - 2;
@@ -100,4 +100,4 @@ std::shared_ptr<ov::Model> MultiplyToGroupConvolutionFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/multiply_with_one_parent.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/multiply_with_one_parent.cpp
@@ -8,7 +8,7 @@
 #include "ov_models/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -30,4 +30,4 @@ std::shared_ptr<ov::Model> MultiplyWithOneParentFunction::getOriginal(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/mvn.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/mvn.cpp
@@ -9,7 +9,7 @@
 #include "ov_ops/type_relaxed.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -19,7 +19,7 @@ std::shared_ptr<ov::Model> MVNFunction::getOriginal(
     const AxisSet& reductionAxes,
     const bool& normalizeVariance,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const int opset_version) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
     auto deqStructure = dequantization;
@@ -67,9 +67,9 @@ std::shared_ptr<ov::Model> MVNFunction::getReference(
     const AxisSet& reductionAxes,
     const bool& normalizeVariance,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter,
     const int opset_version) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
@@ -104,4 +104,4 @@ std::shared_ptr<ov::Model> MVNFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/normalize_dequantization.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/normalize_dequantization.cpp
@@ -8,14 +8,14 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "ov_ops/type_relaxed.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
     std::shared_ptr<ov::Model> NormalizeDequantizationFunction::getOriginal(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantization) {
+        const ov::builder::subgraph::DequantizationOperations dequantization) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
 
         const auto deq = makeDequantization(input, dequantization);
@@ -42,4 +42,4 @@ namespace subgraph {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/normalize_l2.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/normalize_l2.cpp
@@ -10,7 +10,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -68,7 +68,7 @@ std::shared_ptr<ov::Model> NormalizeL2Function::getOriginal(
     const ov::PartialShape& shape,
     const ov::op::EpsMode& epsMode,
     const std::vector<size_t>& axes,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
 
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, shape);
 
@@ -93,9 +93,9 @@ std::shared_ptr<ov::Model> NormalizeL2Function::getReference(
     const ov::PartialShape& shape,
     const ov::op::EpsMode& epsMode,
     const std::vector<size_t>& axes,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, shape);
 
     auto deqBeforeStructure = dequantizationBefore;
@@ -130,4 +130,4 @@ std::shared_ptr<ov::Model> NormalizeL2Function::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/pad.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/pad.cpp
@@ -11,7 +11,7 @@
 #include "ov_lpt_models/pad.hpp"
 #include "low_precision/network_helper.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 std::shared_ptr<ov::Model> PadFunction::get(
@@ -76,4 +76,4 @@ std::shared_ptr<ov::Model> PadFunction::get(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/precision_propagation.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/precision_propagation.cpp
@@ -18,7 +18,7 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -300,4 +300,4 @@ std::shared_ptr<Node> PrecisionPropagationFunction::makeMaxPool(const Output<Nod
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/prelu.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/prelu.cpp
@@ -12,14 +12,14 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "low_precision/network_helper.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 std::shared_ptr<ov::Model> PReluFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> dequantizationOp = makeDequantization(input, dequantization);
@@ -50,9 +50,9 @@ std::shared_ptr<ov::Model> PReluFunction::getOriginal(
 std::shared_ptr<ov::Model> PReluFunction::getReference(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> quantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -69,4 +69,4 @@ std::shared_ptr<ov::Model> PReluFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/recurrent_cell.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/recurrent_cell.cpp
@@ -18,7 +18,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -148,4 +148,4 @@ std::shared_ptr<Node> makeQuantizationAndDequantization(const std::shared_ptr<No
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/relu.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/relu.cpp
@@ -11,14 +11,14 @@
 #include "ov_lpt_models/common/builders.hpp"
 #include "low_precision/network_helper.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 std::shared_ptr<ov::Model> ReluFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> dequantizationOp = makeDequantization(input, dequantization);
@@ -47,9 +47,9 @@ std::shared_ptr<ov::Model> ReluFunction::getOriginal(
 std::shared_ptr<ov::Model> ReluFunction::getReference(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> quantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -69,4 +69,4 @@ std::shared_ptr<ov::Model> ReluFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/reshape.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/reshape.cpp
@@ -7,7 +7,7 @@
 #include "openvino/opsets/opset1.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -15,7 +15,7 @@ std::shared_ptr<ov::Model> ReshapeFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const std::vector<int>& reshapeConstValues,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> dequantizationOp = makeDequantization(input, dequantization);
@@ -58,9 +58,9 @@ std::shared_ptr<ov::Model> ReshapeFunction::getReference(
     const ov::PartialShape& inputShape,
     const std::vector<int>& reshapeConstValues,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> quantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -90,4 +90,4 @@ std::shared_ptr<ov::Model> ReshapeFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/round.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/round.cpp
@@ -11,13 +11,13 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
     std::shared_ptr<ov::Model> RoundWithToleranceFunction::getOriginal(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantization) {
+        const ov::builder::subgraph::DequantizationOperations dequantization) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
         input->set_friendly_name("input");
 
@@ -36,7 +36,7 @@ namespace subgraph {
     std::shared_ptr<ov::Model> RoundWithToleranceFunction::getReference(
         const ov::element::Type precision,
         const ov::Shape& inputShape,
-        const ngraph::builder::subgraph::DequantizationOperations dequantization) {
+        const ov::builder::subgraph::DequantizationOperations dequantization) {
         const auto input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
         input->set_friendly_name("input");
 
@@ -54,4 +54,4 @@ namespace subgraph {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/shuffle_channels.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/shuffle_channels.cpp
@@ -10,7 +10,7 @@
 #include "ov_lpt_models/shuffle_channels.hpp"
 #include "ov_models/subgraph_builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 std::shared_ptr<ov::Model> ShuffleChannelsFunction::getOriginal(
@@ -36,7 +36,7 @@ std::shared_ptr<ov::Model> ShuffleChannelsFunction::getOriginal(
 std::shared_ptr<ov::Model> ShuffleChannelsFunction::getOriginal(
     const ov::element::Type inputPrecision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData,
+    const ov::builder::subgraph::FakeQuantizeOnData& fqOnData,
     const std::int64_t axis,
     const std::int64_t group) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
@@ -56,11 +56,11 @@ std::shared_ptr<ov::Model> ShuffleChannelsFunction::getOriginal(
 std::shared_ptr<ov::Model> ShuffleChannelsFunction::getReference(
     const ov::element::Type inputPrecision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::DequantizationOperations& deqBefore,
+    const ov::builder::subgraph::DequantizationOperations& deqBefore,
     const std::int64_t axis,
     const std::int64_t group,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& deqAfter) {
+    const ov::builder::subgraph::DequantizationOperations& deqAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
     const auto dequantizationBefore = makeDequantization(input, deqBefore);
 
@@ -80,4 +80,4 @@ std::shared_ptr<ov::Model> ShuffleChannelsFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/space_to_batch.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/space_to_batch.cpp
@@ -7,7 +7,7 @@
 #include "openvino/opsets/opset2.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -35,11 +35,11 @@ std::shared_ptr<ov::Model> SpaceToBatchFunction::get(const ov::PartialShape& inp
 
 std::shared_ptr<ov::Model> SpaceToBatchFunction::get(const ov::PartialShape& input_shape,
                                                             const ov::element::Type input_type,
-                                                            const ngraph::builder::subgraph::DequantizationOperations& dequantization_before,
+                                                            const ov::builder::subgraph::DequantizationOperations& dequantization_before,
                                                             const std::vector<size_t>& block_shape,
                                                             const std::vector<size_t>& pads_begin,
                                                             const std::vector<size_t>& pads_end,
-                                                            const ngraph::builder::subgraph::DequantizationOperations& dequantization_after) {
+                                                            const ov::builder::subgraph::DequantizationOperations& dequantization_after) {
     const auto input = std::make_shared<ov::opset1::Parameter>(input_type, input_shape);
 
     std::shared_ptr<Node> parent = dequantization_before.empty() ?
@@ -60,4 +60,4 @@ std::shared_ptr<ov::Model> SpaceToBatchFunction::get(const ov::PartialShape& inp
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/split.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/split.cpp
@@ -13,14 +13,14 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 std::shared_ptr<ov::Model> SplitFunction::getOriginal(
     const element::Type& precision,
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const int64_t splitedAxis,
     const size_t numSplits) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
@@ -41,7 +41,7 @@ std::shared_ptr<ov::Model> SplitFunction::getOriginal(
 std::shared_ptr<ov::Model> SplitFunction::getOriginal(
     const ov::element::Type originalFunctionPrecision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize,
+    const ov::builder::subgraph::FakeQuantizeOnData fakeQuantize,
     int64_t splitedAxis, size_t numSplit) {
     const auto input = std::make_shared<ov::opset1::Parameter>(originalFunctionPrecision, inputShape);
 
@@ -70,9 +70,9 @@ std::shared_ptr<ov::Model> SplitFunction::getReference(
     const element::Type& precision,
     const ov::PartialShape& inputShape,
     const ov::element::Type inputPrecision,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const std::vector<ngraph::builder::subgraph::DequantizationOperations>& dequantizationAfter,
+    const std::vector<ov::builder::subgraph::DequantizationOperations>& dequantizationAfter,
     const int64_t splitedAxis,
     const size_t numSplit) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
@@ -99,4 +99,4 @@ std::shared_ptr<ov::Model> SplitFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/squeeze.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/squeeze.cpp
@@ -9,7 +9,7 @@
 #include "ov_ops/type_relaxed.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -17,7 +17,7 @@ std::shared_ptr<ov::Model> SqueezeFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const std::vector<float>& axes,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const auto dequantizationOp = makeDequantization(input, dequantization);
@@ -57,9 +57,9 @@ std::shared_ptr<ov::Model> SqueezeFunction::getReference(
     const ov::PartialShape& inputShape,
     const std::vector<float>& axes,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> dequantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -77,4 +77,4 @@ std::shared_ptr<ov::Model> SqueezeFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/strided_slice.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/strided_slice.cpp
@@ -13,14 +13,14 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 std::shared_ptr<ov::Model> StridedSliceFunction::getOriginal(
     const ov::element::Type inputPrecision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const std::vector<int64_t>& begin,
     const std::vector<int64_t>& end,
     const std::vector<int64_t>& strides,
@@ -58,7 +58,7 @@ std::shared_ptr<ov::Model> StridedSliceFunction::getOriginal(
 std::shared_ptr<ov::Model> StridedSliceFunction::getOriginal(
     const ov::element::Type inputPrecision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fakeQuantize,
+    const ov::builder::subgraph::FakeQuantizeOnData& fakeQuantize,
     const std::vector<int64_t>& begin,
     const std::vector<int64_t>& end,
     const std::vector<int64_t>& strides,
@@ -104,9 +104,9 @@ std::shared_ptr<ov::Model> StridedSliceFunction::getReference(
     const std::vector<int64_t>& newAxisMask,
     const std::vector<int64_t>& shrinkAxisMask,
     const std::vector<int64_t>& elipsisMask,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
     input->set_friendly_name("input");
     const auto deqBefore = makeDequantization(input, dequantizationBefore);
@@ -137,4 +137,4 @@ std::shared_ptr<ov::Model> StridedSliceFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/subtract.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/subtract.cpp
@@ -12,7 +12,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
     std::shared_ptr<ov::Model> SubtractFunction::getOriginal(
@@ -50,4 +50,4 @@ namespace subgraph {
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/subtract_multiply_to_multiply_add.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/subtract_multiply_to_multiply_add.cpp
@@ -9,14 +9,14 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
 std::shared_ptr<ov::Model> SubtractMultiplyToMultiplyAddFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const ov::element::Type precisionAfterDequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
@@ -30,7 +30,7 @@ std::shared_ptr<ov::Model> SubtractMultiplyToMultiplyAddFunction::getOriginal(
 std::shared_ptr<ov::Model> SubtractMultiplyToMultiplyAddFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const ov::element::Type precision,
-    const ngraph::builder::subgraph::FakeQuantizeOnData& fqOnData) {
+    const ov::builder::subgraph::FakeQuantizeOnData& fqOnData) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precision, inputShape);
     const std::shared_ptr<Node> fq = makeFakeQuantize(input, precision, fqOnData);
 
@@ -54,10 +54,10 @@ std::shared_ptr<ov::Model> SubtractMultiplyToMultiplyAddFunction::getOriginal(
 std::shared_ptr<ov::Model> SubtractMultiplyToMultiplyAddFunction::getReference(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+    const ov::builder::subgraph::DequantizationOperations& dequantization,
     const ov::element::Type precisionAfterDequantization,
-    const ngraph::builder::subgraph::Multiply& multiply,
-    const ngraph::builder::subgraph::Add& add) {
+    const ov::builder::subgraph::Multiply& multiply,
+    const ov::builder::subgraph::Add& add) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     std::shared_ptr<Node> dequantizationOp = makeDequantization(input, dequantization);
@@ -78,4 +78,4 @@ std::shared_ptr<ov::Model> SubtractMultiplyToMultiplyAddFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/transformations_after_split.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/transformations_after_split.cpp
@@ -12,7 +12,7 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -203,4 +203,4 @@ std::shared_ptr<Node> TransformationsAfterSplitFunction::getLayerByTransformatio
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/transpose.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/transpose.cpp
@@ -7,7 +7,7 @@
 #include "openvino/opsets/opset1.hpp"
 #include "ov_lpt_models/common/builders.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -15,7 +15,7 @@ std::shared_ptr<ov::Model> TransposeFunction::getOriginal(
     const ov::PartialShape& inputShape,
     const std::vector<int>& transposeConstValues,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> dequantizationOp = makeDequantization(input, dequantization);
@@ -52,9 +52,9 @@ std::shared_ptr<ov::Model> TransposeFunction::getReference(
     const ov::PartialShape& inputShape,
     const std::vector<int>& transposeConstValues,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> quantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -80,4 +80,4 @@ std::shared_ptr<ov::Model> TransposeFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/transpose_after_mat_mul.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/transpose_after_mat_mul.cpp
@@ -12,7 +12,7 @@
 
 using namespace ov::pass::low_precision;
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
     std::shared_ptr<ov::Model> TransposeAfterMatMulFunction::getOriginal(
@@ -46,4 +46,4 @@ namespace subgraph {
     }
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/unsqueeze.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/unsqueeze.cpp
@@ -9,7 +9,7 @@
 #include "ov_ops/type_relaxed.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
 
@@ -17,7 +17,7 @@ namespace subgraph {
     const ov::PartialShape& inputShape,
     const std::vector<float>& axes,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantization) {
+    const ov::builder::subgraph::DequantizationOperations& dequantization) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const auto dequantizationOp = makeDequantization(input, dequantization);
@@ -57,9 +57,9 @@ std::shared_ptr<ov::Model> UnsqueezeFunction::getReference(
     const ov::PartialShape& inputShape,
     const std::vector<float>& axes,
     const ov::element::Type precisionBeforeDequantization,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationAfter) {
+    const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
 
     const std::shared_ptr<Node> dequantizationOpBefore = makeDequantization(input, dequantizationBefore);
@@ -75,4 +75,4 @@ std::shared_ptr<ov::Model> UnsqueezeFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_lpt_models/src/variadic_split.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/variadic_split.cpp
@@ -12,13 +12,13 @@
 #include "ov_lpt_models/common/dequantization_operations.hpp"
 #include "common_test_utils/node_builders/fake_quantize.hpp"
 
-namespace ngraph {
+namespace ov {
 namespace builder {
 namespace subgraph {
     std::shared_ptr<ov::Model> VariadicSplitFunction::getOriginal(
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
-        const ngraph::builder::subgraph::DequantizationOperations& dequantization,
+        const ov::builder::subgraph::DequantizationOperations& dequantization,
         const int64_t splitedAxis,
         const std::vector<size_t>& splitLengths) {
         const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
@@ -38,7 +38,7 @@ namespace subgraph {
 std::shared_ptr<ov::Model> VariadicSplitFunction::getOriginal(
     const ov::element::Type originalFunctionPrecision,
     const ov::PartialShape& inputShape,
-    const ngraph::builder::subgraph::FakeQuantizeOnData fakeQuantize,
+    const ov::builder::subgraph::FakeQuantizeOnData fakeQuantize,
     const int64_t splitedAxis,
     const std::vector<size_t>& splitLengths) {
     const auto input = std::make_shared<ov::opset1::Parameter>(originalFunctionPrecision, inputShape);
@@ -69,9 +69,9 @@ std::shared_ptr<ov::Model> VariadicSplitFunction::getOriginal(
 std::shared_ptr<ov::Model> VariadicSplitFunction::getReference(
     const ov::PartialShape& inputShape,
     const ov::element::Type inputPrecision,
-    const ngraph::builder::subgraph::DequantizationOperations& dequantizationBefore,
+    const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
     const ov::element::Type precisionAfterOperation,
-    const std::vector<ngraph::builder::subgraph::DequantizationOperations>& dequantizationAfter,
+    const std::vector<ov::builder::subgraph::DequantizationOperations>& dequantizationAfter,
     const int64_t splitedAxis,
     const std::vector<size_t>& splitLengths) {
     const auto input = std::make_shared<ov::opset1::Parameter>(inputPrecision, inputShape);
@@ -92,4 +92,4 @@ std::shared_ptr<ov::Model> VariadicSplitFunction::getReference(
 
 }  // namespace subgraph
 }  // namespace builder
-}  // namespace ngraph
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_fq.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_fq.cpp
@@ -13,64 +13,64 @@ namespace snippets {
 
 std::shared_ptr<ov::Model> ThreeFQFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
-    auto fq0_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+    auto fq0_data = ov::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
                                                                               std::vector<ov::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
                                                                               std::vector<float>{-397898.40625, -435929.78125, -476583.9375},
                                                                               std::vector<float>{394789.84375, 432524.09375, 472860.625},
                                                                               std::vector<float>{0},
                                                                               std::vector<float>{255},
                                                                               ov::element::u8);
-    auto fq0 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(data0, ov::element::f32, fq0_data);
-    auto fq1_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+    auto fq0 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(data0, ov::element::f32, fq0_data);
+    auto fq1_data = ov::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
                                                                               std::vector<ov::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
                                                                               std::vector<float>{5.390228, 9.7712707, 9.333160},
                                                                               std::vector<float>{250.524688, 254.905731, 254.467620},
                                                                               std::vector<float>{-128},
                                                                               std::vector<float>{127},
                                                                               ov::element::i8);
-    auto fq1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq0, ov::element::f32, fq1_data);
-    auto fq2_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+    auto fq1 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq0, ov::element::f32, fq1_data);
+    auto fq2_data = ov::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
                                                                               std::vector<ov::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
                                                                               std::vector<float>{-98.16883, -142.82466, -155.0642700},
                                                                               std::vector<float>{97.334106, 141.599884, 153.8145446},
                                                                               std::vector<float>{0},
                                                                               std::vector<float>{255},
                                                                               ov::element::u8);
-    auto fq2 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq1, ov::element::f32, fq2_data);
+    auto fq2 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq1, ov::element::f32, fq2_data);
     return std::make_shared<ov::Model>(NodeVector{fq2}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> ThreeFQFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
 
     auto indata0 = std::make_shared<op::v0::Parameter>(precision, data0->get_shape());
-    auto fq0_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+    auto fq0_data = ov::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
                                                                               std::vector<ov::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
                                                                               std::vector<float>{-397898.40625, -435929.78125, -476583.9375},
                                                                               std::vector<float>{394789.84375, 432524.09375, 472860.625},
                                                                               std::vector<float>{0},
                                                                               std::vector<float>{255},
                                                                               ov::element::u8);
-    auto fq0 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(indata0, ov::element::f32, fq0_data);
-    auto fq1_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+    auto fq0 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(indata0, ov::element::f32, fq0_data);
+    auto fq1_data = ov::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
                                                                               std::vector<ov::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
                                                                               std::vector<float>{5.390228, 9.7712707, 9.333160},
                                                                               std::vector<float>{250.524688, 254.905731, 254.467620},
                                                                               std::vector<float>{-128},
                                                                               std::vector<float>{127},
                                                                               ov::element::i8);
-    auto fq1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq0, ov::element::f32, fq1_data);
+    auto fq1 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq0, ov::element::f32, fq1_data);
     auto subgraph0 = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0},
                                           std::make_shared<ov::Model>(NodeVector{fq1}, ParameterVector{indata0}));
 
     auto indata1 = std::make_shared<op::v0::Parameter>(precision, subgraph0->get_shape());
-    auto fq2_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+    auto fq2_data = ov::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
                                                                               std::vector<ov::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
                                                                               std::vector<float>{-98.16883, -142.82466, -155.0642700},
                                                                               std::vector<float>{97.334106, 141.599884, 153.8145446},
                                                                               std::vector<float>{0},
                                                                               std::vector<float>{255},
                                                                               ov::element::u8);
-    auto fq2 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(indata1, ov::element::f32, fq2_data);
+    auto fq2 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(indata1, ov::element::f32, fq2_data);
     auto subgraph1 = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{subgraph0},
                                       std::make_shared<ov::Model>(NodeVector{fq2}, ParameterVector{indata1}));
 

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
@@ -779,10 +779,10 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initOriginal() cons
                                               static_cast<int64_t>(input_shapes[0].get_shape()[1])};
     auto reshape1Const = ov::test::utils::deprecated::make_constant(ov::element::i64, {reshape1ConstData.size()}, reshape1ConstData);
 
-    const auto fq_signed_params = ngraph::builder::subgraph::FakeQuantizeOnData(256, {1}, {-36912.66015625}, {36624.28125}, {-128}, {127}, ov::element::i8);
-    const auto fq0 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(transpose0Param, ov::element::i8, fq_signed_params);
-    const auto fq1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(transpose1Param, ov::element::i8, fq_signed_params);
-    const auto fq2 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(transpose2Param, ov::element::i8, fq_signed_params);
+    const auto fq_signed_params = ov::builder::subgraph::FakeQuantizeOnData(256, {1}, {-36912.66015625}, {36624.28125}, {-128}, {127}, ov::element::i8);
+    const auto fq0 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(transpose0Param, ov::element::i8, fq_signed_params);
+    const auto fq1 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(transpose1Param, ov::element::i8, fq_signed_params);
+    const auto fq2 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(transpose2Param, ov::element::i8, fq_signed_params);
 
     float transA = false;
     float transB = false;
@@ -794,7 +794,7 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initOriginal() cons
             ov::op::TemporaryReplaceOutputType(transpose0, element::f32).get(),
             ov::op::TemporaryReplaceOutputType(transpose1, element::f32).get(), transA, transB);
 
-    const auto fq3 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(matMul0, ov::element::i8, fq_signed_params);
+    const auto fq3 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(matMul0, ov::element::i8, fq_signed_params);
     const auto add = std::make_shared<op::TypeRelaxed<ov::op::v1::Add>>(
             std::vector<element::Type>{ element::f32, element::f32 },
             std::vector<element::Type>{ element::f32 },
@@ -811,8 +811,8 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initOriginal() cons
     const auto softMax = std::make_shared<ov::opset1::Softmax>(reshape0, 1);
     const auto reshape1 = std::make_shared<ov::opset1::Reshape>(softMax, reshape1Const, true);
 
-    const auto fq_unsigned_params = ngraph::builder::subgraph::FakeQuantizeOnData(256, {1}, {0}, {0.245}, {0}, {255}, ov::element::u8);
-    const auto fq4 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(reshape1, ov::element::u8, fq_unsigned_params);
+    const auto fq_unsigned_params = ov::builder::subgraph::FakeQuantizeOnData(256, {1}, {0}, {0.245}, {0}, {255}, ov::element::u8);
+    const auto fq4 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(reshape1, ov::element::u8, fq_unsigned_params);
 
     const auto transpose2 = std::make_shared<ov::op::v1::Transpose>(fq2, transpose2Const);
     const auto matMul1 = std::make_shared<op::TypeRelaxed<op::v0::MatMul>>(
@@ -820,7 +820,7 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initOriginal() cons
             std::vector<element::Type>{ element::f32 },
             ov::op::TemporaryReplaceOutputType(fq4, element::f32).get(),
             ov::op::TemporaryReplaceOutputType(transpose2, element::f32).get(), transA, transB);
-    const auto fq5 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(matMul1, ov::element::i8, fq_signed_params);
+    const auto fq5 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(matMul1, ov::element::i8, fq_signed_params);
     const auto transpose3 = std::make_shared<ov::op::v1::Transpose>(fq5, transpose3Const);
 
     ov::ResultVector results{std::make_shared<ov::opset1::Result>(transpose3)};
@@ -833,10 +833,10 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initReference() con
     auto data3 = std::make_shared<ov::opset1::Parameter>(precision, input_shapes[3]);
     ov::ParameterVector ngraphParams = {data0, data1, data2, data3};
 
-    const auto fq_signed_params = ngraph::builder::subgraph::FakeQuantizeOnData(256, {1}, {-36912.66015625}, {36624.28125}, {-128}, {127}, ov::element::i8);
-    const auto fq0 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(data0, ov::element::i8, fq_signed_params);
-    const auto fq1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(data1, ov::element::i8, fq_signed_params);
-    const auto fq2 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(data3, ov::element::i8, fq_signed_params);
+    const auto fq_signed_params = ov::builder::subgraph::FakeQuantizeOnData(256, {1}, {-36912.66015625}, {36624.28125}, {-128}, {127}, ov::element::i8);
+    const auto fq0 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(data0, ov::element::i8, fq_signed_params);
+    const auto fq1 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(data1, ov::element::i8, fq_signed_params);
+    const auto fq2 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(data3, ov::element::i8, fq_signed_params);
     NodeVector subgraph_inputs = {fq0, fq1, data2, fq2};
 
     auto transpose0Param = std::make_shared<ov::opset1::Parameter>(precision, input_shapes[0]);
@@ -872,7 +872,7 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initReference() con
             ov::op::TemporaryReplaceOutputType(transpose0, element::f32).get(),
             ov::op::TemporaryReplaceOutputType(transpose1, element::f32).get(), transA, transB);
 
-    const auto fq3 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(matMul0, ov::element::i8, fq_signed_params);
+    const auto fq3 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(matMul0, ov::element::i8, fq_signed_params);
     const auto add = std::make_shared<op::TypeRelaxed<ov::op::v1::Add>>(
             std::vector<element::Type>{ element::f32, element::f32 },
             std::vector<element::Type>{ element::f32 },
@@ -889,8 +889,8 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initReference() con
     const auto softMax = std::make_shared<ov::opset1::Softmax>(reshape0, 1);
     const auto reshape1 = std::make_shared<ov::opset1::Reshape>(softMax, reshape1Const, true);
 
-    const auto fq_unsigned_params = ngraph::builder::subgraph::FakeQuantizeOnData(256, {1}, {0}, {0.245}, {0}, {255}, ov::element::u8);
-    const auto fq4 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(reshape1, ov::element::u8, fq_unsigned_params);
+    const auto fq_unsigned_params = ov::builder::subgraph::FakeQuantizeOnData(256, {1}, {0}, {0.245}, {0}, {255}, ov::element::u8);
+    const auto fq4 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(reshape1, ov::element::u8, fq_unsigned_params);
 
     const auto transpose2 = std::make_shared<ov::op::v1::Transpose>(transpose2Param, transpose2Const);
     const auto matMul1 = std::make_shared<op::TypeRelaxed<op::v0::MatMul>>(
@@ -898,7 +898,7 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initReference() con
             std::vector<element::Type>{ element::f32 },
             ov::op::TemporaryReplaceOutputType(fq4, element::f32).get(),
             ov::op::TemporaryReplaceOutputType(transpose2, element::f32).get(), transA, transB);
-    const auto fq5 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(matMul1, ov::element::i8, fq_signed_params);
+    const auto fq5 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(matMul1, ov::element::i8, fq_signed_params);
 
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(subgraph_inputs,
                                                                      std::make_shared<ov::Model>(NodeVector{fq5}, subgraph_params));


### PR DESCRIPTION
### Details:
 - src/tests/ov_helpers/ov_lpt_models fix ngraph -> ov namespace

### Tickets:
 - 129934
