### PR TITLE
[GPU] Garbage collection of kv cache memory 

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -226,6 +226,13 @@ public:
     std::shared_ptr<ShapePredictor> get_shape_predictor() { return _shape_predictor; }
     void set_shape_predictor(std::shared_ptr<ShapePredictor> shape_predictor) { _shape_predictor = shape_predictor; }
 
+    std::unordered_map<primitive_id, std::vector<primitive_id>> get_kv_cache_mem_deps() {
+        return _kv_cache_mem_deps;
+    }
+    void add_kv_cache_mem_deps(primitive_id kv_cache, primitive_id read_value) {
+        _kv_cache_mem_deps[kv_cache].push_back(read_value);
+    }
+
 #ifdef GPU_DEBUG_CONFIG
     int64_t get_current_iteration_num() { return iteration; }
 #endif
@@ -266,6 +273,9 @@ private:
     output_chains_map _output_chains;
 
     std::shared_ptr<ShapePredictor> _shape_predictor;
+
+    // Record corresponding read_values for kv_cache so that we can release those read_value's output memories when they are no longer needed
+    std::unordered_map<primitive_id/*kv_cache*/, std::vector<primitive_id/*read_value*/>> _kv_cache_mem_deps;
 
     void build_exec_order();
     void allocate_primitive_instance(program_node const& node);

--- a/src/plugins/intel_gpu/src/graph/include/kv_cache_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/kv_cache_inst.h
@@ -80,6 +80,8 @@ public:
         return max_pad;
     }
 
+    void post_realloc_optimization(const layout& allocated_layout);
+
     typed_primitive_inst(network& network, const kv_cache_node& desc);
     typed_primitive_inst(network& network) : parent(network), memory_state::variable("") {}
 };

--- a/src/plugins/intel_gpu/src/graph/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/kv_cache.cpp
@@ -103,7 +103,9 @@ void kv_cache_inst::post_realloc_optimization(const layout& allocated_layout) {
                 std::vector<primitive_id> mem_deps_eol;
                 for (auto kms : _network.get_kv_cache_mem_deps()) {
                     const auto kv_cache_id = kms.first;
-                    if (_network.has_event(kv_cache_id) && _network.get_primitive_event(kv_cache_id)->is_set()) {
+                    auto queue_type = get_network().get_stream().get_queue_type();
+                    if (queue_type == QueueTypes::in_order ||
+                        (_network.has_event(kv_cache_id) && _network.get_primitive_event(kv_cache_id)->is_set())) {
                         for (auto mem_deps : kms.second) {
                             mem_deps_eol.push_back(mem_deps);
                         }

--- a/src/plugins/intel_gpu/src/graph/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/kv_cache.cpp
@@ -6,6 +6,8 @@
 #include "intel_gpu/plugin/common_utils.hpp"
 #include "intel_gpu/runtime/optionals.hpp"
 #include "kv_cache_inst.h"
+#include "read_value_inst.h"
+#include "gather_inst.h"
 #include "primitive_type_base.h"
 #include <sstream>
 #include <json_object.h>
@@ -53,6 +55,94 @@ std::string kv_cache_inst::to_string(const kv_cache_node& node) {
     std::stringstream primitive_description;
     node_info->dump(primitive_description);
     return primitive_description.str();
+}
+
+void kv_cache_inst::post_realloc_optimization(const layout& allocated_layout) {
+    auto desc = _node->as<kv_cache>().get_primitive();
+    auto& variable = get_network().get_variable(desc->variable_info.variable_id);
+    auto present_layout = _impl_params->output_layouts[0];
+    const auto& sequence_axis = desc->concat_axis;
+    auto sequence_axis_legacy =
+        kv_cache_inst::get_sequence_axis_legacy(sequence_axis, present_layout.get_partial_shape().size());
+    GPU_DEBUG_TRACE_DETAIL << id() << " is kv_cache => set the variable with newly allocated output memory"
+                           << std::endl;
+    bool axis_is_outer_most = true;
+    for (int64_t dim = 0; dim < sequence_axis; ++dim) {
+        if (present_layout.get_shape()[dim] > 1) {
+            axis_is_outer_most = false;
+            break;
+        }
+    }
+    if (present_layout.data_padding.get_dynamic_pad_dims().sizes()[sequence_axis_legacy] == 1) {
+        // Apply padding of variable to make it be optimized in the next iteration
+        auto max_pad = kv_cache_inst::get_max_pad(
+            present_layout,
+            allocated_layout.get_buffer_size().count(),
+            sequence_axis_legacy,
+            "present_layout");
+        if (max_pad > 0) {
+            kv_cache_inst::update_pad(present_layout, max_pad, sequence_axis_legacy);
+            if (!axis_is_outer_most) {
+                GPU_DEBUG_TRACE_DETAIL << id() << ": Update impl with new output padding" << std::endl;
+                set_shape_change();
+                _impl_params->output_layouts[0] = present_layout;
+                update_impl();
+            }
+            GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable " << variable.get_name()
+                                   << "'s memory with allocated kv cache output: " << present_layout.to_short_string()
+                                   << " is_set  = " << variable.is_set() << std::endl;
+            variable.set_memory(_outputs[0], present_layout);
+            _impl_params->_can_be_optimized = true;
+            // No need to copy, still it can be optimized
+            GPU_DEBUG_TRACE_DETAIL << id() << ": Set can_be_optimized = true " << std::endl;
+            {
+                // Garbage collection of kv cache meories :
+                // Once the corresponding kv cache's execution is done, the input mems are no
+                // longer needed and can be released.
+                GPU_DEBUG_TRACE_DETAIL << ": Check releasable kv cache memories" << std::endl;
+                std::vector<primitive_id> mem_deps_eol;
+                for (auto kms : _network.get_kv_cache_mem_deps()) {
+                    const auto kv_cache_id = kms.first;
+                    if (_network.has_event(kv_cache_id) && _network.get_primitive_event(kv_cache_id)->is_set()) {
+                        for (auto mem_deps : kms.second) {
+                            mem_deps_eol.push_back(mem_deps);
+                        }
+                    }
+                }
+                for (auto mem_dep : mem_deps_eol) {
+                    auto mem_dep_inst = _network.get_primitive(mem_dep);
+                    GPU_DEBUG_TRACE_DETAIL << "Release output memory of " << mem_dep_inst->id() << ": "
+                              << ((mem_dep_inst->_outputs.size() > 0 && mem_dep_inst->_outputs[0]) ? mem_dep_inst->_outputs[0]->buffer_ptr() : " 0x0")
+                              << std::endl;
+
+                    mem_dep_inst->_outputs[0] = nullptr;
+                }
+            }
+            {
+                // Add mem_deps for current kv_cache op for future release
+                GPU_DEBUG_TRACE_DETAIL << "Record kv cache mem deps for future garbage collection " << id() << ": " << std::endl;
+                if (_deps[0].first->get_node().is_type<gather>() && _deps[0].first->can_be_optimized()) {
+                    _network.add_kv_cache_mem_deps(id(), _deps[0].first->id());
+                    GPU_DEBUG_TRACE_DETAIL << id() << " can clear " << _deps[0].first->id() << "'s mem" << std::endl;
+                    if (_deps[0].first->_deps[0].first->get_node().is_type<read_value>() &&
+                        _deps[0].first->_deps[0].first->can_be_optimized()) {
+                        _network.add_kv_cache_mem_deps(id(), _deps[0].first->_deps[0].first->id());
+                        GPU_DEBUG_TRACE_DETAIL << id() << " can clear " << _deps[0].first->_deps[0].first->id() << "'s mem" << std::endl;
+                    }
+                }
+            }
+        } else {
+            GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable " << variable.get_name()
+                                   << "'s layout with allocated kv cache output: " << present_layout.to_short_string()
+                                   << " (is_set  = " << variable.is_set() << ") " << std::endl;
+            variable.set_layout(present_layout);
+        }
+    } else {
+        GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable " << variable.get_name()
+                               << "'s layout with allocated kv cache output: " << present_layout.to_short_string()
+                               << " (is_set  = " << variable.is_set() << ") " << std::endl;
+        variable.set_layout(present_layout);
+    }
 }
 
 } // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -443,7 +443,7 @@ void network::reset_execution(bool wait) {
             get_stream().wait_for_events(events);
         }
     }
-
+    _kv_cache_mem_deps.clear();
     // Move events to temporarily map to deallocate them at the end of network::execute() call for better overlapping with
     // kernels execution, since it may take significant time for high amount of events
     _old_events = std::move(_events);


### PR DESCRIPTION
### Details:
 - To release old variable memory (assigned to readvalue & gather) once the corresponding kv cache is executed)
 - (To prevent memory peak for long sequence kv)

### Tickets:
 - 128982
