### PR TITLE
[GPU] assert the allocation size of object is larger than max_alloc_mem_size

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -127,15 +127,27 @@ allocation_type ocl_engine::detect_usm_allocation_type(const void* memory) const
 
 bool ocl_engine::check_allocatable(const layout& layout, allocation_type type) {
     OPENVINO_ASSERT(supports_allocation(type) || type == allocation_type::cl_mem, "[GPU] Unsupported allocation type: ", type);
-    auto alloc_mem_size = layout.bytes_count();
-    auto max_mem_size = get_device_info().max_alloc_mem_size;
-    if (alloc_mem_size > max_mem_size) {
-        auto used_mem = get_used_device_memory(allocation_type::usm_device) + get_used_device_memory(allocation_type::usm_host);
-        GPU_DEBUG_LOG << "[GPU] Mem size info: " << "Required " << alloc_mem_size << " bytes, already occupied : "
-                      << used_mem << " bytes, available memory size is " << get_max_memory_size() << " bytes, but max allocable memory size is "
-                      << max_mem_size << " bytes." << std::endl;
+
+    OPENVINO_ASSERT(layout.bytes_count() <= get_device_info().max_alloc_mem_size,
+                    "[GPU] Exceeded max size of memory object allocation: ",
+                    "Requested ", layout.bytes_count(), " bytes "
+                    "but max alloc size is ", get_device_info().max_alloc_mem_size, " bytes");
+
+    auto used_mem = get_used_device_memory(allocation_type::usm_device) + get_used_device_memory(allocation_type::usm_host);
+#ifdef __unix__
+    // Prevent from being killed by Ooo Killer of Linux
+    OPENVINO_ASSERT(layout.bytes_count() + used_mem <= get_max_memory_size(),
+                    "[GPU] Exceeded max size of memory allocation: ",
+                    "Required ", layout.bytes_count(), " bytes, already occupied : ", used_mem, " bytes, ",
+                    "but available memory size is ", get_max_memory_size(), " bytes");
+#else
+    if (layout.bytes_count() + used_mem > get_max_memory_size()) {
+        GPU_DEBUG_COUT << "[Warning] [GPU] Exceeded max size of memory allocation: " << "Required " << layout.bytes_count() << " bytes, already occupied : "
+                       << used_mem << " bytes, but available memory size is " << get_max_memory_size() << " bytes" << std::endl;
+        GPU_DEBUG_COUT << "Please note that performance might drop due to memory swap." << std::endl;
         return false;
     }
+#endif
 
     return true;
 }
@@ -143,14 +155,7 @@ bool ocl_engine::check_allocatable(const layout& layout, allocation_type type) {
 memory::ptr ocl_engine::allocate_memory(const layout& layout, allocation_type type, bool reset) {
     OPENVINO_ASSERT(!layout.is_dynamic() || layout.has_upper_bound(), "[GPU] Can't allocate memory for dynamic layout");
 
-    bool allocatable = check_allocatable(layout, type);
-    if (!allocatable) {
-#ifdef __unix__
-        OPENVINO_ASSERT(allocatable, "[GPU] Exceeded max size of memory allocation, check debug message for size info");
-#else
-        GPU_DEBUG_COUT << "[Warning][GPU] Please note that performance might drop due to memory swap caused by exceeded mem size alloc." << std::endl;
-#endif
-    }
+    check_allocatable(layout, type);
 
     try {
         memory::ptr res = nullptr;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -130,8 +130,9 @@ bool ocl_engine::check_allocatable(const layout& layout, allocation_type type) {
 
     OPENVINO_ASSERT(layout.bytes_count() <= get_device_info().max_alloc_mem_size,
                     "[GPU] Exceeded max size of memory object allocation: ",
-                    "Requested ", layout.bytes_count(), " bytes "
-                    "but max alloc size is ", get_device_info().max_alloc_mem_size, " bytes");
+                    "requested ", layout.bytes_count(), " bytes, "
+                    "but max alloc size supported by device is ", get_device_info().max_alloc_mem_size, " bytes.",
+                    "Please try to reduce batch size or use lower precision.");
 
     auto used_mem = get_used_device_memory(allocation_type::usm_device) + get_used_device_memory(allocation_type::usm_host);
 #ifdef __unix__

--- a/src/plugins/intel_gpu/tests/functional/dynamic_tests/gpu_dyn_huge_input_range.cpp
+++ b/src/plugins/intel_gpu/tests/functional/dynamic_tests/gpu_dyn_huge_input_range.cpp
@@ -213,7 +213,7 @@ const std::vector<StridedSliceParams> paramsPlain2D_excessive_uppper_boundary = 
         StridedSliceParams{ { 0, 1 }, { 0, 2147483647 }, { 1, 1 }, { 1, 0 }, { 1, 0 },  { },  { },  { } },
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Dynamic_2D_excessive_uppper_boundary, DynamicShapeHugeRangeGPUTest,
+INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_CompareWithRefs_Dynamic_2D_excessive_uppper_boundary, DynamicShapeHugeRangeGPUTest,
                          ::testing::Combine(
                              ::testing::ValuesIn(inputShapesDynamic2D_excessive_uppper_boundary),
                              ::testing::ValuesIn(paramsPlain2D_excessive_uppper_boundary),

--- a/src/plugins/intel_gpu/tests/functional/dynamic_tests/gpu_dyn_huge_input_range.cpp
+++ b/src/plugins/intel_gpu/tests/functional/dynamic_tests/gpu_dyn_huge_input_range.cpp
@@ -118,6 +118,7 @@ protected:
     std::vector<int64_t> stride;
     std::vector<ov::test::utils::InputLayerType> restInputType;
     size_t inferRequestNum = 0;
+    bool exception;
 
     void SetUp() override {
         InputShape shapes;
@@ -180,11 +181,17 @@ protected:
         }
 
         function = std::make_shared<ov::Model>(results, params, "result");
+
+        set_callback_exception([this](const std::exception& exp) {
+            exception = true;
+        });
     }
 };
 
 TEST_P(DynamicShapeHugeRangeGPUTest, Inference) {
     run();
+    if (!exception)
+        FAIL() << "This test case is checking the exception that the object allocation is larger than the max_alloc_mem_size.";
 }
 
 std::map<std::string, std::string> emptyAdditionalConfig;
@@ -213,7 +220,7 @@ const std::vector<StridedSliceParams> paramsPlain2D_excessive_uppper_boundary = 
         StridedSliceParams{ { 0, 1 }, { 0, 2147483647 }, { 1, 1 }, { 1, 0 }, { 1, 0 },  { },  { },  { } },
 };
 
-INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_CompareWithRefs_Dynamic_2D_excessive_uppper_boundary, DynamicShapeHugeRangeGPUTest,
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Dynamic_2D_excessive_uppper_boundary, DynamicShapeHugeRangeGPUTest,
                          ::testing::Combine(
                              ::testing::ValuesIn(inputShapesDynamic2D_excessive_uppper_boundary),
                              ::testing::ValuesIn(paramsPlain2D_excessive_uppper_boundary),

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -44,6 +44,7 @@ protected:
     void update_ref_model();
     void match_parameters();
     void init_input_shapes(const std::vector<InputShape>& shapes);
+    void set_callback_exception(std::function<void(const std::exception& exp)> callback) { callback_exception = callback; }
 
     void TearDown() override {
         if (this->HasFailure() && !is_reported) {
@@ -68,6 +69,8 @@ protected:
     // to provide correct inputs for reference function
     std::map<std::shared_ptr<ov::op::v0::Parameter>, std::shared_ptr<ov::op::v0::Parameter>> matched_parameters;
     precisions_map convert_precisions;
+
+    std::function<void(const std::exception& exp)> callback_exception = nullptr;
 
     constexpr static const double disable_threshold = std::numeric_limits<double>::max();
     double abs_threshold = disable_threshold, rel_threshold = disable_threshold;

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -79,8 +79,14 @@ void SubgraphBaseTest::run() {
             }
             status = ov::test::utils::PassRate::Statuses::PASSED;
         } catch (const std::exception& ex) {
-            status = ov::test::utils::PassRate::Statuses::FAILED;
-            errorMessage = ex.what();
+            if (callback_exception != nullptr) {
+                // exception will be checked by callback.
+                callback_exception(ex);
+                return;
+            } else {
+                status = ov::test::utils::PassRate::Statuses::FAILED;
+                errorMessage = ex.what();
+            }
         } catch (...) {
             status = ov::test::utils::PassRate::Statuses::FAILED;
             errorMessage = "Unknown failure occurred.";


### PR DESCRIPTION
missing case that the object allocation is larger than max_alloc_mem_size

| | Windows| Linux |
|--------|--------|--------|
| **Object allocation size is larger than max_alloc_mem_size** | assert | assert |
| Object allocation and allocated size is larger than max_mem_size  | print log | assert |

### Tickets:
 - 129494
