### PR TITLE
Revert "Move SliceToStridedSlice conversion from MOC to Common transformations (#21556)"

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -89,7 +89,6 @@
 #include "transformations/op_conversions/convert_roi_align_v3_to_v9.hpp"
 #include "transformations/op_conversions/convert_roi_align_v9_to_v3.hpp"
 #include "transformations/op_conversions/convert_scatter_elements_update12_downgrade.hpp"
-#include "transformations/op_conversions/convert_slice_to_strided_slice.hpp"
 #include "transformations/op_conversions/convert_softmax_downgrade.hpp"
 #include "transformations/op_conversions/convert_softmax_upgrade.hpp"
 #include "transformations/op_conversions/convert_space_to_depth.hpp"
@@ -123,9 +122,7 @@ bool ov::pass::CommonOptimizations::run_on_model(const std::shared_ptr<ov::Model
 
     using namespace ov::pass;
     REGISTER_PASS(manager, DisableDecompressionConvertConstantFolding)
-    // MOCTransformations contain StridedSliceOptimization transformation,
-    // so we must call SliceToStridedSlice before MOCTransformations call
-    REGISTER_PASS(manager, SliceToStridedSlice, true)
+
     // Disable low_precision_enabled as all plugins handle low-precision sub-graph manually
     // before CommonOptimization pipeline execution
     REGISTER_PASS(manager, MOCTransformations, true, false)

--- a/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
@@ -17,6 +17,7 @@
 #include "openvino/op/util/sub_graph_base.hpp"
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/manager.hpp"
+#include "transformations/op_conversions/convert_slice_to_strided_slice.hpp"
 
 using namespace ov;
 
@@ -420,6 +421,12 @@ ov::pass::StridedSliceOptimization::StridedSliceOptimization(bool use_shapes) {
 
 bool ov::pass::StridedSliceOptimization::run_on_model(const std::shared_ptr<ov::Model>& f) {
     RUN_ON_FUNCTION_SCOPE(StridedSliceOptimization);
+
+    ov::pass::Manager manager(get_pass_config());
+    using namespace ov::pass;
+    REGISTER_PASS(manager, SliceToStridedSlice, m_use_shapes)
+    manager.run_passes(f);
+
     bool rewritten = false;
     if (m_use_shapes) {
         rewritten = UselessSliceEraser().run_on_model(f);

--- a/src/common/transformations/tests/common_optimizations/optimize_strided_slice_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/optimize_strided_slice_test.cpp
@@ -21,7 +21,6 @@
 #include "openvino/opsets/opset3.hpp"
 #include "openvino/opsets/opset8.hpp"
 #include "openvino/pass/constant_folding.hpp"
-#include "transformations/op_conversions/convert_slice_to_strided_slice.hpp"
 #include "transformations/utils/utils.hpp"
 
 using namespace ov;
@@ -408,7 +407,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_default_axes) {
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
@@ -440,7 +438,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_axes_const_sorted_full) {
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
+        manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{2, 4, 3, 5});
@@ -471,7 +469,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_all_const) {
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
@@ -525,7 +522,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_sorted_le
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
@@ -567,7 +563,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_unsorted)
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
@@ -610,7 +605,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_negative_
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
@@ -643,7 +637,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_dyn_shape_axes_const
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
@@ -687,7 +680,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_static_shape_axes_co
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
@@ -730,7 +722,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_dyn_rank_axes_const_positive) {
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
     {
@@ -805,7 +796,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_begin_param_shape_of_use_shapes
         auto slice = std::make_shared<opset8::Slice>(shape_of_data, begin, end, step, axes);
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin});
 
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>(true);
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -848,7 +838,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_begin_param_shape_of_use_shapes
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin});
 
         manager.register_pass<pass::ConstantFolding>();
-        manager.register_pass<ov::pass::SliceToStridedSlice>(false);
         manager.register_pass<ov::pass::StridedSliceOptimization>(false);
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -951,7 +940,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_slice_all_use_shapes_true) {
         auto slice = std::make_shared<opset8::Slice>(relu, begin, end, step);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>(true);
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -991,7 +979,6 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_slice_all_use_shapes_false) {
         auto slice = std::make_shared<opset8::Slice>(relu, begin, end, step);
 
         model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
-        manager.register_pass<ov::pass::SliceToStridedSlice>(false);
         manager.register_pass<ov::pass::StridedSliceOptimization>(false);
         manager.register_pass<pass::ConstantFolding>();
     }


### PR DESCRIPTION
This reverts commit e07602720cc71ffd684342430298d01e29579d6d due to the perf regression.
RoPE fusion pattern is based on StridedSlice.
