### PR TITLE
[CPU] Enable bf16->fp32 ConvertPrecision pass for any HW

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -282,9 +282,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
             {ov::element::u4,      ov::element::u8}
         };
 
-        // @todo should we always convert to f32 regardless of hardware support, as it is done for f16?
-        if (!hasHardwareSupport(ov::element::bf16))
-            map.insert({ov::element::bf16, ov::element::f32});
+        map.insert({ov::element::bf16, ov::element::f32});
 #if defined(OV_CPU_ARM_ENABLE_FP16)
         if (inferencePrecision != ov::element::f16)
             map.insert({ov::element::f16, ov::element::f32});


### PR DESCRIPTION
### Details:
 - Current CPU transformation pipeline cannot correctly handle models with bf16 activations (e.g. LPT fails with `unexpected precision` error). The idea of this change is to "normalize" the model converting it to fp32 precision. 
EnforceInfencePrecision pass keeps responsible for bf16 precision mark-up based on inference precision hint property.