### PR TITLE
[CPU] Support DEVICE_TYPE and DEVICE_ARCHITECTURE in CPU plugin

### DIFF
--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -773,6 +773,14 @@ ov::Any Engine::get_ro_property(const std::string& name, const ov::AnyMap& optio
         return decltype(ov::device::architecture)::value_type{"intel64"};
 #elif defined(OPENVINO_ARCH_X86)
         return decltype(ov::device::architecture)::value_type{"ia32"};
+#elif defined(OPENVINO_ARCH_ARM)
+        return decltype(ov::device::architecture)::value_type{"armhf"};
+#elif defined(OPENVINO_ARCH_ARM64)
+        return decltype(ov::device::architecture)::value_type{"arm64"};
+#elif defined(OPENVINO_ARCH_RISCV64)
+        return decltype(ov::device::architecture)::value_type{"riscv"};
+#else
+#error "Undefined system processor"
 #endif
     }
 

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -701,6 +701,7 @@ ov::Any Engine::get_ro_property(const std::string& name, const ov::AnyMap& optio
                                                     RO_property(ov::execution_devices.name()),
                                                     RO_property(ov::device::full_name.name()),
                                                     RO_property(ov::device::capabilities.name()),
+                                                    RO_property(ov::device::type.name()),
         };
         // the whole config is RW before model is loaded.
         std::vector<ov::PropertyName> rwProperties {RW_property(ov::num_streams.name()),
@@ -764,6 +765,8 @@ ov::Any Engine::get_ro_property(const std::string& name, const ov::AnyMap& optio
         return decltype(ov::intel_cpu::sparse_weights_decompression_rate)::value_type(engConfig.fcSparseWeiDecompressionRate);
     } else if (name == ov::execution_devices) {
         return decltype(ov::execution_devices)::value_type{get_device_name()};
+    } else if (name == ov::device::type) {
+        return decltype(ov::device::type)::value_type(ov::device::Type::INTEGRATED);
     }
 
     OPENVINO_THROW("Cannot get unsupported property: ", name);

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -702,6 +702,7 @@ ov::Any Engine::get_ro_property(const std::string& name, const ov::AnyMap& optio
                                                     RO_property(ov::device::full_name.name()),
                                                     RO_property(ov::device::capabilities.name()),
                                                     RO_property(ov::device::type.name()),
+                                                    RO_property(ov::device::architecture.name()),
         };
         // the whole config is RW before model is loaded.
         std::vector<ov::PropertyName> rwProperties {RW_property(ov::num_streams.name()),
@@ -767,6 +768,12 @@ ov::Any Engine::get_ro_property(const std::string& name, const ov::AnyMap& optio
         return decltype(ov::execution_devices)::value_type{get_device_name()};
     } else if (name == ov::device::type) {
         return decltype(ov::device::type)::value_type(ov::device::Type::INTEGRATED);
+    } else if (name == ov::device::architecture) {
+#if defined(OPENVINO_ARCH_X86_64)
+        return decltype(ov::device::architecture)::value_type{"intel64"};
+#elif defined(OPENVINO_ARCH_X86)
+        return decltype(ov::device::architecture)::value_type{"ia32"};
+#endif
     }
 
     OPENVINO_THROW("Cannot get unsupported property: ", name);

--- a/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
@@ -35,6 +35,7 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginAllSupportedPropertiesAreAvailable) {
         RO_property(ov::device::full_name.name()),
         RO_property(ov::device::capabilities.name()),
         RO_property(ov::device::type.name()),
+        RO_property(ov::device::architecture.name()),
         // read write
         RW_property(ov::num_streams.name()),
         RW_property(ov::affinity.name()),
@@ -333,6 +334,19 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginCheckCPUDeviceType) {
 
     ASSERT_NO_THROW(value = ie.get_property("CPU", ov::device::type));
     ASSERT_EQ(value.as<ov::device::Type>(), ov::device::Type::INTEGRATED);
+}
+
+TEST_F(OVClassConfigTestCPU, smoke_PluginCheckCPUDeviceArchitecture) {
+    ov::Core ie;
+    ov::Any value;
+
+    ASSERT_NO_THROW(value = ie.get_property("CPU", ov::device::architecture));
+
+#if defined(OPENVINO_ARCH_X86_64)
+    ASSERT_EQ(value.as<std::string>(), "intel64");
+#elif defined(OPENVINO_ARCH_X86)
+    ASSERT_EQ(value.as<std::string>(), "ia32");
+#endif
 }
 
 } // namespace

--- a/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
@@ -34,6 +34,7 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginAllSupportedPropertiesAreAvailable) {
         RO_property(ov::execution_devices.name()),
         RO_property(ov::device::full_name.name()),
         RO_property(ov::device::capabilities.name()),
+        RO_property(ov::device::type.name()),
         // read write
         RW_property(ov::num_streams.name()),
         RW_property(ov::affinity.name()),
@@ -324,6 +325,14 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginCheckCPUExecutionDevice) {
 
     ASSERT_NO_THROW(value = ie.get_property("CPU", ov::execution_devices));
     ASSERT_EQ(value.as<std::string>(), "CPU");
+}
+
+TEST_F(OVClassConfigTestCPU, smoke_PluginCheckCPUDeviceType) {
+    ov::Core ie;
+    ov::Any value;
+
+    ASSERT_NO_THROW(value = ie.get_property("CPU", ov::device::type));
+    ASSERT_EQ(value.as<ov::device::Type>(), ov::device::Type::INTEGRATED);
 }
 
 } // namespace

--- a/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/behavior/ov_plugin/properties.cpp
@@ -346,6 +346,12 @@ TEST_F(OVClassConfigTestCPU, smoke_PluginCheckCPUDeviceArchitecture) {
     ASSERT_EQ(value.as<std::string>(), "intel64");
 #elif defined(OPENVINO_ARCH_X86)
     ASSERT_EQ(value.as<std::string>(), "ia32");
+#elif defined(OPENVINO_ARCH_ARM)
+    ASSERT_EQ(value.as<std::string>(), "armhf");
+#elif defined(OPENVINO_ARCH_ARM64)
+    ASSERT_EQ(value.as<std::string>(), "arm64");
+#elif defined(OPENVINO_ARCH_RISCV64)
+    ASSERT_EQ(value.as<std::string>(), "riscv");
 #endif
 }
 

--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/github/skip_configs/CPU/expected_failures_API.csv
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/github/skip_configs/CPU/expected_failures_API.csv
@@ -1,5 +1,4 @@
 Test Name,Fix Priority
-ov_plugin_mandatory/OVCheckGetSupportedROMetricsPropsTests.ChangeCorrectProperties/target_device=CPU_properties={DEVICE_TYPE:},1.0
 ov_plugin_mandatory/OVCheckGetSupportedROMetricsPropsTests.ChangeCorrectProperties/target_device=CPU_properties={DEVICE_ARCHITECTURE:},1.0
 ov_plugin_mandatory/OVCheckChangePropComplieModleGetPropTests_InferencePrecision.ChangeCorrectProperties/target_device=CPU_,1.0
 ov_plugin_mandatory/OVClassModelTestP.ImportModelWithNullContextThrows/0,1

--- a/src/tests/test_utils/functional_test_utils/layer_tests_summary/github/skip_configs/CPU/expected_failures_API.csv
+++ b/src/tests/test_utils/functional_test_utils/layer_tests_summary/github/skip_configs/CPU/expected_failures_API.csv
@@ -1,5 +1,4 @@
 Test Name,Fix Priority
-ov_plugin_mandatory/OVCheckGetSupportedROMetricsPropsTests.ChangeCorrectProperties/target_device=CPU_properties={DEVICE_ARCHITECTURE:},1.0
 ov_plugin_mandatory/OVCheckChangePropComplieModleGetPropTests_InferencePrecision.ChangeCorrectProperties/target_device=CPU_,1.0
 ov_plugin_mandatory/OVClassModelTestP.ImportModelWithNullContextThrows/0,1
 ov_compiled_model_mandatory/OVClassCompiledModelGetPropertyTest_MODEL_PRIORITY.GetMetricNoThrow/3,1.0


### PR DESCRIPTION
### Details:
 - Add ov::device::type property support for ov::intel_cpu::Engine
 - Add ov::device::architecture property support for ov::intel_cpu::Engine

### Tickets:
 - *CVS-111344*
 - Closes https://github.com/openvinotoolkit/openvino/issues/22153
