### PR TITLE
[GPU] Fixes for multi-output primitives

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/activation.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/activation.hpp
@@ -160,7 +160,7 @@ struct activation : public primitive_base<activation> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
+    std::vector<input_info> get_dependencies() const override {
         if (additional_params_input.empty())
             return {};
         return {additional_params_input};

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
@@ -90,8 +90,8 @@ struct adaptive_pooling : public primitive_base<adaptive_pooling> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         if (!indices_output.empty())
             ret.push_back(indices_output);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
@@ -91,7 +91,7 @@ struct adaptive_pooling : public primitive_base<adaptive_pooling> {
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         if (!indices_output.empty())
             ret.push_back(indices_output);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/condition.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/condition.hpp
@@ -114,7 +114,7 @@ struct condition : public primitive_base<condition> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override { return {}; }
+    std::vector<input_info> get_dependencies() const override { return {}; }
 };
 
 static inline std::ostream& operator<< (std::ostream& os, condition::branch& info) {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
@@ -287,19 +287,19 @@ struct convolution : public primitive_base<convolution> {
         ib >> *const_cast<primitive_id*>(&compensation);
     }
 
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret = {std::ref(weights)};
+    std::vector<input_info> get_dependencies() const override {
+        std::vector<input_info> ret = {weights};
         if (!bias.empty()) {
-            ret.push_back(std::ref(bias));
+            ret.push_back(bias);
         }
         if (!weights_zero_points.empty()) {
-            ret.push_back(std::ref(weights_zero_points));
+            ret.push_back(weights_zero_points);
         }
         if (!activations_zero_points.empty()) {
-            ret.push_back(std::ref(activations_zero_points));
+            ret.push_back(activations_zero_points);
         }
         if (!compensation.empty()) {
-            ret.push_back(std::ref(compensation));
+            ret.push_back(compensation);
         }
 
         return ret;
@@ -483,11 +483,11 @@ struct deformable_conv : public primitive_base<deformable_conv> {
         ib >> *const_cast<primitive_id_arr*>(&bias);
     }
 
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         ret.reserve(weights.size() + bias.size());
-        for (auto& w : weights) ret.push_back(std::ref(w));
-        for (auto& b : bias) ret.push_back(std::ref(b));
+        for (auto& w : weights) ret.push_back(w);
+        for (auto& b : bias) ret.push_back(b);
         return ret;
     }
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
@@ -484,7 +484,7 @@ struct deformable_conv : public primitive_base<deformable_conv> {
     }
 
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         ret.reserve(weights.size() + bias.size());
         for (auto& w : weights) ret.push_back(w);
         for (auto& b : bias) ret.push_back(b);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
@@ -449,7 +449,7 @@ struct deconvolution : public primitive_base<deconvolution> {
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         ret.reserve(weights.size() + bias.size() + (output_shape_id.empty() ? 0 : 1));
         for (auto& w : weights) ret.push_back(w);
         for (auto& b : bias) ret.push_back(b);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
@@ -448,11 +448,11 @@ struct deconvolution : public primitive_base<deconvolution> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         ret.reserve(weights.size() + bias.size() + (output_shape_id.empty() ? 0 : 1));
-        for (auto& w : weights) ret.push_back(std::ref(w));
-        for (auto& b : bias) ret.push_back(std::ref(b));
+        for (auto& w : weights) ret.push_back(w);
+        for (auto& b : bias) ret.push_back(b);
         if (!output_shape_id.empty()) ret.push_back(output_shape_id);
 
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
@@ -137,8 +137,8 @@ struct experimental_detectron_detection_output : public primitive_base<experimen
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         if (!output_classes.empty())
             ret.emplace_back(output_classes);
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
@@ -138,7 +138,7 @@ struct experimental_detectron_detection_output : public primitive_base<experimen
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         if (!output_classes.empty())
             ret.emplace_back(output_classes);
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
@@ -92,8 +92,8 @@ struct experimental_detectron_generate_proposals_single_image
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         if (!output_roi_scores.empty())
             ret.push_back(output_roi_scores);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
@@ -93,7 +93,7 @@ struct experimental_detectron_generate_proposals_single_image
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         if (!output_roi_scores.empty())
             ret.push_back(output_roi_scores);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -186,8 +186,8 @@ struct fully_connected : public primitive_base<fully_connected> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         ret.push_back(weights);
 
         if (!bias.empty())

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -187,7 +187,7 @@ struct fully_connected : public primitive_base<fully_connected> {
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         ret.push_back(weights);
 
         if (!bias.empty())

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
@@ -169,8 +169,8 @@ struct gather : public primitive_base<gather> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
 
         if (decompression_scale.is_valid())
             ret.push_back(decompression_scale.pid);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
@@ -170,7 +170,7 @@ struct gather : public primitive_base<gather> {
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
 
         if (decompression_scale.is_valid())
             ret.push_back(decompression_scale.pid);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/generate_proposals.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/generate_proposals.hpp
@@ -122,7 +122,7 @@ struct generate_proposals
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         if (!output_rois_scores.empty())
             ret.push_back(output_rois_scores);
         if (!output_rois_num.empty())

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/generate_proposals.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/generate_proposals.hpp
@@ -121,8 +121,8 @@ struct generate_proposals
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         if (!output_rois_scores.empty())
             ret.push_back(output_rois_scores);
         if (!output_rois_num.empty())

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
@@ -275,7 +275,7 @@ struct loop : public primitive_base<loop> {
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         // add external_id in dependencies if not exist
         for (const auto& mapping : input_primitive_maps) {
             auto target = std::find_if(input.begin(), input.end(),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
@@ -274,15 +274,15 @@ struct loop : public primitive_base<loop> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         // add external_id in dependencies if not exist
         for (const auto& mapping : input_primitive_maps) {
             auto target = std::find_if(input.begin(), input.end(),
                                     [&](const input_info& info) {
                                         return info.pid == mapping.external_id.pid;});
             if (target == input.end()) {
-                ret.push_back(std::ref(mapping.external_id.pid));
+                ret.push_back(mapping.external_id.pid);
             }
         }
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm.hpp
@@ -138,8 +138,8 @@ struct lstm_elt : public primitive_base<lstm_elt> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         if (!cell.empty())
             ret.push_back(cell);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm.hpp
@@ -139,7 +139,7 @@ struct lstm_elt : public primitive_base<lstm_elt> {
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         if (!cell.empty())
             ret.push_back(cell);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/multiclass_nms.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/multiclass_nms.hpp
@@ -209,7 +209,7 @@ struct multiclass_nms : public primitive_base<multiclass_nms> {
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         ret.emplace_back(output_selected_indices);
         ret.emplace_back(output_selected_num);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/multiclass_nms.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/multiclass_nms.hpp
@@ -208,8 +208,8 @@ struct multiclass_nms : public primitive_base<multiclass_nms> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         ret.emplace_back(output_selected_indices);
         ret.emplace_back(output_selected_num);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
@@ -110,8 +110,8 @@ struct non_max_suppression : public primitive_base<non_max_suppression> {
         #undef cmp_fields
     }
 
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         if (!num_select_per_class.empty())
             ret.push_back(num_select_per_class);
         if (!iou_threshold.empty())

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
@@ -111,7 +111,7 @@ struct non_max_suppression : public primitive_base<non_max_suppression> {
     }
 
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         if (!num_select_per_class.empty())
             ret.push_back(num_select_per_class);
         if (!iou_threshold.empty())

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/normalize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/normalize.hpp
@@ -89,6 +89,6 @@ struct normalize : public primitive_base<normalize> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override { return {scale_input}; }
+    std::vector<input_info> get_dependencies() const override { return {scale_input}; }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
@@ -237,8 +237,8 @@ struct pooling : public primitive_base<pooling> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
-        std::vector<std::reference_wrapper<const primitive_id>> ret;
+    std::vector<input_info> get_dependencies() const override {
+       std::vector<input_info> ret;
         if (!indices_output.empty())
             ret.push_back(indices_output);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
@@ -238,7 +238,7 @@ struct pooling : public primitive_base<pooling> {
 
 protected:
     std::vector<input_info> get_dependencies() const override {
-       std::vector<input_info> ret;
+        std::vector<input_info> ret;
         if (!indices_output.empty())
             ret.push_back(indices_output);
         return ret;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
@@ -138,7 +138,7 @@ public:
     std::vector<input_info> dependencies() const {
         auto result = input;
         auto deps = get_dependencies();
-        for (auto& pid : deps) result.push_back({pid, 0});
+        for (auto& dep : deps) result.push_back(dep);
         return result;
     }
 
@@ -291,7 +291,7 @@ public:
     }
 
 protected:
-    virtual std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const { return {}; }
+    virtual std::vector<input_info> get_dependencies() const { return {}; }
     class condition;
     friend struct primitive_info;
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reorder.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reorder.hpp
@@ -298,7 +298,7 @@ struct reorder : public primitive_base<reorder> {
     }
 
 protected:
-    std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {
+    std::vector<input_info> get_dependencies() const override {
         if (mean.empty())
             return {};
         return {mean};

--- a/src/plugins/intel_gpu/src/graph/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/activation.cpp
@@ -60,7 +60,7 @@ std::string activation_inst::to_string(activation_node const& node) {
 }
 
 activation_inst::typed_primitive_inst(network& network, activation_node const& node) : parent(network, node) {
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto output_layout = node.get_output_layout();
 
     CLDNN_ERROR_NOT_EQUAL(node.id(),

--- a/src/plugins/intel_gpu/src/graph/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/border.cpp
@@ -117,7 +117,7 @@ std::string border_inst::to_string(border_node const& node) {
 }
 
 border_inst::typed_primitive_inst(network& network, border_node const& node) : parent(network, node) {
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     if (input_layout.is_dynamic()) {
         return;
     }

--- a/src/plugins/intel_gpu/src/graph/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/broadcast.cpp
@@ -127,7 +127,7 @@ std::string broadcast_inst::to_string(broadcast_node const& node) {
 }
 
 broadcast_inst::typed_primitive_inst(network& network, broadcast_node const& node) : parent(network, node) {
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     if (input_layout.is_dynamic())
         return;
     const auto& output_sizes = argument->broadcast_sizes;

--- a/src/plugins/intel_gpu/src/graph/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/concatenation.cpp
@@ -106,7 +106,7 @@ std::string concatenation_inst::to_string(concatenation_node const& node) {
 concatenation_inst::typed_primitive_inst(network& network, concatenation_node const& node)
     : parent(network, node) {
     if (node.is_dynamic()) return;
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
 
     auto output_layout = node.get_output_layout();
 

--- a/src/plugins/intel_gpu/src/graph/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/convolution.cpp
@@ -194,7 +194,7 @@ convolution_inst::typed_primitive_inst(network& network, convolution_node const&
     OPENVINO_ASSERT(all_not_zeroes(argument->stride), "[GPU] Convolution strides must be positive numbers");
     OPENVINO_ASSERT(all_not_zeroes(argument->dilation), "[GPU] Convolution dilations must be positive numbers");
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto output_layout = node.get_output_layout();
     auto output_size = output_layout.get_tensor();
 

--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -151,7 +151,7 @@ std::string crop_inst::to_string(crop_node const& node) {
     const auto& desc = node.get_primitive();
     auto ref_in_sizes = desc->reference_input;
     const auto& offsets = desc->offsets;
-    const auto in_layout = node.input().get_output_layout();
+    const auto in_layout = node.get_input_layout();
     auto node_info = node.desc_to_json();
     std::stringstream primitive_description;
     json_composite crop_info;
@@ -179,7 +179,7 @@ std::string crop_inst::to_string(crop_node const& node) {
 
 crop_inst::typed_primitive_inst(network& network, crop_node const& node) : parent(network, node) {
     const auto& ref_in_sizes = argument->reference_input;
-    const auto in_layout = node.input().get_output_layout();
+    const auto in_layout = node.get_input_layout();
     const auto& offsets = argument->offsets;
     tensor null_tensor {};
     tensor value_tensor { 1, 1, 1, 1, 1 };

--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -266,7 +266,7 @@ deconvolution_inst::typed_primitive_inst(network& network, deconvolution_node co
     auto stride = argument->stride;
     auto pad = argument->pad;
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto output_layout = node.get_output_layout();
 
     CLDNN_ERROR_NOT_EQUAL(node.id(),

--- a/src/plugins/intel_gpu/src/graph/deformable_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deformable_convolution.cpp
@@ -53,7 +53,7 @@ GPU_DEFINE_PRIMITIVE_TYPE_ID(deformable_interp)
 layout deformable_interp_inst::calc_output_layout(deformable_interp_node const& node, kernel_impl_params const& impl_param) {
     auto desc = node.get_primitive();
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
 
     auto kernel_size = desc->kernel_size;
     auto input_type = input_layout.data_type;

--- a/src/plugins/intel_gpu/src/graph/eye.cpp
+++ b/src/plugins/intel_gpu/src/graph/eye.cpp
@@ -16,7 +16,7 @@ eye_inst::typed_primitive_inst(network& network, eye_node const& node) : parent(
 
 layout eye_inst::calc_output_layout(eye_node const& node, const kernel_impl_params&) {
     auto primitive = node.get_primitive();
-    return {*(primitive->output_data_types[0]), node.input().get_output_layout().format, primitive->output_shape};
+    return {*(primitive->output_data_types[0]), node.get_input_layout().format, primitive->output_shape};
 }
 
 std::string eye_inst::to_string(eye_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/gather_tree.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather_tree.cpp
@@ -63,7 +63,7 @@ gather_tree_inst::typed_primitive_inst(network& network, gather_tree_node const&
         }
     }
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
 
     const auto input_format = input_layout.format;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
@@ -78,7 +78,7 @@ void prepare_padding::run(program& p) {
                 pad_u.spatial[1] = pe_y;
                 pad_u.spatial[2] = pe_z;
 
-                auto in_layout = prim_node.input().get_output_layout();
+                auto in_layout = prim_node.get_input_layout();
 
                 const auto& actual_lpad = in_layout.data_padding.lower_size();
                 const auto& actual_upad = in_layout.data_padding.upper_size();
@@ -98,7 +98,7 @@ void prepare_padding::run(program& p) {
 
                 auto filter_size = prim_node.weights().get_output_layout().get_tensor();
 
-                auto needed_padding = calc_sliding_window_needed_input_padding(prim_node.input().get_output_layout(),
+                auto needed_padding = calc_sliding_window_needed_input_padding(prim_node.get_input_layout(),
                                                                                prim->output_size,
                                                                                filter_size,
                                                                                prim->pad,
@@ -123,7 +123,7 @@ void prepare_padding::run(program& p) {
                 }
 
                 if (node->get_output_layout().format == format::b_fs_yx_fsv16)
-                    needed_padding = calc_sliding_window_needed_input_padding(prim_node.input().get_output_layout(),
+                    needed_padding = calc_sliding_window_needed_input_padding(prim_node.get_input_layout(),
                                                                               prim->output_size,
                                                                               size,
                                                                               ov::CoordinateDiff(prim->pads_begin.begin(), prim->pads_begin.end()),
@@ -132,7 +132,7 @@ void prepare_padding::run(program& p) {
                                                                               false,
                                                                               1);
                 else
-                    needed_padding = prim_node.input().get_output_layout().data_padding;
+                    needed_padding = prim_node.get_input_layout().data_padding;
 
                 add_required_padding(prim_node, needed_padding);
             }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -72,7 +72,7 @@ void prepare_primitive_fusing::remove_redundant_reshape(program &p) {
                     return;
                 if (prev.first->get_users().size() > 1 || prev.first->get_dependencies().size() > 1)
                     return;
-                if (prev.first->as<reshape>().input().get_output_layout() == node.get_output_layout()) {
+                if (prev.first->as<reshape>().get_input_layout() == node.get_output_layout()) {
                     p.add_optimized_primitive_info(prev.first->id());
                     p.add_optimized_primitive_info(node.id());
                     p.extract_and_remove(*prev.first);
@@ -86,7 +86,7 @@ void prepare_primitive_fusing::remove_redundant_reshape(program &p) {
     while (node_itr != p.get_processing_order().end()) {
         auto node = (*node_itr++);
         program_helpers::do_for_types<reshape>(*node, [&p](reshape_node& node) {
-            auto input_lay = node.input().get_output_layout();
+            auto input_lay = node.get_input_layout();
             auto output_lay = node.get_output_layout();
 
             if (!node.is_in_place())

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -157,7 +157,7 @@ void remove_redundant_reorders::run(program& p) {
         // fp32 -> reorder -> u8 -> reorder -> fp32
         // we can't fuse two reorder primitives as first one must do cast to u8 data type which changes the values
         if (!data_type_traits::is_floating_point(r_dep_node.get_output_layout().data_type) &&
-            data_type_traits::is_floating_point(r_dep_node.input().get_output_layout().data_type)) {
+            data_type_traits::is_floating_point(r_dep_node.get_input_layout().data_type)) {
             continue;
         }
 
@@ -470,7 +470,7 @@ void remove_redundant_reorders::run(program& p) {
         if (!quantize_opt && !convert_color_opt)
             continue;
 
-        auto same_data_type = node.input().get_output_layout().data_type == node.get_output_layout().data_type;
+        auto same_data_type = node.get_input_layout().data_type == node.get_output_layout().data_type;
         if (!same_data_type && !convert_color_opt)
             continue;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -894,12 +894,13 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
 
     const auto reorder_input_pooling = [&p, &rf](typed_program_node<pooling>& pooling_node) {
         // Change input data type of pooling node from i32 to f32
-        auto& input = pooling_node.input();
-        auto input_layout = input.get_output_layout();
+        auto dep = pooling_node.get_dependency_with_port(0);
+        const auto& input = dep.first;
+        auto input_layout = input->get_output_layout();
         if (pooling_node.get_primitive()->mode == pooling_mode::max && input_layout.data_type == data_types::i32) {
             auto new_layout = input_layout;
             new_layout.data_type = data_types::f32;
-            auto new_input = rf.get_reorder(input.id(), input_layout, new_layout);
+            auto new_input = rf.get_reorder(input->id(), dep.second, input_layout, new_layout);
             if (new_input.first) {
                p.add_intermediate(new_input.first, pooling_node, 0);
             }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -552,7 +552,8 @@ void insert_reorders_in_dir(program& p, const std::map<program_node*, format::ty
         // So the priority is preferred_input/output_format --> fmt_map --> output_layout().format
         auto predecessor = travel_direction_wrapper<dir>::first(node, next);
         auto successor = travel_direction_wrapper<dir>::second(node, next);
-        auto in_layout = predecessor->get_output_layout();
+        auto port_idx = successor->get_dependency_output_port(*predecessor);
+        auto in_layout = predecessor->get_output_layout(false, port_idx);
         auto out_layout = in_layout;
 
         in_layout.format = get_target_output_format(lo, fmt_map, predecessor, successor);
@@ -564,7 +565,8 @@ void insert_reorders_in_dir(program& p, const std::map<program_node*, format::ty
         if (in_layout.format == format::any || out_layout.format == format::any)
             continue;
 
-        auto reorder_pair = rf.get_reorder(travel_direction_wrapper<dir>::first(node, next)->id(),
+        auto reorder_pair = rf.get_reorder(predecessor->id(),
+                                           port_idx,
                                            in_layout,
                                            out_layout);
 
@@ -600,7 +602,8 @@ void insert_reorders_in_dir<direction_e::backwards>(program& p, const std::map<p
         // So the priority is preferred_input/output_format --> fmt_map --> output_layout().format
         auto predecessor = travel_direction_wrapper<direction_e::backwards>::first(node, next.first);
         auto successor = travel_direction_wrapper<direction_e::backwards>::second(node, next.first);
-        auto in_layout = predecessor->get_output_layout();
+        auto port_idx = successor->get_dependency_output_port(*predecessor);
+        auto in_layout = predecessor->get_output_layout(false, port_idx);
         auto out_layout = in_layout;
 
         in_layout.format = get_target_output_format(lo, fmt_map, predecessor, successor);
@@ -612,7 +615,8 @@ void insert_reorders_in_dir<direction_e::backwards>(program& p, const std::map<p
         if (in_layout.format == format::any || out_layout.format == format::any)
             continue;
 
-        auto reorder_pair = rf.get_reorder(travel_direction_wrapper<direction_e::backwards>::first(node, next.first)->id(),
+        auto reorder_pair = rf.get_reorder(predecessor->id(),
+                                           port_idx,
                                            in_layout,
                                            out_layout);
 

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -42,6 +42,11 @@ public:
     // pair.first is reorder (may be nullptr if reorder is not needed), pair.second tells if returned reorder was cached
     // (no need to add it to 'ouputs' etc.) for pair.first == nullptr, pair.second == true
     std::pair<std::shared_ptr<reorder>, bool> get_reorder(primitive_id src_id,
+                                                          int32_t src_port,
+                                                          const layout& in_layout,
+                                                          const layout& out_layout);
+
+    std::pair<std::shared_ptr<reorder>, bool> get_reorder(primitive_id src_id,
                                                           const layout& in_layout,
                                                           const layout& out_layout);
 

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -171,27 +171,10 @@ public:
     // Count of original primitive outputs
     size_t get_outputs_count() const { return desc->output_size(); }
 
-    std::vector<layout> const get_input_layouts() const {
-        std::vector<layout> layouts;
-        for (const auto& i : dependencies) {
-            layouts.push_back(i.first->get_output_layout(true, i.second));
-        }
-        return layouts;
-    }
-
-    layout get_input_layout(size_t idx = 0) const {
-       return get_dependency(idx).get_output_layout(false);
-    }
-
-    ov::PartialShape get_input_pshape(size_t idx = 0) const {
-       return get_input_layout(idx).get_partial_shape();
-    }
-
-    ov::PartialShape get_output_pshape(size_t idx = 0) const {
-        if (!is_valid_output_layout(idx))
-            return calc_output_layouts()[idx].get_partial_shape();
-       return get_output_layout(idx).get_partial_shape();
-    }
+    std::vector<layout> const get_input_layouts() const;
+    layout get_input_layout(size_t idx = 0) const;
+    ov::PartialShape get_input_pshape(size_t idx = 0) const;
+    ov::PartialShape get_output_pshape(size_t idx = 0) const;
 
     // replaces idx-th dependency of 'this' with 'new_dep', calls program::remove_if_dangling(old_dep)
     void replace_dependency(size_t idx, program_node& new_dep, bool remove_if_dangling = true);
@@ -206,6 +189,7 @@ public:
     void remove_dependency(size_t idx);
     void remove_dependency(program_node& node);
 
+    int32_t get_dependency_output_port(const program_node& node) const;
     size_t get_dependency_index(const program_node& node) const;
     size_t get_user_index(const program_node& node) const;
 

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -59,7 +59,7 @@ static size_t get_post_ops_count(const program_node& node) {
 static bool is_reduce_blocked_axes(reduce_node const& node) {
     auto prim = node.get_primitive();
     auto reduce_axes = prim->axes;
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto num_spatial = format::spatial_num(node.get_output_layout().format);
     auto dims = node.get_output_layout().format.dimension();
 
@@ -1012,7 +1012,7 @@ bool layout_optimizer::deps_for_convolution_byxf_opt(program_node const& node, u
 
         if (dep.first->is_type<convolution>()) {
             auto& conv_dep = dep.first->as<convolution>();
-            if (!convolution_byxf_opt(conv_dep.input().get_output_layout(),
+            if (!convolution_byxf_opt(conv_dep.get_input_layout(),
                                       conv_dep.get_output_layout(),
                                       conv_dep.weights().get_output_layout(),
                                       conv_dep)) {
@@ -1030,7 +1030,7 @@ bool layout_optimizer::deps_for_convolution_byxf_opt(program_node const& node, u
 }
 
 format layout_optimizer::imad_case(convolution_node const& node) const {
-    auto dims_count = format::dimension(node.input().get_output_layout().format);
+    auto dims_count = format::dimension(node.get_input_layout().format);
 
     bool is_grouped = node.get_groups() > 1;
     bool is_dw = is_depthwise(node);
@@ -1155,7 +1155,7 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
         } else if (output_layout.format == format::bfzyx) {
             expected_format = cldnn::format::bfzyx;
         } else if (_optimization_attributes.bs_fs_yx_bsv16_fsv16_network &&
-                convolution_bs_fs_yx_bsv16_fsv16_opt(node.input().get_output_layout(), output_layout, weights_layout, prim)) {
+                convolution_bs_fs_yx_bsv16_fsv16_opt(node.get_input_layout(), output_layout, weights_layout, prim)) {
             expected_format = cldnn::format::bs_fs_yx_bsv16_fsv16;
         } else if (_optimization_attributes.fs_b_yx_fsv32_network && !node.get_transposed() &&
                 ((convolution_fs_b_yx_fsv32_opt(input_layout,
@@ -1838,7 +1838,7 @@ format layout_optimizer::get_preferred_format(program_node& node) {
 
         if (!allow_new_shape_infer && node.is_type<fully_connected>()) {
             auto& fc_node = node.as<fully_connected>();
-            auto input_layout = fc_node.input().get_output_layout();
+            auto input_layout = fc_node.get_input_layout();
             if (input_layout.format.dimension() > 4) {
                 expected = format::bfyx;
                 node.set_preferred_input_fmt(0, format::bfyx);
@@ -2098,7 +2098,7 @@ void layout_optimizer::set_optimization_attribute(optimization_attributes_type a
 }
 
 bool layout_optimizer::is_format_optimized(const convolution_node& node, const format& format, bool use_weak_restrictions) {
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto weights_layout = node.weights().get_output_layout();
     auto output_layout = node.calc_output_layout();
     auto prim = node.get_primitive();
@@ -2147,7 +2147,7 @@ size_t layout_optimizer::get_optimized_conv_count(const std::pair<format::type, 
 }
 
 bool layout_optimizer::is_format_optimized(const deconvolution_node& node, const format& format) {
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto weights_layout = node.weights().get_output_layout();
     auto prim = node.get_primitive();
 

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -140,24 +140,31 @@ bool layout_optimizer::onednn_check_data_types_for_fc_gemm(data_types in_dt, dat
 }
 
 std::pair<std::shared_ptr<reorder>, bool> reorder_factory::get_reorder(primitive_id src_id,
+                                                                       int32_t src_port,
                                                                        const layout& in_layout,
                                                                        const layout& out_layout) {
     if (in_layout == out_layout)
         return std::make_pair(nullptr, true);
 
-    cache_key ckey{ src_id, out_layout };
+    cache_key ckey{ src_id + "." + std::to_string(src_port), out_layout };
     auto itr = _cached_reorders.find(ckey);
     if (itr != _cached_reorders.end())
         return std::make_pair(itr->second, true);
 
     auto count = _cached_reorders.size();
     std::stringstream ss;
-    ss << src_id << "_reorder_" << count;
+    ss << src_id << "_" << std::to_string(src_port) << "_reorder_" << count;
 
-    auto reorder = std::make_shared<cldnn::reorder>(ss.str(), src_id, out_layout);
+    auto reorder = std::make_shared<cldnn::reorder>(ss.str(), input_info{src_id, src_port}, out_layout);
     _cached_reorders[ckey] = reorder;
 
     return std::make_pair(reorder, false);
+}
+
+std::pair<std::shared_ptr<reorder>, bool> reorder_factory::get_reorder(primitive_id src_id,
+                                                                       const layout& in_layout,
+                                                                       const layout& out_layout) {
+    return get_reorder(src_id, 0, in_layout, out_layout);
 }
 
 std::pair<std::shared_ptr<primitive>, bool> reorder_factory::get_weights_reorder(primitive_id input_id,

--- a/src/plugins/intel_gpu/src/graph/lstm_elt.cpp
+++ b/src/plugins/intel_gpu/src/graph/lstm_elt.cpp
@@ -62,7 +62,7 @@ std::string lstm_elt_inst::to_string(lstm_elt_node const& node) {
 }
 
 lstm_elt_inst::typed_primitive_inst(network& network, lstm_elt_node const& node) : parent(network, node) {
-    auto input_size = node.input().get_output_layout();
+    auto input_size = node.get_input_layout();
     CLDNN_ERROR_NOT_PROPER_FORMAT(node.id(),
                                   "input format",
                                   input_size.format.value,

--- a/src/plugins/intel_gpu/src/graph/normalize.cpp
+++ b/src/plugins/intel_gpu/src/graph/normalize.cpp
@@ -55,7 +55,7 @@ normalize_inst::typed_primitive_inst(network& network, normalize_node const& nod
     auto scale_layout = node.scale().get_output_layout();
     auto scale_size = scale_layout.get_tensor();
     auto scale_feature_size = scale_size.feature[0];
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto input_feature_size = input_layout.feature();
 
     if (scale_feature_size != 1) {

--- a/src/plugins/intel_gpu/src/graph/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/one_hot.cpp
@@ -99,7 +99,7 @@ std::string one_hot_inst::to_string(one_hot_node const& node) {
 }
 
 one_hot_inst::typed_primitive_inst(network& network, one_hot_node const& node) : parent(network, node) {
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
 
     if (input_layout.is_dynamic())
         return;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -742,7 +742,7 @@ void primitive_inst::update_shape_info_tensor(const kernel_impl_params& params) 
     size_t offset = 0;
     for (size_t i = 0; i < _node->get_dependencies().size(); i++) {
         GPU_DEBUG_TRACE_DETAIL << id() << " : update shape_info for input[" << i << "]" << std::endl;
-        const auto& node_in_lay = _node->get_dependency(i).get_output_layout();
+        const auto& node_in_lay = _node->get_input_layout(i);
         const auto& runtime_in_lay = params.input_layouts[i];
         fill_shape_info_data(runtime_in_lay, node_in_lay, shape_info_ptr, offset);
     }

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -403,12 +403,12 @@ void prior_box_node::calc_result() {
     if (get_output_layout().data_type == data_types::f16)
         calculate_prior_box_output<ov::element_type_traits<data_types::f16>::value_type>(result,
                                                                              get_program().get_stream(),
-                                                                             input().get_output_layout(),
+                                                                             get_input_layout(),
                                                                              *typed_desc());
     else
         calculate_prior_box_output<ov::element_type_traits<data_types::f32>::value_type>(result,
                                                                              get_program().get_stream(),
-                                                                             input().get_output_layout(),
+                                                                             get_input_layout(),
                                                                              *typed_desc());
 }
 

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -334,7 +334,7 @@ bool program::analyze_output_size_handling_need() {
 
             auto filter_size = prim_node.weights().get_output_layout().get_tensor();
 
-            auto primInputSize = prim_node.input().get_output_layout().get_tensor();
+            auto primInputSize = prim_node.get_input_layout().get_tensor();
             auto calc_output_range = calc_sliding_window_needed_input_range(primInputSize,
                                                                             filter_size,
                                                                             prim->pad,
@@ -361,7 +361,7 @@ bool program::analyze_output_size_handling_need() {
                 size.spatial[i] = static_cast<tensor::value_type>(prim->size[prim->size.size() - i - 1]);
             }
             // TODO: Check compatibility of output size calculation (with caffe).
-            auto primInputSize = prim_node.input().get_output_layout().get_tensor();
+            auto primInputSize = prim_node.get_input_layout().get_tensor();
             auto calc_output_range = calc_sliding_window_output_range<swor_mode::exceed_once_data>(
                 primInputSize,
                 size,
@@ -1466,8 +1466,8 @@ void program::set_layout_optimizer_attributes(layout_optimizer& lo) {
             prim.type() != cldnn::depth_to_space::type_id() &&
             prim.type() != cldnn::shuffle_channels::type_id() &&
             (prim.type() != cldnn::mvn::type_id()
-             || (prim.as<mvn>().input().get_output_layout().data_type != data_types::u8 &&
-                 prim.as<mvn>().input().get_output_layout().data_type != data_types::i8)
+             || (prim.as<mvn>().get_input_layout().data_type != data_types::u8 &&
+                 prim.as<mvn>().get_input_layout().data_type != data_types::i8)
              || prim.as<mvn>().get_primitive()->across_channels()) &&
             prim.type() != cldnn::arg_max_min::type_id() &&
             prim.type() != cldnn::dft::type_id() &&

--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -179,14 +179,17 @@ void dump_graph_init(std::ofstream& graph,
             return out + invalid_layout_msg;
         }
 
-        auto out_layout = ptr->get_output_layout();
-        if (!out_layout.data_padding) {
-            out += " " +  out_layout.to_short_string();
-        } else {
-            out += " " + out_layout.to_string();
-        }
-        if (get_primitive_inst) {
-            out += "\nshape: " + get_primitive_inst(ptr->id())->get_output_layout().get_partial_shape().to_string();
+        auto out_layouts = ptr->get_output_layouts();
+        for (size_t i = 0; i < out_layouts.size(); i++) {
+            auto& out_layout = out_layouts[i];
+            if (!out_layout.data_padding) {
+                out += "\n" + std::to_string(i) + ": " + out_layout.to_short_string();
+            } else {
+                out += "\n" + std::to_string(i) + ": " + out_layout.to_string();
+            }
+            if (get_primitive_inst) {
+                out += "\nshape: " + get_primitive_inst(ptr->id())->get_output_layout().get_partial_shape().to_string();
+            }
         }
 
         return out;

--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -188,7 +188,7 @@ void dump_graph_init(std::ofstream& graph,
                 out += "\n" + std::to_string(i) + ": " + out_layout.to_string();
             }
             if (get_primitive_inst) {
-                out += "\nshape: " + get_primitive_inst(ptr->id())->get_output_layout().get_partial_shape().to_string();
+                out += "\nshape: " + get_primitive_inst(ptr->id())->get_output_layout(i).get_partial_shape().to_string();
             }
         }
 

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -83,7 +83,7 @@ std::vector<layout> const program_node::get_input_layouts() const {
 
 layout program_node::get_input_layout(size_t idx) const {
     const auto& d = get_dependency_with_port(idx);
-    return d.first->get_output_layout(false, d.second);
+    return d.first->get_output_layout(true, d.second);
 }
 
 ov::PartialShape program_node::get_input_pshape(size_t idx) const {

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -73,6 +73,29 @@ void program_node::replace_dependency(size_t idx, std::pair<program_node*, int32
     new_dep.first->users.push_back(this);
 }
 
+std::vector<layout> const program_node::get_input_layouts() const {
+    std::vector<layout> layouts;
+    for (size_t i = 0; i < dependencies.size(); i++) {
+        layouts.push_back(get_input_layout(i));
+    }
+    return layouts;
+}
+
+layout program_node::get_input_layout(size_t idx) const {
+    const auto& d = get_dependency_with_port(idx);
+    return d.first->get_output_layout(false, d.second);
+}
+
+ov::PartialShape program_node::get_input_pshape(size_t idx) const {
+    return get_input_layout(idx).get_partial_shape();
+}
+
+ov::PartialShape program_node::get_output_pshape(size_t idx) const {
+    if (!is_valid_output_layout(idx))
+        return calc_output_layouts()[idx].get_partial_shape();
+    return get_output_layout(idx).get_partial_shape();
+}
+
 void program_node::replace_dependency(size_t idx, program_node& new_dep, bool remove_if_dangling) {
     return replace_dependency(idx, std::make_pair(&new_dep, 0), remove_if_dangling);
 }
@@ -248,15 +271,22 @@ size_t program_node::get_user_index(const program_node& node) const {
             idx++;
     }
 
-    OPENVINO_ASSERT(false, "Search invalid user node" + node.id() + " node");
+    OPENVINO_THROW("[GPU] Search invalid user node" + node.id() + " node");
 }
 
+int32_t program_node::get_dependency_output_port(const program_node& node) const {
+    for (size_t i = 0; i < dependencies.size(); ++i)
+        if (dependencies[i].first == &node)
+            return dependencies[i].second;
+
+    OPENVINO_THROW("[GPU] Search invalid dependency output port" + node.id() + " node");
+}
 size_t program_node::get_dependency_index(const program_node& node) const {
     for (size_t i = 0; i < dependencies.size(); ++i)
         if (dependencies[i].first == &node)
             return i;
 
-    OPENVINO_ASSERT(false, "Search invalid dependency node" + node.id() + " node");
+    OPENVINO_THROW("[GPU] Search invalid dependency node" + node.id() + " node");
 }
 
 bool program_node::is_detached(bool whole_branch) {

--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -224,7 +224,7 @@ reorder_inst::typed_primitive_inst(network& network, reorder_node const& node) :
     if (is_dynamic())
         return;
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto output_layout = node.get_output_layout();
     if (input_layout.is_static() && output_layout.is_static()) {
         CLDNN_ERROR_LESS_THAN(node.id(),

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -164,7 +164,7 @@ std::string reshape_inst::to_string(reshape_node const& node) {
 
 reshape_inst::typed_primitive_inst(network& network, reshape_node const& node) :
         parent(network, node, (!node.can_be_optimized() && node.get_output_layout().is_static()) ? true : false) {
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = node.get_input_layout();
     auto output_layout = node.get_output_layout();
     CLDNN_ERROR_DATA_TYPES_MISMATCH(node.id(),
                                     "Input layout data typr",

--- a/src/plugins/intel_gpu/tests/unit/passes/test_module_fusing_reorder.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/test_module_fusing_reorder.cpp
@@ -77,7 +77,7 @@ TEST(test_can_fuse_reorder, reorder_for_mixed_type_convolution_fsv32_onednn)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            ASSERT_EQ(false, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(false, lo.can_fuse_reorder(input, *usr, node.get_input_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -114,7 +114,7 @@ TEST(test_can_fuse_reorder, reorder_for_mixed_type_convolution_fsv32_cldnn)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            ASSERT_EQ(true, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(true, lo.can_fuse_reorder(input, *usr, node.get_input_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -187,7 +187,7 @@ TEST_P(test_fused_reorder_deep_depth, no_removal_for_deep_depth_conv)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.get_input_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -243,7 +243,7 @@ TEST_P(test_can_fuse_reorder_cldnn, reorder_for_firstconv_cldnn)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.get_input_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -290,7 +290,7 @@ TEST_P(test_can_fuse_reorder_onednn, reorder_for_firstconv_onednn)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.get_input_layout().format, usr->get_output_layout().format));
         }
     }
 }


### PR DESCRIPTION
### Details:
 - return `input_info` vector instead if prim id in `get_dependencies()` method which allows to handle non-default output port of custom primitive dependencies
 - Fix `program_node::get_input_layout()` impl to respect output port
 - Replaced `input().get_output_layout()` with `get_input_layout()` 
 - Minor fixes in `reorder_inputs` pass related to reorder insertion logic to connect reorder with correct dependency port
 - Covers changes in https://github.com/openvinotoolkit/openvino/pull/21938

