### PR TITLE
[Telemetry ] Fixed initialization of Telemetry.

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/telemetry_utils.py
+++ b/tools/mo/openvino/tools/mo/utils/telemetry_utils.py
@@ -22,13 +22,41 @@ except ImportError:
 
 
 def init_mo_telemetry(app_name='Model Optimizer'):
-    return tm.Telemetry(tid=get_tid(),
-                        app_name=app_name,
-                        app_version=get_rt_version(),
-                        backend='ga4',
-                        enable_opt_in_dialog=False,
-                        disable_in_ci=True
-                        )
+    return init_telemetry_class(tid=get_tid(),
+                                app_name=app_name,
+                                app_version=get_rt_version(),
+                                backend='ga4',
+                                enable_opt_in_dialog=False,
+                                disable_in_ci=True
+                                )
+
+
+def init_telemetry_class(tid,
+                         app_name,
+                         app_version,
+                         backend,
+                         enable_opt_in_dialog,
+                         disable_in_ci):
+    # Init telemetry class
+    telemetry = tm.Telemetry(tid=tid,
+                             app_name=app_name,
+                             app_version=app_version,
+                             backend=backend,
+                             enable_opt_in_dialog=enable_opt_in_dialog,
+                             disable_in_ci=disable_in_ci)
+
+    # Telemetry is a singleton class and if it was already initialized in another tool
+    # some parameters will be incorrect, including app_name.
+    # In this case we need to force reinitialisation of telemetry.
+    if hasattr(telemetry, "backend") and telemetry.backend.app_name != app_name:
+        telemetry.init(tid=tid,
+                       app_name=app_name,
+                       app_version=app_version,
+                       backend=backend,
+                       enable_opt_in_dialog=enable_opt_in_dialog,
+                       disable_in_ci=disable_in_ci)
+    return telemetry
+
 
 def send_framework_info(framework: str):
     """

--- a/tools/ovc/openvino/tools/ovc/telemetry_utils.py
+++ b/tools/ovc/openvino/tools/ovc/telemetry_utils.py
@@ -17,13 +17,40 @@ except ImportError:
 
 
 def init_mo_telemetry(app_name='Model Conversion API'):
-    return tm.Telemetry(tid=get_tid(),
-                        app_name=app_name,
-                        app_version=get_rt_version(),
-                        backend='ga4',
-                        enable_opt_in_dialog=False,
-                        disable_in_ci=True
-                        )
+    return init_telemetry_class(tid=get_tid(),
+                                app_name=app_name,
+                                app_version=get_rt_version(),
+                                backend='ga4',
+                                enable_opt_in_dialog=False,
+                                disable_in_ci=True
+                                )
+
+
+def init_telemetry_class(tid,
+                         app_name,
+                         app_version,
+                         backend,
+                         enable_opt_in_dialog,
+                         disable_in_ci):
+    # Init telemetry class
+    telemetry = tm.Telemetry(tid=tid,
+                             app_name=app_name,
+                             app_version=app_version,
+                             backend=backend,
+                             enable_opt_in_dialog=enable_opt_in_dialog,
+                             disable_in_ci=disable_in_ci)
+
+    # Telemetry is a singleton class and if it was already initialized in another tool
+    # some parameters will be incorrect, including app_name.
+    # In this case we need to force reinitialisation of telemetry.
+    if hasattr(telemetry, "backend") and telemetry.backend.app_name != app_name:
+        telemetry.init(tid=tid,
+                       app_name=app_name,
+                       app_version=app_version,
+                       backend=backend,
+                       enable_opt_in_dialog=enable_opt_in_dialog,
+                       disable_in_ci=disable_in_ci)
+    return telemetry
 
 
 def send_framework_info(framework: str):


### PR DESCRIPTION
Root cause analysis: 
Telemetry is a singleton class and if it was already initialized in another tool some parameters will be incorrect, including application name and version.

Solution: 
If Telemetry was initialized in another tool we need to force reinitialization of telemetry to set correct parameters.

Ticket: CVS-130856


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A