### PR TITLE
[DOCS] Removing NPU plugin specific properties for 23.3

### DIFF
--- a/docs/articles_en/openvino_workflow/running_inference_with_openvino/Device_Plugins/NPU.rst
+++ b/docs/articles_en/openvino_workflow/running_inference_with_openvino/Device_Plugins/NPU.rst
@@ -106,14 +106,6 @@ offer a limited set of supported OpenVINO features.
          ov::device::id
          ov::cache_dir
          ov::internal::exclusive_async_requests
-         ov::intel_vpux::dpu_groups
-         ov::intel_vpux::dma_engines
-         ov::intel_vpux::compilation_mode
-         ov::intel_vpux::compilation_mode_params
-         ov::intel_vpux::print_profiling
-         ov::intel_vpux::profiling_output_file
-         ov::intel_vpux::vpux_platform
-         ov::intel_vpux::use_elf_compiler_backend
 
    .. tab-item:: Read-only properties
 
@@ -128,8 +120,6 @@ offer a limited set of supported OpenVINO features.
          ov::device::uuid
          ov::device::architecture
          ov::device::full_name
-         ov::intel_vpux::device_total_mem_size
-         ov::intel_vpux::driver_version
 
 .. note::
 


### PR DESCRIPTION
Removing the NPU plugin specific (private) properties from the article.
Porting: https://github.com/openvinotoolkit/openvino/pull/22506