### PR TITLE
Try newer NumPy for wheels on MacOS M1

### DIFF
--- a/src/bindings/python/requirements.txt
+++ b/src/bindings/python/requirements.txt
@@ -1,3 +1,4 @@
-numpy>=1.16.6
+numpy>=1.16.6; sys_platform != "darwin" or platform_machine != "arm64"
+numpy>=1.21.0; sys_platform == "darwin" and platform_machine == "arm64"
 openvino-telemetry>=2023.2.1
 packaging


### PR DESCRIPTION
Openvino wheel installation fails on Mac M1 'cause it tries to install an old NumPy (<1.21) as a dependency; prebuilt version for it is missing in PyPi so pip tries to build it from source and fails due to https://github.com/numpy/numpy/issues/17807.  Attempts to workaround this issue lead to another issue https://github.com/pypa/wheel/issues/381; etc. Here I'm trying to force a non-problematic version

### Tickets:
 - 124914
