### PR TITLE
[Spec] Align order of scaling formula in FakeConvert spec

### DIFF
--- a/docs/articles_en/documentation/openvino_ir/operation_sets/operations_specifications/quantization/FakeConvert_13.rst
+++ b/docs/articles_en/documentation/openvino_ir/operation_sets/operations_specifications/quantization/FakeConvert_13.rst
@@ -29,9 +29,9 @@ Each element of the output is defined as the result of the following expression:
 .. code-block:: py
    :force:
 
-    data = (data + shift) / scale
-    ConvertLike(Convert(data, destination_type), data)
     data = data * scale - shift
+    ConvertLike(Convert(data, destination_type), data)
+    data = (data + shift) / scale
 
 
 **Attributes**


### PR DESCRIPTION
### Details:
 - Aligned formula of scaling in FakeConvert spec with the [POC](https://github.com/andreyanufr/openvino/blob/57d566070997e6a6194bfa48323f9854327d0def/src/core/src/op/convert_fp8.cpp#L429-L436) by @andreyanufr and reference implementation:
 https://github.com/openvinotoolkit/openvino/blob/cb679a73c9959c05e2c1ad0e01b12d13d71771a9/src/core/reference/include/openvino/reference/fake_convert.hpp#L43

 - Aligned with: https://github.com/openvinotoolkit/openvino/pull/22433
 
 - It was described in the reversed order unintentionally
 

### Tickets:
 - N/A
