### PR TITLE
[TRANSFORMATIONS] Exclude Gather from Mixed prc propagation

### DIFF
--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -36,7 +36,6 @@
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/util/broadcast_base.hpp"
-#include "openvino/op/util/gather_base.hpp"
 #include "openvino/op/util/pad_base.hpp"
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/manager.hpp"
@@ -97,7 +96,6 @@ const std::shared_ptr<Node> propagate_through_ops =
                        ov::op::v8::Slice,
                        ov::op::v1::VariadicSplit,
                        ov::op::v1::Split,
-                       op::util::GatherBase,
                        ov::op::v0::Concat,
                        ov::op::v0::Convert,  // through Convert can go only to Constants
                        ov::op::v0::Constant,
@@ -389,7 +387,6 @@ public:
                                                                                         ov::op::v8::Slice,
                                                                                         ov::op::v1::VariadicSplit,
                                                                                         ov::op::v1::Split,
-                                                                                        op::util::GatherBase,
                                                                                         ov::op::v0::Concat,
                                                                                         ov::op::v0::Tile>();
 

--- a/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
@@ -7,6 +7,7 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/opsets/opset10.hpp"
 #include "openvino/opsets/opset2.hpp"
+#include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.hpp"
 #include "transformations/rt_info/disable_fp16_compression.hpp"

--- a/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
@@ -7,7 +7,6 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/opsets/opset10.hpp"
 #include "openvino/opsets/opset2.hpp"
-#include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.hpp"
 #include "transformations/rt_info/disable_fp16_compression.hpp"


### PR DESCRIPTION
### Details:
 - *Exclude Gather from sensitive prc types *
 - *Add handling of `Const fp16 ->Gather -> Pow` pattern*

### Tickets:
 - *https://jira.devtools.intel.com/browse/CVS-127678*
