### PR TITLE
Fix windows conditional compilation build

### DIFF
--- a/src/frontends/pytorch/src/op/leaky_relu.cpp
+++ b/src/frontends/pytorch/src/op/leaky_relu.cpp
@@ -16,7 +16,7 @@ using namespace ov::op;
 OutputVector translate_leaky_relu_fx(const NodeContext& context) {
     num_inputs_check(context, 1, 2);
     auto x = context.get_input(0);
-    float default_negative_slope = 1e-2;
+    float default_negative_slope = 1e-2f;
     Output<Node> negative_slope = ov::op::v0::Constant::create(element::f32, Shape{1}, {default_negative_slope});
     if (context.get_input_size() == 1) {
         negative_slope = context.mark_node(std::make_shared<ov::op::v1::ConvertLike>(negative_slope, x));

--- a/src/inference/src/dev/plugin.cpp
+++ b/src/inference/src/dev/plugin.cpp
@@ -17,9 +17,7 @@
     OPENVINO_ASSERT(m_ptr != nullptr, "OpenVINO Runtime Plugin was not initialized."); \
     try {                                                                              \
         __VA_ARGS__;                                                                   \
-    } catch (const ov::NotImplemented& ex) {                                           \
-        OPENVINO_NOT_IMPLEMENTED;                                                      \
-    } catch (const InferenceEngine::NotImplemented& ex) {                              \
+    } catch (const ov::NotImplemented&) {                                              \
         OPENVINO_NOT_IMPLEMENTED;                                                      \
     } catch (const std::exception& ex) {                                               \
         OPENVINO_THROW(ex.what());                                                     \


### PR DESCRIPTION
### Details:
 - Conditional compilation build fails due to multiple warnings: 
` src\inference\src\dev\plugin.cpp(34): warning C4101: 'ex': unreferenced local variable`
Fix these warnings + remove legacy ie exception handling

- Fix 
`src\frontends\pytorch\src\op\leaky_relu.cpp(19): warning C4305: 'initializing': truncation from 'double' to 'float'`
### Tickets:
 - *ticket-id*
