### PR TITLE
[GHA] Disable export in timm tests until problem with timeout is solved

### DIFF
--- a/tests/model_hub_tests/torch_tests/test_timm.py
+++ b/tests/model_hub_tests/torch_tests/test_timm.py
@@ -85,7 +85,7 @@ class TestTimmConvertModel(TestTorchConvertModel):
         self.run(name, None, ie_device)
 
     @pytest.mark.nightly
-    @pytest.mark.parametrize("mode", ["trace", "export"])
+    @pytest.mark.parametrize("mode", ["trace"]) # disable "export" for now
     @pytest.mark.parametrize("name", get_all_models())
     def test_convert_model_all_models(self, mode, name, ie_device):
         self.mode = mode


### PR DESCRIPTION
### Details:
 - *Tests start to take longer then 6h with export testing. Disable export in timm tests until problem with timeout is solved*

### Tickets:
 - *None*
