### PR TITLE
Add raw data comparison into test utils

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/matrix_nms.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/matrix_nms.cpp
@@ -128,7 +128,7 @@ void MatrixNmsLayerTestGPU::compare(const std::vector<ov::Tensor> &expectedOutpu
 
 #define CASE(X, Y, _expected_offset, _actual_offset, _size, _threshold)                                              \
     case X:                                                                                                          \
-        LayerTestsUtils::LayerTestsCommon::Compare(                                                                  \
+        ov::test::utils::compare_raw_data(                                                                  \
             reinterpret_cast<const ov::fundamental_type_for<X>*>(expectedBuffer) + _expected_offset,                 \
             reinterpret_cast<const ov::fundamental_type_for<Y>*>(actualBuffer) + _actual_offset, _size, _threshold); \
         break;

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/multiclass_nms.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/multiclass_nms.cpp
@@ -256,9 +256,9 @@ void MulticlassNmsLayerTestGPU::compare(const std::vector<ov::Tensor> &expectedO
     case ov::element::Type_t::elem_type: {                                                                                 \
         using tensor_type = ov::fundamental_type_for<ov::element::Type_t::elem_type>;                                      \
         using actual_type = ov::fundamental_type_for<ov::element::Type_t::act_type>;                                       \
-        LayerTestsUtils::LayerTestsCommon::Compare(reinterpret_cast<const tensor_type*>(expectedBuffer) + expected_offset, \
-                                                   reinterpret_cast<const actual_type*>(actualBuffer) + actual_offset,     \
-                                                   size, _threshold);                                                      \
+        ov::test::utils::compare_raw_data(reinterpret_cast<const tensor_type*>(expectedBuffer) + expected_offset, \
+                                          reinterpret_cast<const actual_type*>(actualBuffer) + actual_offset,     \
+                                          size, _threshold);                                                      \
         break;                                                                                                             \
     }
                 switch (precision) {

--- a/src/plugins/template/tests/functional/op_reference/base_reference_test.cpp
+++ b/src/plugins/template/tests/functional/op_reference/base_reference_test.cpp
@@ -92,126 +92,124 @@ void CommonReferenceTest::ValidateBlobs(const ov::Tensor& refBlob,
     const auto& element_type = refBlob.get_element_type();
     switch (element_type) {
     case ov::element::bf16:
-        LayerTestsUtils::LayerTestsCommon::Compare<ov::bfloat16, ov::bfloat16>(refBlob.data<const ov::bfloat16>(),
-                                                                               outBlob.data<const ov::bfloat16>(),
-                                                                               actual_comparision_size,
-                                                                               threshold,
-                                                                               abs_threshold);
+        ov::test::utils::compare_raw_data<ov::bfloat16, ov::bfloat16>(refBlob.data<const ov::bfloat16>(),
+                                                                      outBlob.data<const ov::bfloat16>(),
+                                                                      actual_comparision_size,
+                                                                      threshold,
+                                                                      abs_threshold);
         break;
     case ov::element::f16:
-        LayerTestsUtils::LayerTestsCommon::Compare<ov::float16, ov::float16>(refBlob.data<const ov::float16>(),
-                                                                             outBlob.data<const ov::float16>(),
-                                                                             actual_comparision_size,
-                                                                             threshold,
-                                                                             abs_threshold);
+        ov::test::utils::compare_raw_data<ov::float16, ov::float16>(refBlob.data<const ov::float16>(),
+                                                                    outBlob.data<const ov::float16>(),
+                                                                    actual_comparision_size,
+                                                                    threshold,
+                                                                    abs_threshold);
         break;
     case ov::element::f8e4m3:
-        LayerTestsUtils::LayerTestsCommon::Compare<ov::float8_e4m3, ov::float8_e4m3>(
-            refBlob.data<const ov::float8_e4m3>(),
-            outBlob.data<const ov::float8_e4m3>(),
-            actual_comparision_size,
-            threshold,
-            abs_threshold);
+        ov::test::utils::compare_raw_data<ov::float8_e4m3, ov::float8_e4m3>(refBlob.data<const ov::float8_e4m3>(),
+                                                                            outBlob.data<const ov::float8_e4m3>(),
+                                                                            actual_comparision_size,
+                                                                            threshold,
+                                                                            abs_threshold);
         break;
     case ov::element::f8e5m2:
-        LayerTestsUtils::LayerTestsCommon::Compare<ov::float8_e5m2, ov::float8_e5m2>(
-            refBlob.data<const ov::float8_e5m2>(),
-            outBlob.data<const ov::float8_e5m2>(),
-            actual_comparision_size,
-            threshold,
-            abs_threshold);
+        ov::test::utils::compare_raw_data<ov::float8_e5m2, ov::float8_e5m2>(refBlob.data<const ov::float8_e5m2>(),
+                                                                            outBlob.data<const ov::float8_e5m2>(),
+                                                                            actual_comparision_size,
+                                                                            threshold,
+                                                                            abs_threshold);
         break;
     case ov::element::f32:
-        LayerTestsUtils::LayerTestsCommon::Compare<float, float>(refBlob.data<const float>(),
-                                                                 outBlob.data<const float>(),
-                                                                 actual_comparision_size,
-                                                                 threshold,
-                                                                 abs_threshold);
+        ov::test::utils::compare_raw_data<float, float>(refBlob.data<const float>(),
+                                                        outBlob.data<const float>(),
+                                                        actual_comparision_size,
+                                                        threshold,
+                                                        abs_threshold);
         break;
     case ov::element::f64:
-        LayerTestsUtils::LayerTestsCommon::Compare<double, double>(refBlob.data<const double>(),
-                                                                   outBlob.data<const double>(),
-                                                                   actual_comparision_size,
-                                                                   threshold,
-                                                                   abs_threshold);
+        ov::test::utils::compare_raw_data<double, double>(refBlob.data<const double>(),
+                                                          outBlob.data<const double>(),
+                                                          actual_comparision_size,
+                                                          threshold,
+                                                          abs_threshold);
         break;
     case ov::element::i8:
-        LayerTestsUtils::LayerTestsCommon::Compare<int8_t, int8_t>(refBlob.data<const int8_t>(),
-                                                                   outBlob.data<const int8_t>(),
-                                                                   actual_comparision_size,
-                                                                   threshold,
-                                                                   abs_threshold);
+        ov::test::utils::compare_raw_data<int8_t, int8_t>(refBlob.data<const int8_t>(),
+                                                          outBlob.data<const int8_t>(),
+                                                          actual_comparision_size,
+                                                          threshold,
+                                                          abs_threshold);
         break;
     case ov::element::i16:
-        LayerTestsUtils::LayerTestsCommon::Compare<int16_t, int16_t>(refBlob.data<const int16_t>(),
-                                                                     outBlob.data<const int16_t>(),
-                                                                     actual_comparision_size,
-                                                                     threshold,
-                                                                     abs_threshold);
+        ov::test::utils::compare_raw_data<int16_t, int16_t>(refBlob.data<const int16_t>(),
+                                                            outBlob.data<const int16_t>(),
+                                                            actual_comparision_size,
+                                                            threshold,
+                                                            abs_threshold);
         break;
     case ov::element::i32:
-        LayerTestsUtils::LayerTestsCommon::Compare<int32_t, int32_t>(refBlob.data<const int32_t>(),
-                                                                     outBlob.data<const int32_t>(),
-                                                                     actual_comparision_size,
-                                                                     threshold,
-                                                                     abs_threshold);
+        ov::test::utils::compare_raw_data<int32_t, int32_t>(refBlob.data<const int32_t>(),
+                                                            outBlob.data<const int32_t>(),
+                                                            actual_comparision_size,
+                                                            threshold,
+                                                            abs_threshold);
         break;
     case ov::element::i64:
-        LayerTestsUtils::LayerTestsCommon::Compare<int64_t, int64_t>(refBlob.data<const int64_t>(),
-                                                                     outBlob.data<const int64_t>(),
-                                                                     actual_comparision_size,
-                                                                     threshold,
-                                                                     abs_threshold);
+        ov::test::utils::compare_raw_data<int64_t, int64_t>(refBlob.data<const int64_t>(),
+                                                            outBlob.data<const int64_t>(),
+                                                            actual_comparision_size,
+                                                            threshold,
+                                                            abs_threshold);
         break;
     case ov::element::boolean:
-        LayerTestsUtils::LayerTestsCommon::Compare<bool, bool>(refBlob.data<const bool>(),
-                                                               outBlob.data<const bool>(),
-                                                               actual_comparision_size,
-                                                               threshold,
-                                                               abs_threshold);
+        ov::test::utils::compare_raw_data<bool, bool>(refBlob.data<const bool>(),
+                                                      outBlob.data<const bool>(),
+                                                      actual_comparision_size,
+                                                      threshold,
+                                                      abs_threshold);
         break;
     case ov::element::u8:
-        LayerTestsUtils::LayerTestsCommon::Compare<uint8_t, uint8_t>(refBlob.data<const uint8_t>(),
-                                                                     outBlob.data<const uint8_t>(),
-                                                                     actual_comparision_size,
-                                                                     threshold,
-                                                                     abs_threshold);
+        ov::test::utils::compare_raw_data<uint8_t, uint8_t>(refBlob.data<const uint8_t>(),
+                                                            outBlob.data<const uint8_t>(),
+                                                            actual_comparision_size,
+                                                            threshold,
+                                                            abs_threshold);
         break;
     case ov::element::u16:
-        LayerTestsUtils::LayerTestsCommon::Compare<uint16_t, uint16_t>(refBlob.data<const uint16_t>(),
-                                                                       outBlob.data<const uint16_t>(),
-                                                                       actual_comparision_size,
-                                                                       threshold,
-                                                                       abs_threshold);
+        ov::test::utils::compare_raw_data<uint16_t, uint16_t>(refBlob.data<const uint16_t>(),
+                                                              outBlob.data<const uint16_t>(),
+                                                              actual_comparision_size,
+                                                              threshold,
+                                                              abs_threshold);
         break;
     case ov::element::u32:
-        LayerTestsUtils::LayerTestsCommon::Compare<uint32_t, uint32_t>(refBlob.data<const uint32_t>(),
-                                                                       outBlob.data<const uint32_t>(),
-                                                                       actual_comparision_size,
-                                                                       threshold,
-                                                                       abs_threshold);
+        ov::test::utils::compare_raw_data<uint32_t, uint32_t>(refBlob.data<const uint32_t>(),
+                                                              outBlob.data<const uint32_t>(),
+                                                              actual_comparision_size,
+                                                              threshold,
+                                                              abs_threshold);
         break;
     case ov::element::u64:
-        LayerTestsUtils::LayerTestsCommon::Compare<uint64_t, uint64_t>(refBlob.data<const uint64_t>(),
-                                                                       outBlob.data<const uint64_t>(),
-                                                                       actual_comparision_size,
-                                                                       threshold,
-                                                                       abs_threshold);
+        ov::test::utils::compare_raw_data<uint64_t, uint64_t>(refBlob.data<const uint64_t>(),
+                                                              outBlob.data<const uint64_t>(),
+                                                              actual_comparision_size,
+                                                              threshold,
+                                                              abs_threshold);
         break;
     case ov::element::i4:
     case ov::element::u4:
-        LayerTestsUtils::LayerTestsCommon::Compare<int8_t, int8_t>(static_cast<const int8_t*>(refBlob.data()),
-                                                                   static_cast<const int8_t*>(outBlob.data()),
-                                                                   actual_comparision_size / 2,
-                                                                   threshold,
-                                                                   abs_threshold);
+        ov::test::utils::compare_raw_data<int8_t, int8_t>(static_cast<const int8_t*>(refBlob.data()),
+                                                          static_cast<const int8_t*>(outBlob.data()),
+                                                          actual_comparision_size / 2,
+                                                          threshold,
+                                                          abs_threshold);
         break;
     case ov::element::u1:
-        LayerTestsUtils::LayerTestsCommon::Compare<int8_t, int8_t>(static_cast<const int8_t*>(refBlob.data()),
-                                                                   static_cast<const int8_t*>(outBlob.data()),
-                                                                   actual_comparision_size / 8,
-                                                                   threshold,
-                                                                   abs_threshold);
+        ov::test::utils::compare_raw_data<int8_t, int8_t>(static_cast<const int8_t*>(refBlob.data()),
+                                                          static_cast<const int8_t*>(outBlob.data()),
+                                                          actual_comparision_size / 8,
+                                                          threshold,
+                                                          abs_threshold);
         break;
     default:
         FAIL() << "Comparator for " << element_type << " element type isn't supported";

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/infer_correctness.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/infer_correctness.cpp
@@ -117,7 +117,7 @@ bool OVInferConsistencyTest::IsEqual(std::vector<ov::Tensor>& a,
         }
         try {
             // if not equal will throw exception
-            LayerTestsUtils::LayerTestsCommon::Compare(
+            ov::test::utils::compare_raw_data(
                 a[j].data<float>(), b[j].data<float>(), a[j].get_size(), 1e-2f);
         } catch (...) {
             isEqual = false;

--- a/src/tests/functional/shared_test_classes/src/single_op/generate_proposals.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/generate_proposals.cpp
@@ -117,17 +117,17 @@ void GenerateProposalsLayerTest::compare(const std::vector<ov::Tensor>& expected
         const auto outputSize = i == 0 ? 4 : 1;
 
         if (outType == ov::element::f32) {
-            LayerTestsUtils::LayerTestsCommon::Compare(reinterpret_cast<const float*>(expectedBuffer),
-                                                       reinterpret_cast<const float*>(actualBuffer),
-                                                       expectedNumRois * outputSize,
-                                                       rel_threshold,
-                                                       abs_threshold);
+            ov::test::utils::compare_raw_data(reinterpret_cast<const float*>(expectedBuffer),
+                                              reinterpret_cast<const float*>(actualBuffer),
+                                              expectedNumRois * outputSize,
+                                              rel_threshold,
+                                              abs_threshold);
         } else {
-            LayerTestsUtils::LayerTestsCommon::Compare(reinterpret_cast<const float16*>(expectedBuffer),
-                                                       reinterpret_cast<const float16*>(actualBuffer),
-                                                       expectedNumRois * outputSize,
-                                                       rel_threshold,
-                                                       abs_threshold);
+            ov::test::utils::compare_raw_data(reinterpret_cast<const float16*>(expectedBuffer),
+                                              reinterpret_cast<const float16*>(actualBuffer),
+                                              expectedNumRois * outputSize,
+                                              rel_threshold,
+                                              abs_threshold);
         }
 
         if (expectedNumRois < actualNumRois) {

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/data_utils.hpp
@@ -547,6 +547,52 @@ inline ov::float8_e5m2 ie_abs(const ov::float8_e5m2& val) {
     return ov::float8_e5m2::from_bits(val.to_bits() & 0x7F);
 }
 
+template <class T_ACTUAL, class T_EXPECTED>
+static void compare_raw_data(const T_EXPECTED* expected,
+                             const T_ACTUAL* actual,
+                             std::size_t size,
+                             float threshold,
+                             float abs_threshold = -1.f) {
+    for (std::size_t i = 0; i < size; ++i) {
+        const T_EXPECTED& ref = expected[i];
+        const auto& res = actual[i];
+        const auto absoluteDifference = ov::test::utils::ie_abs(res - ref);
+        if (abs_threshold > 0.f && absoluteDifference > abs_threshold) {
+            OPENVINO_THROW("Absolute comparison of values expected: ",
+                           std::to_string(ref),
+                           " and actual: ",
+                           std::to_string(res),
+                           " at index ",
+                           i,
+                           " with absolute threshold ",
+                           abs_threshold,
+                           " failed");
+        }
+        if (absoluteDifference <= threshold) {
+            continue;
+        }
+        double max;
+        if (sizeof(T_ACTUAL) < sizeof(T_EXPECTED)) {
+            max = static_cast<double>(std::max(ov::test::utils::ie_abs(T_EXPECTED(res)), ov::test::utils::ie_abs(ref)));
+        } else {
+            max = static_cast<double>(std::max(ov::test::utils::ie_abs(res), ov::test::utils::ie_abs(T_ACTUAL(ref))));
+        }
+        double diff = static_cast<float>(absoluteDifference) / max;
+        if (max == 0 || (diff > static_cast<float>(threshold)) ||
+            (std::isnan(static_cast<float>(res)) ^ std::isnan(static_cast<float>(ref)))) {
+            OPENVINO_THROW("Relative comparison of values expected: ",
+                           std::to_string(ref),
+                           " and actual: ",
+                           std::to_string(res),
+                           " at index ",
+                           i,
+                           " with threshold ",
+                           threshold,
+                           " failed");
+        }
+    }
+}
+
 }  // namespace utils
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Add raw data comparison into test utils. It is now almost full copy of LayerTestsCommon::Compare
 - Use this new comparator instead of legacy LayerTestsCommon::Compare

### Tickets:
 - CVS-131226
