### PR TITLE
[OP][CORE] ConvertAlignTypes op core implementation

### DIFF
--- a/src/core/include/openvino/op/convert_align_types.hpp
+++ b/src/core/include/openvino/op/convert_align_types.hpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov {
+namespace op {
+namespace v1 {
+/// \brief Elementwise type alignment conversion operation.
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API ConvertAlignTypes : public Op {
+public:
+    OPENVINO_OP("ConvertAlignTypes", "", op::Op);
+
+    /// \brief Constructs a type alignment and conversion operation.
+    ConvertAlignTypes() = default;
+    /// \brief Constructs a type alignment and conversion operation.
+    /// \param lhs  Node with datatype to be aligned.
+    /// \param rhs  Node with datatype to be aligned.
+    /// \param promote_unsafe  Bool attribute wether to allow for promotions that might result in bit-widening,
+    /// precision loss and undefined behaviors.
+    /// \param pytorch_scalar_align  Bool attribute wether to align scalars using  PyTorch-like rules.
+    /// \param u64_integer_promotion_target  Element type attribute to select alignment target for u64 and signed
+    /// integers.
+    ConvertAlignTypes(const Output<Node>& lhs,
+                      const Output<Node>& rhs,
+                      const bool promote_unsafe = false,
+                      const bool pytorch_scalar_align = false,
+                      const element::Type& u64_integer_promotion_target = element::f32);
+    void validate_and_infer_types() override;
+    bool visit_attributes(AttributeVisitor& visitor) override;
+
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+
+    bool get_pytorch_scalar_align() const {
+        return m_pytorch_scalar_align;
+    }
+
+    void set_pytorch_scalar_align(bool pytorch_scalar_align) {
+        m_pytorch_scalar_align = pytorch_scalar_align;
+    }
+
+    bool get_promote_unsafe() const {
+        return m_promote_unsafe;
+    }
+
+    void set_promote_unsafe(bool promote_unsafe) {
+        m_promote_unsafe = promote_unsafe;
+    }
+
+    element::Type get_u64_integer_promotion_target() const {
+        return m_u64_integer_promotion_target;
+    }
+
+    void set_u64_integer_promotion_target(element::Type u64_integer_promotion_target) {
+        m_u64_integer_promotion_target = u64_integer_promotion_target;
+    }
+
+private:
+    bool m_promote_unsafe = false;
+    bool m_pytorch_scalar_align = false;
+    element::Type m_u64_integer_promotion_target = element::f32;
+};
+}  // namespace v1
+}  // namespace op
+}  // namespace ov

--- a/src/core/include/openvino/op/ops.hpp
+++ b/src/core/include/openvino/op/ops.hpp
@@ -32,6 +32,7 @@
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
+#include "openvino/op/convert_align_types.hpp"
 #include "openvino/op/convert_like.hpp"
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/cos.hpp"

--- a/src/core/src/op/convert_align_types.cpp
+++ b/src/core/src/op/convert_align_types.cpp
@@ -1,0 +1,171 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/convert_align_types.hpp"
+
+#include "itt.hpp"
+#include "openvino/core/validation_util.hpp"
+
+namespace ov {
+namespace op {
+namespace {
+
+std::unordered_map<size_t, element::Type> bit_to_int{
+    {4, element::i4},
+    {8, element::i8},
+    {16, element::i16},
+    {32, element::i32},
+    {64, element::i64},
+};
+
+element::Type infer_types(const v1::ConvertAlignTypes* op) {
+    const auto lhs = op->input(0);
+    const auto rhs = op->input(1);
+    const auto promote_unsafe = op->get_promote_unsafe();
+    const auto pytorch_scalar_align = op->get_pytorch_scalar_align();
+    const auto u64_promotion_target = op->get_u64_integer_promotion_target();
+    const auto supported_types = {element::dynamic,
+                                  element::boolean,
+                                  element::f16,
+                                  element::f32,
+                                  element::f64,
+                                  element::i4,
+                                  element::i8,
+                                  element::i16,
+                                  element::i32,
+                                  element::i64,
+                                  element::u1,
+                                  element::u4,
+                                  element::u8,
+                                  element::u16,
+                                  element::u32,
+                                  element::u64,
+                                  element::f8e4m3,
+                                  element::f8e5m2,
+                                  element::bf16};
+    const auto& lhs_type = lhs.get_element_type();
+    const auto& rhs_type = rhs.get_element_type();
+    NODE_VALIDATION_CHECK(op,
+                          std::find(supported_types.begin(), supported_types.end(), lhs_type) != supported_types.end());
+    NODE_VALIDATION_CHECK(op,
+                          std::find(supported_types.begin(), supported_types.end(), rhs_type) != supported_types.end());
+    if (lhs_type.is_dynamic() || rhs_type.is_dynamic()) {
+        return element::dynamic;
+    }
+    if (lhs_type == rhs_type)
+        return lhs_type;
+    if (lhs_type == element::boolean)
+        return rhs_type;
+    if (rhs_type == element::boolean)
+        return lhs_type;
+    const auto& lhs_rank = lhs.get_partial_shape().rank();
+    const auto& rhs_rank = rhs.get_partial_shape().rank();
+    const bool is_lhs_scalar = lhs_rank.is_static() ? lhs_rank.get_length() == 0 : false;
+    const bool is_rhs_scalar = rhs_rank.is_static() ? rhs_rank.get_length() == 0 : false;
+    const bool is_lhs_signed = lhs_type.is_signed();
+    const bool is_rhs_signed = rhs_type.is_signed();
+    const bool is_lhs_real = lhs_type.is_real();
+    const bool is_rhs_real = rhs_type.is_real();
+    const size_t lhs_bitwidth = lhs_type.bitwidth();
+    const size_t rhs_bitwidth = rhs_type.bitwidth();
+
+    if (pytorch_scalar_align && (is_lhs_scalar ^ is_rhs_scalar) && (is_lhs_real == is_rhs_real)) {
+        if (promote_unsafe) {
+            return is_lhs_scalar ? rhs_type : lhs_type;
+        }
+        const auto target = is_lhs_scalar ? rhs_type : lhs_type;
+        const auto scalar = is_lhs_scalar ? lhs_type : rhs_type;
+        if ((target.is_signed() == scalar.is_signed() && target.bitwidth() >= scalar.bitwidth()) ||
+            (target.is_signed() && !scalar.is_signed() && target.bitwidth() * 2 >= scalar.bitwidth())) {
+            return target;
+        }
+        NODE_VALIDATION_CHECK(op, false, " Scalar input cannot be PyTorch-like aligned using safe promotion rules.");
+    }
+    if (is_lhs_real ^ is_rhs_real) {
+        if (promote_unsafe) {
+            return is_lhs_real ? lhs_type : rhs_type;
+        }
+        const auto real = is_lhs_real ? lhs_type : rhs_type;
+        const auto integer = is_lhs_real ? rhs_type : lhs_type;
+        if (real.bitwidth() >= integer.bitwidth() * 2) {
+            return real;
+        }
+        NODE_VALIDATION_CHECK(op, false, "Integer input cannot be safely promoted to floating-point.");
+    }
+    if ((is_lhs_real == is_rhs_real) && (is_lhs_signed ^ is_rhs_signed)) {
+        const auto uint_bitwidth = is_lhs_signed ? rhs_bitwidth : lhs_bitwidth;
+        const auto int_bitwidth = is_lhs_signed ? lhs_bitwidth : rhs_bitwidth;
+        if (uint_bitwidth <= 32 && (promote_unsafe || uint_bitwidth * 2 <= int_bitwidth)) {
+            return bit_to_int.at(std::max({uint_bitwidth * 2, int_bitwidth}));
+        } else if (promote_unsafe) {
+            return u64_promotion_target;
+        } else {
+            NODE_VALIDATION_CHECK(
+                op,
+                false,
+                "Unsigned integer input cannot be safely promoted into any supported signed integer.");
+        }
+    }
+    if ((is_lhs_real == is_rhs_real) && (lhs_bitwidth != rhs_bitwidth)) {
+        return lhs_bitwidth >= rhs_bitwidth ? lhs_type : rhs_type;
+    }
+    if (promote_unsafe && (is_lhs_real == is_rhs_real) && (lhs_bitwidth == rhs_bitwidth)) {
+        const auto lhs_string = lhs_type.to_string();
+        const auto rhs_string = rhs_type.to_string();
+        // f8e4m3 and f8e5m2
+        const std::set<std::string> float8_types{"f8e4m3", "f8e5m2"};
+        if (float8_types.count(lhs_string) && float8_types.count(rhs_string)) {
+            return element::f16;
+        }
+        // bf16 and f16
+        const std::set<std::string> float16_types{"f16", "bf16"};
+        if (float16_types.count(lhs_string) && float16_types.count(rhs_string)) {
+            return element::f32;
+        }
+    }
+    NODE_VALIDATION_CHECK(op, false, "Unsupported input element types for ConvertAlignTypes with given attributes.");
+}
+}  // namespace
+namespace v1 {
+
+ConvertAlignTypes::ConvertAlignTypes(const Output<Node>& lhs,
+                                     const Output<Node>& rhs,
+                                     const bool promote_unsafe,
+                                     const bool pytorch_scalar_align,
+                                     const element::Type& u64_integer_promotion_target)
+    : Op({lhs, rhs}),
+      m_promote_unsafe(promote_unsafe),
+      m_pytorch_scalar_align(pytorch_scalar_align),
+      m_u64_integer_promotion_target(u64_integer_promotion_target) {
+    constructor_validate_and_infer_types();
+}
+
+void ConvertAlignTypes::validate_and_infer_types() {
+    OV_OP_SCOPE(ConvertAlignTypes_validate_and_infer_types);
+    const auto aligned_type = infer_types(this);
+    set_output_type(0, aligned_type, get_input_partial_shape(0));
+    set_output_type(1, aligned_type, get_input_partial_shape(1));
+}
+
+bool ConvertAlignTypes::visit_attributes(AttributeVisitor& visitor) {
+    OV_OP_SCOPE(ConvertAlignTypes_visit_attributes);
+    visitor.on_attribute("promote_unsafe", m_promote_unsafe);
+    visitor.on_attribute("pytorch_scalar_align", m_pytorch_scalar_align);
+    visitor.on_attribute("u64_integer_promotion_target", m_u64_integer_promotion_target);
+    return true;
+}
+
+std::shared_ptr<Node> ConvertAlignTypes::clone_with_new_inputs(const OutputVector& new_args) const {
+    OV_OP_SCOPE(ConvertAlignTypes_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    return std::make_shared<ConvertAlignTypes>(new_args.at(0),
+                                               new_args.at(1),
+                                               m_promote_unsafe,
+                                               m_pytorch_scalar_align,
+                                               m_u64_integer_promotion_target);
+}
+
+}  // namespace v1
+}  // namespace op
+}  // namespace ov

--- a/src/core/tests/type_prop/convert_align_types.cpp
+++ b/src/core/tests/type_prop/convert_align_types.cpp
@@ -1,0 +1,296 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/convert_align_types.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "common_test_utils/type_prop.hpp"
+#include "openvino/op/parameter.hpp"
+
+using namespace ov;
+using namespace testing;
+
+struct ConvertAlignTypesTestParams {
+    PartialShape lhs_shape;
+    element::Type lhs_type;
+    PartialShape rhs_shape;
+    element::Type rhs_type;
+    bool pytorch_scalar_align;
+    bool promote_unsafe;
+    element::Type expected_type;
+    element::Type u64_integer;
+};
+struct ConvertAlignTypesTest : ::testing::TestWithParam<ConvertAlignTypesTestParams> {};
+
+TEST_F(ConvertAlignTypesTest, default_ctor) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::u8, Shape{});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::f16, Shape{});
+    auto c = std::make_shared<op::v1::ConvertAlignTypes>();
+    c->set_arguments(OutputVector{lhs, rhs});
+    c->set_pytorch_scalar_align(true);
+    c->set_promote_unsafe(true);
+    c->set_u64_integer_promotion_target(element::f64);
+    ASSERT_EQ(c->get_output_element_type(0), c->get_output_element_type(1));
+    ASSERT_EQ(c->get_output_element_type(0), element::f16);
+    ASSERT_EQ(c->get_output_partial_shape(0), (Shape{}));
+    ASSERT_EQ(c->get_output_partial_shape(1), (Shape{}));
+}
+
+TEST_P(ConvertAlignTypesTest, convert_align_types_suite) {
+    auto params = GetParam();
+    auto lhs_shape = params.lhs_shape;
+    auto lhs_dynamic = (lhs_shape == PartialShape().dynamic()) ? true : false;
+    if (!lhs_dynamic) {
+        set_shape_labels(lhs_shape, 10);
+    }
+    auto rhs_shape = params.rhs_shape;
+    auto rhs_dynamic = (rhs_shape == PartialShape().dynamic()) ? true : false;
+    if (!rhs_dynamic) {
+        set_shape_labels(rhs_shape, 100);
+    }
+
+    auto lhs = std::make_shared<op::v0::Parameter>(params.lhs_type, lhs_shape);
+    auto rhs = std::make_shared<op::v0::Parameter>(params.rhs_type, rhs_shape);
+    auto c = std::make_shared<op::v1::ConvertAlignTypes>(lhs,
+                                                         rhs,
+                                                         params.pytorch_scalar_align,
+                                                         params.promote_unsafe,
+                                                         params.u64_integer);
+    ASSERT_EQ(c->get_output_element_type(0), c->get_output_element_type(1));
+    ASSERT_EQ(c->get_output_element_type(0), params.expected_type);
+    ASSERT_EQ(c->get_output_partial_shape(0), (lhs_shape));
+    ASSERT_EQ(c->get_output_partial_shape(1), (rhs_shape));
+    ASSERT_EQ(get_shape_labels(c->get_output_partial_shape(0)), get_shape_labels(lhs_shape));
+    ASSERT_EQ(get_shape_labels(c->get_output_partial_shape(1)), get_shape_labels(rhs_shape));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    type_prop,
+    ConvertAlignTypesTest,
+    ::testing::Values(
+        // Test cases:
+        //  dynamic
+        ConvertAlignTypesTestParams{{1, 2, 3, 4},
+                                    element::dynamic,
+                                    {5, 6, 7},
+                                    element::dynamic,
+                                    false,
+                                    true,
+                                    element::dynamic,
+                                    element::f32},
+        ConvertAlignTypesTestParams{{5, 6, 7},
+                                    element::dynamic,
+                                    {1},
+                                    element::f16,
+                                    true,
+                                    false,
+                                    element::dynamic,
+                                    element::f32},
+        ConvertAlignTypesTestParams{{1, 2, 3, 4},
+                                    element::i64,
+                                    {1},
+                                    element::dynamic,
+                                    true,
+                                    false,
+                                    element::dynamic,
+                                    element::f32},
+        ConvertAlignTypesTestParams{{},
+                                    element::dynamic,
+                                    {1},
+                                    element::f32,
+                                    true,
+                                    true,
+                                    element::dynamic,
+                                    element::f32},
+        //  bool
+        ConvertAlignTypesTestParams{{1},
+                                    element::boolean,
+                                    {1, 2, 3, 4},
+                                    element::boolean,
+                                    false,
+                                    true,
+                                    element::boolean,
+                                    element::f32},
+        ConvertAlignTypesTestParams{PartialShape().dynamic(),
+                                    element::boolean,
+                                    {-1, {1, 5}, -1, -1},
+                                    element::u32,
+                                    false,
+                                    true,
+                                    element::u32,
+                                    element::f32},
+        ConvertAlignTypesTestParams{{1}, element::i16, {1}, element::boolean, true, false, element::i16, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::f16, {1}, element::boolean, true, false, element::f16, element::f32},
+        //  u and u
+        ConvertAlignTypesTestParams{{1}, element::u8, {1}, element::u8, true, false, element::u8, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::u8, {1}, element::u4, true, false, element::u8, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::u1, {1}, element::u4, true, false, element::u4, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::u1, {1}, element::u1, true, false, element::u1, element::f32},
+        //  i and i
+        ConvertAlignTypesTestParams{{1}, element::i8, {1}, element::i8, true, false, element::i8, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::i4, {1}, element::i8, true, false, element::i8, element::f32},
+        //  f and f
+        ConvertAlignTypesTestParams{{1}, element::f32, {1}, element::f32, true, false, element::f32, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::f8e4m3, {1}, element::f32, true, false, element::f32, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::f64, {1}, element::f32, true, false, element::f64, element::f32},
+        //  u and i
+        ConvertAlignTypesTestParams{{1}, element::u1, {1}, element::i4, true, false, element::i4, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::u16, {1}, element::i8, true, false, element::i32, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::i4, {1}, element::u32, true, false, element::i64, element::f32},
+        //  u and f
+        ConvertAlignTypesTestParams{{1}, element::u1, {1}, element::f8e5m2, true, false, element::f8e5m2, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::u16, {1}, element::f32, false, false, element::f32, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::f16, {1}, element::u32, true, false, element::f16, element::f32},
+        //  i and f
+        ConvertAlignTypesTestParams{{1}, element::i16, {1}, element::f32, false, false, element::f32, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::f16, {1}, element::i32, true, false, element::f16, element::f32},
+        // All combinations for torch mode:
+        //  l scalar r tensor
+        ConvertAlignTypesTestParams{{},
+                                    element::i32,
+                                    PartialShape().dynamic(),
+                                    element::u8,
+                                    true,
+                                    true,
+                                    element::u8,
+                                    element::f32},
+        ConvertAlignTypesTestParams{{}, element::f16, {1}, element::u32, true, true, element::f16, element::f32},
+        //  l tensor r scalar
+        ConvertAlignTypesTestParams{{-1}, element::i32, {}, element::u8, true, true, element::i32, element::f32},
+        ConvertAlignTypesTestParams{{{1, 5}, 3},
+                                    element::f16,
+                                    {},
+                                    element::u32,
+                                    true,
+                                    true,
+                                    element::f16,
+                                    element::f32},
+        //  l scalar r scalar
+        ConvertAlignTypesTestParams{{}, element::f16, {}, element::u64, true, true, element::f16, element::f32},
+        ConvertAlignTypesTestParams{{}, element::u8, {}, element::i8, true, true, element::i16, element::f32},
+        //  Allowed safe mode:
+        ConvertAlignTypesTestParams{{}, element::f16, {1}, element::f32, false, true, element::f32, element::f32},
+        ConvertAlignTypesTestParams{{}, element::u8, {1}, element::i16, false, true, element::i16, element::f32},
+        ConvertAlignTypesTestParams{{}, element::u8, {1}, element::u16, false, true, element::u16, element::f32},
+        ConvertAlignTypesTestParams{{}, element::u8, {1}, element::f16, false, false, element::f16, element::f32},
+        // Special cases:
+        //  f8
+        ConvertAlignTypesTestParams{{1},
+                                    element::f8e4m3,
+                                    {1},
+                                    element::f8e5m2,
+                                    true,
+                                    false,
+                                    element::f16,
+                                    element::f32},
+        ConvertAlignTypesTestParams{{1},
+                                    element::f8e4m3,
+                                    {1},
+                                    element::f8e4m3,
+                                    true,
+                                    false,
+                                    element::f8e4m3,
+                                    element::f32},
+        ConvertAlignTypesTestParams{{1}, element::f8e4m3, {1}, element::bf16, true, false, element::bf16, element::f32},
+        ConvertAlignTypesTestParams{{1},
+                                    element::f8e4m3,
+                                    {1},
+                                    element::i64,
+                                    true,
+                                    false,
+                                    element::f8e4m3,
+                                    element::f32},
+        //  bf16
+        ConvertAlignTypesTestParams{{1}, element::bf16, {1}, element::bf16, true, false, element::bf16, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::f16, {1}, element::bf16, true, false, element::f32, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::u64, {1}, element::bf16, true, false, element::bf16, element::f32},
+        //  u64
+        ConvertAlignTypesTestParams{{1}, element::u64, {1}, element::i4, true, false, element::f32, element::f32},
+        ConvertAlignTypesTestParams{{1},
+                                    element::u64,
+                                    {1},
+                                    element::f8e4m3,
+                                    true,
+                                    false,
+                                    element::f8e4m3,
+                                    element::f32},
+        ConvertAlignTypesTestParams{{1}, element::u64, {1}, element::u32, true, false, element::u64, element::f32},
+        ConvertAlignTypesTestParams{{1}, element::u64, {1}, element::i4, true, false, element::i64, element::i64},
+        ConvertAlignTypesTestParams{{1}, element::u64, {1}, element::i4, true, false, element::i4, element::i4},
+        ConvertAlignTypesTestParams{{1}, element::u64, {1}, element::i4, true, false, element::u64, element::u64}),
+    PrintToDummyParamName());
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_u_i_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::u8, Shape{});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::i8, Shape{});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, false),
+                    Exception,
+                    HasSubstr("Unsigned integer input cannot be safely promoted into any supported signed integer."));
+}
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_u64_int_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::u64, Shape{});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::i8, Shape{});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, false),
+                    Exception,
+                    HasSubstr("Unsigned integer input cannot be safely promoted into any supported signed integer."));
+}
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_uint_float_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::u16, Shape{});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::f16, Shape{});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, false),
+                    Exception,
+                    HasSubstr("Integer input cannot be safely promoted to floating-point."));
+}
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_int_float_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::i32, Shape{});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::f16, Shape{});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, false),
+                    Exception,
+                    HasSubstr("Integer input cannot be safely promoted to floating-point."));
+}
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_torch_signed_unsigned_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::i64, Shape{});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::u4, Shape{1});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, true),
+                    Exception,
+                    HasSubstr("Scalar input cannot be PyTorch-like aligned using safe promotion rules."));
+}
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_torch_unsigned_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::u64, Shape{});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::u4, Shape{1});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, true),
+                    Exception,
+                    HasSubstr("Scalar input cannot be PyTorch-like aligned using safe promotion rules."));
+}
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_torch_floating_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::f64, Shape{});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::f16, Shape{1});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, true),
+                    Exception,
+                    HasSubstr("Scalar input cannot be PyTorch-like aligned using safe promotion rules."));
+}
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_bf16_f16_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::f16, Shape{1});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::bf16, Shape{1});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, false),
+                    Exception,
+                    HasSubstr("Unsupported input element types for ConvertAlignTypes with given attributes."));
+}
+
+TEST_F(ConvertAlignTypesTest, convert_align_types_exception_f8e4m3_f8e5m2_unsafe) {
+    auto lhs = std::make_shared<op::v0::Parameter>(element::f8e4m3, Shape{1});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::f8e5m2, Shape{1});
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, false, false),
+                    Exception,
+                    HasSubstr("Unsupported input element types for ConvertAlignTypes with given attributes."));
+}

--- a/src/core/tests/visitors/op/convert_align_types.cpp
+++ b/src/core/tests/visitors/op/convert_align_types.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/convert_align_types.hpp"
+
+#include <gtest/gtest.h>
+
+#include "visitors/visitors.hpp"
+
+using namespace ov;
+using ov::test::NodeBuilder;
+
+TEST(attributes, convert_align_types_op_default) {
+    NodeBuilder::opset().insert<op::v1::ConvertAlignTypes>();
+    auto lhs = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 4});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 4});
+
+    const auto convert = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs);
+    NodeBuilder builder(convert, {lhs, rhs});
+
+    const auto expected_attr_count = 3;
+    EXPECT_EQ(builder.get_value_map_size(), expected_attr_count);
+
+    const auto g_convert = ov::as_type_ptr<op::v1::ConvertAlignTypes>(builder.create());
+    EXPECT_EQ(g_convert->get_pytorch_scalar_align(), false);
+    EXPECT_EQ(g_convert->get_promote_unsafe(), false);
+    EXPECT_EQ(g_convert->get_u64_integer_promotion_target(), element::f32);
+}
+
+TEST(attributes, convert_align_types_constructor) {
+    NodeBuilder::opset().insert<op::v1::ConvertAlignTypes>();
+    auto lhs = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 4});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::i32, Shape{2, 4});
+    const bool pytorch_scalar_align = true;
+    const bool promote_unsafe = true;
+
+    const auto convert =
+        std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs, pytorch_scalar_align, promote_unsafe, element::i64);
+    NodeBuilder builder(convert, {lhs, rhs});
+
+    const auto expected_attr_count = 3;
+    EXPECT_EQ(builder.get_value_map_size(), expected_attr_count);
+
+    const auto g_convert = ov::as_type_ptr<op::v1::ConvertAlignTypes>(builder.create());
+    EXPECT_EQ(g_convert->get_pytorch_scalar_align(), convert->get_pytorch_scalar_align());
+    EXPECT_EQ(g_convert->get_promote_unsafe(), convert->get_promote_unsafe());
+    EXPECT_EQ(g_convert->get_u64_integer_promotion_target(), element::i64);
+}
+
+TEST(attributes, convert_align_types_op_setters) {
+    NodeBuilder::opset().insert<op::v1::ConvertAlignTypes>();
+    auto lhs = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 4});
+    auto rhs = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 4});
+
+    const auto convert = std::make_shared<op::v1::ConvertAlignTypes>(lhs, rhs);
+    convert->set_promote_unsafe(true);
+    convert->set_pytorch_scalar_align(true);
+    convert->set_u64_integer_promotion_target(element::u64);
+    NodeBuilder builder(convert, {lhs, rhs});
+
+    const auto expected_attr_count = 3;
+    EXPECT_EQ(builder.get_value_map_size(), expected_attr_count);
+
+    const auto g_convert = ov::as_type_ptr<op::v1::ConvertAlignTypes>(builder.create());
+    EXPECT_EQ(g_convert->get_pytorch_scalar_align(), true);
+    EXPECT_EQ(g_convert->get_promote_unsafe(), true);
+    EXPECT_EQ(g_convert->get_u64_integer_promotion_target(), element::u64);
+}


### PR DESCRIPTION
### Details:
 - *Implement ConvertAlignTypes core - operation that aligns input types into one common one based on type promotion rules*
 - *Operator designed for PT frontend, but rules extend to match also TF-like promotion rules*
 - *PR Contains tests for shape/type validation and visitor tests*

### Tickets:
 - *129198*
 - *129203*

## Currently opset for this operator is left blank, waiting for a final decision to add it and remove "draft" status, PR shouldn't be merged until then.