### PR TITLE
[CI] [GHA] Add `choco` wrapper with retrying mechanism

### DIFF
--- a/.github/utils/ChocoHelper.ps1
+++ b/.github/utils/ChocoHelper.ps1
@@ -1,0 +1,32 @@
+function Choco-Install {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $PackageName,
+        [string[]] $ArgumentList,
+        [int] $RetryCount = 5
+    )
+
+    process {
+        $count = 1
+        while($true)
+        {
+            Write-Host "Running [#$count]: choco install $packageName -y $argumentList"
+            choco install $packageName -y @argumentList
+
+            $pkg = choco list --localonly $packageName --exact --all --limitoutput
+            if ($pkg) {
+                Write-Host "Package installed: $pkg"
+                break
+            }
+            else {
+                $count++
+                if ($count -ge $retryCount) {
+                    Write-Host "Could not install $packageName after $count attempts"
+                    exit 1
+                }
+                Start-Sleep -Seconds 30
+            }
+        }
+    }
+}

--- a/.github/utils/ChocoHelper.ps1
+++ b/.github/utils/ChocoHelper.ps1
@@ -11,18 +11,18 @@ function Choco-Install {
         $count = 1
         while($true)
         {
-            Write-Host "Running [#$count]: choco install $packageName -y $argumentList"
-            choco install $packageName -y @argumentList
+            Write-Host "Running [#$count]: choco install $PackageName -y $ArgumentList"
+            choco install $PackageName -y @ArgumentList
 
-            $pkg = choco list --localonly $packageName --exact --all --limitoutput
+            $pkg = choco list --localonly $PackageName --exact --all --limitoutput
             if ($pkg) {
                 Write-Host "Package installed: $pkg"
                 break
             }
             else {
                 $count++
-                if ($count -ge $retryCount) {
-                    Write-Host "Could not install $packageName after $count attempts"
+                if ($count -ge $RetryCount) {
+                    Write-Host "Could not install $PackageName after $count attempts"
                     exit 1
                 }
                 Start-Sleep -Seconds 30

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -128,7 +128,10 @@ jobs:
           version: "v0.7.5"
 
       - name: Install build dependencies
-        run: choco install --no-progress ninja
+        run: |
+          # Source script with `choco` wrapper that provides the retrying mechanism
+          . ${{ env.OPENVINO_REPO }}/.github/utils/ChocoHelper.ps1
+          Choco-Install -PackageName ninja
 
       #
       # Build

--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -109,7 +109,10 @@ jobs:
           version: "v0.5.4"
 
       - name: Install build dependencies
-        run: choco install --no-progress ninja
+        run: |
+          # Source script with `choco` wrapper that provides the retrying mechanism
+          . ${{ env.OPENVINO_REPO }}/.github/utils/ChocoHelper.ps1
+          Choco-Install -PackageName ninja
 
       - name: Install python dependencies
         run: |


### PR DESCRIPTION
### Details:
 - This PR introduces a wrapper for `choco` package manager command with the retrying mechanism. Hopefully, this should mitigate the [`[NuGet] Response status code does not indicate success: 503 (Service Unavailable).`](https://github.com/openvinotoolkit/openvino/actions/runs/7710979436/job/21015453379) errors when running `choco` install.

- Chocolatey [does not seem to have a retry mechanism](https://github.com/chocolatey/choco/issues/385), the `503` error is present for different projects.

- The wrapper is introduced in the [official Windows GitHub Actions runner images](https://github.com/actions/runner-images/pull/721) to mitigate the very same problem.

<sub><sub>If only we had this pre-installed in our Windows runners.</sub></sub>

### Tickets:
 - *CVS-131217*
