### PR TITLE
[DOCS] Specify number of jobs in build docs

### DIFF
--- a/docs/dev/build_linux.md
+++ b/docs/dev/build_linux.md
@@ -53,7 +53,10 @@ The software was validated on:
      cmake -DCMAKE_BUILD_TYPE=Release ..
      cmake --build . --parallel
    ```
-The process may take some time to finish.
+   The process may take some time to finish. If you are using a system with limited resources, it is advisable to specify a lower number of parallel jobs to avoid overwhelming your system. This can help maintain system responsiveness and stability during the build process. Use `nproc` to find number of processing units available. For example, to use 8 parallel jobs, run the following command:
+      ```sh
+      cmake --build . --parallel 8
+      ```
 
 ### Additional Build Options
 

--- a/docs/dev/build_linux.md
+++ b/docs/dev/build_linux.md
@@ -53,7 +53,7 @@ The software was validated on:
      cmake -DCMAKE_BUILD_TYPE=Release ..
      cmake --build . --parallel
    ```
-   The process may take some time to finish. If you are using a system with limited resources, it is advisable to specify a lower number of parallel jobs to avoid overwhelming your system. This can help maintain system responsiveness and stability during the build process. Use `nproc` to find number of processing units available. For example, to use 8 parallel jobs, run the following command:
+   The process may take some time to finish. If you are using a system with limited resources, it is recommended to specify a lower number of parallel jobs to avoid overloading your system. This can help maintain system responsiveness and stability during the build process. Use `nproc` to find the number of available processing units. For example, to use 8 parallel jobs, run the following command:
       ```sh
       cmake --build . --parallel 8
       ```

--- a/docs/dev/build_windows.md
+++ b/docs/dev/build_windows.md
@@ -44,7 +44,7 @@ Supported configurations:
    >* `-DCMAKE_BUILD_TYPE=RelWithDebInfo`: This option generates PDB files with release information, making it suitable for debugging optimized builds. <br>
    >* `-DCMAKE_BUILD_TYPE=Debug`: This option generates PDB files optimized for debugging, providing comprehensive debugging information. 
 
-4. Build generated solution in Visual Studio or run `cmake --build . --config Release --verbose -j8` to build from the command line. Be aware that this process may take some time.
+4. Build generated solution in Visual Studio or run `cmake --build . --config Release --verbose -j<number_of_jobs>` to build from the command line. View number of processing units available with `WMIC cpu get numberofLogicalProcessors`. Be aware that this process may take some time.
 
 5. Before running the samples, add paths to the Threading Building Blocks (TBB) binaries used for the build to the `%PATH%` environment variable. By default, TBB binaries are downloaded by the CMake-based script to the `<path/to/openvino>/temp/tbb/bin` folder.
 

--- a/docs/dev/build_windows.md
+++ b/docs/dev/build_windows.md
@@ -44,7 +44,7 @@ Supported configurations:
    >* `-DCMAKE_BUILD_TYPE=RelWithDebInfo`: This option generates PDB files with release information, making it suitable for debugging optimized builds. <br>
    >* `-DCMAKE_BUILD_TYPE=Debug`: This option generates PDB files optimized for debugging, providing comprehensive debugging information. 
 
-4. Build generated solution in Visual Studio or run `cmake --build . --config Release --verbose -j<number_of_jobs>` to build from the command line. View number of processing units available with `WMIC cpu get numberofLogicalProcessors`. Be aware that this process may take some time.
+4. Build generated solution in Visual Studio or run `cmake --build . --config Release --verbose -j<number_of_jobs>` to build from the command line. View the number of available processing units with `WMIC cpu get numberofLogicalProcessors`. Be aware that this process may take some time.
 
 5. Before running the samples, add paths to the Threading Building Blocks (TBB) binaries used for the build to the `%PATH%` environment variable. By default, TBB binaries are downloaded by the CMake-based script to the `<path/to/openvino>/temp/tbb/bin` folder.
 


### PR DESCRIPTION
### Details:
 - Add a small note for users to adjust number of jobs in `cmake --build . --parallel <number_of_jobs>`
 - for `build_linux.md` and `build_windows.md`

### Tickets:
 - Closes #22474
