### PR TITLE
[GHA] Testing solution for GitHub Actions workflows telemetry

### DIFF
--- a/.github/workflows/send_workflows_to_opentelemetry.yml
+++ b/.github/workflows/send_workflows_to_opentelemetry.yml
@@ -1,0 +1,42 @@
+name: Send workflows to OpenTelemetry (BETA)
+
+on:
+  workflow_run:
+    workflows:
+      - Android ARM64 with vcpkg
+      - Documentation
+      - Cleanup PIP caches
+      - Code snippets
+      - Code Style
+      - Code coverage
+      - Coverity (Ubuntu 20.04, Python 3.11)
+      - Fedora (RHEL), Python 3.9
+      - Linux (Ubuntu 20.04, Python 3.11)
+      - Linux ARM64 (Ubuntu 20.04, Python 3.11)
+      - Linux Static CC (Ubuntu 22.04, Python 3.11, Clang)
+      - Linux RISC-V with Conan (Ubuntu 22.04, Python 3.10)
+      - macOS (Python 3.11)
+      - macOS ARM64 (Python 3.11)
+      - MO
+      - Python API Checks
+      - Webassembly
+      - Windows (VS 2019, Python 3.11)
+      - Windows Conditional Compilation (VS 2022, Python 3.11)
+    types:
+      - completed
+
+permissions: read-all
+
+jobs:
+  otel-export-trace:
+    name: OpenTelemetry Export Trace
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Export Workflow Trace
+        uses: inception-health/otel-export-trace-action@7eabc7de1f4753f0b45051b44bb0ba46d05a21ef
+        with:
+          otlpEndpoint: grpc://api.honeycomb.io:443/
+          otlpHeaders: ${{ secrets.OTLP_HEADERS }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
### Details:
This PR introduces a GitHub Actions workflow which will be run after each of the specified workflow runs and send their telemetry to a third-party service (which can be replaced later) in OpenTelemetry format. This is not intended for production use yet.