### PR TITLE
Migrate to Ubuntu 22.04 in GHA arm64

### DIFF
--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -1,4 +1,4 @@
-name: Linux ARM64 (Ubuntu 20.04, Python 3.11)
+name: Linux ARM64 (Ubuntu 22.04, Python 3.11)
 on:
   workflow_dispatch:
   pull_request:
@@ -55,7 +55,7 @@ jobs:
         shell: bash
     runs-on: 'aks-linux-16-cores-arm'
     container:
-      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04
+      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04
       volumes:
         - /mount:/mount
       options: -e SCCACHE_AZURE_BLOB_CONTAINER -e SCCACHE_AZURE_CONNECTION_STRING
@@ -77,7 +77,7 @@ jobs:
       INSTALL_TEST_DIR: /__w/openvino/openvino/tests_install
       DEVELOPER_PACKAGE_DIR: /__w/openvino/openvino/developer_package_install
       BUILD_DIR: /__w/openvino/openvino/openvino_build
-      SCCACHE_AZURE_KEY_PREFIX: 'ubuntu20_aarch64_Release'
+      SCCACHE_AZURE_KEY_PREFIX: 'ubuntu22_aarch64_Release'
       ONNX_RUNTIME_UTILS: /__w/openvino/openvino/openvino/src/frontends/onnx/tests/ci_utils/onnxruntime
     if: "!needs.smart_ci.outputs.skip_workflow"
 
@@ -188,7 +188,6 @@ jobs:
 
       - name: Pack Artifacts
         run: |
-
           # Add the ONNX Runtime version and skip tests list to the archive to use in the ONNX Runtime Job
           # w/o the need to checkout repository
 
@@ -301,7 +300,7 @@ jobs:
     uses: ./.github/workflows/job_debian_packages.yml
     with:
       runner: 'aks-linux-16-cores-arm'
-      image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04'
+      image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04'
 
   Samples:
     needs: [ Build, Smart_CI ]
@@ -309,7 +308,7 @@ jobs:
     uses: ./.github/workflows/job_samples_tests.yml
     with:
       runner: 'aks-linux-16-cores-arm'
-      image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04'
+      image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04'
       affected-components: ${{ needs.smart_ci.outputs.affected_components }}
 
   JS_API:
@@ -319,7 +318,7 @@ jobs:
     uses: ./.github/workflows/job_openvino_js.yml
     with:
       runner: 'aks-linux-16-cores-arm'
-      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04"}'
+      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04"}'
 
   ONNX_Runtime:
     name: ONNX Runtime Integration
@@ -340,7 +339,7 @@ jobs:
     uses: ./.github/workflows/job_cxx_unit_tests.yml
     with:
       runner: 'aks-linux-16-cores-arm'
-      image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04'
+      image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04'
       affected-components: ${{ needs.smart_ci.outputs.affected_components }}
 
   Python_Unit_Tests:
@@ -349,7 +348,7 @@ jobs:
     uses: ./.github/workflows/job_python_unit_tests.yml
     with:
       runner: 'aks-linux-16-cores-arm'
-      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04", "volumes": ["/mount:/mount"]}'
+      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04", "volumes": ["/mount:/mount"]}'
       affected-components: ${{ needs.smart_ci.outputs.affected_components }}
 
   CPU_Functional_Tests:
@@ -359,7 +358,7 @@ jobs:
     uses: ./.github/workflows/job_cpu_functional_tests.yml
     with:
       runner: 'aks-linux-16-cores-arm'
-      image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04'
+      image: 'openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04'
 
   TensorFlow_Hub_Models_Tests:
     name: TensorFlow Hub Models tests
@@ -370,7 +369,7 @@ jobs:
     uses: ./.github/workflows/job_tensorflow_hub_models_tests.yml
     with:
       runner: 'aks-linux-16-cores-arm'
-      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04"}'
+      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04"}'
       event: ${{ github.event_name }}
 
   PyTorch_Models_Tests:
@@ -381,7 +380,7 @@ jobs:
     uses: ./.github/workflows/job_pytorch_models_tests.yml
     with:
       runner: 'aks-linux-16-cores-arm'
-      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04"}'
+      container: '{"image": "openvinogithubactions.azurecr.io/dockerhub/ubuntu:22.04"}'
       event: ${{ github.event_name }}
 
   Overall_Status:


### PR DESCRIPTION
### Details:
 - Extracted from https://github.com/openvinotoolkit/openvino/pull/22437
 - Required to build universal ARM plugin, which covers all architectures including fp32, fp16, SVE, SVE2, SME