### PR TITLE
[GPU] Fix gemm_ref and gemm_tiled_opt

### DIFF
--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -49,6 +49,15 @@ layout gemm_inst::calc_output_layout(gemm_node const& node, kernel_impl_params c
         return input_shape_update;
     };
 
+    auto transpose_shape = [](const ov::Shape& shape, const std::vector<int64_t>& order) {
+        auto shape_transposed = ov::Shape(shape);
+        for (size_t i = 0; i < order.size(); i++) {
+            shape_transposed[i] = shape[order[i]];
+        }
+
+        return shape_transposed;
+    };
+
     auto input0_shape_update = update_input_shape(input0_shape, input_rank, input0_order, true);
     auto input1_shape_update = update_input_shape(input1_shape, weight_rank, input1_order, false);
 
@@ -71,6 +80,9 @@ layout gemm_inst::calc_output_layout(gemm_node const& node, kernel_impl_params c
 
     size_t ones_to_add = 4 - std::min(output_shape.size(), static_cast<size_t>(4));
     output_shape.insert(output_shape.begin(), ones_to_add, 1);
+
+    if (prim->output_order.size() > 0)
+        output_shape = transpose_shape(output_shape, prim->output_order);
 
     auto output_type = input0_layout.data_type;
     if ((output_type == data_types::u8 || output_type == data_types::i8) && prim->output_data_types[0])

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -513,6 +513,15 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 }
             }
 
+            auto gemm_prim = node.get_primitive();
+            for (size_t idx = 0; idx < gemm_prim->output_order.size(); ++idx) {
+                size_t output_order_idx = static_cast<size_t>(gemm_prim->output_order[idx]);
+                if (idx != output_order_idx) {
+                    does_support_fusings = false;
+                    break;
+                }
+            }
+
             return does_support_fusings;
         };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_ref.cl
@@ -67,6 +67,9 @@ inline uint FUNC(get_input2_index)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint 
 }
 #endif // INPUT2_TYPE
 
+#define INPUT0_SIZE_F INPUT0_FEATURE_NUM
+#define INPUT0_SIZE_B INPUT0_BATCH_NUM
+
 KERNEL(gemm_ref)(
     OPTIONAL_SHAPE_INFO_ARG
     const __global INPUT0_TYPE* input0,
@@ -84,13 +87,13 @@ KERNEL(gemm_ref)(
     const uint y = (uint)get_global_id(1);
 
     uint bidx = get_global_id(2);
-    const uint b = bidx % OUTPUT_BATCH_NUM;
-    bidx /= OUTPUT_BATCH_NUM;
-    const uint f = bidx % OUTPUT_FEATURE_NUM;
-    bidx /= OUTPUT_FEATURE_NUM;
-    const uint z = bidx % OUTPUT_SIZE_Z;
-    bidx /= OUTPUT_SIZE_Z;
-    const uint w = bidx % OUTPUT_SIZE_W;
+    const uint b = bidx % TR_OUTPUT_BATCH_NUM;
+    bidx /= TR_OUTPUT_BATCH_NUM;
+    const uint f = bidx % TR_OUTPUT_FEATURE_NUM;
+    bidx /= TR_OUTPUT_FEATURE_NUM;
+    const uint z = bidx % TR_OUTPUT_SIZE_Z;
+    bidx /= TR_OUTPUT_SIZE_Z;
+    const uint w = bidx % TR_OUTPUT_SIZE_W;
 
     const uint K = CAT(INPUT0_SIZE_, MATMUL_AXIS);
 
@@ -129,3 +132,6 @@ KERNEL(gemm_ref)(
     output[dst_index] = dequantized;
 #endif
 }
+
+#undef INPUT0_SIZE_F
+#undef INPUT0_SIZE_B

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -124,7 +124,7 @@ KERNEL(gemm_tiled_opt)(
     // Start pointers offsets
 #if TRANSPOSE_INPUT0 == TRANSPOSE_X_LAST
     const __global INPUT0_TYPE* a_ptr = input0 + batch_offset_input0;
-    #if HAS_DYNAMIC_K_PADDING || INPUT0_OFFSET
+    #if HAS_DYNAMIC_K_PADDING || INPUT0_HAS_PADDING
         const uint input0_offset = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (y+1), 0) - batch_offset_input0;
         const uint input0_offset1 = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, (TILE_K)) - batch_offset_input0;
     #else
@@ -133,7 +133,7 @@ KERNEL(gemm_tiled_opt)(
     #endif
 #elif TRANSPOSE_INPUT0 == TRANSPOSE_Y_LAST
     const __global INPUT0_TYPE* a_ptr = input0 + batch_offset_input0;
-    #if HAS_DYNAMIC_K_PADDING || INPUT0_OFFSET
+    #if HAS_DYNAMIC_K_PADDING || INPUT0_HAS_PADDING
         const uint input0_offset = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, 1) - batch_offset_input0;
         const uint input0_offset1 = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, (TILE_K)) - batch_offset_input0;
     #else
@@ -143,14 +143,14 @@ KERNEL(gemm_tiled_opt)(
 #endif // TRANSPOSE_INPUT0
 #if TRANSPOSE_INPUT1 == TRANSPOSE_X_LAST
     const __global INPUT1_TYPE* b_ptr = input1 + batch_offset_input1;
-    #if HAS_DYNAMIC_K_PADDING || INPUT1_OFFSET
+    #if HAS_DYNAMIC_K_PADDING || INPUT1_HAS_PADDING
         const uint input1_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, 1, tile_n_offset) - batch_offset_input1;
     #else
         const uint input1_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR 0, 0, 0, 0, 1, 0);
     #endif
 #elif TRANSPOSE_INPUT1 == TRANSPOSE_Y_LAST
     const __global INPUT1_TYPE* b_ptr = input1 + batch_offset_input1;
-    #if HAS_DYNAMIC_K_PADDING || INPUT1_OFFSET
+    #if HAS_DYNAMIC_K_PADDING || INPUT1_HAS_PADDING
         const uint input1_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, 0, (tile_n_offset + 1)) - batch_offset_input1;
         const uint input1_offset1 = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (TILE_K), tile_n_offset) - batch_offset_input1;
     #else
@@ -187,7 +187,7 @@ KERNEL(gemm_tiled_opt)(
         unroll_for (uint b_load_id = 0; b_load_id < TILE_K; b_load_id++) {
 #if IS_DYNAMIC
 #if TRANSPOSE_INPUT1 == TRANSPOSE_X_LAST
-#if HAS_DYNAMIC_N_PADDING || INPUT1_OFFSET
+#if HAS_DYNAMIC_N_PADDING || INPUT1_HAS_PADDING
             b_tile[b_load_id] = b_raw_global_id > N - 1 ? 0 : b_ptr[sglid];
 #else
             b_tile[b_load_id] = TILE_N_NOT_DIVISIBLE ? (b_raw_global_id > N - 1 ? 0 : b_ptr[sglid]) : BLOCK_READ_B(b_ptr, 0);
@@ -229,7 +229,7 @@ KERNEL(gemm_tiled_opt)(
         unroll_for (uint dot_id = 0; dot_id < tile_m_iterations; dot_id++) {
 #if TRANSPOSE_INPUT0 == TRANSPOSE_X_LAST
 #if IS_DYNAMIC
-#if HAS_DYNAMIC_K_PADDING || INPUT0_OFFSET
+#if HAS_DYNAMIC_K_PADDING || INPUT0_HAS_PADDING
             // In case of dynamic padding we can't guarantee memory access alignment for
             // block reads (4 bytes), so use scattered read
             uint a_idx = FUNC_CALL(get_input0_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, (y + dot_id), (k * TILE_K + sglid));
@@ -286,7 +286,7 @@ KERNEL(gemm_tiled_opt)(
         // Loading leftovers of the matrix B
         unroll_for (uint b_load_id = 0; b_load_id < TILE_K_LEFTOVER; b_load_id++) {
         #if TRANSPOSE_INPUT1 == TRANSPOSE_X_LAST
-            #if HAS_DYNAMIC_N_PADDING || INPUT1_OFFSET
+            #if HAS_DYNAMIC_N_PADDING || INPUT1_HAS_PADDING
                 b_tile[b_load_id] = b_raw_global_id > N - 1 ? 0 : b_ptr[sglid];
             #else
                 b_tile[b_load_id] = TILE_N_NOT_DIVISIBLE ? (b_raw_global_id > N - 1 ? 0 : b_ptr[sglid]) : BLOCK_READ_B(b_ptr, 0);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
@@ -180,13 +180,37 @@ JitConstants GemmKernelBase::GetJitConstants(const gemm_params& params) const {
         MakeJitConstant("QUANTIZATION_TERM", params.quantization != QuantizationType::NONE),
     });
 
+    auto get_output_size = [this](const std::vector<int64_t>& output_order_idx, const int target_idx) {
+        auto output_dims_order = GetDimsOrder(output_order_idx);
+
+        switch (output_dims_order.at(target_idx)) {
+            case 'b':
+                return "OUTPUT_BATCH_NUM";
+            case 'f':
+                return "OUTPUT_FEATURE_NUM";
+            case 'w':
+                return "OUTPUT_SIZE_W";
+            case 'z':
+                return "OUTPUT_SIZE_Z";
+            case 'y':
+                return "OUTPUT_SIZE_Y";
+            case 'x':
+                return "OUTPUT_SIZE_X";
+            default:
+                return "";
+        }
+    };
+
     jit.AddConstants({
         MakeJitConstant("TRANSPOSE_X_LAST", 0),
         MakeJitConstant("TRANSPOSE_Y_LAST", 1),
         MakeJitConstant("TRANSPOSE_OTHER", 2),
         MakeJitConstant("INPUT0_DIMS_ORDER", GetDimsOrder(params.input0_order)),
         MakeJitConstant("INPUT1_DIMS_ORDER", GetDimsOrder(params.input1_order)),
-        MakeJitConstant("MATMUL_AXIS", static_cast<char>(std::toupper(GetDimsOrder(params.input0_order).at(10)))),
+        MakeJitConstant("TR_OUTPUT_SIZE_Z", get_output_size(params.output_order, 6)),
+        MakeJitConstant("TR_OUTPUT_SIZE_W", get_output_size(params.output_order, 4)),
+        MakeJitConstant("TR_OUTPUT_FEATURE_NUM", get_output_size(params.output_order, 2)),
+        MakeJitConstant("TR_OUTPUT_BATCH_NUM", get_output_size(params.output_order, 0)),
     });
 
     return jit;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_ref.cpp
@@ -68,7 +68,9 @@ JitConstants GemmKernelRef::GetJitConstants(const gemm_params& params) const {
         last_idx = (last_idx >= order_idx.size()) ? (order_idx.size() - 1) : last_idx;
 
         std::vector<std::string> dims;
-        if (order_idx.size() == 2) {
+        if (order_idx.size() == 1) {
+            dims = {"X"};
+        } else if (order_idx.size() == 2) {
             dims = {"Y", "X"};
         } else if (order_idx.size() == 3) {
             dims = {"F", "Y", "X"};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -235,6 +235,11 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
             MakeJitConstant("TR_Y", GetTransposedDims(params.output_order, true).at(6)),
             MakeJitConstant("TR_X", GetTransposedDims(params.output_order, true).at(7)),
         });
+
+        if (params.inputs[0].LogicalSize() != params.inputs[0].PhysicalSize())
+            jit.AddConstant(MakeJitConstant("INPUT0_HAS_PADDING", 1));
+        if (params.inputs[1].LogicalSize() != params.inputs[1].PhysicalSize())
+            jit.AddConstant(MakeJitConstant("INPUT1_HAS_PADDING", 1));
     }
 
     if (tuning_data.tile_k_size > tuning_data.simd_size) {

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -668,7 +668,7 @@ TEST(prepare_buffer_fusing, test_implicit_crop_and_outerpadding) {
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
 
     ExecutionConfig ref_config = get_test_default_config(engine);
-    config.set_property(ov::intel_gpu::optimize_data(false));
+    ref_config.set_property(ov::intel_gpu::optimize_data(false));
     cldnn::network ref_network(engine, topology, ref_config);
     ref_network.set_input_data("Input", in_input);
     ref_network.set_input_data("Input_idx_1", input_idx1);


### PR DESCRIPTION
### Details:
 - Fixed `gemm::calc_output_layout()` to consider `output_order`
 - Fixed `gemm_ref` for output transposed cases
 - Fixed wrong matmul axis (K- axis) selection for 2/3 dim inputs
 - Updated `gemm_tiled_opt` to support padded inputs

### Tickets:
 - 131014
