### PR TITLE
[HETERO] Remove ConstantFolding of model in hetero

### DIFF
--- a/src/plugins/hetero/src/compiled_model.cpp
+++ b/src/plugins/hetero/src/compiled_model.cpp
@@ -37,14 +37,6 @@ ov::hetero::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model
 }
 
 void ov::hetero::CompiledModel::compile_model(const std::shared_ptr<ov::Model>& model) {
-    // Calling of ConstantFolding in HETERO plugin is required because
-    // in some cases topology split is happening after constant subgraph.
-    // It may cause replacement of Constant by Parameter in such operations
-    // like Reshape/Transpose/Gather and lead to unexpected dynamism or exception
-    ov::pass::Manager manager;
-    manager.register_pass<ov::pass::ConstantFolding>();
-    manager.run_passes(model);
-
     ov::SupportedOpsMap query_model_result;
     bool user_set_affinities = false;
     // Get user defined affinity


### PR DESCRIPTION
### Details:
constant folding been introduced to hetero, but this may bring other issue in quantized models , for example, in gpu plugin, precision conversion will be applied before constant folding, some ops can be operated in fp16 if hardware support, while direct constant folding in hetero doesn't take hardware capability into account and fold the constants directly, this will result in memory concerns, for example, OOM issue, or the performance issue because of different execution precision
### ticket-id:
CVS-127934
