### PR TITLE
[GHA] Remove push trigger from workflows running in full scope in merge queue

### DIFF
--- a/.github/workflows/android_arm64.yml
+++ b/.github/workflows/android_arm64.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   push:
     branches:
-      - master
+      # - master
       - 'releases/**'
 
 concurrency:

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   push:
     branches:
-      - master
+      # - master
       - 'releases/**'
 
 concurrency:

--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   push:
     branches:
-      - master
+      # - master
       - 'releases/**'
 
 concurrency:

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   push:
     branches:
-      - master
+      # - master
       - 'releases/**'
 
 concurrency:


### PR DESCRIPTION
To remove duplication while we don't need post-commit artifacts. Will need to notify people who are monitoring & reporting sporadic