### PR TITLE
[Core] Remove deprecated leftovers

### DIFF
--- a/src/core/docs/api_details.md
+++ b/src/core/docs/api_details.md
@@ -1,7 +1,6 @@
 # OpenVINO Core API
 
 OpenVINO Core API contains two folders:
- * [ngraph](../include/ngraph/) - is a legacy API, this API is no longer being developed. Only aliases to new operations and operation sets extend this API.
  * [openvino](../include/openvino/) - current public API, this part is described below.
 
 ## Structure of Core API

--- a/src/core/include/openvino/core/core.hpp
+++ b/src/core/include/openvino/core/core.hpp
@@ -13,7 +13,6 @@
 #include "openvino/core/coordinate.hpp"
 #include "openvino/core/coordinate_diff.hpp"
 #include "openvino/core/core_visibility.hpp"
-#include "openvino/core/deprecated.hpp"
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/enum_mask.hpp"
 #include "openvino/core/enum_names.hpp"

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -21,7 +21,6 @@
 
 #include "openvino/core/attribute_visitor.hpp"
 #include "openvino/core/core_visibility.hpp"
-#include "openvino/core/deprecated.hpp"
 #include "openvino/core/descriptor/input.hpp"
 #include "openvino/core/descriptor/output.hpp"
 #include "openvino/core/descriptor/tensor.hpp"

--- a/src/core/include/openvino/core/type.hpp
+++ b/src/core/include/openvino/core/type.hpp
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "openvino/core/core_visibility.hpp"
-#include "openvino/core/deprecated.hpp"
 
 namespace ov {
 
@@ -115,9 +114,7 @@ struct AsTypePtr<std::shared_ptr<In>> {
 /// Type, nullptr otherwise
 template <typename T, typename U>
 auto as_type_ptr(const U& value) -> decltype(::ov::util::AsTypePtr<U>::template call<T>(value)) {
-    OPENVINO_SUPPRESS_DEPRECATED_START
     return ::ov::util::AsTypePtr<U>::template call<T>(value);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 }  // namespace ov
 

--- a/src/core/include/openvino/op/interpolate.hpp
+++ b/src/core/include/openvino/op/interpolate.hpp
@@ -44,16 +44,7 @@ public:
         std::vector<size_t> pads_end;
     };
 
-    enum class InterpolateMode {
-        NEAREST,
-        LINEAR,
-        CUBIC,
-        AREA,
-        nearest OPENVINO_ENUM_DEPRECATED("Please use NEAREST instead") = NEAREST,
-        linear OPENVINO_ENUM_DEPRECATED("Please use LINEAR instead") = LINEAR,
-        cubic OPENVINO_ENUM_DEPRECATED("Please use CUBIC instead") = CUBIC,
-        area OPENVINO_ENUM_DEPRECATED("Please use AREA instead") = AREA
-    };
+    enum class InterpolateMode { NEAREST, LINEAR, CUBIC, AREA };
 
     Interpolate() = default;
     /// \brief Constructs a Interpolate operation

--- a/src/core/include/openvino/op/util/variable_value.hpp
+++ b/src/core/include/openvino/op/util/variable_value.hpp
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "openvino/core/core_visibility.hpp"
-#include "openvino/core/deprecated.hpp"
 #include "openvino/runtime/tensor.hpp"
 
 namespace ov {
@@ -32,20 +31,14 @@ public:
     explicit VariableValue(const ov::Tensor& value);
 
     /// \brief Constructor for VariableValue.
-    /// \deprecated This method is deprecated and will be removed in 2024.0 release. Please use method with ov::Tensor
-    /// instead
     /// \param value Data for Variable.
     /// \param reset The current state of the reset flag.
     VariableValue(const ov::Tensor& value, bool reset);
 
     /// \brief Returns the current stored data.
-    /// \deprecated This method is deprecated and will be removed in 2024.0 release. Please use method with ov::Tensor
-    /// instead
     const ov::Tensor& get_state() const;
 
     /// \brief Sets new values for Variable.
-    /// \deprecated This method is deprecated and will be removed in 2024.0 release. Please use method with ov::Tensor
-    /// instead
     /// \param value New data for Variable.
     void set_state(const ov::Tensor& value);
 

--- a/src/core/include/openvino/opsets/opset.hpp
+++ b/src/core/include/openvino/opsets/opset.hpp
@@ -10,7 +10,6 @@
 #include <set>
 #include <utility>
 
-#include "openvino/core/deprecated.hpp"
 #include "openvino/core/node.hpp"
 
 namespace ov {

--- a/src/core/include/openvino/pass/pass.hpp
+++ b/src/core/include/openvino/pass/pass.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "openvino/core/core_visibility.hpp"
-#include "openvino/core/deprecated.hpp"
 #include "openvino/core/enum_mask.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"

--- a/src/core/include/openvino/pass/pass_config.hpp
+++ b/src/core/include/openvino/pass/pass_config.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "openvino/core/core_visibility.hpp"
-#include "openvino/core/deprecated.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"
 

--- a/src/core/include/openvino/pass/serialize.hpp
+++ b/src/core/include/openvino/pass/serialize.hpp
@@ -14,7 +14,6 @@
 namespace ov {
 namespace pass {
 
-OPENVINO_SUPPRESS_DEPRECATED_START
 /**
  * @brief Serialize transformation converts ov::Model into IR files
  * @attention
@@ -75,7 +74,5 @@ private:
     std::function<void(std::ostream&)> m_custom_data_serializer;
     const Serialize::Version m_version;
 };
-OPENVINO_SUPPRESS_DEPRECATED_END
-
 }  // namespace pass
 }  // namespace ov

--- a/src/core/shape_inference/include/pooling_shape_inference_util.hpp
+++ b/src/core/shape_inference/include/pooling_shape_inference_util.hpp
@@ -248,12 +248,10 @@ TRShape out_shape_infer(const TOp* op, const std::vector<TShape>& input_shapes, 
 
     const auto& data_rank = data_shape.rank();
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     NODE_VALIDATION_CHECK(op,
                           ov::util::is_rank_compatible_any_of(data_rank, {3, 4, 5}),
                           "Expected a 3D, 4D or 5D tensor for the input. Got: ",
                           data_shape);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
     TRShape output_shape;
     if (data_rank.is_static()) {

--- a/src/core/shape_inference/include/utils.hpp
+++ b/src/core/shape_inference/include/utils.hpp
@@ -8,7 +8,6 @@
 
 #include "element_visitor.hpp"
 #include "openvino/core/bound_evaluation_util.hpp"
-#include "openvino/core/deprecated.hpp"
 #include "openvino/opsets/opset1.hpp"
 #include "ov_optional.hpp"
 #include "shape_infer_type_utils.hpp"

--- a/src/core/src/op/experimental_detectron_topkrois.cpp
+++ b/src/core/src/op/experimental_detectron_topkrois.cpp
@@ -38,9 +38,7 @@ void op::v6::ExperimentalDetectronTopKROIs::validate_and_infer_types() {
                               (out_et.is_dynamic() || out_et.is_real()),
                           "ROIs and probabilities of ROIs must same floating-point type.");
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto input_shapes = ov::util::get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_START
 
     const auto output_shapes = shape_infer(this, input_shapes);
     set_output_type(0, out_et, output_shapes[0]);

--- a/src/core/src/op/max_pool.cpp
+++ b/src/core/src/op/max_pool.cpp
@@ -39,10 +39,8 @@ bool MaxPool::visit_attributes(AttributeVisitor& visitor) {
 void MaxPool::validate_and_infer_types() {
     OV_OP_SCOPE(v1_MaxPool_validate_and_infer_types);
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto output_shapes =
         shape_infer(this, ov::util::get_node_input_partial_shapes(*this), m_pads_begin, m_pads_end);
-    OPENVINO_SUPPRESS_DEPRECATED_END
     set_output_type(0, get_input_element_type(0), output_shapes.front());
 }
 
@@ -169,10 +167,8 @@ void MaxPool::validate_and_infer_types() {
         m_axis = ov::util::normalize_axis(this, m_axis, input_shape.rank());
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto output_shapes =
         shape_infer(this, ov::util::get_node_input_partial_shapes(*this), m_pads_begin, m_pads_end);
-    OPENVINO_SUPPRESS_DEPRECATED_END
     set_output_type(0, get_input_element_type(0), output_shapes[0]);
     set_output_type(1, m_index_element_type, output_shapes[1]);
 }

--- a/src/core/src/op/non_max_suppression.cpp
+++ b/src/core/src/op/non_max_suppression.cpp
@@ -473,9 +473,7 @@ float op::v5::NonMaxSuppression::score_threshold_from_input() const {
         return score_threshold;
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto score_threshold_input = ov::util::get_constant_from_source(input_value(score_threshold_port));
-    OPENVINO_SUPPRESS_DEPRECATED_END
     score_threshold = score_threshold_input->cast_vector<float>().at(0);
 
     return score_threshold;
@@ -488,9 +486,7 @@ float op::v5::NonMaxSuppression::soft_nms_sigma_from_input() const {
         return soft_nms_sigma;
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto soft_nms_sigma_input = ov::util::get_constant_from_source(input_value(soft_nms_sigma_port));
-    OPENVINO_SUPPRESS_DEPRECATED_END
     soft_nms_sigma = soft_nms_sigma_input->cast_vector<float>().at(0);
 
     return soft_nms_sigma;
@@ -678,9 +674,7 @@ int64_t op::v9::NonMaxSuppression::max_boxes_output_from_input() const {
         return 0;
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto max_output_boxes_input = ov::util::get_constant_from_source(input_value(max_output_boxes_port));
-    OPENVINO_SUPPRESS_DEPRECATED_END
     max_output_boxes = max_output_boxes_input->cast_vector<int64_t>().at(0);
 
     return max_output_boxes;
@@ -693,9 +687,7 @@ float op::v9::NonMaxSuppression::iou_threshold_from_input() const {
         return iou_threshold;
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto iou_threshold_input = ov::util::get_constant_from_source(input_value(iou_threshold_port));
-    OPENVINO_SUPPRESS_DEPRECATED_END
     iou_threshold = iou_threshold_input->cast_vector<float>().at(0);
 
     return iou_threshold;
@@ -708,9 +700,7 @@ float op::v9::NonMaxSuppression::score_threshold_from_input() const {
         return score_threshold;
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto score_threshold_input = ov::util::get_constant_from_source(input_value(score_threshold_port));
-    OPENVINO_SUPPRESS_DEPRECATED_END
     score_threshold = score_threshold_input->cast_vector<float>().at(0);
 
     return score_threshold;
@@ -723,9 +713,7 @@ float op::v9::NonMaxSuppression::soft_nms_sigma_from_input() const {
         return soft_nms_sigma;
     }
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto soft_nms_sigma_input = ov::util::get_constant_from_source(input_value(soft_nms_sigma_port));
-    OPENVINO_SUPPRESS_DEPRECATED_END
     soft_nms_sigma = soft_nms_sigma_input->cast_vector<float>().at(0);
 
     return soft_nms_sigma;

--- a/src/core/src/op/proposal.cpp
+++ b/src/core/src/op/proposal.cpp
@@ -91,9 +91,7 @@ void op::v4::Proposal::validate_and_infer_types() {
     OV_OP_SCOPE(v4_Proposal_validate_and_infer_types);
 
     validate_element_types();
-    OPENVINO_SUPPRESS_DEPRECATED_START
     const auto intput_shapes = ov::util::get_node_input_partial_shapes(*this);
-    OPENVINO_SUPPRESS_DEPRECATED_END
     const auto output_shapes = shape_infer(this, intput_shapes);
     const auto& out_et = get_input_element_type(0);
 

--- a/src/core/src/op/reduce_logical_and.cpp
+++ b/src/core/src/op/reduce_logical_and.cpp
@@ -39,7 +39,6 @@ std::shared_ptr<Node> ReduceLogicalAnd::clone_with_new_inputs(const OutputVector
 
 bool ReduceLogicalAnd::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     OV_OP_SCOPE(v1_ReduceLogicalAnd_evaluate);
-    OPENVINO_SUPPRESS_DEPRECATED_START
     OPENVINO_ASSERT(inputs.size() == 2);
     OPENVINO_ASSERT(outputs.size() == 1);
 

--- a/src/core/src/op/util/gather_base.cpp
+++ b/src/core/src/op/util/gather_base.cpp
@@ -226,9 +226,7 @@ bool GatherBase::evaluate_upper(TensorVector& output_values) const {
 }
 
 bool GatherBase::evaluate_label(TensorLabelVector& output_labels) const {
-    OPENVINO_SUPPRESS_DEPRECATED_START
     return gather::have_indices_and_axis_bound_set(this) && ov::util::default_label_evaluator(this, output_labels);
-    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 bool GatherBase::constant_fold(OutputVector& output_values, const OutputVector& input_values) {

--- a/src/core/src/op/util/variable_value.cpp
+++ b/src/core/src/op/util/variable_value.cpp
@@ -6,7 +6,6 @@
 
 #include <memory>
 
-#include "openvino/core/deprecated.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/shape_util.hpp"
 #include "openvino/runtime/allocator.hpp"

--- a/src/core/src/pass/manager.cpp
+++ b/src/core/src/pass/manager.cpp
@@ -37,8 +37,7 @@ PerfCounters& perf_counters() {
 
 namespace {
 bool getenv_visualize_tracing() {
-    return ov::util::getenv_bool("NGRAPH_ENABLE_VISUALIZE_TRACING") ||
-           ov::util::getenv_bool("OV_ENABLE_VISUALIZE_TRACING");
+    return ov::util::getenv_bool("OV_ENABLE_VISUALIZE_TRACING");
 }
 }  // namespace
 
@@ -93,11 +92,9 @@ private:
 }  // namespace
 
 bool ov::pass::Manager::run_passes(shared_ptr<ov::Model> func) {
-    OPENVINO_SUPPRESS_DEPRECATED_START
     OV_ITT_SCOPED_TASK(ov::itt::domains::core, "pass::Manager::run_passes");
 
-    static bool profile_enabled =
-        ov::util::getenv_bool("NGRAPH_PROFILE_PASS_ENABLE") || ov::util::getenv_bool("OV_PROFILE_PASS_ENABLE");
+    static bool profile_enabled = ov::util::getenv_bool("OV_PROFILE_PASS_ENABLE");
 
     size_t index = 0;
     stopwatch pass_timer;
@@ -171,7 +168,6 @@ bool ov::pass::Manager::run_passes(shared_ptr<ov::Model> func) {
     if (profile_enabled) {
         cout << "passes done in " << overall_timer.get_milliseconds() << "ms\n";
     }
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
     return function_changed;
 }

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -28,7 +28,6 @@
 #include "transformations/rt_info/disable_fp16_compression.hpp"
 #include "transformations/rt_info/primitives_priority_attribute.hpp"
 
-OPENVINO_SUPPRESS_DEPRECATED_START
 namespace {  // helpers
 template <typename Container>
 std::string join(const Container& c, const char* glue = ", ") {

--- a/src/core/src/pass/visualize_tree.cpp
+++ b/src/core/src/pass/visualize_tree.cpp
@@ -461,10 +461,8 @@ std::string ov::pass::VisualizeTree::get_attributes(std::shared_ptr<Node> node) 
         std::stringstream label;
         label << "label=\"" << get_node_name(node);
 
-        static const bool nvtos = ov::util::getenv_bool("NGRAPH_VISUALIZE_TREE_OUTPUT_SHAPES") ||
-                                  ov::util::getenv_bool("OV_VISUALIZE_TREE_OUTPUT_SHAPES");
-        static const bool nvtot = ov::util::getenv_bool("NGRAPH_VISUALIZE_TREE_OUTPUT_TYPES") ||
-                                  ov::util::getenv_bool("OV_VISUALIZE_TREE_OUTPUT_TYPES");
+        static const bool nvtos = ov::util::getenv_bool("OV_VISUALIZE_TREE_OUTPUT_SHAPES");
+        static const bool nvtot = ov::util::getenv_bool("OV_VISUALIZE_TREE_OUTPUT_TYPES");
         static const bool nvtio = ov::util::getenv_bool("OV_VISUALIZE_TREE_IO");
         static const bool nvtrti = ov::util::getenv_bool("OV_VISUALIZE_TREE_RUNTIME_INFO");
         static const bool ovpvl = ov::util::getenv_bool("OV_VISUALIZE_PARTIAL_VALUES_AND_LABELS");

--- a/src/core/src/pattern/matcher.cpp
+++ b/src/core/src/pattern/matcher.cpp
@@ -140,7 +140,6 @@ bool Matcher::match_permutation(const OutputVector& pattern_args, const OutputVe
 }
 
 bool Matcher::match_arguments(Node* pattern_node, const std::shared_ptr<Node>& graph_node) {
-    OPENVINO_SUPPRESS_DEPRECATED_START
     OPENVINO_DEBUG << "[MATCHER] Match arguments at " << *graph_node << " for pattern " << *pattern_node;
 
     auto args = graph_node->input_values();
@@ -174,7 +173,6 @@ bool Matcher::match_arguments(Node* pattern_node, const std::shared_ptr<Node>& g
     }
 
     OPENVINO_DEBUG << "[MATCHER] Aborting at " << *graph_node << " for pattern " << *pattern_node;
-    OPENVINO_SUPPRESS_DEPRECATED_END
     return false;
 }
 

--- a/src/core/tests/type_prop/batch_to_space.cpp
+++ b/src/core/tests/type_prop/batch_to_space.cpp
@@ -363,7 +363,6 @@ TEST(type_prop, batch_to_space_output_dynamic_shape_5D_when_batch_is_static) {
                                 {100, 150},
                                 {10 * 16, 20 * 16}}));
 }
-OPENVINO_SUPPRESS_DEPRECATED_START
 
 TEST(type_prop, batch_to_space_output_dynamic_shape_5D_when_batch_is_dynamic) {
     auto data_shape = ov::PartialShape{{959, 962}, {2, 34}, {9, 21}, {100, 162}, {1, 1999}};

--- a/src/core/tests/type_prop/depth_to_space.cpp
+++ b/src/core/tests/type_prop/depth_to_space.cpp
@@ -39,8 +39,6 @@ TEST(type_prop, depth_to_space_input_interval_shape_default_block_size) {
     EXPECT_THAT(get_shape_labels(depth_to_space->get_output_partial_shape(0)), ElementsAre(10, 11, 12, 13, 14));
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-
 TEST(type_prop, depth_to_space_output_dynamicshape_block_first_5D_when_depth_is_dynamic) {
     auto A = make_shared<ov::op::v0::Parameter>(element::f32,
                                                 PartialShape{{2, 10}, {81, 82}, {3, 7}, {423, 3000}, {235, 1345}});

--- a/src/core/tests/type_prop/variadic_split.cpp
+++ b/src/core/tests/type_prop/variadic_split.cpp
@@ -6,7 +6,6 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "common_test_utils/type_prop.hpp"
-#include "openvino/core/deprecated.hpp"
 #include "openvino/core/dimension_tracker.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/shape_of.hpp"

--- a/src/core/tests/visitors/visitors.hpp
+++ b/src/core/tests/visitors/visitors.hpp
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "openvino/core/attribute_visitor.hpp"
-#include "openvino/core/deprecated.hpp"
 #include "openvino/op/util/framework_node.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
 #include "openvino/op/util/variable.hpp"


### PR DESCRIPTION
### Details:
 - Cleans up `src/core` from unneeded suppression switches, comments and such remains of legacy API drop.

### Tickets:
 - CVS-131716
