### PR TITLE
[Core] Enable a mandatory test for value checking of Boolean type property

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/ov_plugin/properties.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/ov_plugin/properties.cpp
@@ -14,6 +14,7 @@ namespace {
 
 const std::vector<ov::AnyMap> inproperties = {
         {ov::device::id("UNSUPPORTED_DEVICE_ID_STRING")},
+        {{ov::enable_profiling.name(), "TEST"}},
 };
 
 INSTANTIATE_TEST_SUITE_P(ov_plugin_mandatory, OVPropertiesIncorrectTests,

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
@@ -124,6 +124,12 @@ TEST_P(OVPropertiesTests, canSetPropertyAndCheckGetProperty) {
     }
 }
 
+TEST_P(OVPropertiesIncorrectTests, SetPropertiesNoThrowGetThrowWithInvalidValue) {
+    std::shared_ptr<Core> core = std::make_shared<ov::Core>();
+    OV_ASSERT_NO_THROW(core->set_property(target_device, properties));
+    ASSERT_THROW(core->get_versions(target_device), ov::Exception);
+}
+
 TEST_P(OVPropertiesIncorrectTests, SetPropertiesWithIncorrectKey) {
     core->get_versions(target_device);
     ASSERT_THROW(core->set_property(target_device, properties), ov::Exception);


### PR DESCRIPTION
We found a segment fault issue in a C API test case for the Boolean property value checking and only appeared in release version during this [PR,](https://github.com/openvinotoolkit/openvino/pull/22256), while it disappeared in the latest version of master. We design this test case to cover this situation.
### Details:
 - Add a test case to verify that the value of the Boolean property is valid with initial ov::core.

### Tickets:
 - 22256
