### PR TITLE
[CPU] Fix reading wrong data in the PriorBoxClustered shape infer check

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -62,13 +62,13 @@ bool PriorBoxClustered::needShapeInfer() const {
         return true;
     }
 
-    const auto& outputShape = memory->getShape().getStaticDims();
-    const int* in_data = memory->getDataAs<int>();
+    const auto& output_shape = memory->getShape().getStaticDims();
+    const int* in_data = getSrcDataAtPortAs<int>(0);
     const int h = in_data[0];
     const int w = in_data[1];
     const auto output = static_cast<size_t>(4 * h * w * number_of_priors);
 
-    return outputShape[1] != output;
+    return output_shape[1] != output;
 }
 
 bool PriorBoxClustered::needPrepareParams() const {


### PR DESCRIPTION
### Details:
Instead of reading from the input memory, the `PriorBoxClustered::needShapeInfer()` used the output memory pointer to read `[height, width]`. This led to reading uninitialized data, causing a variety of sporadic SL tests failures

### Tickets:
 - 131476
 - 130078
 - 129659
 - 125463
