### PR TITLE
[CPU] Disable ExportImportTest for AMX platforms

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/behavior/export_import.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/behavior/export_import.cpp
@@ -7,6 +7,7 @@
 #include "common_test_utils/test_common.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
 #include "common_test_utils/node_builders/constant.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
 
 #include <openvino/opsets/opset9.hpp>
 
@@ -33,6 +34,7 @@ std::shared_ptr<ov::Model> MakeMatMulModel() {
 }
 
 TEST_P(ExportOptimalNumStreams, OptimalNumStreams) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     auto original_model = MakeMatMulModel();
     ov::Core core;
     std::string device_name;

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -375,7 +375,6 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(smoke_JIT_AVX512_DW_GroupConv/GroupConvolutionLayerCPUTest.*inFmts=nCdhw16c.*INFERENCE_PRECISION_HINT=bf16.*)");
         // Issue: 131475
         retVector.emplace_back(R"(smoke_ExportImportTest/ExportOptimalNumStreams.OptimalNumStreams/.*)");
-
     }
 
     if (ov::with_cpu_x86_avx512_core_fp16()) {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -373,6 +373,9 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(smoke_MM_Brgemm_Amx_.*/MatMulLayerCPUTest.*TS=\(\(55\.12\)\).*bf16.*_primitive=brgemm_avx512_amx.*)");
         // Issue: 130471
         retVector.emplace_back(R"(smoke_JIT_AVX512_DW_GroupConv/GroupConvolutionLayerCPUTest.*inFmts=nCdhw16c.*INFERENCE_PRECISION_HINT=bf16.*)");
+        // Issue: 131475
+        retVector.emplace_back(R"(smoke_ExportImportTest/ExportOptimalNumStreams.OptimalNumStreams/.*)");
+
     }
 
     if (ov::with_cpu_x86_avx512_core_fp16()) {


### PR DESCRIPTION
### Details:
Disable the sporadically failing `ExportImportTest` test for AMX platforms.

### Tickets:
 - 131475
