### PR TITLE
[GPU] Do not use oneDNN impls with dynamic paddings

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -693,6 +693,14 @@ void prepare_buffer_fusing::run(program& p) {
                 if (gather_prim) {
                     update_dep(gather_prim);
                 }
+
+                // Fallback to ocl impl since oneDNN doesn't support dynamic paddings
+                for (auto user : node.get_users()) {
+                    if (user->get_preferred_impl_type() == impl_types::onednn) {
+                        GPU_DEBUG_TRACE_DETAIL << user->id() << ": change impl to ocl because of dynamic input paddings\n";
+                        user->set_preferred_impl_type(impl_types::ocl);
+                    }
+                }
             }
         });
         program_helpers::do_for_types<read_value>(*node, [](read_value_node& node) {


### PR DESCRIPTION
### Details:
 - This PR fixes the accuracy on dGPUs in LLMs compressed models. oneDNN can't handle dynamic paddings properly, so change impl back to ocl.
 
### Tickets:
 - 131241
