### PR TITLE
Fix names aka locations of operations in TFLite FrontEnd

### DIFF
--- a/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.cpp
+++ b/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.cpp
@@ -96,7 +96,8 @@ std::shared_ptr<DecoderFlatBuffer> GraphIteratorFlatBuffer::get_decoder() const 
         if (type == "CUSTOM") {
             type = operator_code->custom_code()->str();
         }
-        return std::make_shared<DecoderFlatBuffer>(node, type, std::to_string(node_index), input_info, output_info);
+        auto name = std::to_string(node_index - m_graph->inputs()->size() - m_graph->outputs()->size());
+        return std::make_shared<DecoderFlatBuffer>(node, type, name, input_info, output_info);
     } else {
         auto tensor_id = m_nodes[node_index].as<int32_t>();
         auto tensor = (*tensors)[tensor_id];

--- a/src/frontends/tensorflow_lite/src/op/op_translation_utils.hpp
+++ b/src/frontends/tensorflow_lite/src/op/op_translation_utils.hpp
@@ -73,10 +73,13 @@ OutputVector translate_binary_op_with_activation(const ov::frontend::tensorflow_
     ov::frontend::tensorflow_lite::dequantize_inputs(inputs);
     auto context = ov::frontend::tensorflow_lite::NodeContext(node.get_decoder(), inputs);
     auto output = ov::frontend::tensorflow::op::translate_binary_op<OV_TYPE>(context);
+    output[0].get_node()->set_friendly_name("");
+    output[0].set_names({});
     const auto& decoder = get_decoder(context);
     get_activation(output,
                    context,
                    EnumNameActivationFunctionType(decoder->get_attribute(&TF_TYPE::fused_activation_function)));
+    output[0].get_node()->set_friendly_name(node.get_name());
     return output;
 }
 


### PR DESCRIPTION
### Details:
Fix names aka locations of operations in TFLite FrontEnd
Give different names to binary operations with fused activations

### Tickets:
 - *CVS-131328, CVS-111341*
