### PR TITLE
[GPU] Don't increase rank by reorder before RDFT

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1852,7 +1852,8 @@ format layout_optimizer::get_preferred_format(program_node& node) {
     } else if (node.is_type<loop>()) {
         expected = format::get_default_format(node.get_output_layout().get_rank());
     } else if (node.is_type<dft>()) {
-        if (node.as<dft>().get_primitive()->mode == dft_mode::real) {
+        if (node.as<dft>().get_primitive()->mode == dft_mode::real &&
+            node.as<dft>().get_primitive()->direction == dft_direction::forward) {
             node.set_preferred_input_fmt(0, format::get_default_format(node.get_input_layouts()[0].get_rank()));
         }
     }

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -34,6 +34,7 @@
 #include "scatter_nd_update_inst.h"
 #include "gather_inst.h"
 #include "loop_inst.h"
+#include "dft_inst.h"
 #include "to_string_utils.h"
 #include <vector>
 #include <memory>
@@ -1850,6 +1851,10 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         node.set_preferred_input_fmt(0, format::get_default_format(node.as<gather>().get_primitive()->input_rank));
     } else if (node.is_type<loop>()) {
         expected = format::get_default_format(node.get_output_layout().get_rank());
+    } else if (node.is_type<dft>()) {
+        if (node.as<dft>().get_primitive()->mode == dft_mode::real) {
+            node.set_preferred_input_fmt(0, format::get_default_format(node.get_input_layouts()[0].get_rank()));
+        }
     }
 
     if (allow_new_shape_infer && node.get_preferred_input_fmt() != format::any) {

--- a/src/plugins/intel_gpu/tests/unit/passes/add_required_reorders_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/add_required_reorders_test.cpp
@@ -68,54 +68,6 @@ TEST(add_required_reorders, input_reorder_inside_shape_of_subgraph) {
     ASSERT_EQ(eltwise_in_layout.data_type, data_types::f32);
 }
 
-TEST(add_required_reorders, eltwise_input_reorder) {
-    // Topology:
-    //  (bfyx)input  weights
-    //            \  /
-    //            conv1  irdft_input(bfzyx)
-    //            / | \  /
-    // (bfzyx)rdft  |  irdft(bfyx)
-    //              |  /
-    //           eltwise
-    //              |
-    //            conv2
-    //
-    // Expectation:
-    // The selected format of eltwise should be selected as bfzyx (reorder_inputs)
-    // A new reorder that converts from b_fs_yx_fsv16 to bfzyx should be inserted after convolution (reorder_inputs)
-    // If the input format of eltwise is different from the output format, reorder(bfyx->bfzyx) should be added (add_required_reorders)
-
-    auto& engine = get_test_engine();
-
-    auto conv1_weight_mem = engine.allocate_memory(layout{ { 192, 384, 1, 1 }, data_types::f16, format::bfyx });
-    auto conv2_weight_mem = engine.allocate_memory(layout{ { 384, 192, 1, 1 }, data_types::f16, format::bfyx });
-
-    topology topology;
-    topology.add(data("conv1_weights", conv1_weight_mem));
-    topology.add(data("conv2_weights", conv2_weight_mem));
-    topology.add(input_layout("input", layout{ { 1, 384, 36, 64 }, data_types::f16, format::bfyx }));
-    topology.add(input_layout("irdft_input", layout{ { 1, 192, 36, 33, 2 }, data_types::f16, format::bfzyx }));
-    topology.add(convolution("conv1", input_info("input"), "conv1_weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
-    topology.add(dft("rdft", input_info("conv1"), {2, 3}, {36, 64}, {1, 192, 36, 33, 2}, dft_direction::forward, dft_mode::real));
-    topology.add(dft("irdft", input_info("irdft_input"), {2, 3}, {36, 64}, {1, 192, 36, 64}, dft_direction::inverse, dft_mode::real));
-    topology.add(eltwise("eltwise", input_info("conv1"), input_info("irdft"), eltwise_mode::sum));
-    topology.add(convolution("conv2", input_info("eltwise"), "conv2_weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
-
-    ExecutionConfig config = get_test_default_config(engine);
-    ov::intel_gpu::ImplementationDesc conv1_impl = { format::b_fs_yx_fsv16, "" };
-    ov::intel_gpu::ImplementationDesc conv2_impl = { format::b_fs_yx_fsv16, "" };
-    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv1", conv1_impl }, { "conv2", conv2_impl } }));
-    config.set_property(ov::intel_gpu::optimize_data(true));
-
-    program::ptr prog = nullptr;
-    ASSERT_NO_THROW(prog = program::build_program(engine, topology, config));
-    ASSERT_NE(prog, nullptr);
-    auto prog_impl = prog.get();
-    auto& eltwise_node = prog_impl->get_node("eltwise");
-    ASSERT_EQ(eltwise_node.get_input_layouts()[1].format, format::bfzyx);
-    ASSERT_EQ(eltwise_node.get_output_layout().format, format::bfzyx);
-}
-
 TEST(add_required_reorders, prevent_input_dt_changing_for_convs) {
     auto& engine = get_test_engine();
 

--- a/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
@@ -363,11 +363,11 @@ TEST(reorder_inputs, no_need_of_reorder_for_strided_slice) {
 
 TEST(reorder_inputs, no_need_of_reorder_to_change_input_rank_for_rdft) {
     // Topology:
+    //
     // (4d)___conv___(4d)___rdft___(5d)
     //            \__(4d)___eltw___(4d)
 
     tests::random_generator rg(GET_SUITE_NAME);
-
     auto& engine = get_test_engine();
     auto in_layout1 = layout{ ov::PartialShape{1, 240, 96, 96}, data_types::f16, format::b_fs_yx_fsv16 };
     auto in_layout2 = layout{ ov::PartialShape{1, 120, 96, 96}, data_types::f16, format::bfyx };
@@ -396,10 +396,7 @@ TEST(reorder_inputs, no_need_of_reorder_to_change_input_rank_for_rdft) {
     ASSERT_NE(program, nullptr);
 
     auto& dft_node = program->get_node("rdft");
-
-    size_t exp_dim(4);
-    size_t act_dim = format::dimension(dft_node.get_input_layouts()[0].format);
-    ASSERT_EQ(exp_dim, act_dim);
+    ASSERT_EQ(size_t(4), format::dimension(dft_node.get_input_layouts()[0].format));
 }
 
 // TODO Not yet implemented

--- a/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
@@ -361,6 +361,47 @@ TEST(reorder_inputs, no_need_of_reorder_for_strided_slice) {
     ASSERT_EQ(in_order.size(), out_shape.size());
 }
 
+TEST(reorder_inputs, no_need_of_reorder_to_change_input_rank_for_rdft) {
+    // Topology:
+    // (4d)___conv___(4d)___rdft___(5d)
+    //            \__(4d)___eltw___(4d)
+
+    tests::random_generator rg(GET_SUITE_NAME);
+
+    auto& engine = get_test_engine();
+    auto in_layout1 = layout{ ov::PartialShape{1, 240, 96, 96}, data_types::f16, format::b_fs_yx_fsv16 };
+    auto in_layout2 = layout{ ov::PartialShape{1, 120, 96, 96}, data_types::f16, format::bfyx };
+    auto weights = engine.allocate_memory({ data_types::f16, format::bfyx, {120, 240, 1, 1} });
+    auto bias = engine.allocate_memory({ data_types::f16, format::bfyx, {1, 120, 1, 1} });
+
+    topology topology(
+        input_layout("input1", in_layout1),
+        input_layout("input2", in_layout2),
+        data("weights", weights),
+        data("bias", bias),
+        convolution("conv", input_info("input1"), "weights", "bias", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false),
+        eltwise("eltwise", input_info("input2"), input_info("conv"), eltwise_mode::sum),
+        dft("rdft", input_info("conv"), {1, 1}, {1, 1}, {1, 120, 96, 49, 2}, dft_direction::forward, dft_mode::real),
+        reorder("reorder", input_info("rdft"), format::bfzyx, data_types::f16)
+    );
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    auto program = program::build_program(engine, topology, config, false, true);
+    layout_optimizer lo(true);
+    reorder_factory rf;
+    program_wrapper::apply_opt_pass<reorder_inputs>(*program, lo, rf);
+
+    ASSERT_NE(program, nullptr);
+
+    auto& dft_node = program->get_node("rdft");
+
+    size_t exp_dim(4);
+    size_t act_dim = format::dimension(dft_node.get_input_layouts()[0].format);
+    ASSERT_EQ(exp_dim, act_dim);
+}
+
 // TODO Not yet implemented
 //TEST(reorder_inputs, impl_forcing_conv_format_kernel) {
 //    auto& engine = get_test_engine();


### PR DESCRIPTION
### Details:
 - *Do not change the input layout going into RDFT node by adding inappropriate reorder to increase rank by 1 because RDFT will increase it*
 - *Set preferred input format rather than leaving it as format::Any in get_preferred_format() of layout_optimizer*
 - *Remove test case which has been implemented based on wrong behavior of RDFT* 
     - *The test case was implemented assuming that when input and output dimension of RDFT are different, a reorder node should be added.*
     - *But input and output dimension of RDFT are originally different depending on spec.*

### Tickets:
 - *130921*
 - *131412*
