### PR TITLE
Deprecated functions to operate with legacy port names

### DIFF
--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -60,6 +60,7 @@ inline bool has_decompression_converts(const std::shared_ptr<const ov::Model>& f
     return false;
 }
 
+OPENVINO_DEPRECATED("Plugins should use ov::ISyncInferRequest::find_port")
 inline std::string create_ie_output_name(const Output<const Node>& output) {
     std::string out_name;
     OPENVINO_SUPPRESS_DEPRECATED_START
@@ -77,16 +78,25 @@ inline std::string create_ie_output_name(const Output<const Node>& output) {
     return out_name;
 }
 
+OPENVINO_DEPRECATED("Plugins should use ov::ISyncInferRequest::find_port")
 inline std::string create_ie_output_name(const Output<Node>& output) {
+    OPENVINO_SUPPRESS_DEPRECATED_START
     return create_ie_output_name(ov::Output<const Node>(output.get_node(), output.get_index()));
+    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
+OPENVINO_DEPRECATED("Plugins should use ov::ISyncInferRequest::find_port")
 inline std::string get_ie_output_name(const Output<const Node>& output) {
+    OPENVINO_SUPPRESS_DEPRECATED_START
     return create_ie_output_name(output);
+    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
+OPENVINO_DEPRECATED("Plugins should use ov::ISyncInferRequest::find_port")
 inline std::string get_ie_output_name(const Output<Node>& output) {
+    OPENVINO_SUPPRESS_DEPRECATED_START
     return get_ie_output_name(ov::Output<const Node>(output.get_node(), output.get_index()));
+    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 /**

--- a/src/common/transformations/src/transformations/op_conversions/convert_matrix_nms_to_matrix_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_matrix_nms_to_matrix_nms_ie.cpp
@@ -46,13 +46,17 @@ ov::pass::ConvertMatrixNmsToMatrixNmsIE::ConvertMatrixNmsToMatrixNmsIE(bool forc
 
         if (nms->output(1).get_element_type() != output_1.get_element_type()) {
             output_1 = std::make_shared<ov::op::v0::Convert>(output_1, nms->output(1).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_1.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms->output(1)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_1.get_node_shared_ptr());
         }
 
         if (nms->output(2).get_element_type() != output_2.get_element_type()) {
             output_2 = std::make_shared<ov::op::v0::Convert>(output_2, nms->output(2).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_2.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms->output(2)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_2.get_node_shared_ptr());
         }
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
@@ -37,7 +37,9 @@ pass::ConvertMaxPool8ToMaxPool1::ConvertMaxPool8ToMaxPool1() {
                                                                 maxpool_v8_node->get_rounding_type(),
                                                                 maxpool_v8_node->get_auto_pad());
 
+        OPENVINO_SUPPRESS_DEPRECATED_START
         auto out_name = ov::op::util::create_ie_output_name(maxpool_v8_node->output(0));
+        OPENVINO_SUPPRESS_DEPRECATED_END
 
         maxpool_v1_node->set_friendly_name(maxpool_v8_node->get_friendly_name());
         maxpool_v8_node->output(0).replace(maxpool_v1_node->output(0));

--- a/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
@@ -60,13 +60,17 @@ pass::ConvertMulticlassNmsToMulticlassNmsIE::ConvertMulticlassNmsToMulticlassNms
 
         if (nms->output(1).get_element_type() != output_1.get_element_type()) {
             output_1 = std::make_shared<ov::op::v0::Convert>(output_1, nms->output(1).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_1.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms->output(1)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_1.get_node_shared_ptr());
         }
 
         if (nms->output(2).get_element_type() != output_2.get_element_type()) {
             output_2 = std::make_shared<ov::op::v0::Convert>(output_2, nms->output(2).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_2.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms->output(2)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_2.get_node_shared_ptr());
         }
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_nms9_to_nms_ie_internal.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_nms9_to_nms_ie_internal.cpp
@@ -109,14 +109,18 @@ ov::pass::ConvertNMS9ToNMSIEInternal::ConvertNMS9ToNMSIEInternal() {
         Output<Node> output_0 = nms_legacy->output(0);
         if (nms_9->output(0).get_element_type() != output_0.get_element_type()) {
             output_0 = std::make_shared<ov::op::v0::Convert>(output_0, nms_9->output(0).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_0.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms_9->output(0)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_0.get_node_shared_ptr());
         }
 
         Output<Node> output_2 = nms_legacy->output(2);
         if (nms_9->output(2).get_element_type() != output_2.get_element_type()) {
             output_2 = std::make_shared<ov::op::v0::Convert>(output_2, nms_9->output(2).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_2.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms_9->output(2)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_2.get_node_shared_ptr());
         }
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_nms_rotated_to_nms_ie_internal.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_nms_rotated_to_nms_ie_internal.cpp
@@ -87,14 +87,18 @@ ov::pass::ConvertNMSRotatedToNMSIEInternal::ConvertNMSRotatedToNMSIEInternal() {
         Output<Node> output_0 = nms_legacy->output(0);
         if (nms_rotated->output(0).get_element_type() != output_0.get_element_type()) {
             output_0 = std::make_shared<ov::op::v0::Convert>(output_0, nms_rotated->output(0).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_0.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms_rotated->output(0)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_0.get_node_shared_ptr());
         }
 
         Output<Node> output_2 = nms_legacy->output(2);
         if (nms_rotated->output(2).get_element_type() != output_2.get_element_type()) {
             output_2 = std::make_shared<ov::op::v0::Convert>(output_2, nms_rotated->output(2).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_2.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms_rotated->output(2)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_2.get_node_shared_ptr());
         }
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_nms_to_nms_ie_internal.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_nms_to_nms_ie_internal.cpp
@@ -108,14 +108,18 @@ ov::pass::ConvertNMSToNMSIEInternal::ConvertNMSToNMSIEInternal() {
         Output<Node> output_0 = nms_legacy->output(0);
         if (nms_5->output(0).get_element_type() != output_0.get_element_type()) {
             output_0 = std::make_shared<ov::op::v0::Convert>(output_0, nms_5->output(0).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_0.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms_5->output(0)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_0.get_node_shared_ptr());
         }
 
         Output<Node> output_2 = nms_legacy->output(2);
         if (nms_5->output(2).get_element_type() != output_2.get_element_type()) {
             output_2 = std::make_shared<ov::op::v0::Convert>(output_2, nms_5->output(2).get_element_type());
+            OPENVINO_SUPPRESS_DEPRECATED_START
             output_2.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms_5->output(2)));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             new_ops.emplace_back(output_2.get_node_shared_ptr());
         }
 

--- a/src/inference/src/dev/icompiled_model.cpp
+++ b/src/inference/src/dev/icompiled_model.cpp
@@ -76,7 +76,9 @@ ov::ICompiledModel::ICompiledModel(const std::shared_ptr<const ov::Model>& model
         for (const auto& result : model->get_results()) {
             auto fake_param = std::make_shared<ov::op::v0::Parameter>(result->get_output_element_type(0),
                                                                       result->get_output_partial_shape(0));
+            OPENVINO_SUPPRESS_DEPRECATED_START
             const std::string res_name = ov::op::util::create_ie_output_name(result->input_value(0));
+            OPENVINO_SUPPRESS_DEPRECATED_END
             fake_param->set_friendly_name(res_name);
             fake_param->set_element_type(result->get_element_type());
             fake_param->validate_and_infer_types();

--- a/src/inference/src/model_reader.cpp
+++ b/src/inference/src/model_reader.cpp
@@ -76,7 +76,11 @@ void update_v10_model(std::shared_ptr<ov::Model>& model, bool frontendMode = fal
         // we need to add operation names as tensor names for inputs and outputs
         {
             for (const auto& result : model->get_results()) {
+                OPENVINO_SUPPRESS_DEPRECATED_START
+                // Note, upon removal of 'create_ie_output_name', just move it to this file as a local function
+                // we still need to add operation names as tensor names for outputs for IR v10
                 auto res_name = ov::op::util::create_ie_output_name(result->input_value(0));
+                OPENVINO_SUPPRESS_DEPRECATED_END
                 OPENVINO_ASSERT(leaf_names.find(res_name) == leaf_names.end() ||
                                     result->output(0).get_names().find(res_name) != result->output(0).get_names().end(),
                                 "Model operation names have collisions with tensor names.",


### PR DESCRIPTION
### Details:
 - Such names are created as `operation_name.<port index>` which are not needed in OpenVINO 2.0, because it's legacy behavior.
 - Plugins should migrate to `ov::ISyncInferRequest::find_port` which can return index and port type (input or output) and work with this index (if required) instead of port **_legacy_** names.