### PR TITLE
[CPU] FuseConvolutionSum: fixed a mistake in dynamic bcast pattern check

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -1806,19 +1806,24 @@ void GraphOptimizer::FuseConvolutionSumAndConvolutionSumActivation(Graph &graph)
 #endif
         // Disable fusing for Add with broadcasing in case of known data ranges. Add with brodcasting triggers
         // non-optimal code path inside Convolution node, so better to avoid fusing at all.
-        auto shape1 = sum->getInputShapeAtPort(0);
-        auto shape2 = sum->getInputShapeAtPort(1);
+        const auto& shape1 = sum->getInputShapeAtPort(0);
+        const auto& shape2 = sum->getInputShapeAtPort(1);
         if (shape1.getRank() != shape2.getRank())
             continue;
 
-        auto dims1 = shape1.getDims();
-        auto dims2 = shape2.getDims();
+        const auto& dims1 = shape1.getDims();
+        const auto& dims2 = shape2.getDims();
+        bool dynamic_bcast_pattern = false;
         for (size_t d = 2; d < shape1.getRank(); d++) {
             bool cond1 = (dims1[d] == Shape::UNDEFINED_DIM) && (dims2[d] == 1U);
             bool cond2 = (dims2[d] == Shape::UNDEFINED_DIM) && (dims1[d] == 1U);
             if (cond1 || cond2) {
-                continue;
+                dynamic_bcast_pattern = true;
+                break;
             }
+        }
+        if (dynamic_bcast_pattern) {
+            continue;
         }
 
         auto lastNode = sum;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/conv_sum_broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/conv_sum_broadcast.cpp
@@ -298,6 +298,36 @@ TEST_P(ConvSumBroadcastTest, CompareWithRefs) {
     CheckPluginRelatedResults(compiledModel, "Convolution");
 }
 
+class Conv1x1SumUnsupportedBroadcastTest : public ConvSumInPlaceTest {
+public:
+    Conv1x1SumUnsupportedBroadcastTest() {
+        _convOutChannels = 8;
+        _kernel = {1, 1};
+    }
+
+    std::shared_ptr<ov::Node> addSum(std::shared_ptr<ov::Node> lastNode, const ov::ParameterVector& inputParams) override {
+        return std::make_shared<ov::op::v1::Add>(lastNode, inputParams[1]);
+    }
+
+protected:
+    bool primTypeCheck(std::string primType) const override {
+        auto isaType = getISA(runtimeType == ov::element::Type_t::f32);
+        if (isaType == "")
+            return primType == "ref";
+        else
+            return primType == makeSelectedTypeStr(std::string("jit_") + isaType + std::string("_1x1"), runtimeType)
+                || primType == makeSelectedTypeStr(std::string("brgconv_") + isaType+ std::string("_1x1"), runtimeType);
+    }
+};
+
+TEST_P(Conv1x1SumUnsupportedBroadcastTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    run();
+
+    CheckPluginRelatedResults(compiledModel, "Convolution");
+}
+
 namespace {
 const auto fusingMulAddFQMullAdd = fusingSpecificParams{ std::make_shared<postNodesMgr>(std::vector<postNodeBuilder>{
         {[](postNodeConfig& cfg) {
@@ -504,6 +534,31 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_StaticShape, ConvSumBroadcastT
                                  ::testing::Values(convInpShapeStaticShape),
                                  ::testing::Values(secondInpStaticShape),
                                  ::testing::Values(true),
+                                 ::testing::Values(emptyFusingSpec),
+                                 ::testing::Values(empty_plugin_config)),
+                         ConvSumInPlaceTest::getTestCaseName);
+
+InputShape convSum1x1BcastShape1 = {
+    // dynamic shapes
+    {-1, 8, 1, 1},
+    { // target static shapes
+        {1, 8, 1, 1}
+    }
+};
+
+InputShape convSum1x1BcastShape2 = {
+    // dynamic shapes
+    {-1, 8, -1, -1},
+    { // target static shapes
+        {1, 8, 6, 6}
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_1x1_Broadcast, Conv1x1SumUnsupportedBroadcastTest,
+                         ::testing::Combine(
+                                 ::testing::Values(convSum1x1BcastShape1),
+                                 ::testing::Values(convSum1x1BcastShape2),
+                                 ::testing::Values(false),
                                  ::testing::Values(emptyFusingSpec),
                                  ::testing::Values(empty_plugin_config)),
                          ConvSumInPlaceTest::getTestCaseName);


### PR DESCRIPTION
### Details:
`FuseConvolutionSumAndConvolutionSumActivation`: fixed a mistake in dynamic broadcast pattern check.

### Tickets:
 - *CVS-129631*
