### PR TITLE
Removed AddOldApiMapToParameters during FP16 weights compression

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/compress_float_constants.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/compress_float_constants.hpp
@@ -11,7 +11,6 @@ namespace ov {
 namespace pass {
 
 class TRANSFORMATIONS_API CompressFloatConstantsImpl;
-class TRANSFORMATIONS_API AddOldApiMapToParameters;
 class TRANSFORMATIONS_API CompressFloatConstants;
 
 }  // namespace pass
@@ -35,16 +34,6 @@ public:
 
 /**
  * @ingroup ie_transformation_common_api
- * @brief AddOldApiMapToParameters transformation adds OldApiMap to each float input to the model.
- */
-class ov::pass::AddOldApiMapToParameters : public ov::pass::MatcherPass {
-public:
-    OPENVINO_RTTI("AddOldApiMapToParameters", "0");
-    AddOldApiMapToParameters();
-};
-
-/**
- * @ingroup ie_transformation_common_api
  * @brief CompressFloatConstants transformation replaces FP32/FP64 Constants with FP16 ones.
  */
 class ov::pass::CompressFloatConstants : public ov::pass::GraphRewrite {
@@ -54,6 +43,5 @@ public:
     /// @param postponed Postponed compression, see ov::pass::CompressFloatConstantsImpl for details.
     CompressFloatConstants(bool postponed = false) {
         add_matcher<ov::pass::CompressFloatConstantsImpl>(postponed);
-        add_matcher<ov::pass::AddOldApiMapToParameters>();
     }
 };

--- a/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/compress_float_constants.cpp
@@ -149,27 +149,3 @@ ov::pass::CompressFloatConstantsImpl::CompressFloatConstantsImpl(bool postponed)
     auto m = std::make_shared<pattern::Matcher>(const_pattern, matcher_name);
     this->register_matcher(m, callback);
 }
-
-ov::pass::AddOldApiMapToParameters::AddOldApiMapToParameters() {
-    MATCHER_SCOPE(AddOldApiMapToParameters);
-    auto param_pattern = pattern::wrap_type<ov::op::v0::Parameter>();
-
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        const auto& pattern_map = m.get_pattern_value_map();
-        auto node = pattern_map.at(param_pattern).get_node_shared_ptr();
-
-        auto param_node = std::dynamic_pointer_cast<ov::op::v0::Parameter>(node);
-        if (!param_node)
-            return false;
-        auto p_type = param_node->get_element_type();
-        if (p_type == ov::element::f32 || p_type == ov::element::f64) {
-            ov::set_old_api_map_element_type(node, ov::OldApiMapElementType(ov::element::Type_t::f16));
-        } else {
-            return false;
-        }
-        return true;
-    };
-
-    auto m = std::make_shared<pattern::Matcher>(param_pattern, matcher_name);
-    this->register_matcher(m, callback);
-}


### PR DESCRIPTION
### Details:
 - It was required for old API only