### PR TITLE
[CPU] Fixed descriptor creation bug for 3D quantized deconvolution

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -518,7 +518,7 @@ void Deconvolution::getSupportedDescriptors() {
         const auto& rank = getInputShapeAtPort(0).getRank();
         auto format = rank == 5   ? dnnl::memory::format_tag::ndhwc
                       : rank == 4 ? dnnl::memory::format_tag::nhwc
-                                  : dnnl::memory::format_tag::ntc;
+                                  : dnnl::memory::format_tag::nwc;
         MemoryDescPtr in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(0), inputDataType, format);
         MemoryDescPtr out_candidate = std::make_shared<DnnlBlockedMemoryDesc>(getOutputShapeAtPort(0), outputDataType, format);
         createDescriptor({in_candidate}, {out_candidate});

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/convolution_backprop_data_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/convolution_backprop_data_transformation.cpp
@@ -100,21 +100,56 @@ const std::vector<LayerTestsDefinitions::ConvolutionBackpropDataTransformationPa
     }
 };
 
-const std::vector<std::pair<ov::PartialShape, bool>> inputShapes = {
+const std::vector<std::pair<ov::PartialShape, bool>> inputShapes_4D = {
     {{ 1, 8, 16, 16 }, true}
 };
 
-const std::vector<ov::Shape> outputShapes = {
+const std::vector<ov::Shape> outputShapes_4D = {
     { 16, 16 }
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionBackpropDataTransformation,
+INSTANTIATE_TEST_SUITE_P(smoke_LPT_4D, ConvolutionBackpropDataTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
-        ::testing::ValuesIn(inputShapes),
-        ::testing::ValuesIn(outputShapes),
+        ::testing::ValuesIn(inputShapes_4D),
+        ::testing::ValuesIn(outputShapes_4D),
         ::testing::Values(ov::test::utils::DEVICE_CPU),
         ::testing::ValuesIn(trasformationParamValues),
         ::testing::ValuesIn(params)),
+    ConvolutionBackpropDataTransformation::getTestCaseName);
+
+const std::vector<std::pair<ov::PartialShape, bool>> inputShapes_3D = {
+    {{ 1, 8, 16 }, true}
+};
+
+const std::vector<ov::Shape> outputShapes_3D = {
+    { 16 }
+};
+
+const std::vector<LayerTestsDefinitions::ConvolutionBackpropDataTransformationParam> params_3D = {
+    // FQ on weights
+    {
+        {256ul, ov::Shape{1, 1, 1}, { 0.f }, { 25.5f }, { 0.f }, { 25.5f }},
+        {255ul, ov::Shape{1, 1, 1}, { -12.7f }, { 12.7f }, { -12.7f }, { 12.7f }},
+        "convolutionBackpropData_original",
+        "u8"
+    },
+    // Qdq on weights
+    {
+        {256ul, ov::Shape{1, 1, 1}, { 0.f }, { 255.f }, { 0.f }, { 25.5f }},
+        {{ov::element::f32}, {}, { {4.f}, ov::element::f32, {}, false }},
+        "convolutionBackpropData_original",
+        "u8"
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_LPT_3D, ConvolutionBackpropDataTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(inputShapes_3D),
+        ::testing::ValuesIn(outputShapes_3D),
+        ::testing::Values(ov::test::utils::DEVICE_CPU),
+        ::testing::ValuesIn(trasformationParamValues),
+        ::testing::ValuesIn(params_3D)),
     ConvolutionBackpropDataTransformation::getTestCaseName);
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/convolution_backprop_data_transformation.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/low_precision_transformations/convolution_backprop_data_transformation.cpp
@@ -102,22 +102,57 @@ const std::vector<LayerTestsDefinitions::ConvolutionBackpropDataTransformationPa
     }
 };
 
-const std::vector<std::pair<ov::PartialShape, bool>> inputShapes = {
+const std::vector<std::pair<ov::PartialShape, bool>> inputShapes_4D = {
         {{ 1, 8, 16, 16 }, false},
         {{ 1, 32, 16, 16 }, true}
 };
 
-const std::vector<ov::Shape> outputShapes = {
+const std::vector<ov::Shape> outputShapes_4D = {
         { 16, 16 }
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionBackpropDataTransformation,
+INSTANTIATE_TEST_SUITE_P(smoke_LPT_4D, ConvolutionBackpropDataTransformation,
     ::testing::Combine(
             ::testing::ValuesIn(netPrecisions),
-            ::testing::ValuesIn(inputShapes),
-            ::testing::ValuesIn(outputShapes),
+            ::testing::ValuesIn(inputShapes_4D),
+            ::testing::ValuesIn(outputShapes_4D),
             ::testing::Values(ov::test::utils::DEVICE_GPU),
             ::testing::ValuesIn(trasformationParamValues),
             ::testing::ValuesIn(params)),
+    ConvolutionBackpropDataTransformation::getTestCaseName);
+
+const std::vector<std::pair<ov::PartialShape, bool>> inputShapes_3D = {
+    {{ 1, 32, 16, 16 }, true}
+};
+
+const std::vector<ov::Shape> outputShapes_3D = {
+    { 16 }
+};
+
+const std::vector<LayerTestsDefinitions::ConvolutionBackpropDataTransformationParam> params_3D = {
+    // FQ on weights
+    {
+        {256ul, ov::Shape{1, 1, 1}, { 0.f }, { 25.5f }, { 0.f }, { 25.5f }},
+        {255ul, ov::Shape{1, 1, 1}, { -12.7f }, { 12.7f }, { -12.7f }, { 12.7f }},
+        "convolutionBackpropData_original",
+        "u8"
+    },
+    // Qdq on weights
+    {
+        {256ul, ov::Shape{1, 1, 1}, { 0.f }, { 255.f }, { 0.f }, { 25.5f }},
+        {{ov::element::f32}, {}, { {4.f}, ov::element::f32, {}, false }},
+        "convolutionBackpropData_original",
+        "u8"
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_LPT_3D, ConvolutionBackpropDataTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(inputShapes_3D),
+        ::testing::ValuesIn(outputShapes_3D),
+        ::testing::Values(ov::test::utils::DEVICE_GPU),
+        ::testing::ValuesIn(trasformationParamValues),
+        ::testing::ValuesIn(params_3D)),
     ConvolutionBackpropDataTransformation::getTestCaseName);
 }  // namespace

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_backprop_data_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/convolution_backprop_data_transformation.cpp
@@ -41,11 +41,11 @@ void ConvolutionBackpropDataTransformation::SetUp() {
 
     std::shared_ptr<ov::Node> weights;
 
-    const auto inputShape = inputShapeAndHandling.first;
-
+    const auto& inputShape = inputShapeAndHandling.first;
+    const auto rank = inputShape.rank();
     init_input_shapes(inputShape);
 
-    ov::Shape weightsShape(4, 1ul);
+    ov::Shape weightsShape(rank.get_length(), 1ul);
     weightsShape[0] = inputShape[1].get_length();
     weightsShape[1] = inputShape[1].get_length() / 2;
 

--- a/src/tests/ov_helpers/ov_lpt_models/src/convolution_backprop_data.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/convolution_backprop_data.cpp
@@ -20,6 +20,23 @@ namespace ov {
 namespace builder {
 namespace subgraph {
 
+namespace {
+const std::shared_ptr<ov::opset1::ConvolutionBackpropData> buildConvBackpropData(const Output<Node>& data, const Output<Node>& weights) {
+    const auto rank = data.get_partial_shape().rank();
+    const auto rank_value = rank.is_static() ? rank.get_length() : 4;
+    OPENVINO_ASSERT(rank_value == 3 || rank_value == 4,
+                    "ConvolutionBackpropData test class doesn't support input shape ",
+                    data.get_partial_shape());
+    return std::make_shared<ov::opset1::ConvolutionBackpropData>(
+        data,
+        weights,
+        rank_value == 4 ? Strides{1, 1} : Strides{1},
+        rank_value == 4 ? CoordinateDiff{0, 0} : CoordinateDiff{0},
+        rank_value == 4 ? CoordinateDiff{0, 0} : CoordinateDiff{0},
+        rank_value == 4 ? Strides{1, 1} : Strides{1});
+}
+}  // namespace
+
 std::shared_ptr<ov::Model> ConvolutionBackpropDataFunction::get(const ov::element::Type netPrecision,
                                                                 const PartialShape& inputShape,
                                                                 const Shape& outputShape,
@@ -28,13 +45,7 @@ std::shared_ptr<ov::Model> ConvolutionBackpropDataFunction::get(const ov::elemen
     const auto input = std::make_shared<ov::opset1::Parameter>(netPrecision, inputShape);
     const auto fq = makeFakeQuantize(input, netPrecision, fqOnData);
 
-    auto convolutionBackpropData = std::make_shared<ov::opset1::ConvolutionBackpropData>(
-        fq,
-        weights,
-        Strides{ 1, 1 },
-        CoordinateDiff{ 0, 0 },
-        CoordinateDiff{ 0, 0 },
-        Strides{ 1, 1 });
+    const auto convolutionBackpropData = buildConvBackpropData(fq, weights);
     convolutionBackpropData->set_friendly_name("convolutionBackpropData");
 
     ov::ResultVector results{ std::make_shared<ov::opset1::Result>(convolutionBackpropData) };
@@ -114,14 +125,7 @@ std::shared_ptr<ov::Model> ConvolutionBackpropDataFunction::getOriginal(
     dequantizationStructure.multiply.outPrecision = netPrecision;
     const auto activations = makeDequantization(input, dequantizationStructure);
 
-    auto convolutionBackpropData = std::make_shared<ov::opset1::ConvolutionBackpropData>(
-            activations,
-            weights,
-            Strides{ 1, 1 },
-            CoordinateDiff{ 0, 0 },
-            CoordinateDiff{ 0, 0 },
-            Strides{ 1, 1 });
-
+    const auto convolutionBackpropData = buildConvBackpropData(activations, weights);
     convolutionBackpropData->set_friendly_name("output");
     ov::ResultVector results{ std::make_shared<ov::opset1::Result>(convolutionBackpropData) };
     return std::make_shared<ov::Model>(results, ov::ParameterVector{ input }, "ConvolutionBackpropDataTransformation");


### PR DESCRIPTION
### Details:
 - *Added supported ranks in `canBeExecutedInInt8`*
 - *`getSupportedDescriptors`: added 3D case handling*
 - *Added 3D ConvolutionBackpropData test cases to LPT plugin tests*

### Tickets:
 - *CVS-132070*
