### PR TITLE
[PyOV] Add missing is_shared flag in memory sharing scenarios 

### DIFF
--- a/src/bindings/python/src/openvino/runtime/utils/data_helpers/data_dispatcher.py
+++ b/src/bindings/python/src/openvino/runtime/utils/data_helpers/data_dispatcher.py
@@ -134,7 +134,7 @@ def _(
 def to_c_style(value: Any, is_shared: bool = False) -> Any:
     if not isinstance(value, np.ndarray):
         if hasattr(value, "__array__"):
-            return to_c_style(np.array(value, copy=False)) if is_shared else np.array(value, copy=True)
+            return to_c_style(np.array(value, copy=False), is_shared) if is_shared else np.array(value, copy=True)
         return value
     return value if value.flags["C_CONTIGUOUS"] else np.ascontiguousarray(value)
 
@@ -149,7 +149,7 @@ def normalize_arrays(
 ) -> Any:
     # Check the special case of the array-interface
     if hasattr(inputs, "__array__"):
-        return to_c_style(np.array(inputs, copy=False)) if is_shared else np.array(inputs, copy=True)
+        return to_c_style(np.array(inputs, copy=False), is_shared) if is_shared else np.array(inputs, copy=True)
     # Error should be raised if type does not match any dispatchers
     raise TypeError(f"Incompatible inputs of type: {type(inputs)}")
 
@@ -159,7 +159,7 @@ def _(
     inputs: dict,
     is_shared: bool = False,
 ) -> dict:
-    return {k: to_c_style(v) if is_shared else v for k, v in inputs.items()}
+    return {k: to_c_style(v, is_shared) if is_shared else v for k, v in inputs.items()}
 
 
 @normalize_arrays.register(OVDict)
@@ -167,7 +167,7 @@ def _(
     inputs: OVDict,
     is_shared: bool = False,
 ) -> dict:
-    return {i: to_c_style(v) if is_shared else v for i, (_, v) in enumerate(inputs.items())}
+    return {i: to_c_style(v, is_shared) if is_shared else v for i, (_, v) in enumerate(inputs.items())}
 
 
 @normalize_arrays.register(list)
@@ -176,7 +176,7 @@ def _(
     inputs: Union[list, tuple],
     is_shared: bool = False,
 ) -> dict:
-    return {i: to_c_style(v) if is_shared else v for i, v in enumerate(inputs)}
+    return {i: to_c_style(v, is_shared) if is_shared else v for i, v in enumerate(inputs)}
 
 
 @normalize_arrays.register(np.ndarray)
@@ -184,7 +184,7 @@ def _(
     inputs: dict,
     is_shared: bool = False,
 ) -> Any:
-    return to_c_style(inputs) if is_shared else inputs
+    return to_c_style(inputs, is_shared) if is_shared else inputs
 ###
 # End of array normalization.
 ###

--- a/src/bindings/python/tests/test_utils/test_data_dispatch.py
+++ b/src/bindings/python/tests/test_utils/test_data_dispatch.py
@@ -7,7 +7,7 @@ import pytest
 from copy import deepcopy
 import numpy as np
 
-from tests.utils.helpers import generate_relu_compiled_model
+from tests.utils.helpers import generate_add_compiled_model, generate_relu_compiled_model
 
 from openvino import Core, Model, Type, Shape, Tensor
 import openvino.runtime.opset13 as ops
@@ -20,8 +20,16 @@ def _get_value(value):
     return value.data if isinstance(value, Tensor) else value
 
 
-def _run_dispatcher(device, input_data, is_shared, input_shape, input_dtype=np.float32):
+def _run_dispatcher_single_input(device, input_data, is_shared, input_shape, input_dtype=np.float32):
     compiled_model = generate_relu_compiled_model(device, input_shape, input_dtype)
+    infer_request = compiled_model.create_infer_request()
+    result = _data_dispatch(infer_request, input_data, is_shared)
+
+    return result, infer_request
+
+
+def _run_dispatcher_multi_input(device, input_data, is_shared, input_shape, input_dtype=np.float32):
+    compiled_model = generate_add_compiled_model(device, input_shape, input_dtype)
     infer_request = compiled_model.create_infer_request()
     result = _data_dispatch(infer_request, input_data, is_shared)
 
@@ -35,7 +43,7 @@ def test_scalars_dispatcher_old(device, data_type, input_shape, is_shared):
     test_data = data_type(2)
     expected = Tensor(np.ndarray([], data_type, np.array(test_data)))
 
-    result, _ = _run_dispatcher(device, test_data, is_shared, input_shape)
+    result, _ = _run_dispatcher_single_input(device, test_data, is_shared, input_shape)
 
     assert isinstance(result, Tensor)
     assert result.get_shape() == Shape([])
@@ -56,7 +64,7 @@ def test_scalars_dispatcher_old(device, data_type, input_shape, is_shared):
 def test_scalars_dispatcher_new_0(device, input_data, input_dtype, input_shape, is_shared):
     expected = Tensor(np.array(input_data, dtype=input_dtype))
 
-    result, _ = _run_dispatcher(device, input_data, is_shared, input_shape, input_dtype)
+    result, _ = _run_dispatcher_single_input(device, input_data, is_shared, input_shape, input_dtype)
 
     assert isinstance(result, Tensor)
     assert result.get_shape() == Shape([])
@@ -72,7 +80,7 @@ def test_scalars_dispatcher_new_0(device, input_data, input_dtype, input_shape, 
 ])
 @pytest.mark.parametrize("input_shape", [[], [1]])
 def test_scalars_dispatcher_new_1(device, input_data, is_shared, expected, input_shape):
-    result, _ = _run_dispatcher(device, input_data, is_shared, input_shape, np.float32)
+    result, _ = _run_dispatcher_single_input(device, input_data, is_shared, input_shape, np.float32)
 
     assert isinstance(result, type(expected))
     if isinstance(result, dict):
@@ -90,7 +98,7 @@ def test_tensor_dispatcher(device, input_shape, is_shared):
 
     test_data = Tensor(array, is_shared)
 
-    result, _ = _run_dispatcher(device, test_data, is_shared, input_shape)
+    result, _ = _run_dispatcher_single_input(device, test_data, is_shared, input_shape)
 
     assert isinstance(result, Tensor)
     assert result.get_shape() == Shape(input_shape)
@@ -107,7 +115,7 @@ def test_tensor_dispatcher(device, input_shape, is_shared):
 def test_ndarray_shared_dispatcher(device, input_shape):
     test_data = np.ones(input_shape).astype(np.float32)
 
-    result, _ = _run_dispatcher(device, test_data, True, input_shape)
+    result, _ = _run_dispatcher_single_input(device, test_data, True, input_shape)
 
     assert isinstance(result, Tensor)
     assert result.get_shape() == Shape(test_data.shape)
@@ -123,7 +131,7 @@ def test_ndarray_shared_dispatcher(device, input_shape):
 def test_ndarray_shared_dispatcher_casting(device, input_shape):
     test_data = np.ones(input_shape)
 
-    result, infer_request = _run_dispatcher(device, test_data, True, input_shape)
+    result, infer_request = _run_dispatcher_single_input(device, test_data, True, input_shape)
 
     assert isinstance(result, Tensor)
     assert result.get_shape() == Shape(test_data.shape)
@@ -139,7 +147,7 @@ def test_ndarray_shared_dispatcher_casting(device, input_shape):
 def test_ndarray_shared_dispatcher_misalign(device, input_shape):
     test_data = np.asfortranarray(np.ones(input_shape).astype(np.float32))
 
-    result, _ = _run_dispatcher(device, test_data, True, input_shape)
+    result, _ = _run_dispatcher_single_input(device, test_data, True, input_shape)
 
     assert isinstance(result, Tensor)
     assert result.get_shape() == Shape(test_data.shape)
@@ -155,7 +163,7 @@ def test_ndarray_shared_dispatcher_misalign(device, input_shape):
 def test_ndarray_copied_dispatcher(device, input_shape):
     test_data = np.ones(input_shape)
 
-    result, infer_request = _run_dispatcher(device, test_data, False, input_shape)
+    result, infer_request = _run_dispatcher_single_input(device, test_data, False, input_shape)
 
     assert result == {}
     assert np.array_equal(infer_request.input_tensors[0].data, test_data)
@@ -163,6 +171,98 @@ def test_ndarray_copied_dispatcher(device, input_shape):
     test_data[0] = 2.0
 
     assert not np.array_equal(infer_request.input_tensors[0].data, test_data)
+
+
+class FakeTensor():
+    def __init__(self, array):
+        self.array = array
+
+    def __array__(self):
+        return self.array
+
+
+@pytest.mark.parametrize("input_shape", [[1, 2, 3], [2, 2]])
+def test_array_interface_copied_dispatcher(device, input_shape):
+    np_data = np.ascontiguousarray(np.ones((input_shape), dtype=np.float32))
+    test_data = FakeTensor(np_data)
+
+    result, infer_request = _run_dispatcher_single_input(device, test_data, False, input_shape)
+
+    assert result == {}
+    assert np.array_equal(infer_request.input_tensors[0].data, test_data)
+    assert not np.shares_memory(infer_request.input_tensors[0].data, test_data)
+
+    np.array(test_data, copy=False)[0] = 2.0
+
+    assert not np.array_equal(infer_request.input_tensors[0].data, test_data)
+
+
+@pytest.mark.parametrize("input_shape", [[1, 2, 3], [2, 2]])
+@pytest.mark.parametrize("input_container", [list, tuple, dict])
+def test_array_interface_copied_multi_dispatcher(device, input_shape, input_container):
+    np_data_one = np.ascontiguousarray(np.ones((input_shape), dtype=np.float32))
+    test_data_one = FakeTensor(np_data_one)
+
+    np_data_two = np.ascontiguousarray(np.ones((input_shape), dtype=np.float32))
+    test_data_two = FakeTensor(np_data_two)
+
+    if input_container is dict:
+        test_inputs = {0: test_data_one, 1: test_data_two}
+    else:
+        test_inputs = input_container([test_data_one, test_data_two])
+
+    results, infer_request = _run_dispatcher_multi_input(device, test_inputs, False, input_shape)
+
+    assert results == {}
+    for i in range(len(results)):
+        assert np.array_equal(infer_request.input_tensors[i].data, test_inputs[i])
+        assert not np.shares_memory(infer_request.input_tensors[i].data, test_inputs[i])
+
+        np.array(test_inputs[i], copy=False)[0] = 2.0
+
+        assert not np.array_equal(infer_request.input_tensors[i].data, test_inputs[i])
+
+
+@pytest.mark.parametrize("input_shape", [[1, 2, 3], [2, 2]])
+def test_array_interface_shared_single_dispatcher(device, input_shape):
+    np_data = np.ascontiguousarray(np.ones((input_shape), dtype=np.float32))
+    test_data = FakeTensor(np_data)
+
+    result, _ = _run_dispatcher_single_input(device, test_data, True, input_shape)
+
+    assert isinstance(result, Tensor)
+    assert np.array_equal(result.data, test_data)
+    assert np.shares_memory(result.data, test_data)
+
+    np.array(test_data, copy=False)[0] = 2.0
+
+    assert np.array_equal(result.data, test_data)
+
+
+@pytest.mark.parametrize("input_shape", [[1, 2, 3], [2, 2]])
+@pytest.mark.parametrize("input_container", [list, tuple, dict])
+def test_array_interface_shared_multi_dispatcher(device, input_shape, input_container):
+    np_data_one = np.ascontiguousarray(np.ones((input_shape), dtype=np.float32))
+    test_data_one = FakeTensor(np_data_one)
+
+    np_data_two = np.ascontiguousarray(np.ones((input_shape), dtype=np.float32))
+    test_data_two = FakeTensor(np_data_two)
+
+    if input_container is dict:
+        test_inputs = {0: test_data_one, 1: test_data_two}
+    else:
+        test_inputs = input_container([test_data_one, test_data_two])
+
+    results, _ = _run_dispatcher_multi_input(device, test_inputs, True, input_shape)
+
+    assert len(results) == 2
+    for i in range(len(results)):
+        assert np.array_equal(results[i].data, test_inputs[i])
+        assert np.shares_memory(results[i].data, test_inputs[i])
+
+        np.array(test_inputs[i], copy=False)[0] = 2.0
+
+        assert np.array_equal(results[i].data, test_inputs[i])
 
 
 @pytest.mark.parametrize(

--- a/src/bindings/python/tests/utils/helpers.py
+++ b/src/bindings/python/tests/utils/helpers.py
@@ -202,11 +202,25 @@ def generate_model_and_image(device, input_shape: List[int] = None):
     return (generate_relu_compiled_model(device, input_shape), generate_image(input_shape))
 
 
-def generate_add_model() -> openvino._pyopenvino.Model:
-    param1 = ops.parameter(Shape([2, 1]), dtype=np.float32, name="data1")
-    param2 = ops.parameter(Shape([2, 1]), dtype=np.float32, name="data2")
+def generate_add_model(input_shape: List[int] = None, input_dtype=np.float32) -> openvino.Model:
+    if input_shape is None:
+        input_shape = [2, 1]
+    param1 = ops.parameter(Shape(input_shape), dtype=np.float32, name="data1")
+    param2 = ops.parameter(Shape(input_shape), dtype=np.float32, name="data2")
     add = ops.add(param1, param2)
     return Model(add, [param1, param2], "TestModel")
+
+
+def generate_add_compiled_model(
+    device,
+    input_shape: List[int] = None,
+    input_dtype=np.float32,
+) -> openvino.CompiledModel:
+    if input_shape is None:
+        input_shape = [1, 3, 32, 32]
+    model = generate_add_model(input_shape, input_dtype)
+    core = Core()
+    return core.compile_model(model, device, {})
 
 
 def generate_model_with_memory(input_shape, data_type) -> openvino._pyopenvino.Model:


### PR DESCRIPTION
### Details:
 - Add missing flag propagation in containers dispatchers for memory sharing scenarios.
 - Expected boost in cases of already aligned memory storages with `__array__` interface, i.e. PyTorch tensors.
 - Added testcases.
 
### Tickets:
 - *132092*
