### PR TITLE
[GHA] Increase timeout for Conformance tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -318,7 +318,7 @@ jobs:
 
   Conformance:
     needs: [ Build, Smart_CI ]
-    timeout-minutes: ${{ matrix.TEST_TYPE == 'API' && 5 || 20 }}
+    timeout-minutes: ${{ matrix.TEST_TYPE == 'API' && 5 || 30 }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Details:
 - Temporarily increase the timeout for Conformance op tests (the root cause is to be investigated)

### Tickets:
 - 131820
