### PR TITLE
[GPU] Allow cpu impl to be skipped

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
@@ -16,9 +16,6 @@ void mark_runtime_skippable_nodes::run(program& p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
         auto& node = *itr++;
-        // Skip if the node is impl_types::cpu
-        if (node->get_preferred_impl_type() == impl_types::cpu)
-            return;
         // Set gathers that might be skipped at runtime as can_be_optimized.
         // If not set, memory dependency will not work for the nodes that are skipped at runtime
         program_helpers::do_for_types<gather>(*node, [](gather_node& node){

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/gather.cpp
@@ -57,6 +57,10 @@ struct gather_impl : public typed_primitive_impl<gather> {
         OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, "gather::execute_impl");
         auto& stream = instance.get_network().get_stream();
 
+        if (instance.can_be_optimized()) {
+            return aggregate_events(events, stream, false, instance.is_output());
+        }
+
         for (auto e : events) {
             e->wait();
         }

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/gather.cpp
@@ -58,7 +58,7 @@ struct gather_impl : public typed_primitive_impl<gather> {
         auto& stream = instance.get_network().get_stream();
 
         if (instance.can_be_optimized()) {
-            return aggregate_events(events, stream, false, instance.is_output());
+            return stream.group_events(events);
         }
 
         for (auto e : events) {

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
@@ -85,6 +85,10 @@ struct strided_slice_impl : public typed_primitive_impl<strided_slice> {
         OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, "strided_slice::execute_impl");
         auto& stream = instance.get_network().get_stream();
 
+        if (instance.can_be_optimized()) {
+            return aggregate_events(events, stream, false, instance.is_output());
+        }
+
         for (auto e : events) {
             e->wait();
         }

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
@@ -86,7 +86,7 @@ struct strided_slice_impl : public typed_primitive_impl<strided_slice> {
         auto& stream = instance.get_network().get_stream();
 
         if (instance.can_be_optimized()) {
-            return aggregate_events(events, stream, false, instance.is_output());
+            return stream.group_events(events);
         }
 
         for (auto e : events) {

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -472,17 +472,6 @@ struct typed_primitive_impl : public primitive_impl {
 
     using primitive_impl::primitive_impl;
 
-    event::ptr aggregate_events(const std::vector<event::ptr>& events, stream& stream, bool group = false, bool is_output = false) const {
-        if (events.size() == 1 && !is_output)
-            return events[0];
-
-        if (group && !is_output)
-            return stream.group_events(events);
-
-        return events.empty() ? stream.create_user_event(true)
-                              : stream.enqueue_marker(events, is_output);
-    }
-
 private:
     event::ptr execute(const std::vector<event::ptr>& event, primitive_inst& instance) override {
         if (instance.type() != PType::type_id())

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -472,6 +472,17 @@ struct typed_primitive_impl : public primitive_impl {
 
     using primitive_impl::primitive_impl;
 
+    event::ptr aggregate_events(const std::vector<event::ptr>& events, stream& stream, bool group = false, bool is_output = false) const {
+        if (events.size() == 1 && !is_output)
+            return events[0];
+
+        if (group && !is_output)
+            return stream.group_events(events);
+
+        return events.empty() ? stream.create_user_event(true)
+                              : stream.enqueue_marker(events, is_output);
+    }
+
 private:
     event::ptr execute(const std::vector<event::ptr>& event, primitive_inst& instance) override {
         if (instance.type() != PType::type_id())

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/stateful_model.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/stateful_model.cpp
@@ -157,8 +157,8 @@ TEST(stateful_model, not_skip_gather_in_cpuimpl) {
 
     network network(engine, topology, config);
     auto gather_inst = network.get_primitive("gather");
-    ASSERT_EQ(gather_inst->get_node().can_be_optimized(), false);
-    ASSERT_EQ(gather_inst->can_be_optimized(), false);
+    ASSERT_EQ(gather_inst->get_node().can_be_optimized(), true);
+    ASSERT_EQ(gather_inst->can_be_optimized(), true);
 
     auto KV_SIZE = 24;
     auto BATCH_SIZE = 1;

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/stateful_model.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/stateful_model.cpp
@@ -179,7 +179,7 @@ TEST(stateful_model, not_skip_gather_in_cpuimpl) {
     network.set_input_data("present", present_mem);
     network.set_input_data("beam_idx", beam_idx_mem);
     network.execute();
-    ASSERT_EQ(gather_inst->can_be_optimized(), false);
+    ASSERT_EQ(gather_inst->can_be_optimized(), true);
     auto gather_output_mem = network.get_output_memory("gather");
     cldnn::mem_lock<float, mem_lock_type::read> gather_output_ptr(gather_output_mem, get_test_stream());
     for (size_t i = 0; i < gather_output_mem->get_layout().count(); ++i) {


### PR DESCRIPTION
### Details:
 - cpu impls that are skiped at runtime should not do anything because it may overwrite the parent node's memory which might be shared with other nodes 

### Tickets:
 - *ticket-id*