### PR TITLE
[IE] Throw if empty context on model import

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -850,6 +850,7 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::import_model(std::istream& modelStre
                                                          const ov::SoPtr<ov::IRemoteContext>& context,
                                                          const ov::AnyMap& config) const {
     OV_ITT_SCOPED_TASK(ov::itt::domains::OV, "Core::import_model");
+    OPENVINO_ASSERT(context, "Remote context must not be empty.");
     auto parsed = parseDeviceNameIntoConfig(context->get_device_name(), config);
     return get_plugin(parsed._deviceName).import_model(modelStream, context, parsed._config);
 }

--- a/src/inference/tests/functional/import_model.cpp
+++ b/src/inference/tests/functional/import_model.cpp
@@ -6,8 +6,7 @@
 #include "gtest/gtest.h"
 #include "openvino/runtime/core.hpp"
 
-// Test is disabled due to issue 128924
-TEST(ImportModel, DISABLED_ImportModelWithNullContextThrows) {
+TEST(ImportModel, ImportModelWithNullContextThrows) {
     ov::Core core;
     ov::RemoteContext context;
     std::istringstream stream("None");


### PR DESCRIPTION
### Details:
 - Throws when empty Remote Context is provided to `ov::CoreImpl::import_model(..)`

### Tickets:
 - CVS-128924
