### PR TITLE
Fixed performance of CPU ShapeInferFallback case

### DIFF
--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -204,7 +204,7 @@ public:
         for (size_t i = 0; i < op->get_input_size(); ++i) {
             if (auto t = tensor_accessor(i)) {
                 new_inputs.push_back(
-                    std::make_shared<ov::opset1::Constant>(t.get_element_type(), t.get_shape(), t.data()));
+                    std::make_shared<ov::opset1::Constant>(t));
             } else if (dynamic_cast<ov::opset1::Constant*>(op->get_input_node_ptr(i))) {
                 new_inputs.push_back(op->get_input_node_ptr(i)->clone_with_new_inputs(ov::OutputVector{}));
             } else {


### PR DESCRIPTION
### Details:
 - Avoid memory copying during `ov::Constant` creation
 - Important for very big inputs like in vLLM case