### PR TITLE
[CPU][Snippets] Fixed thread count per stream in tokenization config

### DIFF
--- a/src/inference/dev_api/openvino/runtime/threading/istreams_executor.hpp
+++ b/src/inference/dev_api/openvino/runtime/threading/istreams_executor.hpp
@@ -160,43 +160,37 @@ public:
          */
         ov::Any get_property(const std::string& key) const;
 
-        std::string get_name() {
+        std::string get_name() const {
             return _name;
-        }
-        int get_streams() {
-            return _streams;
         }
         int get_streams() const {
             return _streams;
         }
-        int get_threads() {
-            return _threads;
-        }
         int get_threads() const {
             return _threads;
         }
-        int get_threads_per_stream() {
+        int get_threads_per_stream() const {
             return _threads_per_stream;
         }
-        bool get_cpu_reservation() {
+        bool get_cpu_reservation() const {
             return _cpu_reservation;
         }
-        std::vector<std::vector<int>> get_streams_info_table() {
+        std::vector<std::vector<int>> get_streams_info_table() const {
             return _streams_info_table;
         }
-        std::vector<std::vector<int>> get_stream_processor_ids() {
+        std::vector<std::vector<int>> get_stream_processor_ids() const {
             return _stream_processor_ids;
         }
-        ThreadBindingType get_thread_binding_type() {
+        ThreadBindingType get_thread_binding_type() const {
             return _threadBindingType;
         }
-        int get_thread_binding_step() {
+        int get_thread_binding_step() const {
             return _threadBindingStep;
         }
-        int get_thread_binding_offset() {
+        int get_thread_binding_offset() const {
             return _threadBindingOffset;
         }
-        bool operator==(const Config& config){
+        bool operator==(const Config& config) {
             if (_name == config._name && _streams == config._streams &&
                 _threads_per_stream == config._threads_per_stream && _threadBindingType == config._threadBindingType &&
                 _thread_preferred_core_type == config._thread_preferred_core_type) {

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -721,7 +721,7 @@ void Transformations::MainSnippets(void) {
     // To avoid sitations when Transpose is not alone node between MatMul and Result,
     // Plugin disables Transpose tokenization on output
     tokenization_config.mha_token_enable_transpose_on_output = (inferencePrecision == ov::element::f32);
-    tokenization_config.concurrency = config.threadsPerStream;
+    tokenization_config.concurrency = config.streamExecutorConfig.get_threads_per_stream();
     if (tokenization_config.concurrency == 0)
         tokenization_config.concurrency = parallel_get_max_threads();
     // The optimization "SplitDimensionM" depends on target machine (thread count).


### PR DESCRIPTION
### Details:
 - *After the https://github.com/openvinotoolkit/openvino/pull/22414 Snippets passes get incorrect thread count per stream in CPU Plugin  - `config.threadsPerStream` equals to `0` so plugin sets `concurrency = parallel_get_max_threads()`. The real count of threads per stream is inited in `streamExecutorConfig` on this stage. The PR returns the previous behavior*

### Tickets:
 - *N/A*
