### PR TITLE
[OVC] Removed wrong text from extension parameter description.

### DIFF
--- a/tools/ovc/openvino/tools/ovc/convert.py
+++ b/tools/ovc/openvino/tools/ovc/convert.py
@@ -82,8 +82,7 @@ def convert_model(
         :param extension:
             Paths to libraries (.so or .dll) with extensions, comma-separated
             list of paths, objects derived from BaseExtension class or lists of
-            objects. To disable all extensions including those that are placed
-            at the default location, pass an empty string.
+            objects.
         :param verbose:
             Print detailed information about conversion.
         :param share_weights:

--- a/tools/ovc/openvino/tools/ovc/help.py
+++ b/tools/ovc/openvino/tools/ovc/help.py
@@ -38,8 +38,7 @@ def get_convert_model_help_specifics():
         'extension':
             {'description':
                  'Paths or a comma-separated list of paths to libraries '
-                 '(.so or .dll) with extensions. To disable all extensions including '
-                 'those that are placed at the default location, pass an empty string.',
+                 '(.so or .dll) with extensions.',
              'action': CanonicalizePathCheckExistenceAction,
              'type': readable_files_or_empty},
         'version':


### PR DESCRIPTION
### Details:
 - "To disable all extensions including those that are placed at the default location, pass an empty string." - this line applies only to legacy MO.

### Tickets:
 - 132289
