### PR TITLE
[GPU] Fixes for gemm and border

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/border_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/border_gpu_ref.cl
@@ -18,6 +18,9 @@ KERNEL(border_gpu_ref)(
 #endif
     __global OUTPUT_TYPE* output)
 {
+#if defined(BEGIN_TYPE) || defined(END_TYPE)
+    uint pad_info_length = INPUT1_LENGTH;
+#endif
 #ifdef BEGIN_TYPE
     const int begin_b = begin[0];
     const int begin_f = begin[1];
@@ -30,8 +33,8 @@ KERNEL(border_gpu_ref)(
     const int begin_z = begin[begin_offset];
     begin_offset += 1;
     #endif
-    const int begin_y = begin[begin_offset];
-    const int begin_x = begin[begin_offset + 1];
+    const int begin_y = (pad_info_length > begin_offset) ? begin[begin_offset] : 0;
+    const int begin_x = (pad_info_length > (begin_offset + 1)) ? begin[begin_offset + 1] : 0;
 #else
     const uint begin_b = LT_SIZES_BATCH_NUM;
     const uint begin_f = LT_SIZES_FEATURE_NUM;
@@ -57,8 +60,8 @@ KERNEL(border_gpu_ref)(
     const int end_z = end[end_offset];
     end_offset += 1;
     #endif
-    const int end_y = end[end_offset];
-    const int end_x = end[end_offset + 1];
+    const int end_y = (pad_info_length > end_offset) ? end[end_offset] : 0;
+    const int end_x = (pad_info_length > (end_offset + 1)) ? end[end_offset + 1] : 0;
 #else
     const uint end_b = RB_SIZES_BATCH_NUM;
     const uint end_f = RB_SIZES_FEATURE_NUM;

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_matmul_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_matmul_fusion.cpp
@@ -91,10 +91,14 @@ TransposeMatMulMatcher::TransposeMatMulMatcher() {
         auto order_a = default_order(matmul->get_input_partial_shape(0).size());
         auto order_b = default_order(matmul->get_input_partial_shape(1).size());
         auto order_c = default_order(matmul->get_output_partial_shape(0).size());
+        size_t input_a_output_idx = matmul->get_input_source_output(0).get_index();
+        size_t input_b_output_idx = matmul->get_input_source_output(1).get_index();
 
         if (pattern_map.count(transpose_a_m) > 0) {
             auto tranpose_a_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_a_order_m).get_node_shared_ptr());
             order_a = tranpose_a_order->cast_vector<int64_t>();
+            auto tranpose_a = std::dynamic_pointer_cast<ov::op::v1::Transpose>(pattern_map.at(transpose_a_m).get_node_shared_ptr());
+            input_a_output_idx = tranpose_a->get_input_source_output(0).get_index();
         }
         if (matmul->get_transpose_a() && order_a.size() > 1) {
             std::swap(*(order_a.end() - 1), *(order_a.end() - 2));
@@ -102,13 +106,15 @@ TransposeMatMulMatcher::TransposeMatMulMatcher() {
         if (pattern_map.count(transpose_b_m) > 0) {
             auto tranpose_b_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_b_order_m).get_node_shared_ptr());
             order_b = tranpose_b_order->cast_vector<int64_t>();
+            auto tranpose_b = std::dynamic_pointer_cast<ov::op::v1::Transpose>(pattern_map.at(transpose_b_m).get_node_shared_ptr());
+            input_b_output_idx = tranpose_b->get_input_source_output(0).get_index();
         }
         if (matmul->get_transpose_b() && order_b.size() > 1) {
             std::swap(*(order_b.end() - 1), *(order_b.end() - 2));
         }
 
-        auto input_a = ov::Output<Node>(pattern_map.at(input_a_m).get_node_shared_ptr(), matmul->get_input_source_output(0).get_index());
-        auto input_b = ov::Output<Node>(pattern_map.at(input_b_m).get_node_shared_ptr(), matmul->get_input_source_output(1).get_index());
+        auto input_a = ov::Output<Node>(pattern_map.at(input_a_m).get_node_shared_ptr(), input_a_output_idx);
+        auto input_b = ov::Output<Node>(pattern_map.at(input_b_m).get_node_shared_ptr(), input_b_output_idx);
 
         auto gemm = std::make_shared<op::Gemm>(input_a, input_b, order_a, order_b, order_c);
         gemm->set_friendly_name(matmul->get_friendly_name());
@@ -159,10 +165,14 @@ TransposeMatMulTransposeMatcher::TransposeMatMulTransposeMatcher() {
         auto order_a = default_order(matmul->get_input_partial_shape(0).size());
         auto order_b = default_order(matmul->get_input_partial_shape(1).size());
         auto order_c = tranpose_c_order->cast_vector<int64_t>();
+        size_t input_a_output_idx = matmul->get_input_source_output(0).get_index();
+        size_t input_b_output_idx = matmul->get_input_source_output(1).get_index();
 
         if (pattern_map.count(transpose_a_m) > 0) {
             auto tranpose_a_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_a_order_m).get_node_shared_ptr());
             order_a = tranpose_a_order->cast_vector<int64_t>();
+            auto tranpose_a = std::dynamic_pointer_cast<ov::op::v1::Transpose>(pattern_map.at(transpose_a_m).get_node_shared_ptr());
+            input_a_output_idx = tranpose_a->get_input_source_output(0).get_index();
         }
         if (matmul->get_transpose_a() && order_a.size() > 1) {
             std::swap(*(order_a.end() - 1), *(order_a.end() - 2));
@@ -170,13 +180,15 @@ TransposeMatMulTransposeMatcher::TransposeMatMulTransposeMatcher() {
         if (pattern_map.count(transpose_b_m) > 0) {
             auto tranpose_b_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(transpose_b_order_m).get_node_shared_ptr());
             order_b = tranpose_b_order->cast_vector<int64_t>();
+            auto tranpose_b = std::dynamic_pointer_cast<ov::op::v1::Transpose>(pattern_map.at(transpose_b_m).get_node_shared_ptr());
+            input_b_output_idx = tranpose_b->get_input_source_output(0).get_index();
         }
         if (matmul->get_transpose_b() && order_b.size() > 1) {
             std::swap(*(order_b.end() - 1), *(order_b.end() - 2));
         }
 
-        auto input_a = ov::Output<Node>(pattern_map.at(input_a_m).get_node_shared_ptr(), matmul->get_input_source_output(0).get_index());
-        auto input_b = ov::Output<Node>(pattern_map.at(input_b_m).get_node_shared_ptr(), matmul->get_input_source_output(1).get_index());
+        auto input_a = ov::Output<Node>(pattern_map.at(input_a_m).get_node_shared_ptr(), input_a_output_idx);
+        auto input_b = ov::Output<Node>(pattern_map.at(input_b_m).get_node_shared_ptr(), input_b_output_idx);
 
         auto gemm = std::make_shared<op::Gemm>(input_a, input_b, order_a, order_b, order_c);
         gemm->set_friendly_name(m.get_match_root()->get_friendly_name());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/border_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/border_gpu_test.cpp
@@ -1919,4 +1919,92 @@ TEST(border_gpu, basic_zero_input) {
         ASSERT_EQ(ref_output[i], output_ptr[i]);
     }
 }
+
+TEST(border_gpu, 3d_input) {
+    tests::random_generator rg;
+    rg.set_seed(GET_SUITE_NAME);
+
+    ov::op::PadMode pad_mode = ov::op::PadMode::CONSTANT;
+    ov::float16 pad_value = 0;
+    format::type fmt = format::type::bfyx;
+    std::array<int, 3> sh_in = {2, 3, 4};
+    std::vector<int> cd_lt = {5, 6, 7};
+    std::vector<int> cd_rb = {1, 8, 9};
+    std::array<int, 3> sh_out = {sh_in[0] + cd_lt[0] + cd_rb[0],
+                                 sh_in[1] + cd_lt[1] + cd_rb[1],
+                                 sh_in[2] + cd_lt[2] + cd_rb[2]};
+    bool allow_negative_pads = false;
+    auto& engine = get_test_engine();
+
+    auto input_data = rg.generate_random_1d<ov::float16>(mult(sh_in), -9, 9, 1);
+    auto input = engine.allocate_memory({{sh_in[0], sh_in[1], sh_in[2]}, data_types::f16, format::bfyx});
+    set_values(input, input_data);
+
+    auto begin = engine.allocate_memory({{3}, data_types::i32, format::bfyx});
+    set_values(begin, cd_lt);
+
+    auto end = engine.allocate_memory({{3}, data_types::i32, format::bfyx});
+    set_values(end, cd_rb);
+
+    topology target_topology;
+    const auto input_layout_dynamic = layout{ov::PartialShape::dynamic(3), data_types::f16, format::bfyx};
+
+    target_topology.add(input_layout("input", input_layout_dynamic));
+    target_topology.add(data("begin", begin));
+    target_topology.add(data("end", end));
+    target_topology.add(reorder("border_input", input_info("input"), fmt, data_types::f16),
+                        border("border",
+                               {input_info("border_input"), input_info("begin"), input_info("end")},
+                               cldnn::border::PAD_NON_CONST_INPUT::BEGIN | cldnn::border::PAD_NON_CONST_INPUT::END,
+                               std::vector<int64_t>{},
+                               std::vector<int64_t>{},
+                               pad_mode,
+                               pad_value,
+                               allow_negative_pads),
+                        reorder("output", input_info("border"), cldnn::format::bfyx, data_types::f16));
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network target_network(engine, target_topology, config);
+    target_network.set_input_data("input", input);
+    auto target_output = target_network.execute().at("output").get_memory();
+    cldnn::mem_lock<ov::float16> target_output_ptr(target_output, get_test_stream());
+
+    topology base_topology;
+    base_topology.add(input_layout("input", input_layout_dynamic));
+    base_topology.add(data("begin", begin));
+    base_topology.add(data("end", end));
+    base_topology.add(border("border",
+                             {input_info("input"), input_info("begin"), input_info("end")},
+                             cldnn::border::PAD_NON_CONST_INPUT::BEGIN | cldnn::border::PAD_NON_CONST_INPUT::END,
+                             std::vector<int64_t>{},
+                             std::vector<int64_t>{},
+                             pad_mode,
+                             pad_value,
+                             allow_negative_pads));
+    network base_network(engine, base_topology, config);
+    base_network.set_input_data("input", input);
+    auto base_output = base_network.execute().at("border").get_memory();
+    cldnn::mem_lock<ov::float16> base_output_ptr(base_output, get_test_stream());
+
+    ASSERT_TRUE(!memcmp(target_output_ptr.data(), base_output_ptr.data(), sizeof(ov::float16) * mult(sh_out)));
+
+    for (auto b = 0; b < sh_out[0]; ++b) {
+        for (auto f = 0; f < sh_out[1]; ++f) {
+            for (auto y = 0; y < sh_out[2]; ++y) {
+                const auto output_off = ((b * sh_out[1] + f) * sh_out[2] + y);
+                ASSERT_GE(output_off, 0);
+
+                if (b < cd_lt[0] || b >= sh_out[0] - cd_rb[0] ||
+                    f < cd_lt[1] || f >= sh_out[1] - cd_rb[1] ||
+                    y < cd_lt[2] || y >= sh_out[2] - cd_rb[2]) {
+                    ASSERT_EQ(target_output_ptr[output_off], pad_value);
+                } else {
+                    const auto input_off  = (((b - cd_lt[0]) * sh_in[1] + f - cd_lt[1]) * sh_in[2] + y - cd_lt[2]);
+                    ASSERT_GE(input_off, 0);
+                    ASSERT_EQ(target_output_ptr[output_off], input_data[input_off]);
+                }
+            }
+        }
+    }
+}
 };  // namespace


### PR DESCRIPTION
### Details:
 - fixes the tr_matmul_tr transformation pass to use explicit output indexes to transpose layers
 - fixes `border_gpu_ref` kernel to consider pad-info inputs with rank less than 4

### Tickets:
 - 131014
 - 131032
