### PR TITLE
Enhance searching of plugins XML configuration

### DIFF
--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -46,8 +46,9 @@ public:
      * 1. (default) Use XML configuration file in case of dynamic libraries build;
      * 2. Use strictly defined configuration in case of static libraries build.
      *
-     * @param xml_config_file Path to the .xml file with plugins to load from. If the XML configuration file is not
-     * specified, default OpenVINO Runtime plugins are loaded from:
+     * @param xml_config_file Path to the .xml file with plugins to load from. If path contains only file name
+     * with extension, file will be searched in a folder with OpenVINO runtime shared library.
+     * If the XML configuration file is not specified, default OpenVINO Runtime plugins are loaded from:
      * 1. (dynamic build) default `plugins.xml` file located in the same folder as OpenVINO runtime shared library;
      * 2. (static build) statically defined configuration. In this case path to the .xml file is ignored.
      */

--- a/src/inference/src/cpp/core.cpp
+++ b/src/inference/src/cpp/core.cpp
@@ -10,7 +10,6 @@
 #include "openvino/frontend/manager.hpp"
 #include "openvino/runtime/device_id_parser.hpp"
 #include "openvino/runtime/iremote_context.hpp"
-#include "openvino/util/common_util.hpp"
 #include "openvino/util/file_util.hpp"
 
 namespace ov {
@@ -23,12 +22,9 @@ std::string find_plugins_xml(const std::string& xml_file) {
         // Default plugin xml file name, will search in OV folder.
         xml_file_name = "plugins.xml";
     } else {
-        // User can set any path for plugins xml file but need guarantee security issue if apply file path out of OV
-        // folder.
-        // If the xml file exists or file path contains file separator, return file path;
-        // Else search it in OV folder with no restriction on file name and extension.
-        if (ov::util::file_exists(xml_file_name) ||
-            xml_file_name.find(util::FileTraits<char>().file_separator) != xml_file_name.npos) {
+        // If file path contains file separator, return file path;
+        // Otherwise search it in OV folder with no restriction on file name and extension.
+        if (xml_file_name.find(util::FileTraits<char>().file_separator) != xml_file_name.npos) {
             return xml_file_name;
         }
     }

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -13,7 +13,7 @@
 
 #ifndef OPENVINO_STATIC_LIBRARY
 
-static void create_plugin_xml(const std::string& file_name, const std::string& plugin_name="1") {
+static void create_plugin_xml(const std::string& file_name, const std::string& plugin_name = "1") {
     std::ofstream file(file_name);
 
     file << "<ie><plugins><plugin location=\"";

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -13,7 +13,7 @@
 
 #ifndef OPENVINO_STATIC_LIBRARY
 
-static void create_plugin_xml(const std::string& file_name) {
+static void create_plugin_xml(const std::string& file_name, const std::string& plugin_name="1") {
     std::ofstream file(file_name);
 
     file << "<ie><plugins><plugin location=\"";
@@ -24,7 +24,7 @@ static void create_plugin_xml(const std::string& file_name) {
     file << OV_BUILD_POSTFIX;
     file << ov::util::FileTraits<char>::dot_symbol;
     file << ov::util::FileTraits<char>::library_ext();
-    file << "\" name=\"1\"></plugin></plugins></ie>";
+    file << "\" name=\"" << plugin_name << "\"></plugin></plugins></ie>";
     file.flush();
     file.close();
 }
@@ -76,6 +76,23 @@ TEST(CoreBaseTest, LoadRelativeCWPathPluginXML) {
     create_plugin_xml(xml_file_path);
     EXPECT_NO_THROW(ov::Core core(xml_file_name));
     remove_plugin_xml(xml_file_path);
+}
+
+TEST(CoreBaseTest, LoadOVFolderOverCWPathPluginXML) {
+    std::string xml_file_name = "test_plugin.xml";
+    std::string cwd_file_path =
+        ov::test::utils::getCurrentWorkingDir() + ov::util::FileTraits<char>::file_separator + xml_file_name;
+    std::string ov_file_path =
+        ov::test::utils::getOpenvinoLibDirectory() + ov::util::FileTraits<char>::file_separator + xml_file_name;
+    create_plugin_xml(cwd_file_path);
+    create_plugin_xml(ov_file_path, "2");
+    ov::Core core(xml_file_name);
+    auto version = core.get_versions("2");
+    EXPECT_EQ(1, version.size());
+    version = core.get_versions("1");
+    EXPECT_EQ(0, version.size());
+    remove_plugin_xml(cwd_file_path);
+    remove_plugin_xml(ov_file_path);
 }
 
 #endif


### PR DESCRIPTION
### Details:
 - It may be not secure for software vendors which are using OpenVINO if `custom_plugins.xml` will be loaded from CWD first over OV. So, for now, if `custom_plugins.xml` exists in OV folder, it will be used first. Otherwise, load `custom_plugins.xml` from CWD

Improvement for https://github.com/openvinotoolkit/openvino/pull/22525

### Tickets:
 - CVS-131048