### PR TITLE
[GPU] Defer updating memory of reshape after execution if it is static-shaped and its input memory is null

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -53,7 +53,7 @@ public:
     }
 
     bool is_in_place() const {
-        if (this->is_output() || this->has_fused_primitives() || this->get_users().size() > 1)
+        if (this->is_output() || this->has_fused_primitives())
             return false;
 
         if (has_padding())

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -53,7 +53,7 @@ public:
     }
 
     bool is_in_place() const {
-        if (this->is_output() || this->has_fused_primitives())
+        if (this->is_output() || this->has_fused_primitives() || this->get_users().size() > 1)
             return false;
 
         if (has_padding())

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -763,7 +763,8 @@ void network::allocate_primitives() {
             if (!node->get_dependencies().empty() && opt_inst->dependencies().empty()) {
                 opt_inst->build_deps();
             }
-            opt_inst->update_output_memory();
+            if (opt_inst->input_memory_ptr())
+                opt_inst->update_output_memory();
         }
     }
 

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -422,29 +422,13 @@ void network::set_arguments() {
                 // In that case some_op is static and we may want to set arguments once,
                 // but dynamic optimized out reshape means that output buffer of reshape is unavailable
                 // and attempt to set args will fail.
-                std::function<bool(const std::pair<const primitive_inst*, int32_t>&)> is_dep_output_memory_null;
-                is_dep_output_memory_null = [&](const std::pair<const primitive_inst*, int32_t>& dep) -> bool {
-                    if (dep.first->can_be_optimized()) {
-                        for (auto& dep_dep : dep.first->dependencies()) {
-                            if (dep_dep.first->is_dynamic()) {
-                                return is_dep_output_memory_null(dep_dep);
-                            } else {
-                                if (dep_dep.first->output_memory_ptr() == nullptr)
-                                    return true;
-                            }
-                        }
-                    }
-                    if (dep.first->output_memory_ptr() == nullptr)
-                        return true;
-                    return false;
-                };
 
                 // (dynamic) -> static optimizable reshape -> static optimizable reshape -> some_op
                 // In that case, it is a limit about second reshape.
                 auto prim = dep.first->get_impl_params()->desc;
                 if (dep.first->can_be_optimized() && (dep.first->is_dynamic() ||
-                                                      prim->type == read_value::type_id() ||
-                                                      is_dep_output_memory_null(dep)))
+                                                      dep.first->output_memory_ptr() == nullptr ||
+                                                      prim->type == read_value::type_id()))
                     can_set_args = false;
             }
 

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -423,7 +423,9 @@ void network::set_arguments() {
                 // but dynamic optimized out reshape means that output buffer of reshape is unavailable
                 // and attempt to set args will fail.
                 auto prim = dep.first->get_impl_params()->desc;
-                if (dep.first->can_be_optimized() && (dep.first->is_dynamic() || prim->type == read_value::type_id()))
+                if (dep.first->can_be_optimized() && (dep.first->is_dynamic() ||
+                                                      dep.first->output_memory_ptr() == nullptr ||
+                                                      prim->type == read_value::type_id()))
                     can_set_args = false;
             }
 

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -439,6 +439,8 @@ void network::set_arguments() {
                     return false;
                 };
 
+                // (dynamic) -> static optimizable reshape -> static optimizable reshape -> some_op
+                // In that case, it is a limit about second reshape.
                 auto prim = dep.first->get_impl_params()->desc;
                 if (dep.first->can_be_optimized() && (dep.first->is_dynamic() ||
                                                       prim->type == read_value::type_id() ||
@@ -763,8 +765,7 @@ void network::allocate_primitives() {
             if (!node->get_dependencies().empty() && opt_inst->dependencies().empty()) {
                 opt_inst->build_deps();
             }
-            if (opt_inst->input_memory_ptr())
-                opt_inst->update_output_memory();
+            opt_inst->update_output_memory();
         }
     }
 

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -207,6 +207,9 @@ void reshape_inst::update_output_memory() {
         return;
 
     build_deps();  // reshape need deps
+    if (node->get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer) &&
+        input_memory_ptr() == nullptr)
+        return;
     OPENVINO_ASSERT(input_memory_ptr() != nullptr, "[GPU] Failed to reuse input in ", id(), " primitive: input memory was not allocated");
     _outputs = {_network.get_engine().reinterpret_buffer(input_memory(), _impl_params->get_output_layout())};
 }

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -187,22 +187,16 @@ reshape_inst::typed_primitive_inst(network& network, reshape_node const& node) :
             _outputs = allocate_outputs();
             _mem_allocated = true;
         } else {
-            build_deps();  // reshape need deps
-            if (input_memory_ptr())
-                update_output_memory();
-        }
-    } else {
-        if (_exec_deps.size() > 0 && input_memory_ptr()) {
-            build_deps();  // reshape need deps
             update_output_memory();
         }
+    } else {
+        if (_exec_deps.size() > 0 && input_memory_ptr())
+            update_output_memory();
     }
 }
 
 void reshape_inst::on_execute() {
-    build_deps();  // reshape need deps
-    if (input_memory_ptr())
-        update_output_memory();
+    update_output_memory();
 }
 
 void reshape_inst::update_output_memory() {
@@ -212,6 +206,10 @@ void reshape_inst::update_output_memory() {
     if (_outputs[0] && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;
 
+    build_deps();  // reshape need deps
+    if (node->get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer) &&
+        input_memory_ptr() == nullptr)
+        return;
     OPENVINO_ASSERT(input_memory_ptr() != nullptr, "[GPU] Failed to reuse input in ", id(), " primitive: input memory was not allocated");
     _outputs = {_network.get_engine().reinterpret_buffer(input_memory(), _impl_params->get_output_layout())};
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
@@ -1043,6 +1043,56 @@ TEST(reshape_gpu_f32, basic_dynamic_shape_to_static_optimized_out) {
     }
 }
 
+TEST(reshape_gpu_f32, basic_dynamic_shape_to_static_optimized_out_static_optimized_out) {
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory(layout{ov::PartialShape{1, 2, 10}, data_types::f32, format::bfyx});
+    topology topology;
+    topology.add(input_layout("input", layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx}));
+    topology.add(reshape("reshape_1", input_info("input"), false, {1, 2, 10}, {1, 2, 10}));
+    topology.add(reduce("reduce_1", input_info("reshape_1"), reduce_mode::max, {1}, true));
+    topology.add(reshape("reshape", input_info("reshape_1"), false, {2, 10}, {2, 10}));
+    topology.add(reduce("reduce", input_info("reshape"), reduce_mode::max, {1}, true));
+
+    // clang-format off
+    std::vector<float> input_data = {
+        0.0, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+        0.0, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+    };
+    // clang-format on
+
+    set_values(input, input_data);
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+
+    ASSERT_TRUE(network.get_primitive("reshape")->can_be_optimized());
+
+    ASSERT_EQ(outputs.size(), size_t(2));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
+
+    auto output = outputs.at("reduce").get_memory();
+
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
+    ASSERT_EQ(output->get_layout().format, format::bfyx);
+    ASSERT_TRUE(output->get_layout().is_static());
+    ov::PartialShape expected_shape = {2, 1};
+    ASSERT_EQ(output->get_layout().get_partial_shape(), expected_shape);
+
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    std::vector<float> expected_res = {9.f, 9.f};
+    ASSERT_EQ(output_ptr.size(), expected_res.size());
+
+
+    for (size_t i = 0; i < expected_res.size(); i++) {
+        ASSERT_EQ(expected_res[i], output_ptr[i]);
+    }
+}
+
 TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_activation_fusion) {
     auto& engine = get_test_engine();
 


### PR DESCRIPTION
### Details:
 - *Added a condition to defer reshape memory update*
 - *If the reshape is static shaped and has null dep memory, its memory update will be deferred*

### Tickets:
 - *125236*
