### PR TITLE
[TF FE][Layer tests] Run layer tests for TF FE by default and use_legacy_frontend for legacy FE

### DIFF
--- a/.github/workflows/job_python_unit_tests.yml
+++ b/.github/workflows/job_python_unit_tests.yml
@@ -261,7 +261,7 @@ jobs:
         run: |
           # requires 'unit_tests' from 'mo'
           export PYTHONPATH=${INSTALL_TEST_DIR}/mo
-          python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow_tests/ --use_new_frontend -m precommit_tf_fe -n logical --junitxml=${INSTALL_TEST_DIR}/TEST-tf_fe.xml
+          python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow_tests/ -m precommit_tf_fe -n logical --junitxml=${INSTALL_TEST_DIR}/TEST-tf_fe.xml
         env:
           TEST_DEVICE: CPU
           TEST_PRECISION: FP16
@@ -271,7 +271,7 @@ jobs:
         run: |
           # requires 'unit_tests' from 'mo'
           export PYTHONPATH=${INSTALL_TEST_DIR}/mo
-          python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow2_keras_tests/ --use_new_frontend -m precommit_tf_fe --junitxml=${INSTALL_TEST_DIR}/TEST-tf2_fe.xml
+          python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow2_keras_tests/ -m precommit_tf_fe --junitxml=${INSTALL_TEST_DIR}/TEST-tf2_fe.xml
         env:
           TEST_DEVICE: CPU
           TEST_PRECISION: FP16
@@ -284,11 +284,11 @@ jobs:
 
       - name: TensorFlow 1 Layer Tests - Legacy FE
         if: fromJSON(inputs.affected-components).TF_FE.test
-        run: python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow_tests/test_tf_Roll.py --ir_version=10 --junitxml=${INSTALL_TEST_DIR}/TEST-tf_Roll.xml
+        run: python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow_tests/test_tf_Roll.py --use_legacy_frontend --ir_version=10 --junitxml=${INSTALL_TEST_DIR}/TEST-tf_Roll.xml
 
       - name: TensorFlow 2 Layer Tests - Legacy FE
         if: fromJSON(inputs.affected-components).TF_FE.test
-        run: python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow2_keras_tests/test_tf2_keras_activation.py --ir_version=11 -k "sigmoid" --junitxml=${INSTALL_TEST_DIR}/TEST-tf2_Activation.xml
+        run: python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow2_keras_tests/test_tf2_keras_activation.py --use_legacy_frontend --ir_version=11 -k "sigmoid" --junitxml=${INSTALL_TEST_DIR}/TEST-tf2_Activation.xml
         env:
           TEST_DEVICE: CPU
           TEST_PRECISION: FP16

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -607,7 +607,7 @@ jobs:
         run: |
           :: requires 'unit_tests' from 'tools/mo'
           set PYTHONPATH=${{ env.INSTALL_TEST_DIR }}\mo;%PYTHONPATH%
-          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow_tests/ --use_new_frontend -n logical -m precommit_tf_fe  --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tf_fe.xml
+          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow_tests/ -n logical -m precommit_tf_fe  --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tf_fe.xml
         env:
           TEST_DEVICE: CPU
           TEST_PRECISION: FP16
@@ -619,7 +619,7 @@ jobs:
           :: requires 'unit_tests' from 'tools/mo'
           set PYTHONPATH=${{ env.INSTALL_TEST_DIR }}\mo;%PYTHONPATH%
 
-          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow2_keras_tests/ --use_new_frontend -m precommit_tf_fe --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tf2_fe.xml
+          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow2_keras_tests/ -m precommit_tf_fe --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tf2_fe.xml
         env:
           TEST_DEVICE: CPU
 
@@ -627,13 +627,13 @@ jobs:
         if: fromJSON(needs.smart_ci.outputs.affected_components).TF_FE.test
         shell: cmd
         run: |
-          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow_tests/test_tf_Roll.py --ir_version=10  --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tf_Roll.xml
+          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow_tests/test_tf_Roll.py --use_legacy_frontend --ir_version=10  --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tf_Roll.xml
 
       - name: TensorFlow 2 Layer Tests - Legacy FE
         if: fromJSON(needs.smart_ci.outputs.affected_components).TF_FE.test
         shell: cmd
         run: |
-          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow2_keras_tests/test_tf2_keras_activation.py --ir_version=11 --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tf2_Activation.xml -k "sigmoid"
+          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow2_keras_tests/test_tf2_keras_activation.py --use_legacy_frontend --ir_version=11 --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tf2_Activation.xml -k "sigmoid"
         env:
           TEST_DEVICE: CPU
           TEST_PRECISION: FP16

--- a/src/frontends/tensorflow/README.md
+++ b/src/frontends/tensorflow/README.md
@@ -196,12 +196,12 @@ To set up environment for running the layer tests, follow these [instructions](.
 
 To test the whole suite of the TensorFlow 1 operation set support, run the following command:
 ```bash
-py.test tensorflow_tests --use_new_frontend
+py.test tensorflow_tests
 ```
 
 The command line for one operation:
 ```bash
-py.test tensorflow_tests/test_tf_Unique.py --use_new_frontend
+py.test tensorflow_tests/test_tf_Unique.py
 ```
 
 ## See also

--- a/tests/layer_tests/common/layer_test_class.py
+++ b/tests/layer_tests/common/layer_test_class.py
@@ -26,14 +26,14 @@ class CommonLayerTest:
                            " the specific framework")
 
     def _test(self, framework_model, ref_net, ie_device, precision, ir_version, temp_dir,
-              use_new_frontend=True, infer_timeout=60, enabled_transforms='',
+              use_legacy_frontend=False, infer_timeout=60, enabled_transforms='',
               disabled_transforms='', **kwargs):
         """
         :param enabled_transforms/disabled_transforms: string with idxs of transforms that should be enabled/disabled.
                                                        Example: "transform_1,transform_2"
         """
         model_path = self.produce_model_path(framework_model=framework_model, save_path=temp_dir)
-        self.use_new_frontend = use_new_frontend
+        self.use_legacy_frontend = use_legacy_frontend
         # TODO Pass environment variables via subprocess environment
         os.environ['MO_ENABLED_TRANSFORMS'] = enabled_transforms
         os.environ['MO_DISABLED_TRANSFORMS'] = disabled_transforms
@@ -53,9 +53,7 @@ class CommonLayerTest:
         if 'input_names' in kwargs and len(kwargs['input_names']):
             mo_params.update(dict(input=','.join(kwargs['input_names'])))
 
-        if use_new_frontend:
-            mo_params["use_new_frontend"] = True
-        else:
+        if use_legacy_frontend:
             mo_params["use_legacy_frontend"] = True
 
         exit_code, stderr = generate_ir_python_api(**mo_params)
@@ -83,7 +81,7 @@ class CommonLayerTest:
         ie_engine = InferAPI(model=path_to_xml,
                              weights=path_to_bin,
                              device=ie_device,
-                             use_new_frontend=use_new_frontend)
+                             use_legacy_frontend=use_legacy_frontend)
         # Prepare feed dict
         if 'kwargs_to_prepare_input' in kwargs and kwargs['kwargs_to_prepare_input']:
             inputs_dict = self._prepare_input(ie_engine.get_inputs_info(precision),

--- a/tests/layer_tests/common/layer_utils.py
+++ b/tests/layer_tests/common/layer_utils.py
@@ -33,12 +33,12 @@ class BaseInfer:
         return self.res
 
 class InferAPI(BaseInfer):
-    def __init__(self, model, weights, device, use_new_frontend):
+    def __init__(self, model, weights, device, use_legacy_frontend):
         super().__init__('OpenVINO')
         self.device = device
         self.model = model
         self.weights = weights
-        self.use_new_frontend = use_new_frontend
+        self.use_legacy_frontend = use_legacy_frontend
 
     def fw_infer(self, input_data, config=None):
         print("OpenVINO version: {}".format(ie2_get_version()))
@@ -60,7 +60,7 @@ class InferAPI(BaseInfer):
             # For the new frontend we make this the right way because
             # we know that tensor can have several names due to fusing
             # and one of them the framework uses
-            if self.use_new_frontend:
+            if not self.use_legacy_frontend:
                 for tensor_name in out_obj.get_names():
                     result[tensor_name] = out_tensor
             else:

--- a/tests/layer_tests/common/tf2_layer_test_class.py
+++ b/tests/layer_tests/common/tf2_layer_test_class.py
@@ -32,13 +32,13 @@ class CommonTF2LayerTest(CommonLayerTest):
             return self.get_tf2_keras_results(inputs_dict, model_path)
         else:
             # get results from tflite
-            return get_tflite_results(self.use_new_frontend, inputs_dict, model_path)
+            return get_tflite_results(self.use_legacy_frontend, inputs_dict, model_path)
 
     def get_tf2_keras_results(self, inputs_dict, model_path):
         import tensorflow as tf
 
         result = dict()
-        if self.use_new_frontend:
+        if not self.use_legacy_frontend:
             imported = tf.saved_model.load(model_path)
             f = imported.signatures["serving_default"]
             result = f(**inputs_dict)

--- a/tests/layer_tests/common/tf_layer_test_class.py
+++ b/tests/layer_tests/common/tf_layer_test_class.py
@@ -33,7 +33,7 @@ class CommonTFLayerTest(CommonLayerTest):
         graph_summary = summarize_graph(model_path=model_path)
         outputs_list = graph_summary["outputs"]
         fw_outputs_list = [out + ":0" for out in outputs_list]
-        if self.use_new_frontend:
+        if not self.use_legacy_frontend:
             outputs_list = fw_outputs_list
 
         tf.compat.v1.reset_default_graph()
@@ -61,4 +61,4 @@ class CommonTFLayerTest(CommonLayerTest):
             return self.get_tf_results(inputs_dict, model_path)
         else:
             # get results from tflite
-            return get_tflite_results(self.use_new_frontend, inputs_dict, model_path)
+            return get_tflite_results(self.use_legacy_frontend, inputs_dict, model_path)

--- a/tests/layer_tests/common/tflite_layer_test_class.py
+++ b/tests/layer_tests/common/tflite_layer_test_class.py
@@ -44,7 +44,7 @@ class TFLiteLayerTest(CommonLayerTest):
         return self.model_path
 
     def get_framework_results(self, inputs_dict, model_path):
-        return get_tflite_results(self.use_new_frontend, inputs_dict, model_path)
+        return get_tflite_results(self.use_legacy_frontend, inputs_dict, model_path)
 
     def check_tflite_model_has_only_allowed_ops(self):
         if self.allowed_ops is None:

--- a/tests/layer_tests/common/tflite_layer_test_class.py
+++ b/tests/layer_tests/common/tflite_layer_test_class.py
@@ -77,4 +77,4 @@ class TFLiteLayerTest(CommonLayerTest):
         model = self.make_model(params)
         self.model_path = self.produce_tflite_model(model, temp_dir)
         self.check_tflite_model_has_only_allowed_ops()
-        super()._test(model, None, ie_device, precision, None, temp_dir, True, **params)
+        super()._test(model, None, ie_device, precision, None, temp_dir, False, **params)

--- a/tests/layer_tests/common/utils/tf_utils.py
+++ b/tests/layer_tests/common/utils/tf_utils.py
@@ -130,16 +130,16 @@ def summarize_graph(model_path, output_nodes_for_freeze=None, reshape_net=None):
     return result
 
 
-def permute_nhwc_to_nchw(shape, use_new_frontend=False):
-    if use_new_frontend:
+def permute_nhwc_to_nchw(shape, use_legacy_frontend=True):
+    if not use_legacy_frontend:
         return shape
     perm = PermuteAttrs.get_nhwc_to_nchw_permutation(len(shape)).perm
     new_shape = np.array(shape)[perm]
     return new_shape
 
 
-def permute_nchw_to_nhwc(shape, use_new_frontend=False):
-    if use_new_frontend:
+def permute_nchw_to_nhwc(shape, use_legacy_frontend=True):
+    if not use_legacy_frontend:
         return shape
     perm = PermuteAttrs.get_nchw_to_nhwc_permutation(len(shape)).perm
     new_shape = np.array(shape)[perm]

--- a/tests/layer_tests/common/utils/tflite_utils.py
+++ b/tests/layer_tests/common/utils/tflite_utils.py
@@ -80,7 +80,7 @@ def save_pb_to_tflite(pb_model):
     return tflite_model_path
 
 
-def get_tflite_results(use_new_frontend, inputs_dict, model_path):
+def get_tflite_results(use_legacy_frontend, inputs_dict, model_path):
     interpreter = tf.compat.v1.lite.Interpreter(model_path=model_path)
     interpreter.allocate_tensors()
     input_details = interpreter.get_input_details()

--- a/tests/layer_tests/conftest.py
+++ b/tests/layer_tests/conftest.py
@@ -61,10 +61,10 @@ def pytest_addoption(parser):
         action="store",
         help="Version of IR to generate by Model Optimizer")
     parser.addoption(
-        "--use_new_frontend",
+        "--use_legacy_frontend",
         required=False,
         action="store_true",
-        help="Use Model Optimizer with new FrontEnd")
+        help="Use Model Optimizer with legacy FrontEnd")
     parser.addoption(
         "--tflite",
         required=False,
@@ -79,9 +79,9 @@ def ir_version(request):
 
 
 @pytest.fixture(scope="session")
-def use_new_frontend(request):
+def use_legacy_frontend(request):
     """Fixture function for command-line option."""
-    return request.config.getoption('use_new_frontend')
+    return request.config.getoption('use_legacy_frontend')
 
 
 @pytest.fixture(scope="session")

--- a/tests/layer_tests/mo_python_api_tests/test_mo_convert_complex_params.py
+++ b/tests/layer_tests/mo_python_api_tests/test_mo_convert_complex_params.py
@@ -187,7 +187,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_mo_convert_tf_model(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend):
+                                 temp_dir, use_legacy_frontend):
         tf_net_path = self.create_tf_model(temp_dir)
 
         test_params = params['params_test']
@@ -221,7 +221,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_mo_convert_tf_model_no_concat(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend):
+                                 temp_dir, use_legacy_frontend):
         tf_net_path = self.create_tf_model_no_concat(temp_dir)
 
         test_params = params['params_test']
@@ -310,7 +310,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_tf_model_single_input_output(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_new_frontend):
+                                                     temp_dir, use_legacy_frontend):
         tf_net_path = self.create_tf_model_single_input_output(temp_dir)
 
         test_params = params['params_test']
@@ -323,7 +323,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_clearing_transformation_registry(self, ie_device, precision, ir_version,
-                                                         temp_dir, use_new_frontend):
+                                                         temp_dir, use_legacy_frontend):
         tf_net_path = self.create_tf_model_single_input_output(temp_dir)
         from openvino.tools.mo import convert_model
 

--- a/tests/layer_tests/mo_python_api_tests/test_mo_convert_extensions.py
+++ b/tests/layer_tests/mo_python_api_tests/test_mo_convert_extensions.py
@@ -113,7 +113,7 @@ class TestExtensions(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_extensions(self, params, ie_device, precision, ir_version,
-                                   temp_dir, use_new_frontend):
+                                   temp_dir, use_legacy_frontend):
         onnx_net_path = self.create_onnx_model(temp_dir)
 
         test_params = params['params_test']

--- a/tests/layer_tests/mo_python_api_tests/test_mo_convert_pytorch.py
+++ b/tests/layer_tests/mo_python_api_tests/test_mo_convert_pytorch.py
@@ -1011,7 +1011,7 @@ class TestMoConvertPyTorch(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_import_from_memory(self, create_model, ie_device, precision, ir_version,
-                                   temp_dir, use_new_frontend):
+                                   temp_dir, use_legacy_frontend):
         fw_model, graph_ref, mo_params = create_model(temp_dir)
 
         test_params = {'input_model': fw_model}
@@ -1240,7 +1240,7 @@ class TestPrecisionSensitive():
                                                                                                      'aarch64',
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 122714, 122710')
-    def test_precision_sensitive(self, create_model, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_precision_sensitive(self, create_model, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         import numpy.testing as npt
         from pathlib import Path
 

--- a/tests/layer_tests/ovc_python_api_tests/test_complex_params.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_complex_params.py
@@ -110,7 +110,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_mo_convert_tf_model(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend):
+                                 temp_dir, use_legacy_frontend):
         tf_net_path = self.create_tf_model(temp_dir)
 
         test_params = params['params_test']
@@ -150,7 +150,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_tf_model_single_input_output(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_new_frontend):
+                                                     temp_dir, use_legacy_frontend):
         tf_net_path = self.create_tf_model_single_input_output(temp_dir)
 
         test_params = params['params_test']
@@ -259,7 +259,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_ovc_convert_model_with_comma_in_names(self, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         onnx_net_path = self.create_onnx_model_with_comma_in_names(temp_dir)
         ref_model = self.create_ref_graph_with_comma_in_names()
         test_params = {'input_model': onnx_net_path, 'output': 'relu_1,relu_2'}
@@ -269,7 +269,7 @@ class TestComplexParams(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_ovc_convert_model_with_several_output(self, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         onnx_net_path = self.create_onnx_model_with_several_outputs(temp_dir)
         convert_model_params = {'input_model': onnx_net_path, 'output': ['Relu_1_data', 'concat']}
         cli_tool_params = {'input_model': onnx_net_path, 'output': 'Relu_1_data,concat'}

--- a/tests/layer_tests/ovc_python_api_tests/test_extensions.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_extensions.py
@@ -113,7 +113,7 @@ class TestExtensions(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_convert_extensions(self, params, ie_device, precision, ir_version,
-                                   temp_dir, use_new_frontend):
+                                   temp_dir, use_legacy_frontend):
         onnx_net_path = self.create_onnx_model(temp_dir)
 
         test_params = params['params_test']

--- a/tests/layer_tests/ovc_python_api_tests/test_paddle.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_paddle.py
@@ -126,7 +126,7 @@ class TestPaddleConversionParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conversion_params(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend):
+                                 temp_dir, use_legacy_frontend):
         fw_model = params['fw_model']
         test_params = params['params_test']
         ref_model = params['ref_model']

--- a/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
@@ -1077,7 +1077,7 @@ class TestMoConvertPyTorch(CommonMOConvertTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mo_import_from_memory(self, create_model, ie_device, precision, ir_version,
-                                   temp_dir, use_new_frontend):
+                                   temp_dir, use_legacy_frontend):
         fw_model, graph_ref, mo_params = create_model(temp_dir)
 
         test_params = {'input_model': fw_model}
@@ -1231,7 +1231,7 @@ class TestPytorchConversionParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conversion_params(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend):
+                                 temp_dir, use_legacy_frontend):
         fw_model = params['fw_model']
         test_params = params['params_test']
         ref_model = params['ref_model']

--- a/tests/layer_tests/ovc_python_api_tests/test_tf.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_tf.py
@@ -1066,7 +1066,7 @@ class TestTFConversionParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_mo_convert_tf_model(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend):
+                                 temp_dir, use_legacy_frontend):
         fw_model = params['fw_model']
         test_params = params['params_test']
         ref_model = params['ref_model']

--- a/tests/layer_tests/tensorflow2_keras_tests/conftest.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/conftest.py
@@ -27,6 +27,6 @@ def rename_tf_fe_libs(request):
 
     tf_fe_lib_names = ['libopenvino_tensorflow_fe', 'libopenvino_tensorflow_frontend']
 
-    if request.config.getoption('use_new_frontend'):
+    if request.config.getoption('use_legacy_frontend'):
         log.info('Using new frontend...')
         copy_files_by_pattern(openvino_lib_path, tf_fe_lib_names[0], tf_fe_lib_names[1])

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
@@ -70,7 +70,7 @@ class TestKerasActivation(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_keras_activation_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
@@ -33,10 +33,10 @@ class TestKerasActivityRegularization(CommonTF2LayerTest):
     @pytest.mark.precommit
     def test_keras_activity_regularization_case1_float32(self, params, ie_device, precision,
                                                          ir_version, temp_dir,
-                                                         use_new_frontend):
+                                                         use_legacy_frontend):
         self._test(*self.create_keras_activity_regularization_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [
         dict(l1_param=0.07, l2_param=0.05, input_names=["x1"], input_shapes=[[1]],

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
@@ -92,10 +92,10 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_add_float32_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -110,10 +110,10 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_add_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
         dict(input_names=["x1", "x2", "x3"],
@@ -124,10 +124,10 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.precommit
     def test_keras_add_float32_several_inputs_precommit(self, params, ie_device, precision,
                                                         ir_version, temp_dir,
-                                                        use_new_frontend):
+                                                        use_legacy_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
                                              input_shapes=[[5, 4], [5, 4], [5, 4]],
@@ -147,7 +147,7 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_add_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                              temp_dir, use_new_frontend):
+                                              temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
@@ -34,10 +34,10 @@ class TestKerasAdditiveAttention(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_additive_attention_float32_case1(self, params, ie_device, precision, ir_version,
-                                                    temp_dir, use_new_frontend):
+                                                    temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [
         dict(use_scale=False, causal=True, dropout=0.5,
@@ -69,7 +69,7 @@ class TestKerasAdditiveAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_additive_attention_float32_case2(self, params, ie_device, precision, ir_version,
-                                                    temp_dir, use_new_frontend):
+                                                    temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
@@ -29,10 +29,10 @@ class TestKerasAlphaDropout(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_keras_alpha_dropout_case1_float32(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_new_frontend):
+                                                     temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [dict(rate=0.5, input_names=["x1"], input_shapes=[[1]],
                                        input_type=tf.float32),
@@ -48,7 +48,7 @@ class TestKerasAlphaDropout(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_keras_alpha_dropout_case2_float32(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_new_frontend):
+                                                     temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
@@ -32,10 +32,10 @@ class TestKerasAttention(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_attention_float32_case1(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [
         dict(use_scale=False, causal=True, dropout=0.0,
@@ -68,7 +68,7 @@ class TestKerasAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_attention_float32_case2(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
@@ -40,10 +40,10 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_average_case1_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[1], [1]],
                                        input_type=tf.float32),
@@ -59,10 +59,10 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_average_case2_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_several_inputs = [
         dict(input_names=["x1", "x2", "x3"], input_shapes=[[1], [1], [1]], input_type=tf.float32),
@@ -76,7 +76,7 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_average_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
@@ -34,10 +34,10 @@ class TestKerasAveragePooling1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_1D_case1_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_new_frontend):
+                                             temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [
         dict(pool_size=3, strides=None, padding='same', data_format='channels_first',
@@ -50,7 +50,7 @@ class TestKerasAveragePooling1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_1D_case2_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_new_frontend):
+                                             temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
@@ -34,10 +34,10 @@ class TestKerasAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_2D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend):
+                                       use_legacy_frontend):
         self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [
         dict(pool_size=(3, 3), strides=None, padding='same', data_format='channels_last',
@@ -53,7 +53,7 @@ class TestKerasAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_2D_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
@@ -33,10 +33,10 @@ class TestKerasAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_3D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend):
+                                       use_legacy_frontend):
         self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [
         dict(pool_size=(3, 3, 3), strides=None, padding='same', data_format='channels_last',
@@ -52,7 +52,7 @@ class TestKerasAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_3D_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
@@ -34,11 +34,11 @@ class TestKerasBatchNormalization(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_batch_normalization_float32(self, params, ie_device, precision, ir_version,
-                                               temp_dir, use_new_frontend):
+                                               temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [dict(axis=1, momentum=0.5, epsilon=1e-4, center=True, scale=False,
                                        input_names=["x1"], input_shapes=[[3, 4]],
@@ -58,7 +58,7 @@ class TestKerasBatchNormalization(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_batch_normalization_extended_float32(self, params, ie_device, precision,
-                                                        ir_version, temp_dir, use_new_frontend):
+                                                        ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
@@ -46,7 +46,7 @@ class TestKerasBidirectional(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_bidirectional_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_keras_bidirectional_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
@@ -33,11 +33,11 @@ class TestKerasConcatenate(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_concatenate_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend):
+                                       use_legacy_frontend):
         self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_extended_float32 = [
         dict(axis=-1, input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -58,8 +58,8 @@ class TestKerasConcatenate(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_concatenate_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
@@ -61,8 +61,8 @@ class TestKerasConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_conv1d_net(**params, ir_version=ir_version), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
@@ -67,8 +67,8 @@ class TestKerasConv1DTranspose(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(reason="Needs tensorflow 2.3.0.")
     def test_keras_conv_1d_case1_transpose_float32(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_new_frontend):
+                                                   temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_conv1d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
@@ -60,8 +60,8 @@ class TestKerasConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_conv2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
@@ -65,8 +65,8 @@ class TestKerasConv2DTranspose(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_2d_transpose_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_new_frontend):
+                                             temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_conv_2d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
@@ -63,7 +63,7 @@ class TestKerasConv3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_3d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_conv3d_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
@@ -65,8 +65,8 @@ class TestKerasConv3DTranspose(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_3D_transpose_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_new_frontend):
+                                             temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_conv_3d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
@@ -54,8 +54,8 @@ class TestKerasConvLSTM2D(CommonTF2LayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_keras_conv_lstm_2d_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_keras_conv_lstm_2d_net(**params), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
@@ -34,7 +34,7 @@ class TestKerasCropping1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend):
+                                       use_legacy_frontend):
         self._test(*self.create_keras_cropping_1d_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
@@ -36,8 +36,8 @@ class TestKerasCropping2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend):
+                                       use_legacy_frontend):
         self._test(*self.create_keras_cropping_2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
@@ -36,8 +36,8 @@ class TestKerasCropping3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_3d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend):
+                                       use_legacy_frontend):
         self._test(*self.create_keras_cropping_3d_net(**params, ir_version=ir_version), ie_device,
                    precision,
                    temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
@@ -43,10 +43,10 @@ class TestKerasDense(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dense_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_activation = [
         dict(input_names=["x"], input_shapes=[[5, 4]], input_type=tf.float32, units=1,
@@ -67,7 +67,7 @@ class TestKerasDense(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
@@ -52,10 +52,10 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dconv2D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_use_bias_true = [
         dict(input_names=["x"], input_shapes=[[5, 7, 3, 3]], input_type=tf.float32, kernel_size=1,
@@ -78,10 +78,10 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_use_bias_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_activations = [
         dict(input_names=["x"], input_shapes=[[5, 7, 16, 3]], input_type=tf.float32, kernel_size=1,
@@ -104,7 +104,7 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activations_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend):
+                                       use_legacy_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
@@ -44,10 +44,10 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_normalize_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_difficult_axes_float32 = [
         dict(input_names=["x", "y"], input_shapes=[[5, 4, 4], [5, 4, 4]], input_type=tf.float32,
@@ -70,10 +70,10 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_difficult_axes_float32(self, params, ie_device, precision, temp_dir,
-                                              ir_version, use_new_frontend):
+                                              ir_version, use_legacy_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_normalize_higher_rank = [
         dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
@@ -99,7 +99,7 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_normalize_higher_rank(self, params, ie_device, precision, temp_dir,
-                                             ir_version, use_new_frontend):
+                                             ir_version, use_legacy_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
@@ -33,10 +33,10 @@ class TestKerasDropout(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [
         dict(input_names=["x"], input_shapes=[[5, 2]], input_type=tf.float32, rate=0.1,
@@ -56,7 +56,7 @@ class TestKerasDropout(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
@@ -107,10 +107,10 @@ class TestKerasELU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [
         dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, alpha=1.0),
@@ -121,10 +121,10 @@ class TestKerasELU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_alpha2 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
                                      input_type=tf.float32, alpha=2.0),
@@ -140,7 +140,7 @@ class TestKerasELU(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="51109")
     def test_keras_elu_float32_alpha2(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -41,10 +41,10 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_mask_zero_false = [
         dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
@@ -61,7 +61,7 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_emb_without_zero_mask_float32(self, params, ie_device, precision, ir_version,
-                                                 temp_dir, use_new_frontend):
+                                                 temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
@@ -35,7 +35,7 @@ class TestKerasFlatten(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_flatten_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_flatten_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
@@ -35,7 +35,7 @@ class TestKerasGlobalAvgPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling1D_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_global_avg_pooling1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
@@ -34,7 +34,7 @@ class TestKerasGlobalAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling2D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, use_new_frontend):
+                                                ir_version, use_legacy_frontend):
         self._test(*self.create_keras_global_avg_pooling2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
@@ -34,7 +34,7 @@ class TestKerasGlobalAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling3D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, use_new_frontend):
+                                                ir_version, use_legacy_frontend):
         self._test(*self.create_keras_global_avg_pooling3D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
@@ -35,7 +35,7 @@ class TestKerasGlobalMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_max_pooling1D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, use_new_frontend):
+                                                ir_version, use_legacy_frontend):
         self._test(*self.create_keras_global_max_pooling1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
@@ -35,7 +35,7 @@ class TestKerasGlobalMaxPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_max_pooling2D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, use_new_frontend):
+                                                ir_version, use_legacy_frontend):
         self._test(*self.create_keras_global_maxpool2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
@@ -34,7 +34,7 @@ class TestKerasGlobalMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_maxpool3D_float32(self, params, ie_device, precision, temp_dir,
-                                            ir_version, use_new_frontend):
+                                            ir_version, use_legacy_frontend):
         self._test(*self.create_keras_global_maxpool3D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
@@ -56,10 +56,10 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_gru_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_without_bias = [
         dict(input_names=["x"], input_shapes=[[2, 2, 7]], input_type=tf.float32, units=1,
@@ -77,10 +77,10 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_without_bias_float32(self, params, ie_device, precision, temp_dir,
-                                            ir_version, use_new_frontend):
+                                            ir_version, use_legacy_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_different_flags = [
         dict(input_names=["x"], input_shapes=[[2, 3, 2]], input_type=tf.float32, units=1,
@@ -104,10 +104,10 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                     use_new_frontend):
+                                     use_legacy_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_zero_recurrent_dropout = [
         dict(input_names=["x"], input_shapes=[[8, 2, 3]], input_type=tf.float32, units=3,
@@ -130,7 +130,7 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.xfail(reason="50176")
     def test_keras_gru_flags_zero_recurrent_dropout_float32(self, params, ie_device, precision,
                                                             temp_dir, ir_version,
-                                                            use_new_frontend):
+                                                            use_legacy_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
@@ -50,7 +50,7 @@ class TestKerasGRUCell(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49537")
     def test_keras_grucell_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_grucell_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
@@ -80,7 +80,7 @@ class TestKerasLambda(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lambda_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_keras_lambda_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
@@ -33,10 +33,10 @@ class TestKerasLayerNormalization(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_keras_lnorm_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [
         dict(input_names=["x"], input_shapes=[[5, 10]], input_type=tf.float32, axis=1, epsilon=1e-6,

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
@@ -33,7 +33,7 @@ class TestKerasLeakyRelu(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_leaky_relu_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_keras_leaky_relu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
@@ -49,10 +49,10 @@ class TestKerasLocallyConnected1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected1D_float32(self, params, ie_device, precision, temp_dir,
-                                               ir_version, use_new_frontend):
+                                               ir_version, use_legacy_frontend):
         self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_simple_channels_first = [
         dict(input_names=["x"], input_shapes=[[5, 14, 14]], input_type=tf.float32, filters=3,
@@ -74,7 +74,7 @@ class TestKerasLocallyConnected1D(CommonTF2LayerTest):
     @pytest.mark.precommit
     def test_keras_locally_connected1D_channels_first_float32(self, params, ie_device, precision,
                                                               temp_dir, ir_version,
-                                                              use_new_frontend):
+                                                              use_legacy_frontend):
         self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
@@ -49,10 +49,10 @@ class TestKerasLocallyConnected2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected2D_float32(self, params, ie_device, precision, temp_dir,
-                                               ir_version, use_new_frontend):
+                                               ir_version, use_legacy_frontend):
         self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_simple_channels_first = [
         dict(input_names=["x"], input_shapes=[[5, 7, 7, 4]], input_type=tf.float32, filters=3,
@@ -74,7 +74,7 @@ class TestKerasLocallyConnected2D(CommonTF2LayerTest):
     @pytest.mark.precommit
     def test_keras_locally_connected2D_channels_first_float32(self, params, ie_device, precision,
                                                               temp_dir, ir_version,
-                                                              use_new_frontend):
+                                                              use_legacy_frontend):
         self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
@@ -56,10 +56,10 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_lstm_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                          use_new_frontend):
+                                          use_legacy_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_without_bias = [
         dict(input_names=["x"], input_shapes=[[2, 2, 7]], input_type=tf.float32, units=1,
@@ -79,10 +79,10 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_without_bias_float32(self, params, ie_device, precision, temp_dir,
-                                             ir_version, use_new_frontend):
+                                             ir_version, use_legacy_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_different_flags = [
         dict(input_names=["x"], input_shapes=[[2, 3, 2]], input_type=tf.float32, units=1,
@@ -100,7 +100,7 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
@@ -54,7 +54,7 @@ class TestKerasLSTMCell(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49537")
     def test_keras_lstmcell_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_lstmcell_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
@@ -37,7 +37,7 @@ class TestKerasMasking(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49567")
     def test_keras_masking_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_masking_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
@@ -92,10 +92,10 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -110,10 +110,10 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
         dict(input_names=["x1", "x2", "x3"],
@@ -123,10 +123,10 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_several_inputs = [
         dict(input_names=["x1", "x2", "x3"],
@@ -145,7 +145,7 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
@@ -44,10 +44,10 @@ class TestKerasMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool1D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, use_new_frontend):
+                                                  ir_version, use_legacy_frontend):
         self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_p_dformat_float32 = [
         dict(input_names=["x"], input_shapes=[[5, 6, 1]], input_type=tf.float32, pool_size=1,
@@ -64,7 +64,7 @@ class TestKerasMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool1D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
-                                                     ir_version, use_new_frontend):
+                                                     ir_version, use_legacy_frontend):
         self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
@@ -49,7 +49,7 @@ class TestKerasMaxPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool2D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, use_new_frontend):
+                                                  ir_version, use_legacy_frontend):
         self._test(*self.create_keras_maxpool2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
@@ -45,10 +45,10 @@ class TestKerasMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool3D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, use_new_frontend):
+                                                  ir_version, use_legacy_frontend):
         self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_p_dformat_float32 = [
         dict(input_names=["x"], input_shapes=[[2, 2, 4, 6, 8]], input_type=tf.float32, pool_size=1,
@@ -65,7 +65,7 @@ class TestKerasMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool3D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
-                                                     ir_version, use_new_frontend):
+                                                     ir_version, use_legacy_frontend):
         self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
@@ -92,10 +92,10 @@ class TestKerasMinimum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -110,10 +110,10 @@ class TestKerasMinimum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
         dict(input_names=["x1", "x2", "x3"],
@@ -145,7 +145,7 @@ class TestKerasMinimum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_minimum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
@@ -80,10 +80,10 @@ class TestKerasMultiHeadAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.precommit
     def test_keras_multiheadattention(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests to cover no bias cases
     test_data_no_bias = [
@@ -108,7 +108,7 @@ class TestKerasMultiHeadAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_no_bias)
     @pytest.mark.nightly
     def test_keras_multiheadattention_no_bias(self, params, ie_device, precision, ir_version,
-                                              temp_dir, use_new_frontend):
+                                              temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
@@ -92,10 +92,10 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -110,10 +110,10 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
         dict(input_names=["x1", "x2", "x3"],
@@ -123,10 +123,10 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_new_frontend):
+                                                   temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
                                              input_shapes=[[5, 4], [5, 4], [5, 4]],
@@ -146,7 +146,7 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_new_frontend):
+                                                   temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
@@ -31,7 +31,7 @@ class TestKerasPermute(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_permute_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_permute_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
@@ -28,10 +28,10 @@ class TestKerasPReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [
         dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, shared_axes=None),
@@ -44,10 +44,10 @@ class TestKerasPReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32_shared_axes = [
         dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, shared_axes=[1]),
@@ -60,7 +60,7 @@ class TestKerasPReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_shared_axes)
     @pytest.mark.nightly
     def test_keras_prelu_float32_shared_axes(self, params, ie_device, precision, ir_version,
-                                             temp_dir, use_new_frontend):
+                                             temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
@@ -54,10 +54,10 @@ class TestKerasRelu(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend):
+                                use_legacy_frontend):
         self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
                               input_type=tf.float32),
@@ -71,7 +71,7 @@ class TestKerasRelu(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend):
+                                use_legacy_frontend):
         self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
@@ -30,7 +30,7 @@ class TestKerasRepeatVector(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_repeatvector(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend):
+                                use_legacy_frontend):
         self._test(*self.create_keras_repeatvector_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
@@ -34,7 +34,7 @@ class TestKerasReshape(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_reshape(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         self._test(*self.create_keras_reshape_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
@@ -60,10 +60,10 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_rnn(self, params, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend):
+                       use_legacy_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for default parameter values
     test_data_multiple_outputs = [
@@ -82,10 +82,10 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_multiple_outputs)
     @pytest.mark.nightly
     def test_keras_rnn_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend):
+                                        use_legacy_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for other attributes: go_backward and time_major
     test_data_others = [
@@ -104,7 +104,7 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_others)
     @pytest.mark.nightly
     def test_keras_rnn_others(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend):
+                              use_legacy_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
@@ -41,9 +41,9 @@ class TestKerasRoll(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_keras_roll(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend):
+                        use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_keras_roll_net(**params, ir_version=ir_version), ie_device,
                    precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
@@ -47,10 +47,10 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_separableconv1d(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for different activations
     test_data_different_activations = [
@@ -81,10 +81,10 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_activations(self, params, ie_device, precision,
                                                          ir_version, temp_dir,
-                                                         use_new_frontend):
+                                                         use_legacy_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for different padding
     test_data_different_padding = [
@@ -102,10 +102,10 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_padding)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_padding(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_new_frontend):
+                                                     temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for different bias
     test_data_different_bias = [
@@ -120,7 +120,7 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_bias)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_bias(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
@@ -50,10 +50,10 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_separableconv2d(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for different activations
     test_data_different_activations = [
@@ -86,10 +86,10 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_activations(self, params, ie_device, precision,
                                                          ir_version, temp_dir,
-                                                         use_new_frontend):
+                                                         use_legacy_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for different padding
     test_data_different_padding = [
@@ -104,10 +104,10 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_padding)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_padding(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, use_new_frontend):
+                                                     temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for different bias
     test_data_different_bias = [
@@ -123,7 +123,7 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_bias)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_bias(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
@@ -57,10 +57,10 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_simplernn_different_activations(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_new_frontend):
+                                                   temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for RNN with dropout
     test_data_dropout = [
@@ -77,10 +77,10 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_dropout)
     @pytest.mark.nightly
     def test_keras_simplernn_dropout(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend):
+                                     use_legacy_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for RNN with other attributes
     test_data_other = [
@@ -97,10 +97,10 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_other)
     @pytest.mark.nightly
     def test_keras_simplernn_other(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     # Tests for RNN with multiple outputs
     test_data_multipleoutput = [
@@ -125,7 +125,7 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_multipleoutput)
     @pytest.mark.nightly
     def test_keras_simplernn_test_data_multipleoutput(self, params, ie_device, precision,
-                                                      ir_version, temp_dir, use_new_frontend):
+                                                      ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
@@ -54,10 +54,10 @@ class TestKerasSoftmax(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
                               input_type=tf.float32),
@@ -71,7 +71,7 @@ class TestKerasSoftmax(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
@@ -55,10 +55,10 @@ class TestKerasSoftplus(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49516")
     def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
                          dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32),
@@ -73,7 +73,7 @@ class TestKerasSoftplus(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49516")
     def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
@@ -31,7 +31,7 @@ class TestKerasSpatialDropout1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout1d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_spatialdropout1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
@@ -34,10 +34,10 @@ class TestKerasSpatialDropout2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout2d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_channels_first = [
         dict(input_names=["x1"], input_shapes=[[4, 3, 2, 1]], input_type=tf.float32, rate=0.0,
@@ -51,7 +51,7 @@ class TestKerasSpatialDropout2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_spatialdropout2d_channels_first(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_new_frontend):
+                                                   temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
@@ -34,10 +34,10 @@ class TestKerasSpatialDropout3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout3d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_channels_first = [
         dict(input_names=["x1"], input_shapes=[[3, 2, 3, 4, 5]], input_type=tf.float32, rate=0.0,
@@ -51,7 +51,7 @@ class TestKerasSpatialDropout3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_spatialdropout3d_channels_first(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, use_new_frontend):
+                                                   temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
@@ -42,7 +42,7 @@ class TestKerasStackedRNNCells(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_stackedrnncells_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
@@ -62,10 +62,10 @@ class TestKerasSubtract(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -80,7 +80,7 @@ class TestKerasSubtract(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
@@ -54,10 +54,10 @@ class TestKerasSWish(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
                          dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32),
@@ -70,7 +70,7 @@ class TestKerasSWish(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
@@ -28,10 +28,10 @@ class TestKerasThresholdedReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
     def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data = [
         dict(input_names=["x1"], input_shapes=[[5, 2]], input_type=tf.float32, theta=0.0),
@@ -43,7 +43,7 @@ class TestKerasThresholdedReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
@@ -37,7 +37,7 @@ class TestKerasTimeDistributed(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_timedistributed(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_keras_timedistributed_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
@@ -32,7 +32,7 @@ class TestKerasUpSampling1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_upsampling1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend):
+                                        use_legacy_frontend):
         self._test(*self.create_keras_upsampling1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -53,8 +53,8 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     def test_keras_upsampling2d_nearest(self, params, input_type, data_format, interpolation,
                                         ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend):
+                                        use_legacy_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, input_type=input_type, data_format=data_format,
                                                        interpolation=interpolation, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
@@ -35,10 +35,10 @@ class TestKerasUpSampling3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_upsampling3(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_channels_first = [
         pytest.param(
@@ -54,7 +54,7 @@ class TestKerasUpSampling3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
-                                               temp_dir, use_new_frontend):
+                                               temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
@@ -31,7 +31,7 @@ class TestKerasZeroPadding1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_zeropadding1d(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_keras_zeropadding1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
@@ -51,7 +51,7 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_zeropadding2d_channels_first(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
@@ -34,10 +34,10 @@ class TestKerasZeroPadding3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_zeropadding3d_channels_last(self, params, ie_device, precision, ir_version,
-                                               temp_dir, use_new_frontend):
+                                               temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)
 
     test_data_channels_first = [
         dict(input_names=["x1"], input_shapes=[[1, 3, 8, 4, 5]], input_type=tf.float32,
@@ -51,7 +51,7 @@ class TestKerasZeroPadding3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_zeropadding3d_channels_first(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
@@ -53,9 +53,9 @@ class TestMapFN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_basic)
     @pytest.mark.precommit
     @pytest.mark.nightly
-    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)
 
     test_multiple_inputs = [
@@ -71,9 +71,9 @@ class TestMapFN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_multiple_inputs)
     @pytest.mark.nightly
-    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)
 
     test_multiple_outputs = [
@@ -91,9 +91,9 @@ class TestMapFN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_multiple_outputs)
     @pytest.mark.nightly
-    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)
 
     test_multiple_inputs_outputs_int32 = [
@@ -113,7 +113,7 @@ class TestMapFN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_multiple_inputs_outputs_int32)
     @pytest.mark.nightly
     def test_multiple_inputs_outputs_int32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)

--- a/tests/layer_tests/tensorflow_tests/conftest.py
+++ b/tests/layer_tests/tensorflow_tests/conftest.py
@@ -29,6 +29,6 @@ def rename_tf_fe_libs(request):
 
     tf_fe_lib_names = ['libopenvino_tensorflow_fe', 'libopenvino_tensorflow_frontend']
 
-    if request.config.getoption('use_new_frontend'):
-        log.info('Using new frontend...')
+    if request.config.getoption('use_legacy_frontend'):
+        log.info('Using legacy frontend...')
         copy_files_by_pattern(openvino_lib_path, tf_fe_lib_names[0], tf_fe_lib_names[1])

--- a/tests/layer_tests/tensorflow_tests/test_tf_Add.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Add.py
@@ -5,54 +5,27 @@ import numpy as np
 import pytest
 
 from common.tf_layer_test_class import CommonTFLayerTest
-from common.utils.tf_utils import permute_nchw_to_nhwc
 
 
 class TestAdd(CommonTFLayerTest):
-    def create_add_placeholder_const_net(self, x_shape, y_shape, ir_version, use_legacy_frontend):
-        """
-            Tensorflow net                  IR net
-
-            Placeholder->Add       =>       Placeholder->Add
-                         /                               /
-            Const-------/                   Const-------/
-
-        """
-
+    def create_add_placeholder_const_net(self, x_shape, y_shape, use_legacy_frontend):
         import tensorflow as tf
-
         tf.compat.v1.reset_default_graph()
 
         # Create the graph and model
         with tf.compat.v1.Session() as sess:
-            tf_x_shape = x_shape.copy()
-            tf_y_shape = y_shape.copy()
-
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
-            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_legacy_frontend)
-
-            x = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
-            constant_value = np.random.randint(-256, 256, tf_y_shape).astype(np.float32)
+            x = tf.compat.v1.placeholder(tf.float32, x_shape, 'Input')
+            constant_value = np.random.randint(-256, 256, y_shape).astype(np.float32)
             if (constant_value == 0).all():
                 # Avoid elimination of the layer from IR
                 constant_value = constant_value + 1
             y = tf.constant(constant_value)
-
-            add = tf.add(x, y, name="Operation")
-            add_shape = add.shape.as_list()
+            tf.add(x, y, name="Operation")
 
             tf.compat.v1.global_variables_initializer()
             tf_net = sess.graph_def
 
-        #
-        #   Create reference IR net
-        #   Please, specify 'type': 'Input' for input node
-        #   Moreover, do not forget to validate ALL layer attributes!!!
-        #
-
-        ref_net = None
-
-        return tf_net, ref_net
+        return tf_net, None
 
     # TODO: implement tests for 2 Consts + Add
 
@@ -65,8 +38,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_add_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_add_placeholder_const_net(**params, use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -82,7 +54,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_add_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -102,7 +74,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_add_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -120,7 +92,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_add_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -138,7 +110,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_add_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -157,7 +129,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_1D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -175,7 +147,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_2D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -200,7 +172,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_3D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -208,14 +180,14 @@ class TestAdd(CommonTFLayerTest):
     test_data_broadcast_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1]),
         dict(x_shape=[1, 3, 1, 1], y_shape=[1]),
-        dict(x_shape=[1, 3, 1, 1], y_shape=[3]),
-        dict(x_shape=[1, 3, 100, 224], y_shape=[3]),
         dict(x_shape=[1, 1, 1, 3], y_shape=[3]),
-        pytest.param(dict(x_shape=[1, 3, 1, 1], y_shape=[3, 1]), marks=pytest.mark.precommit_tf_fe),
-        dict(x_shape=[1, 2, 1, 3], y_shape=[3, 1, 2]),
-        dict(x_shape=[1, 2, 1, 3], y_shape=[1, 3, 2]),
+        dict(x_shape=[1, 100, 224, 3], y_shape=[3]),
+        dict(x_shape=[1, 1, 1, 3], y_shape=[3]),
+        pytest.param(dict(x_shape=[1, 1, 3, 1], y_shape=[3, 1]), marks=pytest.mark.precommit_tf_fe),
+        dict(x_shape=[1, 3, 2, 1], y_shape=[3, 1, 2]),
+        dict(x_shape=[1, 1, 3, 2], y_shape=[1, 3, 2]),
         dict(x_shape=[1, 3, 100, 224], y_shape=[1, 1, 1, 224]),
-        dict(x_shape=[2, 3, 1, 2], y_shape=[1, 3, 2, 1])
+        dict(x_shape=[2, 3, 2, 1], y_shape=[1, 3, 2, 1])
     ]
 
     @pytest.mark.parametrize("params", test_data_broadcast_4D)
@@ -223,7 +195,7 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.precommit
     def test_add_placeholder_const_broadcast_4D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -231,11 +203,11 @@ class TestAdd(CommonTFLayerTest):
     test_data_broadcast_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1]),
         dict(x_shape=[1, 3, 1, 1, 1], y_shape=[1, 1]),
-        dict(x_shape=[1, 3, 1, 1, 1], y_shape=[3]),
         dict(x_shape=[1, 1, 1, 1, 3], y_shape=[3]),
-        dict(x_shape=[1, 3, 1, 1, 1], y_shape=[3, 1]),
-        dict(x_shape=[1, 2, 1, 1, 3], y_shape=[1, 3, 2]),
-        dict(x_shape=[1, 3, 5, 1, 2], y_shape=[5, 3, 2, 1]),
+        dict(x_shape=[1, 1, 1, 1, 3], y_shape=[3]),
+        dict(x_shape=[1, 1, 1, 3, 1], y_shape=[3, 1]),
+        dict(x_shape=[1, 2, 1, 3, 2], y_shape=[1, 3, 2]),
+        dict(x_shape=[1, 5, 3, 2, 1], y_shape=[5, 3, 2, 1]),
         dict(x_shape=[1, 3, 50, 100, 224], y_shape=[1, 1, 1, 1, 224]),
         dict(x_shape=[2, 3, 1, 2, 1], y_shape=[1, 3, 2, 1, 1])
     ]
@@ -246,7 +218,7 @@ class TestAdd(CommonTFLayerTest):
     def test_add_placeholder_const_broadcast_5D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
         # we do not perform transpose in the test in case of new frontend
-        self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
+        self._test(*self.create_add_placeholder_const_net(**params,
                                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision,
                    ir_version=ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Add.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Add.py
@@ -9,7 +9,7 @@ from common.utils.tf_utils import permute_nchw_to_nhwc
 
 
 class TestAdd(CommonTFLayerTest):
-    def create_add_placeholder_const_net(self, x_shape, y_shape, ir_version, use_new_frontend):
+    def create_add_placeholder_const_net(self, x_shape, y_shape, ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -28,8 +28,8 @@ class TestAdd(CommonTFLayerTest):
             tf_x_shape = x_shape.copy()
             tf_y_shape = y_shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
-            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
+            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_legacy_frontend)
 
             x = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
             constant_value = np.random.randint(-256, 256, tf_y_shape).astype(np.float32)
@@ -64,11 +64,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
     def test_add_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_2D = [
         dict(x_shape=[1, 1], y_shape=[1, 1]),
@@ -81,11 +81,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_add_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1, 1, 1]),
@@ -101,11 +101,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_add_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1, 1, 1, 1]),
@@ -119,11 +119,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_add_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1, 1, 1, 1, 1]),
@@ -137,11 +137,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_add_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     ###############################################################################################
     #                                                                                             #
@@ -156,11 +156,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_1D)
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_1D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_2D = [
         dict(x_shape=[1, 1], y_shape=[1]),
@@ -174,11 +174,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_2D)
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_2D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1]),
@@ -199,11 +199,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_3D)
     @pytest.mark.nightly
     def test_add_placeholder_const_broadcast_3D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1]),
@@ -222,11 +222,11 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_add_placeholder_const_broadcast_4D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1]),
@@ -244,9 +244,9 @@ class TestAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_add_placeholder_const_broadcast_5D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         # we do not perform transpose in the test in case of new frontend
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision,
-                   ir_version=ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   ir_version=ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_AddN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AddN.py
@@ -14,8 +14,8 @@ import logging
 class TestAddN(CommonTFLayerTest):
     # input_shapes - should be an array, could be a single shape, or array of n-dimentional shapes
     # ir_version - common parameter
-    # use_new_frontend - common parameter
-    def create_addn_placeholder_const_net(self, input_shapes, ir_version, use_new_frontend):
+    # use_legacy_frontend - common parameter
+    def create_addn_placeholder_const_net(self, input_shapes, ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -28,7 +28,7 @@ class TestAddN(CommonTFLayerTest):
         if len(input_shapes) == 0:
             raise RuntimeError("Input list couldn't be empty")
 
-        if len(input_shapes) == 1 and not use_new_frontend:
+        if len(input_shapes) == 1 and not use_legacy_frontend:
             pytest.xfail(reason="96687")
         import tensorflow as tf
 
@@ -61,8 +61,8 @@ class TestAddN(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_addn_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_addn_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_AddTypes.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AddTypes.py
@@ -50,7 +50,7 @@ class TestAddTypes(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_add_types(self, const_shape, input_type, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend):
+                       use_legacy_frontend):
         self._test(*self.create_add_types_net(const_shape, input_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_AdjustContrastv2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AdjustContrastv2.py
@@ -43,7 +43,7 @@ class TestAdjustContrastv2(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_adjust_contrast_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_adjust_contrast_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ArgMinMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ArgMinMax.py
@@ -61,9 +61,9 @@ class TestArgMinMax(CommonTFLayerTest):
                                                                                          'aarch64',
                                                                                          'arm64', 'ARM64'],
                        reason='Ticket - 126314')
-    def test_argmin_max_net(self, input_shape, dimension, input_type, output_type, op_type, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_argmin_max_net(self, input_shape, dimension, input_type, output_type, op_type, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         params = dict(input_shape=input_shape, dimension=dimension)
         self._test(*self.create_argmin_max_net(**params, input_type=input_type,
                                                output_type=output_type, op_type=OPS[op_type]),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_AssignOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AssignOps.py
@@ -98,27 +98,27 @@ class TestAssignOps(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_assign(self, const_shape, input_type, ie_device, precision, ir_version, temp_dir,
-                    use_new_frontend):
+                    use_legacy_frontend):
         self._test(*self.create_assign_net(const_shape, input_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.parametrize("const_shape", [[], [2], [3, 4], [3, 2, 1, 4]])
     @pytest.mark.parametrize("assign_op", ['tf.raw_ops.AssignAdd', 'tf.raw_ops.AssignSub'])
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_assign_ops(self, const_shape, assign_op, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend):
+                        use_legacy_frontend):
         self._test(*self.create_assign_op_net(const_shape, OPS[assign_op]),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.parametrize("const_shape", [[], [2], [3, 4], [3, 2, 1, 4]])
     @pytest.mark.parametrize("assign_op", ['tf.raw_ops.AssignAdd', 'tf.raw_ops.AssignSub'])
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_assign_ops2(self, const_shape, assign_op, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_assign_op_net2(const_shape, OPS[assign_op]),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_AssignVariableOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AssignVariableOps.py
@@ -44,7 +44,7 @@ class TestAssignVariableOps(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_assign_variable_ops(self, const_shape, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_assign_variable_ops_net(const_shape),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Atan2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Atan2.py
@@ -40,7 +40,7 @@ class TestAtan2(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_atan2_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_atan2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BatchToSpace.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BatchToSpace.py
@@ -33,10 +33,10 @@ class TestBatchToSpace(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_batch_to_space_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_batch_to_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(in_shape=[4, 1, 1, 3], block_shape_value=[2, 2], crops_value=[[0, 0], [0, 0]]),
@@ -48,10 +48,10 @@ class TestBatchToSpace(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_batch_to_space_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_batch_to_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(in_shape=[144, 2, 1, 4, 1], block_shape_value=[3, 4, 2, 2],
@@ -61,7 +61,7 @@ class TestBatchToSpace(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_batch_to_space_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_batch_to_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BatchToSpaceND.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BatchToSpaceND.py
@@ -29,7 +29,7 @@ class TestBatchToSpaceND(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_batch_to_space_nd_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend):
+                                     use_legacy_frontend):
         self._test(*self.create_batch_to_space_nd_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BiasAdd.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BiasAdd.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 import numpy as np
 
 class TestBiasAdd(CommonTFLayerTest):
-    def create_bias_add_placeholder_const_net(self, shape, ir_version, use_new_frontend, output_type=tf.float32):
+    def create_bias_add_placeholder_const_net(self, shape, ir_version, use_legacy_frontend, output_type=tf.float32):
         """
             Tensorflow net                      IR net
 
@@ -25,7 +25,7 @@ class TestBiasAdd(CommonTFLayerTest):
         with tf.compat.v1.Session() as sess:
             tf_x_shape = shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
             tf_y_shape = tf_x_shape[-1:]
 
             x = tf.compat.v1.placeholder(output_type, tf_x_shape, 'Input')
@@ -44,7 +44,7 @@ class TestBiasAdd(CommonTFLayerTest):
 
         return tf_net, ref_net
 
-    def create_bias_add_2_consts_net(self, shape, ir_version, use_new_frontend, output_type=tf.float32):
+    def create_bias_add_2_consts_net(self, shape, ir_version, use_legacy_frontend, output_type=tf.float32):
         """
             Tensorflow net                         IR net
 
@@ -68,7 +68,7 @@ class TestBiasAdd(CommonTFLayerTest):
         with tf.compat.v1.Session() as sess:
             tf_x_shape = shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
             tf_y_shape = tf_x_shape[-1:]
 
             constant_value_x = np.random.randint(-256, 256, tf_x_shape).astype(output_type.as_numpy_dtype())
@@ -98,20 +98,20 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_bias_add_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_bias_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                               use_new_frontend=use_new_frontend),
+                                                               use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_bias_add_2_consts_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
-                                                      use_new_frontend=use_new_frontend),
+                                                      use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_3D = [
         pytest.param(dict(shape=[1, 1, 224]), marks=pytest.mark.xfail(reason="*-19053")),
@@ -121,20 +121,20 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_bias_add_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_bias_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                               use_new_frontend=use_new_frontend),
+                                                               use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_bias_add_2_consts_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
-                                                      use_new_frontend=use_new_frontend),
+                                                      use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(shape=[1, 1, 100, 224]),
@@ -146,20 +146,20 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_bias_add_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_bias_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                               use_new_frontend=use_new_frontend),
+                                                               use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_bias_add_2_consts_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
-                                                      use_new_frontend=use_new_frontend),
+                                                      use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(shape=[1, 1, 50, 100, 224]),
@@ -170,17 +170,17 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_bias_add_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_bias_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                               use_new_frontend=use_new_frontend),
+                                                               use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_bias_add_2_consts_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
-                                                      use_new_frontend=use_new_frontend),
+                                                      use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
@@ -43,7 +43,7 @@ class TestBinaryOps(CommonTFLayerTest):
         return inputs_dict
 
     def create_add_placeholder_const_net(self, x_shape, y_shape, ir_version, op_type,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         """
             Tensorflow net                       IR net
 
@@ -52,7 +52,7 @@ class TestBinaryOps(CommonTFLayerTest):
             Const-------/                         Const-------/
 
         """
-        if not use_new_frontend and op_type == "Xdivy":
+        if not use_legacy_frontend and op_type == "Xdivy":
             pytest.xfail(reason="95499")
 
         self.current_op_type = op_type
@@ -101,8 +101,8 @@ class TestBinaryOps(CommonTFLayerTest):
             tf_x_shape = x_shape.copy()
             tf_y_shape = y_shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
-            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
+            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_legacy_frontend)
 
             x = tf.compat.v1.placeholder(type, tf_x_shape, 'Input')
             constant_value = generate_input(op_type, tf_y_shape)
@@ -140,14 +140,14 @@ class TestBinaryOps(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_binary_op(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                       use_new_frontend):
-        if not use_new_frontend and op_type in ['BitwiseAnd', 'BitwiseOr', 'BitwiseXor']:
+                       use_legacy_frontend):
+        if not use_legacy_frontend and op_type in ['BitwiseAnd', 'BitwiseOr', 'BitwiseXor']:
             pytest.skip("Bitwise ops are supported only by new TF FE.")
         if precision == "FP16":
             pytest.skip("BinaryOps tests are skipped with FP16 precision."
                         "They don't pass accuracy checks because chaotic output.")
         self._test(
             *self.create_add_placeholder_const_net(**params, ir_version=ir_version, op_type=op_type,
-                                                   use_new_frontend=use_new_frontend), ie_device,
+                                                   use_legacy_frontend=use_legacy_frontend), ie_device,
             precision,
-            ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+            ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BroadcastArgs.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BroadcastArgs.py
@@ -56,7 +56,7 @@ class TestBroadcastArgs(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_broadcast_args_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_broadcast_args_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_broadcast_args_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BroadcastTo.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BroadcastTo.py
@@ -13,8 +13,8 @@ class TestBroadcastTo(CommonTFLayerTest):
     # input_shape - shape a tensor for a broadcast
     # broadcast_shape - shape of output
     # ir_version - common parameter
-    # use_new_frontend - common parameter
-    def create_broadcastto_placeholder_const_net(self, input_shape, broadcast_shape, ir_version, use_new_frontend):
+    # use_legacy_frontend - common parameter
+    def create_broadcastto_placeholder_const_net(self, input_shape, broadcast_shape, ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -48,8 +48,8 @@ class TestBroadcastTo(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_broadcastto_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_broadcastto_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Bucketize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Bucketize.py
@@ -45,7 +45,7 @@ class TestBucketize(CommonTFLayerTest):
     @pytest.mark.xfail(platform.machine() in ["aarch64", "arm64", "ARM64"],
                        reason='Ticket - 122716')
     def test_bucketize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
+                             use_legacy_frontend):
         self._test(*self.create_bucketize_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CTCGreedyDecoder.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CTCGreedyDecoder.py
@@ -15,9 +15,9 @@ class TestCTCGreedyDecoder(CommonTFLayerTest):
     # input_shape - shape a tensor for a decoder
     # merge_repeated - bool, enables/disable merge repeated classes in decoder
     # ir_version - common parameter
-    # use_new_frontend - common parameter
+    # use_legacy_frontend - common parameter
     def create_ctcgreedydecoder_placeholder_const_net(self, input_shape, merge_repeated,
-                                            ir_version, use_new_frontend):
+                                            ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -25,7 +25,7 @@ class TestCTCGreedyDecoder(CommonTFLayerTest):
 
         """
 
-        if use_new_frontend == False:
+        if use_legacy_frontend == False:
             pytest.skip('Legacy path isn\'t supported by CTCGreedyDecoder')
 
         seq_lens = np.array([input_shape[2]], dtype=np.int32)
@@ -61,10 +61,10 @@ class TestCTCGreedyDecoder(CommonTFLayerTest):
     @pytest.mark.parametrize("merge_repeated", [False, True])
     @pytest.mark.nightly
     def test_ctcgreedydecoder_placeholder_const(self, params, merge_repeated, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104860')
         self._test(*self.create_ctcgreedydecoder_placeholder_const_net(**params, ir_version=ir_version,
-                                                             use_new_frontend=use_new_frontend, merge_repeated=merge_repeated),
+                                                             use_legacy_frontend=use_legacy_frontend, merge_repeated=merge_repeated),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend, merge_repeated=merge_repeated)
+                   use_legacy_frontend=use_legacy_frontend, merge_repeated=merge_repeated)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CTCLoss.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CTCLoss.py
@@ -63,9 +63,9 @@ class TestCTCLoss(CommonTFLayerTest):
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_ctcloss_placeholder_const(self, params, preprocess_collapse_repeated, ctc_merge_repeated,
                                        ie_device, precision, ir_version, temp_dir,
-                                       use_new_frontend):
+                                       use_legacy_frontend):
         self._test(*self.create_ctcloss_placeholder_const_net(**params,
                                                               preprocess_collapse_repeated=preprocess_collapse_repeated,
                                                               ctc_merge_repeated=ctc_merge_repeated),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Cast.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Cast.py
@@ -23,8 +23,8 @@ class TestCastOp(CommonTFLayerTest):
     # output_type - type of output value
     # truncate - boolean flag of truncation
     # ir_version - common parameter
-    # use_new_frontend - common parameter
-    def create_cast_op_placeholder_const_net(self, input_shape, input_type, output_type, truncate, ir_version, use_new_frontend):
+    # use_legacy_frontend - common parameter
+    def create_cast_op_placeholder_const_net(self, input_shape, input_type, output_type, truncate, ir_version, use_legacy_frontend):
         if(input_type == output_type):
             pytest.skip("Input and output types shouldn't be equal")
 
@@ -65,9 +65,9 @@ class TestCastOp(CommonTFLayerTest):
     @pytest.mark.parametrize("truncate", [ False, True ])
     @pytest.mark.nightly
     def test_cast_op_placeholder_const(self, params, input_type, output_type, truncate, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_cast_op_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend, input_type=input_type,
+                                                          use_legacy_frontend=use_legacy_frontend, input_type=input_type,
                                                           output_type=output_type, truncate=truncate),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CheckNumerics.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CheckNumerics.py
@@ -46,8 +46,8 @@ class TestCheckNumerics(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_check_numerics_basic(self, input_shape, input_type, op, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         params = dict(input_shape=input_shape, input_type=input_type, op=OPS[op])
         self._test(*self.create_check_numerics_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ClipByValue.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ClipByValue.py
@@ -43,8 +43,8 @@ class TestClipByValue(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_clip_by_value_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(
             *self.create_clip_by_value_net(**params), ie_device,
-            precision, temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+            precision, temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
             **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ComplexFFT.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ComplexFFT.py
@@ -77,12 +77,12 @@ class TestComplexFFT(CommonTFLayerTest):
                        reason='Ticket - 126314')
     def test_complex_fft_basic(self, input_shape, shift_roll, axis_roll, fft_op,
                                ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         params = dict(input_shape=input_shape, shift_roll=shift_roll, axis_roll=axis_roll)
         self._test(
             *self.create_complex_fft_net(**params, fft_op=OPS[fft_op]),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend, custom_eps=1e-2)
+            use_legacy_frontend=use_legacy_frontend, custom_eps=1e-2)
 
 
 class TestComplexAbs(CommonTFLayerTest):
@@ -121,11 +121,11 @@ class TestComplexAbs(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_abs_basic(self, input_shape, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(
             *self.create_complex_abs_net(input_shape),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)
 
 
 class TestComplexRFFT(CommonTFLayerTest):
@@ -164,12 +164,12 @@ class TestComplexRFFT(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_rfft_basic(self, input_shape, fft_length, rfft_op, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend):
+                                use_legacy_frontend):
         params = dict(input_shape=input_shape, fft_length=fft_length, rfft_op=OPS[rfft_op])
         self._test(
             *self.create_complex_rfft_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)
 
 
 class TestComplexIRFFT(CommonTFLayerTest):
@@ -210,9 +210,9 @@ class TestComplexIRFFT(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_irfft_basic(self, input_shape, fft_length, irfft_op, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         params = dict(input_shape=input_shape, fft_length=fft_length, irfft_op=OPS[irfft_op])
         self._test(
             *self.create_complex_irfft_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Concat.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Concat.py
@@ -7,7 +7,7 @@ from common.tf_layer_test_class import CommonTFLayerTest
 
 
 class TestConcat(CommonTFLayerTest):
-    def create_concat_net(self, input_shapes, axis, is_v2, ir_version, use_new_frontend):
+    def create_concat_net(self, input_shapes, axis, is_v2, ir_version, use_legacy_frontend):
         # tf.concat is equivalent to tf.raw_ops.ConcatV2
         # only tf.concat accepts one input
         import tensorflow as tf
@@ -40,11 +40,11 @@ class TestConcat(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_concat_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_concat_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
-                                           use_new_frontend=use_new_frontend),
+                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_1D = [
         dict(input_shapes=[[1], [2]], axis=0, is_v2=False),
@@ -52,11 +52,11 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_concat_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_concat_1D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
-                                           use_new_frontend=use_new_frontend),
+                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_2D = [
         dict(input_shapes=[[1, 4], [1, 2]], axis=-1, is_v2=True)
@@ -64,11 +64,11 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_concat_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_concat_2D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
-                                           use_new_frontend=use_new_frontend),
+                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_3D = [
         dict(input_shapes=[[1, 3, 2], [1, 3, 5]], axis=-1, is_v2=True),
@@ -77,11 +77,11 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_concat_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_concat_3D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
-                                           use_new_frontend=use_new_frontend),
+                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(input_shapes=[[1, 3, 5, 7], [3, 3, 5, 7], [2, 3, 5, 7]], axis=0, is_v2=False),
@@ -91,11 +91,11 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_concat_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_concat_4D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
-                                           use_new_frontend=use_new_frontend),
+                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(input_shapes=[[1, 3, 5, 7, 8], [2, 3, 5, 7, 8]], axis=0, is_v2=True),
@@ -103,8 +103,8 @@ class TestConcat(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_concat_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_concat_5D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_concat_net(**params, ir_version=ir_version,
-                                           use_new_frontend=use_new_frontend),
+                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conj.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conj.py
@@ -55,7 +55,7 @@ class TestComplexConjugate(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_conjugate(self, input_shape, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_complex_conjugate_net(input_shape),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ConjugateTranspose.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ConjugateTranspose.py
@@ -65,10 +65,10 @@ class TestComplexConjugateTranspose(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_conjugate_transpose(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_complex_conjugate_transpose_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestConjugateTranspose(CommonTFLayerTest):
@@ -116,7 +116,7 @@ class TestConjugateTranspose(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_conjugate_transpose(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_conjugate_transpose_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conv2D.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conv2D.py
@@ -15,9 +15,9 @@ class TestConv2D(CommonTFLayerTest):
     # input_strides - should be an array, defines strides of a sliding window to use
     # input_padding - should be a string, defines padding algorithm
     # ir_version - common parameter
-    # use_new_frontend - common parameter
+    # use_legacy_frontend - common parameter
     def create_conv2d_placeholder_const_net(self, input_shape, input_filter, input_strides, input_padding, dilations,
-                                            ir_version, use_new_frontend):
+                                            ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -35,7 +35,7 @@ class TestConv2D(CommonTFLayerTest):
         #               Batch   Height Width  Channel
         expl_paddings = [0, 0, 1, 1, 1, 1, 0, 0]
 
-        if input_padding == 'EXPLICIT' and use_new_frontend == False:
+        if input_padding == 'EXPLICIT' and use_legacy_frontend == False:
             pytest.xfail(reason="100300")
 
         tf.compat.v1.reset_default_graph()
@@ -82,10 +82,10 @@ class TestConv2D(CommonTFLayerTest):
     @pytest.mark.parametrize("padding", ['EXPLICIT', 'SAME', 'VALID'])
     @pytest.mark.nightly
     def test_conv2d_placeholder_const(self, params, padding, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104862')
         self._test(*self.create_conv2d_placeholder_const_net(**params, input_padding=padding, ir_version=ir_version,
-                                                             use_new_frontend=use_new_frontend),
+                                                             use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, input_padding=padding, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conv2DBackprop.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conv2DBackprop.py
@@ -17,8 +17,8 @@ class TestConv2DBackprop(CommonTFLayerTest):
     # input_strides - should be an array, defines strides of a sliding window to use
     # input_padding - should be a string, defines padding algorithm
     # ir_version - common parameter
-    # use_new_frontend - common parameter
-    def create_conv2dbackprop_placeholder_const_net(self, input_shape, input_filter, out_backprop, input_strides, input_padding, dilations, ir_version, use_new_frontend):
+    # use_legacy_frontend - common parameter
+    def create_conv2dbackprop_placeholder_const_net(self, input_shape, input_filter, out_backprop, input_strides, input_padding, dilations, ir_version, use_legacy_frontend):
         """
             TensorFlow net                               IR net
 
@@ -70,8 +70,8 @@ class TestConv2DBackprop(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conv2dbackprop_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_conv2dbackprop_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conv3D.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conv3D.py
@@ -15,9 +15,9 @@ class TestConv3D(CommonTFLayerTest):
     # input_strides - should be an array, defines strides of a sliding window to use
     # input_padding - should be a string, defines padding algorithm
     # ir_version - common parameter
-    # use_new_frontend - common parameter
+    # use_legacy_frontend - common parameter
     def create_conv3d_placeholder_const_net(self, input_shape, input_filter, input_strides, input_padding, dilations,
-                                            ir_version, use_new_frontend):
+                                            ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -76,8 +76,8 @@ class TestConv3D(CommonTFLayerTest):
     @pytest.mark.parametrize("padding", ['SAME', 'VALID'])
     @pytest.mark.nightly
     def test_conv3d_placeholder_const(self, params, padding, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_conv3d_placeholder_const_net(**params, input_padding=padding, ir_version=ir_version,
-                                                             use_new_frontend=use_new_frontend),
+                                                             use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, input_padding=padding, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Conv3DBackprop.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Conv3DBackprop.py
@@ -18,8 +18,8 @@ class TestConv3DBackprop(CommonTFLayerTest):
     # input_strides - should be an array, defines strides of a sliding window to use
     # input_padding - should be a string, defines padding algorithm
     # ir_version - common parameter
-    # use_new_frontend - common parameter
-    def create_conv3dbackprop_placeholder_const_net(self, input_shape, input_filter, out_backprop, input_strides, input_padding, dilations, ir_version, use_new_frontend):
+    # use_legacy_frontend - common parameter
+    def create_conv3dbackprop_placeholder_const_net(self, input_shape, input_filter, out_backprop, input_strides, input_padding, dilations, ir_version, use_legacy_frontend):
         """
             TensorFlow net                                 IR net
 
@@ -72,8 +72,8 @@ class TestConv3DBackprop(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conv3dbackprop_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_conv3dbackprop_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CropAndResize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CropAndResize.py
@@ -58,7 +58,7 @@ class TestCropAndResize(CommonTFLayerTest):
     @pytest.mark.xfail(platform.machine() in ["aarch64", "arm64", "ARM64"],
                        reason='Ticket - 122716')
     def test_crop_and_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_crop_and_resize_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Cumsum.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Cumsum.py
@@ -50,7 +50,7 @@ class TestCumsum(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_cumsum_basic(self, params, exclusive, reverse, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend):
+                          use_legacy_frontend):
         self._test(*self.create_cumsum_net(**params, exclusive=exclusive, reverse=reverse),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_DepthToSpace.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_DepthToSpace.py
@@ -29,7 +29,7 @@ class TestDepthToSpace(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_depth_to_space_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_depth_to_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Div.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Div.py
@@ -44,7 +44,7 @@ class TestDiv(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_div_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend):
+                       use_legacy_frontend):
         self._test(*self.create_div_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_DivNoNan.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_DivNoNan.py
@@ -46,7 +46,7 @@ class TestDivNoNan(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_div_no_nan_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend):
+                              use_legacy_frontend):
         self._test(*self.create_div_no_nan_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_DynamicPartition.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_DynamicPartition.py
@@ -45,14 +45,14 @@ class TestDynamicPartition(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_dynamic_partition_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend):
+                                     use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
-        if not use_new_frontend:
+        if not use_legacy_frontend:
             pytest.skip("DynamicPartition operation is not supported via legacy frontend.")
         self._test(*self.create_dynamic_partition_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_other_types = [
         dict(data_shape=[10], partitions_shape=[10], num_partitions=10, data_type=tf.int32),
@@ -62,11 +62,11 @@ class TestDynamicPartition(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_other_types)
     @pytest.mark.nightly
     def test_dynamic_partition_other_types(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
-        if not use_new_frontend:
+        if not use_legacy_frontend:
             pytest.skip("DynamicPartition operation is not supported via legacy frontend.")
         self._test(*self.create_dynamic_partition_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Eltwise.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Eltwise.py
@@ -8,7 +8,7 @@ from common.utils.tf_utils import permute_nchw_to_nhwc
 
 
 class TestEltwise(CommonTFLayerTest):
-    def create_eltwise_net(self, shape, operation, ir_version, use_new_frontend):
+    def create_eltwise_net(self, shape, operation, ir_version, use_legacy_frontend):
         """
             Tensorflow net                 IR net
 
@@ -25,7 +25,7 @@ class TestEltwise(CommonTFLayerTest):
 
             tf_x_shape = shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
 
             x = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
             y = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')  # Input_1 in graph_def
@@ -59,11 +59,11 @@ class TestEltwise(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_eltwise(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_eltwise(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_eltwise_net(**params, ir_version=ir_version,
-                                            use_new_frontend=use_new_frontend),
+                                            use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = []
     for operation in ['sum', 'max', 'mul']:
@@ -73,10 +73,10 @@ class TestEltwise(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_eltwise_5D_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_eltwise_net(**params, ir_version=ir_version,
-                                            use_new_frontend=use_new_frontend),
+                                            use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_EnsureShape.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_EnsureShape.py
@@ -38,7 +38,7 @@ class TestEnsureShape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_ensure_shape_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend):
+                                use_legacy_frontend):
         self._test(*self.create_ensure_shape_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Equal.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Equal.py
@@ -38,13 +38,13 @@ class TestTFEqual(CommonTFLayerTest):
         return inputs_dict
 
     # ir_version - common parameter
-    # use_new_frontend - common parameter
+    # use_legacy_frontend - common parameter
     # x_shape - first argument, should be an array (shape)
     # output_type - type of operands (numpy types: int32, int64, float16, etc...), different types for operands are not suppoted by TF
     # y_shape - second argument, should be an array (shape). Might be None if y_value is passed
     # x_value - fills x_shape by chosen value, uses randint instead
     # y_value - if y_shape is None - uses y_value as scalar, otherwise fills y_shape by chosen value, uses randint instead
-    def create_tf_equal_net(self, ir_version, use_new_frontend, x_shape, output_type, y_shape = None, x_value = None, y_value = None):
+    def create_tf_equal_net(self, ir_version, use_legacy_frontend, x_shape, output_type, y_shape = None, x_value = None, y_value = None):
         self.x_value = x_value
         self.y_value = y_value
         self.output_type = output_type
@@ -57,9 +57,9 @@ class TestTFEqual(CommonTFLayerTest):
             self.y_shape = y_shape.copy() if isinstance(y_shape, list) else y_shape
 
             if isinstance(x_shape, list):
-                self.x_shape = permute_nchw_to_nhwc(self.x_shape, use_new_frontend)
+                self.x_shape = permute_nchw_to_nhwc(self.x_shape, use_legacy_frontend)
             if isinstance(y_shape, list):
-                self.y_shape = permute_nchw_to_nhwc(self.y_shape, use_new_frontend)
+                self.y_shape = permute_nchw_to_nhwc(self.y_shape, use_legacy_frontend)
 
             if self.output_type == np.float16:
                 x = tf.compat.v1.placeholder(tf.float16, self.x_shape, 'Input')
@@ -111,11 +111,11 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_int32)
     @pytest.mark.nightly
-    def test_tf_equal_int32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_tf_equal_int32(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
-                                             use_new_frontend=use_new_frontend, output_type=np.int32),
+                                             use_legacy_frontend=use_legacy_frontend, output_type=np.int32),
                    ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)
 
     test_data_int64 = [
@@ -133,11 +133,11 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_int64)
     @pytest.mark.nightly
-    def test_tf_equal_int64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_tf_equal_int64(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
-                                             use_new_frontend=use_new_frontend, output_type=np.int64),
+                                             use_legacy_frontend=use_legacy_frontend, output_type=np.int64),
                    ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)
 
     # Values for checking important corner cases for float values
@@ -158,11 +158,11 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float16)
     @pytest.mark.nightly
-    def test_tf_equal_float16(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_tf_equal_float16(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
-                                             use_new_frontend=use_new_frontend, output_type=np.float16),
+                                             use_legacy_frontend=use_legacy_frontend, output_type=np.float16),
                    ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)
 
     test_data_float32 = [
@@ -178,11 +178,11 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_tf_equal_float32(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_tf_equal_float32(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
-                                             use_new_frontend=use_new_frontend, output_type=np.float32),
+                                             use_legacy_frontend=use_legacy_frontend, output_type=np.float32),
                    ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)
 
     test_data_float64 = [
@@ -198,9 +198,9 @@ class TestTFEqual(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_float64)
     @pytest.mark.nightly
-    def test_tf_equal_float64(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_tf_equal_float64(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_tf_equal_net(**params, ir_version=ir_version,
-                                             use_new_frontend=use_new_frontend, output_type=np.float64),
+                                             use_legacy_frontend=use_legacy_frontend, output_type=np.float64),
                    ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ExpandDims.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ExpandDims.py
@@ -36,7 +36,7 @@ class TestExpandDims(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_basic)
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
-    def test_expand_dims_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_expand_dims_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_expand_dims_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ExtractImagePatches.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ExtractImagePatches.py
@@ -37,7 +37,7 @@ class TestExtractImagePatches(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
     def test_extract_image_patches_basic(self, params, padding, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_extract_image_patches_net(**params, padding=padding),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Eye.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Eye.py
@@ -16,7 +16,6 @@ class TestTFEye(CommonTFLayerTest):
             inputs_dict[input] = np.zeros(inputs_dict[input]).astype(self.eye_output_type_param)
         return inputs_dict
 
-
     def create_tf_eye_net(self, num_rows, num_columns, batch_shape, output_type):
         tf.compat.v1.reset_default_graph()
 
@@ -28,7 +27,8 @@ class TestTFEye(CommonTFLayerTest):
                 eye = tf.eye(num_rows=num_rows, num_columns=num_columns, batch_shape=batch_shape)
             else:
                 self.eye_output_type_param = output_type
-                eye = tf.eye(num_rows=num_rows, num_columns=num_columns, batch_shape=batch_shape, dtype=tf.as_dtype(output_type))
+                eye = tf.eye(num_rows=num_rows, num_columns=num_columns, batch_shape=batch_shape,
+                             dtype=tf.as_dtype(output_type))
 
             # Dummy Add layer to prevent fully const network
             input_zero = tf.compat.v1.placeholder(tf.as_dtype(self.eye_output_type_param), [1], 'Input')
@@ -54,6 +54,8 @@ class TestTFEye(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_tf_eye(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
+        if not use_legacy_frontend:
+            pytest.xfail(reason="132517: MatrixDiagV3 needs to be supported")
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_tf_eye_net(**params), ie_device,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Eye.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Eye.py
@@ -53,10 +53,10 @@ class TestTFEye(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_tf_eye(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_tf_eye(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_tf_eye_net(**params), ie_device,
                    precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantWithMinMaxVars.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantWithMinMaxVars.py
@@ -52,11 +52,11 @@ class TestFakeQuantWithMinMaxVars(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
-    def test_fake_quant_with_min_max_vars_basic(self, inputs_shape, min_value, max_value, num_bits, narrow_range, fake_quant_op, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_fake_quant_with_min_max_vars_basic(self, inputs_shape, min_value, max_value, num_bits, narrow_range, fake_quant_op, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         params = dict(inputs_shape=inputs_shape, min_value=min_value, max_value=max_value, num_bits=num_bits, narrow_range=narrow_range)
         self._test(*self.create_fake_quant_with_min_max_vars_net(**params, fake_quant_op=OPS[fake_quant_op]),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_per_channel_basic = [
         [[2, 6, 4], [-4, -3, -5, -8], [4, 7, 9, 5], None, None, 'tf.raw_ops.FakeQuantWithMinMaxVarsPerChannel'],
@@ -66,8 +66,8 @@ class TestFakeQuantWithMinMaxVars(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     @pytest.mark.xfail("104822")
-    def test_fake_quant_with_min_max_vars_per_channel_basic(self, inputs_shape, min_value, max_value, num_bits, narrow_range, fake_quant_op, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_fake_quant_with_min_max_vars_per_channel_basic(self, inputs_shape, min_value, max_value, num_bits, narrow_range, fake_quant_op, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         params=dict(inputs_shape=inputs_shape, min_value=min_value, max_value=max_value, num_bits=num_bits, narrow_range=narrow_range, fake_quant_op=OPS[fake_quant_op])
         self._test(*self.create_fake_quant_with_min_max_vars_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantize.py
@@ -36,7 +36,7 @@ class TestFakeQuantize(CommonTFLayerTest):
         ])}
 
     def create_fake_quantize_net(self, il, ih, num_bits, narrow_range, nudged_il, nudged_ih,
-                                 expected_step, ir_version, use_new_frontend):
+                                 expected_step, ir_version, use_legacy_frontend):
         # original tf model
         import tensorflow as tf
         tf.compat.v1.reset_default_graph()
@@ -52,7 +52,7 @@ class TestFakeQuantize(CommonTFLayerTest):
 
         # reference graph to compare with IR
         ref_net = None
-        if check_ir_version(10, None, ir_version) and not use_new_frontend:
+        if check_ir_version(10, None, ir_version) and not use_legacy_frontend:
             levels = 2 ** num_bits - int(narrow_range)
 
             # data (shape, value) -> const (shape, vale) -> data (shape, no value)
@@ -140,9 +140,9 @@ class TestFakeQuantize(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_fake_quantize(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         self._test(*self.create_fake_quantize_net(**params, ir_version=ir_version,
-                                                  use_new_frontend=use_new_frontend), ie_device,
+                                                  use_legacy_frontend=use_legacy_frontend), ie_device,
                    precision, ir_version,
                    kwargs_to_prepare_input=params, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Fill.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Fill.py
@@ -22,8 +22,8 @@ class TestFillOps(CommonTFLayerTest):
     # input_shape - should be an array
     # value - value which should be set to tensor
     # ir_version - common parameter
-    # use_new_frontend - common parameter
-    def create_fill_ops_placeholder_const_net(self, input_shape, value, ir_version, use_new_frontend):
+    # use_legacy_frontend - common parameter
+    def create_fill_ops_placeholder_const_net(self, input_shape, value, ir_version, use_legacy_frontend):
         self.stored_shape = input_shape
 
         import tensorflow as tf
@@ -52,8 +52,8 @@ class TestFillOps(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_fill_ops_placeholder_const(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_fill_ops_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FloorDiv.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FloorDiv.py
@@ -13,7 +13,7 @@ def list_arm_platforms():
     return ['arm', 'armv7l', 'aarch64', 'arm64', 'ARM64']
 
 class TestFloorDiv(CommonTFLayerTest):
-    def create_add_placeholder_const_net(self, x_shape, dtype, ir_version, use_new_frontend):
+    def create_add_placeholder_const_net(self, x_shape, dtype, ir_version, use_legacy_frontend):
         import tensorflow as tf
         self.dtype = dtype
         tf.compat.v1.reset_default_graph()
@@ -63,14 +63,14 @@ class TestFloorDiv(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
     def test_add_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         if platform.system() == 'Linux' and platform.machine() in list_arm_platforms() and np.issubdtype(params['dtype'], np.signedinteger):
             pytest.xfail(reason='Ticket CVS-132377 - Divide inconsistent behavior on different systems')
 
         self._test(*self.create_add_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestFloorDivStaticInput(CommonTFLayerTest):
@@ -79,7 +79,7 @@ class TestFloorDivStaticInput(CommonTFLayerTest):
     step = 1
     dtype = np.int32
 
-    def create_flordiv_tf_net(self, min, max, step, y, dtype, ir_version, use_new_frontend):
+    def create_flordiv_tf_net(self, min, max, step, y, dtype, ir_version, use_legacy_frontend):
         import tensorflow as tf
         x = np.arange(min, max, step, dtype=dtype)
         
@@ -122,8 +122,8 @@ class TestFloorDivStaticInput(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Linux' and platform.machine() in list_arm_platforms(),
                        reason='Ticket CVS-132377 - Divide inconsistent behavior on different systems')
     def test_floordiv(self, params, dtype, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_flordiv_tf_net(**params, dtype=dtype, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                    use_new_frontend=use_new_frontend)
+                    use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_FusedBatchNorm.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FusedBatchNorm.py
@@ -106,7 +106,7 @@ class TestFusedBatchNorm(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_fused_batch_norm_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_fused_batch_norm_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_GRUBlockCell.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_GRUBlockCell.py
@@ -61,9 +61,9 @@ class TestTFGRUBlockCell(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_tf_gru_block_cell(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("Skip TF GRUBlockCell test on GPU")
         self._test(*self.create_tf_gru_block_cell(**params),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, custom_eps=1e-3, **params)
+                   use_legacy_frontend=use_legacy_frontend, custom_eps=1e-3, **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Gather.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Gather.py
@@ -73,7 +73,7 @@ class TestGather(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_gather(self, params, params_type, indices_type, ie_device, precision, ir_version, temp_dir,
-                    use_new_frontend):
+                    use_legacy_frontend):
         self._test(*self.create_gather_net(**params, params_type=params_type, indices_type=indices_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_GatherNd.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_GatherNd.py
@@ -58,7 +58,7 @@ class TestGatherNd(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_gather_nd_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_gather_nd_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_gather_nd_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Identity.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Identity.py
@@ -39,8 +39,8 @@ class TestIdentity(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_identity_basic(self, input_shape, identity_op, ie_device, precision, ir_version, temp_dir,
-                            use_new_frontend):
+                            use_legacy_frontend):
         params = dict(input_shape=input_shape, identity_op=OPS[identity_op])
         self._test(*self.create_identity_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_IdentityN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_IdentityN.py
@@ -39,7 +39,7 @@ class TestIdentityN(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_split_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_identityn_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_If.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_If.py
@@ -72,12 +72,12 @@ class TestIfFloat(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend):
+                      use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         self._test(*self.create_if_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestIfInt(CommonTFLayerTest):
@@ -144,12 +144,12 @@ class TestIfInt(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend):
+                      use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         self._test(*self.create_if_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestNestedIf(CommonTFLayerTest):
@@ -224,12 +224,12 @@ class TestNestedIf(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend):
+                      use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         self._test(*self.create_if_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestSequantialIfs(CommonTFLayerTest):
@@ -316,9 +316,9 @@ class TestSequantialIfs(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend):
+                      use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
         self._test(*self.create_sequential_ifs_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Inv.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Inv.py
@@ -38,7 +38,7 @@ class TestInv(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_inv_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_inv_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_InvertPermutation.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_InvertPermutation.py
@@ -38,7 +38,7 @@ class TestInvertPermutation(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_invert_permutation_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_invert_permutation_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_IsFinite.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_IsFinite.py
@@ -40,11 +40,11 @@ class TestIsFinite(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_is_finite_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
+                             use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
-        if not use_new_frontend:
+        if not use_legacy_frontend:
             pytest.skip("IsFinite operation is not supported via legacy frontend.")
         self._test(*self.create_is_finite_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_IsInf.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_IsInf.py
@@ -38,11 +38,11 @@ class TestIsInf(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_is_inf_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend):
+                          use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
-        if not use_new_frontend:
+        if not use_legacy_frontend:
             pytest.skip("IsInf operation is not supported via legacy frontend.")
         self._test(*self.create_is_inf_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_IsNan.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_IsNan.py
@@ -40,11 +40,11 @@ class TestIsNan(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_is_nan_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend):
+                          use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104855')
-        if not use_new_frontend:
+        if not use_legacy_frontend:
             pytest.skip("IsNan operation is not supported via legacy frontend.")
         self._test(*self.create_is_nan_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_L2Loss.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_L2Loss.py
@@ -28,11 +28,11 @@ class TestL2Loss(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_l2_loss_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.xfail('104863')
-        if not use_new_frontend:
+        if not use_legacy_frontend:
             pytest.skip("L2Loss is not supported by legacy FE.")
         self._test(*self.create_l2_loss_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LRN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LRN.py
@@ -29,7 +29,7 @@ class TestLRN(CommonTFLayerTest):
     #@pytest.mark.precommit_tf_fe - ticket 116032
     @pytest.mark.nightly
     def test_lrn_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend):
+                       use_legacy_frontend):
         self._test(*self.create_lrn_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LeakyRelu.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LeakyRelu.py
@@ -36,7 +36,7 @@ class TestLeakyRelu(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_leaky_relu_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend):
+                              use_legacy_frontend):
         self._test(*self.create_leaky_relu_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LinSpace.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LinSpace.py
@@ -33,7 +33,7 @@ class TestLinSpace(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_lin_space_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
+                             use_legacy_frontend):
         self._test(*self.create_lin_space_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ListDiff.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ListDiff.py
@@ -42,7 +42,7 @@ class TestListDiff(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_list_diff_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
+                             use_legacy_frontend):
         self._test(*self.create_list_diff_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Log1p.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Log1p.py
@@ -37,7 +37,7 @@ class TestLog1p(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_log1p_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_log1p_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LogSoftmax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LogSoftmax.py
@@ -44,7 +44,7 @@ class TestLogSoftmax(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_log_softmax_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_log_softmax_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_LookupTableFind.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LookupTableFind.py
@@ -72,8 +72,8 @@ class TestLookupTableFindOps(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_lookup_table_find(self, hash_table_type, keys_shape, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_lookup_table_find_net(hash_table_type=hash_table_type,
                                                       keys_shape=keys_shape, **params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MatMul.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MatMul.py
@@ -8,7 +8,7 @@ from common.tf_layer_test_class import CommonTFLayerTest
 
 class TestMatMul(CommonTFLayerTest):
 
-    def create_net_with_matmul_op(self, x_shape, y_shape, x_bool, y_bool, op_type, ir_version, use_new_frontend):
+    def create_net_with_matmul_op(self, x_shape, y_shape, x_bool, y_bool, op_type, ir_version, use_legacy_frontend):
         import tensorflow as tf
         op_type_to_tf = {
             'BatchMatMul': tf.raw_ops.BatchMatMul,
@@ -59,11 +59,11 @@ class TestMatMul(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_matmul_op_precommit(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_net_with_matmul_op(**params, ir_version=ir_version, op_type=op_type,
-                                                  use_new_frontend=use_new_frontend, x_bool=False, y_bool=False),
+                                                  use_legacy_frontend=use_legacy_frontend, x_bool=False, y_bool=False),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data = test_data_precommit + [
         dict(x_shape=[2, 3, 4, 4], y_shape=[2, 3, 4, 4]),   #Tests 4D shapes
@@ -85,8 +85,8 @@ class TestMatMul(CommonTFLayerTest):
         ])
     @pytest.mark.nightly
     def test_matmul_op_nightly(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                                x_bool, y_bool, use_new_frontend):
+                                x_bool, y_bool, use_legacy_frontend):
         self._test(*self.create_net_with_matmul_op(**params, ir_version=ir_version, op_type=op_type,
-                                                  use_new_frontend=use_new_frontend, x_bool=x_bool, y_bool=y_bool),
+                                                  use_legacy_frontend=use_legacy_frontend, x_bool=x_bool, y_bool=y_bool),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MatrixDiag.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MatrixDiag.py
@@ -38,7 +38,7 @@ class TestMatrixDiag(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_matrix_diag_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_matrix_diag_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MaxPoolWithArgmax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MaxPoolWithArgmax.py
@@ -68,10 +68,10 @@ class TestMaxPoolWithArgmax(CommonTFLayerTest):
     def test_max_pool_with_argmax_basic(self, params, input_type, padding, targmax,
                                         include_batch_in_index, with_second_output,
                                         ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend):
+                                        use_legacy_frontend):
         self._test(
             *self.create_max_pool_with_argmax_net(**params, input_type=input_type, padding=padding, targmax=targmax,
                                                   include_batch_in_index=include_batch_in_index,
                                                   with_second_output=with_second_output),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MinMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MinMax.py
@@ -15,8 +15,8 @@ class TestMinMaxOps(CommonTFLayerTest):
     # axis - array which points on axis for the operation
     # op_type - type of tested operation
     # ir_version - common parameter
-    # use_new_frontend - common parameter
-    def create_minmax_ops_placeholder_const_net(self, input_shape, axis, op_type, keep_dims, ir_version, use_new_frontend):
+    # use_legacy_frontend - common parameter
+    def create_minmax_ops_placeholder_const_net(self, input_shape, axis, op_type, keep_dims, ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -59,8 +59,8 @@ class TestMinMaxOps(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_minmax_ops_placeholder_const(self, params, op_type, keep_dims, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_minmax_ops_placeholder_const_net(**params, op_type=op_type, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend, keep_dims=keep_dims),
+                                                          use_legacy_frontend=use_legacy_frontend, keep_dims=keep_dims),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Mul.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Mul.py
@@ -5,53 +5,29 @@ import numpy as np
 import pytest
 
 from common.tf_layer_test_class import CommonTFLayerTest
-from common.utils.tf_utils import permute_nchw_to_nhwc
 
 
 class TestMul(CommonTFLayerTest):
-    def create_mul_placeholder_const_net(self, x_shape, y_shape, ir_version, use_legacy_frontend):
-        """
-            Tensorflow net                  IR net
-
-            Placeholder->Mul       =>       Placeholder->Multiply
-                         /                               /
-            Const-------/                   Const-------/
-
-        """
-
+    def create_mul_placeholder_const_net(self, x_shape, y_shape):
         import tensorflow as tf
 
         tf.compat.v1.reset_default_graph()
 
         # Create the graph and model
         with tf.compat.v1.Session() as sess:
-            tf_x_shape = x_shape.copy()
-            tf_y_shape = y_shape.copy()
-
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
-            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_legacy_frontend)
-
-            x = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
-            constant_value = np.random.randint(-255, 255, tf_y_shape).astype(np.float32)
+            x = tf.compat.v1.placeholder(tf.float32, x_shape, 'Input')
+            constant_value = np.random.randint(-255, 255, y_shape).astype(np.float32)
             if (constant_value == 1).all():
                 # Avoid elimination of the layer from IR
                 constant_value = constant_value + 1
             y = tf.constant(constant_value)
 
-            mul = tf.multiply(x, y, name="Operation")
+            tf.multiply(x, y, name="Operation")
 
             tf.compat.v1.global_variables_initializer()
             tf_net = sess.graph_def
 
-        #
-        #   Create reference IR net
-        #   Please, specify 'type': 'Input' for input node
-        #   Moreover, do not forget to validate ALL layer attributes!!!
-        #
-
-        ref_net = None
-
-        return tf_net, ref_net
+        return tf_net, None
 
     # TODO: implement tests for 2 Consts + Mul
 
@@ -64,8 +40,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -81,8 +56,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -101,8 +75,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -118,8 +91,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -136,8 +108,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -155,8 +126,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_1D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -173,8 +143,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_2D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -199,8 +168,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_3D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -208,11 +176,11 @@ class TestMul(CommonTFLayerTest):
         dict(x_shape=[1, 1, 1, 1], y_shape=[1]),
         dict(x_shape=[1, 3, 1, 1], y_shape=[1]),
         dict(x_shape=[1, 3, 1, 1], y_shape=[3]),
-        dict(x_shape=[1, 3, 100, 224], y_shape=[3]),
+        dict(x_shape=[1, 100, 224, 3], y_shape=[3]),
         dict(x_shape=[1, 1, 1, 3], y_shape=[3]),
         dict(x_shape=[1, 3, 1, 1], y_shape=[3, 1]),
-        dict(x_shape=[1, 2, 1, 3], y_shape=[3, 1, 2]),
-        dict(x_shape=[1, 2, 1, 3], y_shape=[1, 3, 2]),
+        dict(x_shape=[1, 3, 1, 2], y_shape=[3, 1, 2]),
+        dict(x_shape=[1, 2, 1, 2], y_shape=[1, 3, 2]),
         dict(x_shape=[1, 3, 100, 224], y_shape=[1, 1, 1, 224]),
         dict(x_shape=[2, 3, 1, 2], y_shape=[1, 3, 2, 1])
     ]
@@ -222,8 +190,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.precommit
     def test_mul_placeholder_const_broadcast_4D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -234,7 +201,7 @@ class TestMul(CommonTFLayerTest):
         dict(x_shape=[1, 1, 1, 1, 3], y_shape=[3]),
         dict(x_shape=[1, 3, 1, 1, 1], y_shape=[3, 1]),
         dict(x_shape=[1, 3, 1, 1, 2], y_shape=[1, 3, 2]),
-        dict(x_shape=[1, 3, 5, 1, 2], y_shape=[5, 3, 2, 1]),
+        dict(x_shape=[1, 5, 3, 1, 2], y_shape=[5, 3, 2, 1]),
         dict(x_shape=[1, 3, 50, 100, 224], y_shape=[1, 1, 1, 1, 224]),
         dict(x_shape=[2, 3, 1, 2, 1], y_shape=[1, 3, 2, 1, 1])
     ]
@@ -243,8 +210,7 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_5D(self, params, ie_device, precision, ir_version,
                                                 temp_dir, use_legacy_frontend):
-        self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_legacy_frontend=use_legacy_frontend),
+        self._test(*self.create_mul_placeholder_const_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
 
@@ -293,11 +259,12 @@ class TestComplexMul(CommonTFLayerTest):
         dict(input_shape=[2, 3, 4]),
         dict(input_shape=[3, 4, 5, 6]),
     ]
+
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_mul(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_legacy_frontend):
+                         use_legacy_frontend):
         self._test(
             *self.create_complex_mul_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,

--- a/tests/layer_tests/tensorflow_tests/test_tf_Mul.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Mul.py
@@ -9,7 +9,7 @@ from common.utils.tf_utils import permute_nchw_to_nhwc
 
 
 class TestMul(CommonTFLayerTest):
-    def create_mul_placeholder_const_net(self, x_shape, y_shape, ir_version, use_new_frontend):
+    def create_mul_placeholder_const_net(self, x_shape, y_shape, ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -28,8 +28,8 @@ class TestMul(CommonTFLayerTest):
             tf_x_shape = x_shape.copy()
             tf_y_shape = y_shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
-            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
+            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_legacy_frontend)
 
             x = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
             constant_value = np.random.randint(-255, 255, tf_y_shape).astype(np.float32)
@@ -63,11 +63,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_2D = [
         dict(x_shape=[1, 1], y_shape=[1, 1]),
@@ -80,11 +80,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1, 1, 1]),
@@ -100,11 +100,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1, 1, 1, 1]),
@@ -117,11 +117,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1, 1, 1, 1, 1]),
@@ -135,11 +135,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     ###############################################################################################
     #                                                                                             #
@@ -154,11 +154,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_1D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_1D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_2D = [
         dict(x_shape=[1, 1], y_shape=[1]),
@@ -172,11 +172,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_2D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_2D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1]),
@@ -198,11 +198,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_3D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_3D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1]),
@@ -221,11 +221,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_mul_placeholder_const_broadcast_4D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1]),
@@ -242,11 +242,11 @@ class TestMul(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_5D)
     @pytest.mark.nightly
     def test_mul_placeholder_const_broadcast_5D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_mul_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestComplexMul(CommonTFLayerTest):
@@ -297,8 +297,8 @@ class TestComplexMul(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_mul(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(
             *self.create_complex_mul_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_MulNoNan.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_MulNoNan.py
@@ -41,7 +41,7 @@ class TestMulNoNan(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_mul_no_nan_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend):
+                              use_legacy_frontend):
         self._test(*self.create_mul_no_nan_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Multinomial.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Multinomial.py
@@ -120,7 +120,7 @@ class TestMultinomial(CommonTFLayerTest):
         precision,
         ir_version,
         temp_dir,
-        use_new_frontend,
+        use_legacy_frontend,
     ):
         if ie_device == "GPU":
             pytest.skip("Multinomial is not supported on GPU")
@@ -137,6 +137,6 @@ class TestMultinomial(CommonTFLayerTest):
             precision,
             temp_dir=temp_dir,
             ir_version=ir_version,
-            use_new_frontend=use_new_frontend,
+            use_legacy_frontend=use_legacy_frontend,
             kwargs_to_prepare_input={"input": input, "num_samples": num_samples},
         )

--- a/tests/layer_tests/tensorflow_tests/test_tf_NestedWhile.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_NestedWhile.py
@@ -70,12 +70,12 @@ class TestNestedWhile(CommonTFLayerTest):
         return g, None
 
     @pytest.mark.nightly
-    def test_simple_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_simple_while(self, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_simple_while(), ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_nested_while(self, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_nested_while(self, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_nested_while(), ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_NonMaxSupression.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_NonMaxSupression.py
@@ -14,7 +14,7 @@ class TestNonMaxSuppression(CommonTFLayerTest):
 
     # overload inputs generation to suit NMS use case
     def _prepare_input(self, inputs_dict):
-        channel = ':0' if not self.use_new_frontend else ''
+        channel = ':0' if not self.use_legacy_frontend else ''
         input_data = {}
         for input in inputs_dict.keys():
             input_data[input + channel] = np.random.uniform(low=0, high=1,
@@ -88,19 +88,19 @@ class TestNonMaxSuppression(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_NonMaxSuppression(self, test_params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend):
+                              use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("Skip TF NonMaxSuppresion test on GPU")
         self._test(*self.create_nms_net(test_params), ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.parametrize("test_params", test_params)
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_tf_fe
     def test_NonMaxSuppressionWithScores(self, test_params, ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend):
+                                        use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("Skip TF NonMaxSuppresionWithScores test on GPU")
         self._test(*self.create_nms_net(test_params, with_scores=True), ie_device, precision,
-                   ir_version, temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_NormalizeL2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_NormalizeL2.py
@@ -37,10 +37,10 @@ class TestNormalizeL2(CommonTFLayerTest):
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 126314, 122716')
     def test_normalize_l2_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend):
+                                use_legacy_frontend):
         self._test(*self.create_normalize_l2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_complex = [
         dict(shape=[2, 3, 5, 4], axes=[1, 2, 3]),
@@ -50,7 +50,7 @@ class TestNormalizeL2(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_complex)
     @pytest.mark.nightly
     def test_normalize_l2_complex(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_normalize_l2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_OneHot.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_OneHot.py
@@ -32,10 +32,10 @@ class TestOneHot(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_one_hot_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_one_hot_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_one_hot_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_complex = [
         dict(shape=[3, 4], depth=1, on_value=1.0, off_value=-5.0, axis=-2),
@@ -44,7 +44,7 @@ class TestOneHot(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.nightly
-    def test_one_hot_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_one_hot_complex(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_one_hot_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_OnesLike.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_OnesLike.py
@@ -39,7 +39,7 @@ class TestOnesLike(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_ones_like(self, params, ie_device, precision, ir_version, temp_dir,
-                       use_new_frontend):
+                       use_legacy_frontend):
         self._test(*self.create_ones_like_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Pack.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Pack.py
@@ -47,7 +47,7 @@ class TestPack(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_pack_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend):
+                        use_legacy_frontend):
         self._test(*self.create_pack_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Pad.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Pad.py
@@ -39,10 +39,10 @@ class TestPad(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_pad_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_pad_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_pad_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestComplexPad(CommonTFLayerTest):
@@ -83,7 +83,7 @@ class TestComplexPad(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_pad_complex(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_pad_complex(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_pad_complex_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ParallelDynamicStitch.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ParallelDynamicStitch.py
@@ -71,12 +71,12 @@ class TestParallelDynamicStitch(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_parallel_dynamic_stitch_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
-        if not use_new_frontend:
+                               use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("DynamicStitch operation is not supported via legacy frontend.")
         self._test(*self.create_parallel_dynamic_stitch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_different_types = [
         dict(data_input_cnt=4, shape_of_element=[3, 2], data_type=tf.float64),
@@ -87,9 +87,9 @@ class TestParallelDynamicStitch(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_different_types)
     @pytest.mark.nightly
     def test_parallel_dynamic_stitch_different_types(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
-        if not use_new_frontend:
+                               use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("DynamicStitch operation is not supported via legacy frontend.")
         self._test(*self.create_parallel_dynamic_stitch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Placeholder.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Placeholder.py
@@ -49,7 +49,7 @@ class TestPlaceholder(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_placeholder(self, input_shape, input_type, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_placeholder_net(input_shape, input_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Pooling.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Pooling.py
@@ -12,7 +12,7 @@ from unit_tests.utils.graph import build_graph
 
 class TestPooling(CommonTFLayerTest):
     def create_pooling_net(self, kernel_size, strides, pads, in_shape, out_shape, method,
-                           ir_version, use_new_frontend):
+                           ir_version, use_legacy_frontend):
         """
             Tensorflow net                 IR net
 
@@ -149,11 +149,11 @@ class TestPooling(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
-    def test_pool_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_pool_4D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_pooling_net(**params, ir_version=ir_version,
-                                            use_new_frontend=use_new_frontend),
+                                            use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = []
     for method in ['max', 'avg']:
@@ -232,10 +232,10 @@ class TestPooling(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
-    def test_pool_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_pool_5D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_pooling_net(**params, ir_version=ir_version,
-                                            use_new_frontend=use_new_frontend),
+                                            use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
@@ -16,7 +16,7 @@ from unit_tests.utils.graph import build_graph, regular_op_with_shaped_data, con
 class TestRandomUniform(CommonTFLayerTest):
     def create_tf_random_uniform_net(self, global_seed, op_seed, x_shape, min_val, max_val,
                                      input_type, precision,
-                                     ir_version, use_new_frontend):
+                                     ir_version, use_legacy_frontend):
         tf.compat.v1.reset_default_graph()
 
         # Create the graph and model
@@ -93,13 +93,13 @@ class TestRandomUniform(CommonTFLayerTest):
     @pytest.mark.xfail(platform.machine() in ["aarch64", "arm64", "ARM64"],
                        reason='Ticket - 122716')
     def test_random_uniform_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("RandomUniform is not supported on GPU")
         self._test(
             *self.create_tf_random_uniform_net(**params, precision=precision, ir_version=ir_version,
-                                               use_new_frontend=use_new_frontend), ie_device,
-            precision, temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                                               use_legacy_frontend=use_legacy_frontend), ie_device,
+            precision, temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
             **params)
 
     test_data_other = [
@@ -115,11 +115,11 @@ class TestRandomUniform(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_other)
     @pytest.mark.nightly
     def test_random_uniform_other(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("RandomUniform is not supported on GPU")
         self._test(
             *self.create_tf_random_uniform_net(**params, precision=precision, ir_version=ir_version,
-                                               use_new_frontend=use_new_frontend), ie_device,
-            precision, temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                                               use_legacy_frontend=use_legacy_frontend), ie_device,
+            precision, temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
             **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Range.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Range.py
@@ -52,7 +52,7 @@ class TestRange(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_range_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_range_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Rank.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Rank.py
@@ -29,7 +29,7 @@ class TestRank(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_rank_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend):
+                        use_legacy_frontend):
         self._test(*self.create_rank_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReLU6.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReLU6.py
@@ -10,7 +10,7 @@ from unit_tests.utils.graph import build_graph
 
 
 class TestReLU6(CommonTFLayerTest):
-    def create_relu6_net(self, shape, ir_version, use_new_frontend):
+    def create_relu6_net(self, shape, ir_version, use_legacy_frontend):
         """
             Tensorflow net                 IR net
 
@@ -26,7 +26,7 @@ class TestReLU6(CommonTFLayerTest):
         with tf.compat.v1.Session() as sess:
             tf_x_shape = shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
             input = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
 
             tf.nn.relu6(input, name='Operation')
@@ -42,7 +42,7 @@ class TestReLU6(CommonTFLayerTest):
 
         ref_net = None
 
-        if check_ir_version(10, None, ir_version) and not use_new_frontend:
+        if check_ir_version(10, None, ir_version) and not use_legacy_frontend:
             nodes_attributes = {
                 'input': {'kind': 'op', 'type': 'Parameter'},
                 'input_data': {'shape': shape, 'kind': 'data'},
@@ -66,11 +66,11 @@ class TestReLU6(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_relu6_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
+                             use_legacy_frontend):
         self._test(*self.create_relu6_net(**params, ir_version=ir_version,
-                                          use_new_frontend=use_new_frontend),
+                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data = [dict(shape=[1]),
                  pytest.param(dict(shape=[1, 224]), marks=pytest.mark.precommit_tf_fe),
@@ -80,8 +80,8 @@ class TestReLU6(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_relu6(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_relu6(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_relu6_net(**params, ir_version=ir_version,
-                                          use_new_frontend=use_new_frontend),
+                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Reciprocal.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Reciprocal.py
@@ -37,7 +37,7 @@ class TestReciprocal(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_reciprocal_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend):
+                              use_legacy_frontend):
         self._test(*self.create_reciprocal_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReduceArithmeticOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReduceArithmeticOps.py
@@ -14,7 +14,7 @@ class TestReduceArithmeticOps(CommonTFLayerTest):
         inputs_data['input'] = np.random.randint(-10, 10, x_shape).astype(np.float32)
         return inputs_data
 
-    def create_reduce_net(self, shape, axis, operation, keep_dims, ir_version, use_new_frontend):
+    def create_reduce_net(self, shape, axis, operation, keep_dims, ir_version, use_legacy_frontend):
         import tensorflow as tf
         ops_mapping = {
             "Max": tf.raw_ops.Max,
@@ -45,8 +45,8 @@ class TestReduceArithmeticOps(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit_tf_fe
     def test_reduce(self, params, operation, keep_dims, ie_device, precision, ir_version, temp_dir,
-                    use_new_frontend):
+                    use_legacy_frontend):
         self._test(*self.create_reduce_net(**params, operation=operation, keep_dims=keep_dims, ir_version=ir_version,
-                                           use_new_frontend=use_new_frontend),
+                                           use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReduceLogicalOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReduceLogicalOps.py
@@ -21,8 +21,8 @@ class TestLogicalOps(CommonTFLayerTest):
     # axis - array which points on axis for the operation
     # op_type - type of tested operation
     # ir_version - common parameter
-    # use_new_frontend - common parameter
-    def create_logical_ops_placeholder_const_net(self, input_shape, axis, op_type, ir_version, use_new_frontend):
+    # use_legacy_frontend - common parameter
+    def create_logical_ops_placeholder_const_net(self, input_shape, axis, op_type, ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -65,8 +65,8 @@ class TestLogicalOps(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_logical_ops_placeholder_const(self, params, op_type, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_logical_ops_placeholder_const_net(**params, op_type=op_type, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Resample_pattern_new.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Resample_pattern_new.py
@@ -14,7 +14,7 @@ class TestResamplePattern(CommonTFLayerTest):
             inputs_dict[input] = np.random.randint(1, 256, inputs_dict[input]).astype(np.float32)
         return inputs_dict
 
-    def create_resample_net(self, shape, factor, use_new_frontend):
+    def create_resample_net(self, shape, factor, use_legacy_frontend):
         """
             The sub-graph in TF that could be expressed as a single Resample operation.
         """
@@ -46,7 +46,7 @@ class TestResamplePattern(CommonTFLayerTest):
         #
 
         ref_net = None
-        if not use_new_frontend:
+        if not use_legacy_frontend:
             new_shape = shape.copy()
             new_shape[2] *= factor
             new_shape[3] *= factor
@@ -73,7 +73,7 @@ class TestResamplePattern(CommonTFLayerTest):
     # TODO mark as precommit (after successfully passing in nightly)
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_resample(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
-        self._test(*self.create_resample_net(params['shape'], params['factor'], use_new_frontend),
+    def test_resample(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
+        self._test(*self.create_resample_net(params['shape'], params['factor'], use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Reshape.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Reshape.py
@@ -45,10 +45,10 @@ class TestReshape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_reshape_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         self._test(*self.create_reshape_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 class TestComplexReshape(CommonTFLayerTest):
     def _prepare_input(self, inputs_info):
@@ -87,9 +87,9 @@ class TestComplexReshape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_reshape(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(
             *self.create_complex_transpose_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)
 

--- a/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
@@ -58,8 +58,8 @@ class TestResize(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
-    def test_resize_basic(self, images_shape, images_type, size_value, align_corners, half_pixel_centers, resize_op, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_resize_basic(self, images_shape, images_type, size_value, align_corners, half_pixel_centers, resize_op, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         params = dict(images_shape=images_shape, images_type=images_type, size_value=size_value, align_corners=align_corners, half_pixel_centers=half_pixel_centers, resize_op=OPS[resize_op])
         self._test(*self.create_resize_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ReverseSequence.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ReverseSequence.py
@@ -47,7 +47,7 @@ class TestReverseSequence(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_reverse_sequence_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_reverse_sequence_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Roll.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Roll.py
@@ -8,14 +8,14 @@ from common.utils.tf_utils import permute_nchw_to_nhwc
 
 
 class TestTFRoll(CommonTFLayerTest):
-    def create_tf_roll_net(self, shift, axis, x_shape, input_type, ir_version, use_new_frontend):
+    def create_tf_roll_net(self, shift, axis, x_shape, input_type, ir_version, use_legacy_frontend):
         tf.compat.v1.reset_default_graph()
 
         # Create the graph and model
         with tf.compat.v1.Session() as sess:
             tf_x_shape = x_shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
 
             x = tf.compat.v1.placeholder(input_type, tf_x_shape, 'Input')
             roll = tf.roll(x, shift=shift, axis=axis)
@@ -41,11 +41,11 @@ class TestTFRoll(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_tf_roll(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_tf_roll(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_tf_roll_net(**params, ir_version=ir_version,
-                                            use_new_frontend=use_new_frontend), ie_device,
+                                            use_legacy_frontend=use_legacy_frontend), ie_device,
                    precision,
-                   temp_dir=temp_dir, ir_version=ir_version, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_legacy_frontend=use_legacy_frontend,
                    **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Rsqrt.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Rsqrt.py
@@ -14,7 +14,7 @@ class TestRsqrt(CommonTFLayerTest):
             inputs_dict[input] = np.random.randint(1, 256, inputs_dict[input]).astype(np.float32)
         return inputs_dict
 
-    def create_rsqrt_net(self, shape, ir_version, use_new_frontend):
+    def create_rsqrt_net(self, shape, ir_version, use_legacy_frontend):
         """
             Tensorflow net                 IR net
 
@@ -30,7 +30,7 @@ class TestRsqrt(CommonTFLayerTest):
         with tf.compat.v1.Session() as sess:
             tf_x_shape = shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
             input = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
 
             tf.math.rsqrt(input, name='Operation')
@@ -54,11 +54,11 @@ class TestRsqrt(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_rsqrt_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
+                             use_legacy_frontend):
         self._test(*self.create_rsqrt_net(**params, ir_version=ir_version,
-                                          use_new_frontend=use_new_frontend),
+                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data = [dict(shape=[1]),
                  pytest.param(dict(shape=[1, 224]), marks=pytest.mark.precommit_tf_fe),
@@ -68,8 +68,8 @@ class TestRsqrt(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_rsqrt(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_rsqrt(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_rsqrt_net(**params, ir_version=ir_version,
-                                          use_new_frontend=use_new_frontend),
+                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ScatterND.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ScatterND.py
@@ -11,7 +11,7 @@ from common.utils.tf_utils import permute_nchw_to_nhwc
 
 class TestTFScatterND(CommonTFLayerTest):
     def create_tf_scatternd_placeholder_const_net(self, x_shape, indices, updates, ir_version,
-                                                  use_new_frontend):
+                                                  use_legacy_frontend):
         #
         #   Create Tensorflow model
         #
@@ -24,7 +24,7 @@ class TestTFScatterND(CommonTFLayerTest):
         with tf.compat.v1.Session() as sess:
             tf_x_shape = x_shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
 
             x = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
             tf_indices = tf.constant(indices)
@@ -74,8 +74,8 @@ class TestTFScatterND(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_tf_scatter_nd(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         self._test(*self.create_tf_scatternd_placeholder_const_net(**params, ir_version=ir_version,
-                                                                   use_new_frontend=use_new_frontend),
+                                                                   use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   use_new_frontend=use_new_frontend, **params)
+                   use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SegmentSum.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SegmentSum.py
@@ -46,12 +46,12 @@ class TestSegmentSum(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_segment_sum_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
-        if not use_new_frontend:
+                               use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("SegmentSum operation is not supported via legacy frontend.")
         self._test(*self.create_segment_sum_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_different_types = [
         dict(data_shape=[2, 3], segment_ids_shape=[2], data_type=tf.int32, segment_ids_type=tf.int32),
@@ -63,9 +63,9 @@ class TestSegmentSum(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_different_types)
     @pytest.mark.nightly
     def test_segment_sum_different_types(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend):
-        if not use_new_frontend:
+                                         use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("SegmentSum operation is not supported via legacy frontend.")
         self._test(*self.create_segment_sum_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Select.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Select.py
@@ -46,9 +46,9 @@ class TestSelect(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_select_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend):
-        if not use_new_frontend:
+                          use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("Select tests are not passing for the legacy frontend.")
         self._test(*self.create_select_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SelectV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SelectV2.py
@@ -45,9 +45,9 @@ class TestSelectV2(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_select_v2_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
-        if not use_new_frontend:
+                             use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("Select tests are not passing for the legacy frontend.")
         self._test(*self.create_select_v2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Shape.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Shape.py
@@ -51,12 +51,12 @@ class TestShape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_shape_basic(self, input_shape, input_type, out_type, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         if input_shape == [] and out_type == tf.int64:
             pytest.skip('129100 - Hangs or segfault')
         self._test(*self.create_shape_net(input_shape=input_shape, input_type=input_type, out_type=out_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestComplexShape(CommonTFLayerTest):
@@ -96,8 +96,8 @@ class TestComplexShape(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_shape(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         self._test(
             *self.create_complex_shape_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ShapeN.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ShapeN.py
@@ -32,7 +32,7 @@ class TestShapeN(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_shape_n_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         self._test(*self.create_shape_n_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Size.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Size.py
@@ -39,7 +39,7 @@ class TestSize(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_size_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend):
+                        use_legacy_frontend):
         self._test(*self.create_size_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Slice.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Slice.py
@@ -30,7 +30,7 @@ class TestSlice(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    def test_slice_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_slice_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Softmax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Softmax.py
@@ -39,7 +39,7 @@ class TestSoftmax(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_softmax_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         self._test(*self.create_softmax_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Softsign.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Softsign.py
@@ -10,7 +10,7 @@ from unit_tests.utils.graph import build_graph
 
 
 class TestSoftsign(CommonTFLayerTest):
-    def create_softsign_net(self, shape, ir_version, use_new_frontend):
+    def create_softsign_net(self, shape, ir_version, use_legacy_frontend):
         """
             Tensorflow net                 IR net
 
@@ -26,7 +26,7 @@ class TestSoftsign(CommonTFLayerTest):
         with tf.compat.v1.Session() as sess:
             tf_x_shape = shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
             input = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
 
             tf.nn.softsign(input)
@@ -42,7 +42,7 @@ class TestSoftsign(CommonTFLayerTest):
 
         ref_net = None
 
-        if check_ir_version(10, None, ir_version) and not use_new_frontend:
+        if check_ir_version(10, None, ir_version) and not use_legacy_frontend:
             nodes_attributes = {
                 'input': {'kind': 'op', 'type': 'Parameter'},
                 'input_data': {'shape': shape, 'kind': 'data'},
@@ -71,8 +71,8 @@ class TestSoftsign(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_softsign(self, params, ie_device, precision, ir_version, temp_dir,
-                      use_new_frontend):
+                      use_legacy_frontend):
         self._test(*self.create_softsign_net(**params, ir_version=ir_version,
-                                             use_new_frontend=use_new_frontend),
+                                             use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SpaceToBatch.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SpaceToBatch.py
@@ -38,10 +38,10 @@ class TestSpaceToBatch(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_space_to_batch_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_space_to_batch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(in_shape=[1, 2, 2, 3], block_shape_value=[2, 2], pads_value=[[0, 0], [0, 0]]),
@@ -51,10 +51,10 @@ class TestSpaceToBatch(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_space_to_batch_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_space_to_batch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(in_shape=[3, 3, 4, 5, 2], block_shape_value=[3, 4, 2],
@@ -66,7 +66,7 @@ class TestSpaceToBatch(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_space_to_batch_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_space_to_batch_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SpaceToBatchND.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SpaceToBatchND.py
@@ -29,7 +29,7 @@ class TestSpaceToBatchND(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_space_to_batch_nd_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend):
+                                     use_legacy_frontend):
         self._test(*self.create_space_to_batch_nd_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SpaceToDepth.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SpaceToDepth.py
@@ -29,7 +29,7 @@ class TestSpaceToDepth(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_space_to_depth_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_space_to_depth_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Split.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Split.py
@@ -31,7 +31,7 @@ class TestSplit(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_split_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_split_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SplitV.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SplitV.py
@@ -36,7 +36,7 @@ class TestSplitV(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == 'true', reason="Ticket - 113359")
     def test_split_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_splitv_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Squeeze.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Squeeze.py
@@ -40,10 +40,10 @@ class TestSqueeze(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_squeeze_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                           use_new_frontend):
+                           use_legacy_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_1D = [
         dict(input_shape=[1], axis=[], input_type=np.float32),
@@ -52,10 +52,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_squeeze_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_squeeze_1D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_2D = [
         dict(input_shape=[1, 2], axis=[0], input_type=np.float32),
@@ -64,10 +64,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_squeeze_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_squeeze_2D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_3D = [
         dict(input_shape=[2, 1, 3], axis=[], input_type=np.float32),
@@ -76,10 +76,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_squeeze_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_squeeze_3D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(input_shape=[1, 1, 5, 10], axis=[], input_type=np.int32),
@@ -89,10 +89,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_squeeze_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_squeeze_4D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(input_shape=[1, 1, 5, 10, 22], axis=[], input_type=np.float32),
@@ -105,10 +105,10 @@ class TestSqueeze(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_squeeze_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_squeeze_5D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_squeeze_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestComplexSqueeze(CommonTFLayerTest):
@@ -150,8 +150,8 @@ class TestComplexSqueeze(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_squeeze(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(
             *self.create_complex_squeeze_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_StridedSlice.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_StridedSlice.py
@@ -45,10 +45,10 @@ class TestStridedSlice(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_strided_slice_basic(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_new_frontend):
+                                 temp_dir, use_legacy_frontend):
         self._test(*self.create_strided_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_squeeze_data = [
         dict(input_shape=[1, 5], begin_value=[0, 0], end_value=[1, 5], strides_value=[1, 1], begin_mask=0,
@@ -84,10 +84,10 @@ class TestStridedSlice(CommonTFLayerTest):
     @pytest.mark.parametrize('params', test_squeeze_data)
     @pytest.mark.nightly
     def test_strided_slice_replace_with_squeeze(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_strided_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_unsqueeze_data = [
         dict(input_shape=[1, 5], begin_value=[0, 0], end_value=[1, 5], strides_value=[1, 1], begin_mask=0,
@@ -114,10 +114,10 @@ class TestStridedSlice(CommonTFLayerTest):
     @pytest.mark.parametrize('params', test_unsqueeze_data)
     @pytest.mark.nightly
     def test_strided_slice_replace_with_unsqueeze(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, use_new_frontend):
+                                                  temp_dir, use_legacy_frontend):
         self._test(*self.create_strided_slice_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 class TestComplexStridedSlice(CommonTFLayerTest):
     def _prepare_input(self, inputs_info):
@@ -222,8 +222,8 @@ class TestComplexStridedSlice(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_strided_slice(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(
             *self.create_complex_strided_slice_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Sub.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Sub.py
@@ -9,7 +9,7 @@ from common.utils.tf_utils import permute_nchw_to_nhwc
 
 
 class TestSub(CommonTFLayerTest):
-    def create_sub_placeholder_const_net(self, x_shape, y_shape, ir_version, use_new_frontend):
+    def create_sub_placeholder_const_net(self, x_shape, y_shape, ir_version, use_legacy_frontend):
         """
             Tensorflow net                  IR net
 
@@ -28,8 +28,8 @@ class TestSub(CommonTFLayerTest):
             tf_x_shape = x_shape.copy()
             tf_y_shape = y_shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
-            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
+            tf_y_shape = permute_nchw_to_nhwc(tf_y_shape, use_legacy_frontend)
 
             x = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
             constant_value = np.random.randint(-256, 256, tf_y_shape).astype(np.float32)
@@ -64,11 +64,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_1D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     test_data_2D = [
         dict(x_shape=[1, 1], y_shape=[1, 1]),
@@ -80,11 +80,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_2D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     test_data_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1, 1, 1]),
@@ -98,11 +98,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_3D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1, 1, 1, 1]),
@@ -115,11 +115,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_4D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1, 1, 1, 1, 1]),
@@ -132,11 +132,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_5D(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     ###############################################################################################
     #                                                                                             #
@@ -151,11 +151,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_1D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_1D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_2D = [
         dict(x_shape=[1, 1], y_shape=[1]),
@@ -168,11 +168,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_2D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_2D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_3D = [
         dict(x_shape=[1, 1, 1], y_shape=[1]),
@@ -188,11 +188,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_3D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_3D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_4D = [
         dict(x_shape=[1, 1, 1, 1], y_shape=[1]),
@@ -211,11 +211,11 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_4D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_4D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)
 
     test_data_broadcast_5D = [
         dict(x_shape=[1, 1, 1, 1, 1], y_shape=[1, 1, 1, 1, 1]),
@@ -233,8 +233,8 @@ class TestSub(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_broadcast_5D)
     @pytest.mark.nightly
     def test_sub_placeholder_const_broadcast_5D(self, params, ie_device, precision, ir_version,
-                                                temp_dir, use_new_frontend):
+                                                temp_dir, use_legacy_frontend):
         self._test(*self.create_sub_placeholder_const_net(**params, ir_version=ir_version,
-                                                          use_new_frontend=use_new_frontend),
+                                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version,
-                   temp_dir=temp_dir, use_new_frontend=use_new_frontend)
+                   temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Swish.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Swish.py
@@ -10,7 +10,7 @@ from unit_tests.utils.graph import build_graph
 
 
 class TestSwish(CommonTFLayerTest):
-    def create_swish_net(self, shape, ir_version, use_new_frontend):
+    def create_swish_net(self, shape, ir_version, use_legacy_frontend):
         """
             Tensorflow net                 IR net
 
@@ -26,7 +26,7 @@ class TestSwish(CommonTFLayerTest):
         with tf.Session() as sess:
             tf_x_shape = shape.copy()
 
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
             input = tf.placeholder(tf.float32, tf_x_shape, 'Input')
 
             tf.nn.swish(input)
@@ -42,7 +42,7 @@ class TestSwish(CommonTFLayerTest):
 
         ref_net = None
 
-        if check_ir_version(10, None, ir_version) and not use_new_frontend:
+        if check_ir_version(10, None, ir_version) and not use_legacy_frontend:
             nodes_attributes = {
                 'input': {'kind': 'op', 'type': 'Parameter'},
                 'input_data': {'shape': shape, 'kind': 'data'},
@@ -69,11 +69,11 @@ class TestSwish(CommonTFLayerTest):
     @pytest.mark.precommit
     @pytest.mark.nightly
     def test_swish_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
+                             use_legacy_frontend):
         self._test(*self.create_swish_net(**params, ir_version=ir_version,
-                                          use_new_frontend=use_new_frontend),
+                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data = [dict(shape=[1]),
                  dict(shape=[1, 224]),
@@ -83,8 +83,8 @@ class TestSwish(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_swish(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_swish(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_swish_net(**params, ir_version=ir_version,
-                                          use_new_frontend=use_new_frontend),
+                                          use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SwitchMerge.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SwitchMerge.py
@@ -59,7 +59,7 @@ class TestSwitchMerge(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_merge_eliminating_several_cond_flows(self, params, cond_value, x_type, ie_device, precision, ir_version,
                                                   temp_dir,
-                                                  use_new_frontend):
+                                                  use_legacy_frontend):
         self._test(*self.merge_eliminating_several_cond_flows_net(**params, cond_value=cond_value, x_type=x_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorArrayOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorArrayOps.py
@@ -52,10 +52,10 @@ class TestTensorArraySizeV3(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tensor_array_size_v3(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_tensor_array_size_v3(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestTensorArrayReadV3(CommonTFLayerTest):
@@ -96,10 +96,10 @@ class TestTensorArrayReadV3(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tensor_array_read_v3(self, params, ie_device, precision, ir_version, temp_dir,
-                                  use_new_frontend):
+                                  use_legacy_frontend):
         self._test(*self.create_tensor_array_read_v3(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestTensorArrayWriteGatherV3(CommonTFLayerTest):
@@ -162,10 +162,10 @@ class TestTensorArrayWriteGatherV3(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tensor_array_write_v3(self, params, ie_device, precision, ir_version, temp_dir,
-                                   use_new_frontend):
+                                   use_legacy_frontend):
         self._test(*self.create_tensor_array_write_v3(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestTensorArrayConcatV3(CommonTFLayerTest):
@@ -205,7 +205,7 @@ class TestTensorArrayConcatV3(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tensor_array_concat_v3(self, params, ie_device, precision, ir_version, temp_dir,
-                                    use_new_frontend):
+                                    use_legacy_frontend):
         self._test(*self.create_tensor_array_concat_v3(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListConcatV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListConcatV2.py
@@ -43,7 +43,7 @@ class TestTensorListConcatV2(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_tensor_list_resize(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListLength.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListLength.py
@@ -42,10 +42,10 @@ class TestTensorListLength(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_length_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_tensor_list_length(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestTensorListLengthEmptyList(CommonTFLayerTest):
@@ -81,7 +81,7 @@ class TestTensorListLengthEmptyList(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_length_empty_list(self, params, ie_device, precision, ir_version, temp_dir,
-                                           use_new_frontend):
+                                           use_legacy_frontend):
         self._test(*self.create_tensor_list_length_empty_list(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListResize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListResize.py
@@ -46,7 +46,7 @@ class TestTensorListResize(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                      use_new_frontend):
+                                      use_legacy_frontend):
         self._test(*self.create_tensor_list_resize(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Tile.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Tile.py
@@ -40,7 +40,7 @@ class TestTile(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_tile_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                        use_new_frontend):
+                        use_legacy_frontend):
         self._test(*self.create_tile_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ToBool.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ToBool.py
@@ -37,7 +37,7 @@ class TestToBool(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_to_bool_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                         use_new_frontend):
+                                         use_legacy_frontend):
         self._test(*self.create_tobool_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TopK.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopK.py
@@ -12,7 +12,7 @@ from unit_tests.utils.graph import build_graph
 
 class Test_TopK(CommonTFLayerTest):
     @staticmethod
-    def create_topK_net(shape, k, ir_version, use_new_frontend):
+    def create_topK_net(shape, k, ir_version, use_legacy_frontend):
         """
             Tensorflow net:
 
@@ -56,11 +56,11 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_1D)
     @pytest.mark.nightly
-    def test_TopK_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_TopK_1D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
-                                         use_new_frontend=use_new_frontend),
+                                         use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_2D = [
         dict(shape=[14, 15], k=10),
@@ -69,11 +69,11 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_2D)
     @pytest.mark.nightly
-    def test_TopK_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_TopK_2D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
-                                         use_new_frontend=use_new_frontend),
+                                         use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_3D = [
         dict(shape=[13, 14, 15], k=10),
@@ -82,11 +82,11 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_3D)
     @pytest.mark.nightly
-    def test_TopK_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_TopK_3D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
-                                         use_new_frontend=use_new_frontend),
+                                         use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_4D = [
         dict(shape=[12, 13, 14, 15], k=10),
@@ -95,11 +95,11 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_4D)
     @pytest.mark.nightly
-    def test_TopK_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_TopK_4D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
-                                         use_new_frontend=use_new_frontend),
+                                         use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_5D = [
         dict(shape=[11, 12, 13, 14, 15], k=10),
@@ -108,8 +108,8 @@ class Test_TopK(CommonTFLayerTest):
 
     @pytest.mark.parametrize("params", test_data_5D)
     @pytest.mark.nightly
-    def test_TopK_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_TopK_5D(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_topK_net(**params, ir_version=ir_version,
-                                         use_new_frontend=use_new_frontend),
+                                         use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
@@ -52,7 +52,7 @@ class TestTopKV2(CommonTFLayerTest):
                                                                                                      'aarch64',
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 126314, 122716')
-    def test_topk_v2_basic(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend):
+    def test_topk_v2_basic(self, params, ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         self._test(*self.create_topk_v2_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Transpose.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Transpose.py
@@ -28,10 +28,10 @@ class TestTranspose(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_transpose_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                             use_new_frontend):
+                             use_legacy_frontend):
         self._test(*self.create_transpose_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestComplexTranspose(CommonTFLayerTest):
@@ -72,8 +72,8 @@ class TestComplexTranspose(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_complex_transpose(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(
             *self.create_complex_transpose_net(**params),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TruncateDiv.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TruncateDiv.py
@@ -49,7 +49,7 @@ class TestTruncateDiv(CommonTFLayerTest):
                                                                                                      'arm64', 'ARM64'),
                        reason='Ticket - 126314, 122716')
     def test_truncate_div_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_truncate_div_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TruncateMod.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TruncateMod.py
@@ -43,7 +43,7 @@ class TestTruncateMod(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_truncate_mod_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                               use_new_frontend):
+                               use_legacy_frontend):
         self._test(*self.create_truncate_mod_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnaryOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnaryOps.py
@@ -49,7 +49,7 @@ class TestUnaryOps(CommonTFLayerTest):
 
         return inputs_dict
 
-    def create_net_with_mish(self, shape, ir_version, use_new_frontend):
+    def create_net_with_mish(self, shape, ir_version, use_legacy_frontend):
         import tensorflow as tf
         import tensorflow_addons as tfa
 
@@ -57,7 +57,7 @@ class TestUnaryOps(CommonTFLayerTest):
 
         with tf.compat.v1.Session() as sess:
             tf_x_shape = shape.copy()
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
 
             input = tf.compat.v1.placeholder(tf.float32, tf_x_shape, 'Input')
             tfa.activations.mish(input)
@@ -69,7 +69,7 @@ class TestUnaryOps(CommonTFLayerTest):
 
         return tf_net, ref_net
 
-    def create_net_with_unary_op(self, shape, ir_version, op_type, use_new_frontend):
+    def create_net_with_unary_op(self, shape, ir_version, op_type, use_legacy_frontend):
         import tensorflow as tf
 
         self.current_op_type = op_type
@@ -115,7 +115,7 @@ class TestUnaryOps(CommonTFLayerTest):
         # Create the graph and model
         with tf.compat.v1.Session() as sess:
             tf_x_shape = shape.copy()
-            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_new_frontend)
+            tf_x_shape = permute_nchw_to_nhwc(tf_x_shape, use_legacy_frontend)
 
             input = tf.compat.v1.placeholder(type, tf_x_shape, 'Input')
             if self.current_op_type == 'Mish':
@@ -163,31 +163,31 @@ class TestUnaryOps(CommonTFLayerTest):
                                          ])
     @pytest.mark.precommit
     def test_unary_op_precommit(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                                use_new_frontend):
-        if not use_new_frontend and op_type in ['BitwiseNot']:
+                                use_legacy_frontend):
+        if not use_legacy_frontend and op_type in ['BitwiseNot']:
             pytest.skip("Bitwise ops are supported only by new TF FE.")
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_net_with_unary_op(**params, ir_version=ir_version, op_type=op_type,
-                                                  use_new_frontend=use_new_frontend),
+                                                  use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.xfail(sys.version_info > (3, 10),
                        reason="tensorflow_addons package is not available for Python 3.11 and higher")
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
     def test_unary_op_mish_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                     use_new_frontend):
+                                     use_legacy_frontend):
         """
         TODO: Move to `test_unary_op_precommit()` once tensorflow_addons package is available for Python 3.11
         """
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_net_with_mish(**params, ir_version=ir_version,
-                                              use_new_frontend=use_new_frontend),
+                                              use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data = [pytest.param(dict(shape=[10, 12]), marks=pytest.mark.precommit_tf_fe),
                  dict(shape=[8, 10, 12]),
@@ -228,28 +228,28 @@ class TestUnaryOps(CommonTFLayerTest):
     @pytest.mark.skipif(sys.platform == 'darwin', reason="Ticket - 122182")
     @pytest.mark.xfail(platform.machine() in ["aarch64", "arm64", "ARM64"], reason='Ticket - 122716')
     def test_unary_op(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                      use_new_frontend):
-        if not use_new_frontend and op_type in ['BitwiseNot']:
+                      use_legacy_frontend):
+        if not use_legacy_frontend and op_type in ['BitwiseNot']:
             pytest.skip("Bitwise ops are supported only by new TF FE.")
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_net_with_unary_op(**params, ir_version=ir_version, op_type=op_type,
-                                                  use_new_frontend=use_new_frontend),
+                                                  use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     @pytest.mark.xfail(sys.version_info > (3, 10),
                        reason="tensorflow_addons package is not available for Python 3.11 and higher")
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_unary_op_mish(self, params, ie_device, precision, ir_version, temp_dir, op_type,
-                           use_new_frontend):
+                           use_legacy_frontend):
         """
         TODO: Move to `test_unary_op()` once tensorflow_addons package is available for Python 3.11
         """
         if ie_device == 'GPU':
             pytest.skip("5D tensors is not supported on GPU")
         self._test(*self.create_net_with_mish(**params, ir_version=ir_version,
-                                              use_new_frontend=use_new_frontend),
+                                              use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Unique.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Unique.py
@@ -39,12 +39,12 @@ class TestUnique(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_unique_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend):
-        if not use_new_frontend:
+                          use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("Unique operation is not supported via legacy frontend.")
         self._test(*self.create_unique_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
     test_data_other_types = [
         dict(x_shape=[10], data_type=tf.int32, out_idx=tf.int32),
@@ -54,9 +54,9 @@ class TestUnique(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_other_types)
     @pytest.mark.nightly
     def test_unique_other_types(self, params, ie_device, precision, ir_version, temp_dir,
-                                use_new_frontend):
-        if not use_new_frontend:
+                                use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("Unique operation is not supported via legacy frontend.")
         self._test(*self.create_unique_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_UniqueWithCounts.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UniqueWithCounts.py
@@ -39,9 +39,9 @@ class TestUnique(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_unique_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend):
-        if not use_new_frontend:
+                          use_legacy_frontend):
+        if use_legacy_frontend:
             pytest.skip("Unique operation is not supported via legacy frontend.")
         self._test(*self.create_unique_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Unpack.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Unpack.py
@@ -49,7 +49,7 @@ class TestUnpack(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_unpack_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                          use_new_frontend):
+                          use_legacy_frontend):
         self._test(*self.create_unpack_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnravelIndex.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnravelIndex.py
@@ -38,7 +38,7 @@ class TestUnravelIndex(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_unravel_index_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                 use_new_frontend):
+                                 use_legacy_frontend):
         self._test(*self.create_unravel_index_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentSum.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_UnsortedSegmentSum.py
@@ -61,11 +61,11 @@ class TestUnsortedSegmentSum(CommonTFLayerTest):
                        reason='Ticket - 122716')
     def test_unsorted_segment_sum_basic(self, params, data_type, segment_ids_type, num_segments_type, ie_device,
                                         precision, ir_version, temp_dir,
-                                        use_new_frontend):
-        if not use_new_frontend:
+                                        use_legacy_frontend):
+        if not use_legacy_frontend:
             pytest.skip("UnsortedSegmentSum operation is not supported via legacy frontend.")
         self._test(
             *self.create_unsorted_segment_sum_net(**params, data_type=data_type, segment_ids_type=segment_ids_type,
                                                   num_segments_type=num_segments_type),
             ie_device, precision, ir_version, temp_dir=temp_dir,
-            use_new_frontend=use_new_frontend)
+            use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Where.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Where.py
@@ -37,7 +37,7 @@ class TestWhere(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_where_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_where_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_While.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_While.py
@@ -60,10 +60,10 @@ class TestWhile(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_while_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestWhileShapeVariant(CommonTFLayerTest):
@@ -120,10 +120,10 @@ class TestWhileShapeVariant(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_while_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)
 
 
 class TestWhileWithNestedIf(CommonTFLayerTest):
@@ -194,7 +194,7 @@ class TestWhileWithNestedIf(CommonTFLayerTest):
     @pytest.mark.nightly
     @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_with_nested_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                                        use_new_frontend):
+                                        use_legacy_frontend):
         self._test(*self.create_while_with_nested_if_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Xlog1py.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Xlog1py.py
@@ -47,7 +47,7 @@ class TestXlog1py(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_xlog1py_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_xlog1py_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Xlogy.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Xlogy.py
@@ -47,7 +47,7 @@ class TestXlogy(CommonTFLayerTest):
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_xlogy_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                         use_new_frontend):
+                         use_legacy_frontend):
         self._test(*self.create_xlogy_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_ZerosLike.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ZerosLike.py
@@ -29,7 +29,7 @@ class TestZerosLike(CommonTFLayerTest):
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     def test_zeros_like_basic(self, params, ie_device, precision, ir_version, temp_dir,
-                              use_new_frontend):
+                              use_legacy_frontend):
         self._test(*self.create_zeros_like_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
-                   use_new_frontend=use_new_frontend)
+                   use_legacy_frontend=use_legacy_frontend)


### PR DESCRIPTION
**Details:** Run layer tests for TF FE by default and use_legacy_frontend for legacy FE. Developers have to add `use_new_frontend` for running layer tests for TF FE. This is not convenient. Instead, let us use `use_legacy_frontend` option for legacy FE that is rarely run.

**Tickets:** TBD
