### PR TITLE
[DOCS] Update OpenVINO API references

### DIFF
--- a/docs/articles_en/about-openvino/release-notes-openvino.rst
+++ b/docs/articles_en/about-openvino/release-notes-openvino.rst
@@ -102,7 +102,6 @@ Support Change and Deprecation Notices
     We encourage developers to use the Neural Processing Unit (NPU) for low-powered systems
     like Intel® CoreTM Ultra or 14th generation and beyond.
   * OpenVINO C++/C/Python 1.0 APIs are deprecated and will be discontinued in the 2024.0 release.
-    Please use API 2.0 in your applications going forward to avoid disruption.
   * OpenVINO property Affinity API will be deprecated from 2024.0 and will be discontinued in 2025.0.
     It will be replaced with CPU binding configurations (``ov::hint::enable_cpu_pinning``).
 

--- a/docs/articles_en/about-openvino/release-notes-openvino.rst
+++ b/docs/articles_en/about-openvino/release-notes-openvino.rst
@@ -102,6 +102,7 @@ Support Change and Deprecation Notices
     We encourage developers to use the Neural Processing Unit (NPU) for low-powered systems
     like Intel® CoreTM Ultra or 14th generation and beyond.
   * OpenVINO C++/C/Python 1.0 APIs are deprecated and will be discontinued in the 2024.0 release.
+    Please use API 2.0 in your applications going forward to avoid disruption.
   * OpenVINO property Affinity API will be deprecated from 2024.0 and will be discontinued in 2025.0.
     It will be replaced with CPU binding configurations (``ov::hint::enable_cpu_pinning``).
 

--- a/docs/articles_en/openvino-workflow/deployment-locally.rst
+++ b/docs/articles_en/openvino-workflow/deployment-locally.rst
@@ -64,7 +64,7 @@ The granularity of OpenVINO packages may vary for different distribution types. 
 .. image:: _static/images/deployment_simplified.svg
 
 
-- The main library ``openvino`` is used by users' C++ applications to link against with. For C language applications, ``openvino_c`` is additionally required for distribution. The library includes OpenVINO API 2.0.
+- The main library ``openvino`` is used by users' C++ applications to link against with. For C language applications, ``openvino_c`` is additionally required for distribution. The library includes OpenVINO API.
 - The "optional" plugin libraries like ``openvino_intel_cpu_plugin`` (matching the ``openvino_.+_plugin`` pattern) are used to provide inference capabilities on specific devices or additional capabilities like :doc:`Hetero Execution <openvino_docs_OV_UG_Hetero_execution>` and :doc:`Multi-Device Execution <openvino_docs_OV_UG_Running_on_multiple_devices>`.
 - The "optional" plugin libraries like ``openvino_ir_frontend`` (matching ``openvino_.+_frontend``) are used to provide capabilities to read models of different file formats such as OpenVINO IR, TensorFlow, ONNX, and PaddlePaddle.
 

--- a/docs/articles_en/openvino-workflow/running-inference/optimize-inference/high-level-performance-hints.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/optimize-inference/high-level-performance-hints.rst
@@ -15,7 +15,7 @@ The preferred way to configure performance in OpenVINO Runtime is using performa
 
 The hints also set the direction of the configuration in the right order. Instead of mapping the application needs to the low-level performance settings, and keeping an associated application logic to configure each possible device separately, the hints express a target scenario with a single config key and let the *device* configure itself in response.
 
-Previously, a certain level of automatic configuration was the result of the *default* values of the parameters. For example, the number of CPU streams was deduced from the number of CPU cores, when `ov::streams::AUTO <groupov_runtime_cpp_prop_api.html#doxid-group-ov-runtime-cpp-prop-api-1gaddb29425af71fbb6ad3379c59342ff0e>`__ (``CPU_THROUGHPUT_AUTO`` in the pre-API 2.0 terminology) was set. However, the resulting number of streams did not account for actual compute requirements of the model to be inferred.
+Previously, a certain level of automatic configuration was the result of the *default* values of the parameters. For example, the number of CPU streams was deduced from the number of CPU cores, when `ov::streams::AUTO <groupov_runtime_cpp_prop_api.html#doxid-group-ov-runtime-cpp-prop-api-1gaddb29425af71fbb6ad3379c59342ff0e>`__ (previously ``CPU_THROUGHPUT_AUTO``) was set. However, the resulting number of streams did not account for actual compute requirements of the model to be inferred.
 The hints, in contrast, respect the actual model, so the parameters for optimal throughput are calculated for each model individually (based on its compute versus memory bandwidth requirements and capabilities of the device).
 
 Performance Hints: Latency and Throughput

--- a/docs/articles_en/openvino-workflow/running-inference/optimize-inference/high-level-performance-hints.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/optimize-inference/high-level-performance-hints.rst
@@ -15,7 +15,7 @@ The preferred way to configure performance in OpenVINO Runtime is using performa
 
 The hints also set the direction of the configuration in the right order. Instead of mapping the application needs to the low-level performance settings, and keeping an associated application logic to configure each possible device separately, the hints express a target scenario with a single config key and let the *device* configure itself in response.
 
-Previously, a certain level of automatic configuration was the result of the *default* values of the parameters. For example, the number of CPU streams was deduced from the number of CPU cores, when `ov::streams::AUTO <groupov_runtime_cpp_prop_api.html#doxid-group-ov-runtime-cpp-prop-api-1gaddb29425af71fbb6ad3379c59342ff0e>`__ (previously ``CPU_THROUGHPUT_AUTO``) was set. However, the resulting number of streams did not account for actual compute requirements of the model to be inferred.
+Previously, a certain level of automatic configuration was the result of the *default* values of the parameters. For example, the number of CPU streams was deduced from the number of CPU cores, when `ov::streams::AUTO <groupov_runtime_cpp_prop_api.html#doxid-group-ov-runtime-cpp-prop-api-1gaddb29425af71fbb6ad3379c59342ff0e>`__ was set. However, the resulting number of streams did not account for actual compute requirements of the model to be inferred.
 The hints, in contrast, respect the actual model, so the parameters for optimal throughput are calculated for each model individually (based on its compute versus memory bandwidth requirements and capabilities of the device).
 
 Performance Hints: Latency and Throughput

--- a/docs/sphinx_setup/api/api_reference.rst
+++ b/docs/sphinx_setup/api/api_reference.rst
@@ -20,7 +20,7 @@ OpenVINO toolkit offers **APIs for Python, C, and C++** which share most feature
 most comprehensive one), have a common structure, naming convention styles, namespaces,
 and no duplicate structures.
 
-OpenVINO API 2.0 may be described by the following:
+OpenVINO API may be described by the following:
 
 - Preserves input element types and order of dimensions (layouts), and stores tensor names from the
   original models (Model Conversion API).

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -422,7 +422,7 @@ int main(int argc, char* argv[]) {
                 if (it_device_nstreams != device_nstreams.end()) {
                     // set to user defined value
                     if (supported(ov::num_streams.name())) {
-                        // Use API 2.0 key for streams
+                        // Use OpenVINO API key for streams
                         device_config[key] = it_device_nstreams->second;
                     } else if (is_virtual_device(device)) {
                         update_device_config_for_virtual_device(it_device_nstreams->second,
@@ -445,7 +445,7 @@ int main(int argc, char* argv[]) {
                                << slog::endl;
 
                     if (supported(ov::num_streams.name())) {
-                        // Use API 2.0 key for streams
+                        // Use OpenVINO API key for streams
                         device_config[key] = ov::streams::AUTO;
                     } else if (is_virtual_device(device)) {
                         // Set nstreams to default value auto if no nstreams specified from cmd line.

--- a/src/bindings/python/src/openvino/__init__.py
+++ b/src/bindings/python/src/openvino/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
     pass
 
 # #
-# # API 2.0
+# # OpenVINO API
 # # This __init__.py forces checking of runtime modules to propagate errors.
 # # It is not compared with init files from openvino-dev package.
 # #

--- a/tools/benchmark_tool/openvino/__init__.py
+++ b/tools/benchmark_tool/openvino/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
     pass
 
 # #
-# # API 2.0
+# # OpenVINO API
 # # This __init__.py forces checking of runtime modules to propagate errors.
 # # It is not compared with init files from openvino-dev package.
 # #

--- a/tools/mo/openvino/__init__.py
+++ b/tools/mo/openvino/__init__.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     pass
 
-# API 2.0
+# OpenVINO API
 try:
     # Import all public modules
     from openvino import runtime as runtime

--- a/tools/openvino_dev/src/openvino/__init__.py
+++ b/tools/openvino_dev/src/openvino/__init__.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     pass
 
-# API 2.0
+# OpenVINO API
 try:
     # Import all public modules
     from openvino import runtime as runtime

--- a/tools/ovc/openvino/__init__.py
+++ b/tools/ovc/openvino/__init__.py
@@ -13,7 +13,7 @@ except ImportError:
     pass
 
 # #
-# # API 2.0
+# # OpenVINO API
 # # This __init__.py forces checking of runtime modules to propagate errors.
 # # It is not compared with init files from openvino-dev package.
 # #


### PR DESCRIPTION
Changing references from "OpenVINO API 2.0"  to "OpenVINO API", as mentioned in https://github.com/openvinotoolkit/openvino/pull/22873#discussion_r1492115073
