### PR TITLE
[BUGFIX][shapeinference]: Fixed a bug in get_input_bounds with op with no input on specifed port

### DIFF
--- a/src/core/shape_inference/include/utils.hpp
+++ b/src/core/shape_inference/include/utils.hpp
@@ -365,7 +365,7 @@ ov::optional<TResult> get_input_bounds(const ov::Node* op, size_t port, const IT
         out.emplace();
         out->reserve(lowers.size());
         std::transform(lowers.cbegin(), lowers.cend(), lowers.cbegin(), std::back_inserter(*out), make_bound(et));
-    } else {
+    } else if (port < op->get_input_size()) {
         auto bounds = ov::evaluate_both_bounds(op->get_input_source_output(port));
 
         if (bounds.first && bounds.second) {

--- a/src/core/tests/shape_inference_utils_test.cpp
+++ b/src/core/tests/shape_inference_utils_test.cpp
@@ -1,11 +1,11 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "../shape_inference/include/tensor_data_accessor.hpp"
-#include "../shape_inference/include/utils.hpp"
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "openvino/op/reverse.hpp"
+#include "utils.hpp"
 
 TEST(shape_inference_utils_test, get_input_bounds_not_valid_port) {
     ov::op::v1::Reverse dummy_op;

--- a/src/core/tests/utils_tests.cpp
+++ b/src/core/tests/utils_tests.cpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "../shape_inference/include/tensor_data_accessor.hpp"
+#include "../shape_inference/include/utils.hpp"
+#include "gtest/gtest.h"
+#include "openvino/op/reverse.hpp"
+
+TEST(shape_inference_utils_test, get_input_bounds_not_valid_port) {
+    ov::op::v1::Reverse dummy_op;
+    const size_t not_valid_port = 100;
+    const ov::ITensorAccessor& ta = ov::make_tensor_accessor();
+
+    const auto ret = ov::op::get_input_bounds<ov::PartialShape, int64_t>(&dummy_op, not_valid_port, ta);
+    ASSERT_FALSE(ret);
+}


### PR DESCRIPTION
### Details:
Fixed a bug in get_input_bounds(), where method tries to access input at specified port, but operator does not have anything attached at that port - the result was a crash. 

This situation was encountered when calling shape_infer() method with slice op, which did not have any attached inputs.