### PR TITLE
Get rid of API1.0 in `stress_tests`

### DIFF
--- a/tests/stress_tests/.automation/memcheck_tests/nightly_configs/desktop_test_config.xml
+++ b/tests/stress_tests/.automation/memcheck_tests/nightly_configs/desktop_test_config.xml
@@ -3,10 +3,6 @@
         <value>CPU</value>
         <value>GPU</value>
     </devices>
-    <api_versions>
-        <value>1</value>
-        <value>2</value>
-    </api_versions>
     <models>
         <!--Models with FP32 precision-->
         <model name="mobilenet-v2-1.4-224" precision="FP32" source="omz" />

--- a/tests/stress_tests/.automation/memcheck_tests/precommit_configs/desktop_test_config.xml
+++ b/tests/stress_tests/.automation/memcheck_tests/precommit_configs/desktop_test_config.xml
@@ -3,10 +3,6 @@
         <value>CPU</value>
         <value>GPU</value>
     </devices>
-    <api_versions>
-        <value>1</value>
-        <value>2</value>
-    </api_versions>
     <models>
         <!--Models with FP32 precision-->
         <model name="vgg16" precision="FP32" source="omz" />

--- a/tests/stress_tests/.automation/memcheck_tests/weekly_configs/desktop_test_config.xml
+++ b/tests/stress_tests/.automation/memcheck_tests/weekly_configs/desktop_test_config.xml
@@ -3,10 +3,6 @@
         <value>CPU</value>
         <value>GPU</value>
     </devices>
-    <api_versions>
-        <value>1</value>
-        <value>2</value>
-    </api_versions>
     <models>
         <!--Models with FP32 precision-->
         <model name="mobilenet-v2-1.4-224" precision="FP32" source="omz" />

--- a/tests/stress_tests/.automation/unittests/nightly_configs/desktop_test_config.xml
+++ b/tests/stress_tests/.automation/unittests/nightly_configs/desktop_test_config.xml
@@ -14,10 +14,6 @@
         <value>CPU</value>
         <value>GPU</value>
     </devices>
-    <api_versions>
-        <value>1</value>
-        <value>2</value>
-    </api_versions>
     <models>
         <model name="alexnet" precision="FP32" source="omz" />
         <model name="mobilenet-ssd" precision="FP32" source="omz" />

--- a/tests/stress_tests/.automation/unittests/weekly_configs/desktop_test_config.xml
+++ b/tests/stress_tests/.automation/unittests/weekly_configs/desktop_test_config.xml
@@ -15,10 +15,6 @@
         <value>CPU</value>
         <value>GPU</value>
     </devices>
-    <api_versions>
-        <value>1</value>
-        <value>2</value>
-    </api_versions>
     <models>
         <model name="alexnet" precision="FP32" source="omz" />
         <model name="mobilenet-ssd" precision="FP32" source="omz" />

--- a/tests/stress_tests/common/ie_pipelines/pipelines.cpp
+++ b/tests/stress_tests/common/ie_pipelines/pipelines.cpp
@@ -12,9 +12,9 @@
 #include <openvino/openvino.hpp>
 
 
-std::function<void()> load_unload_plugin(const std::string &target_device, const int &api_version) {
+std::function<void()> load_unload_plugin(const std::string &target_device) {
     return [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         // get_versions silently register plugin in `plugins` through `get_plugin`
         ie_api_wrapper->load_plugin(target_device);
         // Remove plugin for target_device from `plugins`
@@ -22,40 +22,40 @@ std::function<void()> load_unload_plugin(const std::string &target_device, const
     };
 }
 
-std::function<void()> read_cnnnetwork(const std::string &model, const int &api_version) {
+std::function<void()> read_cnnnetwork(const std::string &model) {
     return [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->read_network(model);
     };
 }
 
-std::function<void()> cnnnetwork_reshape_batch_x2(const std::string &model, const int &iter, const int &api_version) {
+std::function<void()> cnnnetwork_reshape_batch_x2(const std::string &model, const int &iter) {
     return [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->read_network(model);
         ie_api_wrapper->change_batch_size(2, iter);
     };
 }
 
-std::function<void()> set_input_params(const std::string &model, const int &api_version) {
+std::function<void()> set_input_params(const std::string &model) {
     return [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->read_network(model);
         ie_api_wrapper->set_input_params(model);
     };
 }
 
 std::function<void()>
-create_compiled_model(const std::string &model, const std::string &target_device, const int &api_version) {
+create_compiled_model(const std::string &model, const std::string &target_device) {
     return [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->read_network(model);
         ie_api_wrapper->load_network(target_device);
     };
 }
 
 std::function<void()> recreate_compiled_model(std::shared_ptr<InferApiBase> &ie_wrapper,
-                                              const std::string &target_device, const int &api_version) {
+                                              const std::string &target_device) {
     return [=] {
         ie_wrapper->load_network(target_device);
     };
@@ -63,9 +63,9 @@ std::function<void()> recreate_compiled_model(std::shared_ptr<InferApiBase> &ie_
 
 
 std::function<void()>
-create_infer_request(const std::string &model, const std::string &target_device, const int &api_version) {
+create_infer_request(const std::string &model, const std::string &target_device) {
     return [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->read_network(model);
         ie_api_wrapper->load_network(target_device);
         ie_api_wrapper->create_infer_request();
@@ -81,9 +81,9 @@ std::function<void()> recreate_infer_request(std::shared_ptr<InferApiBase> &ie_w
 
 
 std::function<void()>
-infer_request_inference(const std::string &model, const std::string &target_device, const int &api_version) {
+infer_request_inference(const std::string &model, const std::string &target_device) {
     return [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->read_network(model);
         ie_api_wrapper->load_network(target_device);
         ie_api_wrapper->create_infer_request();
@@ -112,11 +112,10 @@ std::function<void()> recreate_and_infer_in_thread(std::shared_ptr<InferApiBase>
 }
 
 std::function<void()>
-inference_with_streams(const std::string &model, const std::string &target_device, const int &nstreams,
-                       const int &api_version) {
+inference_with_streams(const std::string &model, const std::string &target_device, const int &nstreams) {
     return [&] {
         unsigned int nireq = nstreams;
-        auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->load_plugin(target_device);
         ie_api_wrapper->set_config(target_device, ov::AnyMap{ov::num_streams(nstreams)});
         ie_api_wrapper->read_network(model);

--- a/tests/stress_tests/common/ie_pipelines/pipelines.h
+++ b/tests/stress_tests/common/ie_pipelines/pipelines.h
@@ -6,30 +6,28 @@
 #include <functional>
 #include "../infer_api/infer_api.h"
 
-std::function<void()> load_unload_plugin(const std::string &target_device, const int &api_version);
+std::function<void()> load_unload_plugin(const std::string &target_device);
 
-std::function<void()> read_cnnnetwork(const std::string &model, const int &api_version);
+std::function<void()> read_cnnnetwork(const std::string &model);
 
-std::function<void()> cnnnetwork_reshape_batch_x2(const std::string &model, const int &iter, const int &api_version);
+std::function<void()> cnnnetwork_reshape_batch_x2(const std::string &model, const int &iter);
 
-std::function<void()> set_input_params(const std::string &model, const int &api_version);
-
-std::function<void()>
-create_compiled_model(const std::string &model, const std::string &target_device, const int &api_version);
+std::function<void()> set_input_params(const std::string &model);
 
 std::function<void()>
-create_infer_request(const std::string &model, const std::string &target_device, const int &api_version);
+create_compiled_model(const std::string &model, const std::string &target_device);
 
 std::function<void()>
-infer_request_inference(const std::string &model, const std::string &target_device, const int &api_version);
+create_infer_request(const std::string &model, const std::string &target_device);
 
 std::function<void()>
-inference_with_streams(const std::string &model, const std::string &target_device, const int &nstreams,
-                       const int &api_version);
+infer_request_inference(const std::string &model, const std::string &target_device);
 
 std::function<void()>
-recreate_compiled_model(std::shared_ptr<InferApiBase> &ie_wrapper, const std::string &target_device,
-                        const int &api_version);
+inference_with_streams(const std::string &model, const std::string &target_device, const int &nstreams);
+
+std::function<void()>
+recreate_compiled_model(std::shared_ptr<InferApiBase> &ie_wrapper, const std::string &target_device);
 
 std::function<void()> recreate_infer_request(std::shared_ptr<InferApiBase> &ie_wrapper);
 

--- a/tests/stress_tests/common/infer_api/infer_api.cpp
+++ b/tests/stress_tests/common/infer_api/infer_api.cpp
@@ -84,10 +84,6 @@ void InferAPI2::set_input_params(const std::string &model) {
     inputs = network->inputs();
 }
 
-std::shared_ptr<InferApiBase> create_infer_api_wrapper(const int &api_version) {
-    if (api_version == 2) {
-        return std::make_shared<InferAPI2>(InferAPI2());
-    } else {
-        throw std::logic_error("Unsupported API version");
-    }
+std::shared_ptr<InferApiBase> create_infer_api_wrapper() {
+    return std::make_shared<InferAPI2>(InferAPI2());
 }

--- a/tests/stress_tests/common/infer_api/infer_api.h
+++ b/tests/stress_tests/common/infer_api/infer_api.h
@@ -70,4 +70,4 @@ private:
     std::map<std::string, ov::Any> config;
 };
 
-std::shared_ptr<InferApiBase> create_infer_api_wrapper(const int &api_version);
+std::shared_ptr<InferApiBase> create_infer_api_wrapper();

--- a/tests/stress_tests/common/tests_utils.cpp
+++ b/tests/stress_tests/common/tests_utils.cpp
@@ -19,7 +19,7 @@ std::vector<TestCase> generateTestsParams(std::initializer_list<std::string> fie
     std::vector<TestCase> tests_cases;
     const pugi::xml_document &test_config = Environment::Instance().getTestConfig();
 
-    std::vector<int> processes, threads, iterations, api_versions;
+    std::vector<int> processes, threads, iterations;
     std::vector<std::string> devices, models, models_names, precisions;
 
     pugi::xml_node values;
@@ -40,10 +40,6 @@ std::vector<TestCase> generateTestsParams(std::initializer_list<std::string> fie
             values = test_config.child("attributes").child("devices");
             for (pugi::xml_node val = values.first_child(); val; val = val.next_sibling())
                 devices.emplace_back(val.text().as_string());
-        } else if (field == "api_versions") {
-            values = test_config.child("attributes").child("api_versions");
-            for (pugi::xml_node val = values.first_child(); val; val = val.next_sibling())
-                api_versions.push_back(val.text().as_int());
         } else if (field == "models") {
             values = test_config.child("attributes").child("models");
             for (pugi::xml_node val = values.first_child(); val; val = val.next_sibling()) {
@@ -66,7 +62,6 @@ std::vector<TestCase> generateTestsParams(std::initializer_list<std::string> fie
     processes = !processes.empty() ? processes : std::vector<int>{1};
     threads = !threads.empty() ? threads : std::vector<int>{1};
     iterations = !iterations.empty() ? iterations : std::vector<int>{1};
-    api_versions = !api_versions.empty() ? api_versions : std::vector<int>{1, 2};
     devices = !devices.empty() ? devices : std::vector<std::string>{"NULL"};
     models = !models.empty() ? models : std::vector<std::string>{"NULL"};
     precisions = !precisions.empty() ? precisions : std::vector<std::string>{"NULL"};
@@ -75,11 +70,10 @@ std::vector<TestCase> generateTestsParams(std::initializer_list<std::string> fie
     for (auto &numprocesses: processes)
         for (auto &numthreads: threads)
             for (auto &numiters: iterations)
-                for (auto &api_version: api_versions)
-                    for (auto &device: devices)
-                        for (int i = 0; i < models.size(); i++)
-                            tests_cases.emplace_back(numprocesses, numthreads, numiters, api_version, device, models[i],
-                                                     models_names[i], precisions[i]);
+                for (auto &device: devices)
+                    for (int i = 0; i < models.size(); i++)
+                        tests_cases.emplace_back(numprocesses, numthreads, numiters, device, models[i],
+                                                    models_names[i], precisions[i]);
     return tests_cases;
 }
 
@@ -99,7 +93,6 @@ std::vector<MemLeaksTestCase> generateTestsParamsMemLeaks() {
         numprocesses = device.attribute("processes").as_int(1);
         numthreads = device.attribute("threads").as_int(1);
         numiterations = device.attribute("iterations").as_int(1);
-        std::vector<int> api_versions{1, 2};
 
         std::vector<std::map<std::string, std::string>> models;
 
@@ -117,9 +110,7 @@ std::vector<MemLeaksTestCase> generateTestsParamsMemLeaks() {
                                                          {"precision", precision}};
             models.push_back(model_map);
         }
-        for (auto api_version: api_versions) {
-            tests_cases.emplace_back(numprocesses, numthreads, numiterations, api_version, device_name, models);
-        }
+        tests_cases.emplace_back(numprocesses, numthreads, numiterations, device_name, models);
     }
 
     return tests_cases;
@@ -133,16 +124,16 @@ std::string getTestCaseNameMemLeaks(const testing::TestParamInfo<MemLeaksTestCas
     return obj.param.test_case_name;
 }
 
-void test_wrapper(const std::function<void(std::string, std::string, int, int)> &tests_pipeline,
+void test_wrapper(const std::function<void(std::string, std::string, int)> &tests_pipeline,
                   const TestCase &params) {
-    tests_pipeline(params.model, params.device, params.numiters, params.api_version);
+    tests_pipeline(params.model, params.device, params.numiters);
 }
 
-void _runTest(const std::function<void(std::string, std::string, int, int)> &tests_pipeline, const TestCase &params) {
+void _runTest(const std::function<void(std::string, std::string, int)> &tests_pipeline, const TestCase &params) {
     run_in_threads(params.numthreads, test_wrapper, tests_pipeline, params);
 }
 
-void runTest(const std::function<void(std::string, std::string, int, int)> &tests_pipeline, const TestCase &params) {
+void runTest(const std::function<void(std::string, std::string, int)> &tests_pipeline, const TestCase &params) {
 #if DEBUG_MODE
     tests_pipeline(params.model, params.device, params.numiters);
 #else

--- a/tests/stress_tests/common/tests_utils.h
+++ b/tests/stress_tests/common/tests_utils.h
@@ -24,7 +24,6 @@ public:
     int numprocesses;
     int numthreads;
     int numiters;
-    int api_version;
     std::string precision;
     std::string test_case_name;
     std::string model_name;
@@ -45,15 +44,14 @@ class TestCase : public TestCaseBase {
 public:
     std::string model;
 
-    TestCase(int _numprocesses, int _numthreads, int _numiters, int _api_version, std::string _device,
+    TestCase(int _numprocesses, int _numthreads, int _numiters, std::string _device,
              const std::string &_model,
              const std::string &_model_name, const std::string &_precision) {
-        numprocesses = _numprocesses, numthreads = _numthreads, numiters = _numiters, api_version = _api_version,
+        numprocesses = _numprocesses, numthreads = _numthreads, numiters = _numiters,
         device = _device, model = _model, model_name = _model_name, precision = _precision;
         test_case_name = "Numprocesses_" + std::to_string(numprocesses) + "_Numthreads_" + std::to_string(numthreads) +
                          "_Numiters_" + std::to_string(numiters) + "_Device_" + update_item_for_name(device) +
-                         "_Precision_" + update_item_for_name(precision) + "_Model_" + update_item_for_name(model_name)
-                         + "_API_" + std::to_string(api_version);
+                         "_Precision_" + update_item_for_name(precision) + "_Model_" + update_item_for_name(model_name);
     }
 };
 
@@ -61,13 +59,12 @@ class MemLeaksTestCase : public TestCaseBase {
 public:
     std::vector<std::map<std::string, std::string>> models;
 
-    MemLeaksTestCase(int _numprocesses, int _numthreads, int _numiters, int _api_version, std::string _device,
+    MemLeaksTestCase(int _numprocesses, int _numthreads, int _numiters, std::string _device,
                      std::vector<std::map<std::string, std::string>> _models) {
-        numprocesses = _numprocesses, numthreads = _numthreads, numiters = _numiters, api_version = _api_version,
+        numprocesses = _numprocesses, numthreads = _numthreads, numiters = _numiters,
         device = _device, models = _models;
         test_case_name = "Numprocesses_" + std::to_string(numprocesses) + "_Numthreads_" + std::to_string(numthreads) +
-                         "_Numiters_" + std::to_string(numiters) + "_Device_" + update_item_for_name(device) + "_API_" +
-                         std::to_string(api_version);
+                         "_Numiters_" + std::to_string(numiters) + "_Device_" + update_item_for_name(device);
         for (int i = 0; i < models.size(); i++) {
             test_case_name += "_Model" + std::to_string(i + 1) + "_" + update_item_for_name(models[i]["name"]) + "_" +
                               update_item_for_name(models[i]["precision"]);
@@ -106,9 +103,9 @@ std::string getTestCaseName(const testing::TestParamInfo<TestCase> &obj);
 
 std::string getTestCaseNameMemLeaks(const testing::TestParamInfo<MemLeaksTestCase> &obj);
 
-void runTest(const std::function<void(std::string, std::string, int, int)> &tests_pipeline, const TestCase &params);
+void runTest(const std::function<void(std::string, std::string, int)> &tests_pipeline, const TestCase &params);
 
-void _runTest(const std::function<void(std::string, std::string, int, int)> &tests_pipeline, const TestCase &params);
+void _runTest(const std::function<void(std::string, std::string, int)> &tests_pipeline, const TestCase &params);
 
-void test_wrapper(const std::function<void(std::string, std::string, int, int)> &tests_pipeline,
+void test_wrapper(const std::function<void(std::string, std::string, int)> &tests_pipeline,
                   const TestCase &params);

--- a/tests/stress_tests/memcheck_tests/tests.cpp
+++ b/tests/stress_tests/memcheck_tests/tests.cpp
@@ -49,7 +49,7 @@ TEST_P(MemCheckTestSuite, create_exenetwork) {
     auto test_params = GetParam();
     MemCheckPipeline memCheckPipeline;
     auto test_pipeline = [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(test_params.api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->load_plugin(device);
         ie_api_wrapper->read_network(model);
         ie_api_wrapper->load_network(device);
@@ -70,7 +70,7 @@ TEST_P(MemCheckTestSuite, infer_request_inference) {
     auto test_params = GetParam();
     MemCheckPipeline memCheckPipeline;
     auto test_pipeline = [&] {
-        auto ie_api_wrapper = create_infer_api_wrapper(test_params.api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->load_plugin(device);
         ie_api_wrapper->read_network(model);
         ie_api_wrapper->load_network(device);
@@ -107,7 +107,7 @@ TEST_P(MemCheckTestSuite, inference_with_streams) {
     auto test_pipeline = [&] {
         MemCheckPipeline memCheckPipeline;
         unsigned int nireq = nstreams;
-        auto ie_api_wrapper = create_infer_api_wrapper(test_params.api_version);
+        auto ie_api_wrapper = create_infer_api_wrapper();
         ie_api_wrapper->load_plugin(device);
         ie_api_wrapper->set_config(device, ov::AnyMap{ov::num_streams(nstreams)});
         ie_api_wrapper->read_network(model);

--- a/tests/stress_tests/memleaks_tests/tests.cpp
+++ b/tests/stress_tests/memleaks_tests/tests.cpp
@@ -37,7 +37,7 @@ inline void test_runner(int numthreads, const std::function<TestResult()> &test_
 TEST_P(MemLeaksTestSuiteNoModel, load_unload_plugin) {
     auto test_params = GetParam();
 
-    std::vector<std::function<void()>> pipeline = {load_unload_plugin(test_params.device, test_params.api_version)};
+    std::vector<std::function<void()>> pipeline = {load_unload_plugin(test_params.device)};
     auto test = [&] {
         log_info("Load/unload plugin for \"" << test_params.device << "\" device"
                                              << " for " << test_params.numiters << " times");
@@ -52,7 +52,7 @@ TEST_P(MemLeaksTestSuiteNoDevice, read_network) {
 
     pipeline.reserve(test_params.models.size());
     for (int i = 0; i < test_params.models.size(); i++) {
-        pipeline.push_back(read_cnnnetwork(test_params.models[i]["full_path"], test_params.api_version));
+        pipeline.push_back(read_cnnnetwork(test_params.models[i]["full_path"]));
     }
     auto test = [&] {
         log_info("Read networks: " << test_params.model_name << " for " << test_params.numiters << " times");
@@ -67,7 +67,7 @@ TEST_P(MemLeaksTestSuiteNoDevice, cnnnetwork_reshape_batch_x2) {
 
     pipeline.reserve(test_params.models.size());
     for (int i = 0; i < test_params.models.size(); i++) {
-        pipeline.push_back(cnnnetwork_reshape_batch_x2(test_params.models[i]["full_path"], i, test_params.api_version));
+        pipeline.push_back(cnnnetwork_reshape_batch_x2(test_params.models[i]["full_path"], i));
     }
     auto test = [&] {
         log_info("Reshape to batch*=2 of CNNNetworks created from networks: " << test_params.model_name << " for "
@@ -83,7 +83,7 @@ TEST_P(MemLeaksTestSuiteNoDevice, set_input_params) {
 
     pipeline.reserve(test_params.models.size());
     for (int i = 0; i < test_params.models.size(); i++) {
-        pipeline.push_back(set_input_params(test_params.models[i]["full_path"], test_params.api_version));
+        pipeline.push_back(set_input_params(test_params.models[i]["full_path"]));
     }
     auto test = [&] {
         log_info("Apply preprocessing for CNNNetworks from networks: " << test_params.model_name << " for "
@@ -99,10 +99,9 @@ TEST_P(MemLeaksTestSuite, recreate_compiled_model) {
 
     pipeline.reserve(test_params.models.size());
     for (int i = 0; i < test_params.models.size(); i++) {
-        auto ie_wrapper = create_infer_api_wrapper(test_params.api_version);
+        auto ie_wrapper = create_infer_api_wrapper();
         ie_wrapper->read_network(test_params.models[i]["full_path"]);
-        pipeline.push_back(recreate_compiled_model(ie_wrapper, test_params.device,
-                                                   test_params.api_version));
+        pipeline.push_back(recreate_compiled_model(ie_wrapper, test_params.device));
     }
     auto test = [&] {
         log_info("Recreate CompiledModels within existing ov::Core from networks: "
@@ -119,7 +118,7 @@ TEST_P(MemLeaksTestSuite, recreate_infer_request) {
     size_t n_models = test_params.models.size();
 
     for (int i = 0; i < n_models; i++) {
-        auto ie_wrapper = create_infer_api_wrapper(test_params.api_version);
+        auto ie_wrapper = create_infer_api_wrapper();
         ie_wrapper->read_network(test_params.models[i]["full_path"]);
         ie_wrapper->load_network(test_params.device);
         pipeline.push_back(recreate_infer_request(ie_wrapper));
@@ -139,7 +138,7 @@ TEST_P(MemLeaksTestSuite, reinfer_request_inference) {
     size_t n_models = test_params.models.size();
 
     for (int i = 0; i < n_models; i++) {
-        auto ie_wrapper = create_infer_api_wrapper(test_params.api_version);
+        auto ie_wrapper = create_infer_api_wrapper();
         ie_wrapper->read_network(test_params.models[i]["full_path"]);
         ie_wrapper->load_network(test_params.device);
         ie_wrapper->create_infer_request();
@@ -161,8 +160,7 @@ TEST_P(MemLeaksTestSuite, infer_request_inference) {
     std::vector<std::function<void()>> pipeline;
     pipeline.reserve(test_params.models.size());
     for (int i = 0; i < test_params.models.size(); i++) {
-        pipeline.push_back(infer_request_inference(test_params.models[i]["full_path"], test_params.device,
-                                                   test_params.api_version));
+        pipeline.push_back(infer_request_inference(test_params.models[i]["full_path"], test_params.device));
     }
     auto test = [&] {
         log_info("Inference of InferRequests from networks: " << test_params.model_name << " for \""
@@ -179,8 +177,7 @@ TEST_P(MemLeaksTestSuite, inference_with_streams) {
     std::vector<std::function<void()>> pipeline;
     pipeline.reserve(test_params.models.size());
     for (int i = 0; i < test_params.models.size(); i++) {
-        pipeline.push_back(inference_with_streams(test_params.models[i]["full_path"], test_params.device, nstreams,
-                                                  test_params.api_version));
+        pipeline.push_back(inference_with_streams(test_params.models[i]["full_path"], test_params.device, nstreams));
     }
     auto test = [&] {
         log_info("Inference of InferRequests from networks: " << test_params.model_name << " for \""
@@ -197,7 +194,7 @@ TEST_P(MemLeaksTestSuite, recreate_and_infer_in_thread) {
     size_t n_models = test_params.models.size();
 
     for (int i = 0; i < n_models; i++) {
-        auto ie_wrapper = create_infer_api_wrapper(test_params.api_version);
+        auto ie_wrapper = create_infer_api_wrapper();
         ie_wrapper->read_network(test_params.models[i]["full_path"]);
         ie_wrapper->load_network(test_params.device);
         pipeline.push_back(recreate_and_infer_in_thread(ie_wrapper));

--- a/tests/stress_tests/unittests/tests.cpp
+++ b/tests/stress_tests/unittests/tests.cpp
@@ -79,15 +79,15 @@ TEST_P(UnitTestSuite, infer_request_inference_full_pipeline) {
 
 INSTANTIATE_TEST_SUITE_P(StressUnitTests, UnitTestSuiteNoModel,
                          ::testing::ValuesIn(generateTestsParams(
-                                 {"processes", "threads", "iterations", "devices", "api_versions"})),
+                                 {"processes", "threads", "iterations", "devices"})),
                          getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(StressUnitTests, UnitTestSuiteNoDevice,
                          ::testing::ValuesIn(generateTestsParams(
-                                 {"processes", "threads", "iterations", "models", "api_versions"})),
+                                 {"processes", "threads", "iterations", "models"})),
                          getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(StressUnitTests, UnitTestSuite,
                          ::testing::ValuesIn(generateTestsParams(
-                                 {"processes", "threads", "iterations", "devices", "models", "api_versions"})),
+                                 {"processes", "threads", "iterations", "devices", "models"})),
                          getTestCaseName);

--- a/tests/stress_tests/unittests/tests_pipelines/tests_pipelines.cpp
+++ b/tests/stress_tests/unittests/tests_pipelines/tests_pipelines.cpp
@@ -6,51 +6,47 @@
 
 #include <string>
 
-void test_load_unload_plugin(const std::string &model, const std::string &target_device, const int &n,
-                             const int &api_version) {
+void test_load_unload_plugin(const std::string &model, const std::string &target_device, const int &n) {
     log_info("Load/unload plugin for device: " << target_device << " for " << n << " times");
     for (int i = 0; i < n; i++) {
         if (i == n / 2) {
             log_info("Half of the test have already passed");
         }
-        load_unload_plugin(target_device, api_version)();
+        load_unload_plugin(target_device)();
     }
 }
 
-void test_read_network(const std::string &model, const std::string &target_device, const int &n, const int &api_version) {
+void test_read_network(const std::string &model, const std::string &target_device, const int &n) {
     log_info("Read network: \"" << model << "\" for " << n << " times");
     for (int i = 0; i < n; i++) {
         if (i == n / 2) {
             log_info("Half of the test have already passed");
         }
-        read_cnnnetwork(model, api_version)();
+        read_cnnnetwork(model)();
     }
 }
 
-void test_cnnnetwork_reshape_batch_x2(const std::string &model, const std::string &target_device, const int &n,
-                                      const int &api_version) {
+void test_cnnnetwork_reshape_batch_x2(const std::string &model, const std::string &target_device, const int &n) {
     log_info("Reshape to batch*=2 of CNNNetwork created from network: \"" << model << "\" for " << n << " times");
     for (int i = 0; i < n; i++) {
         if (i == n / 2) {
             log_info("Half of the test have already passed");
         }
-        cnnnetwork_reshape_batch_x2(model, i, api_version)();
+        cnnnetwork_reshape_batch_x2(model, i)();
     }
 }
 
-void test_set_input_params(const std::string &model, const std::string &target_device, const int &n,
-                           const int &api_version) {
+void test_set_input_params(const std::string &model, const std::string &target_device, const int &n) {
     log_info("Apply preprocessing for CNNNetwork from network: \"" << model << "\" for " << n << " times");
     for (int i = 0; i < n; i++) {
         if (i == n / 2) {
             log_info("Half of the test have already passed");
         }
-        set_input_params(model, api_version)();
+        set_input_params(model)();
     }
 }
 
-void test_create_compiled_model(const std::string &model, const std::string &target_device, const int &n,
-                                const int &api_version) {
+void test_create_compiled_model(const std::string &model, const std::string &target_device, const int &n) {
     log_info("Create ExecutableNetwork from network: \"" << model
                                                          << "\" for device: \"" << target_device << "\" for " << n
                                                          << " times");
@@ -58,12 +54,11 @@ void test_create_compiled_model(const std::string &model, const std::string &tar
         if (i == n / 2) {
             log_info("Half of the test have already passed");
         }
-        create_compiled_model(model, target_device, api_version)();
+        create_compiled_model(model, target_device)();
     }
 }
 
-void test_create_infer_request(const std::string &model, const std::string &target_device, const int &n,
-                               const int &api_version) {
+void test_create_infer_request(const std::string &model, const std::string &target_device, const int &n) {
     log_info("Create InferRequest from network: \"" << model
                                                     << "\" for device: \"" << target_device << "\" for " << n
                                                     << " times");
@@ -71,12 +66,11 @@ void test_create_infer_request(const std::string &model, const std::string &targ
         if (i == n / 2) {
             log_info("Half of the test have already passed");
         }
-        create_infer_request(model, target_device, api_version)();
+        create_infer_request(model, target_device)();
     }
 }
 
-void test_infer_request_inference(const std::string &model, const std::string &target_device, const int &n,
-                                  const int &api_version) {
+void test_infer_request_inference(const std::string &model, const std::string &target_device, const int &n) {
     log_info("Inference of InferRequest from network: \"" << model
                                                           << "\" for device: \"" << target_device << "\" for " << n
                                                           << " times");
@@ -84,6 +78,6 @@ void test_infer_request_inference(const std::string &model, const std::string &t
         if (i == n / 2) {
             log_info("Half of the test have already passed");
         }
-        infer_request_inference(model, target_device, api_version)();
+        infer_request_inference(model, target_device)();
     }
 }

--- a/tests/stress_tests/unittests/tests_pipelines/tests_pipelines.h
+++ b/tests/stress_tests/unittests/tests_pipelines/tests_pipelines.h
@@ -10,47 +10,33 @@
 #include <string>
 
 // tests_pipelines/tests_pipelines.cpp
-void test_load_unload_plugin(const std::string &model, const std::string &target_device, const int &n,
-                             const int &api_version);
+void test_load_unload_plugin(const std::string &model, const std::string &target_device, const int &n);
 
-void test_read_network(const std::string &model, const std::string &target_device, const int &n,
-                       const int &api_version);
+void test_read_network(const std::string &model, const std::string &target_device, const int &n);
 
-void test_cnnnetwork_reshape_batch_x2(const std::string &model, const std::string &target_device, const int &n,
-                                      const int &api_version);
+void test_cnnnetwork_reshape_batch_x2(const std::string &model, const std::string &target_device, const int &n);
 
-void test_set_input_params(const std::string &model, const std::string &target_device, const int &n,
-                           const int &api_version);
+void test_set_input_params(const std::string &model, const std::string &target_device, const int &n);
 
-void test_create_compiled_model(const std::string &model, const std::string &target_device, const int &n,
-                                const int &api_version);
+void test_create_compiled_model(const std::string &model, const std::string &target_device, const int &n);
 
-void test_create_infer_request(const std::string &model, const std::string &target_device, const int &n,
-                               const int &api_version);
+void test_create_infer_request(const std::string &model, const std::string &target_device, const int &n);
 
-void test_infer_request_inference(const std::string &model, const std::string &target_device, const int &n,
-                                  const int &api_version);
+void test_infer_request_inference(const std::string &model, const std::string &target_device, const int &n);
 // tests_pipelines/tests_pipelines.cpp
 
 // tests_pipelines/tests_pipelines_full_pipeline.cpp
-void test_load_unload_plugin_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                           const int &api_version);
+void test_load_unload_plugin_full_pipeline(const std::string &model, const std::string &target_device, const int &n);
 
-void test_read_network_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                     const int &api_version);
+void test_read_network_full_pipeline(const std::string &model, const std::string &target_device, const int &n);
 
-void test_set_input_params_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                         const int &api_version);
+void test_set_input_params_full_pipeline(const std::string &model, const std::string &target_device, const int &n);
 
-void test_cnnnetwork_reshape_batch_x2_full_pipeline(const std::string &model, const std::string &target_device,
-                                                    const int &n, const int &api_version);
+void test_cnnnetwork_reshape_batch_x2_full_pipeline(const std::string &model, const std::string &target_device, const int &n);
 
-void test_create_exenetwork_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                          const int &api_version);
+void test_create_exenetwork_full_pipeline(const std::string &model, const std::string &target_device, const int &n);
 
-void test_create_infer_request_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                             const int &api_version);
+void test_create_infer_request_full_pipeline(const std::string &model, const std::string &target_device, const int &n);
 
-void test_infer_request_inference_full_pipeline(const std::string &model, const std::string &target_device,
-                                                const int &n, const int &api_version);
+void test_infer_request_inference_full_pipeline(const std::string &model, const std::string &target_device, const int &n);
 // tests_pipelines/tests_pipelines_full_pipeline.cpp

--- a/tests/stress_tests/unittests/tests_pipelines/tests_pipelines_full_pipeline.cpp
+++ b/tests/stress_tests/unittests/tests_pipelines/tests_pipelines_full_pipeline.cpp
@@ -31,10 +31,9 @@
     else                                                                \
         throw std::logic_error("Reshape wasn't applied for a model.");
 
-void test_load_unload_plugin_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                           const int &api_version) {
+void test_load_unload_plugin_full_pipeline(const std::string &model, const std::string &target_device, const int &n) {
     log_info("Load/unload plugin for device: " << target_device << " for " << n << " times");
-    auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+    auto ie_api_wrapper = create_infer_api_wrapper();
     for (int i = 0; i < n; i++) {
         if (i == n / 2) {
             log_info("Half of the test have already passed");
@@ -51,9 +50,8 @@ void test_load_unload_plugin_full_pipeline(const std::string &model, const std::
     ie_api_wrapper->infer();
 }
 
-void test_read_network_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                     const int &api_version) {
-    auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+void test_read_network_full_pipeline(const std::string &model, const std::string &target_device, const int &n) {
+    auto ie_api_wrapper = create_infer_api_wrapper();
     log_info("Read network: \"" << model << "\" for " << n << " times");
     for (int i = 0; i < n; i++) {
         if (i == n / 2) {
@@ -67,9 +65,8 @@ void test_read_network_full_pipeline(const std::string &model, const std::string
     ie_api_wrapper->infer();
 }
 
-void test_set_input_params_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                         const int &api_version) {
-    auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+void test_set_input_params_full_pipeline(const std::string &model, const std::string &target_device, const int &n) {
+    auto ie_api_wrapper = create_infer_api_wrapper();
     log_info("Apply preprocessing for CNNNetwork from network: \"" << model << "\" for " << n << " times");
     for (int i = 0; i < n; i++) {
         if (i == n / 2) {
@@ -84,8 +81,8 @@ void test_set_input_params_full_pipeline(const std::string &model, const std::st
 }
 
 void test_cnnnetwork_reshape_batch_x2_full_pipeline(const std::string &model, const std::string &target_device,
-                                                    const int &n, const int &api_version) {
-    auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+                                                    const int &n) {
+    auto ie_api_wrapper = create_infer_api_wrapper();
     log_info("Reshape to batch*=2 of CNNNetwork created from network: \"" << model << "\" for " << n << " times");
     ie_api_wrapper->read_network(model);
     for (int i = 0; i < n; i++) {
@@ -100,9 +97,8 @@ void test_cnnnetwork_reshape_batch_x2_full_pipeline(const std::string &model, co
     ie_api_wrapper->infer();
 }
 
-void test_create_exenetwork_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                          const int &api_version) {
-    auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+void test_create_exenetwork_full_pipeline(const std::string &model, const std::string &target_device, const int &n) {
+    auto ie_api_wrapper = create_infer_api_wrapper();
     log_info("Create ExecutableNetwork from network: \"" << model
                                                          << "\" for device: \"" << target_device << "\" for " << n
                                                          << " times");
@@ -118,9 +114,8 @@ void test_create_exenetwork_full_pipeline(const std::string &model, const std::s
     ie_api_wrapper->infer();
 }
 
-void test_create_infer_request_full_pipeline(const std::string &model, const std::string &target_device, const int &n,
-                                             const int &api_version) {
-    auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+void test_create_infer_request_full_pipeline(const std::string &model, const std::string &target_device, const int &n) {
+    auto ie_api_wrapper = create_infer_api_wrapper();
     log_info("Create InferRequest from network: \"" << model
                                                     << "\" for device: \"" << target_device << "\" for " << n
                                                     << " times");
@@ -138,8 +133,8 @@ void test_create_infer_request_full_pipeline(const std::string &model, const std
 
 
 void test_infer_request_inference_full_pipeline(const std::string &model, const std::string &target_device,
-                                                const int &n, const int &api_version) {
-    auto ie_api_wrapper = create_infer_api_wrapper(api_version);
+                                                const int &n) {
+    auto ie_api_wrapper = create_infer_api_wrapper();
     log_info("Inference of InferRequest from network: \"" << model
                                                           << "\" for device: \"" << target_device << "\" for " << n
                                                           << " times");


### PR DESCRIPTION
### Details:
Run of tests with `api_version=1` causes `Unsupported API version` runtime error

### Tickets:
- CVS-129879