### PR TITLE
[Snippets][CPU] Fixed AddressSanitizer: stack-use-after-scope

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -726,50 +726,51 @@ void Transformations::MainSnippets(void) {
         CPU_DISABLE_PASS_X64(snippetsManager, snippets::pass::ExtractReshapesFromMHA);
     }
 
-    if (snippetsMode != Config::SnippetsMode::IgnoreCallback) {
 #if defined(OPENVINO_ARCH_X86_64)
-        auto is_supported_matmul = [this](const std::shared_ptr<const ov::Node>& n) {
-            const auto matmul = ov::as_type_ptr<const ov::op::v0::MatMul>(n);
-            if (!matmul)
-                return false;
-            const auto in_type0 = matmul->get_input_element_type(0);
-            const auto in_type1 = matmul->get_input_element_type(1);
-            if (in_type0 == ov::element::f32 && in_type1 == ov::element::f32 && inferencePrecision == ov::element::f32)
-                return true;
-            // [114487] brgemm kernel in oneDNN requires brgemm_copy_b kernel if MatMul node has transposed_b=True
-            // The current solution with ExtractExplicitMatMulTranspose pass is slower for non-f32 cases than using of brgemm_copy_b kernel
-            if (matmul->get_transpose_a() || matmul->get_transpose_b())
-                return false;
-            // [115165] At the moment Quantized and BF16 Brgemm doesn't support blocking by K and N.
-            // Big shapes may lead to perf degradation
-            const auto K = *(matmul->get_input_partial_shape(0).rbegin());
-            const auto N = *(matmul->get_input_partial_shape(1).rbegin());
-            if ((K.is_static() && K.get_length() > 512) || // heuristic values
-                (N.is_static() && N.get_length() > 256))
-                return false;
-            if (in_type0 == ov::element::i8)
-                return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_vnni);
-            if ((in_type0 == ov::element::bf16 && in_type1 == ov::element::bf16) ||
-                ((in_type0 == element::f32 && in_type1 == ov::element::f32 && inferencePrecision == ov::element::bf16))) {
-                // Implementation calls AMX BF16 brgemm only for tensors with K and N aligned on 2, otherwise fallbacks on vector impl
-                // Vector madd BF16 instruction on SPR has reduced performance on HW level, which results in overall perf degradation
-                size_t bf16Factor = 2;
-                if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
-                    return K.is_static() && (K.get_length() % bf16Factor == 0) &&
-                           N.is_static() && (N.get_length() % bf16Factor == 0);
-                }
-                return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16);
-            }
+    auto is_supported_matmul = [this](const std::shared_ptr<const ov::Node>& n) {
+        const auto matmul = ov::as_type_ptr<const ov::op::v0::MatMul>(n);
+        if (!matmul)
+            return false;
+        const auto in_type0 = matmul->get_input_element_type(0);
+        const auto in_type1 = matmul->get_input_element_type(1);
+        if (in_type0 == ov::element::f32 && in_type1 == ov::element::f32 && inferencePrecision == ov::element::f32)
             return true;
-        };
-        auto is_unsupported_parallel_work_amount = [&](const std::shared_ptr<const ov::Node>& n, const ov::Shape& shape) {
-            const size_t parallel_work_amount = std::accumulate(shape.rbegin() + 2, shape.rend(), 1, std::multiplies<size_t>());
-            const auto is_unsupported_parallel_work_amount =
-                parallel_work_amount < tokenization_config.concurrency &&
-                !ov::snippets::pass::SplitDimensionM::can_be_optimized(n, tokenization_config.concurrency);
-            return is_unsupported_parallel_work_amount;
-        };
+        // [114487] brgemm kernel in oneDNN requires brgemm_copy_b kernel if MatMul node has transposed_b=True
+        // The current solution with ExtractExplicitMatMulTranspose pass is slower for non-f32 cases than using of brgemm_copy_b kernel
+        if (matmul->get_transpose_a() || matmul->get_transpose_b())
+            return false;
+        // [115165] At the moment Quantized and BF16 Brgemm doesn't support blocking by K and N.
+        // Big shapes may lead to perf degradation
+        const auto K = *(matmul->get_input_partial_shape(0).rbegin());
+        const auto N = *(matmul->get_input_partial_shape(1).rbegin());
+        if ((K.is_static() && K.get_length() > 512) || // heuristic values
+            (N.is_static() && N.get_length() > 256))
+            return false;
+        if (in_type0 == ov::element::i8)
+            return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_vnni);
+        if ((in_type0 == ov::element::bf16 && in_type1 == ov::element::bf16) ||
+            ((in_type0 == element::f32 && in_type1 == ov::element::f32 && inferencePrecision == ov::element::bf16))) {
+            // Implementation calls AMX BF16 brgemm only for tensors with K and N aligned on 2, otherwise fallbacks on vector impl
+            // Vector madd BF16 instruction on SPR has reduced performance on HW level, which results in overall perf degradation
+            size_t bf16Factor = 2;
+            if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
+                return K.is_static() && (K.get_length() % bf16Factor == 0) &&
+                       N.is_static() && (N.get_length() % bf16Factor == 0);
+            }
+            return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16);
+        }
+        return true;
+    };
+    auto is_unsupported_parallel_work_amount = [&](const std::shared_ptr<const ov::Node>& n, const ov::Shape& shape) {
+        const size_t parallel_work_amount = std::accumulate(shape.rbegin() + 2, shape.rend(), 1, std::multiplies<size_t>());
+        const auto is_unsupported_parallel_work_amount =
+            parallel_work_amount < tokenization_config.concurrency &&
+            !ov::snippets::pass::SplitDimensionM::can_be_optimized(n, tokenization_config.concurrency);
+        return is_unsupported_parallel_work_amount;
+    };
 #endif // OPENVINO_ARCH_X86_64
+
+    if (snippetsMode != Config::SnippetsMode::IgnoreCallback) {
         CPU_SET_CALLBACK_X64(snippetsManager, [&](const std::shared_ptr<const ov::Node>& n) -> bool {
             // Tranformation callback is called on MatMul0
             if (!is_supported_matmul(n))


### PR DESCRIPTION
### Details:
 - *Moved lambda functions that are used in callbacks to the one visible area with manager. Before when callbacks of the passes called these lambda functions `is_supported_matmul` and `is_unsupported_parallel_work_amount`, these functions were destroyed with `If` body in `void Transformations::MainSnippets`*

### Tickets:
 - *132849*
