### PR TITLE
[DOCS] Removal of Inference Engine from 2024.0

### DIFF
--- a/docs/articles_en/about-openvino/compatibility-and-support/supported-operations-framework-frontend.rst
+++ b/docs/articles_en/about-openvino/compatibility-and-support/supported-operations-framework-frontend.rst
@@ -633,10 +633,10 @@ This page lists operations supported by OpenVINO Framework Frontend.
        logical_xor
        lookup_table
        matmul
-       matrix_nms                                                              Only supports IE CPU plugin with "number of selected boxes" static shape (e.g.: ``min(min(num_boxes, nms_top_k) * num_classes_output, keep_top_k)``).
+       matrix_nms                                                              Only supports CPU plugin with "number of selected boxes" static shape (e.g.: ``min(min(num_boxes, nms_top_k) * num_classes_output, keep_top_k)``).
        max_pool2d_with_index
        meshgrid
-       multiclass_nms                                                          Only supports IE CPU plugin with "number of selected boxes" static shape (e.g.: ``min(min(num_boxes, nms_top_k) * num_classes_output, keep_top_k)``).
+       multiclass_nms                                                          Only supports CPU plugin with "number of selected boxes" static shape (e.g.: ``min(min(num_boxes, nms_top_k) * num_classes_output, keep_top_k)``).
        nearest_interp                                                          ``NCW``, ``NWC``, ``NHWC``, ``NCDHW``, ``NDHWC`` data_layout are not supported.
        not_equal
        p_norm

--- a/docs/articles_en/learn-openvino/openvino-samples/benchmark-tool.rst
+++ b/docs/articles_en/learn-openvino/openvino-samples/benchmark-tool.rst
@@ -583,8 +583,8 @@ following usage message:
                 -pcsort                 Optional. Report performance counters and analysis the sort hotpoint opts.  "sort" Analysis opts time cost, print by hotpoint order  "no_sort" Analysis    opts time cost, print by normal order  "simple_sort" Analysis opts time cost, only print EXECUTED opts by normal order
                 -pcseq                  Optional. Report latencies for each shape in -data_shape sequence.
                 -exec_graph_path        Optional. Path to a file where to store executable graph information serialized.
-                -dump_config            Optional. Path to JSON file to dump IE parameters, which were set by application.
-                -load_config            Optional. Path to JSON file to load custom IE parameters. Please note, command line parameters have higher priority then parameters from configuration    file.
+                -dump_config            Optional. Path to JSON file to dump device properties, which were set by application.
+                -load_config            Optional. Path to JSON file to load custom device properties. Please note, command line parameters have higher priority then parameters from configuration file.
                                     Example 1: a simple JSON file for HW device with primary properties.
                                              {
                                                   "CPU": {"NUM_STREAMS": "3", "PERF_COUNT": "NO"}

--- a/docs/dev/build_android.md
+++ b/docs/dev/build_android.md
@@ -1,6 +1,6 @@
 # Build OpenVINO™ Runtime for Android systems
 
-This article describes how to build Inference Engine for Android operating systems.
+This article describes how to build OpenVINO for Android operating systems.
 
 ## Software requirements
 

--- a/docs/dev/installing.md
+++ b/docs/dev/installing.md
@@ -223,7 +223,7 @@ classid probability
 </p>
 </details>
 
-## Adding OpenVINO Runtime (Inference Engine) to Your Project
+## Adding OpenVINO Runtime to Your Project
 
 <details>
 <summary>For versions prior to 2022.1</summary>
@@ -256,7 +256,7 @@ For CMake projects, set the `OpenVINO_DIR` and when you run CMake tool:
 cmake -DOpenVINO_DIR=<INSTALLDIR>/runtime/cmake .
 ```
 
-Then you can find OpenVINO Runtime (Inference Engine) by [`find_package`]:
+Then you can find OpenVINO Runtime by [`find_package`]:
 
 ```cmake
 find_package(OpenVINO REQUIRED)


### PR DESCRIPTION
Port from https://github.com/openvinotoolkit/openvino/pull/22852

Removing mentions of deprecated Inference Engine (API 1.0) in docs

Jira: 131850