### PR TITLE
[ TRANSFORMATIONS ] Fix `convert_seq_to_ti` transformation  with enabled mask

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_sequences_to_tensor_iterator.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_sequences_to_tensor_iterator.cpp
@@ -256,8 +256,8 @@ bool convert_sequence_to_ti(const std::shared_ptr<ov::Node>& sequence,
     if (enable_mask) {
         // create initial values for body_parameters in outer graph
         // aggregated Y_h - concatenation of the last non-zero values for each batch
-        auto H_body_param_shape = ov::op::util::make_try_fold<ov::op::v3::ShapeOf>(H_body_param);
-        auto aggregated_Y_h_scalar = ov::op::v0::Constant::create(H_body_param->get_element_type(), {}, {0.f});
+        auto H_body_param_shape = ov::op::util::make_try_fold<ov::op::v3::ShapeOf>(squeezed_h);
+        auto aggregated_Y_h_scalar = ov::op::v0::Constant::create(squeezed_h->get_element_type(), {}, {0.f});
         auto aggregated_Y_h =
             ov::op::util::make_try_fold<ov::op::v3::Broadcast>(aggregated_Y_h_scalar, H_body_param_shape);
 
@@ -272,14 +272,14 @@ bool convert_sequence_to_ti(const std::shared_ptr<ov::Node>& sequence,
         H_out = tensor_iterator->get_function()->get_results()[1];
 
         if (cell_state_defined) {
-            auto C_body_param_shape = ov::op::util::make_try_fold<ov::op::v3::ShapeOf>(C_body_param);
-            auto aggregated_Y_c_scalar = ov::op::v0::Constant::create(C_body_param->get_element_type(), {}, {0.f});
+            auto C_body_param_shape = ov::op::util::make_try_fold<ov::op::v3::ShapeOf>(squeezed_c);
+            auto aggregated_Y_c_scalar = ov::op::v0::Constant::create(squeezed_c->get_element_type(), {}, {0.f});
             auto aggregated_Y_c =
                 ov::op::util::make_try_fold<ov::op::v3::Broadcast>(aggregated_Y_c_scalar, C_body_param_shape);
             ov::copy_runtime_info(sequence, aggregated_Y_c);
 
             // set initial value and back edge for aggregated C
-            tensor_iterator->set_merged_input(body_params.at(2), aggregated_Y_c, body_results.at(2));
+            // tensor_iterator->set_merged_input(body_params.at(2), aggregated_Y_c, body_results.at(2));
             C_out = tensor_iterator->get_function()->get_results()[2];
         }
     }

--- a/src/common/transformations/src/transformations/op_conversions/convert_sequences_to_tensor_iterator.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_sequences_to_tensor_iterator.cpp
@@ -279,7 +279,7 @@ bool convert_sequence_to_ti(const std::shared_ptr<ov::Node>& sequence,
             ov::copy_runtime_info(sequence, aggregated_Y_c);
 
             // set initial value and back edge for aggregated C
-            // tensor_iterator->set_merged_input(body_params.at(2), aggregated_Y_c, body_results.at(2));
+            tensor_iterator->set_merged_input(body_params.at(2), aggregated_Y_c, body_results.at(2));
             C_out = tensor_iterator->get_function()->get_results()[2];
         }
     }

--- a/src/common/transformations/tests/op_conversions/convert_sequences_to_ti_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_sequences_to_ti_test.cpp
@@ -10,7 +10,6 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "openvino/core/model.hpp"
-#include "openvino/openvino.hpp"
 #include "openvino/opsets/opset5.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/init_node_info.hpp"

--- a/src/common/transformations/tests/op_conversions/convert_sequences_to_ti_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_sequences_to_ti_test.cpp
@@ -10,6 +10,7 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "openvino/core/model.hpp"
+#include "openvino/openvino.hpp"
 #include "openvino/opsets/opset5.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/init_node_info.hpp"
@@ -797,6 +798,40 @@ TEST(TransformationTests, ConvertQuantizedGRUSequenceToTensorIterator) {
 
     auto res = compare_functions(f, f_ref);
     ASSERT_TRUE(res.first) << res.second;
+}
+
+TEST(TransformationTests, convert_lstm_seq_to_ti_with_enabled_mask) {
+    auto param_x = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1, -1});
+    auto param_init_cell_state =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, 1, 256});
+    auto param_hidden_cell_state =
+        std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, 1, 256});
+    auto param_seq_len = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto param_w = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 1024, 40});
+    auto param_r = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 1024, 256});
+    auto param_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 1024});
+    std::int64_t hidden_size = 256;
+    ov::op::v5::LSTMSequence::direction lstm_direction = ov::op::v5::LSTMSequence::direction::FORWARD;
+    auto lstm_cell = std::make_shared<ov::op::v5::LSTMSequence>(param_x,
+                                                                param_init_cell_state,
+                                                                param_hidden_cell_state,
+                                                                param_seq_len,
+                                                                param_w,
+                                                                param_r,
+                                                                param_b,
+                                                                hidden_size,
+                                                                lstm_direction);
+    auto model = std::make_shared<ov::Model>(lstm_cell->outputs(),
+                                             ov::ParameterVector{param_x,
+                                                                 param_init_cell_state,
+                                                                 param_hidden_cell_state,
+                                                                 param_seq_len,
+                                                                 param_w,
+                                                                 param_r,
+                                                                 param_b});
+    pass::Manager m;
+    m.register_pass<ov::pass::ConvertSequenceToTensorIterator>();
+    m.run_passes(model);
 }
 
 TEST(TransformationTests, ConvertLSTMSequenceWithDynSeqLenToTensorIterator) {


### PR DESCRIPTION
### Details:
- Fix `convert_seq_to_ti` transformation  with enabled mask

### Tickets:
 - CVS-128000
