### PR TITLE
fix sporadic failure in auto unit test

### DIFF
--- a/src/plugins/auto/tests/unit/compile_model_metric_test.cpp
+++ b/src/plugins/auto/tests/unit/compile_model_metric_test.cpp
@@ -312,7 +312,6 @@ const std::vector<ConfigParams> testConfigs = {
     ConfigParams{false, 3, 5, false, 2, 5, true, ov::test::utils::DEVICE_GPU, 1, 0, false, true},
     ConfigParams{true, 3, 5, false, 2, 5, true, ov::test::utils::DEVICE_GPU, 48, 0, false, true},
     ConfigParams{false, 3, 5, true, 2, 5, false, ov::test::utils::DEVICE_GPU, 2, 0, false, true},
-    ConfigParams{false, 3, 5, false, 2, 5, false, ov::test::utils::DEVICE_GPU, 2, 0, false, true},
     ConfigParams{true, 3, 5, true, 2, 5, false, ov::test::utils::DEVICE_GPU, 2, 0, false, true},
     ConfigParams{true, 3, 5, false, 2, 5, true, ov::test::utils::DEVICE_GPU, 48, 48, false, true},
     ConfigParams{true, 3, 5, false, 2, 5, true, ov::test::utils::DEVICE_GPU, 6, 6, false, true},


### PR DESCRIPTION
### Details:
 - disable a invalid case, shouldn't make arbitrary assumptions when there is thread compiling in background

### Tickets:
 - 131628
