### PR TITLE
Fix template tests cmake to use not aliased name

### DIFF
--- a/src/plugins/template/tests/functional/CMakeLists.txt
+++ b/src/plugins/template/tests/functional/CMakeLists.txt
@@ -15,7 +15,7 @@ ov_add_test_target(
         DEPENDENCIES
             openvino_template_plugin
         LINK_LIBRARIES
-            openvino::funcSharedTests
+            funcSharedTests
             openvino::runtime::dev
         INCLUDES
             "${OpenVINOTemplatePlugin_SOURCE_DIR}/include"


### PR DESCRIPTION
### Details:
 - Fix template tests cmake to use not aliased name

### Tickets:
 - *ticket-id*
