### PR TITLE
[ONNX][core] Fix resolving symlink for model external data

### DIFF
--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -85,31 +85,32 @@ std::string ov::util::get_file_ext(const std::string& s) {
 }
 
 std::string ov::util::get_directory(const std::string& s) {
-    std::string rc = s;
     // Linux-style separator
     auto pos = s.find_last_of('/');
     if (pos != std::string::npos) {
-        rc = s.substr(0, pos ? pos : 1);
-        return rc;
+        return s.substr(0, pos ? pos : 1);
     }
     // Windows-style separator
     pos = s.find_last_of('\\');
     if (pos != std::string::npos) {
-        rc = s.substr(0, pos);
-        return rc;
+        return s.substr(0, pos);
+    } else if (s.empty()) {
+        return {};
+    } else {
+        return {'.'};
     }
-    return rc;
 }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 std::wstring ov::util::get_directory(const std::wstring& s) {
-    std::wstring rc = s;
     auto pos = s.find_last_of(ov::util::FileTraits<wchar_t>::file_separator);
     if (pos != std::wstring::npos) {
-        rc = s.substr(0, pos);
-        return rc;
+        return s.substr(0, pos);
+    } else if (s.empty()) {
+        return {};
+    } else {
+        return {L'.'};
     }
-    return rc;
 }
 #endif
 

--- a/src/frontends/onnx/frontend/src/utils/onnx_internal.cpp
+++ b/src/frontends/onnx/frontend/src/utils/onnx_internal.cpp
@@ -94,10 +94,7 @@ std::shared_ptr<ov::Model> import_onnx_model(std::shared_ptr<ModelProto> model_p
                                              detail::MappedMemoryHandles mmap_cache,
                                              ov::frontend::ExtensionHolder extensions) {
     apply_transformations(*model_proto);
-    Graph graph{ov::util::get_directory(ov::util::get_absolute_file_path(model_path)),
-                model_proto,
-                mmap_cache,
-                std::move(extensions)};
+    Graph graph{ov::util::get_directory(model_path), model_proto, mmap_cache, std::move(extensions)};
     return graph.convert();
 }
 
@@ -106,10 +103,7 @@ std::shared_ptr<ov::Model> decode_to_framework_nodes(std::shared_ptr<ModelProto>
                                                      detail::MappedMemoryHandles mmap_cache,
                                                      ov::frontend::ExtensionHolder extensions) {
     apply_transformations(*model_proto);
-    auto graph = std::make_shared<Graph>(ov::util::get_directory(ov::util::get_absolute_file_path(model_path)),
-                                         model_proto,
-                                         mmap_cache,
-                                         extensions);
+    auto graph = std::make_shared<Graph>(ov::util::get_directory(model_path), model_proto, mmap_cache, extensions);
     return graph->decode();
 }
 }  // namespace detail

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
@@ -57,7 +57,7 @@ Buffer<ov::MappedMemory> TensorExternalData::load_external_mmap_data(const std::
 }
 
 Buffer<ov::AlignedBuffer> TensorExternalData::load_external_data(const std::string& model_dir) const {
-    const auto full_path = ov::util::get_absolute_file_path(ov::util::path_join({model_dir, m_data_location}));
+    auto full_path = ov::util::get_absolute_file_path(ov::util::path_join({model_dir, m_data_location}));
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
     ov::util::convert_path_win_style(full_path);
     std::ifstream external_data_stream(ov::util::string_to_wstring(full_path).c_str(),

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.cpp
@@ -34,7 +34,7 @@ TensorExternalData::TensorExternalData(const TensorProto& tensor) {
 
 Buffer<ov::MappedMemory> TensorExternalData::load_external_mmap_data(const std::string& model_dir,
                                                                      MappedMemoryHandles cache) const {
-    auto full_path = ov::util::path_join({model_dir, m_data_location});
+    const auto full_path = ov::util::get_absolute_file_path(ov::util::path_join({model_dir, m_data_location}));
     const int64_t file_size = ov::util::file_size(full_path);
     if (file_size <= 0 || m_offset + m_data_length > static_cast<uint64_t>(file_size)) {
         throw error::invalid_external_data{*this};
@@ -57,7 +57,7 @@ Buffer<ov::MappedMemory> TensorExternalData::load_external_mmap_data(const std::
 }
 
 Buffer<ov::AlignedBuffer> TensorExternalData::load_external_data(const std::string& model_dir) const {
-    auto full_path = ov::util::path_join({model_dir, m_data_location});
+    const auto full_path = ov::util::get_absolute_file_path(ov::util::path_join({model_dir, m_data_location}));
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
     ov::util::convert_path_win_style(full_path);
     std::ifstream external_data_stream(ov::util::string_to_wstring(full_path).c_str(),

--- a/src/tests/test_utils/common_test_utils/tests/utils_tests.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/utils_tests.cpp
@@ -14,6 +14,18 @@ TEST(UtilsTests, get_directory_returns_root) {
     ASSERT_EQ(get_directory("/test"), "/");
 }
 
+TEST(UtilsTests, get_directory_returns_empty) {
+    ASSERT_EQ(get_directory(""), "");
+}
+
+TEST(UtilsTests, get_directory_current_dir) {
+    ASSERT_EQ(get_directory("my_file.txt"), ".");
+}
+
+TEST(UtilsTests, get_directory_return_file_dir) {
+    ASSERT_EQ(get_directory("../test/path/my_file.txt"), "../test/path");
+}
+
 TEST(UtilsTests, filter_lines_by_prefix) {
     auto lines = "abc\nkkb\nabpp\n";
     auto res = filter_lines_by_prefix(lines, "ab");


### PR DESCRIPTION
### Details:
 - Store in ONNX graph model directory without get absolute path. The real `model_dir` path has to be resolved when used for example to load external model data. 
 If symbolic links used the model real directory and exteranal data real directory can be different. The real path for model data is resolved after joining with model data location.
 - Update `ov::utils::get_directory` function to resolve special cases such as empty string and current folder.

### Tickets:
 - #22736 
