### PR TITLE
[GHA] Fix for premature sccache server shutdown on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,6 +55,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       SCCACHE_IGNORE_SERVER_IO_ERROR: 1
       SCCACHE_SERVER_PORT: 35555
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_ERROR_LOG: "${{ github.workspace }}\\openvino\\sccache_log.txt"
       SCCACHE_LOG: warn
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"

--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -58,6 +58,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       SCCACHE_IGNORE_SERVER_IO_ERROR: 1
       SCCACHE_SERVER_PORT: 35555
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_ERROR_LOG: "${{ github.workspace }}\\openvino\\sccache_log.txt"
       SCCACHE_LOG: warn
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"
@@ -278,6 +279,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       SCCACHE_IGNORE_SERVER_IO_ERROR: 1
       SCCACHE_SERVER_PORT: 35555
+      SCCACHE_IDLE_TIMEOUT: 0
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"
       BUILD_DIR: "${{ github.workspace }}\\openvino_build"
       MODELS_PATH: "${{ github.workspace }}\\testdata"


### PR DESCRIPTION
### Details:
This should fix the following sporadic issues:

```
2024-02-16T21:40:26.9140419Z sccache: error: failed to execute compile
2024-02-16T21:40:26.9141391Z sccache: caused by: Failed to send data to or receive data from server
2024-02-16T21:40:26.9142455Z sccache: caused by: Failed to read response header
2024-02-16T21:40:26.9144951Z sccache: caused by: A connection attempt
failed because the connected party did not properly respond after a
period of time, or established connection failed because connected
host has failed to respond. (os error 10060)
```

and

```
2024-02-16T21:40:26.9140419Z sccache: error: failed to execute compile
2024-02-16T21:40:26.9141391Z sccache: caused by: Failed to send data to or receive data from server
2024-02-16T21:40:26.9142455Z sccache: caused by: Failed to read response header
2024-02-16T21:40:26.9144951Z sccache: caused by: A connection attempt
failed because the connected party did not properly respond after a
period of time, or established connection failed because connected
host has failed to respond. (os error 10060)
```