### PR TITLE
[CPU] Fix selecting conv primitive for the FC node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
@@ -45,10 +45,14 @@ public:
           m_context(context),
           m_shapeAgnosticData(DnnlFCPrimitive::createShapeAgnosticData(m_attrs, postOps, memory, m_context, cacheWeights)),
           m_primArgs(m_shapeAgnosticData->primAttrs.dnnlArgs) {}
-    void update(const MemoryArgs& memory) override {
+    bool update(const MemoryArgs& memory) override {
         const auto primitive = createPrimitive(memory);
+        if (!primitive) {
+            return false;
+        }
         updateMemory(m_primitive, primitive, memory);
         m_primitive = primitive;
+        return true;
     }
 
     void execute(const MemoryArgs& memory) override {
@@ -61,7 +65,7 @@ public:
     }
 
     impl_desc_type implType() const override {
-        return m_primitive->implType();
+        return m_primitive ? m_primitive->implType() : undef;
     }
 
 private:

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -135,7 +135,11 @@ using ExecutorFactoryLegacyCPtr = std::shared_ptr<const ExecutorFactoryLegacy>;
 
 class Executor {
 public:
-    virtual void update(const MemoryArgs& memory) {}
+    // returns false if the stage has failed and the executor must be rejected
+    virtual bool update(const MemoryArgs& memory) {
+        OPENVINO_THROW_NOT_IMPLEMENTED("This version of the 'update' method is not implemented by executor");
+        return false;
+    }
     virtual void execute() const {}
     // dnnl_fullyconnected 3D workaround version
     virtual void execute(const MemoryArgs& memory) {

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -255,11 +255,18 @@ const std::vector<ExecutorImplementation<FCAttrs>>& getImplementations() {
                         const ExecutorContext::CPtr context,
                         std::shared_ptr<DnnlShapeAgnosticData> shareAgnosticData) const {
                         ConvAttrs convAttrs{attrs.withBias};
-                        return DefaultInstantiator<DnnlConvolutionPrimitive, ConvAttrs, DnnlShapeAgnosticData>{}(
+                        auto primitive =
+                            DefaultInstantiator<DnnlConvolutionPrimitive, ConvAttrs, DnnlShapeAgnosticData>{}(
                             memory,
                             convAttrs,
                             context,
                             shareAgnosticData);
+
+                        if (!primitive || primitive->implType() != brgconv_avx512_1x1) {
+                            // only brgconv_avx512_1x1 primitive is acceptable from the performance perspective
+                            return nullptr;
+                        }
+                        return primitive;
                     }
                 };
 

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -108,7 +108,7 @@ MlasGemmExecutor::MlasGemmExecutor(const FCAttrs& attrs,
                                    const ExecutorContext::CPtr context)
     : packedWeights(prepareWeightMemory(memory.at(ARG_WEI), context, !attrs.weightsNonTransposed)) {}
 
-void MlasGemmExecutor::update(const MemoryArgs& memory) {
+bool MlasGemmExecutor::update(const MemoryArgs& memory) {
     const auto& weiDesc = memory.at(ARG_WEI)->getDescPtr();
     const auto& dstDesc = memory.at(ARG_DST)->getDescPtr();
     const auto& wgtDims = weiDesc->getShape().getStaticDims();
@@ -124,6 +124,7 @@ void MlasGemmExecutor::update(const MemoryArgs& memory) {
     } else {
         M = outDims[0];
     }
+    return true;
 }
 
 void MlasGemmExecutor::execute(const MemoryArgs& memory) {

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
@@ -27,7 +27,7 @@ public:
     }
 
     // offloads execution data preparation from the exec call
-    void update(const MemoryArgs& memory) override;
+    bool update(const MemoryArgs& memory) override;
 
     static bool supports(const FCConfig& config);
 


### PR DESCRIPTION
### Details:
Fix convolution primitive selection algorithm for the FC node implementation. This PR brings back the old behavior, where only `brgconv_avx512_1x1` were allowed to perform FC operations.

### Tickets:
 - 132558
