### PR TITLE
Fixed conversion errors in node.h and edge.h!

### DIFF
--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -87,7 +87,9 @@ private:
     std::weak_ptr<Node> parent;
     std::weak_ptr<Node> child;
     int parent_port;
-    int child_port;
+    // Changed to handle full range of size_t, matching the value being assigned
+    // to it
+    size_t child_port;
 
     bool useExternalMemory = false;
     EdgeWeakPtr memoryFromEdge;

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <ie_api.h>
 #include <common/utils.hpp>
 #include <oneapi/dnnl/dnnl.hpp>
 #include "cpu_memory.h"
@@ -340,8 +341,9 @@ public:
         return fusingPort;
     }
 
-    void setFusingPort(int fusingPort) {
-        this->fusingPort = fusingPort;
+    // size_t to accomdate values and address compiler.
+    void setFusingPort(size_t fusingPort) {
+        this->fusingPort = static_cast<int>(fusingPort);
     }
 
     const std::string &getName() const {


### PR DESCRIPTION
The changes to size_t were made to fix compiler warnings about the loss of precision when converting from a larger to a smaller integer type. 

Issue: https://github.com/openvinotoolkit/openvino/issues/19891