### PR TITLE
[CPU] Solving the build failure caused by setting the "ENABLE_OV_ONNX_FRONTEND" option to "OFF"

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
@@ -16,7 +16,7 @@ set(LINK_LIBRARIES funcSharedTests cpuSpecificRtInfo openvino::snippets ov_snipp
 if(ENABLE_OV_ONNX_FRONTEND)
     list(APPEND DEFINES TEST_MODELS="${TEST_MODEL_ZOO}")
 else()
-    set(EXCLUDED_SOURCE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/extension ${CMAKE_CURRENT_SOURCE_DIR}/shared_tests_instances/onnx)
+    set(EXCLUDED_SOURCE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/custom/extension ${CMAKE_CURRENT_SOURCE_DIR}/shared_tests_instances/onnx)
 endif()
 
 if(NOT (ARM OR AARCH64))


### PR DESCRIPTION
### Details:
See the [ticket description](https://jira.devtools.intel.com/browse/CVS-132119). The solution was checked only on a local setup on Ubuntu, if there's a way to check that using the CI please let me know (or if you could run the job and paste the link in the comments I would be grateful).

Disclaimer: I'm not a CPU plugin developer, so I can't tell for sure if this is the ideal fix and no side effects are introduced. Please take that into account when reviewing/merging.

### Tickets:
 - [CVS-132119](https://jira.devtools.intel.com/browse/CVS-132119)
