### PR TITLE
Return precomp.hpp to ov_models to fix build

### DIFF
--- a/src/tests/ov_helpers/ov_models/src/precomp.hpp
+++ b/src/tests/ov_helpers/ov_models/src/precomp.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <unordered_set>
+#include <utility>
+#include <vector>


### PR DESCRIPTION
### Details:
 - Restore src/tests/ov_helpers/ov_models/src/precomp.hpp, deleted in  https://github.com/openvinotoolkit/openvino/pull/22709
 - Fix build with -DENABLE_FASTER_BUILD=ON key

### Tickets:
 - *ticket-id*
