### PR TITLE
[GHA] Split test data storage for ONNX Model Tests into two replicas

### DIFF
--- a/.github/workflows/job_onnx_models_tests.yml
+++ b/.github/workflows/job_onnx_models_tests.yml
@@ -28,7 +28,10 @@ jobs:
       INSTALL_DIR: ${{ github.workspace }}/install
       INSTALL_TEST_DIR: ${{ github.workspace }}/install/tests
       ONNX_MODELS_PATH: ${{ github.workspace }}/onnx_test_models
-      MODELS_SHARE_PATH: "/mount/onnxtestdata"
+      # instead of using static MODELS_SHARE_PATH
+      # choose one of the replicas dynamically instead
+      # depending on GITHUB_RUN_NUMBER variable
+      NUMBER_OF_REPLICAS: 2
       ONNX_MODEL_ZOO_SHA: "5faef4c33eba0395177850e1e31c4a6a9e634c82"
     if: ${{ github.event_name != 'merge_group' }}
     steps:
@@ -53,6 +56,8 @@ jobs:
           echo "OPENVINO_REPO=$GITHUB_WORKSPACE/openvino" >> "$GITHUB_ENV"
           echo "INSTALL_DIR=$GITHUB_WORKSPACE/install" >> "$GITHUB_ENV"
           echo "INSTALL_TEST_DIR=$GITHUB_WORKSPACE/install/tests" >> "$GITHUB_ENV"
+          echo "MODELS_SHARE_PATH=/mount/onnxtestdata$((GITHUB_RUN_NUMBER % NUMBER_OF_REPLICAS))" >> "$GITHUB_ENV"
+          echo $MODELS_SHARE_PATH
 
       - name: Extract OpenVINO packages
         run: |


### PR DESCRIPTION
### Details:
ONNX Model Tests workflow job reads models from shared drive, but the IOPS and bandwidth requirements are so high that we need to spread the load between few replicas.
This approach assumes replicas are mounted to separate mount points in the filesystem, then a very simple Bash snippet is used to choose one of them.