### PR TITLE
[ONNX] Enable ONNX castlike tests

### DIFF
--- a/src/frontends/onnx/tests/__init__.py
+++ b/src/frontends/onnx/tests/__init__.py
@@ -145,7 +145,6 @@ xfail_issue_82039 = xfail_test(reason="Unsupported data type Optional, RuntimeEr
                                       "CPU plugin: Input image format UNSPECIFIED is not supported yet...")
 
 xfail_issue_86911 = xfail_test(reason="LSTM_Seq_len_unpacked - AssertionError: zoo models results mismatch")
-skip_issue_91151 = pytest.mark.skip(reason="RuntimeError: model input (shape={3,4}) and blob (shape=(1)) are incompatible") # Need to enable after bumping to 1.15
 xfail_issue_101965 = xfail_test(reason="Mismatch with numpy-based expected results.")
 xfail_issue_113506 = xfail_test(reason="Unsupported operation of type: LSTMSequence Node expects 7 inputs. Actual: 8")
 
@@ -170,7 +169,7 @@ xfail_issue_125485 = xfail_test(reason="AffineGrid operation is not supported")
 xfail_issue_125488 = xfail_test(reason="ImageDecoder operation is not supported")
 skip_issue_125487 = pytest.mark.skip(reason="GridSample doesn't support cubic and linear modes, and 4D tensor") # Need to enable after bumping to 1.15
 skip_issue_125489 = pytest.mark.skip(reason="IsInf changed behavior since opset-20") # Need to enable after opset-20 will be released
-skip_issue_124587 = pytest.mark.skip(reason="Fail on new macos machines") 
+skip_issue_124587 = pytest.mark.skip(reason="Fail on new macos machines")
 xfail_issue_125491 = xfail_test(reason="AveragePool mismatch with differences in shapes")
 xfail_issue_125492 = xfail_test(reason="DFT mismatch")
 xfail_issue_125493 = xfail_test(reason="Reduce* mismatch")
@@ -182,4 +181,3 @@ xfail_issue_122775 = xfail_test(reason="test_resize_downsample_scales_linear_cpu
 skip_misalignment = pytest.mark.skip(reason="Misalignment between onnx versions") # Need to enable after bumping to 1.15
 skip_issue_127649 = pytest.mark.skip(reason="Not equal to tolerance rtol=0.001, atol=1e-07 - "
                                              "Mismatched elements: 1 / 1000 (0.1%)")
-

--- a/src/frontends/onnx/tests/tests_python/test_backend.py
+++ b/src/frontends/onnx/tests/tests_python/test_backend.py
@@ -60,7 +60,6 @@ from tests import (
     xfail_issue_99970,
     xfail_issue_99972,
     xfail_issue_99973,
-    skip_issue_91151,
     xfail_issue_101965,
     xfail_issue_113506,
     skip_dynamic_model,
@@ -575,11 +574,6 @@ tests_expected_to_fail = [
         xfail_issue_99973,
         "OnnxBackendNodeModelTest.test_split_1d_uneven_split_opset18_cpu",
         "OnnxBackendNodeModelTest.test_split_2d_uneven_split_opset18_cpu",
-    ),
-    (
-        skip_issue_91151,
-        "OnnxBackendNodeModelTest.test_castlike_BFLOAT16_to_FLOAT_cpu",
-        "OnnxBackendNodeModelTest.test_castlike_FLOAT_to_BFLOAT16_cpu",
     ),
     (
         xfail_issue_101965,


### PR DESCRIPTION
### Details:
 - OV uses ONNX >= `1.15.0` which got bug fix for disabled tests.

### Tickets:
 - CVS-91151
