### PR TITLE
[GPU] Added rounding to nearest even for integer Interpolate output

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_onnx.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_onnx.cl
@@ -14,7 +14,12 @@
 #define ACC_VEC_TYPE                    MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, VEC_SIZE)
 #define TO_ACC_VEC_TYPE(x)              CAT(convert_, ACC_VEC_TYPE)(x)
 #define OUT_VEC_TYPE                    MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE)
-#define TO_OUT_VEC_TYPE(x)              CAT(convert_, OUT_VEC_TYPE)(x)
+
+#ifdef RTE_OUTPUT
+    #define TO_OUT_VEC_TYPE(x)          CAT(CAT(convert_, OUT_VEC_TYPE), _rte)(x)
+#else
+    #define TO_OUT_VEC_TYPE(x)          CAT(convert_, OUT_VEC_TYPE)(x)
+#endif
 
 inline float FUNC(get_original_coordinate)(float num, float scale, int length_resized, int length_original)
 {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
@@ -20,7 +20,13 @@
 #define ACC_VEC_TYPE                    MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, VEC_SIZE)
 #define TO_ACC_VEC_TYPE(x)              CAT(convert_, ACC_VEC_TYPE)(x)
 #define OUT_VEC_TYPE                    MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE)
-#define TO_OUT_VEC_TYPE(x)              CAT(convert_, OUT_VEC_TYPE)(x)
+
+#ifdef RTE_OUTPUT
+    #define TO_OUT_VEC_TYPE(x)          CAT(CAT(convert_, OUT_VEC_TYPE), _rte)(x)
+    #define TO_OUTPUT_TYPE(x)           CAT(CAT(convert_, OUTPUT_TYPE), _rte)(x)
+#else
+    #define TO_OUT_VEC_TYPE(x)          CAT(convert_, OUT_VEC_TYPE)(x)
+#endif
 
 inline float FUNC(get_original_coordinate)(float num, float scale, int length_resized, int length_original)
 {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_ref.cl
@@ -4,6 +4,10 @@
 
 #include "include/fetch_utils.cl"
 
+#ifdef RTE_OUTPUT
+    #define TO_OUTPUT_TYPE(x)   CAT(CAT(convert_, OUTPUT_TYPE), _rte)(x)
+#endif
+
 inline int FUNC(get_nearest_val)(float num, bool is_downsample)
 {
 #if defined(NEAREST_ROUND_PREFER_FLOOR)
@@ -159,7 +163,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
     #undef oy
     #undef ox
 #else // HAS_FUSED_OPS
-    OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(interp_val, ACTIVATION_PARAMS));
+    OUTPUT_TYPE res = ACTIVATION(TO_OUTPUT_TYPE(interp_val), ACTIVATION_PARAMS);
 #endif // HAS_FUSED_OPS
     output[FUNC_CALL(get_output_index)(out_coords[0], out_coords[1], 0, out_coords[2], out_coords[3], out_coords[4])] = res;
 #elif defined(SAMPLE_TYPE_CUBIC) // defined(SAMPLE_TYPE_NEAREST) && FEATURE_PACKED_MODE

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.cpp
@@ -211,6 +211,10 @@ JitConstants ResampleKernelBase::GetJitConstants(const resample_params& params) 
 
     jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
 
+    if (output.GetDType() != Datatype::F16 && output.GetDType() != Datatype::F32) {
+        jit.AddConstant(MakeJitConstant("RTE_OUTPUT", 1));
+    }
+
     return jit;
 }
 


### PR DESCRIPTION
### Details:
 - *By default rounding float to int does not match the implementation in the CPUPlugin*

### Tickets:
 - *Part of 127417*
