### PR TITLE
[core] Restore OV exception create function

### DIFF
--- a/src/core/include/openvino/core/except.hpp
+++ b/src/core/include/openvino/core/except.hpp
@@ -27,8 +27,11 @@ public:
 
     [[noreturn]] static void create(const char* file, int line, const std::string& explanation);
 
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info, const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const std::string&
+                                                                                                        explanation);
     virtual ~Exception();
 
     static const std::string default_msg;
@@ -73,10 +76,13 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const std::string& context_info,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const std::string&
+                                                                                                        context_info,
+                                                                                                    const std::string&
+                                                                                                        explanation);
 
 protected:
     OPENVINO_SUPPRESS_DEPRECATED_START
@@ -89,10 +95,13 @@ class OPENVINO_API NotImplemented : public AssertFailure {
 public:
     [[noreturn]] static void create(const char* file, int line, const std::string& explanation);
 
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const std::string& context_info,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const std::string&
+                                                                                                        context_info,
+                                                                                                    const std::string&
+                                                                                                        explanation);
 
     [[noreturn]] OPENVINO_DEPRECATED(
         "This function is deprecated and will be removed, please use "

--- a/src/core/include/openvino/core/except.hpp
+++ b/src/core/include/openvino/core/except.hpp
@@ -13,6 +13,12 @@
 
 namespace ov {
 
+struct CheckLocInfo {
+    const char* file;
+    int line;
+    const char* check_string;
+};
+
 /// Base error for ov runtime errors.
 class OPENVINO_API Exception : public std::runtime_error {
 public:
@@ -20,6 +26,9 @@ public:
     explicit Exception(const std::string& what_arg);
 
     [[noreturn]] static void create(const char* file, int line, const std::string& explanation);
+
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info, const std::string& explanation);
     virtual ~Exception();
 
     static const std::string default_msg;
@@ -64,6 +73,11 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
+                                    const std::string& context_info,
+                                    const std::string& explanation);
+
 protected:
     OPENVINO_SUPPRESS_DEPRECATED_START
     explicit AssertFailure(const std::string& what_arg) : ov::Exception(what_arg) {}
@@ -74,6 +88,11 @@ protected:
 class OPENVINO_API NotImplemented : public AssertFailure {
 public:
     [[noreturn]] static void create(const char* file, int line, const std::string& explanation);
+
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
+                                    const std::string& context_info,
+                                    const std::string& explanation);
 
     [[noreturn]] OPENVINO_DEPRECATED(
         "This function is deprecated and will be removed, please use "

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -534,6 +534,17 @@ public:
                                     std::pair<const Node*, const std::vector<TShape>*>&& ctx,
                                     const std::string& explanation);
 
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
+                                    const Node* node,
+                                    const std::string& explanation);
+
+    template <class TShape>
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
+                                    std::pair<const Node*, const std::vector<TShape>*>&& ctx,
+                                    const std::string& explanation);
+
 protected:
     explicit NodeValidationFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
 };
@@ -552,6 +563,12 @@ OPENVINO_API void NodeValidationFailure::create(const char* file,
                                                 const char* check_string,
                                                 std::pair<const Node*, const std::vector<PartialShape>*>&& ctx,
                                                 const std::string& explanation);
+
+template <>
+OPENVINO_API void NodeValidationFailure::create(const CheckLocInfo& check_loc_info,
+                                                std::pair<const Node*, const std::vector<PartialShape>*>&& ctx,
+                                                const std::string& explanation);
+
 }  // namespace ov
 #define NODE_VALIDATION_CHECK(node, ...) OPENVINO_ASSERT_HELPER(::ov::NodeValidationFailure, (node), __VA_ARGS__)
 

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -534,16 +534,19 @@ public:
                                     std::pair<const Node*, const std::vector<TShape>*>&& ctx,
                                     const std::string& explanation);
 
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const Node* node,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const Node* node,
+                                                                                                    const std::string&
+                                                                                                        explanation);
 
     template <class TShape>
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    std::pair<const Node*, const std::vector<TShape>*>&& ctx,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 "
+        "release") static void create(const CheckLocInfo& check_loc_info,
+                                      std::pair<const Node*, const std::vector<TShape>*>&& ctx,
+                                      const std::string& explanation);
 
 protected:
     explicit NodeValidationFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}

--- a/src/core/src/except.cpp
+++ b/src/core/src/except.cpp
@@ -14,6 +14,10 @@ void ov::Exception::create(const char* file, int line, const std::string& explan
     OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
+void ov::Exception::create(const CheckLocInfo& check_loc_info, const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, explanation);
+}
+
 std::string ov::Exception::make_what(const char* file,
                                      int line,
                                      const char* check_string,
@@ -47,8 +51,20 @@ void ov::AssertFailure::create(const char* file,
     throw ov::AssertFailure(make_what(file, line, check_string, context_info, explanation));
 }
 
+void ov::AssertFailure::create(const CheckLocInfo& check_loc_info,
+                               const std::string& context_info,
+                               const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, check_loc_info.check_string, context_info, explanation);
+}
+
 void ov::NotImplemented::create(const char* file, int line, const std::string& explanation) {
     throw ov::NotImplemented(make_what(file, line, nullptr, default_msg, explanation));
+}
+
+void ov::NotImplemented::create(const CheckLocInfo& check_loc_info,
+                                const std::string&,
+                                const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, explanation);
 }
 
 void ov::NotImplemented::create(const char* file,

--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -28,6 +28,12 @@ static const char idx_txt[] = "index '";
 static const char out_of_range_txt[] = "' out of range";
 }  // namespace
 
+void ov::NodeValidationFailure::create(const CheckLocInfo& check_loc_info,
+                                       const Node* node,
+                                       const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, check_loc_info.check_string, node, explanation);
+}
+
 void ov::NodeValidationFailure::create(const char* file,
                                        int line,
                                        const char* check_string,
@@ -48,6 +54,13 @@ void ov::NodeValidationFailure::create(const char* file,
                                               check_string,
                                               node_validation_failure_loc_string(ctx.first),
                                               op::validate::shape_infer_explanation_str(*ctx.second, explanation)));
+}
+
+template <>
+void ov::NodeValidationFailure::create(const CheckLocInfo& check_loc_info,
+                                       std::pair<const Node*, const std::vector<PartialShape>*>&& ctx,
+                                       const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, check_loc_info.check_string, std::move(ctx), explanation);
 }
 
 atomic<size_t> ov::Node::m_next_instance_id(0);

--- a/src/core/tests/check.cpp
+++ b/src/core/tests/check.cpp
@@ -61,3 +61,53 @@ TEST(check, ov_throw_exception_check_relative_path_to_source) {
                     ov::Exception,
                     AnyOf(StartsWith(exp_native_slash), StartsWith(exp_fwd_slash)));
 }
+
+TEST(check, create_ov_exception) {
+    constexpr int line = 145;
+    constexpr char test_file[] = "src/test_file.cpp";
+    const std::string explanation = "test error message";
+    const std::string exp_error_msg = "Exception from src/test_file.cpp:145:\ntest error message\n";
+
+    OV_EXPECT_THROW(ov::Exception::create(test_file, line, explanation), ov::Exception, exp_error_msg);
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    OV_EXPECT_THROW(ov::Exception::create({test_file, line, nullptr}, explanation), ov::Exception, exp_error_msg);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+}
+
+TEST(check, create_ov_assert_failure) {
+    constexpr int line = 145;
+    constexpr char test_file[] = "src/test_file.cpp";
+    constexpr char check_string[] = "value != 0";
+    const std::string explanation = "test error message";
+    const std::string ctx_info = "My context";
+    const std::string exp_error_msg =
+        "Check 'value != 0' failed at src/test_file.cpp:145:\nMy context:\ntest error message\n";
+
+    OV_EXPECT_THROW(ov::AssertFailure::create(test_file, line, check_string, ctx_info, explanation),
+                    ov::AssertFailure,
+                    exp_error_msg);
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    OV_EXPECT_THROW(ov::AssertFailure::create({test_file, line, check_string}, ctx_info, explanation),
+                    ov::AssertFailure,
+                    exp_error_msg);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+}
+
+TEST(check, create_ov_not_implemented) {
+    constexpr int line = 145;
+    constexpr char test_file[] = "src/test_file.cpp";
+    constexpr char check_string[] = "value != 0";
+    const std::string explanation = "test error message";
+    const std::string ctx_info = "My context";
+    const std::string exp_error_msg = "Exception from src/test_file.cpp:145:\nNot Implemented:\ntest error message\n";
+
+    OV_EXPECT_THROW(ov::NotImplemented::create(test_file, line, explanation), ov::NotImplemented, exp_error_msg);
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    OV_EXPECT_THROW(ov::NotImplemented::create({test_file, line, check_string}, ctx_info, explanation),
+                    ov::NotImplemented,
+                    exp_error_msg);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+}

--- a/src/core/tests/frontend/frontend_manager.cpp
+++ b/src/core/tests/frontend/frontend_manager.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "common_test_utils/file_utils.hpp"
+#include "common_test_utils/test_assertions.hpp"
 #include "openvino/frontend/exception.hpp"
 #include "openvino/frontend/manager.hpp"
 #include "openvino/util/file_util.hpp"
@@ -305,6 +306,81 @@ TEST(FrontEndExceptionTest, frontend_initialization_error_throw_info) {
         FAIL() << "Not expected exception type.";
     }
     FAIL() << "Test is expected to throw an exception.";
+}
+
+TEST(FrontEndExceptionTest, create_general_error) {
+    constexpr int line = 341;
+    constexpr char test_file[] = "test_file.cpp";
+    constexpr char check_string[] = "value != 0";
+    const std::string msg = "msg example";
+    const std::string exp_error_msg =
+        "Check 'value != 0' failed at test_file.cpp:341:\nFrontEnd API failed with GeneralFailure:\nmsg example\n";
+
+    OV_EXPECT_THROW(GeneralFailure::create(test_file, line, check_string, {}, msg), GeneralFailure, exp_error_msg);
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    OV_EXPECT_THROW(GeneralFailure::create({test_file, line, check_string}, {}, msg), GeneralFailure, exp_error_msg);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+}
+
+TEST(FrontEndExceptionTest, create_initialization_failure) {
+    constexpr int line = 341;
+    constexpr char test_file[] = "test_file.cpp";
+    constexpr char check_string[] = "value != 0";
+    const std::string msg = "msg example";
+    const std::string exp_error_msg = "Check 'value != 0' failed at test_file.cpp:341:\nFrontEnd API failed with "
+                                      "InitializationFailure:\nmsg example\n";
+
+    OV_EXPECT_THROW(InitializationFailure::create(test_file, line, check_string, {}, msg), InitializationFailure, exp_error_msg);
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    OV_EXPECT_THROW(InitializationFailure::create({test_file, line, check_string}, {}, msg), InitializationFailure, exp_error_msg);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+}
+
+TEST(FrontEndExceptionTest, create_op_validation_failure) {
+    constexpr int line = 341;
+    constexpr char test_file[] = "test_file.cpp";
+    constexpr char check_string[] = "value != 0";
+    const std::string msg = "msg example";
+    const std::string exp_error_msg =
+        "Check 'value != 0' failed at test_file.cpp:341:\nFrontEnd API failed with OpValidationFailure:\nmsg example\n";
+
+    OV_EXPECT_THROW(OpValidationFailure::create(test_file, line, check_string, {}, msg), OpValidationFailure, exp_error_msg);
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    OV_EXPECT_THROW(OpValidationFailure::create({test_file, line, check_string}, {}, msg), OpValidationFailure, exp_error_msg);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+}
+
+TEST(FrontEndExceptionTest, create_op_conversion_failure) {
+    constexpr int line = 341;
+    constexpr char test_file[] = "test_file.cpp";
+    constexpr char check_string[] = "value != 0";
+    const std::string msg = "msg example";
+    const std::string exp_error_msg =
+        "Check 'value != 0' failed at test_file.cpp:341:\nFrontEnd API failed with OpConversionFailure:\nmsg example\n";
+
+    OV_EXPECT_THROW(OpConversionFailure::create(test_file, line, check_string, {}, msg), OpConversionFailure, exp_error_msg);
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    OV_EXPECT_THROW(OpConversionFailure::create({test_file, line, check_string}, {}, msg), OpConversionFailure, exp_error_msg);
+    OPENVINO_SUPPRESS_DEPRECATED_END
+}
+
+TEST(FrontEndExceptionTest, create_not_implemented_failure) {
+    constexpr int line = 341;
+    constexpr char test_file[] = "test_file.cpp";
+    constexpr char check_string[] = "value != 0";
+    const std::string msg = "msg example";
+    const std::string exp_error_msg = "Check 'value != 0' failed at test_file.cpp:341:\nFrontEnd API failed with "
+                                      "NotImplementedFailure:\nmsg example\n";
+
+    OV_EXPECT_THROW(NotImplementedFailure::create(test_file, line, check_string, {}, msg), NotImplementedFailure, exp_error_msg);
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    OV_EXPECT_THROW(NotImplementedFailure::create({test_file, line, check_string}, {}, msg), NotImplementedFailure, exp_error_msg);
+    OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
 // FrontEndManager exception safety

--- a/src/frontends/common/include/openvino/frontend/exception.hpp
+++ b/src/frontends/common/include/openvino/frontend/exception.hpp
@@ -20,6 +20,11 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
+                                    const std::string& context_info,
+                                    const std::string& explanation);
+
 protected:
     explicit GeneralFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
 };
@@ -29,6 +34,10 @@ public:
     [[noreturn]] static void create(const char* file,
                                     int line,
                                     const char* check_string,
+                                    const std::string& context_info,
+                                    const std::string& explanation);
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
                                     const std::string& context_info,
                                     const std::string& explanation);
 
@@ -44,6 +53,11 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
+                                    const std::string& context_info,
+                                    const std::string& explanation);
+
 protected:
     explicit OpValidationFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
 };
@@ -56,6 +70,11 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
+                                    const std::string& context_info,
+                                    const std::string& explanation);
+
 protected:
     explicit OpConversionFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
 };
@@ -65,6 +84,11 @@ public:
     [[noreturn]] static void create(const char* file,
                                     int line,
                                     const char* check_string,
+                                    const std::string& context_info,
+                                    const std::string& explanation);
+
+    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
+    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
                                     const std::string& context_info,
                                     const std::string& explanation);
 

--- a/src/frontends/common/include/openvino/frontend/exception.hpp
+++ b/src/frontends/common/include/openvino/frontend/exception.hpp
@@ -20,10 +20,13 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const std::string& context_info,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const std::string&
+                                                                                                        context_info,
+                                                                                                    const std::string&
+                                                                                                        explanation);
 
 protected:
     explicit GeneralFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
@@ -36,10 +39,13 @@ public:
                                     const char* check_string,
                                     const std::string& context_info,
                                     const std::string& explanation);
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const std::string& context_info,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const std::string&
+                                                                                                        context_info,
+                                                                                                    const std::string&
+                                                                                                        explanation);
 
 protected:
     explicit InitializationFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
@@ -53,10 +59,13 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const std::string& context_info,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const std::string&
+                                                                                                        context_info,
+                                                                                                    const std::string&
+                                                                                                        explanation);
 
 protected:
     explicit OpValidationFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
@@ -70,10 +79,13 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const std::string& context_info,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const std::string&
+                                                                                                        context_info,
+                                                                                                    const std::string&
+                                                                                                        explanation);
 
 protected:
     explicit OpConversionFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}
@@ -87,10 +99,13 @@ public:
                                     const std::string& context_info,
                                     const std::string& explanation);
 
-    OPENVINO_DEPRECATED("This function is deprecated and will be removed in the 2024.0 release")
-    [[noreturn]] static void create(const CheckLocInfo& check_loc_info,
-                                    const std::string& context_info,
-                                    const std::string& explanation);
+    [[noreturn]] OPENVINO_DEPRECATED(
+        "This function is deprecated and will be removed in the 2024.0 release") static void create(const CheckLocInfo&
+                                                                                                        check_loc_info,
+                                                                                                    const std::string&
+                                                                                                        context_info,
+                                                                                                    const std::string&
+                                                                                                        explanation);
 
 protected:
     explicit NotImplementedFailure(const std::string& what_arg) : ov::AssertFailure(what_arg) {}

--- a/src/frontends/common/src/exception.cpp
+++ b/src/frontends/common/src/exception.cpp
@@ -13,6 +13,12 @@ void ov::frontend::GeneralFailure::create(const char* file,
         make_what(file, line, check_string, "FrontEnd API failed with GeneralFailure" + context_info, explanation));
 }
 
+void ov::frontend::GeneralFailure::create(const CheckLocInfo& check_loc_info,
+                                          const std::string& context_info,
+                                          const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, check_loc_info.check_string, context_info, explanation);
+}
+
 void ov::frontend::InitializationFailure::create(const char* file,
                                                  int line,
                                                  const char* check_string,
@@ -23,6 +29,12 @@ void ov::frontend::InitializationFailure::create(const char* file,
                                                         check_string,
                                                         "FrontEnd API failed with InitializationFailure" + context_info,
                                                         explanation));
+}
+
+void ov::frontend::InitializationFailure::create(const CheckLocInfo& check_loc_info,
+                                                 const std::string& context_info,
+                                                 const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, check_loc_info.check_string, context_info, explanation);
 }
 
 void ov::frontend::OpValidationFailure::create(const char* file,
@@ -37,6 +49,12 @@ void ov::frontend::OpValidationFailure::create(const char* file,
                                                       explanation));
 }
 
+void ov::frontend::OpValidationFailure::create(const CheckLocInfo& check_loc_info,
+                                               const std::string& context_info,
+                                               const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, check_loc_info.check_string, context_info, explanation);
+}
+
 void ov::frontend::OpConversionFailure::create(const char* file,
                                                int line,
                                                const char* check_string,
@@ -49,6 +67,12 @@ void ov::frontend::OpConversionFailure::create(const char* file,
                                                       explanation));
 }
 
+void ov::frontend::OpConversionFailure::create(const CheckLocInfo& check_loc_info,
+                                               const std::string& context_info,
+                                               const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, check_loc_info.check_string, context_info, explanation);
+}
+
 void ov::frontend::NotImplementedFailure::create(const char* file,
                                                  int line,
                                                  const char* check_string,
@@ -59,4 +83,10 @@ void ov::frontend::NotImplementedFailure::create(const char* file,
                                                         check_string,
                                                         "FrontEnd API failed with NotImplementedFailure" + context_info,
                                                         explanation));
+}
+
+void ov::frontend::NotImplementedFailure::create(const CheckLocInfo& check_loc_info,
+                                                 const std::string& context_info,
+                                                 const std::string& explanation) {
+    create(check_loc_info.file, check_loc_info.line, check_loc_info.check_string, context_info, explanation);
 }


### PR DESCRIPTION
### Details:
 - Restore `create` member function in OV exception classes to be compatible with 2023.2 API.

### Tickets:
 - [CVS-133319](https://jira.devtools.intel.com/browse/CVS-133319)
