### PR TITLE
[GPU] Unified FillCLKernelData's parameter that affects adding SHAPE_INFO to arguments during kernel generating

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_base.cpp
@@ -109,7 +109,7 @@ KernelsData ActivationKernelBase::GetCommonKernelsData(const Params& params) con
     auto& kernel = kd.kernels[0];
     FillCLKernelData(kernel, dispatchData, params.engineInfo, kernelName, jit, entry_point,
                      EXE_MODE_DEFAULT, false, false, 1,
-                     GetFusedPrimitiveInputsCount(params), 1, newParams.outputs[0].is_dynamic());
+                     GetFusedPrimitiveInputsCount(params), 1, newParams.is_shape_agnostic);
 
     if (!newParams.inputActivationParams.empty()) {
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::SLOPE, 0});

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -165,7 +165,7 @@ KernelsData ArgMaxMinKernelAxis::GetKernelsData(const Params& params) const {
                      1,
                      GetFusedPrimitiveInputsCount(params),
                      orgParams.use_multiple_outputs ? 2 : 1,
-                     is_dynamic);
+                     orgParams.is_shape_agnostic);
 
     if (orgParams.has_second_output && !orgParams.use_multiple_outputs)
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INPUT, 1});

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_base.cpp
@@ -79,7 +79,7 @@ KernelsData ArgMaxMinKernelBase::GetCommonKernelsData(const Params& params) cons
                      (uint32_t)orgParams.inputs.size(),
                      GetFusedPrimitiveInputsCount(params),
                      (uint32_t)orgParams.outputs.size(),
-                     orgParams.has_dynamic_tensors());
+                     orgParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_base.cpp
@@ -114,7 +114,7 @@ KernelsData BatchToSpaceKernelBase::GetCommonKernelsData(const Params& params) c
 
     FillCLKernelData(kernel, dispatchData, params.engineInfo, kernelName, jit, entry_point,
                      "", false, false, static_cast<int>(newParams.inputs.size()),
-                     GetFusedPrimitiveInputsCount(params), 1, newParams.has_dynamic_tensors());
+                     GetFusedPrimitiveInputsCount(params), 1, newParams.is_shape_agnostic);
 
     return { kd };
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/beam_table_update/beam_table_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/beam_table_update/beam_table_update_kernel_ref.cpp
@@ -53,7 +53,7 @@ KernelsData BeamTableUpdateKernelRef::GetKernelsData(const Params& params) const
                      static_cast<int>(kernel_params.inputs.size()),
                      GetFusedPrimitiveInputsCount(kernel_params),
                      static_cast<int>(kernel_params.outputs.size()),
-                     kernel_params.outputs[0].is_dynamic());
+                     kernel_params.is_shape_agnostic);
 
     ScalarDescriptor is_state_set;
     is_state_set.t = ScalarDescriptor::Types::UINT8;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/border/border_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/border/border_kernel_base.cpp
@@ -104,7 +104,7 @@ KernelsData BorderKernelBase::GetCommonKernelsData(const Params& params) const {
                      (uint32_t)prim_params.inputs.size(),
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     prim_params.outputs[0].is_dynamic());
+                     prim_params.is_shape_agnostic);
 
     return {k_data};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/broadcast/broadcast_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/broadcast/broadcast_kernel_base.cpp
@@ -146,7 +146,7 @@ KernelsData BroadcastKernelBase::GetCommonKernelsData(const Params& params) cons
                      1,
                      0,
                      1,
-                     prim_params.inputs[0].is_dynamic() || prim_params.outputs[0].is_dynamic());
+                     prim_params.is_shape_agnostic);
 
     return {k_data};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
@@ -232,7 +232,7 @@ KernelsData ConvolutionKernelBase::GetCommonKernelsData(const Params& params,
                      true,
                      !newParams.bias.empty(),
                      1, 0, 1,
-                     newParams.inputs[0].is_dynamic() || newParams.outputs[0].is_dynamic());
+                     newParams.is_shape_agnostic);
 
     if (newParams.deformable_mode) {
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INPUT, 1});

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -36,7 +36,7 @@ protected:
     bool NeedPaddedInput() const override { return true; }
     DispatchData SetDefault(const convolution_params& arg, int autoTuneIndex = -1) const override;
     size_t GetSubGroupSize(const convolution_params& params) const {
-        if (params.engineInfo.computeUnitsCount <= 24) {
+        if (params.engineInfo.computeUnitsCount <= 24 && !params.is_shape_agnostic) {
             // Smaller # EU tends to be computation bounds.
             // In such case, using larger worksize will result in larger computational inefficiency
             // w.r.t the unalined output feature

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/cum_sum/cum_sum_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/cum_sum/cum_sum_kernel_base.cpp
@@ -98,7 +98,7 @@ KernelsData CumSumKernelBase::GetCommonKernelsData(const Params& params) const {
                      "", false, false, 1,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     newParams.outputs[0].is_dynamic());
+                     newParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
@@ -757,7 +757,7 @@ KernelsData EltwiseKernelBase::GetCommonKernelsData(const Params& params) const 
 
     kernel.params.workGroups.global = dispatchData.gws;
     kernel.params.workGroups.local = dispatchData.lws;
-    bool is_dynamic = newParams.has_dynamic_tensors();
+    bool is_dynamic = newParams.is_shape_agnostic;
     kernel.params.arguments = GetArgsDesc((uint32_t)newParams.inputs.size(),
                                    false,
                                    false,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.cpp
@@ -146,7 +146,7 @@ KernelsData FullyConnectedKernelBase::GetCommonKernelsData(const Params &params,
                      inputs_count,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     orgParams.outputs[0].is_dynamic());
+                     orgParams.is_shape_agnostic);
 
     // TODO Pass estimated time only through DispatchData
     kd.autoTuneIndex = autoTuneIndex;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_ref.cpp
@@ -178,7 +178,7 @@ KernelsData GatherElementsKernelRef::GetKernelsData(const Params& params) const 
 
     auto& kernel = kd.kernels[0];
     FillCLKernelData(kernel, dispatchData, params.engineInfo, kernelName, jit, entry_point,
-                     "", false, false, 2, GetFusedPrimitiveInputsCount(params), 1, newParams.has_dynamic_tensors());
+                     "", false, false, 2, GetFusedPrimitiveInputsCount(params), 1, newParams.is_shape_agnostic);
     return { kd };
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
@@ -385,7 +385,7 @@ KernelsData GatherKernelRef::GetKernelsData(const Params& params) const {
                      inputs_count,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     newParams.has_dynamic_tensors());
+                     newParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_ref.cpp
@@ -212,7 +212,7 @@ KernelsData GatherNDKernelRef::GetKernelsData(const Params& params) const {
                      2,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     newParams.has_dynamic_tensors());
+                     newParams.is_shape_agnostic);
 
     return { kd };
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
@@ -278,7 +278,7 @@ KernelsData GemmKernelBase::GetCommonKernelsData(const Params& params) const {
                      (uint32_t)prim_params.inputs.size(),
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     prim_params.has_dynamic_tensors());
+                     prim_params.is_shape_agnostic);
 
     return {k_data};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_base.cpp
@@ -90,7 +90,7 @@ KernelsData MVNKernelBase::GetCommonKernelsData(const Params& params) const {
                      1,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     orgParams.outputs[0].is_dynamic());
+                     orgParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/count_nonzero_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/count_nonzero_kernel_ref.cpp
@@ -102,7 +102,7 @@ KernelsData CountNonzeroKernelRef::GetKernelsData(const Params& params) const {
                      1,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     newParams.inputs[0].is_dynamic());
+                     newParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/gather_nonzero_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/gather_nonzero_kernel_ref.cpp
@@ -105,7 +105,7 @@ KernelsData GatherNonzeroKernelRef::GetKernelsData(const Params& params) const {
                      2,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     newParams.outputs[0].is_dynamic());
+                     newParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_base.cpp
@@ -69,7 +69,7 @@ KernelsData PermuteKernelBase::GetKernelsData(const Params& params) const {
                      1,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     newParams.outputs[0].is_dynamic());
+                     newParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_base.cpp
@@ -271,7 +271,7 @@ KernelsData ReduceKernelBase::GetCommonKernelsData(const Params& p) const {
                      1,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     params.inputs[0].is_dynamic());
+                     params.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_base.cpp
@@ -259,9 +259,9 @@ KernelsData ReorderKernelBase::GetCommonKernelsData(const reorder_params& params
                      1,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     newParams.outputs[0].is_dynamic());
+                     newParams.is_shape_agnostic);
 
-    kernel.params.arguments = GetArgsDesc(1, false, false, GetFusedPrimitiveInputsCount(params), 1, newParams.outputs[0].is_dynamic());
+    kernel.params.arguments = GetArgsDesc(1, false, false, GetFusedPrimitiveInputsCount(params), 1, newParams.is_shape_agnostic);
     if (newParams.mode == MeanSubtractMode::IN_BUFFER) {
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::BIAS, 0});
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp
@@ -78,7 +78,7 @@ KernelsData RMSKernelBase::GetCommonKernelsData(const Params& params) const {
                      2,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     orgParams.outputs[0].is_dynamic());
+                     orgParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_nd_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_nd_update_kernel_ref.cpp
@@ -222,7 +222,7 @@ KernelsData ScatterNDUpdateKernelRef::GetKernelsData(const Params& params) const
         clKernelData& kernel = kd.kernels[i];
 
         FillCLKernelData(kernel, dispatchData, params.engineInfo, kernelName, jit, entry_point,
-                         "", false, false, inputs_number, GetFusedPrimitiveInputsCount(params), 1, newParams.has_dynamic_tensors());
+                         "", false, false, inputs_number, GetFusedPrimitiveInputsCount(params), 1, newParams.is_shape_agnostic);
     }
 
     return {kd};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -351,7 +351,7 @@ KernelsData ScatterUpdateKernelRef::GetKernelsData(const Params& params) const {
         clKernelData& kernel = kd.kernels[i - start_with_iteration];
 
         FillCLKernelData(kernel, dispatchData, params.engineInfo, kernelName, jit, entry_point,
-                         "", false, false, 3, GetFusedPrimitiveInputsCount(params), 1, newParams.has_dynamic_tensors());
+                         "", false, false, 3, GetFusedPrimitiveInputsCount(params), 1, newParams.is_shape_agnostic);
     }
 
     return {kd};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/select/select_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/select/select_kernel_base.cpp
@@ -142,7 +142,7 @@ KernelsData SelectKernelBase::GetCommonKernelsData(const Params& params) const {
                      (uint32_t)newParams.inputs.size(),
                      0,
                      1,
-                     newParams.outputs[0].is_dynamic());
+                     newParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/shape_of/shape_of_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/shape_of/shape_of_kernel_ref.cpp
@@ -60,7 +60,7 @@ KernelsData ShapeOfKernelRef::GetKernelsData(const Params &params) const {
     GetUpdateDispatchDataFunc(kernel_data);
 
     FillCLKernelData(clKernelData, dispatch_data, params.engineInfo, kernelName, jit, entry_point, EXE_MODE_DEFAULT,
-                     false, false, 0, 0, 1, derived_params.inputs[0].is_dynamic());
+                     false, false, 0, 0, 1, derived_params.is_shape_agnostic);
     return kernels_data;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_base.cpp
@@ -69,7 +69,7 @@ KernelsData SoftmaxKernelBase::GetCommonKernelsData(const Params& params) const 
                      1,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     orgParams.outputs[0].is_dynamic());
+                     orgParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_base.cpp
@@ -114,7 +114,7 @@ KernelsData SpaceToBatchKernelBase::GetCommonKernelsData(const Params& params) c
 
     FillCLKernelData(kernel, dispatchData, params.engineInfo, kernelName, jit, entry_point,
                      "", false, false, static_cast<int>(newParams.inputs.size()),
-                     GetFusedPrimitiveInputsCount(params), 1, newParams.has_dynamic_tensors());
+                     GetFusedPrimitiveInputsCount(params), 1, newParams.is_shape_agnostic);
 
     return { kd };
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_ref.cpp
@@ -252,7 +252,7 @@ KernelsData StridedSliceKernelRef::GetKernelsData(const Params& params) const {
 
     FillCLKernelData(kernel, dispatchData, params.engineInfo, kernelName, jit, entry_point,
                      "", false, false, static_cast<int>(newParams.inputs.size()),
-                     0, 1, newParams.has_dynamic_tensors());
+                     0, 1, newParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.cpp
@@ -86,7 +86,7 @@ KernelsData SwiGLUKernelRef::GetKernelsData(const Params& params) const {
                      1,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     orgParams.has_dynamic_tensors());
+                     orgParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/tile/tile_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/tile/tile_kernel_ref.cpp
@@ -77,7 +77,7 @@ KernelsData TileKernelRef::GetKernelsData(const Params& params) const {
     auto& kernel = kd.kernels[0];
 
     FillCLKernelData(kernel, dispatchData, params.engineInfo, kernelName, jit, entry_point,
-                     EXE_MODE_DEFAULT, false, false, 1, 0, 1, newParams.has_dynamic_tensors());
+                     EXE_MODE_DEFAULT, false, false, 1, 0, 1, newParams.is_shape_agnostic);
 
     return {kd};
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/unique/unique_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/unique/unique_kernel_ref.cpp
@@ -165,7 +165,7 @@ KernelsData UniqueCountKernelRef::GetKernelsData(const Params& params) const {
                      static_cast<int>(kernel_params.inputs.size()),
                      GetFusedPrimitiveInputsCount(kernel_params),
                      static_cast<int>(kernel_params.outputs.size()),
-                     kernel_params.inputs.front().is_dynamic());
+                     kernel_params.is_shape_agnostic);
 
     // Additional buffer to save intermediate algorithm results
     kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 0});
@@ -276,7 +276,7 @@ KernelsData UniqueGatherKernelRef::GetKernelsData(const Params& params) const {
                      static_cast<int>(kernel_params.inputs.size()),
                      GetFusedPrimitiveInputsCount(kernel_params),
                      static_cast<int>(kernel_params.outputs.size()),
-                     kernel_params.outputs.front().is_dynamic());
+                     kernel_params.is_shape_agnostic);
 
     return {kernel_data};
 }

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/eltwise_fusion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/eltwise_fusion.cpp
@@ -1,0 +1,98 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "common_test_utils/file_utils.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/add.hpp"
+
+namespace {
+
+using ov::test::InputShape;
+
+using StaticEltwiseDynamicFusionsParams = std::tuple<std::vector<InputShape>,   // input shapes
+                                                     ov::element::Type>;        // input precision
+
+class StaticEltwiseDynamicFusions : public testing::WithParamInterface<StaticEltwiseDynamicFusionsParams>,
+                     virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<StaticEltwiseDynamicFusionsParams> obj) {
+        std::vector<InputShape> input_shapes;
+        ov::element::Type input_precision;
+
+        std::tie(input_shapes, input_precision) = obj.param;
+
+        std::ostringstream result;
+        result << "IS=(";
+        for (const auto& shape : input_shapes) {
+            result << ov::test::utils::partialShape2str({shape.first}) << "_";
+        }
+        result << ")_TS=";
+        for (const auto& shape : input_shapes) {
+            result << "(";
+            if (!shape.second.empty()) {
+                auto itr = shape.second.begin();
+                do {
+                    result << ov::test::utils::vec2str(*itr);
+                } while (++itr != shape.second.end() && result << "_");
+            }
+            result << ")_";
+        }
+        result << "input_precision=" << input_precision;
+        return result.str();
+    }
+
+protected:
+    std::shared_ptr<ov::Model> init_subgraph(std::vector<ov::PartialShape>& input_shapes,
+                                             const ov::element::Type input_precision) {
+        auto input0 = std::make_shared<ov::op::v0::Parameter>(input_precision, input_shapes[0] /* static input */);
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(input_precision, input_shapes[1] /* dynamic input */);
+
+        auto mul_const = ov::op::v0::Constant::create(input_precision, ov::Shape{}, {0.5f});
+        auto mul = std::make_shared<ov::op::v1::Multiply>(input0, mul_const);
+        auto add = std::make_shared<ov::op::v1::Add>(mul, input1);
+        auto mul2 = std::make_shared<ov::op::v1::Multiply>(add, mul_const);
+
+        add->set_friendly_name("Add1");
+        mul->set_friendly_name("Mul1");
+        mul2->set_friendly_name("Mul2");
+
+        return std::make_shared<ov::Model>(ov::NodeVector{mul2}, ov::ParameterVector{input0, input1}, "StaticEltwiseDynamicFusions");
+    }
+
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+
+        std::vector<InputShape> input_shapes;
+        ov::element::Type input_precision;
+
+        std::tie(input_shapes, input_precision) = GetParam();
+
+        init_input_shapes(input_shapes);
+
+        inType = outType = input_precision;
+        function = init_subgraph(inputDynamicShapes, input_precision);
+    }
+};
+
+TEST_P(StaticEltwiseDynamicFusions, Inference) {
+    run();
+}
+
+const std::vector<ov::element::Type> input_precisions2 = {ov::element::f32, ov::element::f16};
+
+const std::vector<std::vector<InputShape>> input_shapes_dyn2 = {
+    {{{2, 2, 32}, {{2, 2, 32}}}, {{-1, -1, 32}, {{1, 1, 32}}}},
+};
+
+INSTANTIATE_TEST_SUITE_P(StaticEltwiseDynamicFusions_basic,
+                         StaticEltwiseDynamicFusions,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_dyn2),
+                                            ::testing::ValuesIn(input_precisions2)),
+                         StaticEltwiseDynamicFusions::getTestCaseName);
+} // namespace


### PR DESCRIPTION
### Details:
 - Updated `FillCLKernelData`'s parameter to `params.is_shape_agnostic` in all kernels. Currently we use `params.has_dynamic_inputs()`/`params.has_dynamic_outputs()`/`params.has_dynamic_tensors()`, but there may be situations when kernel expects shape_info tensor (because of dynamism of some other input/output tensors), but we ignore it because of insufficient check for adding SHAPE_INFO to kernel's arguments list. Furthermore, none of these parameters takes into account dynamism of fused dependencies. So, replace it with `params.is_shape_agnostic` (for current implementation is_shape_agnostic will be true only when there is at least one dynamic input(including fused_dependencies) or output). It fixes multiple clEnqueueNDRangeKernel error with code -54/-52.
 - Fixed sub_group size selection for convolution_bfyx_os_iyx_osv16 kernel in case of EU <= 24

### Tickets:
 - 101325
