### PR TITLE
Fix use of `OPENVINO_ASSERT`

### DIFF
--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -324,7 +324,7 @@ ov::Any py_object_to_any(const py::object& py_obj) {
                     detected_type = type;
                     return;
                 }
-                OPENVINO_ASSERT("Incorrect attribute. Mixed types in the list are not allowed.");
+                OPENVINO_ASSERT(false, "Incorrect attribute. Mixed types in the list are not allowed.");
             };
             if (py::isinstance<py::str>(it)) {
                 check_type(PY_TYPE::STR);

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -324,7 +324,7 @@ ov::Any py_object_to_any(const py::object& py_obj) {
                     detected_type = type;
                     return;
                 }
-                OPENVINO_ASSERT(false, "Incorrect attribute. Mixed types in the list are not allowed.");
+                OPENVINO_THROW("Incorrect attribute. Mixed types in the list are not allowed.");
             };
             if (py::isinstance<py::str>(it)) {
                 check_type(PY_TYPE::STR);

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2017,7 +2017,10 @@ bool primitive_inst::is_valid_fusion() const {
         if (fd.is_type<eltwise>() || fd.is_type<activation>()) {
             fused_eltwise_prims.push_back(fd);
         } else {
-            OPENVINO_THROW("[GPU] Unsupported fused operation in dynamic shape : ", fd.desc->id);
+            if (fd.is_type<reorder>())
+                continue;
+
+            OPENVINO_THROW("[GPU] Unsupported fused operation in dynamic shape: type=", fd.desc->type_string(), ", id=", fd.desc->id);
         }
     }
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2017,7 +2017,7 @@ bool primitive_inst::is_valid_fusion() const {
         if (fd.is_type<eltwise>() || fd.is_type<activation>()) {
             fused_eltwise_prims.push_back(fd);
         } else {
-            OPENVINO_ASSERT("[GPU] Unsupported fused operation in dynamic shape : ", fd.desc->id);
+            OPENVINO_ASSERT(false, "[GPU] Unsupported fused operation in dynamic shape : ", fd.desc->id);
         }
     }
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1374,7 +1374,7 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
                     auto ev = get_network().get_primitive_event(id);
                     dependencies.emplace_back(ev);
                 } catch (const std::out_of_range& oor) {
-                    OPENVINO_ASSERT(false, "[GPU] execution order corrupted: ", oor.what());
+                    OPENVINO_THROW("[GPU] execution order corrupted: ", oor.what());
                 }
             }
         }
@@ -2017,7 +2017,7 @@ bool primitive_inst::is_valid_fusion() const {
         if (fd.is_type<eltwise>() || fd.is_type<activation>()) {
             fused_eltwise_prims.push_back(fd);
         } else {
-            OPENVINO_ASSERT(false, "[GPU] Unsupported fused operation in dynamic shape : ", fd.desc->id);
+            OPENVINO_THROW("[GPU] Unsupported fused operation in dynamic shape : ", fd.desc->id);
         }
     }
 

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -24,7 +24,7 @@ layout reshape_inst::calc_output_layout(reshape_node const& node, kernel_impl_pa
         if (desc->output_partial_shape.size() != 0) {
             return layout{desc->output_partial_shape, input_layout.data_type, input_layout.format};
         } else {
-            OPENVINO_ASSERT("[GPU] Output shape is not provided");
+            OPENVINO_ASSERT(false, "[GPU] Output shape is not provided");
         }
     }
 
@@ -110,7 +110,7 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& node, 
                 break;
             }
             default:
-                OPENVINO_ASSERT("Unsupported reshape mode");
+                OPENVINO_ASSERT(false, "Unsupported reshape mode");
         }
     };
 

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -24,7 +24,7 @@ layout reshape_inst::calc_output_layout(reshape_node const& node, kernel_impl_pa
         if (desc->output_partial_shape.size() != 0) {
             return layout{desc->output_partial_shape, input_layout.data_type, input_layout.format};
         } else {
-            OPENVINO_ASSERT(false, "[GPU] Output shape is not provided");
+            OPENVINO_THROW("[GPU] Output shape is not provided");
         }
     }
 
@@ -110,7 +110,7 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& node, 
                 break;
             }
             default:
-                OPENVINO_ASSERT(false, "Unsupported reshape mode");
+                OPENVINO_THROW("Unsupported reshape mode");
         }
     };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
@@ -189,7 +189,7 @@ JitConstants EltwiseKernel_blocked_opt::MakeLoadJitConstants(const eltwise_param
             else if (DataTensor::ChannelsCount(params.inputs[input_idx].GetLayout()) == 5)
                 default_indexing_str = "b, (f_block * " + toCodeString(vec_size) +"), z, y, x";
             else
-                OPENVINO_ASSERT(false, "MakeLoadJit : Unexpected dimension for eltwise optimized kernel.");
+                OPENVINO_THROW("MakeLoadJit : Unexpected dimension for eltwise optimized kernel.");
 
             // Generate Jit
             switch (input.mode) {
@@ -439,7 +439,7 @@ static inline int GetInnerBatchBlockSize(const DataTensor& tensor) {
     case DataLayout::bs_fs_zyx_bsv32_fsv16:
         return 32;
     default:
-        OPENVINO_ASSERT(false, "GetInnerBatchBlockSize : Unexpected format for eltwise_blocked_optimized kernel.");
+        OPENVINO_THROW("GetInnerBatchBlockSize : Unexpected format for eltwise_blocked_optimized kernel.");
     }
 
     return 1;
@@ -465,7 +465,7 @@ static inline int GetInnerFeatureBlockSize(const DataTensor& tensor) {
     case DataLayout::bs_fs_zyx_bsv16_fsv32:
         return 32;
     default:
-        OPENVINO_ASSERT(false, "GetInnerFeatureBlockSize : Unexpected format for eltwise_blocked_optimized kernel.");
+        OPENVINO_THROW("GetInnerFeatureBlockSize : Unexpected format for eltwise_blocked_optimized kernel.");
     }
 
     return 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
@@ -189,7 +189,7 @@ JitConstants EltwiseKernel_blocked_opt::MakeLoadJitConstants(const eltwise_param
             else if (DataTensor::ChannelsCount(params.inputs[input_idx].GetLayout()) == 5)
                 default_indexing_str = "b, (f_block * " + toCodeString(vec_size) +"), z, y, x";
             else
-                OPENVINO_ASSERT("MakeLoadJit : Unexpected dimension for eltwise optimized kernel.");
+                OPENVINO_ASSERT(false, "MakeLoadJit : Unexpected dimension for eltwise optimized kernel.");
 
             // Generate Jit
             switch (input.mode) {
@@ -439,7 +439,7 @@ static inline int GetInnerBatchBlockSize(const DataTensor& tensor) {
     case DataLayout::bs_fs_zyx_bsv32_fsv16:
         return 32;
     default:
-        OPENVINO_ASSERT("GetInnerBatchBlockSize : Unexpected format for eltwise_blocked_optimized kernel.");
+        OPENVINO_ASSERT(false, "GetInnerBatchBlockSize : Unexpected format for eltwise_blocked_optimized kernel.");
     }
 
     return 1;
@@ -465,7 +465,7 @@ static inline int GetInnerFeatureBlockSize(const DataTensor& tensor) {
     case DataLayout::bs_fs_zyx_bsv16_fsv32:
         return 32;
     default:
-        OPENVINO_ASSERT("GetInnerFeatureBlockSize : Unexpected format for eltwise_blocked_optimized kernel.");
+        OPENVINO_ASSERT(false, "GetInnerFeatureBlockSize : Unexpected format for eltwise_blocked_optimized kernel.");
     }
 
     return 1;

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
@@ -18,9 +18,8 @@ static void CreateScatterElementsUpdateOp(ProgramBuilder& p, const std::shared_p
     std::string layerName = layer_type_name_ID(op);
 
     auto axes_constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(op->get_input_node_shared_ptr(3));
-    if (!axes_constant) {
-        OPENVINO_ASSERT("Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
-    }
+    OPENVINO_ASSERT(axes_constant, "Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
+    
     int64_t axis = ov::util::normalize_axis(op.get(), axes_constant->cast_vector<int64_t>()[0], op->get_input_partial_shape(0).rank());
 
     auto mode = cldnn::ScatterElementsUpdateOp::Reduction::NONE;

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
@@ -19,7 +19,7 @@ static void CreateScatterElementsUpdateOp(ProgramBuilder& p, const std::shared_p
 
     auto axes_constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(op->get_input_node_shared_ptr(3));
     OPENVINO_ASSERT(axes_constant, "Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
-    
+
     int64_t axis = ov::util::normalize_axis(op.get(), axes_constant->cast_vector<int64_t>()[0], op->get_input_partial_shape(0).rank());
 
     auto mode = cldnn::ScatterElementsUpdateOp::Reduction::NONE;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
@@ -3206,7 +3206,7 @@ TEST(eltwise_gpu_f32, broadcast_test_dim3_dim4) {
     // in1:dim3, int2:dim4
     {
         ov::Shape in1_shape = {2, 4, 2};
-        
+
         auto input = engine.allocate_memory({ ov::PartialShape(in1_shape), data_types::f32, format::bfyx });
         set_values(input, const_input);
 
@@ -3239,7 +3239,7 @@ TEST(eltwise_gpu_f32, broadcast_test_dim3_dim4) {
     // So explicit 4d input shpae {1, 2, 4, 2} should have same result from input{2, 4, 2}
     {
         ov::Shape in1_shape = {1, 2, 4, 2};
-        
+
         auto input = engine.allocate_memory({ ov::PartialShape(in1_shape), data_types::f32, format::bfyx });
         set_values(input, const_input);
 
@@ -4506,9 +4506,9 @@ struct eltwise_layout_test_params {
 };
 
 #define CASE_ELTWISE_TEST1  eltwise_mode::sum, {1, 2, 1, 1}, {4, 2, 4, 4}, format::b_fs_yx_fsv16, format::bfyx, "generic_eltwise_ref"
-#define CASE_ELTWISE_TEST2  eltwise_mode::sum, {4, 1, 4, 4}, {1, 5, 1, 1}, format::b_fs_yx_fsv16, format::bfyx, "eltwise_blocked_opt"
+#define CASE_ELTWISE_TEST2  eltwise_mode::sum, {4, 1, 4, 4}, {1, 5, 1, 1}, format::b_fs_yx_fsv16, format::bfyx, "generic_eltwise_ref"
 #define CASE_ELTWISE_TEST3  eltwise_mode::sum, {4, 5, 4, 1}, {4, 1, 4, 1}, format::b_fs_yx_fsv16, format::bfyx, "generic_eltwise_ref"
-#define CASE_ELTWISE_TEST4  eltwise_mode::sum, {4, 2, 4, 4}, {1, 1, 1, 1}, format::b_fs_yx_fsv16, format::bfyx, "eltwise_blocked_opt"
+#define CASE_ELTWISE_TEST4  eltwise_mode::sum, {4, 2, 4, 4}, {1, 1, 1, 1}, format::b_fs_yx_fsv16, format::bfyx, "generic_eltwise_ref"
 #define CASE_ELTWISE_TEST5  eltwise_mode::sum, {1, 2, 1, 1}, {4, 2, 4, 4}, format::bfyx, format::b_fs_yx_fsv16, "generic_eltwise_ref"
 #define CASE_ELTWISE_TEST6  eltwise_mode::sum, {4, 1, 4, 4}, {1, 5, 1, 1}, format::bfyx, format::b_fs_yx_fsv16, "generic_eltwise_ref"
 #define CASE_ELTWISE_TEST7  eltwise_mode::sum, {4, 5, 4, 1}, {4, 1, 4, 1}, format::bfyx, format::b_fs_yx_fsv16, "generic_eltwise_ref"

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
@@ -4508,7 +4508,7 @@ struct eltwise_layout_test_params {
 #define CASE_ELTWISE_TEST1  eltwise_mode::sum, {1, 2, 1, 1}, {4, 2, 4, 4}, format::b_fs_yx_fsv16, format::bfyx, "generic_eltwise_ref"
 #define CASE_ELTWISE_TEST2  eltwise_mode::sum, {4, 1, 4, 4}, {1, 5, 1, 1}, format::b_fs_yx_fsv16, format::bfyx, "generic_eltwise_ref"
 #define CASE_ELTWISE_TEST3  eltwise_mode::sum, {4, 5, 4, 1}, {4, 1, 4, 1}, format::b_fs_yx_fsv16, format::bfyx, "generic_eltwise_ref"
-#define CASE_ELTWISE_TEST4  eltwise_mode::sum, {4, 2, 4, 4}, {1, 1, 1, 1}, format::b_fs_yx_fsv16, format::bfyx, "generic_eltwise_ref"
+#define CASE_ELTWISE_TEST4  eltwise_mode::sum, {4, 2, 4, 4}, {1, 1, 1, 1}, format::b_fs_yx_fsv16, format::bfyx, "eltwise_blocked_opt"
 #define CASE_ELTWISE_TEST5  eltwise_mode::sum, {1, 2, 1, 1}, {4, 2, 4, 4}, format::bfyx, format::b_fs_yx_fsv16, "generic_eltwise_ref"
 #define CASE_ELTWISE_TEST6  eltwise_mode::sum, {4, 1, 4, 4}, {1, 5, 1, 1}, format::bfyx, format::b_fs_yx_fsv16, "generic_eltwise_ref"
 #define CASE_ELTWISE_TEST7  eltwise_mode::sum, {4, 5, 4, 1}, {4, 1, 4, 1}, format::bfyx, format::b_fs_yx_fsv16, "generic_eltwise_ref"

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
@@ -502,7 +502,7 @@ void test_calc_output_shape(bool is_caching_test) {
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(reshape("reshape", input_info("input"), tensor(1, 1, 0, -1)));
+    topology.add(reshape("reshape", input_info("input"), tensor(1, 1, 1, -1)));
 
     set_values(input, {-1.f, 2.f, -3.f, 4.f});
 


### PR DESCRIPTION
### Details:
 - `OPENVINO_ASSERT` takes boolean expression as first argument. In order to explicitly throw AssertFailure, need to specify `false`, non-empty string will be treated as `true`