### PR TITLE
[CPU] Updated aux GPR count for Load/Store emitters

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.cpp
@@ -61,10 +61,15 @@ size_t store_emitter_params::hash() const {
     return seed;
 }
 
-static int get_aux_regs_as_temp(const size_t byte_size, const bool is_fill = false) {
-    if (one_of(byte_size % 16, 1u, 2u, 3u))
-        return 1;
+static int get_aux_regs_as_temp(const int elem_count, const int data_size, bool is_pure_move,
+                                const int avx512_threshold_for_mask = 0, const bool is_fill = false) {
     if (mayiuse(cpu::x64::avx512_core) && is_fill)
+        return 1;
+
+    const int byte_size = elem_count * data_size;
+    if ((is_pure_move && one_of(byte_size, 16, 32, 64)) || (!is_pure_move && one_of(elem_count, 4, 8, 16)))
+        return 0;
+    if ((mayiuse(cpu::x64::avx512_core) && (byte_size > avx512_threshold_for_mask)) || (one_of(byte_size % 16, 1, 2, 3)))
         return 1;
     return 0;
 }
@@ -84,7 +89,10 @@ size_t jit_load_emitter::get_inputs_num() const { return 1; }
 
 size_t jit_load_emitter::aux_gprs_count() const {
     // 0 for temp reg for mask load in avx512 if needed
-    int count = get_aux_regs_as_temp(load_num_ * dst_prc_.size(), is_fill_);
+    const auto is_pure_load = (src_prc_ == dst_prc_) ||
+                                (one_of(src_prc_, ov::element::f32, ov::element::i32) &&
+                                 one_of(dst_prc_, ov::element::f32, ov::element::i32));
+    int count = get_aux_regs_as_temp(load_num_, static_cast<int>(src_prc_.size()), is_pure_load, threshold_for_mask_emu_load, is_fill_);
 
     // 1 for table address
     if (is_fill_)
@@ -619,7 +627,10 @@ inline bool jit_store_emitter::is_truncation_emulation() const {
 
 size_t jit_store_emitter::aux_gprs_count() const {
     // for temp reg for store(mask version or special number cases)
-    int count = get_aux_regs_as_temp(store_num_ * src_prc_.size());
+    const auto is_pure_store = (src_prc_ == dst_prc_) ||
+                                (one_of(src_prc_, ov::element::f32, ov::element::i32) &&
+                                 one_of(dst_prc_, ov::element::f32, ov::element::i32));
+    int count = get_aux_regs_as_temp(store_num_, static_cast<int>(dst_prc_.size()), is_pure_store, threshold_for_mask_emu_store);
 
     // for table value in truncation arithmetic mode
     if (is_truncation_emulation())

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.cpp
@@ -62,7 +62,7 @@ size_t store_emitter_params::hash() const {
 }
 
 static int get_aux_regs_as_temp(const size_t byte_size, const bool is_fill = false) {
-    if (!one_of(byte_size, 64u, 32u, 16u))
+    if (one_of(byte_size % 16, 1u, 2u, 3u))
         return 1;
     if (mayiuse(cpu::x64::avx512_core) && is_fill)
         return 1;

--- a/src/plugins/intel_cpu/tests/unit/jit_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/jit_kernel_test.cpp
@@ -324,13 +324,23 @@ TEST(JitKernel, variable_load_and_store) {
     {
         jit_variable_load_store_test_kernel<uint8_t, float> kernel;
         if (mayiuse(cpu_isa_t::avx512_core)) {
-            kernel.test<16, 11, false>();
+            kernel.test<16, 16, false>();
+            kernel.test<16, 15, false>();
+            kernel.test<16, 10, false>();
+            kernel.test<16, 1, false>();
         }
         if (mayiuse(cpu_isa_t::avx2)) {
+            kernel.test<8, 8, false>();
+            kernel.test<8, 7, false>();
+            kernel.test<8, 6, false>();
             kernel.test<8, 5, false>();
+            kernel.test<8, 4, false>();
         }
         if (mayiuse(cpu_isa_t::sse41)) {
+            kernel.test<4, 4, false>();
             kernel.test<4, 3, false>();
+            kernel.test<4, 2, false>();
+            kernel.test<4, 1, false>();
         }
     }
 
@@ -357,6 +367,29 @@ TEST(JitKernel, variable_load_and_store) {
         }
         if (mayiuse(cpu_isa_t::sse41)) {
             kernel.test<4, 3, true>();
+        }
+    }
+
+    {
+        jit_variable_load_store_test_kernel<float, uint8_t> kernel;
+        if (mayiuse(cpu_isa_t::avx512_core)) {
+            kernel.test<16, 16, true>();
+            kernel.test<16, 10, true>();
+            kernel.test<16, 2, true>();
+            kernel.test<16, 1, true>();
+        }
+        if (mayiuse(cpu_isa_t::avx2)) {
+            kernel.test<8, 8, true>();
+            kernel.test<8, 7, true>();
+            kernel.test<8, 6, true>();
+            kernel.test<8, 5, true>();
+            kernel.test<8, 4, true>();
+        }
+        if (mayiuse(cpu_isa_t::sse41)) {
+            kernel.test<4, 4, true>();
+            kernel.test<4, 3, true>();
+            kernel.test<4, 2, true>();
+            kernel.test<4, 1, true>();
         }
     }
 


### PR DESCRIPTION
### Details:
 - *Adjusted `get_aux_gpr` for Load and Store emitters to avoid extra `push` and `pop` for some cases. Example of one FP32 element loading on `AVX512` machine:*
![image](https://github.com/openvinotoolkit/openvino/assets/43129309/1257d654-94cb-4fcb-a64c-9a0a71f15aba)


### Tickets:
 - *N/A*
