### PR TITLE
[GPU] Convert input to output data type in ActivationJitConstants

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.h
@@ -310,7 +310,8 @@ JitConstants MakeActivationJitConstants(std::vector<kernel_selector::base_activa
                                         Datatype output_dt,
                                         const std::string& suffix = "",
                                         bool use_type_parameter = false,
-                                        bool disable_type_conversion = false);
+                                        bool disable_type_conversion = false,
+                                        bool convert_input_to_output_dt = false);
 JitConstants MakeBaseParamsJitConstants(const base_params& params);
 JitConstants MakeLoopUnrollParamsJitConstants(uint32_t loopCount);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base.cpp
@@ -90,7 +90,9 @@ JitConstants KernelBase::MakeBaseParamsJitConstants(const base_params& params, b
     // Changed data type from unit type to output data type to fix the issue case that
     // the activation function makes cl kernel build error when the output data type
     // and unit type are different and activation param is existed
-    jit.Merge(MakeActivationJitConstants(params.activations, params.outputs[0].GetDType()));
+    bool convert_input_to_output_dt = (params.outputs[0].GetDType() == Datatype::F32 && params.inputs[0].GetDType() == Datatype::F16);
+    // If input is FP16 and output is FP32, convert input to float before running activation function.
+    jit.Merge(MakeActivationJitConstants(params.activations, params.outputs[0].GetDType(), "", false, false, convert_input_to_output_dt));
 
     if (add_tensor_definitions) {
         for (size_t i = 0; i < params.inputs.size(); i++) {
@@ -128,7 +130,7 @@ bool KernelBase::IsSIMDSizeSupported(const EngineInfo &info, size_t simd_size) c
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// MakeBaseParamsJitConstants
+// MakeFusedOpsJitConstants
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 JitConstants KernelBase::MakeFusedOpsJitConstants(const kernel_selector::base_params &params,
                                                   const std::vector<FusedOpsConfiguration> &conf) const {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/depth_to_space_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/depth_to_space_gpu_test.cpp
@@ -10,6 +10,7 @@
 #include <intel_gpu/primitives/reshape.hpp>
 #include <intel_gpu/primitives/permute.hpp>
 #include <intel_gpu/primitives/reorder.hpp>
+#include <intel_gpu/primitives/eltwise.hpp>
 
 #include <cstddef>
 
@@ -422,4 +423,65 @@ TEST(depth_to_space_fp32_gpu, d1822_bs2_depth_first) {
 
 TEST(export_import_depth_to_space_fp32_gpu, d1822_bs2_depth_first) {
     test_depth_to_space_fp32_gpu_d1822_bs2_depth_first<float>(true);
+}
+
+
+template <typename T>
+void test_depth_to_space_fp32_paul(bool is_caching_test) {
+    //  Input  : 1x8x2x2
+    //  Block size : 2
+    //  Output : 1x2x4x4
+    //  Input values in fp32
+
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 4, 5 } });
+    auto weights = engine.allocate_memory({ data_types::f16, format::bfyx, { 1, 1, 3, 2 } });
+
+    size_t block_size = 1;
+
+    set_values(input, {
+        1.0f, 2.0f, 3.0f, 4.0f, 5.0f,
+        2.0f, 2.0f, 3.0f, 4.0f, 6.0f,
+        3.0f, 3.0f, 3.0f, 5.0f, 1.0f,
+        1.0f, 1.0f, 1.0f, 1.0f, 1.0f
+    });
+    set_values(weights, {
+        ov::float16(1.0f), ov::float16(2.0f), ov::float16(1.0f),
+        ov::float16(2.0f), ov::float16(1.0f), ov::float16(2.0f)
+    });
+
+    topology topology;
+    topology.add(cldnn::input_layout("input", input->get_layout()));
+    topology.add(cldnn::data("weights", weights));
+    topology.add(cldnn::reorder("reorder_input", input_info("input"), cldnn::layout(data_types::f16, format::byxf, { 1, 1, 4, 5 })));
+    topology.add(cldnn::convolution("conv", input_info("reorder_input"), "weights", "", 1, { 2, 1 }, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(cldnn::depth_to_space("depth_to_space", input_info("conv"), block_size, depth_to_space_mode::depth_first));
+    topology.add(cldnn::activation("activate", input_info("depth_to_space"), cldnn::activation_func::relu_negative_slope, {0.25f, 0.f}));
+    topology.add(cldnn::reorder("convert:output", input_info("activate"), format::any, data_types::f32, {}, reorder_mean_mode::subtract, padding(), true));
+    topology.add(cldnn::reorder("result:output/sink_port_0", input_info("convert:output"), format::bfyx, data_types::f32, {}, reorder_mean_mode::subtract, padding(), false));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
+
+    network->set_input_data("input", input);
+
+    auto outputs = network->execute();
+
+    auto output = outputs.at("result:output/sink_port_0").get_memory();
+    cldnn::mem_lock<T> output_ptr(output, get_test_stream());
+
+    std::vector<T> expected_results = {
+        24.0f, 24.0f, 32.0f, 28.0f
+    };
+
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
+    }
+}
+
+TEST(depth_to_space_fp32_gpu, check_internal_activation) {
+    test_depth_to_space_fp32_paul<float>(false);
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/depth_to_space_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/depth_to_space_gpu_test.cpp
@@ -425,14 +425,7 @@ TEST(export_import_depth_to_space_fp32_gpu, d1822_bs2_depth_first) {
     test_depth_to_space_fp32_gpu_d1822_bs2_depth_first<float>(true);
 }
 
-
-template <typename T>
-void test_depth_to_space_fp32_paul(bool is_caching_test) {
-    //  Input  : 1x8x2x2
-    //  Block size : 2
-    //  Output : 1x2x4x4
-    //  Input values in fp32
-
+static void test_depth_to_space_fp16_input_fp32_output(bool is_caching_test) {
     auto& engine = get_test_engine();
 
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 4, 5 } });
@@ -451,6 +444,7 @@ void test_depth_to_space_fp32_paul(bool is_caching_test) {
         ov::float16(2.0f), ov::float16(1.0f), ov::float16(2.0f)
     });
 
+    // Apply existed topology that makes kernel build failure because of input and output data types are different.
     topology topology;
     topology.add(cldnn::input_layout("input", input->get_layout()));
     topology.add(cldnn::data("weights", weights));
@@ -471,9 +465,9 @@ void test_depth_to_space_fp32_paul(bool is_caching_test) {
     auto outputs = network->execute();
 
     auto output = outputs.at("result:output/sink_port_0").get_memory();
-    cldnn::mem_lock<T> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
-    std::vector<T> expected_results = {
+    std::vector<float> expected_results = {
         24.0f, 24.0f, 32.0f, 28.0f
     };
 
@@ -482,6 +476,6 @@ void test_depth_to_space_fp32_paul(bool is_caching_test) {
     }
 }
 
-TEST(depth_to_space_fp32_gpu, check_internal_activation) {
-    test_depth_to_space_fp32_paul<float>(false);
+TEST(depth_to_space_gpu, fp16_input_fp32_output) {
+    test_depth_to_space_fp16_input_fp32_output(false);
 }


### PR DESCRIPTION
### Details:
 - *Convert the input to the output data type to fix that cl kernel build failed for an ambiguous issue of the fmax/fmin functions occurring by the different data types between input and output.*

### Tickets:
 - *133562*
