### PR TITLE
Fix CS issue

### DIFF
--- a/src/plugins/intel_cpu/src/graph_context.h
+++ b/src/plugins/intel_cpu/src/graph_context.h
@@ -21,7 +21,7 @@ public:
                  WeightsSharing::Ptr w_cache,
                  bool isGraphQuantized)
         : config(config),
-          weightsCache(w_cache),
+          weightsCache(std::move(w_cache)),
           isGraphQuantizedFlag(isGraphQuantized) {
         rtParamsCache = std::make_shared<MultiCache>(config.rtCacheCapacity);
         rtScratchPad = std::make_shared<DnnlScratchPad>(getEngine());


### PR DESCRIPTION
### Details:
 *** CID 1534777:  Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
/agent/_work/1/openvino/src/plugins/intel_cpu/src/graph_context.h: 24 in ov::intel_cpu::GraphContext::GraphContext(const ov::intel_cpu::Config &, std::shared_ptr<ov::intel_cpu::WeightsSharing>, bool)()
18         typedef std::shared_ptr<const GraphContext> CPtr;
19     
20         GraphContext(const Config& config,
21                      WeightsSharing::Ptr w_cache,
22                      bool isGraphQuantized)
23             : config(config),
>>>     CID 1534777:  Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
>>>     "w_cache" is copied in call to copy constructor "std::shared_ptr<ov::intel_cpu::WeightsSharing>", when it could be moved instead.
24               weightsCache(w_cache),
25               isGraphQuantizedFlag(isGraphQuantized) {
26             rtParamsCache = std::make_shared<MultiCache>(config.rtCacheCapacity);
27             rtScratchPad = std::make_shared<DnnlScratchPad>(getEngine());
28         }
29     


### Tickets:
 - *ticket-id*
