### PR TITLE
Don't use complex dependencies in Python API tests

### DIFF
--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -1,6 +1,4 @@
 -c ./constraints.txt
-protobuf
-onnx
 numpy
 bandit
 black
@@ -38,9 +36,3 @@ retrying
 tox
 types-pkg_resources
 wheel
-torch
-torchvision; platform_machine == 'arm64' and python_version >= '3.8'
-torchvision; platform_machine != 'arm64'
-sympy; platform_machine == 'arm64' and python_version >= '3.8'
-sympy; platform_machine != 'arm64'
-pillow

--- a/src/bindings/python/tests/test_runtime/test_compiled_model.py
+++ b/src/bindings/python/tests/test_runtime/test_compiled_model.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 import pytest
 import numpy as np
 
@@ -29,6 +30,10 @@ def test_get_runtime_model(device):
     assert isinstance(runtime_model, Model)
 
 
+@pytest.mark.skipif(
+    condition=sys.version_info >= (3, 12),
+    reason="Fails on any Linux platform with Python 3.12. Ticket CVS-133903",
+)
 def test_export_import(device):
     core = Core()
 

--- a/src/frontends/paddle/tests/requirements.txt
+++ b/src/frontends/paddle/tests/requirements.txt
@@ -1,5 +1,5 @@
 # PaddlePaddle - generate test models
--c ../../../../src/bindings/python/constraints.txt
+-c ../../../bindings/python/constraints.txt
 protobuf
 numpy
 six

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -8,6 +8,7 @@ pymongo>=3.12.0
 PyYAML>=5.4.1
 scipy>=1.7; python_version <= "3.8"
 scipy>=1.11.1; python_version >= "3.9"
+sympy>=1.10
 wheel>=0.38.1
 defusedxml>=0.7.1
 fastjsonschema~=2.17.1

--- a/tests/layer_tests/py_frontend_tests/test_torchvision_preprocessor.py
+++ b/tests/layer_tests/py_frontend_tests/test_torchvision_preprocessor.py
@@ -66,6 +66,10 @@ def test_normalize():
     assert np.max(np.absolute(torch_result - ov_result)) < 4e-05
 
 
+@pytest.mark.skipif(
+    condition=platform.machine() in ("arm", "armv7l", "aarch64", "arm64", "ARM64"),
+    reason="Ticket: 114816",
+)
 @pytest.mark.parametrize(
     ("target_size", "interpolation", "tolerance"),
     [
@@ -78,8 +82,6 @@ def test_normalize():
     ],
 )
 def test_resize(target_size, interpolation, tolerance):
-    if platform.machine() in ["arm", "armv7l", "aarch64", "arm64", "ARM64"]:
-        pytest.skip("Ticket: 114816")
     test_input = np.random.randint(255, size=target_size, dtype=np.uint8)
     preprocess_pipeline = transforms.Compose(
         [
@@ -219,9 +221,11 @@ def test_pipeline_1():
     assert np.max(np.absolute(torch_result - ov_result)) < 4e-05
 
 
+@pytest.mark.skipif(
+    condition=platform.machine() in ("arm", "armv7l", "aarch64", "arm64", "ARM64"),
+    reason="Ticket: 114816",
+)
 def test_pipeline_2():
-    if platform.machine() in ["arm", "armv7l", "aarch64", "arm64", "ARM64"]:
-        pytest.skip("Ticket: 114816")
     test_input = np.random.randint(255, size=(224, 224, 3), dtype=np.uint8)
     preprocess_pipeline = transforms.Compose(
         [

--- a/tests/layer_tests/requirements.txt
+++ b/tests/layer_tests/requirements.txt
@@ -4,9 +4,13 @@ numpy
 onnxruntime
 requests
 torch
-torchvision
+torchvision; platform_machine == 'arm64' and python_version >= '3.8'
+torchvision; platform_machine != 'arm64'
+sympy; platform_machine == 'arm64' and python_version >= '3.8'
+sympy; platform_machine != 'arm64'
 transformers
 packaging
+pillow
 pytest
 tensorflow-addons; python_version <= '3.10'
 jax; sys_platform == "linux" and platform_machine == "x86_64" # https://jax.readthedocs.io/en/latest/installation.html#pip-installation-cpu - wheels are for "x86_64" only


### PR DESCRIPTION
### Details:
 - Removed frontend dependencies from Python API tests
 - Moved torchvision preprocessing tests to pytorch layer tests folder.

### Tickets:
 - *ticket-id*
