### PR TITLE
fix Tensorflow and Pytorch Layer Tests fail on macOS

### DIFF
--- a/tests/layer_tests/common/layer_test_class.py
+++ b/tests/layer_tests/common/layer_test_class.py
@@ -93,9 +93,9 @@ class CommonLayerTest:
         #     assert flag, '\n'.join(resp)
 
         config = None
-        # GPU default execution precision is FP16, so if we want to check FP32 inference
+        # GPU and some CPU arm platforms default execution precision is FP16, so if we want to check FP32 inference
         # we need to set explicit precision hint
-        if ie_device == 'GPU' and precision == 'FP32':
+        if precision == 'FP32':
             config = {'INFERENCE_PRECISION_HINT': 'f32'}
 
         ie_engine = InferAPI(model=path_to_xml,

--- a/tests/layer_tests/common/layer_utils.py
+++ b/tests/layer_tests/common/layer_utils.py
@@ -99,3 +99,13 @@ class InferAPI(BaseInfer):
                 inputs_info[item.get_any_name()] = item.partial_shape.to_shape()
 
         return inputs_info
+
+    def cnn_model_type_check(self):
+        core = Core()
+        net = core.read_model(self.model, self.weights)
+        arm_cnn_types = ["Convolution", "ConvolutionBackpropData"]
+        for op in net.get_ops():
+            op_type = op.get_type_info().name
+            if op_type in arm_cnn_types:
+                return True
+        return False

--- a/tests/layer_tests/pytorch_tests/pytorch_layer_test_class.py
+++ b/tests/layer_tests/pytorch_tests/pytorch_layer_test_class.py
@@ -137,8 +137,13 @@ class PytorchLayerTest:
                         assert self._check_kind_exist(
                             smodel.inlined_graph, op), f"Operation {op} type doesn't exist in provided graph"
             # OV infer:
+            # GPU and some CPU arm platforms default execution precision is FP16, so if we want to check FP32 inference
+            # we need to set explicit precision hint
+            config = None
+            if precision == 'FP32':
+                config = {'INFERENCE_PRECISION_HINT': 'f32'}
             core = Core()
-            compiled = core.compile_model(converted_model, ie_device)
+            compiled = core.compile_model(converted_model, ie_device, config=config)
             infer_res = compiled(deepcopy(ov_inputs))
 
             if hasattr(self, 'skip_framework') and self.skip_framework:

--- a/tests/layer_tests/pytorch_tests/test_set_item.py
+++ b/tests/layer_tests/pytorch_tests/test_set_item.py
@@ -34,5 +34,7 @@ class TestSetItem(PytorchLayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() in ('x64', 'x86_64'),
                        reason='Ticket - 132747')
+    # skip for random Aborted issue on macOS
+    @pytest.mark.skipif(platform.system() == 'Darwin', reason="Ticket - 122182")
     def test_set_item_list(self, idx, ie_device, precision, ir_version):
         self._test(*self.create_model(idx), ie_device, precision, ir_version)

--- a/tests/layer_tests/pytorch_tests/test_upsample.py
+++ b/tests/layer_tests/pytorch_tests/test_upsample.py
@@ -43,7 +43,6 @@ class TestUpsample1D(PytorchLayerTest):
     ])
     @pytest.mark.nightly
     @pytest.mark.precommit
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_upsample1d(self, mode, size, scale, ie_device, precision, ir_version):
         self._test(*self.create_model(size, scale, mode), ie_device,
                    precision, ir_version, trace_model=True)

--- a/tests/layer_tests/tensorflow_tests/test_tf_CTCLoss.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_CTCLoss.py
@@ -60,7 +60,6 @@ class TestCTCLoss(CommonTFLayerTest):
     @pytest.mark.parametrize("ctc_merge_repeated", [True, False, None])
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_ctcloss_placeholder_const(self, params, preprocess_collapse_repeated, ctc_merge_repeated,
                                        ie_device, precision, ir_version, temp_dir,
                                        use_legacy_frontend):

--- a/tests/layer_tests/tensorflow_tests/test_tf_FusedBatchNorm.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FusedBatchNorm.py
@@ -104,7 +104,6 @@ class TestFusedBatchNorm(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_fused_batch_norm_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                     use_legacy_frontend):
         self._test(*self.create_fused_batch_norm_net(**params),

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListConcatV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListConcatV2.py
@@ -41,7 +41,6 @@ class TestTensorListConcatV2(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
         self._test(*self.create_tensor_list_resize(**params),

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListLength.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListLength.py
@@ -40,7 +40,6 @@ class TestTensorListLength(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_length_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
         self._test(*self.create_tensor_list_length(**params),
@@ -79,7 +78,6 @@ class TestTensorListLengthEmptyList(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_tensor_list_length_empty_list)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_length_empty_list(self, params, ie_device, precision, ir_version, temp_dir,
                                            use_legacy_frontend):
         self._test(*self.create_tensor_list_length_empty_list(**params),

--- a/tests/layer_tests/tensorflow_tests/test_tf_TensorListResize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TensorListResize.py
@@ -44,7 +44,6 @@ class TestTensorListResize(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_tensor_list_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                       use_legacy_frontend):
         self._test(*self.create_tensor_list_resize(**params),

--- a/tests/layer_tests/tensorflow_tests/test_tf_While.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_While.py
@@ -58,7 +58,6 @@ class TestWhile(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_basic(self, params, ie_device, precision, ir_version, temp_dir,
                          use_legacy_frontend):
         self._test(*self.create_while_net(**params),
@@ -118,7 +117,6 @@ class TestWhileShapeVariant(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_basic(self, params, ie_device, precision, ir_version, temp_dir,
                          use_legacy_frontend):
         self._test(*self.create_while_net(**params),
@@ -192,7 +190,6 @@ class TestWhileWithNestedIf(CommonTFLayerTest):
     @pytest.mark.parametrize("params", test_data_basic)
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
-    @pytest.mark.skipif(platform == 'darwin', reason="Ticket - 122182")
     def test_while_with_nested_if_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                         use_legacy_frontend):
         self._test(*self.create_while_with_nested_if_net(**params),


### PR DESCRIPTION
### Details:
 - *Tensorflow and Pytorch Layer Tests fail on macOS, because CPU plugin will use FP16 execution precision for some arm platforms*


### Tickets:
 - *122182*
