### PR TITLE
[Transformations] Fix warning: implicit capture of ‘this’ via ‘[=]’

### DIFF
--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -19,6 +19,18 @@
 #include "transformations/rt_info/attributes.hpp"
 #include "transformations_visibility.hpp"
 
+/* This macro is intended to fix C++20 [=] lambda
+warning. Although C++20 identifier is 202002L,
+some compilers supporting C++20, or their drafts like
+C++2a, producing the warning, are using 201402L value.
+Also, MSVC requires a special check due to the
+__cplusplus value compatibility issues.*/
+#if (defined(_MSVC_LANG) && (_MSVC_LANG >= 202002L)) || (__cplusplus >= 201402L)
+#    define OV_CAPTURE_CPY_AND_THIS =, this
+#else
+#    define OV_CAPTURE_CPY_AND_THIS =
+#endif /* C++20 */
+
 namespace ov {
 namespace op {
 namespace util {

--- a/src/common/transformations/src/transformations/common_optimizations/add_fake_quantize_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/add_fake_quantize_fusion.cpp
@@ -33,7 +33,7 @@ ov::pass::AddFakeQuantizeFusion::AddFakeQuantizeFusion() {
                                                                               pass::pattern::any_input(),
                                                                               pass::pattern::any_input(),
                                                                               pass::pattern::any_input()});
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_value_map = m.get_pattern_value_map();
         const auto& input = pattern_value_map.at(input_pattern);
         const auto& type = input.get_element_type();

--- a/src/common/transformations/src/transformations/common_optimizations/batch_to_space_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/batch_to_space_fusion.cpp
@@ -44,7 +44,7 @@ ov::pass::BatchToSpaceFusion::BatchToSpaceFusion() {
     auto reshape_or_transpose_after_pattern =
         std::make_shared<pattern::op::Or>(OutputVector{reshape_after_pattern, trans_after_pattern});
 
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
         auto get_reshape_or_transpose = [&pattern_map](

--- a/src/common/transformations/src/transformations/common_optimizations/clamp_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/clamp_fusion.cpp
@@ -30,7 +30,7 @@ ov::pass::ClampFusion::ClampFusion() {
                                                                           pattern::consumers_count(1));
     auto root = std::make_shared<ov::pass::pattern::op::Or>(ov::OutputVector{min_pattern1, max_pattern2});
 
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto pattern_map = m.get_pattern_value_map();
         auto data = pattern_map.at(data_pattern);
         auto min_const =

--- a/src/common/transformations/src/transformations/common_optimizations/concat_reduce_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/concat_reduce_fusion.cpp
@@ -44,7 +44,7 @@ ov::pass::PullSqueezeThroughEltwise::PullSqueezeThroughEltwise() {
     auto squeeze_axes_pattern = pattern::wrap_type<ov::op::v0::Constant>();
     auto squeeze_pattern = pattern::wrap_type<ov::op::v0::Squeeze>({eltwise_pattern, squeeze_axes_pattern});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_map();
         const auto& eltwise = pattern_map.at(eltwise_pattern);
         const auto& squeeze = pattern_map.at(squeeze_pattern);
@@ -91,7 +91,7 @@ ov::pass::ReplaceConcatReduceByMinOrMax::ReplaceConcatReduceByMinOrMax() {
     auto reduce_pattern = ov::pass::pattern::wrap_type<ov::op::v1::ReduceMin, ov::op::v1::ReduceMax>(
         {concat_pattern, reduce_axes_pattern});
 
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
         auto concat = as_type_ptr<ov::op::v0::Concat>(pattern_map.at(concat_pattern).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
@@ -81,7 +81,7 @@ ov::pass::ConvertQuantizeDequantize::ConvertQuantizeDequantize() {
     auto scale_pattern = pass::pattern::any_input();
     auto mul_pattern = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({sub_pattern, scale_pattern});
 
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto pattern_map = m.get_pattern_value_map();
 
         if (transformation_callback(m.get_match_root())) {

--- a/src/common/transformations/src/transformations/common_optimizations/convolution_to_group_convolution.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convolution_to_group_convolution.cpp
@@ -14,6 +14,7 @@
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/common_optimizations/convolution_to_group_convolution_fusion.hpp"
+#include "transformations/utils/utils.hpp"
 
 static bool compare_convolutions(const ov::op::v1::Convolution* conv1, ov::Node* node) {
     const auto conv2 = ov::as_type<ov::op::v1::Convolution>(node);
@@ -104,7 +105,7 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
     };
     auto concat_label = pattern::wrap_type<ov::op::v0::Concat>(has_conv_inputs);
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_value_map = m.get_pattern_value_map();
         const auto& concat = pattern_value_map.at(concat_label).get_node_shared_ptr();
 

--- a/src/common/transformations/src/transformations/common_optimizations/dilated_convolution_converter.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/dilated_convolution_converter.cpp
@@ -36,7 +36,7 @@ ov::pass::DilatedConvolutionConverter::DilatedConvolutionConverter() {
     auto batch_to_space_pattern = pattern::wrap_type<ov::op::v1::BatchToSpace>(
         {conv_pattern, pattern::any_input(), crops_begin_pattern, crops_end_pattern});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
         auto block_shape =
             std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(block_shape_pattern).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/common_optimizations/divide_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/divide_fusion.cpp
@@ -23,7 +23,7 @@ ov::pass::DivideFusion::DivideFusion() {
     auto p_mul_input = pattern::any_input();
     auto p_mul = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({p_mul_input, p_pow});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         const auto& minuend_input = pattern_to_output.at(p_mul_input);
         const auto& subtrahend_input = pattern_to_output.at(p_pow_input);

--- a/src/common/transformations/src/transformations/common_optimizations/eliminate_unsqueeze_gather.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/eliminate_unsqueeze_gather.cpp
@@ -78,7 +78,7 @@ ov::pass::EliminateGatherUnsqueeze::EliminateGatherUnsqueeze() {
     const auto or_label = std::make_shared<pattern::op::Or>(OutputVector{gather_label, be_label});
     const auto unsqueeze_label = wrap_type<v0::Unsqueeze, v1::Reshape>({or_label, any_input()}, rank_equals(1));
 
-    ov::matcher_pass_callback callback = [=](Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         auto pattern_nodes = m.get_pattern_map();
         auto& gather = pattern_nodes.at(gather_label);
         auto& unsqueeze = pattern_nodes.at(unsqueeze_label);

--- a/src/common/transformations/src/transformations/common_optimizations/fq_mul_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fq_mul_fusion.cpp
@@ -54,7 +54,7 @@ ov::pass::FakeQuantizeMulFusion::FakeQuantizeMulFusion() {
     const auto mul_node_p =
         ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({fq_node_p, mul_constant_p}, pattern::consumers_count(1));
 
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
         const auto& data = pattern_map.at(data_p);

--- a/src/common/transformations/src/transformations/common_optimizations/hsigmoid_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/hsigmoid_fusion.cpp
@@ -32,7 +32,7 @@ ov::pass::HSigmoidFusionWithReluDiv::HSigmoidFusionWithReluDiv() {
     auto div_constant = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto div = ov::pass::pattern::wrap_type<ov::op::v1::Divide>({min, div_constant});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto x_output = pattern_to_output.at(input);
 
@@ -82,7 +82,7 @@ ov::pass::HSigmoidFusionWithReluMul::HSigmoidFusionWithReluMul() {
     auto mul_constant = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto mul_second = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({min, mul_constant});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto x_output = pattern_to_output.at(input);
 
@@ -131,7 +131,7 @@ ov::pass::HSigmoidFusionWithoutRelu::HSigmoidFusionWithoutRelu() {
     auto div = ov::pass::pattern::wrap_type<ov::op::v1::Divide>({min, div_constant});
     auto mul = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({input, div});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto x_output = pattern_to_output.at(input);
 
@@ -179,7 +179,7 @@ ov::pass::HSigmoidFusionWithClampMul::HSigmoidFusionWithClampMul() {
     auto mul_constant = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto mul_first = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({clamp, mul_constant});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto x_output = pattern_to_output.at(input);
 
@@ -225,7 +225,7 @@ ov::pass::HSigmoidFusionWithClampDiv::HSigmoidFusionWithClampDiv() {
     auto div_constant = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto div = ov::pass::pattern::wrap_type<ov::op::v1::Divide>({clamp, div_constant});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto x_output = pattern_to_output.at(input);
 

--- a/src/common/transformations/src/transformations/common_optimizations/interpolate_sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/interpolate_sequence_fusion.cpp
@@ -22,6 +22,7 @@
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 namespace {
 using namespace ov;
@@ -211,7 +212,7 @@ ov::NodeVector subgraph_for_scales_calculation_mode(const std::shared_ptr<ov::op
 ov::pass::InterpolateSequenceFusion::InterpolateSequenceFusion() {
     MATCHER_SCOPE(InterpolateSequenceFusion);
     auto interpolate_pattern = ov::pass::pattern::wrap_type<ov::op::v4::Interpolate>();
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto snd_interpolate = std::dynamic_pointer_cast<ov::op::v4::Interpolate>(m.get_match_root());
         if (!snd_interpolate)
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/leaky_relu_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/leaky_relu_fusion.cpp
@@ -23,7 +23,7 @@ ov::pass::LeakyReluFusion::LeakyReluFusion() {
         ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({data_pattern, alpha_pattern}, pattern::consumers_count(1));
     auto max_pattern = ov::pass::pattern::wrap_type<ov::op::v1::Maximum>({data_pattern, multiply_pattern});
 
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
         const auto& original_alpha_pattern = pattern_map.at(alpha_pattern);
 

--- a/src/common/transformations/src/transformations/common_optimizations/lin_op_sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/lin_op_sequence_fusion.cpp
@@ -33,7 +33,7 @@ ov::pass::AddMultiplyFusion::AddMultiplyFusion() {
     auto m_mul_constant = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto m_mul = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({m_add, m_mul_constant});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) -> bool {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) -> bool {
         auto& label_to_output = m.get_pattern_value_map();
 
         auto mul = label_to_output[m_mul].get_node_shared_ptr();
@@ -81,7 +81,7 @@ ov::pass::AddAddFusion::AddAddFusion() {
     auto m_add2_constant = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto m_add2 = ov::pass::pattern::wrap_type<ov::op::v1::Add>({m_add1, m_add2_constant});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) -> bool {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) -> bool {
         auto& label_to_output = m.get_pattern_value_map();
 
         auto add1 = label_to_output[m_add1].get_node_shared_ptr();
@@ -116,7 +116,7 @@ ov::pass::MultiplyMultiplyFusion::MultiplyMultiplyFusion() {
     auto m_mul2_constant = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto m_mul2 = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>({m_mul1, m_mul2_constant});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) -> bool {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) -> bool {
         auto& label_to_output = m.get_pattern_value_map();
 
         auto mul1 = label_to_output[m_mul1].get_node_shared_ptr();

--- a/src/common/transformations/src/transformations/common_optimizations/lstm_cell_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/lstm_cell_fusion.cpp
@@ -141,7 +141,7 @@ ov::pass::LSTMCellFusion::LSTMCellFusion() {
     auto Co_activation_label = pattern::wrap_type<op::v0::Relu, op::v0::Sigmoid, op::v0::Tanh>({Co_label});
     auto Ho_label = pattern::wrap_type<op::v1::Multiply>({Co_activation_label, ot_label});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
         const auto& X = pattern_map.at(x_label);

--- a/src/common/transformations/src/transformations/common_optimizations/matmul_multiply_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/matmul_multiply_fusion.cpp
@@ -154,7 +154,7 @@ pass::MatMulMultiplyFusion::MatMulMultiplyFusion() {
     auto matmul_pattern = pattern::wrap_type<ov::op::v0::MatMul>({input_pattern, weights_pattern});
     auto mul_pattern = pattern::wrap_type<ov::op::v1::Multiply>({matmul_pattern, mul_const_pattern});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
         const auto& weights = pattern_map.at(weights_pattern);
         auto mul = pattern_map.at(mul_pattern).get_node_shared_ptr();

--- a/src/common/transformations/src/transformations/common_optimizations/mul_fake_quantize_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/mul_fake_quantize_fusion.cpp
@@ -30,7 +30,7 @@ ov::pass::MulFakeQuantizeFusion::MulFakeQuantizeFusion() {
                                                                               pass::pattern::any_input(),
                                                                               pass::pattern::any_input(),
                                                                               pass::pattern::any_input()});
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_value_map = m.get_pattern_value_map();
         const auto& input = pattern_value_map.at(input_pattern);
         const auto& type = input.get_element_type();

--- a/src/common/transformations/src/transformations/common_optimizations/nearest_neighbor_upsampling_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nearest_neighbor_upsampling_fusion.cpp
@@ -281,7 +281,7 @@ ov::pass::NearestNeighborUpsamplingFusion::NearestNeighborUpsamplingFusion() {
     auto mul = pattern::wrap_type<ov::op::v1::Multiply>({reshape_1, mul_const});
     auto reshape_2 = pattern::wrap_type<ov::op::v1::Reshape>({mul, concat_2});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
 
         const auto reshape_2_node =

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -397,7 +397,7 @@ pass::EliminateConvertNonZero::EliminateConvertNonZero() {
     auto convert_pattern = pattern::wrap_type<ov::op::v0::Convert>(pattern::consumers_count(1));
     auto non_zero = pattern::wrap_type<ov::op::v3::NonZero>({convert_pattern});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_map();
         auto convert = pattern_map.at(convert_pattern);
         // remove convert
@@ -977,7 +977,7 @@ ov::pass::PrepareShapeOpsForEliminationAroundBE::PrepareShapeOpsForEliminationAr
     auto second_label = pattern::wrap_type<op::v1::Reshape, op::v0::Unsqueeze>({binary_op_label, pattern::any_input()},
                                                                                pattern::rank_equals(1));
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_to_node = m.get_pattern_map();
 
         auto second_node = pattern_to_node.at(second_label);

--- a/src/common/transformations/src/transformations/common_optimizations/normalize_l2_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/normalize_l2_fusion.cpp
@@ -49,7 +49,7 @@ ov::pass::NormalizeL2Fusion::NormalizeL2Fusion() {
     auto mul = std::make_shared<ov::op::v1::Multiply>(input, reversed_pow_as_sqrt);
     auto divide_or_mul = std::make_shared<pattern::op::Or>(OutputVector{divide, mul});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
 
         const auto data_input = pattern_to_output.at(input);

--- a/src/common/transformations/src/transformations/common_optimizations/relu_fake_quantize_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/relu_fake_quantize_fusion.cpp
@@ -26,7 +26,7 @@ ov::pass::ReluFakeQuantizeFusion::ReluFakeQuantizeFusion() {
                                                                               pass::pattern::any_input(),
                                                                               pass::pattern::any_input()});
 
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto pattern_map = m.get_pattern_value_map();
         auto data = pattern_map[data_pattern];
         auto relu = pattern_map[relu_pattern];

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -33,7 +33,7 @@ pass::GroupedGatherElimination::GroupedGatherElimination() {
     MATCHER_SCOPE(GroupedGatherElimination);
     auto concat_label = wrap_type<v0::Concat>(rank_equals(1));
 
-    matcher_pass_callback callback = [=](Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         auto concat = m.get_match_root();
         OutputVector inputs = concat->input_values();
         NodeRegistry new_ops;

--- a/src/common/transformations/src/transformations/common_optimizations/softmax_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/softmax_fusion.cpp
@@ -37,7 +37,7 @@ ov::pass::SoftmaxFusion::SoftmaxFusion() {
         ov::pass::pattern::wrap_type<ov::op::v1::ReduceSum>({exp_pattern, reduce_sum_axes_pattern});
     auto div_pattern = ov::pass::pattern::wrap_type<ov::op::v1::Divide>({exp_pattern, reduce_sum_pattern});
 
-    ov::matcher_pass_callback callback = [=](pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pass::pattern::Matcher& m) {
         if (transformation_callback(m.get_match_root()))
             return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/space_to_batch_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/space_to_batch_fusion.cpp
@@ -46,7 +46,7 @@ ov::pass::SpaceToBatchFusion::SpaceToBatchFusion() {
     auto reshape_or_transpose_after_pattern =
         std::make_shared<pattern::op::Or>(OutputVector{reshape_after_pattern, trans_after_pattern});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
         auto get_reshape_or_transpose = [&pattern_map](

--- a/src/common/transformations/src/transformations/common_optimizations/split_concat_pair_to_interpolate_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/split_concat_pair_to_interpolate_fusion.cpp
@@ -26,6 +26,7 @@
 #include "openvino/op/strided_slice.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/disable_constant_folding.hpp"
+#include "transformations/utils/utils.hpp"
 
 using namespace ov;
 
@@ -150,7 +151,7 @@ ov::pass::SplitConcatPairToInterpolateFusion::SplitConcatPairToInterpolateFusion
     //
     // Detect only concat, because we don't know how many inputs will go into concat.
     auto concat_pattern = ov::pass::pattern::wrap_type<ov::op::v0::Concat>();
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto concat = std::dynamic_pointer_cast<ov::op::v0::Concat>(m.get_match_root());
         if (!concat)
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/split_squeeze_concat_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/split_squeeze_concat_fusion.cpp
@@ -17,6 +17,7 @@
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 static bool is_axis_squeezed_by_node(const std::shared_ptr<ov::Node>& squeeze_node, int64_t axis, bool use_shapes);
 
@@ -25,7 +26,7 @@ ov::pass::SplitSqueezeConcatFusion::SplitSqueezeConcatFusion(bool use_shapes) {
     // Detect only concat, because we don't know how many inputs will go into concat
     auto concat_pattern = ov::pass::pattern::wrap_type<ov::op::v0::Concat>();
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto concat =
             std::dynamic_pointer_cast<ov::op::v0::Concat>(pattern_to_output.at(concat_pattern).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/common_optimizations/subtract_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/subtract_fusion.cpp
@@ -31,7 +31,7 @@ ov::pass::SubtractFusion::SubtractFusion() {
     auto p_add_input = pattern::any_input();
     auto p_add = ov::pass::pattern::wrap_type<ov::op::v1::Add>({p_add_input, p_mul_or_neg});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         const auto& minuend_input = pattern_to_output.at(p_add_input);
         const auto& subtrahend_input = pattern_to_output.at(p_input);

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -82,7 +82,7 @@ ov::pass::TransposeEltwise::TransposeEltwise() {
         pattern::wrap_type<ov::op::v1::Transpose>({eltwise_p, pattern::wrap_type<ov::op::v0::Constant>()},
                                                   pattern::consumers_count(1));
 
-    auto callback = [=](ov::pass::pattern::Matcher& m) {
+    auto callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto eltwise = pattern_to_output.at(eltwise_p).get_node_shared_ptr();
         auto eltwise_const_input = pattern_to_output.at(eltwise_const_input_p);
@@ -126,7 +126,7 @@ ov::pass::TransposeConvert::TransposeConvert() {
                                                   pattern::consumers_count(1));
     auto convert_label = pattern::wrap_type<ov::op::v0::Convert>({transpose_label});
 
-    matcher_pass_callback matcher_pass_callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto convert = pattern_to_output.at(convert_label).get_node_shared_ptr();
@@ -156,7 +156,7 @@ ov::pass::TransposeReduction::TransposeReduction() {
                            op::util::LogicalReductionKeepDims,
                            ov::op::v0::Squeeze>({transpose_label, pattern::wrap_type<ov::op::v0::Constant>()});
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
 
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
@@ -230,7 +230,7 @@ ov::pass::TransposeFQReduction::TransposeFQReduction() {
                            op::util::LogicalReductionKeepDims,
                            ov::op::v0::Squeeze>({fq_label, pattern::wrap_type<ov::op::v0::Constant>()});
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
 
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
@@ -294,7 +294,7 @@ ov::pass::TransposeFuse::TransposeFuse() {
     auto transpose_2 =
         pattern::wrap_type<ov::op::v1::Transpose>({transpose_1, pattern::wrap_type<ov::op::v0::Constant>()});
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
 
         auto transpose1 = pattern_to_output.at(transpose_1).get_node_shared_ptr();

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_to_reshape.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_to_reshape.cpp
@@ -25,7 +25,7 @@ ov::pass::TransposeToReshape::TransposeToReshape() {
 
     auto transpose_label = pattern::wrap_type<ov::op::v1::Transpose>(
         {pattern::any_input(pattern::has_static_rank()), pattern::wrap_type<ov::op::v0::Constant>()});
-    ov::matcher_pass_callback matcher_pass_callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto transpose = m.get_match_root();
         auto data = transpose->input_value(0);
         const auto input_shape = transpose->input(0).get_partial_shape();

--- a/src/common/transformations/src/transformations/fp16_compression/mark_decompression_convert_constant_folding.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_decompression_convert_constant_folding.cpp
@@ -15,6 +15,7 @@
 #include "transformations/rt_info/disable_fp16_compression.hpp"
 #include "transformations/rt_info/is_shape_subgraph.hpp"
 #include "transformations/rt_info/keep_const_precision.hpp"
+#include "transformations/utils/utils.hpp"
 
 using namespace ov;
 
@@ -55,7 +56,7 @@ pass::KeepConstAndDecompression::KeepConstAndDecompression() {
 
     auto node_pattern = pattern::wrap_type<ov::op::v0::Convert>();
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto node = m.get_match_root();
         if (!is_decompression(node) || !is_type<ov::op::v0::Convert>(node) ||
             ov::is_shape_subgraph(node->shared_from_this()))
@@ -81,7 +82,7 @@ pass::KeepConstantsPrecisionAndAddConverts::KeepConstantsPrecisionAndAddConverts
     MATCHER_SCOPE(KeepConstantsPrecisionAndAddConverts);
     auto const_pattern = pattern::wrap_type<ov::op::v0::Constant>();
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto const_node = m.get_match_root();
 
         if (transformation_callback(const_node)) {

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -32,7 +32,7 @@ ov::pass::MarkDequantizationSubgraph::MarkDequantizationSubgraph(const element::
     auto multiply_no_subtract_pattern = pattern::wrap_type<opset10::Multiply>({convert_pattern, pattern::any_input()});
     auto root = std::make_shared<pattern::op::Or>(OutputVector{multiply_pattern, multiply_no_subtract_pattern});
 
-    ov::matcher_pass_callback callback = [=](pattern::Matcher& m) -> bool {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) -> bool {
         const auto& pattern_map = m.get_pattern_value_map();
         auto convert = pattern_map.at(convert_pattern).get_node_shared_ptr();
         auto input = pattern_map.at(input_pattern);

--- a/src/common/transformations/src/transformations/op_conversions/convert_bitwise_to_logical_bool.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_bitwise_to_logical_bool.cpp
@@ -15,13 +15,15 @@
 #include "openvino/op/logical_or.hpp"
 #include "openvino/op/logical_xor.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
 ov::pass::ConvertBitwiseAndToLogicalAnd::ConvertBitwiseAndToLogicalAnd() {
     MATCHER_SCOPE(ConvertBitwiseAndToLogicalAnd);
     auto pattern =
         pattern::wrap_type<ov::op::v13::BitwiseAnd>({pattern::any_input(pattern::type_matches(element::boolean)),
                                                      pattern::any_input(pattern::type_matches(element::boolean))});
 
-    const matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto bitwise = std::dynamic_pointer_cast<ov::op::v13::BitwiseAnd>(m.get_match_root());
         if (!bitwise || transformation_callback(bitwise)) {
             return false;
@@ -45,7 +47,7 @@ ov::pass::ConvertBitwiseNotToLogicalNot::ConvertBitwiseNotToLogicalNot() {
     auto pattern =
         pattern::wrap_type<ov::op::v13::BitwiseNot>({pattern::any_input(pattern::type_matches(element::boolean))});
 
-    const matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto bitwise = std::dynamic_pointer_cast<ov::op::v13::BitwiseNot>(m.get_match_root());
         if (!bitwise || transformation_callback(bitwise)) {
             return false;
@@ -69,7 +71,7 @@ ov::pass::ConvertBitwiseOrToLogicalOr::ConvertBitwiseOrToLogicalOr() {
         pattern::wrap_type<ov::op::v13::BitwiseOr>({pattern::any_input(pattern::type_matches(element::boolean)),
                                                     pattern::any_input(pattern::type_matches(element::boolean))});
 
-    const matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto bitwise = std::dynamic_pointer_cast<ov::op::v13::BitwiseOr>(m.get_match_root());
         if (!bitwise || transformation_callback(bitwise)) {
             return false;
@@ -95,7 +97,7 @@ ov::pass::ConvertBitwiseXorToLogicalXor::ConvertBitwiseXorToLogicalXor() {
         pattern::wrap_type<ov::op::v13::BitwiseXor>({pattern::any_input(pattern::type_matches(element::boolean)),
                                                      pattern::any_input(pattern::type_matches(element::boolean))});
 
-    const matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto bitwise = std::dynamic_pointer_cast<ov::op::v13::BitwiseXor>(m.get_match_root());
         if (!bitwise || transformation_callback(bitwise)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_interpolate11_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_interpolate11_downgrade.cpp
@@ -57,7 +57,7 @@ ov::pass::ConvertInterpolate11ToInterpolate4::ConvertInterpolate11ToInterpolate4
 
     const auto interpolate_v11_pattern = pattern::wrap_type<ov::op::v11::Interpolate>();
 
-    const matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto v4_compatible_interpolation_mode = [](const op::util::InterpolateBase::InterpolateMode mode) {
             constexpr std::array<op::util::InterpolateBase::InterpolateMode, 4> allowed_modes = {
                 op::util::InterpolateBase::InterpolateMode::NEAREST,

--- a/src/common/transformations/src/transformations/op_conversions/convert_matrix_nms_to_matrix_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_matrix_nms_to_matrix_nms_ie.cpp
@@ -19,7 +19,7 @@ ov::pass::ConvertMatrixNmsToMatrixNmsIE::ConvertMatrixNmsToMatrixNmsIE(bool forc
     MATCHER_SCOPE(ConvertMatrixNmsToMatrixNmsIE);
     auto nms = ov::pass::pattern::wrap_type<ov::op::v8::MatrixNms>();
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto nms = std::dynamic_pointer_cast<ov::op::v8::MatrixNms>(m.get_match_root());
         if (!nms || transformation_callback(nms)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
@@ -20,7 +20,7 @@ pass::ConvertMulticlassNmsToMulticlassNmsIE::ConvertMulticlassNmsToMulticlassNms
     MATCHER_SCOPE(ConvertMulticlassNmsToMulticlassNmsIE);
     auto nms = pattern::wrap_type<op::util::MulticlassNmsBase>();
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto nms = std::dynamic_pointer_cast<op::util::MulticlassNmsBase>(m.get_match_root());
         if (!nms || transformation_callback(nms)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_nms9_to_nms_ie_internal.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_nms9_to_nms_ie_internal.cpp
@@ -21,7 +21,7 @@ ov::pass::ConvertNMS9ToNMSIEInternal::ConvertNMS9ToNMSIEInternal() {
     MATCHER_SCOPE(ConvertNMS9ToNMSIEInternal);
     auto nms = ov::pass::pattern::wrap_type<ov::op::v9::NonMaxSuppression>();
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto nms_9 = std::dynamic_pointer_cast<ov::op::v9::NonMaxSuppression>(m.get_match_root());
         if (!nms_9 || transformation_callback(nms_9)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_nms_rotated_to_nms_ie_internal.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_nms_rotated_to_nms_ie_internal.cpp
@@ -21,7 +21,7 @@ ov::pass::ConvertNMSRotatedToNMSIEInternal::ConvertNMSRotatedToNMSIEInternal() {
     MATCHER_SCOPE(ConvertNMSRotatedToNMSIEInternal);
     auto nms = ov::pass::pattern::wrap_type<ov::op::v13::NMSRotated>();
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto nms_rotated = std::dynamic_pointer_cast<ov::op::v13::NMSRotated>(m.get_match_root());
         if (!nms_rotated || transformation_callback(nms_rotated)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_nms_to_nms_ie_internal.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_nms_to_nms_ie_internal.cpp
@@ -21,7 +21,7 @@ ov::pass::ConvertNMSToNMSIEInternal::ConvertNMSToNMSIEInternal() {
     MATCHER_SCOPE(ConvertNMSToNMSIEInternal);
     auto nms = ov::pass::pattern::wrap_type<ov::op::v5::NonMaxSuppression>();
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto nms_5 = std::dynamic_pointer_cast<ov::op::v5::NonMaxSuppression>(m.get_match_root());
         if (!nms_5 || transformation_callback(nms_5)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_pad12_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_pad12_downgrade.cpp
@@ -8,13 +8,14 @@
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/pad.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::ConvertPad12ToPad1::ConvertPad12ToPad1() {
     MATCHER_SCOPE(ConvertPad12ToPad1);
 
     const auto pad_v12_pattern = pattern::wrap_type<ov::op::v12::Pad>();
 
-    const matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto pad_v12 = std::dynamic_pointer_cast<ov::op::v12::Pad>(m.get_match_root());
         if (!pad_v12 || transformation_callback(pad_v12)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_scatter_elements_update12_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_scatter_elements_update12_downgrade.cpp
@@ -8,6 +8,7 @@
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/scatter_elements_update.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::ConvertScatterElementsUpdate12ToScatterElementsUpdate3::
     ConvertScatterElementsUpdate12ToScatterElementsUpdate3() {
@@ -15,7 +16,7 @@ ov::pass::ConvertScatterElementsUpdate12ToScatterElementsUpdate3::
 
     const auto seu_v12_pattern = pattern::wrap_type<ov::op::v12::ScatterElementsUpdate>();
 
-    const matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto seu_v12 = std::dynamic_pointer_cast<ov::op::v12::ScatterElementsUpdate>(m.get_match_root());
         if (!seu_v12 || transformation_callback(seu_v12) ||
             seu_v12->get_reduction() != ov::op::v12::ScatterElementsUpdate::Reduction::NONE) {

--- a/src/common/transformations/src/transformations/op_conversions/convert_sequences_to_tensor_iterator.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_sequences_to_tensor_iterator.cpp
@@ -353,7 +353,7 @@ ov::pass::ConvertRNNSequenceToTensorIterator::ConvertRNNSequenceToTensorIterator
     auto B_m = pattern::any_input();
     auto rnn_seq = ov::pass::pattern::wrap_type<ov::op::v5::RNNSequence>({X_m, H_t_m, seq_lengths_m, W_m, R_m, B_m});
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto sequence = ov::as_type_ptr<ov::op::v5::RNNSequence>(m.get_match_root());
 
         // Bidirectional Sequence op should be decomposed to Reverse + Forward
@@ -396,7 +396,7 @@ ov::pass::ConvertGRUSequenceToTensorIterator::ConvertGRUSequenceToTensorIterator
     auto B_m = pattern::any_input();
     auto gru_seq = ov::pass::pattern::wrap_type<ov::op::v5::GRUSequence>({X_m, H_t_m, seq_lengths_m, W_m, R_m, B_m});
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto sequence = ov::as_type_ptr<ov::op::v5::GRUSequence>(m.get_match_root());
 
         // Bidirectional Sequence op should be decomposed to Reverse + Forward
@@ -441,7 +441,7 @@ ov::pass::ConvertLSTMSequenceToTensorIterator::ConvertLSTMSequenceToTensorIterat
     auto lstm_seq =
         ov::pass::pattern::wrap_type<ov::op::v5::LSTMSequence>({X_m, H_t_m, C_t_m, seq_lengths_m, W_m, R_m, B_m});
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto sequence = ov::as_type_ptr<ov::op::v5::LSTMSequence>(m.get_match_root());
 
         // Bidirectional Sequence op should be decomposed to Reverse + Forward

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -577,7 +577,7 @@ ov::pass::ConvertLoopToLSTMSequence::ConvertLoopToLSTMSequence() {
         pattern::rank_equals(3));
     auto loop_output_label = pattern::wrap_type<op::v0::Result>({scatter_body_label});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
         auto match_root = m.get_match_root();
 
@@ -1091,7 +1091,7 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
 
     auto concat_label = pattern::wrap_type<op::v0::Concat>({squeeze_forward_label, squeeze_reverse_label});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_map();
         auto lstm_forward = ov::as_type_ptr<op::v5::LSTMSequence>(pattern_map.at(lstm_sequence_forward_label));
         auto lstm_reverse = ov::as_type_ptr<op::v5::LSTMSequence>(pattern_map.at(lstm_sequence_reverse_label));

--- a/src/common/transformations/src/transformations/op_conversions/convert_topk11_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_topk11_downgrade.cpp
@@ -8,13 +8,14 @@
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/topk.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::ConvertTopK11ToTopK3::ConvertTopK11ToTopK3() {
     MATCHER_SCOPE(ConvertTopK11ToTopK3);
 
     const auto topk_v11_pattern = pattern::wrap_type<ov::op::v11::TopK>();
 
-    const matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto topk_v11 = std::dynamic_pointer_cast<ov::op::v11::TopK>(m.get_match_root());
         if (!topk_v11 || transformation_callback(topk_v11)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/eye_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/eye_decomposition.cpp
@@ -23,6 +23,7 @@
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 namespace ov {
 namespace pass {
@@ -126,7 +127,7 @@ EyeDecomposition::EyeDecomposition() {
 
     auto p_eye = std::make_shared<pattern::op::Or>(OutputVector{p_eye_batch, p_eye_no_batch});
 
-    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto m_eye = std::dynamic_pointer_cast<ov::op::v9::Eye>(m.get_match_root());
 
         if ((!m_eye) || transformation_callback(m_eye)) {

--- a/src/common/transformations/src/transformations/op_conversions/fq_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/fq_decomposition.cpp
@@ -20,6 +20,7 @@
 #include "openvino/op/round.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 namespace {
 
@@ -52,7 +53,7 @@ ov::pass::FakeQuantizeDecomposition::FakeQuantizeDecomposition() {
     auto oh = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto fake_quantize = ov::pass::pattern::wrap_type<ov::op::v0::FakeQuantize>({data, il, ih, ol, oh});
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         const auto fake_quantize_node = std::dynamic_pointer_cast<ov::op::v0::FakeQuantize>(
             pattern_to_output.at(fake_quantize).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/op_conversions/gelu7_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/gelu7_downgrade.cpp
@@ -10,12 +10,13 @@
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/gelu.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::Gelu7Downgrade::Gelu7Downgrade() {
     MATCHER_SCOPE(Gelu7Downgrade);
     auto gelu = ov::pass::pattern::wrap_type<ov::op::v7::Gelu>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto gelu_node = std::dynamic_pointer_cast<ov::op::v7::Gelu>(pattern_to_output.at(gelu).get_node_shared_ptr());
 

--- a/src/common/transformations/src/transformations/op_conversions/group_normalization_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_normalization_decomposition.cpp
@@ -65,7 +65,7 @@ ov::pass::GroupNormalizationDecomposition::GroupNormalizationDecomposition() {
 
     auto group_norm_pattern = pattern::wrap_type<v12::GroupNormalization>();
 
-    matcher_pass_callback callback = [=](pattern::Matcher& matcher) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& matcher) {
         NodeRegistry reg;
 
         const auto group_norm_node = std::dynamic_pointer_cast<v12::GroupNormalization>(matcher.get_match_root());

--- a/src/common/transformations/src/transformations/op_conversions/hsigmoid_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/hsigmoid_decomposition.cpp
@@ -15,13 +15,14 @@
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/relu.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::HSigmoidDecomposition::HSigmoidDecomposition() {
     MATCHER_SCOPE(HSigmoidDecomposition);
     // Decomposes HSigmoid(x) op into sub-graph (min(Relu(x + 3), 6) * const(1/6)
     auto hsigmoid = ov::pass::pattern::wrap_type<ov::op::v5::HSigmoid>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto hsigmoid_node = pattern_to_output.at(hsigmoid).get_node_shared_ptr();
 

--- a/src/common/transformations/src/transformations/op_conversions/hswish_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/hswish_decomposition.cpp
@@ -15,13 +15,14 @@
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/relu.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::HSwishDecomposition::HSwishDecomposition() {
     MATCHER_SCOPE(HSwishDecomposition);
     // Decomposes HSwish(x) op into sub-graph x * (min(Relu(x + 3), 6) * const(1/6)
     auto hswish = ov::pass::pattern::wrap_type<ov::op::v4::HSwish>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto hswish_node = pattern_to_output.at(hswish).get_node_shared_ptr();
 

--- a/src/common/transformations/src/transformations/op_conversions/log_softmax_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/log_softmax_decomposition.cpp
@@ -16,13 +16,14 @@
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::LogSoftmaxDecomposition::LogSoftmaxDecomposition() {
     MATCHER_SCOPE(LogSoftmaxDecomposition);
     // Decomposes LogSoftmax(x, axis) op into sub-graph x - log(reduce_sum(exp(x), axis))
     auto log_softmax = ov::pass::pattern::wrap_type<ov::op::v5::LogSoftmax>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto log_softmax_node =
             std::dynamic_pointer_cast<ov::op::v5::LogSoftmax>(pattern_to_output.at(log_softmax).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/op_conversions/mvn6_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/mvn6_decomposition.cpp
@@ -17,6 +17,7 @@
 #include "openvino/op/sqrt.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::MVN6Decomposition::MVN6Decomposition() {
     MATCHER_SCOPE(MVN6Decomposition);
@@ -25,7 +26,7 @@ ov::pass::MVN6Decomposition::MVN6Decomposition() {
     // (x - ReduceMean(x, axes)) / Sqrt(ReduceMean((x - ReduceMean(x, axes)) ^ 2))
     auto mvn = ov::pass::pattern::wrap_type<ov::op::v6::MVN>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto mvn_node = std::dynamic_pointer_cast<ov::op::v6::MVN>(pattern_to_output.at(mvn).get_node_shared_ptr());
 

--- a/src/common/transformations/src/transformations/op_conversions/normalize_l2_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/normalize_l2_decomposition.cpp
@@ -17,12 +17,13 @@
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/sqrt.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::NormalizeL2Decomposition::NormalizeL2Decomposition() {
     MATCHER_SCOPE(NormalizeL2Decomposition);
     auto normalize_l2_pattern = ov::pass::pattern::wrap_type<ov::op::v0::NormalizeL2>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto normalize_l2 = std::dynamic_pointer_cast<ov::op::v0::NormalizeL2>(m.get_match_root());
 
         if (!normalize_l2 || transformation_callback(normalize_l2)) {

--- a/src/common/transformations/src/transformations/op_conversions/reduce_l1_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/reduce_l1_decomposition.cpp
@@ -12,13 +12,14 @@
 #include "openvino/op/reduce_l1.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::ReduceL1Decomposition::ReduceL1Decomposition() {
     MATCHER_SCOPE(ReduceL1Decomposition);
     // decomposes ReduceL1 operations into ReduceSum(abs(x))
     auto reduce_l1 = ov::pass::pattern::wrap_type<ov::op::v4::ReduceL1>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto reduce_l1_node =
             std::dynamic_pointer_cast<ov::op::v4::ReduceL1>(pattern_to_output.at(reduce_l1).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/op_conversions/reduce_l2_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/reduce_l2_decomposition.cpp
@@ -15,13 +15,14 @@
 #include "openvino/op/sqrt.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::ReduceL2Decomposition::ReduceL2Decomposition() {
     MATCHER_SCOPE(ReduceL2Decomposition);
     // decomposes ReduceL2 operations into sqrt(ReduceSum(x * x))
     auto reduce_l2 = ov::pass::pattern::wrap_type<ov::op::v4::ReduceL2>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto reduce_l2_node =
             std::dynamic_pointer_cast<ov::op::v4::ReduceL2>(pattern_to_output.at(reduce_l2).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/op_conversions/scaled_dot_product_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/scaled_dot_product_attention_decomposition.cpp
@@ -29,12 +29,13 @@
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::ScaledDotProductAttentionDecomposition::ScaledDotProductAttentionDecomposition() {
     MATCHER_SCOPE(ScaledDotProductAttentionDecomposition);
     auto pattern_node = ov::pass::pattern::wrap_type<ov::op::v13::ScaledDotProductAttention>();
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto node = std::dynamic_pointer_cast<ov::op::v13::ScaledDotProductAttention>(
             pattern_to_output.at(pattern_node).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/op_conversions/softmax_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/softmax_decomposition.cpp
@@ -18,11 +18,12 @@
 #include "openvino/op/subtract.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::SoftmaxDecomposition::SoftmaxDecomposition() {
     MATCHER_SCOPE(SoftmaxDecomposition);
     auto softmax = pattern::wrap_type<ov::op::v1::Softmax, ov::op::v8::Softmax>();
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto m_softmax = m.get_match_root();
         Output<Node> input;
         int64_t softmax_axis;

--- a/src/common/transformations/src/transformations/op_conversions/softplus_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/softplus_decomposition.cpp
@@ -15,6 +15,7 @@
 #include "openvino/op/log.hpp"
 #include "openvino/op/softplus.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::SoftPlusDecomposition::SoftPlusDecomposition() {
     MATCHER_SCOPE(SoftPlusDecomposition);
@@ -22,7 +23,7 @@ ov::pass::SoftPlusDecomposition::SoftPlusDecomposition() {
     auto input = pattern::any_input();
     auto softplus = std::make_shared<ov::op::v4::SoftPlus>(input);
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto softplus_input = pattern_to_output.at(input);
         auto softplus_node = pattern_to_output.at(softplus).get_node_shared_ptr();

--- a/src/common/transformations/src/transformations/op_conversions/softsign_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/softsign_decomposition.cpp
@@ -14,11 +14,12 @@
 #include "openvino/op/divide.hpp"
 #include "openvino/op/softsign.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 ov::pass::SoftSignDecomposition::SoftSignDecomposition() {
     MATCHER_SCOPE(SoftSignDecomposition);
     auto softsign = pattern::wrap_type<ov::op::v9::SoftSign>();
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto m_softsign = m.get_match_root();
 
         if (transformation_callback(m_softsign)) {

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_base.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_base.cpp
@@ -22,7 +22,7 @@ using namespace ov::pass::transpose_sinking::utils;
 
 void TSForwardBase::transpose_sinking(const std::string& pass_name,
                                       const TSForwardBase::sinking_function& sinking_transformation) {
-    ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto main_node = pattern_to_output.at(m_pattern).get_node_shared_ptr();
         utils::TransposeInputsInfo transpose_input_info =

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_binary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_binary.cpp
@@ -97,7 +97,7 @@ TSBinaryBackward::TSBinaryBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_concat.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_concat.cpp
@@ -23,8 +23,8 @@ TSConcatForward::TSConcatForward() {
 
     create_pattern<ov::op::v0::Concat>(true);
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         // todo: support dynamic rank case
         auto concat_node = as_type_ptr<ov::op::v0::Concat>(main_node);
         if (!concat_node) {
@@ -70,7 +70,7 @@ TSConcatBackward::TSConcatBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_cumsum.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_cumsum.cpp
@@ -27,8 +27,8 @@ TSCumSumForward::TSCumSumForward() {
 
     create_pattern<ov::op::v0::CumSum>(true, {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         if (transformation_callback(main_node)) {
             return false;
         }
@@ -60,7 +60,7 @@ TSCumSumBackward::TSCumSumBackward() {
                                                             [](const Output<Node>& output) -> bool {
                                                                 return has_static_rank()(output);
                                                             });
-    matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_data_movement.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_data_movement.cpp
@@ -43,8 +43,8 @@ TSDataMovementForward::TSDataMovementForward() {
         true,
         {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         // remove Transpose on 1st input:
         auto transpose_parent = main_node->input_value(0).get_node()->input_value(0);
         main_node->input(0).replace_source_output(transpose_parent);
@@ -87,7 +87,7 @@ TSDataMovementBackward::TSDataMovementBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
@@ -26,7 +26,7 @@ TSFuse::TSFuse() {
                                                   CheckTransposeConsumers);
     auto transpose_2_label =
         pattern::wrap_type<ov::op::v1::Transpose>({transpose_1_label, pattern::wrap_type<ov::op::v0::Constant>()});
-    ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
         auto transpose1 = pattern_to_output.at(transpose_1_label);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_gather.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_gather.cpp
@@ -25,8 +25,8 @@ TSGatherForward::TSGatherForward() {
 
     create_pattern<ov::op::v8::Gather>(true, {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         auto gather = as_type_ptr<ov::op::v8::Gather>(main_node);
         if (!gather) {
             return false;
@@ -158,7 +158,7 @@ TSGatherBackward::TSGatherBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
         auto transpose = as_type_ptr<ov::op::v1::Transpose>(pattern_to_output.at(transpose_label));

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_interpolate.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_interpolate.cpp
@@ -14,6 +14,7 @@
 #include "openvino/util/common_util.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
+#include "transformations/utils/utils.hpp"
 
 using namespace ov;
 using namespace ov::pass::pattern;
@@ -24,8 +25,8 @@ TSInterpolateForward::TSInterpolateForward() {
     MATCHER_SCOPE(TSInterpolateForward);
     create_pattern<ov::op::v4::Interpolate>(true, {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         // remove Transpose on 1st input:
         auto transpose_parent = transpose_info.transpose->input_value(0);
         main_node->input(0).replace_source_output(transpose_parent);
@@ -75,7 +76,7 @@ TSInterpolateBackward::TSInterpolateBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_reduction.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_reduction.cpp
@@ -43,8 +43,8 @@ TSReductionForward::TSReductionForward() {
     MATCHER_SCOPE(TSReductionForward);
 
     create_pattern<op::util::ArithmeticReductionKeepDims, op::util::LogicalReductionKeepDims>(true, {0});
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         auto keep_dims = get_keep_dims(main_node);
         auto transpose_order = transpose_info.transpose_const;
         auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
@@ -100,7 +100,7 @@ TSReductionBackward::TSReductionBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
         auto transpose = pattern_to_output.at(transpose_label);
         auto main_node = pattern_to_output.at(reduce_label);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_slice.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_slice.cpp
@@ -25,8 +25,8 @@ TSSliceForward::TSSliceForward() {
     MATCHER_SCOPE(TSSliceForward);
     create_pattern<ov::op::v8::Slice>(true, {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         if (main_node->get_input_size() < 5) {
             return false;
         }
@@ -67,7 +67,7 @@ TSSliceBackward::TSSliceBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
@@ -100,8 +100,8 @@ TSSplitForward::TSSplitForward() {
 
     create_pattern<ov::op::v1::Split, ov::op::v1::VariadicSplit>(true, {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         auto split_axis_constant = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
         if (!split_axis_constant) {
             return false;
@@ -161,7 +161,7 @@ TSSplitBackward::TSSplitBackward() {
     auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
     auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), transpose_const_label}, IsSplitSinked);
 
-    matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_label_node = pattern_to_output.at(transpose_label).get_node();
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_squeeze.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_squeeze.cpp
@@ -106,8 +106,8 @@ TSSqueezeForward::TSSqueezeForward() {
 
     create_pattern<ov::op::v0::Squeeze, ov::op::v1::Reshape>(true, {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         std::vector<size_t> non_negative_axes;
         std::shared_ptr<ov::op::v0::Constant> squeeze_axes;
         if (main_node->get_input_size() > 1) {
@@ -195,7 +195,7 @@ TSSqueezeBackward::TSSqueezeBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
         auto transpose = pattern_to_output.at(transpose_label);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_tile.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_tile.cpp
@@ -27,8 +27,8 @@ TSTileForward::TSTileForward() {
 
     create_pattern<ov::op::v0::Tile>(true, {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         if (transformation_callback(main_node)) {
             return false;
         }
@@ -61,7 +61,7 @@ TSTileBackward::TSTileBackward() {
                                                             [](const Output<Node>& output) -> bool {
                                                                 return has_static_rank()(output);
                                                             });
-    matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
@@ -96,7 +96,7 @@ TSUnaryBackward::TSUnaryBackward() {
 
     auto transpose_label = wrap_type<ov::op::v1::Transpose>({unary_label, transpose_const_label});
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unsqueeze.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unsqueeze.cpp
@@ -106,8 +106,8 @@ TSUnsqueezeForward::TSUnsqueezeForward() {
 
     create_pattern<ov::op::v0::Unsqueeze, ov::op::v1::Reshape>(true, {0});
 
-    auto sinking_transformation = [=](const std::shared_ptr<Node>& main_node,
-                                      const TransposeInputsInfo& transpose_info) -> bool {
+    auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
+                                                            const TransposeInputsInfo& transpose_info) -> bool {
         auto unsqueeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!unsqueeze_axes) {
             return false;
@@ -169,7 +169,7 @@ TSUnsqueezeBackward::TSUnsqueezeBackward() {
                                                                 return has_static_rank()(output);
                                                             });
 
-    ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
+    ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
         auto transpose = pattern_to_output.at(transpose_label);


### PR DESCRIPTION
[Transformations] Fix warning: implicit capture of ‘this’ via ‘[=]’

Details:
Implicit capture of 'this' for lambdas is deprecated since C++20. Fix it by adding a special macro OV_CAPTURE_CPY_AND_THIS which expands into '=' or '=, this' depending on a C++ standard used.

Note:
Although C++20 identifier is 202002L, some compilers supporting C++20, or its drafts like C++2a, producing the warning, are using 201402L value. Also, MSVC requires a special check due to the __cplusplus value compatibility issues.

Ticket: CVS-132688

Signed-off-by: Andrii Staikov andrii.staikov@intel.com