### PR TITLE
[DOCS] Linkfix for Get Started section + removal of GPU drivers table in configurations for 2024

### DIFF
--- a/docs/articles_en/get-started.rst
+++ b/docs/articles_en/get-started.rst
@@ -68,7 +68,7 @@ Learn the basics of working with models and inference in OpenVINO. Begin with �
 Interactive Tutorials - Jupyter Notebooks
 -----------------------------------------
 
-Start with :doc:`interactive Python learn-openvino/interactive-tutorials-python <learn-openvino/interactive-tutorials-python>` that show the basics of model inferencing, the OpenVINO API, how to convert models to OpenVINO format, and more.
+Start with :doc:`interactive Python <learn-openvino/interactive-tutorials-python>` that show the basics of model inferencing, the OpenVINO API, how to convert models to OpenVINO format, and more.
 
 * `Hello Image Classification <notebooks/001-hello-world-with-output.html>`__ - Load an image classification model in OpenVINO and use it to apply a label to an image
 * `OpenVINO Runtime API Tutorial <notebooks/002-openvino-api-with-output.html>`__ - Learn the basic Python API for working with models in OpenVINO
@@ -101,7 +101,6 @@ Model Compression and Quantization
 
 Use OpenVINO’s model compression tools to reduce your model’s latency and memory footprint while maintaining good accuracy.
 
-* Tutorial - `OpenVINO Post-Training Model Quantization <notebooks/111-yolov5-quantization-migration-with-output.html>`__
 * Tutorial - `Quantization-Aware Training in TensorFlow with OpenVINO NNCF <notebooks/305-tensorflow-quantization-aware-training-with-output.html>`__
 * Tutorial - `Quantization-Aware Training in PyTorch with NNCF <notebooks/302-pytorch-quantization-aware-training-with-output.html>`__
 * :doc:`Model Optimization Guide <openvino-workflow/model-optimization>`

--- a/docs/articles_en/get-started.rst
+++ b/docs/articles_en/get-started.rst
@@ -101,8 +101,8 @@ Model Compression and Quantization
 
 Use OpenVINO’s model compression tools to reduce your model’s latency and memory footprint while maintaining good accuracy.
 
-* Tutorial - `Quantization-Aware Training in TensorFlow with OpenVINO NNCF <notebooks/305-tensorflow-quantization-aware-training-with-output.html>`__
-* Tutorial - `Quantization-Aware Training in PyTorch with NNCF <notebooks/302-pytorch-quantization-aware-training-with-output.html>`__
+* Tutorial - `Quantization-Aware Training in TensorFlow with OpenVINO NNCF <notebooks/305-tensorflow-quantization-aware-training-with-output>`__
+* Tutorial - `Quantization-Aware Training in PyTorch with NNCF <notebooks/302-pytorch-quantization-aware-training-with-output>`__
 * :doc:`Model Optimization Guide <openvino-workflow/model-optimization>`
 
 Automated Device Configuration

--- a/docs/articles_en/get-started/configurations/configurations-intel-gpu.rst
+++ b/docs/articles_en/get-started/configurations/configurations-intel-gpu.rst
@@ -22,7 +22,7 @@ To use a GPU device for OpenVINO inference, you must install OpenCL runtime pack
 If you are using a discrete GPU (for example Arc 770), you must also be using a supported Linux kernel as per `documentation. <https://dgpu-docs.intel.com/driver/kernel-driver-types.html>`__
 
 - For Arc GPU, kernel 6.2 or higher is recommended.
-- For Max and Flex GPU, or Arc with kernel version lower than 6.2, you must also install the ``intel-i915-dkms`` and ``xpu-smi`` kernel modules as described in the installation ../../documentation for `Max/Flex <https://dgpu-docs.intel.com/driver/installation.html>`__ or `Arc. <https://dgpu-docs.intel.com/driver/client/overview.html>`__
+- For Max and Flex GPU, or Arc with kernel version lower than 6.2, you must also install the ``intel-i915-dkms`` and ``xpu-smi`` kernel modules as described in the installation documentation for `Max/Flex <https://dgpu-docs.intel.com/driver/installation.html>`__ or `Arc. <https://dgpu-docs.intel.com/driver/client/overview.html>`__
 
 Below are the instructions on how to install the OpenCL packages on supported Linux distributions. These instructions install the `Intel(R) Graphics Compute Runtime for oneAPI Level Zero and OpenCL(TM) Driver <https://github.com/intel/compute-runtime/releases/tag/23.22.26516.18>`__ and its dependencies:
 

--- a/docs/articles_en/get-started/configurations/configurations-intel-gpu.rst
+++ b/docs/articles_en/get-started/configurations/configurations-intel-gpu.rst
@@ -128,25 +128,28 @@ Below are the required steps to make it work with OpenVINO:
 Additional Resources
 ####################
 
-The following Intel® Graphics Driver versions were used during OpenVINO's internal validation:
+.. The following Intel® Graphics Driver versions were used during OpenVINO's internal validation:
 
-+------------------+-------------------------------------------------------------------------------------------+
-| Operation System | Driver version                                                                            |
-+==================+===========================================================================================+
-| Ubuntu 22.04     | `22.43.24595.30 <https://github.com/intel/compute-runtime/releases/tag/22.43.24595.30>`__ |
-+------------------+-------------------------------------------------------------------------------------------+
-| Ubuntu 20.04     | `22.35.24055 <https://github.com/intel/compute-runtime/releases/tag/22.35.24055>`__       |
-+------------------+-------------------------------------------------------------------------------------------+
-| Ubuntu 18.04     | `21.38.21026 <https://github.com/intel/compute-runtime/releases/tag/21.38.21026>`__       |
-+------------------+-------------------------------------------------------------------------------------------+
-| CentOS 7         | `19.41.14441 <https://github.com/intel/compute-runtime/releases/tag/19.41.14441>`__       |
-+------------------+-------------------------------------------------------------------------------------------+
-| RHEL 8           | `22.28.23726 <https://github.com/intel/compute-runtime/releases/tag/22.28.23726>`__       |
-+------------------+-------------------------------------------------------------------------------------------+
+.. <The table below is out of date and we do not have an updated list of drivers used for validation as of 2024.0 release date.>
+.. <The table will be updated when an updated list of drivers is available>
+
+.. +------------------+-------------------------------------------------------------------------------------------+
+.. | Operation System | Driver version                                                                            |
+.. +==================+===========================================================================================+
+.. | Ubuntu 22.04     | `22.43.24595.30 <https://github.com/intel/compute-runtime/releases/tag/22.43.24595.30>`__ |
+.. +------------------+-------------------------------------------------------------------------------------------+
+.. | Ubuntu 20.04     | `22.35.24055 <https://github.com/intel/compute-runtime/releases/tag/22.35.24055>`__       |
+.. +------------------+-------------------------------------------------------------------------------------------+
+.. | Ubuntu 18.04     | `21.38.21026 <https://github.com/intel/compute-runtime/releases/tag/21.38.21026>`__       |
+.. +------------------+-------------------------------------------------------------------------------------------+
+.. | CentOS 7         | `19.41.14441 <https://github.com/intel/compute-runtime/releases/tag/19.41.14441>`__       |
+.. +------------------+-------------------------------------------------------------------------------------------+
+.. | RHEL 8           | `22.28.23726 <https://github.com/intel/compute-runtime/releases/tag/22.28.23726>`__       |
+.. +------------------+-------------------------------------------------------------------------------------------+
 
 
-What’s Next?
-############
+.. What’s Next?
+.. ############
 
 * :doc:`GPU Device <../../openvino-workflow/running-inference/inference-devices-and-modes/gpu-device>`
 * :doc:`Install Intel® Distribution of OpenVINO™ toolkit from a Docker Image <../install-openvino/install-openvino-archive-linux>`

--- a/docs/articles_en/get-started/install-openvino/install-openvino-apt.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-apt.rst
@@ -248,7 +248,7 @@ You can also try the following:
 * See pre-trained deep learning models in our :doc:`Open Model Zoo <../../../documentation/legacy-features/model-zoo>`.
 * Learn more about :doc:`Inference with OpenVINO Runtime <../../../openvino-workflow/running-inference>`.
 * See sample applications in :doc:`OpenVINO toolkit Samples Overview <../../../learn-openvino/openvino-samples>`.
-* Take a glance at the OpenVINO product home page: https://software.intel.com/en-us/openvino-toolkit.
+* Take a glance at the OpenVINO `product home page <https://software.intel.com/en-us/openvino-toolkit>`__ .
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-apt.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-apt.rst
@@ -228,7 +228,7 @@ What's Next?
 #######################################
 
 Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications!
-Learn more about how to integrate a model in OpenVINO applications by trying out the following ../../../learn-openvino/interactive-tutorials-python:
+Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials:
 
 * Try the `C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>`_ for step-by-step
   instructions on building and running a basic image classification C++ application.

--- a/docs/articles_en/get-started/install-openvino/install-openvino-apt.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-apt.rst
@@ -230,7 +230,7 @@ What's Next?
 Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications!
 Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials:
 
-* Try the `C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>`_ for step-by-step
+* Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos>` for step-by-step
   instructions on building and running a basic image classification C++ application.
 
   .. image:: https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg
@@ -238,8 +238,8 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
 * Visit the :ref:`Samples <code samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-  * `Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`_
-  * `Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`_
+  * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd>`
+  * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification>`
 
 You can also try the following:
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -283,7 +283,7 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../../notebooks/201-vision-monodepth-with-output>`
+      Try the `Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output.html>`__
       to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
@@ -291,9 +291,9 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../../../notebooks/205-vision-background-removal-with-output>`
+      * `OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output.html>`__
+      * `Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output.html>`__
+      * `Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output.html>`__
 
 
    .. tab-item:: Get started with C++

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -276,14 +276,14 @@ What's Next?
 ############################################################
 
 Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications!
-Learn more about how to integrate a model in OpenVINO applications by trying out the following ../../../learn-openvino/interactive-tutorials-python.
+Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials.
 
 .. tab-set::
 
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the `Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>`_
+      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>`
       to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
@@ -291,9 +291,9 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * `OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output.html>`__
-      * `Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output.html>`__
-      * `Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output.html>`__
+      * :doc:`OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output.html>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output.html>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output.html>`
 
 
    .. tab-item:: Get started with C++
@@ -307,8 +307,8 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
       Visit the :doc:`Samples <../../../learn-openvino/openvino-samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-      * `Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`__
-      * `Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`__
+      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`
+      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -283,7 +283,7 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output>`
+      Try the :doc:`Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output>`
       to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
@@ -291,9 +291,9 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output>`
+      * :doc:`OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output>`
 
 
    .. tab-item:: Get started with C++

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -283,7 +283,7 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output>`
+      Try the :doc:`Python Quick Start Example <../../../../notebooks/201-vision-monodepth-with-output>`
       to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
@@ -291,9 +291,9 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output>`
+      * :doc:`OpenVINO Python API Tutorial <../../../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../../../notebooks/205-vision-background-removal-with-output>`
 
 
    .. tab-item:: Get started with C++

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -283,7 +283,7 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>`
+      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output>`
       to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
@@ -291,9 +291,9 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output.html>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output.html>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output.html>`
+      * :doc:`OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output>`
 
 
    .. tab-item:: Get started with C++
@@ -307,8 +307,8 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
       Visit the :doc:`Samples <../../../learn-openvino/openvino-samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`
-      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`
+      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd>`
+      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification>`
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -156,16 +156,16 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the :doc:`Python Quick Start Example <../../../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output>`
+      * :doc:`OpenVINO Python API Tutorial <../../../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../../../notebooks/205-vision-background-removal-with-output>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -156,16 +156,16 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the :doc:`Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
-      Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>`` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
+      Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output>`
+      * :doc:`OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -156,16 +156,16 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the `Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output.html>`__ to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../../../notebooks/205-vision-background-removal-with-output>`
+      * `OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output.html>`__
+      * `Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output.html>`__
+      * `Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output.html>`__
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -156,29 +156,29 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :ref:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output.html>`
-      * :doc:`Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output.html>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output.html>`
+      * :doc:`OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output`
+      * :doc:`Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp
 
-      Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>` for step-by-step instructions on building and running a basic image classification C++ application.
+      Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos>` for step-by-step instructions on building and running a basic image classification C++ application.
 
       .. image:: https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg
          :width: 400
 
       Visit the :ref:`Samples <code samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`
-      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`
+      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd>`
+      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification>`
 
 Uninstalling Intel® Distribution of OpenVINO™ Toolkit
 #####################################################

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -149,36 +149,36 @@ If you have more than one OpenVINO™ version on your machine, you can easily sw
 What's Next?
 ####################
 
-Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following ../../../learn-openvino/interactive-tutorials-python.
+Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials.
 
 .. tab-set::
 
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the `Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>`__ to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :ref:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * `OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output.html>`__
-      * `Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output.html>`__
-      * `Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output.html>`__
+      * :doc:`OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output.html>`
+      * :doc:`Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output.html>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output.html>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp
 
-      Try the `C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>`_ for step-by-step instructions on building and running a basic image classification C++ application.
+      Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>` for step-by-step instructions on building and running a basic image classification C++ application.
 
       .. image:: https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg
          :width: 400
 
       Visit the :ref:`Samples <code samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-      * `Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`_
-      * `Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`_
+      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`
+      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`
 
 Uninstalling Intel® Distribution of OpenVINO™ Toolkit
 #####################################################

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -161,11 +161,11 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
-      Visit the :ref:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
+      Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>`` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output`
-      * :doc:`Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output>`
+      * :doc:`OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp
@@ -205,8 +205,8 @@ Additional Resources
 * :doc:`Troubleshooting Guide for OpenVINO Installation & Configuration <../install-openvino>`
 * Converting models for use with OpenVINO™: :ref:`Model Optimizer User Guide <deep learning model optimizer>`
 * Writing your own OpenVINO™ applications: :ref:`OpenVINO™ Runtime User Guide <deep learning openvino runtime>`
-* Sample applications: :ref:`OpenVINO™ Toolkit Samples Overview <code samples>`
-* Pre-trained deep learning models: :ref:`Overview of OpenVINO™ Toolkit Pre-Trained Models <model zoo>`
+* Sample applications: :doc:`OpenVINO™ Toolkit Samples Overview <../../../learn-openvino/openvino-samples>`
+* Pre-trained deep learning models: :doc:`Overview of OpenVINO™ Toolkit Pre-Trained Models <../../../documentation/legacy-features/model-zoo>`
 * IoT libraries and code samples in the GitHUB repository: `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -199,11 +199,11 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
-      Visit the :ref:`Tutorials <notebook ../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
+      Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output>`
+      * :doc:`OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp
@@ -250,7 +250,7 @@ Additional Resources
 * :doc:`Troubleshooting Guide for OpenVINO Installation & Configuration <../install-openvino>`
 * Converting models for use with OpenVINO™: :ref:`Model Optimizer Developer Guide <deep learning model optimizer>`
 * Writing your own OpenVINO™ applications: :ref:`OpenVINO™ Runtime User Guide <deep learning openvino runtime>`
-* Sample applications: :ref:`OpenVINO™ Toolkit Samples Overview <code samples>`
-* Pre-trained deep learning models: :ref:`Overview of OpenVINO™ Toolkit Pre-Trained Models <model zoo>`
+* Sample applications: :doc:`OpenVINO™ Toolkit Samples Overview <../../../learn-openvino/openvino-samples>`
+* Pre-trained deep learning models: :doc:`Overview of OpenVINO™ Toolkit Pre-Trained Models <../../../documentation/legacy-features/model-zoo>`
 * IoT libraries and code samples in the GitHUB repository: `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -52,7 +52,7 @@ System Requirements
 
       .. important::
 
-          When installing Python, make sure you click the option **Add Python 3.x to PATH** to `add Python <https://docs.python.org/3/using/windows.html#installation-steps>`__ to your `PATH` environment variable.
+         When installing Python, make sure you click the option **Add Python 3.x to PATH** to `add Python <https://docs.python.org/3/using/windows.html#installation-steps>`__ to your `PATH` environment variable.
 
 
 
@@ -139,7 +139,7 @@ to see if your case needs any of them.
 The ``C:\Program Files (x86)\Intel\openvino_2023`` folder now contains the core components for OpenVINO.
 If you used a different path in Step 1, you will find the ``openvino_2023`` folder there.
 The path to the ``openvino_2023`` directory is also referred as ``<INSTALL_DIR>``
-throughout the OpenVINO ../../../documentation.
+throughout the OpenVINO documentation.
 
 
 
@@ -187,36 +187,36 @@ You must update several environment variables before you can compile and run Ope
 What's Next?
 ####################
 
-Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following ../../../learn-openvino/interactive-tutorials-python.
+Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials.
 
 .. tab-set::
 
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the `Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>`__ to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :ref:`Tutorials <notebook ../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * `OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output.html>`__
-      * `Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output.html>`__
-      * `Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output.html>`__
+      * :doc:`OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output.html>`
+      * :doc:`Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output.html>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output.html>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp
 
-      Try the `C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>`_ for step-by-step instructions on building and running a basic image classification C++ application.
+      Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>` for step-by-step instructions on building and running a basic image classification C++ application.
 
       .. image:: https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg
          :width: 400
 
       Visit the :ref:`Samples <code samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-      * `Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`_
-      * `Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`_
+      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`
+      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`
 
 
 .. _uninstall-from-windows:

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -194,29 +194,29 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output.html>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :ref:`Tutorials <notebook ../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output.html>`
-      * :doc:`Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output.html>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output.html>`
+      * :doc:`OpenVINO Python API Tutorial <notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <notebooks/205-vision-background-removal-with-output>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp
 
-      Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>` for step-by-step instructions on building and running a basic image classification C++ application.
+      Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos>` for step-by-step instructions on building and running a basic image classification C++ application.
 
       .. image:: https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg
          :width: 400
 
       Visit the :ref:`Samples <code samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`
-      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`
+      * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd>`
+      * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification>`
 
 
 .. _uninstall-from-windows:

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -194,16 +194,16 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the :doc:`Python Quick Start Example <../../../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output>`
+      * :doc:`OpenVINO Python API Tutorial <../../../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../../../notebooks/205-vision-background-removal-with-output>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -194,16 +194,16 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the `Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output.html>`__ to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../../../notebooks/205-vision-background-removal-with-output>`
+      * `OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output.html>`__
+      * `Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output.html>`__
+      * `Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output.html>`__
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -194,16 +194,16 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
    .. tab-item:: Get started with Python
       :sync: get-started-py
 
-      Try the :doc:`Python Quick Start Example <../../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+      Try the :doc:`Python Quick Start Example <../../notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
       .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
          :width: 400
 
       Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-      * :doc:`OpenVINO Python API Tutorial <../../../notebooks/002-openvino-api-with-output>`
-      * :doc:`Basic image classification program with Hello Image Classification <../../../notebooks/001-hello-world-with-output>`
-      * :doc:`Convert a PyTorch model and use it for image background removal <../../../notebooks/205-vision-background-removal-with-output>`
+      * :doc:`OpenVINO Python API Tutorial <../../notebooks/002-openvino-api-with-output>`
+      * :doc:`Basic image classification program with Hello Image Classification <../../notebooks/001-hello-world-with-output>`
+      * :doc:`Convert a PyTorch model and use it for image background removal <../../notebooks/205-vision-background-removal-with-output>`
 
    .. tab-item:: Get started with C++
       :sync: get-started-cpp

--- a/docs/articles_en/get-started/install-openvino/install-openvino-brew.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-brew.rst
@@ -99,7 +99,7 @@ Now that you've installed OpenVINO Runtime, you can try the following things:
 * See pre-trained deep learning models in our :doc:`Open Model Zoo <../../../documentation/legacy-features/model-zoo>`.
 * Learn more about :doc:`Inference with OpenVINO Runtime <../../../openvino-workflow/running-inference>`.
 * See sample applications in :doc:`OpenVINO toolkit Samples Overview <../../../learn-openvino/openvino-samples>`.
-* Check out the OpenVINO product home page: https://software.intel.com/en-us/openvino-toolkit.
+* Check out the OpenVINO `product home page <https://software.intel.com/en-us/openvino-toolkit>`__.
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-conan.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-conan.rst
@@ -23,20 +23,20 @@ Install OpenVINO™ Runtime from Conan Package Manager
    .. tab-item:: System Requirements
       :sync: system-requirements
 
-      Full requirement listing is available in:
-      :doc:`System Requirements Page <../../../about-openvino/system-requirements>`
+      | Full requirement listing is available in:
+      | :doc:`System Requirements Page <../../../about-openvino/system-requirements>`
 
    .. tab-item:: Processor Notes
       :sync: processor-notes
 
-      To see if your processor includes the integrated graphics technology and supports iGPU inference, refer to:
-      `Product Specifications <https://ark.intel.com/content/www/us/en/ark.html>`__
+      | To see if your processor includes the integrated graphics technology and supports iGPU inference, refer to:
+      | `Product Specifications <https://ark.intel.com/content/www/us/en/ark.html>`__
 
    .. tab-item:: Software
       :sync: software
 
-      There are many ways to work with Conan Package Manager. Before you proceed, learn more about it on the
-      `Conan distribution page <https://conan.io/downloads>`__
+      | There are many ways to work with Conan Package Manager. Before you proceed, learn more about it on the
+      | `Conan distribution page <https://conan.io/downloads>`__
 
 Installing OpenVINO Runtime with Conan Package Manager
 ############################################################
@@ -93,6 +93,6 @@ Additional Resources
 * To prepare your models for working with OpenVINO, see :doc:`Model Preparation <../../../openvino-workflow/model-preparation>`.
 * Learn more about :doc:`Inference with OpenVINO Runtime <../../../openvino-workflow/running-inference>`.
 * See sample applications in :doc:`OpenVINO toolkit Samples Overview <../../../learn-openvino/openvino-samples>`.
-* Check out the OpenVINO product `home page <https://software.intel.com/en-us/openvino-toolkit>`__.
+* Check out the OpenVINO `product home page <https://software.intel.com/en-us/openvino-toolkit>`__.
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
@@ -37,8 +37,8 @@ Install OpenVINO™ Runtime from Conda Forge
    .. tab-item:: Software
       :sync: software
 
-      There are many ways to work with Conda. Before you proceed, learn more about it on the
-      `Anaconda distribution page <https://www.anaconda.com/products/individual/>`__
+      | There are many ways to work with Conda. Before you proceed, learn more about it on the
+      | `Anaconda distribution page <https://www.anaconda.com/products/individual/>`__
 
 
 Installing OpenVINO Runtime with Anaconda Package Manager

--- a/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
@@ -120,8 +120,8 @@ on building and running a basic image classification C++ application.
 
 Visit the :doc:`Samples <../../../learn-openvino/openvino-samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-* :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`
-* :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`
+* :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd>`
+* :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification>`
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
@@ -110,7 +110,7 @@ What's Next?
 ############################################################
 
 Now that you've installed OpenVINO Runtime, you are ready to run your own machine learning applications!
-To learn more about how to integrate a model in OpenVINO applications, try out some ../../../learn-openvino/interactive-tutorials-python and sample applications.
+To learn more about how to integrate a model in OpenVINO applications, try out some tutorials and sample applications.
 
 Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos>` for step-by-step instructions
 on building and running a basic image classification C++ application.
@@ -120,8 +120,8 @@ on building and running a basic image classification C++ application.
 
 Visit the :doc:`Samples <../../../learn-openvino/openvino-samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-* `Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`__
-* `Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`__
+* :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`
+* :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-docker-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-docker-linux.rst
@@ -40,7 +40,7 @@ To start using Dockerfiles the following conditions must be met:
 .. note::
 
    OpenVINO's `Docker <https://docs.docker.com/>`__ and :doc:`Bare Metal <../install-openvino>`
-   distributions are identical, so the ../../../documentation applies to both.
+   distributions are identical, so the documentation applies to both.
 
 .. note::
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
@@ -130,7 +130,7 @@ to see if your case needs any of them.
 What's Next?
 ####################
 
-Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following ../../../learn-openvino/interactive-tutorials-python.
+Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials.
 
 .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
    :width: 400

--- a/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
@@ -135,16 +135,16 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
 .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
    :width: 400
 
-Try the `Python Quick Start Example <https://docs.openvino.ai/2024/notebooks/201-vision-monodepth-with-output.html>`__ to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+Try the :doc:`Python Quick Start Example <https://docs.openvino.ai/2024/notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
 Get started with Python
 +++++++++++++++++++++++
 
 Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-* `OpenVINO Python API Tutorial <https://docs.openvino.ai/2024/notebooks/002-openvino-api-with-output.html>`__
-* `Basic image classification program with Hello Image Classification <https://docs.openvino.ai/2024/notebooks/001-hello-world-with-output.html>`__
-* `Convert a PyTorch model and use it for image background removal <https://docs.openvino.ai/2024/notebooks/205-vision-background-removal-with-output.html>`__
+* :doc:`OpenVINO Python API Tutorial <https://docs.openvino.ai/2024/notebooks/002-openvino-api-with-output>`
+* :doc:`Basic image classification program with Hello Image Classification <https://docs.openvino.ai/2024/notebooks/001-hello-world-with-output>`
+* :doc:`Convert a PyTorch model and use it for image background removal <https://docs.openvino.ai/2024/notebooks/205-vision-background-removal-with-output>`
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
@@ -142,15 +142,15 @@ Get started with Python
 
 Visit the :doc:`Tutorials <../../../learn-openvino/interactive-tutorials-python>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
 
-* :doc:`OpenVINO Python API Tutorial <https://docs.openvino.ai/2024/notebooks/002-openvino-api-with-output>`
-* :doc:`Basic image classification program with Hello Image Classification <https://docs.openvino.ai/2024/notebooks/001-hello-world-with-output>`
-* :doc:`Convert a PyTorch model and use it for image background removal <https://docs.openvino.ai/2024/notebooks/205-vision-background-removal-with-output>`
+* `OpenVINO Python API Tutorial <https://docs.openvino.ai/2024/notebooks/002-openvino-api-with-output.html>`__
+* `Basic image classification program with Hello Image Classification <https://docs.openvino.ai/2024/notebooks/001-hello-world-with-output.html>`__
+* `Convert a PyTorch model and use it for image background removal <https://docs.openvino.ai/2024/notebooks/205-vision-background-removal-with-output.html>`__
 
 
 
 Additional Resources
 ####################
 
-- Intel® Distribution of OpenVINO™ toolkit home page: https://software.intel.com/en-us/openvino-toolkit
+- Intel® Distribution of OpenVINO™ `toolkit home page <https://software.intel.com/en-us/openvino-toolkit>`__
 - For IoT Libraries & Code Samples, see `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__.
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
@@ -135,7 +135,7 @@ Now that you've installed OpenVINO Runtime, you're ready to run your own machine
 .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
    :width: 400
 
-Try the :doc:`Python Quick Start Example <https://docs.openvino.ai/2024/notebooks/201-vision-monodepth-with-output>` to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+Try the `Python Quick Start Example <https://docs.openvino.ai/2024/notebooks/201-vision-monodepth-with-output.html>`__ to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
 Get started with Python
 +++++++++++++++++++++++

--- a/docs/articles_en/get-started/install-openvino/install-openvino-vcpkg.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-vcpkg.rst
@@ -104,7 +104,7 @@ Now that you've installed OpenVINO Runtime, you can try the following things:
 * See pre-trained deep learning models in our :doc:`Open Model Zoo <../../../documentation/legacy-features/model-zoo>`.
 * Learn more about :doc:`Inference with OpenVINO Runtime <../../../openvino-workflow/running-inference>`.
 * See sample applications in :doc:`OpenVINO toolkit Samples Overview <../../../learn-openvino/openvino-samples>`.
-* Check out the OpenVINO product home page: https://software.intel.com/en-us/openvino-toolkit.
+* Check out the OpenVINO `product home page <https://software.intel.com/en-us/openvino-toolkit>`__ .
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-yum.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-yum.rst
@@ -208,7 +208,7 @@ What's Next?
 #############
 
 Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications!
-Learn more about how to integrate a model in OpenVINO applications by trying out the following ../../../learn-openvino/interactive-tutorials-python:
+Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials:
 
 * Try the `C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>`_
   for step-by-step instructions on building and running a basic image classification C++ application.

--- a/docs/articles_en/get-started/install-openvino/install-openvino-yum.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-yum.rst
@@ -228,7 +228,7 @@ You can also try the following things:
 * See pre-trained deep learning models in our :doc:`Open Model Zoo <../../../documentation/legacy-features/model-zoo>`.
 * Learn more about :doc:`Inference with OpenVINO Runtime <../../../openvino-workflow/running-inference>`.
 * See sample applications in :doc:`OpenVINO toolkit Samples Overview <../../../learn-openvino/openvino-samples>`.
-* Take a glance at the OpenVINO product `home page <https://software.intel.com/en-us/openvino-toolkit>`__ .
+* Take a glance at the OpenVINO `product home page <https://software.intel.com/en-us/openvino-toolkit>`__ .
 
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-yum.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-yum.rst
@@ -210,7 +210,7 @@ What's Next?
 Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications!
 Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials:
 
-* Try the `C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos.html>`_
+* Try the :doc:`C++ Quick Start Example <../../../learn-openvino/openvino-samples/get-started-demos>`
   for step-by-step instructions on building and running a basic image classification C++ application.
 
   .. image:: https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg
@@ -218,8 +218,8 @@ Learn more about how to integrate a model in OpenVINO applications by trying out
 
 * Visit the :ref:`Samples <code samples>` page for other C++ example applications to get you started with OpenVINO, such as:
 
-  * `Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd.html>`_
-  * `Object classification sample <../../../learn-openvino/openvino-samples/hello-classification.html>`_
+  * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd>`
+  * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification>`
 
 You can also try the following things:
 
@@ -228,7 +228,7 @@ You can also try the following things:
 * See pre-trained deep learning models in our :doc:`Open Model Zoo <../../../documentation/legacy-features/model-zoo>`.
 * Learn more about :doc:`Inference with OpenVINO Runtime <../../../openvino-workflow/running-inference>`.
 * See sample applications in :doc:`OpenVINO toolkit Samples Overview <../../../learn-openvino/openvino-samples>`.
-* Take a glance at the OpenVINO product home page: https://software.intel.com/en-us/openvino-toolkit.
+* Take a glance at the OpenVINO product `home page <https://software.intel.com/en-us/openvino-toolkit>`__ .
 
 
 


### PR DESCRIPTION
* Fixed links in Get Started section of documentation
* Hid the table with GPU drivers used for validation. Current list outdated, and the new one will be provided at later date.