### PR TITLE
[DOCS] Linking issues fix in Legacy Features for 24.0

### DIFF
--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api.rst
@@ -23,7 +23,7 @@ Legacy Conversion API
                  optimal execution on target devices.
 
 .. note::
-   This part of the ../../../documentation describes a legacy approach to model conversion. Starting with OpenVINO 2023.1, a simpler alternative API for model conversion is available: ``openvino.convert_model`` and OpenVINO Model Converter ``ovc`` CLI tool. Refer to :doc:`Model preparation <../../../openvino-workflow/model-preparation>` for more details. If you are still using `openvino.tools.mo.convert_model` or `mo` CLI tool, you can still refer to this ../../../documentation. However, consider checking the :doc:`transition guide <../transition-legacy-conversion-api>` to learn how to migrate from the legacy conversion API to the new one. Depending on the model topology, the new API can be a better option for you.
+   This part of the documentation describes a legacy approach to model conversion. Starting with OpenVINO 2023.1, a simpler alternative API for model conversion is available: ``openvino.convert_model`` and OpenVINO Model Converter ``ovc`` CLI tool. Refer to :doc:`Model preparation <../../../openvino-workflow/model-preparation>` for more details. If you are still using `openvino.tools.mo.convert_model` or `mo` CLI tool, you can still refer to this documentation. However, consider checking the :doc:`transition guide <../transition-legacy-conversion-api>` to learn how to migrate from the legacy conversion API to the new one. Depending on the model topology, the new API can be a better option for you.
 
 To convert a model to OpenVINO model format (``ov.Model``), you can use the following command:
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats.rst
@@ -550,7 +550,7 @@ to OpenVINO IR or ONNX before running inference should be considered the default
 .. note::
 
    If you want to keep working with the legacy formats the old way, refer to a previous
-   `OpenVINO LTS version and its ../../../../documentation <https://docs.openvino.ai/2022.3/Supported_Model_Formats.html>`__ .
+   `OpenVINO LTS version and its documentation <https://docs.openvino.ai/2022.3/Supported_Model_Formats.html>`__ .
 
    OpenVINO versions of 2023 are mostly compatible with the old instructions,
    through a deprecated MO tool, installed with the deprecated OpenVINO Developer Tools package.

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials.rst
@@ -43,7 +43,7 @@
 
    The code described in the tutorials has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../learn-openvino/interactive-tutorials-python <../../../../../learn-openvino/interactive-tutorials-python>`.
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../learn-openvino/interactive-tutorials-python>`.
 
 This section provides a set of tutorials that demonstrate conversion methods for specific
 TensorFlow, ONNX, and PyTorch models. Note that these instructions do not cover all use
@@ -55,7 +55,7 @@ Before studying the tutorials, try to convert the model out-of-the-box by specif
 
    Apache MXNet, Caffe, and Kaldi are no longer directly supported by OpenVINO.
 
-You will find a collection of :doc:`Python ../../../../../learn-openvino/interactive-tutorials-python <../../../../../learn-openvino/interactive-tutorials-python>` written for running on Jupyter notebooks
+You will find a collection of :doc:`Python tutorials <../../../../../learn-openvino/interactive-tutorials-python>` written for running on Jupyter notebooks
 that provide an introduction to the OpenVINO™ toolkit and explain how to use the Python API and tools for
 optimized deep learning inference.
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-onnx-faster-r-cnn.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-onnx-faster-r-cnn.rst
@@ -5,15 +5,15 @@ Converting an ONNX Faster R-CNN Model
 
 
 .. meta::
-   :description: Learn how to convert a Faster R-CNN model 
+   :description: Learn how to convert a Faster R-CNN model
                  from ONNX to the OpenVINO Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 The instructions below are applicable **only** to the Faster R-CNN model converted to the ONNX file format from the `maskrcnn-benchmark model <https://github.com/facebookresearch/maskrcnn-benchmark>`__:
 
 1. Download the pretrained model file from `onnx/models <https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/faster-rcnn>`__ (commit-SHA: 8883e49e68de7b43e263d56b9ed156dfa1e03117).
@@ -30,7 +30,10 @@ The instructions below are applicable **only** to the Faster R-CNN model convert
       --transformations_config front/onnx/faster_rcnn.json
 
 
-   Be aware that the height and width specified with the ``input_shape`` command line parameter could be different. For more information about supported input image dimensions    and required pre- and post-processing steps, refer to the `Faster R-CNN article <https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/   faster-rcnn>`__.
+   Be aware that the height and width specified with the ``input_shape`` command line parameter
+   could be different. For more information about supported input image dimensions and
+   required pre- and post-processing steps, refer to the
+   `Faster R-CNN article <https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/faster-rcnn>`__.
 
 3. Interpret the outputs of the generated IR: class indices, probabilities and box coordinates. Below are the outputs from the ``DetectionOutput`` layer:
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-onnx-gpt-2.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-onnx-gpt-2.rst
@@ -5,14 +5,14 @@ Converting an ONNX GPT-2 Model
 
 
 .. meta::
-   :description: Learn how to convert a pre-trained GPT-2 
+   :description: Learn how to convert a pre-trained GPT-2
                  model from ONNX to the OpenVINO Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
 
 `Public pre-trained GPT-2 model <https://github.com/onnx/models/tree/master/text/machine_comprehension/gpt-2>`__ is a large
 transformer-based language model with a simple objective: predict the next word, given all of the previous words within some text.
@@ -20,9 +20,9 @@ transformer-based language model with a simple objective: predict the next word,
 Downloading the Pre-Trained Base GPT-2 Model
 ############################################
 
-To download the model, go to `this model <https://github.com/onnx/models/blob/master/text/machine_comprehension/gpt-2/model/gpt2-10.onnx>`__, and press **Download**.
+To download the model, go to `this model <https://github.com/onnx/models/blob/main/validated/text/machine_comprehension/gpt-2/model/gpt2-10.onnx>`__, and press **Download**.
 
-To download the model and sample test data, go to `this model <https://github.com/onnx/models/blob/master/text/machine_comprehension/gpt-2/model/gpt2-10.tar.gz>`__, and press **Download**.
+To download the model and sample test data, go to `this model <https://github.com/onnx/models/blob/main/validated/text/machine_comprehension/gpt-2/model/gpt2-10.tar.gz>`__, and press **Download**.
 
 Converting an ONNX GPT-2 Model to IR
 ####################################

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-onnx-mask-r-cnn.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-onnx-mask-r-cnn.rst
@@ -5,18 +5,18 @@ Converting an ONNX Mask R-CNN Model
 
 
 .. meta::
-   :description: Learn how to convert a pre-trained Mask 
+   :description: Learn how to convert a pre-trained Mask
                  R-CNN model from ONNX to the OpenVINO Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
 
 The instructions below are applicable **only** to the Mask R-CNN model converted to the ONNX file format from the `maskrcnn-benchmark model <https://github.com/facebookresearch/maskrcnn-benchmark>`__.
 
-1. Download the pretrained model file from `onnx/models <https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/mask-rcnn>`__ (commit-SHA: 8883e49e68de7b43e263d56b9ed156dfa1e03117).
+1. Download the pretrained model file from `onnx/models <https://github.com/onnx/models/tree/main/validated/vision/object_detection_segmentation/mask-rcnn>`__ (commit-SHA: 8883e49e68de7b43e263d56b9ed156dfa1e03117).
 
 2. Generate the Intermediate Representation of the model by changing your current working directory to the model conversion API installation directory and running model conversion with the following parameters:
 
@@ -30,7 +30,7 @@ The instructions below are applicable **only** to the Mask R-CNN model converted
       --transformations_config front/onnx/mask_rcnn.json
 
 
-   Be aware that the height and width specified with the ``input_shape`` command line parameter could be different. For more information about supported input image dimensions    and required pre- and post-processing steps, refer to the `../../../../../../documentation <https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/mask-rcnn>`__.
+   Be aware that the height and width specified with the ``input_shape`` command line parameter could be different. For more information about supported input image dimensions    and required pre- and post-processing steps, refer to the `documentation <https://github.com/onnx/models/tree/main/validated/vision/object_detection_segmentation/mask-rcnn>`__.
 
 3. Interpret the outputs of the generated IR file: masks, class indices, probabilities and box coordinates:
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-bert-ner.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-bert-ner.rst
@@ -12,7 +12,7 @@ Converting a PyTorch BERT-NER Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
 
 The goal of this article is to present a step-by-step guide on how to convert PyTorch BERT-NER model to OpenVINO IR. First, you need to download the model and convert it to ONNX.
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-cascade-rcnn-r-101.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-cascade-rcnn-r-101.rst
@@ -5,7 +5,7 @@ Converting a PyTorch Cascade RCNN R-101 Model
 
 
 .. meta::
-   :description: Learn how to convert a Cascade RCNN R-101 
+   :description: Learn how to convert a Cascade RCNN R-101
                  model from PyTorch to the OpenVINO Intermediate Representation.
 
 
@@ -13,8 +13,8 @@ Converting a PyTorch Cascade RCNN R-101 Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 The goal of this article is to present a step-by-step guide on how to convert a PyTorch Cascade RCNN R-101 model to OpenVINO IR. First, you need to download the model and convert it to ONNX.
 
 Downloading and Converting Model to ONNX
@@ -30,7 +30,7 @@ Downloading and Converting Model to ONNX
 
   .. note::
 
-     To set up an environment, refer to the `instructions <https://github.com/open-mmlab/mmdetection/blob/master/docs/en/../../../../../../get-started.md#installation>`__.
+     To set up an environment, refer to the `instructions <https://github.com/open-mmlab/mmdetection/blob/master/docs/en/get_started.md#installation>`__.
 
 * Download the pre-trained `model <https://download.openmmlab.com/mmdetection/v2.0/cascade_rcnn/cascade_rcnn_r101_fpn_1x_coco/cascade_rcnn_r101_fpn_1x_coco_20200317-0b6a2fbf.pth>`__. The model is also available `here <https://github.com/open-mmlab/mmdetection/blob/master/configs/cascade_rcnn/README.md>`__.
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-f3-net.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-f3-net.rst
@@ -12,8 +12,8 @@ Converting a PyTorch F3Net Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 `F3Net <https://github.com/weijun88/F3Net>`__ : Fusion, Feedback and Focus for Salient Object Detection
 
 Cloning the F3Net Repository

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-quartz-net.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-quartz-net.rst
@@ -12,8 +12,8 @@ Converting a PyTorch QuartzNet Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 `NeMo project <https://github.com/NVIDIA/NeMo>`__ provides the QuartzNet model.
 
 Downloading the Pre-trained QuartzNet Model
@@ -28,10 +28,10 @@ Here are the instructions on how to obtain QuartzNet in ONNX format.
 
    .. code-block:: py
       :force:
-   
+
       import nemo
       import nemo.collections.asr as nemo_asr
-   
+
       quartznet = nemo_asr.models.EncDecCTCModel.from_pretrained(model_name="QuartzNet15x5Base-En")
       # Export QuartzNet model to ONNX format
       quartznet.decoder.export('decoder_qn.onnx')

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-rcan.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-rcan.rst
@@ -12,8 +12,8 @@ Converting a PyTorch RCAN Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 `RCAN <https://github.com/yulunzhang/RCAN>`__ : Image Super-Resolution Using Very Deep Residual Channel Attention Networks
 
 Downloading and Converting the Model to ONNX

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-rnn-t.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-rnn-t.rst
@@ -12,8 +12,8 @@ Converting a PyTorch RNN-T Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 This guide covers conversion of RNN-T model from `MLCommons <https://github.com/mlcommons>`__ repository. Follow
 the instructions below to export a PyTorch model into ONNX, before converting it to IR:
 
@@ -60,7 +60,7 @@ if you were following the `guide <https://github.com/mlcommons/inference/tree/ma
 
 .. note::
 
-   If you already have a full clone of MLCommons inference repository, you need 
+   If you already have a full clone of MLCommons inference repository, you need
    to specify the ``mlcommons_inference_path`` variable.
 
 .. code-block:: py

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-yolact.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-pytorch-yolact.rst
@@ -13,8 +13,8 @@ Converting a PyTorch YOLACT Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 You Only Look At CoefficienTs (YOLACT) is a simple, fully convolutional model for real-time instance segmentation.
 The PyTorch implementation is publicly available in `this GitHub repository <https://github.com/dbolya/yolact>`__.
 The YOLACT++ model is not supported, because it uses deformable convolutional layers that cannot be represented in ONNX format.

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-attention-ocr.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-attention-ocr.rst
@@ -5,8 +5,8 @@ Converting a TensorFlow Attention OCR Model
 
 
 .. meta::
-   :description: Learn how to convert the Attention OCR 
-                 model from the TensorFlow Attention OCR repository to the 
+   :description: Learn how to convert the Attention OCR
+                 model from the TensorFlow Attention OCR repository to the
                  OpenVINO Intermediate Representation.
 
 
@@ -14,7 +14,7 @@ Converting a TensorFlow Attention OCR Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
 
 This tutorial explains how to convert the Attention OCR (AOCR) model from the `TensorFlow Attention OCR repository <https://github.com/emedvedev/attention-ocr>`__ to the Intermediate Representation (IR).
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-bert.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-bert.rst
@@ -5,7 +5,7 @@ Converting a TensorFlow BERT Model
 
 
 .. meta::
-   :description: Learn how to convert a BERT model 
+   :description: Learn how to convert a BERT model
                  from TensorFlow to the OpenVINO Intermediate Representation.
 
 
@@ -13,8 +13,8 @@ Converting a TensorFlow BERT Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 Pretrained models for BERT (Bidirectional Encoder Representations from Transformers) are
 `publicly available <https://github.com/google-research/bert>`__.
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-crnn.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-crnn.rst
@@ -5,7 +5,7 @@ Converting a TensorFlow CRNN Model
 
 
 .. meta::
-   :description: Learn how to convert a CRNN model 
+   :description: Learn how to convert a CRNN model
                  from TensorFlow to the OpenVINO Intermediate Representation.
 
 
@@ -13,8 +13,8 @@ Converting a TensorFlow CRNN Model
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 This tutorial explains how to convert a CRNN model to OpenVINO™ Intermediate Representation (IR).
 
 There are several public versions of TensorFlow CRNN model implementation available on GitHub. This tutorial explains how to convert the model from

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-deep-speech.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-deep-speech.rst
@@ -5,15 +5,15 @@ Converting a TensorFlow DeepSpeech Model
 
 
 .. meta::
-   :description: Learn how to convert a DeepSpeech model 
+   :description: Learn how to convert a DeepSpeech model
                  from TensorFlow to the OpenVINO Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 `DeepSpeech project <https://github.com/mozilla/DeepSpeech>`__ provides an engine to train speech-to-text models.
 
 Downloading the Pretrained DeepSpeech Model

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-language-1b.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-language-1b.rst
@@ -5,16 +5,16 @@ Converting a TensorFlow Language Model on One Billion Word Benchmark
 
 
 .. meta::
-   :description: Learn how to convert a TensorFlow Language 
-                 Model on One Billion Word Benchmark to the OpenVINO Intermediate 
+   :description: Learn how to convert a TensorFlow Language
+                 Model on One Billion Word Benchmark to the OpenVINO Intermediate
                  Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 Downloading a Pre-trained Language Model on One Billion Word Benchmark
 ######################################################################
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-ncf.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-ncf.rst
@@ -5,15 +5,15 @@ Converting a TensorFlow Neural Collaborative Filtering Model
 
 
 .. meta::
-   :description: Learn how to convert a Neural Collaborative 
-                 Filtering Model from TensorFlow to the OpenVINO Intermediate 
+   :description: Learn how to convert a Neural Collaborative
+                 Filtering Model from TensorFlow to the OpenVINO Intermediate
                  Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
 
 This tutorial explains how to convert Neural Collaborative Filtering (NCF) model to the OpenVINO Intermediate Representation.
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-object-detection.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-object-detection.rst
@@ -5,8 +5,8 @@ Converting TensorFlow Object Detection API Models
 
 
 .. meta::
-   :description: Learn how to convert Object Detection 
-                 API Models from TensorFlow to the OpenVINO Intermediate 
+   :description: Learn how to convert Object Detection
+                 API Models from TensorFlow to the OpenVINO Intermediate
                  Representation.
 
 
@@ -14,8 +14,8 @@ Converting TensorFlow Object Detection API Models
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 * Starting with the 2022.1 release, model conversion API can convert the TensorFlow Object Detection API Faster and Mask RCNNs topologies differently. By default, model conversion adds operation "Proposal" to the generated IR. This operation needs an additional input to the model with name "image_info" which should be fed with several values describing the preprocessing applied to the input image (refer to the :doc:`Proposal <../../../../../openvino-ir-format/operation-sets/operations-specifications/detection/proposal-4>` operation specification for more information). However, this input is redundant for the models trained and inferred with equal size images. Model conversion API can generate IR for such models and insert operation :doc:`DetectionOutput <../../../../../openvino-ir-format/operation-sets/operations-specifications/detection/detectionoutput-1>` instead of ``Proposal``. The `DetectionOutput` operation does not require additional model input "image_info". Moreover, for some models the produced inference results are closer to the original TensorFlow model. In order to trigger new behavior, the attribute "operation_to_add" in the corresponding JSON transformation configuration file should be set to value "DetectionOutput" instead of default one "Proposal".
 * Starting with the 2021.1 release, model conversion API converts the TensorFlow Object Detection API SSDs, Faster and Mask RCNNs topologies keeping shape-calculating sub-graphs by default, so topologies can be re-shaped in the OpenVINO Runtime using dedicated reshape API. Refer to the :doc:`Using Shape Inference <../../../../../../openvino-workflow/running-inference/changing-input-shape>` guide for more information on how to use this feature. It is possible to change the both spatial dimensions of the input image and batch size.
 * To generate IRs for TF 1 SSD topologies, model conversion API creates a number of ``PriorBoxClustered`` operations instead of a constant node with prior boxes calculated for the particular input image size. This change allows you to reshape the topology in the OpenVINO Runtime using dedicated API. The reshaping is supported for all SSD topologies except FPNs, which contain hardcoded shapes for some operations preventing from changing topology input shape.
@@ -169,7 +169,7 @@ Models with ``keep_aspect_ratio_resizer`` were trained to recognize object in re
 Model Conversion Process in Detail
 ##################################
 
-This section is intended for users who want to understand how model conversion API performs Object Detection API models conversion in details. The information in this section is also useful for users having complex models that are not converted with model conversion API out of the box. It is highly recommended to read the **Graph Transformation Extensions** section in the :doc:`[Legacy] Model Optimizer Extensibility <../../../legacy-model-optimizer-extensibility>` ../../../../../../documentation first to understand sub-graph replacement concepts which are used here.
+This section is intended for users who want to understand how model conversion API performs Object Detection API models conversion in details. The information in this section is also useful for users having complex models that are not converted with model conversion API out of the box. It is highly recommended to read the **Graph Transformation Extensions** section in the :doc:`[Legacy] Model Optimizer Extensibility <../../../legacy-model-optimizer-extensibility>` documentation first to understand sub-graph replacement concepts which are used here.
 
 It is also important to open the model in the `TensorBoard <https://www.tensorflow.org/guide/summaries_and_tensorboard>`__ to see the topology structure. Model conversion API can create an event file that can be then fed to the TensorBoard tool. Run model conversion, providing two command line parameters:
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-slim-library.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-slim-library.rst
@@ -5,15 +5,15 @@ Converting TensorFlow Slim Image Classification Model Library Models
 
 
 .. meta::
-   :description: Learn how to convert a Slim Image 
-                 Classification model from TensorFlow to the OpenVINO 
+   :description: Learn how to convert a Slim Image
+                 Classification model from TensorFlow to the OpenVINO
                  Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
 
 `TensorFlow-Slim Image Classification Model Library <https://github.com/tensorflow/models/tree/master/research/slim/README.md>`__ is a library to define, train and evaluate classification models in TensorFlow. The library contains Python scripts defining the classification topologies together with checkpoint files for several pre-trained classification topologies. To convert a TensorFlow-Slim library model, complete the following steps:
 
@@ -24,7 +24,7 @@ Converting TensorFlow Slim Image Classification Model Library Models
 
 The `Example of an Inception V1 Model Conversion <#example_of_an_inception_v1_model_conversion>`__ below illustrates the process of converting an Inception V1 Model.
 
-Example of an Inception V1 Model Conversion 
+Example of an Inception V1 Model Conversion
 ###########################################
 
 This example demonstrates how to convert the model on Linux OSes, but it could be easily adopted for the Windows OSes.
@@ -87,7 +87,7 @@ The ``-b`` command line parameter is required because model conversion API canno
 
 For the information on why ``--mean_values`` and ``--scale`` command-line parameters are used, refer to the `Mean and Scale Values for TensorFlow-Slim Models <#Mean-and-Scale-Values-for-TensorFlow-Slim-Models>`__.
 
-Mean and Scale Values for TensorFlow-Slim Models 
+Mean and Scale Values for TensorFlow-Slim Models
 #################################################
 
 The TensorFlow-Slim Models were trained with normalized input data. There are several different normalization algorithms used in the Slim library. OpenVINO classification sample does not perform image pre-processing except resizing to the input layer size. It is necessary to pass mean and scale values to model conversion API so they are embedded into the generated IR in order to get correct classification results.

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-xlnet.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-xlnet.rst
@@ -5,15 +5,15 @@ Converting a TensorFlow XLNet Model
 
 
 .. meta::
-   :description: Learn how to convert an XLNet model from 
+   :description: Learn how to convert an XLNet model from
                  TensorFlow to the OpenVINO Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 Pretrained models for XLNet (Bidirectional Encoder Representations from Transformers) are
 `publicly available <https://github.com/zihangdai/xlnet>`__.
 
@@ -41,7 +41,7 @@ To get pb-file from the archive contents, you need to do the following.
 1. Run commands
 
    .. code-block:: sh
-   
+
       cd ~
       mkdir XLNet-Base
       cd XLNet-Base
@@ -49,7 +49,7 @@ To get pb-file from the archive contents, you need to do the following.
       wget https://storage.googleapis.com/xlnet/released_models/cased_L-12_H-768_A-12.zip
       unzip cased_L-12_H-768_A-12.zip
       mkdir try_save
-   
+
 
 2. Save and run the following Python script in `~/XLNet-Base/xlnet`:
 
@@ -59,10 +59,10 @@ To get pb-file from the archive contents, you need to do the following.
       :force:
 
       from collections import namedtuple
-      
+
       import tensorflow as tf
       from tensorflow.python.framework import graph_io
-      
+
       import model_utils
       import xlnet
 
@@ -71,46 +71,46 @@ To get pb-file from the archive contents, you need to do the following.
       OUTPUT_DIR = '~/XLNet-Base/try_save/'
       INIT_CKPT_PATH = '~/XLNet-Base/xlnet_cased_L-12_H-768_A-12/xlnet_model.ckpt'
       XLNET_CONFIG_PATH = '~/XLNet-Base/xlnet_cased_L-12_H-768_A-12/xlnet_config.json'
-      
+
       FLags = namedtuple('FLags', 'use_tpu init_checkpoint')
       FLAGS = FLags(use_tpu=False, init_checkpoint=INIT_CKPT_PATH)
-      
+
       xlnet_config = xlnet.XLNetConfig(json_path=XLNET_CONFIG_PATH)
       run_config = xlnet.RunConfig(is_training=False, use_tpu=False, use_bfloat16=False, dropout=0.1, dropatt=0.1,)
-      
-      
+
+
       sentence_features_input_idx = tf.compat.v1.placeholder(tf.int32, shape=[LENGTHS, BATCH], name='input_ids')
       sentence_features_segment_ids = tf.compat.v1.placeholder(tf.int32, shape=[LENGTHS, BATCH], name='seg_ids')
       sentence_features_input_mask = tf.compat.v1.placeholder(tf.float32, shape=[LENGTHS, BATCH], name='input_mask')
-      
+
       with tf.compat.v1.Session() as sess:
          xlnet_model = xlnet.XLNetModel(xlnet_config=xlnet_config, run_config=run_config,
                                        input_ids=sentence_features_input_idx,
                                        seg_ids=sentence_features_segment_ids,
                                        input_mask=sentence_features_input_mask)
-      
+
          sess.run(tf.compat.v1.global_variables_initializer())
          model_utils.init_from_checkpoint(FLAGS, True)
-      
+
          # Save the variables to disk.
          saver = tf.compat.v1.train.Saver()
-      
+
          # Saving checkpoint
          save_path = saver.save(sess, OUTPUT_DIR + "model.ckpt")
-      
+
          # Freezing model
          outputs = ['model/transformer/dropout_2/Identity']
          graph_def_freezed = tf.compat.v1.graph_util.convert_variables_to_constants(sess, sess.graph.as_graph_def(), outputs)
-      
+
          # Saving non-frozen and frozen  model to pb
          graph_io.write_graph(sess.graph.as_graph_def(), OUTPUT_DIR, 'model.pb', as_text=False)
          graph_io.write_graph(graph_def_freezed,OUTPUT_DIR, 'model_frozen.pb',
                               as_text=False)
-      
+
          # Write to tensorboard
          with tf.compat.v1.summary.FileWriter(logdir=OUTPUT_DIR, graph_def=graph_def_freezed) as writer:
             writer.flush()
- 
+
 Downloading the Pretrained Large XLNet Model
 ############################################
 
@@ -135,7 +135,7 @@ To get ``pb-file`` from the archive contents, follow the instructions below:
       wget https://storage.googleapis.com/xlnet/released_models/cased_L-24_H-1024_A-16.zip
       unzip cased_L-24_H-1024_A-16.zip
       mkdir try_save
-   
+
 
 2. Save and run the following Python script in ``~/XLNet-Large/xlnet``:
 
@@ -143,54 +143,54 @@ To get ``pb-file`` from the archive contents, follow the instructions below:
       :force:
 
       from collections import namedtuple
-      
+
       import tensorflow as tf
       from tensorflow.python.framework import graph_io
-      
+
       import model_utils
       import xlnet
-      
+
       LENGTHS = 50
       BATCH = 1
       OUTPUT_DIR = '~/XLNet-Large/try_save'
       INIT_CKPT_PATH = '~/XLNet-Large/cased_L-24_H-1024_A-16/xlnet_model.ckpt'
       XLNET_CONFIG_PATH = '~/XLNet-Large/cased_L-24_H-1024_A-16/xlnet_config.json'
-      
+
       FLags = namedtuple('FLags', 'use_tpu init_checkpoint')
       FLAGS = FLags(use_tpu=False, init_checkpoint=INIT_CKPT_PATH)
-      
+
       xlnet_config = xlnet.XLNetConfig(json_path=XLNET_CONFIG_PATH)
       run_config = xlnet.RunConfig(is_training=False, use_tpu=False, use_bfloat16=False, dropout=0.1, dropatt=0.1,)
-      
-      
+
+
       sentence_features_input_idx = tf.compat.v1.placeholder(tf.int32, shape=[LENGTHS, BATCH], name='input_ids')
       sentence_features_segment_ids = tf.compat.v1.placeholder(tf.int32, shape=[LENGTHS, BATCH], name='seg_ids')
       sentence_features_input_mask = tf.compat.v1.placeholder(tf.float32, shape=[LENGTHS, BATCH], name='input_mask')
-      
+
       with tf.compat.v1.Session() as sess:
          xlnet_model = xlnet.XLNetModel(xlnet_config=xlnet_config, run_config=run_config,
                                        input_ids=sentence_features_input_idx,
                                        seg_ids=sentence_features_segment_ids,
                                        input_mask=sentence_features_input_mask)
-      
+
          sess.run(tf.compat.v1.global_variables_initializer())
          model_utils.init_from_checkpoint(FLAGS, True)
-      
+
          # Save the variables to disk.
          saver = tf.compat.v1.train.Saver()
-      
+
          # Saving checkpoint
          save_path = saver.save(sess, OUTPUT_DIR + "model.ckpt")
-      
+
          # Freezing model
          outputs = ['model/transformer/dropout_2/Identity']
          graph_def_freezed = tf.compat.v1.graph_util.convert_variables_to_constants(sess, sess.graph.as_graph_def(), outputs)
-      
+
          # Saving non-frozen and frozen  model to pb
          graph_io.write_graph(sess.graph.as_graph_def(), OUTPUT_DIR, 'model.pb', as_text=False)
          graph_io.write_graph(graph_def_freezed,OUTPUT_DIR, 'model_frozen.pb',
                               as_text=False)
-      
+
          # Write to tensorboard
          with tf.compat.v1.summary.FileWriter(logdir=OUTPUT_DIR, graph_def=graph_def_freezed) as writer:
             writer.flush()

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-yolo.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensorflow-yolo.rst
@@ -5,14 +5,14 @@ Converting TensorFlow YOLO Models
 
 
 .. meta::
-   :description: Learn how to convert YOLO models from 
+   :description: Learn how to convert YOLO models from
                  TensorFlow to the OpenVINO Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
 
 This document explains how to convert real-time object detection YOLOv1, YOLOv2, YOLOv3 and YOLOv4 public models to the Intermediate Representation (IR). All YOLO models are originally implemented in the DarkNet framework and consist of two files:
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensroflow-wide-and-deep-family.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-conversion-tutorials/convert-tensroflow-wide-and-deep-family.rst
@@ -5,7 +5,7 @@ Converting TensorFlow Wide and Deep Family Models
 
 
 .. meta::
-   :description: Learn how to convert Wide and Deep Family 
+   :description: Learn how to convert Wide and Deep Family
                  models from TensorFlow to the OpenVINO Intermediate Representation.
 
 
@@ -13,8 +13,8 @@ Converting TensorFlow Wide and Deep Family Models
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python ../../../../../../learn-openvino/interactive-tutorials-python <../../../../../../learn-openvino/interactive-tutorials-python>`.
-   
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Python tutorials <../../../../../../learn-openvino/interactive-tutorials-python>`.
+
 The Wide and Deep models is a combination of wide and deep parts for memorization and generalization of object features respectively.
 These models can contain different types of object features such as numerical, categorical, sparse and sequential features. These feature types are specified
 through Tensorflow tf.feature_column API. Table below presents what feature types are supported by the OpenVINO toolkit.

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-convert-paddle.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-convert-paddle.rst
@@ -5,8 +5,8 @@
 
 
 .. meta::
-   :description: Learn how to convert a model from the 
-                 PaddlePaddle format to the OpenVINO Intermediate Representation. 
+   :description: Learn how to convert a model from the
+                 PaddlePaddle format to the OpenVINO Intermediate Representation.
 
 
 .. danger::
@@ -23,7 +23,7 @@ This page provides general instructions on how to convert a model from a PaddleP
 Converting PaddlePaddle Model Inference Format
 ##############################################
 
-PaddlePaddle inference model includes ``.pdmodel`` (storing model structure) and ``.pdiparams`` (storing model weight). For how to export PaddlePaddle inference model, please refer to the `Exporting PaddlePaddle Inference Model <https://www.paddlepaddle.org.cn/../../../../../documentation/docs/zh/develop/guides/beginner/model_save_load_cn.html>`__ Chinese guide.
+PaddlePaddle inference model includes ``.pdmodel`` (storing model structure) and ``.pdiparams`` (storing model weight). For how to export PaddlePaddle inference model, please refer to the `Exporting PaddlePaddle Inference Model <https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/beginner/model_save_load_cn.html>`__ Chinese guide.
 
 
 To convert a PaddlePaddle model, use the ``mo`` script and specify the path to the input ``.pdmodel`` model file:

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-convert-tensorflow.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-convert-tensorflow.rst
@@ -4,14 +4,14 @@
 ============================================
 
 .. meta::
-   :description: Learn how to convert a model from a 
+   :description: Learn how to convert a model from a
                  TensorFlow format to the OpenVINO Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Converting a TensorFlow Model <../../../../../openvino-workflow/model-preparation/convert-model-tensorflow>` article. 
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Converting a TensorFlow Model <../../../../../openvino-workflow/model-preparation/convert-model-tensorflow>` article.
 
 
 .. note:: TensorFlow models are supported via FrontEnd API. You may skip conversion to IR and read models directly by OpenVINO runtime API. Refer to the :doc:`inference example <../../../../../openvino-workflow/running-inference/integrate-openvino-with-your-application>` for more details. Using ``convert_model`` is still necessary in more complex cases, such as new custom inputs/outputs in model pruning, adding pre-processing, or using Python conversion extensions.
@@ -125,7 +125,7 @@ TensorFlow 2 SavedModel format has a specific graph structure due to eager execu
 pruning, find custom input nodes in the ``StatefulPartitionedCall/*`` subgraph.
 
 Since the 2023.0 release, direct pruning of models in SavedModel format is not supported.
-It is essential to freeze the model before pruning. Use the following code snippet for model freezing: 
+It is essential to freeze the model before pruning. Use the following code snippet for model freezing:
 
 .. code-block:: py
    :force:
@@ -331,7 +331,7 @@ In this document, you learned:
 Additional Resources
 ####################
 
-See the :doc:`Model Conversion Tutorials <[legacy]-conversion-tutorials>` page for a set of ../../../../../learn-openvino/interactive-tutorials-python providing step-by-step instructions for converting specific TensorFlow models. Here are some examples:
+See the :doc:`Model Conversion Tutorials <[legacy]-conversion-tutorials>` page for a set of tutorials providing step-by-step instructions for converting specific TensorFlow models. Here are some examples:
 
 * :doc:`Convert TensorFlow EfficientDet Models <[legacy]-conversion-tutorials/convert-tensorflow-efficient-det>`
 * :doc:`Convert TensorFlow FaceNet Models <[legacy]-conversion-tutorials/convert-tensorflow-face-net>`

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-model-optimizer-extensibility/[legacy]-extending-model-optimizer-with-caffe-python-layers.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-model-optimizer-extensibility/[legacy]-extending-model-optimizer-with-caffe-python-layers.rst
@@ -4,17 +4,17 @@
 ============================================================
 
 .. meta::
-  :description: Learn how to extract operator attributes in Model Optimizer to 
+  :description: Learn how to extract operator attributes in Model Optimizer to
                 support a custom Caffe operation written only in Python.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated TensorFlow conversion method. The guide on the new and recommended method, using a new frontend, can be found in the  :doc:`Frontend Extensions <../../../openvino-extensibility/frontend-extensions>` article. 
+   This guide describes a deprecated TensorFlow conversion method. The guide on the new and recommended method, using a new frontend, can be found in the  :doc:`Frontend Extensions <../../../openvino-extensibility/frontend-extensions>` article.
 
 This article provides instructions on how to support a custom Caffe operation written only in Python. For example, the
-`Faster-R-CNN model <https://dl.dropboxusercontent.com/s/o6ii098bu51d139/faster_rcnn_models.tgz?dl=0>`__ implemented in
+`Faster-R-CNN model <https://dl.opencv.org/models/faster_rcnn_models.tgz>`__ implemented in
 Caffe contains a custom proposal layer written in Python. The layer is described in the
 `Faster-R-CNN prototxt <https://raw.githubusercontent.com/rbgirshick/py-faster-rcnn/master/models/pascal_voc/VGG16/faster_rcnn_end2end/test.prototxt>`__ in the following way:
 
@@ -62,19 +62,19 @@ page. For a detailed explanation of the extractor, refer to the source code belo
 
    from openvino.tools.mo.ops.proposal import ProposalOp
    from openvino.tools.mo.front.extractor import CaffePythonFrontExtractorOp
-   
-   
+
+
    class ProposalPythonFrontExtractor(CaffePythonFrontExtractorOp):
        op = 'rpn.proposal_layer.ProposalLayer'  # module + "." + layer
        enabled = True  # extractor is enabled
-   
+
        @staticmethod
        def extract_proposal_params(node, defaults):
            param = node.pb.python_param  # get the protobuf message representation of the layer attributes
            # parse attributes from the layer protobuf message to a Python dictionary
            attrs = CaffePythonFrontExtractorOp.parse_param_str(param.param_str)
            update_attrs = defaults
-   
+
            # the operation expects ratio and scale values to be called "ratio" and "scale" while Caffe uses different names
            if 'ratios' in attrs:
                attrs['ratio'] = attrs['ratios']
@@ -82,10 +82,10 @@ page. For a detailed explanation of the extractor, refer to the source code belo
            if 'scales' in attrs:
                attrs['scale'] = attrs['scales']
                del attrs['scales']
-   
+
            update_attrs.update(attrs)
            ProposalOp.update_node_stat(node, update_attrs)  # update the node attributes
-   
+
        @classmethod
        def extract(cls, node):
            # define default values for the Proposal layer attributes


### PR DESCRIPTION
Fixing issues with references to articles and external resources in the `Legacy Features` section of the docs.
