### PR TITLE
[WIP] Fix the hetero synthetic test with multi add ops model

### DIFF
--- a/src/plugins/hetero/src/compiled_model.cpp
+++ b/src/plugins/hetero/src/compiled_model.cpp
@@ -10,6 +10,7 @@
 #include "graph_debug_dump.hpp"
 #include "itt.hpp"
 #include "op/device_subgraph.hpp"
+#include "openvino/op/ops.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
@@ -53,8 +54,23 @@ void ov::hetero::CompiledModel::compile_model(const std::shared_ptr<ov::Model>& 
         auto it_info = node_info.find("affinity");
         if (it_info != node_info.end()) {
             OPENVINO_ASSERT(it_info->second.is<std::string>(), "Unexpected type of \"affinity\" attribute");
-            query_model_result.emplace(node->get_friendly_name(), it_info->second.as<std::string>());
+            auto node_affinity = it_info->second.as<std::string>();
+            query_model_result.emplace(node->get_friendly_name(), node_affinity);
             user_set_affinities = true;
+            if (ov::op::util::is_parameter(node)) {
+                for (const auto& output : node->outputs()) {
+                    for (auto out_inputs : output.get_target_inputs()) {
+                        auto node_info = out_inputs.get_node()->get_rt_info();
+                        auto it_info = node_info.find("affinity");
+                        if (it_info->second.as<std::string>() != node_affinity) {
+                            auto convert = std::make_shared<ov::op::v0::Convert>(output, out_inputs.get_element_type());
+                            ov::copy_runtime_info(node, convert);
+                            out_inputs.replace_source_output(convert);
+                            query_model_result.emplace(convert->get_friendly_name(), node_affinity);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/hetero_synthetic.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/hetero_synthetic.cpp
@@ -6,12 +6,13 @@
 
 #include <random>
 
-#include "common_test_utils/subgraph_builders/split_conv_concat.hpp"
-#include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"
+#include "common_test_utils/file_utils.hpp"
+#include "common_test_utils/ov_plugin_cache.hpp"
+#include "common_test_utils/subgraph_builders/multi_add.hpp"
 #include "common_test_utils/subgraph_builders/nested_branch_conv_concat.hpp"
 #include "common_test_utils/subgraph_builders/nested_split_conv_concat.hpp"
-#include "common_test_utils/ov_plugin_cache.hpp"
-#include "common_test_utils/file_utils.hpp"
+#include "common_test_utils/subgraph_builders/split_conv_concat.hpp"
+#include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"
 #include "openvino/op/util/op_types.hpp"
 
 namespace ov {
@@ -19,6 +20,7 @@ namespace test {
 namespace behavior {
 
 static std::vector<std::function<std::shared_ptr<ov::Model>()>> builders = {
+    [] {return ov::test::utils::make_multi_add();},
     [] {return ov::test::utils::make_split_multi_conv_concat();},
     [] {return ov::test::utils::make_nested_split_conv_concat();},
     [] {return ov::test::utils::make_cplit_conv_concat_nested_in_branch();},

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/subgraph_builders/multi_add.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/subgraph_builders/multi_add.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "openvino/core/model.hpp"
+
+namespace ov {
+namespace test {
+namespace utils {
+std::shared_ptr<ov::Model> make_multi_add(ov::Shape input_shape = {1, 4, 20, 20},
+                                          ov::element::Type type = ov::element::f32);
+}  // namespace utils
+}  // namespace test
+}  // namespace ov

--- a/src/tests/test_utils/common_test_utils/src/subgraph_builders/multi_add.cpp
+++ b/src/tests/test_utils/common_test_utils/src/subgraph_builders/multi_add.cpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/include/common_test_utils/subgraph_builders/multi_add.hpp"
+
+#include "openvino/op/ops.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+
+namespace ov {
+namespace test {
+namespace utils {
+std::shared_ptr<ov::Model> make_multi_add(ov::Shape input_shape, ov::element::Type type) {
+    auto param = std::make_shared<ov::op::v0::Parameter>(type, input_shape);
+    param->set_friendly_name("input");
+
+    auto const_value1 = ov::op::v0::Constant::create(type, input_shape, {1});
+    const_value1->set_friendly_name("const_value1");
+    auto add1 = std::make_shared<ov::op::v1::Add>(param, const_value1);
+    add1->set_friendly_name("add1");
+
+    auto const_value2 = ov::op::v0::Constant::create(type, input_shape, {1});
+    const_value2->set_friendly_name("const_value2");
+    auto add2 = std::make_shared<ov::op::v1::Add>(param, const_value2);
+    add2->set_friendly_name("add2");
+
+    auto add3 = std::make_shared<ov::op::v1::Add>(add1, add2);
+    add3->set_friendly_name("add3");
+
+    auto const_value4 = ov::op::v0::Constant::create(type, input_shape, {1});
+    const_value4->set_friendly_name("const_value4");
+    auto add4 = std::make_shared<ov::op::v1::Add>(add3, const_value4);
+    add4->set_friendly_name("add4");
+
+    auto const_value5 = ov::op::v0::Constant::create(type, input_shape, {1});
+    const_value5->set_friendly_name("const_value5");
+    auto add5 = std::make_shared<ov::op::v1::Add>(add3, const_value5);
+    add5->set_friendly_name("add5");
+
+    auto add6 = std::make_shared<ov::op::v1::Add>(add4, add5);
+    add6->set_friendly_name("add6");
+
+    auto result = std::make_shared<ov::op::v0::Result>(add6);
+    result->set_friendly_name("res");
+
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param});
+    model->set_friendly_name("Multiadd");
+    return model;
+}
+}  // namespace utils
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - When user set ops affinity with HETERO plugin by user,  the result is inconsistent with the expected result if the parameter has different affinity with it's output nodes, like this:

![image](https://github.com/openvinotoolkit/openvino/assets/31067432/ba58f21e-adef-4ca5-ae90-4fc2345a9b44)

Because hetero will insert a result(copy from input) after input when split model, and will share the tensor `a` to the input of other sub-model, so if user use `set input tensor` `b`, it will change the tensor of input and result to `b`, but other sub-model will get the wrong result from `a`.
so we add a convert op after parameter to avoid this.
![image](https://github.com/openvinotoolkit/openvino/assets/31067432/90d2e059-075d-46f3-8743-059216a2404d)


