### PR TITLE
[CPU] Fix segfault in `dump_graph_as_ie_ngraph_net()`

### DIFF
--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -191,7 +191,7 @@ std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph &graph) {
         node2layer[node] = nodes.back();
     }
 
-    auto holder = results[0];
+    auto holder = !results.empty() ? results[0] : std::make_shared<ov::op::v0::Result>();
     for (auto &node : to_hold) {
         holder->add_control_dependency(node);
     }


### PR DESCRIPTION
### Details:
 - OV Model API allows to create `ov::Model` with empty ResultVector. And it may cause segmentation fault on `graph.dump()` e.g. when `get_property("NETWORK_NAME")`

### Tickets:
 - [CVS-134517](https://jira.devtools.intel.com/browse/CVS-134517)
