### PR TITLE
Removed usage of matrix param in TF models tests job.

### DIFF
--- a/.github/workflows/job_tensorflow_models_tests.yml
+++ b/.github/workflows/job_tensorflow_models_tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   TensorFlow_Models_Tests:
     name: TensorFlow Models tests
-    timeout-minutes: ${{ inputs.model_scope != 'precommit' && 600 || 25 }}
+    timeout-minutes: ${{ inputs.model_scope != 'precommit' && 400 || 25 }}
     runs-on: ${{ inputs.runner }}
     container: ${{ fromJSON(inputs.container) }}
     defaults:

--- a/.github/workflows/job_tensorflow_models_tests.yml
+++ b/.github/workflows/job_tensorflow_models_tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   TensorFlow_Models_Tests:
     name: TensorFlow Models tests
-    timeout-minutes: ${{ inputs.model_scope != 'precommit' && 400 || 25 }}
+    timeout-minutes: ${{ inputs.model_scope != 'precommit' && 600 || 25 }}
     runs-on: ${{ inputs.runner }}
     container: ${{ fromJSON(inputs.container) }}
     defaults:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -511,18 +511,23 @@ jobs:
       runner: 'ubuntu-20.04-8-cores'
       model_scope: 'precommit'
 
-  TensorFlow_Models_Tests_Nightly:
+  TensorFlow_Models_Tests_Nightly_TF_HUB:
     name: TensorFlow Models tests
   #  if: ${{ github.event_name == 'schedule' }}
     needs: [ Build, Smart_CI, Openvino_tokenizers ]
-    strategy:
-      max-parallel: 2
-      matrix:
-        MODEL_SCOPE: ['nightly_hf', 'nightly_tf_hub']
     uses: ./.github/workflows/job_tensorflow_models_tests.yml
     with:
       runner: 'ubuntu-20.04-16-cores'
-      model_scope: ${{ matrix.MODEL_SCOPE }}
+      model_scope: 'nightly_tf_hub'
+
+  TensorFlow_Models_Tests_Nightly_HF:
+    name: TensorFlow Models tests
+  #  if: ${{ github.event_name == 'schedule' }}
+    needs: [ Build, Smart_CI, Openvino_tokenizers ]
+    uses: ./.github/workflows/job_tensorflow_models_tests.yml
+    with:
+      runner: 'ubuntu-20.04-16-cores'
+      model_scope: 'nightly_hf'
 
   # TODO: Switch back to self-hosted runners
   # container:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -513,7 +513,7 @@ jobs:
 
   TensorFlow_Models_Tests_Nightly:
     name: TensorFlow Models tests
-    if: ${{ github.event_name == 'schedule' }}
+  #  if: ${{ github.event_name == 'schedule' }}
     needs: [ Build, Smart_CI, Openvino_tokenizers ]
     strategy:
       max-parallel: 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -512,8 +512,8 @@ jobs:
       model_scope: 'precommit'
 
   TensorFlow_Models_Tests_Nightly_TF_HUB:
-    name: TensorFlow Models tests
-  #  if: ${{ github.event_name == 'schedule' }}
+    name: TensorFlow TF Hub Models tests
+    if: ${{ github.event_name == 'schedule' }}
     needs: [ Build, Smart_CI, Openvino_tokenizers ]
     uses: ./.github/workflows/job_tensorflow_models_tests.yml
     with:
@@ -521,8 +521,8 @@ jobs:
       model_scope: 'nightly_tf_hub'
 
   TensorFlow_Models_Tests_Nightly_HF:
-    name: TensorFlow Models tests
-  #  if: ${{ github.event_name == 'schedule' }}
+    name: TensorFlow Hugging Face Models tests
+    if: ${{ github.event_name == 'schedule' }}
     needs: [ Build, Smart_CI, Openvino_tokenizers ]
     uses: ./.github/workflows/job_tensorflow_models_tests.yml
     with:


### PR DESCRIPTION
### Details:
 - Removed usage of matrix param in TF models tests job, as the timeout is shared between jobs launched by matrix, which causes nightly jobs abortion by timeout.

### Tickets:
 - 
