### PR TITLE
Fixed comparison method in TF Hugging Face tests for case when output structure is not the same as in FW

### DIFF
--- a/tests/model_hub_tests/tensorflow/model_lists/precommit
+++ b/tests/model_hub_tests/tensorflow/model_lists/precommit
@@ -32,3 +32,5 @@ facebook/convnext-tiny-224,hf_transformers
 google/vit-base-patch16-224,hf_transformers
 sentence-transformers/paraphrase-mpnet-base-v2,hf_transformers
 facebook/sam-vit-base,hf_transformers
+distilbert/distilgpt2,hf_transformers
+openai-community/gpt2,hf_transformers

--- a/tests/model_hub_tests/tensorflow/test_tf_convert_model.py
+++ b/tests/model_hub_tests/tensorflow/test_tf_convert_model.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 
+import numpy as np
 import pytest
 import tensorflow as tf
 import tensorflow.compat.v1 as tf_v1
@@ -16,12 +17,58 @@ import tensorflow_text  # do not delete, needed for text models
 
 from models_hub_common.constants import tf_hub_cache_dir, hf_cache_dir
 from models_hub_common.test_convert_model import TestConvertModel
+from models_hub_common.utils import compare_two_tensors
 from models_hub_common.utils import get_models_list
 from utils import type_map, load_graph, get_input_signature, get_output_signature
 
 
 def is_hf_link(link: str):
     return link.startswith("hf_")
+
+
+def get_output_signature_from_keras_layer(model):
+    try:
+        from openvino.frontend.tensorflow.utils import trace_tf_model_if_needed
+        traced_model = trace_tf_model_if_needed(model, None, None, None)
+        return traced_model.structured_outputs
+    except:
+        return None
+
+
+def tf_tensor_to_numpy(tensor):
+    if isinstance(tensor, tf.Tensor):
+        return tensor.numpy()
+    elif isinstance(tensor, (list, tuple)):
+        res = []
+        for elem in tensor:
+            res.append(tf_tensor_to_numpy(elem))
+        if isinstance(tensor, list):
+            return res
+        else:
+            return tuple(res)
+    elif isinstance(tensor, dict):
+        res = {}
+        for out_name, out_value in tensor.items():
+            res[out_name] = tf_tensor_to_numpy(out_value)
+        return res
+    raise Exception("Unknown output type of original FW inference result: {}".format(type(tensor)))
+
+
+def compare_by_signature(ov_out, ref, signature, fw_eps):
+    if isinstance(ref, np.ndarray):
+        assert isinstance(signature, tf.Tensor), "Accuracy comparison failed due to mismatch of obtained signature and FW outputs."
+        return compare_two_tensors(ov_out[signature.name], ref, fw_eps)
+    elif isinstance(ref, (list, tuple)):
+        res = True
+        for idx, elem in enumerate(ref):
+            res = res and compare_by_signature(ov_out, elem, signature[idx], fw_eps)
+        return res
+    elif isinstance(ref, dict):
+        res = True
+        for out_name, out_value in ref.items():
+            res = res and compare_by_signature(ov_out, out_value, signature[out_name], fw_eps)
+        return res
+    raise Exception("Unknown FW reference type: {}".format(type(ref)))
 
 
 class TestTFHubConvertModel(TestConvertModel):
@@ -63,6 +110,34 @@ class TestTFHubConvertModel(TestConvertModel):
         concrete_func._backref_to_saved_model = load
         return concrete_func
 
+    def compare_results(self, fw_outputs, ov_outputs):
+        fw_eps = 5e-2
+
+        # TF FE loses output structure in case when original model has output dictionary, where values are tuples.
+        # OV generates in this case a list of tensors with inner tensor names.
+        # Comparison of results in this case can be performed if output signature is known.
+        # TODO: When OV supports output dictionary of tuples need to remove usage of output signature here and update comparison method - Ticket TODO
+        if len(fw_outputs) != len(ov_outputs):
+            assert self.output_signature is not None, "The number of outputs between framework and OpenVINO is different and could not obtain output signature."
+            return compare_by_signature(ov_outputs, fw_outputs, self.output_signature, fw_eps)
+
+        is_ok = True
+        if isinstance(fw_outputs, dict):
+            for out_name in fw_outputs.keys():
+                cur_fw_res = fw_outputs[out_name]
+                assert out_name in ov_outputs, \
+                    "OpenVINO outputs does not contain tensor with name {}".format(out_name)
+                cur_ov_res = ov_outputs[out_name]
+                print(f"fw_re: {cur_fw_res};\n ov_res: {cur_ov_res}")
+                is_ok = is_ok and compare_two_tensors(cur_ov_res, cur_fw_res, fw_eps)
+        else:
+            for i in range(len(ov_outputs)):
+                cur_fw_res = fw_outputs[i]
+                cur_ov_res = ov_outputs[i]
+                print(f"fw_res: {cur_fw_res};\n ov_res: {cur_ov_res}")
+                is_ok = is_ok and compare_two_tensors(cur_ov_res, cur_fw_res, fw_eps)
+        assert is_ok, "Accuracy validation failed"
+
     def get_inputs_info(self, model_obj):
         if type(model_obj) is tf_v1.Graph:
             input_signature = get_input_signature(model_obj)
@@ -95,6 +170,7 @@ class TestTFHubConvertModel(TestConvertModel):
             assert input_info.dtype in type_map, "Unsupported input type: {}".format(input_info.dtype)
             inputs_info.append((input_name, input_shape, type_map[input_info.dtype]))
 
+        self.output_signature = get_output_signature_from_keras_layer(model_obj)
         return inputs_info
 
     def infer_fw_model(self, model_obj, inputs):
@@ -123,12 +199,7 @@ class TestTFHubConvertModel(TestConvertModel):
         tf_inputs = {}
         for input_name, input_value in inputs.items():
             tf_inputs[input_name] = tf.constant(input_value)
-
-        output_dict = {}
-        for out_name, out_value in model_obj(**tf_inputs).items():
-            output_dict[out_name] = out_value.numpy()
-
-        return output_dict
+        return tf_tensor_to_numpy(model_obj(**tf_inputs))
 
     def clean_dir(self, dir_name: str):
         if os.path.exists(dir_name):


### PR DESCRIPTION
### Details:
 - Tests for Hugging Face models fail when output structure has dictionary of tuples. For such case comparison method was changed to compare outputs using original model output signature, which has inner tensor names that can be matched with OV output.

### Tickets:
 - 134405
