### PR TITLE
[PyOV] convert  ExecutionMode enum to any

### DIFF
--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -373,6 +373,8 @@ ov::Any py_object_to_any(const py::object& py_obj) {
         return py::cast<ov::intel_auto::SchedulePolicy>(py_obj);
     } else if (py::isinstance<ov::hint::SchedulingCoreType>(py_obj)) {
         return py::cast<ov::hint::SchedulingCoreType>(py_obj);
+    } else if (py::isinstance<ov::hint::ExecutionMode>(py_obj)) {
+        return py::cast<ov::hint::ExecutionMode>(py_obj);
     } else if (py::isinstance<ov::log::Level>(py_obj)) {
         return py::cast<ov::log::Level>(py_obj);
     } else if (py::isinstance<ov::device::Type>(py_obj)) {

--- a/src/bindings/python/tests/test_runtime/test_core.py
+++ b/src/bindings/python/tests/test_runtime/test_core.py
@@ -113,6 +113,7 @@ def get_model_path(request, tmp_path):
 @pytest.mark.parametrize("config", [
     None,
     {hints.performance_mode(): hints.PerformanceMode.THROUGHPUT},
+    {hints.execution_mode: hints.ExecutionMode.PERFORMANCE},
 ])
 def test_compact_api(model_type, device_name, config, request):
     compiled_model = None


### PR DESCRIPTION
### Details:
 - ExecutionMode enum binding was missed to be added to `py_object_to_any` function that caused  segfault

### Tickets:
 - CVS-134484
