### PR TITLE
[GPU] Fix CreateStridedSliceOp()  not to use fixed Rank 4 reshape for new_shape_infer case

### DIFF
--- a/src/plugins/intel_gpu/src/graph/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/condition.cpp
@@ -263,7 +263,8 @@ void condition_inst::postprocess_output_memory(network::ptr executed_net, cldnn:
         }
 
         _outputs[out_mem_idx] = mem_ptr;
-        GPU_DEBUG_LOG << "Inner net - Outputs[" << out_mem_idx << "]" << mem_ptr->get_layout().to_short_string() << std::endl;
+        if (mem_ptr)
+            GPU_DEBUG_LOG << "Inner net - Outputs[" << out_mem_idx << "]" << mem_ptr->get_layout().to_short_string() << std::endl;
     }
 }
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
@@ -53,7 +53,7 @@ static void CreateStridedSliceOp(ProgramBuilder& p, const std::shared_ptr<ov::op
     std::vector<int64_t> strides = stride_constant ? stride_constant->cast_vector<int64_t>() : std::vector<int64_t>{};
 
     do {
-        if (!begin_constant || !end_constant || !stride_constant || input_pshape.is_dynamic()) {
+        if (!begin_constant || !end_constant || !stride_constant || input_pshape.is_dynamic() || p.use_new_shape_infer()) {
             break;
         }
 
@@ -265,7 +265,7 @@ static void CreateStridedSliceOp(ProgramBuilder& p, const std::shared_ptr<ov::op
     auto output_shape = output_pshape.is_static() ? output_pshape.to_shape() : ov::Shape{};
 
     std::shared_ptr<cldnn::strided_slice> stridedSlicePrim = nullptr;
-    if (begin_constant && end_constant && stride_constant && !input_pshape.is_dynamic() && !output_pshape.is_dynamic()) {
+    if (begin_constant && end_constant && stride_constant && !input_pshape.is_dynamic() && !output_pshape.is_dynamic() && !p.use_new_shape_infer()) {
         stridedSlicePrim = std::make_shared<cldnn::strided_slice>(layerName,
                                                                   inputs[0],
                                                                   begin,


### PR DESCRIPTION
### Details:
 - Fix CreateStridedSliceOp()  not to use fixed Rank 4 reshape for new_shape_infer case
 - Add a func test case
 - Fix debug log in condition

### Tickets:
 - 130775
