### PR TITLE
[GPU] Skip broadcast when input and output shapes are identical

### DIFF
--- a/src/plugins/intel_gpu/src/graph/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/broadcast.cpp
@@ -126,6 +126,25 @@ std::string broadcast_inst::to_string(broadcast_node const& node) {
     return primitive_description.str();
 }
 
+void broadcast_inst::on_execute() {
+    update_output_memory();
+}
+
+void broadcast_inst::update_output_memory() {
+    if (!can_be_optimized())
+        return;
+    if (static_cast<bool>(_outputs[0]) && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
+        return;
+
+    if (_node != nullptr)
+        build_deps();
+
+    GPU_DEBUG_TRACE_DETAIL << id() << " : update_output_memory with mem of input " << get_node().get_dependency(0).id()
+                           << " : " << input_memory_ptr()->buffer_ptr() << std::endl;
+    _outputs[0] = input_memory_ptr();
+    _mem_allocated = false;
+}
+
 broadcast_inst::typed_primitive_inst(network& network, broadcast_node const& node) : parent(network, node) {
     auto input_layout = node.get_input_layout();
     if (input_layout.is_dynamic())

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -21,6 +21,7 @@
 #include "gather_inst.h"
 #include "permute_inst.h"
 #include "strided_slice_inst.h"
+#include "broadcast_inst.h"
 
 #include <vector>
 #include <list>
@@ -88,7 +89,8 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
             !((impl_param.is_type<concatenation>() ||
                impl_param.is_type<gather>() ||
                impl_param.is_type<permute>() ||
-               impl_param.is_type<strided_slice>()) && impl_param.is_dynamic())) {
+               impl_param.is_type<strided_slice>() ||
+               impl_param.is_type<broadcast>()) && impl_param.is_dynamic())) {
             return make_unique<ImplType>(kernel_selector::kernel_data{});
         }
         auto kernel_params = ImplType::get_kernel_params(ImplType::static_canonicalize_shapes(impl_param));

--- a/src/plugins/intel_gpu/src/graph/include/broadcast_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/broadcast_inst.h
@@ -39,6 +39,10 @@ public:
     static layout calc_output_layout(broadcast_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(broadcast_node const& node);
     typed_primitive_inst(network& network, broadcast_node const& node);
+    void update_output_memory() override;
+
+private:
+    void on_execute() override;
 };
 
 using broadcast_inst = typed_primitive_inst<broadcast>;

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -235,6 +235,7 @@ public:
     void do_runtime_skip_gather();
     void do_runtime_skip_permute();
     void do_runtime_skip_strided_slice();
+    void do_runtime_skip_broadcast();
     void do_runtime_in_place_concat();
     void do_runtime_in_place_kv_cache();
     void configure_shape_of_dependencies();

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -29,6 +29,7 @@
 #include "kv_cache_inst.h"
 #include "condition_inst.h"
 #include "gather_inst.h"
+#include "broadcast_inst.h"
 #include "experimental_detectron_roi_feature_extractor_inst.hpp"
 #include "implementation_map.hpp"
 #include "graph_optimizer/prepare_buffer_fusing.h"
@@ -538,7 +539,8 @@ event::ptr primitive_inst::realloc_if_needed() {
     }
 
     // Clear out memory if if was previously reused, but now primitive can't be optimized
-    if (_node->is_type<gather>() || _node->is_type<permute>() || _node->is_type<reshape>() || _node->is_type<reorder>() || _node->is_type<strided_slice>()) {
+    if (_node->is_type<gather>() || _node->is_type<permute>() || _node->is_type<reshape>() || _node->is_type<reorder>() ||
+        _node->is_type<strided_slice>() || _node->is_type<broadcast>()) {
         if (can_be_optimized()) {
             _max_output_layout_count = _deps[0].first->_max_output_layout_count;
             GPU_DEBUG_PROFILED_STAGE_MEMALLOC_INFO("can_be_optimized");
@@ -1156,6 +1158,30 @@ void primitive_inst::do_runtime_skip_strided_slice() {
     set_can_be_optimized(true);
 }
 
+void primitive_inst::do_runtime_skip_broadcast() {
+    OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, openvino::itt::handle("do_runtime_skip_broadcast: " + id()));
+    // Check pattern
+    if (!get_node().is_type<broadcast>() || !get_node().can_be_optimized())
+        return;
+
+    GPU_DEBUG_TRACE_DETAIL << "[do_runtime_skip_broadcast] " << id() << " : check optimizability" << std::endl;
+    auto input_layout = _impl_params->get_input_layout(0);
+    auto output_layout = _impl_params->get_output_layout();
+
+    // Check runtime shape (need to reset can_be_optimized)
+    if (input_layout != output_layout) {
+        set_can_be_optimized(false);
+        GPU_DEBUG_TRACE_DETAIL << "--- Cannot optimize because input layout(" << input_layout.to_short_string()
+                               << ") != output layout(" << output_layout.to_short_string() << ")" << std::endl;
+        return;
+    }
+
+    GPU_DEBUG_TRACE_DETAIL << "[do_runtime_skip_broadcast] " << id() << " : can_be_optimized" << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << "            - Input layout : " << _impl_params->get_input_layout(0).to_short_string() << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << "            - Output layout : " << _impl_params->get_output_layout().to_short_string() << std::endl;
+    set_can_be_optimized(true);
+}
+
 void primitive_inst::do_runtime_in_place_concat() {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, openvino::itt::handle("do_runtime_in_place_concat: " + id()));
     GPU_DEBUG_GET_INSTANCE(debug_config);
@@ -1280,6 +1306,7 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
         do_runtime_in_place_kv_cache();
         do_runtime_skip_permute();
         do_runtime_skip_strided_slice();
+        do_runtime_skip_broadcast();
 
         if (!is_valid_fusion()) {
             OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, openvino::itt::handle("unfused_subgraph_exec: " + id()));


### PR DESCRIPTION
### Details:
 - This PR makes some `Broadcast` layers to be skipped if input and output shapes are same.

### Tickets:
 - 135100