### PR TITLE
[ONNX] Extended BatchNorm to support opsets 1-6-7-9-14-15

### DIFF
--- a/src/frontends/onnx/frontend/src/op/batch_norm.cpp
+++ b/src/frontends/onnx/frontend/src/op/batch_norm.cpp
@@ -52,42 +52,12 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
     OPENVINO_THROW("Cannot create OpenVINO batch norm with unsupported number of inputs");
 }
 }  // namespace set_1
-
-namespace set_6 {
-// This version supports ONNX BatchNormalization-1 and BatchNormalization-6
-ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
-    ov::OutputVector inputs{node.get_ov_inputs()};
-    auto x = inputs.at(0);
-    auto scale = inputs.at(1);
-    auto bias = inputs.at(2);
-    ov::Output<ov::Node> mean;
-    ov::Output<ov::Node> var;
-
-    double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
-
-    // Currently only BatchNormalization inference mode is supported by OpenVINO
-    std::int64_t is_test{node.get_attribute_value<std::int64_t>("is_test", 1)};
-    CHECK_VALID_NODE(node, is_test, "only 'is_test' mode is supported.");
-
-    // optional outputs
-    auto after_bn_mean = std::make_shared<NullNode>();
-    auto after_bn_var = std::make_shared<NullNode>();
-    auto saved_mean = std::make_shared<NullNode>();
-    auto saved_var = std::make_shared<NullNode>();
-
-    if (inputs.size() >= 5) {
-        mean = inputs.at(3);
-        var = inputs.at(4);
-        return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon),
-                after_bn_mean,
-                after_bn_var,
-                saved_mean,
-                saved_var};
-    }
-
-    OPENVINO_THROW("Cannot create OpenVINO batch norm with unsupported number of inputs");
-}
-}  // namespace set_6
+/*
+     Opset 6 is skipped because there are no significant difference between opset1 and opset6.
+     Found difference is:
+     1. In Training, the computation of ReduceMean and ReduceVar uses float
+        to avoid overflow for float16 inputs.
+ */
 
 namespace set_7 {
 // This version supports ONNX BatchNormalization-7 and BatchNormalization-9
@@ -108,28 +78,17 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
     return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
 }
 }  // namespace set_7
+/*
+    Opset 9 is skipped because there are no significant difference between opset7 and opset9.
+    Found difference is:
+    1. removed -> spatial : int (default is 1)
+    If true, compute the mean and variance across per activation. If false, compute the mean and variance across
+    per feature over each mini-batch.
 
-namespace set_9 {
-// This version supports ONNX BatchNormalization-7 and BatchNormalization-9
-ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
-    ov::OutputVector inputs{node.get_ov_inputs()};
-    auto x = inputs.at(0);
-    auto scale = inputs.at(1);
-    auto bias = inputs.at(2);
-    auto mean = inputs.at(3);
-    auto var = inputs.at(4);
-
-    double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
-    // Attribute "spatial" is ignored, as we only support inference mode of
-    // BatchNormalization
-
-    CHECK_VALID_NODE(node, node.get_outputs_size() == 1, "Training mode of BatchNormalization is not supported.");
-
-    return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
-}
-}  // namespace set_9
+ */
 
 namespace set_14 {
+// This version supports ONNX BatchNormalization-14 BatchNormalization-15
 ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
     ov::OutputVector inputs{node.get_ov_inputs()};
     auto x = inputs.at(0);
@@ -147,25 +106,12 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
     return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
 }
 }  // namespace set_14
-
-namespace set_15 {
-ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
-    ov::OutputVector inputs{node.get_ov_inputs()};
-    auto x = inputs.at(0);
-    auto scale = inputs.at(1);
-    auto bias = inputs.at(2);
-    auto mean = inputs.at(3);
-    auto var = inputs.at(4);
-
-    double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
-    int64_t training_mode{node.get_attribute_value<int64_t>("training_mode", 0)};
-
-    CHECK_VALID_NODE(node,
-                     training_mode == false && node.get_outputs_size() == 1,
-                     "Training mode of BatchNormalization is not supported.");
-    return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
-}
-}  // namespace set_15
+/*
+     Opset 15 is skipped because there are no significant difference between opset14 and opset15.
+     Found difference is:
+     1. In Training, the computation of ReduceMean and ReduceVar uses float
+        to avoid overflow for float16 inputs.
+ */
 
 }  // namespace op
 }  // namespace onnx

--- a/src/frontends/onnx/frontend/src/op/batch_norm.cpp
+++ b/src/frontends/onnx/frontend/src/op/batch_norm.cpp
@@ -53,6 +53,42 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
 }
 }  // namespace set_1
 
+namespace set_6 {
+// This version supports ONNX BatchNormalization-1 and BatchNormalization-6
+ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
+    ov::OutputVector inputs{node.get_ov_inputs()};
+    auto x = inputs.at(0);
+    auto scale = inputs.at(1);
+    auto bias = inputs.at(2);
+    ov::Output<ov::Node> mean;
+    ov::Output<ov::Node> var;
+
+    double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
+
+    // Currently only BatchNormalization inference mode is supported by OpenVINO
+    std::int64_t is_test{node.get_attribute_value<std::int64_t>("is_test", 1)};
+    CHECK_VALID_NODE(node, is_test, "only 'is_test' mode is supported.");
+
+    // optional outputs
+    auto after_bn_mean = std::make_shared<NullNode>();
+    auto after_bn_var = std::make_shared<NullNode>();
+    auto saved_mean = std::make_shared<NullNode>();
+    auto saved_var = std::make_shared<NullNode>();
+
+    if (inputs.size() >= 5) {
+        mean = inputs.at(3);
+        var = inputs.at(4);
+        return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon),
+                after_bn_mean,
+                after_bn_var,
+                saved_mean,
+                saved_var};
+    }
+
+    OPENVINO_THROW("Cannot create OpenVINO batch norm with unsupported number of inputs");
+}
+}  // namespace set_6
+
 namespace set_7 {
 // This version supports ONNX BatchNormalization-7 and BatchNormalization-9
 ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
@@ -73,6 +109,43 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
 }
 
 }  // namespace set_7
+namespace set_9 {
+// This version supports ONNX BatchNormalization-7 and BatchNormalization-9
+ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
+    ov::OutputVector inputs{node.get_ov_inputs()};
+    auto x = inputs.at(0);
+    auto scale = inputs.at(1);
+    auto bias = inputs.at(2);
+    auto mean = inputs.at(3);
+    auto var = inputs.at(4);
+
+    double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
+    // Attribute "spatial" is ignored, as we only support inference mode of
+    // BatchNormalization
+
+    CHECK_VALID_NODE(node, node.get_outputs_size() == 1, "Training mode of BatchNormalization is not supported.");
+
+    return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
+}
+
+}  // namespace set_9
+namespace set_14 {
+ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
+    ov::OutputVector inputs{node.get_ov_inputs()};
+    auto x = inputs.at(0);
+    auto scale = inputs.at(1);
+    auto bias = inputs.at(2);
+    auto mean = inputs.at(3);
+    auto var = inputs.at(4);
+
+    double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
+
+    CHECK_VALID_NODE(node,
+                     node.get_outputs_size() == 1,
+                     "Inference set in flag training_mode, but expected more than a single output");
+    return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
+}  // namespace set_14
+namespace set_15 {}  // namespace set_15
 }  // namespace op
 }  // namespace onnx
 }  // namespace frontend

--- a/src/frontends/onnx/frontend/src/op/batch_norm.cpp
+++ b/src/frontends/onnx/frontend/src/op/batch_norm.cpp
@@ -107,8 +107,8 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
 
     return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
 }
-
 }  // namespace set_7
+
 namespace set_9 {
 // This version supports ONNX BatchNormalization-7 and BatchNormalization-9
 ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
@@ -127,8 +127,8 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
 
     return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
 }
-
 }  // namespace set_9
+
 namespace set_14 {
 ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
     ov::OutputVector inputs{node.get_ov_inputs()};
@@ -139,13 +139,34 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
     auto var = inputs.at(4);
 
     double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
+    int training_mode{node.get_attribute_value<int>("training_mode", 0)};
 
     CHECK_VALID_NODE(node,
-                     node.get_outputs_size() == 1,
-                     "Inference set in flag training_mode, but expected more than a single output");
+                     training_mode == false && node.get_outputs_size() == 1,
+                     "Training mode of BatchNormalization is not supported.");
     return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
+}
 }  // namespace set_14
-namespace set_15 {}  // namespace set_15
+
+namespace set_15 {
+ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
+    ov::OutputVector inputs{node.get_ov_inputs()};
+    auto x = inputs.at(0);
+    auto scale = inputs.at(1);
+    auto bias = inputs.at(2);
+    auto mean = inputs.at(3);
+    auto var = inputs.at(4);
+
+    double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
+    int training_mode{node.get_attribute_value<int>("training_mode", 0)};
+
+    CHECK_VALID_NODE(node,
+                     training_mode == false && node.get_outputs_size() == 1,
+                     "Training mode of BatchNormalization is not supported.");
+    return {std::make_shared<v5::BatchNormInference>(x, scale, bias, mean, var, epsilon)};
+}
+}  // namespace set_15
+
 }  // namespace op
 }  // namespace onnx
 }  // namespace frontend

--- a/src/frontends/onnx/frontend/src/op/batch_norm.cpp
+++ b/src/frontends/onnx/frontend/src/op/batch_norm.cpp
@@ -139,7 +139,7 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
     auto var = inputs.at(4);
 
     double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
-    int training_mode{node.get_attribute_value<int>("training_mode", 0)};
+    int64_t training_mode{node.get_attribute_value<int64_t>("training_mode", 0)};
 
     CHECK_VALID_NODE(node,
                      training_mode == false && node.get_outputs_size() == 1,
@@ -158,7 +158,7 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node) {
     auto var = inputs.at(4);
 
     double epsilon{node.get_attribute_value<double>("epsilon", 1e-5)};
-    int training_mode{node.get_attribute_value<int>("training_mode", 0)};
+    int64_t training_mode{node.get_attribute_value<int64_t>("training_mode", 0)};
 
     CHECK_VALID_NODE(node,
                      training_mode == false && node.get_outputs_size() == 1,

--- a/src/frontends/onnx/frontend/src/op/batch_norm.hpp
+++ b/src/frontends/onnx/frontend/src/op/batch_norm.hpp
@@ -15,10 +15,30 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
 
 }  // namespace set_1
 
+namespace set_6 {
+ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
+
+}  // namespace set_6
+
 namespace set_7 {
 ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
 
 }  // namespace set_7
+
+namespace set_9 {
+ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
+
+}  // namespace set_9
+
+namespace set_14 {
+ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
+
+}  // namespace set_14
+
+namespace set_15 {
+ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
+
+}  // namespace set_15
 }  // namespace op
 }  // namespace onnx
 }  // namespace frontend

--- a/src/frontends/onnx/frontend/src/op/batch_norm.hpp
+++ b/src/frontends/onnx/frontend/src/op/batch_norm.hpp
@@ -15,30 +15,15 @@ ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
 
 }  // namespace set_1
 
-namespace set_6 {
-ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
-
-}  // namespace set_6
-
 namespace set_7 {
 ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
 
 }  // namespace set_7
 
-namespace set_9 {
-ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
-
-}  // namespace set_9
-
 namespace set_14 {
 ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
 
 }  // namespace set_14
-
-namespace set_15 {
-ov::OutputVector batch_norm(const ov::frontend::onnx::Node& node);
-
-}  // namespace set_15
 }  // namespace op
 }  // namespace onnx
 }  // namespace frontend

--- a/src/frontends/onnx/frontend/src/ops_bridge.cpp
+++ b/src/frontends/onnx/frontend/src/ops_bridge.cpp
@@ -359,11 +359,8 @@ OperatorsBridge::OperatorsBridge() {
     REGISTER_OPERATOR("Atanh", 1, atanh);
     REGISTER_OPERATOR("AveragePool", 1, average_pool);
     REGISTER_OPERATOR("BatchNormalization", 1, batch_norm);
-    REGISTER_OPERATOR("BatchNormalization", 6, batch_norm);
     REGISTER_OPERATOR("BatchNormalization", 7, batch_norm);
-    REGISTER_OPERATOR("BatchNormalization", 9, batch_norm);
     REGISTER_OPERATOR("BatchNormalization", 14, batch_norm);
-    REGISTER_OPERATOR("BatchNormalization", 15, batch_norm);
     REGISTER_OPERATOR("BitShift", 1, bitshift);
     REGISTER_OPERATOR("BitwiseAnd", 1, bitwise_and);
     REGISTER_OPERATOR("BitwiseNot", 1, bitwise_not);

--- a/src/frontends/onnx/frontend/src/ops_bridge.cpp
+++ b/src/frontends/onnx/frontend/src/ops_bridge.cpp
@@ -359,7 +359,11 @@ OperatorsBridge::OperatorsBridge() {
     REGISTER_OPERATOR("Atanh", 1, atanh);
     REGISTER_OPERATOR("AveragePool", 1, average_pool);
     REGISTER_OPERATOR("BatchNormalization", 1, batch_norm);
+    REGISTER_OPERATOR("BatchNormalization", 6, batch_norm);
     REGISTER_OPERATOR("BatchNormalization", 7, batch_norm);
+    REGISTER_OPERATOR("BatchNormalization", 9, batch_norm);
+    REGISTER_OPERATOR("BatchNormalization", 14, batch_norm);
+    REGISTER_OPERATOR("BatchNormalization", 15, batch_norm);
     REGISTER_OPERATOR("BitShift", 1, bitshift);
     REGISTER_OPERATOR("BitwiseAnd", 1, bitwise_and);
     REGISTER_OPERATOR("BitwiseNot", 1, bitwise_not);

--- a/src/frontends/onnx/tests/models/batchnorm_opset1.prototxt
+++ b/src/frontends/onnx/tests/models/batchnorm_opset1.prototxt
@@ -1,0 +1,113 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "s"
+    input: "bias"
+    input: "mean"
+    input: "var"
+    output: "y"
+    op_type: "BatchNormalization"
+  }
+  name: "test_batchnorm_example"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "s"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "bias"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "mean"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "var"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/batchnorm_opset14.prototxt
+++ b/src/frontends/onnx/tests/models/batchnorm_opset14.prototxt
@@ -1,0 +1,113 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "s"
+    input: "bias"
+    input: "mean"
+    input: "var"
+    output: "y"
+    op_type: "BatchNormalization"
+  }
+  name: "test_batchnorm_example"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "s"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "bias"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "mean"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "var"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 14
+}

--- a/src/frontends/onnx/tests/models/batchnorm_opset15.prototxt
+++ b/src/frontends/onnx/tests/models/batchnorm_opset15.prototxt
@@ -1,0 +1,113 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "s"
+    input: "bias"
+    input: "mean"
+    input: "var"
+    output: "y"
+    op_type: "BatchNormalization"
+  }
+  name: "test_batchnorm_example"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "s"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "bias"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "mean"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "var"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/batchnorm_opset6.prototxt
+++ b/src/frontends/onnx/tests/models/batchnorm_opset6.prototxt
@@ -1,0 +1,113 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "s"
+    input: "bias"
+    input: "mean"
+    input: "var"
+    output: "y"
+    op_type: "BatchNormalization"
+  }
+  name: "test_batchnorm_example"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "s"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "bias"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "mean"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "var"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 6
+}

--- a/src/frontends/onnx/tests/models/batchnorm_opset7.prototxt
+++ b/src/frontends/onnx/tests/models/batchnorm_opset7.prototxt
@@ -1,0 +1,113 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "s"
+    input: "bias"
+    input: "mean"
+    input: "var"
+    output: "y"
+    op_type: "BatchNormalization"
+  }
+  name: "test_batchnorm_example"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "s"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "bias"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "mean"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "var"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 7
+}

--- a/src/frontends/onnx/tests/models/batchnorm_opset9.prototxt
+++ b/src/frontends/onnx/tests/models/batchnorm_opset9.prototxt
@@ -1,0 +1,113 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "s"
+    input: "bias"
+    input: "mean"
+    input: "var"
+    output: "y"
+    op_type: "BatchNormalization"
+  }
+  name: "test_batchnorm_example"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "s"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "bias"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "mean"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "var"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -320,6 +320,81 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_default) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset1) {
+    // Batch Normalization with default parameters
+    auto model = convert_model("batchnorm_default.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
+    test_case.add_input<float>({1.f, 1.5f});                      // scale
+    test_case.add_input<float>({0.f, 1.f});                       // bias
+    test_case.add_input<float>({0.f, 3.f});                       // mean
+    test_case.add_input<float>({1.f, 1.5f});                      // var
+    test_case.add_expected_output<float>(Shape{1, 2, 1, 3},
+                                         {-0.999995f, 0.f, 0.999995f, -0.22474074f, 1.f, 2.2247407f});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset6) {
+    // Batch Normalization with default parameters
+    auto model = convert_model("batchnorm_default.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
+    test_case.add_input<float>({1.f, 1.5f});                      // scale
+    test_case.add_input<float>({0.f, 1.f});                       // bias
+    test_case.add_input<float>({0.f, 3.f});                       // mean
+    test_case.add_input<float>({1.f, 1.5f});                      // var
+    test_case.add_expected_output<float>(Shape{1, 2, 1, 3},
+                                         {-0.999995f, 0.f, 0.999995f, -0.22474074f, 1.f, 2.2247407f});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset9) {
+    // Batch Normalization with default parameters
+    auto model = convert_model("batchnorm_default.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
+    test_case.add_input<float>({1.f, 1.5f});                      // scale
+    test_case.add_input<float>({0.f, 1.f});                       // bias
+    test_case.add_input<float>({0.f, 3.f});                       // mean
+    test_case.add_input<float>({1.f, 1.5f});                      // var
+    test_case.add_expected_output<float>(Shape{1, 2, 1, 3},
+                                         {-0.999995f, 0.f, 0.999995f, -0.22474074f, 1.f, 2.2247407f});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset14) {
+    // Batch Normalization with default parameters
+    auto model = convert_model("batchnorm_default.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
+    test_case.add_input<float>({1.f, 1.5f});                      // scale
+    test_case.add_input<float>({0.f, 1.f});                       // bias
+    test_case.add_input<float>({0.f, 3.f});                       // mean
+    test_case.add_input<float>({1.f, 1.5f});                      // var
+    test_case.add_expected_output<float>(Shape{1, 2, 1, 3},
+                                         {-0.999995f, 0.f, 0.999995f, -0.22474074f, 1.f, 2.2247407f});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset15) {
+    // Batch Normalization with default parameters
+    auto model = convert_model("batchnorm_default.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
+    test_case.add_input<float>({1.f, 1.5f});                      // scale
+    test_case.add_input<float>({0.f, 1.f});                       // bias
+    test_case.add_input<float>({0.f, 3.f});                       // mean
+    test_case.add_input<float>({1.f, 1.5f});                      // var
+    test_case.add_expected_output<float>(Shape{1, 2, 1, 3},
+                                         {-0.999995f, 0.f, 0.999995f, -0.22474074f, 1.f, 2.2247407f});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_relu) {
     // Simple ReLU test
     auto model = convert_model("relu.onnx");

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -322,7 +322,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_default) {
 
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset1) {
     // Batch Normalization with default parameters
-    auto model = convert_model("batchnorm_default.onnx");
+    auto model = convert_model("batchnorm_opset1.onnx");
 
     auto test_case = ov::test::TestCase(model, s_device);
     test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
@@ -337,7 +337,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset1) {
 
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset6) {
     // Batch Normalization with default parameters
-    auto model = convert_model("batchnorm_default.onnx");
+    auto model = convert_model("batchnorm_opset6.onnx");
 
     auto test_case = ov::test::TestCase(model, s_device);
     test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
@@ -350,9 +350,23 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset6) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset7) {
+    // Batch Normalization with default parameters
+    auto model = convert_model("batchnorm_opset7.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
+    test_case.add_input<float>({1.f, 1.5f});                      // scale
+    test_case.add_input<float>({0.f, 1.f});                       // bias
+    test_case.add_input<float>({0.f, 3.f});                       // mean
+    test_case.add_input<float>({1.f, 1.5f});                      // var
+    test_case.add_expected_output<float>(Shape{1, 2, 1, 3},
+                                         {-0.999995f, 0.f, 0.999995f, -0.22474074f, 1.f, 2.2247407f});
+    test_case.run();
+}
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset9) {
     // Batch Normalization with default parameters
-    auto model = convert_model("batchnorm_default.onnx");
+    auto model = convert_model("batchnorm_opset9.onnx");
 
     auto test_case = ov::test::TestCase(model, s_device);
     test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
@@ -367,7 +381,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset9) {
 
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset14) {
     // Batch Normalization with default parameters
-    auto model = convert_model("batchnorm_default.onnx");
+    auto model = convert_model("batchnorm_opset14.onnx");
 
     auto test_case = ov::test::TestCase(model, s_device);
     test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
@@ -382,7 +396,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset14) {
 
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_batch_norm_opset15) {
     // Batch Normalization with default parameters
-    auto model = convert_model("batchnorm_default.onnx");
+    auto model = convert_model("batchnorm_opset15.onnx");
 
     auto test_case = ov::test::TestCase(model, s_device);
     test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}


### PR DESCRIPTION
### Details:
 - *Addition of Batchnorm opset 1 6 7 9 14 & 15*
 - *Creation of the tests CPP for the respective opset, and their prototxt models.*

### Tickets:
 - 20554 : [20554](https://github.com/openvinotoolkit/openvino/issues/20554)
 - 18485 :  [18485](https://github.com/openvinotoolkit/openvino/issues/18485)
