### PR TITLE
Don't bind more and more event listeners

### DIFF
--- a/docs/sphinx_setup/_static/js/graphs.js
+++ b/docs/sphinx_setup/_static/js/graphs.js
@@ -450,14 +450,14 @@ $(document).ready(function () {
         renderData(graph, networkModels, ietype, platforms, kpis, precisions);
         $('.modal-footer').show();
         $('#modal-display-graphs').show();
-        $('.edit-settings-btn').on('click', (event) => {
+        $('.edit-settings-btn').off('click').on('click', (event) => {
             $('#modal-configure-graphs').show();
             $('#modal-display-graphs').hide();
             $('.modal-footer').hide();
             $('.chart-placeholder').empty();
         });
 
-        $('.graph-chart-title-header').on('click', (event) => {
+        $('.graph-chart-title-header').off('click').on('click', (event) => {
             var parent = event.target.parentElement;
 
             if ($(parent).children('.chart-wrap,.empty-chart-container').is(":visible")) {


### PR DESCRIPTION
The current behavior is that each subsequent click to "Edit graph settings" leads to more and more calls to click event listener. You can check it from browser's developer console. They all do the same thing, so from user's view nothing is wrong. This fix is ugly as well but removes listener before adding the new (same) one.
