### PR TITLE
CAPI requires GPU plugin

### DIFF
--- a/.github/components.yml
+++ b/.github/components.yml
@@ -149,6 +149,7 @@ PyTorch_FE:
 C_API:
   build:
     - CPU
+    - GPU
     - HETERO
     - AUTO_BATCH
     - AUTO


### PR DESCRIPTION
### Details:
 - *Add GPU build for CAPI RemoteContext tests*

### Tickets:
 - *CVS-129332*
