### PR TITLE
Automatically move GFIs into Assigned column

### DIFF
--- a/.github/workflows/gfi_board_automation_assigned.yml
+++ b/.github/workflows/gfi_board_automation_assigned.yml
@@ -1,0 +1,15 @@
+name: Move assigned Good First Issues into the Assigned column
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@303f24a24c67ce7adf565a07e96720faf126fe36
+        with:
+          project: Good first issues
+          column: Assigned
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Details:
 - Uses workflow recommended in [official GitHub docs](https://docs.github.com/en/actions/managing-issues-and-pull-requests/moving-assigned-issues-on-project-boards#creating-the-workflow)
 - The workflow is https://github.com/alex-page/github-project-automation-plus
 - A specific commit has been tagged to minimize security concerns
 - This functionality is not available in built-in GitHub Project Workflows
 - If the automation works well let's port it to other repositories engaged in GFI

### Tickets:
 - N/A
