### PR TITLE
[Transformations] BroadcastTransition: fix segfault

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/broadcast_transition.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/broadcast_transition.cpp
@@ -34,7 +34,8 @@ ov::pass::BroadcastTransition::BroadcastTransition() {
             return false;
         }
 
-        const auto bcast = ov::as_type_ptr<ov::op::v3::Broadcast>(pattern_map.at(bcast_m).get_node_shared_ptr());
+        const auto bcast = ov::as_type_ptr<ov::op::util::BroadcastBase>(pattern_map.at(bcast_m).get_node_shared_ptr());
+        OPENVINO_ASSERT(bcast, "The matched node can't be casted to BroadcastBase: ", pattern_map.at(bcast_m).get_node_shared_ptr());
         const auto& bcast_type = bcast->get_broadcast_spec().m_type;
         if (bcast_type != ov::op::BroadcastType::NUMPY && bcast_type != ov::op::BroadcastType::BIDIRECTIONAL) {
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/broadcast_transition.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/broadcast_transition.cpp
@@ -35,7 +35,9 @@ ov::pass::BroadcastTransition::BroadcastTransition() {
         }
 
         const auto bcast = ov::as_type_ptr<ov::op::util::BroadcastBase>(pattern_map.at(bcast_m).get_node_shared_ptr());
-        OPENVINO_ASSERT(bcast, "The matched node can't be casted to BroadcastBase: ", pattern_map.at(bcast_m).get_node_shared_ptr());
+        OPENVINO_ASSERT(bcast,
+                        "The matched node can't be casted to BroadcastBase: ",
+                        pattern_map.at(bcast_m).get_node_shared_ptr());
         const auto& bcast_type = bcast->get_broadcast_spec().m_type;
         if (bcast_type != ov::op::BroadcastType::NUMPY && bcast_type != ov::op::BroadcastType::BIDIRECTIONAL) {
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/broadcast_transition.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/broadcast_transition.cpp
@@ -35,11 +35,8 @@ ov::pass::BroadcastTransition::BroadcastTransition() {
         }
 
         const auto bcast = ov::as_type_ptr<ov::op::util::BroadcastBase>(pattern_map.at(bcast_m).get_node_shared_ptr());
-        OPENVINO_ASSERT(bcast,
-                        "The matched node can't be casted to BroadcastBase: ",
-                        pattern_map.at(bcast_m).get_node_shared_ptr());
-        const auto& bcast_type = bcast->get_broadcast_spec().m_type;
-        if (bcast_type != ov::op::BroadcastType::NUMPY && bcast_type != ov::op::BroadcastType::BIDIRECTIONAL) {
+        if (!bcast || (bcast->get_broadcast_spec().m_type != ov::op::BroadcastType::NUMPY &&
+                       bcast->get_broadcast_spec().m_type != ov::op::BroadcastType::BIDIRECTIONAL)) {
             return false;
         }
 

--- a/src/common/transformations/tests/common_optimizations/broadcast_transition_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/broadcast_transition_test.cpp
@@ -10,23 +10,38 @@
 #include <string>
 
 #include "common_test_utils/ov_test_utils.hpp"
+#include "common_test_utils/node_builders/eltwise.hpp"
 #include "openvino/opsets/opset10.hpp"
 using namespace ov;
 using namespace testing;
 
-std::shared_ptr<ov::Node> getOperation(
+enum class BroadcastVersion { V1, V3 };
+
+std::ostream &operator<<(std::ostream& os, const BroadcastVersion& version) {
+    switch (version) {
+        case BroadcastVersion::V1:
+            return os << "V1";
+        case BroadcastVersion::V3:
+            return os << "V3";
+        default:
+            OPENVINO_THROW("Unexpected BroadcastVersion.");
+    }
+}
+
+std::shared_ptr<ov::Node> getEltwise(
     const ov::Output<ov::Node>& in1,
     const ov::Output<ov::Node>& in2,
-    const std::string& operation_type,
+    const ov::test::utils::EltwiseTypes& eltwise_type,
     const ov::op::AutoBroadcastType& eltwise_bcast_type = ov::op::AutoBroadcastType::NUMPY) {
-    if (operation_type == "Add") {
-        return std::make_shared<ov::opset10::Add>(in1, in2, eltwise_bcast_type);
-    } else if (operation_type == "Multiply") {
-        return std::make_shared<ov::opset10::Multiply>(in1, in2, eltwise_bcast_type);
-    } else if (operation_type == "Subtract") {
-        return std::make_shared<ov::opset10::Subtract>(in1, in2, eltwise_bcast_type);
-    } else {
-        throw std::runtime_error("Unexpected operation type");
+    switch (eltwise_type) {
+        case ov::test::utils::EltwiseTypes::ADD:
+            return std::make_shared<ov::opset10::Add>(in1, in2, eltwise_bcast_type);
+        case ov::test::utils::EltwiseTypes::MULTIPLY:
+            return std::make_shared<ov::opset10::Multiply>(in1, in2, eltwise_bcast_type);
+        case ov::test::utils::EltwiseTypes::SUBTRACT:
+            return std::make_shared<ov::opset10::Subtract>(in1, in2, eltwise_bcast_type);
+        default:
+            OPENVINO_THROW("Unexpected eltwise type");
     }
 }
 
@@ -35,31 +50,51 @@ std::shared_ptr<ov::Model> getOriginal(
     const ov::PartialShape& input_shape,
     const ov::Shape& target_shape,
     const ov::op::BroadcastType& bcast_mode,
-    const std::string& operation_type,
+    const BroadcastVersion& bcast_version,
+    const ov::test::utils::EltwiseTypes& eltwise_type,
     const size_t idx,
     const ov::op::AutoBroadcastType& eltwise_bcast_type = ov::op::AutoBroadcastType::NUMPY) {
     const auto input = std::make_shared<ov::opset10::Parameter>(precision, input_shape);
     const auto data_constant = ov::opset10::Constant::create(precision, {}, {1.f});
     const auto target_shape_node = ov::opset10::Constant::create(ov::element::i32, {target_shape.size()}, target_shape);
-    const auto bcast = std::make_shared<ov::opset10::Broadcast>(data_constant, target_shape_node, bcast_mode);
+
+    std::shared_ptr<ov::Node> bcast;
+    switch (bcast_version) {
+        case BroadcastVersion::V1: {
+            OPENVINO_ASSERT(bcast_mode != ov::op::BroadcastType::BIDIRECTIONAL, "opset1::Broadcast can't be created with BIDIRECTIONAL mode.");
+            static const std::unordered_map<ov::op::BroadcastType, ov::op::AutoBroadcastType> bcast_mode_to_autobcast_type{
+                {ov::op::BroadcastType::EXPLICIT, ov::op::AutoBroadcastType::EXPLICIT},
+                {ov::op::BroadcastType::NONE, ov::op::AutoBroadcastType::NONE},
+                {ov::op::BroadcastType::NUMPY, ov::op::AutoBroadcastType::NUMPY},
+                {ov::op::BroadcastType::PDPD, ov::op::AutoBroadcastType::PDPD},
+            };
+            bcast = std::make_shared<ov::op::v1::Broadcast>(data_constant, target_shape_node, bcast_mode_to_autobcast_type.at(bcast_mode));
+            break;
+        }
+        case BroadcastVersion::V3:
+            bcast = std::make_shared<ov::op::v3::Broadcast>(data_constant, target_shape_node, bcast_mode);
+            break;
+        default:
+            OPENVINO_THROW("Unexpected BroadcastVersion.");
+    }
 
     const auto fst_in = idx == 0 ? bcast->output(0) : input->output(0);
     const auto sec_in = idx == 1 ? bcast->output(0) : input->output(0);
-    const auto operation = getOperation(fst_in, sec_in, operation_type, eltwise_bcast_type);
+    const auto operation = getEltwise(fst_in, sec_in, eltwise_type, eltwise_bcast_type);
     return std::make_shared<ov::Model>(operation, ov::ParameterVector{input});
 }
 
 std::shared_ptr<ov::Model> getReference(const ov::element::Type& precision,
                                         const ov::PartialShape& input_shape,
                                         const ov::Shape& original_target_shape,
-                                        const std::string& operation_type,
+                                        const ov::test::utils::EltwiseTypes& eltwise_type,
                                         const size_t idx) {
     const auto input = std::make_shared<ov::opset10::Parameter>(precision, input_shape);
     const auto data_constant = ov::opset10::Constant::create(precision, {}, {1.f});
 
     const auto fst_in = idx == 0 ? data_constant->output(0) : input->output(0);
     const auto sec_in = idx == 1 ? data_constant->output(0) : input->output(0);
-    const auto operation = getOperation(fst_in, sec_in, operation_type, ov::op::AutoBroadcastType::NUMPY);
+    const auto operation = getEltwise(fst_in, sec_in, eltwise_type, ov::op::AutoBroadcastType::NUMPY);
 
     const auto target_shape = [&]() {
         auto new_shape = original_target_shape;
@@ -80,12 +115,13 @@ std::shared_ptr<ov::Model> getReference(const ov::element::Type& precision,
     return std::make_shared<ov::Model>(bcast, ov::ParameterVector{input});
 }
 
-using BroadcastTransitionParams = std::tuple<ov::element::Type,      // precision
-                                             ov::Shape,              // input shape
-                                             ov::Shape,              // target shape
-                                             ov::op::BroadcastType,  // broadcast mode
-                                             std::string,            // operation type
-                                             size_t                  // broadcast input index
+using BroadcastTransitionParams = std::tuple<ov::element::Type,  // precision
+                                             ov::Shape,          // input shape
+                                             ov::Shape,          // target shape
+                                             ov::op::BroadcastType,
+                                             BroadcastVersion,
+                                             ov::test::utils::EltwiseTypes,
+                                             size_t  // broadcast input index
                                              >;
 
 class StaticBroadcastTransitionTests : public testing::WithParamInterface<BroadcastTransitionParams>,
@@ -100,13 +136,14 @@ public:
         ov::Shape input_shape;
         ov::Shape target_shape;
         ov::op::BroadcastType bcast_mode;
-        std::string operation_type;
+        BroadcastVersion bcast_version;
+        ov::test::utils::EltwiseTypes eltwise_type;
         size_t idx;
-        std::tie(precision, input_shape, target_shape, bcast_mode, operation_type, idx) = obj.param;
+        std::tie(precision, input_shape, target_shape, bcast_mode, bcast_version, eltwise_type, idx) = obj.param;
 
         std::ostringstream result;
-        result << operation_type << "_prc=" << precision << "_IS=" << input_shape << "_TS=" << target_shape
-               << "_bcast_idx=" << idx << "_bcast_type=" << bcast_mode;
+        result << eltwise_type << "_prc=" << precision << "_IS=" << input_shape << "_TS=" << target_shape
+               << "_bcast_idx=" << idx << "_bcast_type=" << bcast_mode << "_bcast_version=" << bcast_version;
         return result.str();
     }
 
@@ -117,13 +154,14 @@ protected:
         ov::Shape input_shape;
         ov::Shape target_shape;
         ov::op::BroadcastType bcast_mode;
-        std::string operation_type;
+        BroadcastVersion bcast_version;
+        ov::test::utils::EltwiseTypes eltwise_type;
         size_t idx;
-        std::tie(precision, input_shape, target_shape, bcast_mode, operation_type, idx) = GetParam();
+        std::tie(precision, input_shape, target_shape, bcast_mode, bcast_version, eltwise_type, idx) = GetParam();
 
         manager.register_pass<ov::pass::BroadcastTransition>();
-        model = getOriginal(precision, input_shape, target_shape, bcast_mode, operation_type, idx);
-        model_ref = getReference(precision, input_shape, target_shape, operation_type, idx);
+        model = getOriginal(precision, input_shape, target_shape, bcast_mode, bcast_version, eltwise_type, idx);
+        model_ref = getReference(precision, input_shape, target_shape, eltwise_type, idx);
     }
 };
 
@@ -141,17 +179,33 @@ std::vector<ov::Shape> target_shapes = {
     {16, 16},
 };
 
-std::vector<ov::op::BroadcastType> bcast_modes = {ov::op::BroadcastType::NUMPY, ov::op::BroadcastType::BIDIRECTIONAL};
+std::vector<BroadcastVersion> bcast_versions = {BroadcastVersion::V1, BroadcastVersion::V3};
 
-std::vector<std::string> operation_types = {"Add", "Multiply", "Subtract"};
+std::vector<ov::test::utils::EltwiseTypes> operation_types = {ov::test::utils::EltwiseTypes::ADD,
+                                                              ov::test::utils::EltwiseTypes::MULTIPLY,
+                                                              ov::test::utils::EltwiseTypes::SUBTRACT};
 std::vector<size_t> bcast_input_idx = {0, 1};
 
-INSTANTIATE_TEST_SUITE_P(TransformationTestsF,
+INSTANTIATE_TEST_SUITE_P(StaticBroadcastTransitionTests_v1_bcast,
                          StaticBroadcastTransitionTests,
                          ::testing::Combine(::testing::Values(ov::element::f32),
                                             ::testing::ValuesIn(input_shapes),
                                             ::testing::ValuesIn(target_shapes),
-                                            ::testing::ValuesIn(bcast_modes),
+                                            ::testing::Values(ov::op::BroadcastType::NUMPY),
+                                            ::testing::Values(BroadcastVersion::V1),
+                                            ::testing::ValuesIn(operation_types),
+                                            ::testing::ValuesIn(bcast_input_idx)),
+                         StaticBroadcastTransitionTests::getTestCaseName);
+
+std::vector<ov::op::BroadcastType> all_bcast_modes = {ov::op::BroadcastType::NUMPY, ov::op::BroadcastType::BIDIRECTIONAL};
+
+INSTANTIATE_TEST_SUITE_P(StaticBroadcastTransitionTests_v3_bcast,
+                         StaticBroadcastTransitionTests,
+                         ::testing::Combine(::testing::Values(ov::element::f32),
+                                            ::testing::ValuesIn(input_shapes),
+                                            ::testing::ValuesIn(target_shapes),
+                                            ::testing::ValuesIn(all_bcast_modes),
+                                            ::testing::Values(BroadcastVersion::V3),
                                             ::testing::ValuesIn(operation_types),
                                             ::testing::ValuesIn(bcast_input_idx)),
                          StaticBroadcastTransitionTests::getTestCaseName);
@@ -166,7 +220,7 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Dynamic_U32TargetShapePrec
 
         const auto data_constant = ov::opset10::Constant::create(data_precision, {}, {1.f});
         const auto bcast = std::make_shared<ov::opset10::Broadcast>(data_constant, target_shape);
-        const auto operation = getOperation(input, bcast, "Add");
+        const auto operation = getEltwise(input, bcast, ov::test::utils::EltwiseTypes::ADD);
         model = std::make_shared<ov::Model>(operation, ov::ParameterVector{input, target_shape});
     }
     manager.register_pass<ov::pass::BroadcastTransition>();
@@ -175,7 +229,7 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Dynamic_U32TargetShapePrec
         const auto target_shape = std::make_shared<ov::opset10::Parameter>(shape_precision, ov::PartialShape{4});
 
         const auto data_constant = ov::opset10::Constant::create(data_precision, {}, {1.f});
-        const auto operation = getOperation(input, data_constant, "Add");
+        const auto operation = getEltwise(input, data_constant, ov::test::utils::EltwiseTypes::ADD);
         const auto shapeof = std::make_shared<ov::opset10::ShapeOf>(operation);
         const auto convert = std::make_shared<ov::opset10::Convert>(shapeof, shape_precision);
         const auto max = std::make_shared<ov::opset10::Maximum>(convert, target_shape);
@@ -193,7 +247,7 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Dynamic_EqualRanks) {
 
         const auto data_constant = ov::opset10::Constant::create(data_precision, {}, {1.f});
         const auto bcast = std::make_shared<ov::opset10::Broadcast>(data_constant, target_shape);
-        const auto operation = getOperation(input, bcast, "Add");
+        const auto operation = getEltwise(input, bcast, ov::test::utils::EltwiseTypes::ADD);
         model = std::make_shared<ov::Model>(operation, ov::ParameterVector{input, target_shape});
     }
     manager.register_pass<ov::pass::BroadcastTransition>();
@@ -202,7 +256,7 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Dynamic_EqualRanks) {
         const auto target_shape = std::make_shared<ov::opset10::Parameter>(shape_precision, ov::PartialShape{4});
 
         const auto data_constant = ov::opset10::Constant::create(data_precision, {}, {1.f});
-        const auto operation = getOperation(input, data_constant, "Add");
+        const auto operation = getEltwise(input, data_constant, ov::test::utils::EltwiseTypes::ADD);
         const auto shapeof = std::make_shared<ov::opset10::ShapeOf>(operation, shape_precision);
         const auto max = std::make_shared<ov::opset10::Maximum>(shapeof, target_shape);
         const auto bcast = std::make_shared<ov::opset10::Broadcast>(operation, max);
@@ -219,7 +273,7 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Dynamic_DataRankLessThanTa
 
         const auto data_constant = ov::opset10::Constant::create(data_precision, {}, {1.f});
         const auto bcast = std::make_shared<ov::opset10::Broadcast>(data_constant, target_shape);
-        const auto operation = getOperation(input, bcast, "Add");
+        const auto operation = getEltwise(input, bcast, ov::test::utils::EltwiseTypes::ADD);
         model = std::make_shared<ov::Model>(operation, ov::ParameterVector{input, target_shape});
     }
     manager.register_pass<ov::pass::BroadcastTransition>();
@@ -228,7 +282,7 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Dynamic_DataRankLessThanTa
         const auto target_shape = std::make_shared<ov::opset10::Parameter>(shape_precision, ov::PartialShape{4});
 
         const auto data_constant = ov::opset10::Constant::create(data_precision, {}, {1.f});
-        const auto operation = getOperation(input, data_constant, "Add");
+        const auto operation = getEltwise(input, data_constant, ov::test::utils::EltwiseTypes::ADD);
         const auto shapeof = std::make_shared<ov::opset10::ShapeOf>(operation, shape_precision);
         const auto constant = ov::opset10::Constant::create(shape_precision, {2}, {1});
         const auto concat = std::make_shared<ov::opset10::Concat>(ov::OutputVector{constant, shapeof}, 0);
@@ -247,7 +301,7 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Dynamic_DataRankGreaterTha
 
         const auto data_constant = ov::opset10::Constant::create(data_precision, {}, {1.f});
         const auto bcast = std::make_shared<ov::opset10::Broadcast>(data_constant, target_shape);
-        const auto operation = getOperation(input, bcast, "Add");
+        const auto operation = getEltwise(input, bcast, ov::test::utils::EltwiseTypes::ADD);
         model = std::make_shared<ov::Model>(operation, ov::ParameterVector{input, target_shape});
     }
     manager.register_pass<ov::pass::BroadcastTransition>();
@@ -256,7 +310,7 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Dynamic_DataRankGreaterTha
         const auto target_shape = std::make_shared<ov::opset10::Parameter>(shape_precision, ov::PartialShape{2});
 
         const auto data_constant = ov::opset10::Constant::create(data_precision, {}, {1.f});
-        const auto operation = getOperation(input, data_constant, "Add");
+        const auto operation = getEltwise(input, data_constant, ov::test::utils::EltwiseTypes::ADD);
         const auto shapeof = std::make_shared<ov::opset10::ShapeOf>(operation, shape_precision);
         const auto constant = ov::opset10::Constant::create(shape_precision, {2}, {1});
         const auto concat = std::make_shared<ov::opset10::Concat>(ov::OutputVector{constant, target_shape}, 0);
@@ -271,7 +325,8 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Negative_ExplicitEltwiseBc
                         ov::PartialShape{1, 3, 16, 16},
                         ov::Shape{1, 3, 16, 16},
                         ov::op::BroadcastType::NUMPY,
-                        "Add",
+                        BroadcastVersion::V3,
+                        ov::test::utils::EltwiseTypes::ADD,
                         0,
                         ov::op::AutoBroadcastType::EXPLICIT);
     manager.register_pass<ov::pass::BroadcastTransition>();
@@ -282,7 +337,8 @@ TEST_F(TransformationTestsF, BroadcastTransitionTests_Negative_PDPDEltwiseBcast)
                         ov::PartialShape{1, 3, 16, 16},
                         ov::Shape{1, 3, 16, 16},
                         ov::op::BroadcastType::NUMPY,
-                        "Add",
+                        BroadcastVersion::V3,
+                        ov::test::utils::EltwiseTypes::ADD,
                         0,
                         ov::op::AutoBroadcastType::PDPD);
     manager.register_pass<ov::pass::BroadcastTransition>();

--- a/src/common/transformations/tests/common_optimizations/broadcast_transition_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/broadcast_transition_test.cpp
@@ -9,22 +9,23 @@
 #include <memory>
 #include <string>
 
-#include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/node_builders/eltwise.hpp"
+#include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/opsets/opset10.hpp"
+
 using namespace ov;
 using namespace testing;
 
 enum class BroadcastVersion { V1, V3 };
 
-std::ostream &operator<<(std::ostream& os, const BroadcastVersion& version) {
+std::ostream& operator<<(std::ostream& os, const BroadcastVersion& version) {
     switch (version) {
-        case BroadcastVersion::V1:
-            return os << "V1";
-        case BroadcastVersion::V3:
-            return os << "V3";
-        default:
-            OPENVINO_THROW("Unexpected BroadcastVersion.");
+    case BroadcastVersion::V1:
+        return os << "V1";
+    case BroadcastVersion::V3:
+        return os << "V3";
+    default:
+        OPENVINO_THROW("Unexpected BroadcastVersion.");
     }
 }
 
@@ -34,14 +35,14 @@ std::shared_ptr<ov::Node> getEltwise(
     const ov::test::utils::EltwiseTypes& eltwise_type,
     const ov::op::AutoBroadcastType& eltwise_bcast_type = ov::op::AutoBroadcastType::NUMPY) {
     switch (eltwise_type) {
-        case ov::test::utils::EltwiseTypes::ADD:
-            return std::make_shared<ov::opset10::Add>(in1, in2, eltwise_bcast_type);
-        case ov::test::utils::EltwiseTypes::MULTIPLY:
-            return std::make_shared<ov::opset10::Multiply>(in1, in2, eltwise_bcast_type);
-        case ov::test::utils::EltwiseTypes::SUBTRACT:
-            return std::make_shared<ov::opset10::Subtract>(in1, in2, eltwise_bcast_type);
-        default:
-            OPENVINO_THROW("Unexpected eltwise type");
+    case ov::test::utils::EltwiseTypes::ADD:
+        return std::make_shared<ov::opset10::Add>(in1, in2, eltwise_bcast_type);
+    case ov::test::utils::EltwiseTypes::MULTIPLY:
+        return std::make_shared<ov::opset10::Multiply>(in1, in2, eltwise_bcast_type);
+    case ov::test::utils::EltwiseTypes::SUBTRACT:
+        return std::make_shared<ov::opset10::Subtract>(in1, in2, eltwise_bcast_type);
+    default:
+        OPENVINO_THROW("Unexpected eltwise type");
     }
 }
 
@@ -60,22 +61,25 @@ std::shared_ptr<ov::Model> getOriginal(
 
     std::shared_ptr<ov::Node> bcast;
     switch (bcast_version) {
-        case BroadcastVersion::V1: {
-            OPENVINO_ASSERT(bcast_mode != ov::op::BroadcastType::BIDIRECTIONAL, "opset1::Broadcast can't be created with BIDIRECTIONAL mode.");
-            static const std::unordered_map<ov::op::BroadcastType, ov::op::AutoBroadcastType> bcast_mode_to_autobcast_type{
-                {ov::op::BroadcastType::EXPLICIT, ov::op::AutoBroadcastType::EXPLICIT},
-                {ov::op::BroadcastType::NONE, ov::op::AutoBroadcastType::NONE},
-                {ov::op::BroadcastType::NUMPY, ov::op::AutoBroadcastType::NUMPY},
-                {ov::op::BroadcastType::PDPD, ov::op::AutoBroadcastType::PDPD},
-            };
-            bcast = std::make_shared<ov::op::v1::Broadcast>(data_constant, target_shape_node, bcast_mode_to_autobcast_type.at(bcast_mode));
-            break;
-        }
-        case BroadcastVersion::V3:
-            bcast = std::make_shared<ov::op::v3::Broadcast>(data_constant, target_shape_node, bcast_mode);
-            break;
-        default:
-            OPENVINO_THROW("Unexpected BroadcastVersion.");
+    case BroadcastVersion::V1: {
+        OPENVINO_ASSERT(bcast_mode != ov::op::BroadcastType::BIDIRECTIONAL,
+                        "opset1::Broadcast can't be created with BIDIRECTIONAL mode.");
+        static const std::map<ov::op::BroadcastType, ov::op::AutoBroadcastType> bcast_mode_to_autobcast_type{
+            {ov::op::BroadcastType::EXPLICIT, ov::op::AutoBroadcastType::EXPLICIT},
+            {ov::op::BroadcastType::NONE, ov::op::AutoBroadcastType::NONE},
+            {ov::op::BroadcastType::NUMPY, ov::op::AutoBroadcastType::NUMPY},
+            {ov::op::BroadcastType::PDPD, ov::op::AutoBroadcastType::PDPD},
+        };
+        bcast = std::make_shared<ov::op::v1::Broadcast>(data_constant,
+                                                        target_shape_node,
+                                                        bcast_mode_to_autobcast_type.at(bcast_mode));
+        break;
+    }
+    case BroadcastVersion::V3:
+        bcast = std::make_shared<ov::op::v3::Broadcast>(data_constant, target_shape_node, bcast_mode);
+        break;
+    default:
+        OPENVINO_THROW("Unexpected BroadcastVersion.");
     }
 
     const auto fst_in = idx == 0 ? bcast->output(0) : input->output(0);
@@ -197,7 +201,8 @@ INSTANTIATE_TEST_SUITE_P(StaticBroadcastTransitionTests_v1_bcast,
                                             ::testing::ValuesIn(bcast_input_idx)),
                          StaticBroadcastTransitionTests::getTestCaseName);
 
-std::vector<ov::op::BroadcastType> all_bcast_modes = {ov::op::BroadcastType::NUMPY, ov::op::BroadcastType::BIDIRECTIONAL};
+std::vector<ov::op::BroadcastType> all_bcast_modes = {ov::op::BroadcastType::NUMPY,
+                                                      ov::op::BroadcastType::BIDIRECTIONAL};
 
 INSTANTIATE_TEST_SUITE_P(StaticBroadcastTransitionTests_v3_bcast,
                          StaticBroadcastTransitionTests,


### PR DESCRIPTION
### Details:
`BroadcastTransition` matches on `ov::op::v1::Broadcast` and `ov::op::v3::Broadcast`. However, the matched Broadcast was always casted to `ov::op::v3::Broadcast`: this led to segfault. This PR fixes this issue and adds test cases for `BroadcastTransition` transformation with `ov::op::v1::Broadcast`
