### PR TITLE
[IE TESTS][OP CONFORMANCE] Move `ConstRanges` range calculation to `InGenData` constructor

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
@@ -139,7 +139,7 @@ void ReadIRTest::SetUp() {
             if (!in_info.is_const) {
                 continue;
             }
-            ov::test::utils::set_const_ranges(in_info.ranges.min, in_info.ranges.max);
+            utils::ConstRanges::set(in_info.ranges.min, in_info.ranges.max);
             // auto next_node = param->get_default_output().get_node_shared_ptr();
             auto next_node = param->get_default_output().get_target_inputs().begin()->get_node()->shared_from_this();
             auto it = inputMap.find(next_node->get_type_info());
@@ -148,7 +148,7 @@ void ReadIRTest::SetUp() {
             const_node->set_friendly_name(param->get_friendly_name());
             ov::replace_node(param, const_node);
             parameter_to_remove.push_back(param);
-            ov::test::utils::reset_const_ranges();
+            utils::ConstRanges::reset();
         }
         for (const auto& param : parameter_to_remove) {
             function->remove_parameter(param);

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/utils/generate_inputs.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/utils/generate_inputs.hpp
@@ -12,9 +12,6 @@ namespace ov {
 namespace test {
 namespace utils {
 
-void set_const_ranges(double _min, double _max);
-void reset_const_ranges();
-
 std::vector<uint8_t> color_test_image(size_t height, size_t width, int b_step, ov::preprocess::ColorFormat format);
 
 using InputsMap = std::map<ov::NodeTypeInfo, std::function<ov::Tensor(

--- a/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
@@ -24,24 +24,6 @@ namespace ov {
 namespace test {
 namespace utils {
 
-namespace {
-struct {
-    double max = 0;
-    double min = 0;
-    bool is_defined = false;
-} const_range;
-}  // namespace
-
-void set_const_ranges(double _min, double _max) {
-    const_range.max = _max;
-    const_range.min = _min;
-    const_range.is_defined = true;
-}
-
-void reset_const_ranges() {
-    const_range.is_defined = false;
-}
-
 std::vector<uint8_t> color_test_image(size_t height, size_t width, int b_step, ov::preprocess::ColorFormat format) {
     // Test all possible r/g/b values within dimensions
     int b_dim = 255 / b_step + 1;
@@ -112,16 +94,6 @@ ov::Tensor generate(const std::shared_ptr<ov::Node>& node,
                              const ov::element::Type& elemType,
                              const ov::Shape& targetShape) {
     InputGenerateData inGenData;
-
-    if (const_range.is_defined) {
-        auto min_orig = inGenData.start_from;
-        auto max_orig = inGenData.start_from + inGenData.range * inGenData.resolution;
-        auto min_ref = const_range.min;
-        auto max_ref = const_range.max;
-        if (min_orig < min_ref || min_orig == 0)
-            inGenData.start_from = min_ref;
-        inGenData.range = (max_orig > max_ref || max_orig == 10 ? max_ref : max_orig - inGenData.start_from) - inGenData.start_from;
-    }
 
     if (elemType.is_real()) {
         set_real_number_generation_data(inGenData);

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/ov_tensor_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/ov_tensor_utils.hpp
@@ -9,6 +9,25 @@
 namespace ov {
 namespace test {
 namespace utils {
+
+// todo: remove w/a to generate correct constant data (replace parameter to const) in conformance with defined range
+struct ConstRanges {
+    static double max, min;
+    static bool is_defined;
+
+    static void set(double _min, double _max) {
+        min = _min;
+        max = _max;
+        is_defined = true;
+    }
+
+    static void reset() {
+        min = std::numeric_limits<double>::max();
+        max = std::numeric_limits<double>::min();
+        is_defined = false;
+    }
+};
+
 struct InputGenerateData {
     double start_from = 0;
     uint32_t range = 10;
@@ -19,7 +38,18 @@ struct InputGenerateData {
         : start_from(_start_from),
           range(_range),
           resolution(_resolution),
-          seed(_seed){};
+          seed(_seed) {
+        if (ConstRanges::is_defined) {
+            auto min_orig = start_from;
+            auto max_orig = start_from + range * resolution;
+            auto min_ref = ConstRanges::min;
+            auto max_ref = ConstRanges::max;
+            if (min_orig < min_ref || min_orig == 0)
+                start_from = min_ref;
+            range =
+                (uint32_t)round((max_orig > max_ref || max_orig == 10 ? max_ref : max_orig - start_from) - start_from);
+        }
+    };
 };
 
 ov::Tensor create_and_fill_tensor(const ov::element::Type element_type,

--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -12,6 +12,11 @@
 namespace ov {
 namespace test {
 namespace utils {
+
+double ConstRanges::max = std::numeric_limits<double>::min();
+double ConstRanges::min = std::numeric_limits<double>::max();
+bool ConstRanges::is_defined = false;
+
 ov::Tensor create_and_fill_tensor(const ov::element::Type element_type,
                                   const ov::Shape& shape,
                                   const InputGenerateData& inGenData) {


### PR DESCRIPTION
### Details:
 - *Move static const range initialization to `InData` structure*

### Tickets:
 - *[125993](https://jira.devtools.intel.com/browse/CVS-125993)*
