### PR TITLE
[CPU] Enable concat nspc layout inplace for urlnet model cases

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -164,6 +164,22 @@ void Concat::initSupportedPrimitiveDescriptors() {
         supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
         if (itr->first != LayoutType::nspc) {
             pdIndexesToReuse.push_back(supportedPrimitiveDescriptors.size() - 1);
+        } else if (canBeInPlace) {
+            // canBeInPlace means all dims before axis are 1, so for nspc layout we only need check sp dimensions in
+            // axis=1 cases here
+            bool InPlaceCondOk = true;
+            if (axis == 1) {
+                const auto& childDims = outputShapes[0].getDims();
+                for (auto it = childDims.rbegin(); it != childDims.rend() - axis - 1; ++it) {
+                    if (*it != 1) {
+                        InPlaceCondOk = false;
+                        break;
+                    }
+                }
+            }
+            if (InPlaceCondOk) {
+                pdIndexesToReuse.push_back(supportedPrimitiveDescriptors.size() - 1);
+            }
         }
     }
 

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -167,17 +167,10 @@ void Concat::initSupportedPrimitiveDescriptors() {
         } else if (canBeInPlace) {
             // canBeInPlace means all dims before axis are 1, so for nspc layout we only need check sp dimensions in
             // axis=1 cases here
-            bool InPlaceCondOk = true;
-            if (axis == 1) {
-                const auto& childDims = outputShapes[0].getDims();
-                for (auto it = childDims.rbegin(); it != childDims.rend() - axis - 1; ++it) {
-                    if (*it != 1) {
-                        InPlaceCondOk = false;
-                        break;
-                    }
-                }
-            }
-            if (InPlaceCondOk) {
+            const auto& childDims = outputShapes[0].getDims();
+            if (axis != 1 || std::all_of(childDims.crbegin(), childDims.crend() - 2, [](const Dim dim) {
+                    return 1 == dim;
+                })) {
                 pdIndexesToReuse.push_back(supportedPrimitiveDescriptors.size() - 1);
             }
         }

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/concat.cpp
@@ -822,6 +822,15 @@ INSTANTIATE_TEST_SUITE_P(smoke_Concat_CPU_planarChannels_inplace_4D_static,
                                             ::testing::Values(planarChannels_inplace_4D)),
                          ConcatLayerCPUTest::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_Concat_CPU_planarChannels_inplace_4D_sp_w_static,
+                         ConcatLayerCPUTest,
+                         ::testing::Combine(::testing::Values(2),
+                                            ::testing::Values(static_shapes_to_test_representation({{1, 1, 32, 32},
+                                                                                                    {1, 1, 32, 32}})),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(planarChannels_inplace_4D)),
+                         ConcatLayerCPUTest::getTestCaseName);
+
 INSTANTIATE_TEST_SUITE_P(smoke_Concat_CPU_planarChannels_inplace_5D_static,
                          ConcatLayerCPUTest,
                          ::testing::Combine(::testing::Values(1),

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/concat.cpp
@@ -105,6 +105,9 @@ const auto planar_5D = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "unknown"};
 const auto planarChannels_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "ref"};
 const auto planarChannels_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "ref"};
 
+const auto planarChannels_inplace_4D = CPUSpecificParams{{nhwc}, {nhwc}, {}, "unknown"};
+const auto planarChannels_inplace_5D = CPUSpecificParams{{ndhwc}, {ndhwc}, {}, "unknown"};
+
 const auto blocked8_4D = CPUSpecificParams{{nChw8c}, {nChw8c}, {}, "unknown"};
 const auto blocked8_5D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {}, "unknown"};
 
@@ -810,6 +813,23 @@ INSTANTIATE_TEST_SUITE_P(smoke_Concat_inPlace,
                                             ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
                          ConcatLayerCPUTest::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_Concat_CPU_planarChannels_inplace_4D_static,
+                         ConcatLayerCPUTest,
+                         ::testing::Combine(::testing::Values(1),
+                                            ::testing::Values(static_shapes_to_test_representation({{1, 32, 1, 1},
+                                                                                                    {1, 32, 1, 1}})),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(planarChannels_inplace_4D)),
+                         ConcatLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Concat_CPU_planarChannels_inplace_5D_static,
+                         ConcatLayerCPUTest,
+                         ::testing::Combine(::testing::Values(1),
+                                            ::testing::Values(static_shapes_to_test_representation({{1, 32, 1, 1, 1},
+                                                                                                    {1, 32, 1, 1, 1}})),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(planarChannels_inplace_5D)),
+                         ConcatLayerCPUTest::getTestCaseName);
 }  // namespace
 
 }  // namespace test


### PR DESCRIPTION
### Details:
 - *enable concat nspc layout inplace for channel only cases, with these concat node use inplace impl, urlnet model  gain performance benefits, and this(intermediate concat node is nspc layout but actually is one dimension) could be common case especially for models with 1D input*


### Tickets:
 - *130282*
