### PR TITLE
[TRANSFORMATIONS] Fix Optional to match even with no inputs

### DIFF
--- a/src/core/src/pattern/op/optional.cpp
+++ b/src/core/src/pattern/op/optional.cpp
@@ -52,8 +52,7 @@ bool ov::pass::pattern::op::Optional::match_value(Matcher* matcher,
     auto pattern = num_input_values_to_optional == 0 ? std::static_pointer_cast<Pattern>(wrap_node)
                                                      : std::static_pointer_cast<Pattern>(std::make_shared<Or>(
                                                            OutputVector{wrap_node, input_values_to_optional[0]}));
-
-    // Add the newly created WrapType node to the list containing its inputs and create an Or node with the list
+  
     if (matcher->match_value(pattern, graph_value) || num_input_values_to_optional == 0) {
         auto& pattern_map = matcher->get_pattern_value_map();
         if (pattern_map.count(wrap_node)) {

--- a/src/core/src/pattern/op/optional.cpp
+++ b/src/core/src/pattern/op/optional.cpp
@@ -8,6 +8,32 @@
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 
+using namespace ov::pass::pattern::op;
+
+                                                                                 
+/*                                                                                 
+                                   ┌──────────────┐                        
+                                   │    Relu      │                        
+   ┌──────────────┐                └──────┬───────┘                        
+   │    Relu      │                       │                                
+   └──────┬───────┘                ┌──────┴───────┐        ┌──────────────┐
+          │                        │Optional<Relu>│        │    Relu      │
+   ┌──────┴───────┐                └──────────┬───┘      ┼ └──┬───────────┘
+   │Optional<Relu>│  Unfolds into             │               │            
+   └──────┬───────┘                           └────┐      ┌───┘            
+          │                                        │      │                
+        ┌─┴─┐                                     ┌┴──────┴┐              
+        │ABS│                                     │   Or   │ 
+        └───┘                                     └────┬───┘               
+                                                       │                   
+                                                     ┌─┴─┐                 
+                                                     │ABS│                 
+                                                     └───┘ 
+
+    In case there're no inputs to the Optional, there's no second branch
+    hence no need in the Or node and we may use WrapType with the entry of the Optional node
+*/
+
 std::vector<ov::DiscreteTypeInfo> ov::pass::pattern::op::Optional::get_optional_types() const {
     return optional_types;
 }
@@ -19,13 +45,18 @@ bool ov::pass::pattern::op::Optional::match_value(Matcher* matcher,
     ov::OutputVector input_values_to_optional = input_values();
     size_t num_input_values_to_optional = input_values_to_optional.size();
     auto wrap_node =
-        std::make_shared<ov::pass::pattern::op::WrapType>(optional_types, m_predicate, input_values_to_optional);
+        std::make_shared<WrapType>(optional_types, m_predicate, input_values_to_optional);
+
+    // Using only the 0th input as a "data" input. (To be changed or considered when Optional starts supporting multiple inputs)
+    // Either continue using the WrapType if there're no inputs to it or create an Or node if
+    // there're other inputs to Optional creating another "branch" for matching
+    OutputVector input_values_to_or {wrap_node, input_values_to_optional[0]};
+    auto pattern = num_input_values_to_optional == 0 ?
+                        std::static_pointer_cast<Pattern>(wrap_node) :
+                        std::static_pointer_cast<Pattern>(std::make_shared<Or>(input_values_to_or));
 
     // Add the newly created WrapType node to the list containing its inputs and create an Or node with the list
-    input_values_to_optional.push_back(wrap_node);
-    auto or_node = std::make_shared<ov::pass::pattern::op::Or>(input_values_to_optional);
-
-    if (matcher->match_value(or_node, graph_value) || num_input_values_to_optional == 0) {
+    if (matcher->match_value(pattern, graph_value) || num_input_values_to_optional == 0) {
         auto& pattern_map = matcher->get_pattern_value_map();
         if (pattern_map.count(wrap_node)) {
             pattern_map[shared_from_this()] = graph_value;

--- a/src/core/src/pattern/op/optional.cpp
+++ b/src/core/src/pattern/op/optional.cpp
@@ -18,7 +18,8 @@ bool ov::pass::pattern::op::Optional::match_value(Matcher* matcher,
     // Turn the Optional node into WrapType node to create a case where the Optional node is present
     ov::OutputVector input_values_to_optional = input_values();
     size_t num_input_values_to_optional = input_values_to_optional.size();
-    auto wrap_node = std::make_shared<ov::pass::pattern::op::WrapType>(optional_types, m_predicate, input_values_to_optional);
+    auto wrap_node =
+        std::make_shared<ov::pass::pattern::op::WrapType>(optional_types, m_predicate, input_values_to_optional);
 
     // Add the newly created WrapType node to the list containing its inputs and create an Or node with the list
     input_values_to_optional.push_back(wrap_node);

--- a/src/core/src/pattern/op/optional.cpp
+++ b/src/core/src/pattern/op/optional.cpp
@@ -15,11 +15,16 @@ std::vector<ov::DiscreteTypeInfo> ov::pass::pattern::op::Optional::get_optional_
 bool ov::pass::pattern::op::Optional::match_value(Matcher* matcher,
                                                   const Output<Node>& pattern_value,
                                                   const Output<Node>& graph_value) {
-    ov::OutputVector or_in_values = input_values();
-    auto wrap_node = std::make_shared<ov::pass::pattern::op::WrapType>(optional_types, m_predicate, or_in_values);
-    or_in_values.push_back(wrap_node);
+    // Turn the Optional node into WrapType node to create a case where the Optional node is present
+    ov::OutputVector input_values_to_optional = input_values();
+    size_t num_input_values_to_optional = input_values_to_optional.size();
+    auto wrap_node = std::make_shared<ov::pass::pattern::op::WrapType>(optional_types, m_predicate, input_values_to_optional);
 
-    if (matcher->match_value(std::make_shared<ov::pass::pattern::op::Or>(or_in_values), graph_value)) {
+    // Add the newly created WrapType node to the list containing its inputs and create an Or node with the list
+    input_values_to_optional.push_back(wrap_node);
+    auto or_node = std::make_shared<ov::pass::pattern::op::Or>(input_values_to_optional);
+
+    if (matcher->match_value(or_node, graph_value) || num_input_values_to_optional == 0) {
         auto& pattern_map = matcher->get_pattern_value_map();
         if (pattern_map.count(wrap_node)) {
             pattern_map[shared_from_this()] = graph_value;

--- a/src/core/src/pattern/op/optional.cpp
+++ b/src/core/src/pattern/op/optional.cpp
@@ -52,7 +52,7 @@ bool ov::pass::pattern::op::Optional::match_value(Matcher* matcher,
     auto pattern = num_input_values_to_optional == 0 ? std::static_pointer_cast<Pattern>(wrap_node)
                                                      : std::static_pointer_cast<Pattern>(std::make_shared<Or>(
                                                            OutputVector{wrap_node, input_values_to_optional[0]}));
-  
+
     if (matcher->match_value(pattern, graph_value) || num_input_values_to_optional == 0) {
         auto& pattern_map = matcher->get_pattern_value_map();
         if (pattern_map.count(wrap_node)) {

--- a/src/core/tests/pattern.cpp
+++ b/src/core/tests/pattern.cpp
@@ -18,7 +18,9 @@
 #include "openvino/op/add.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/cos.hpp"
 #include "openvino/op/divide.hpp"
+#include "openvino/op/exp.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/reduce_sum.hpp"
@@ -538,7 +540,7 @@ TEST(pattern, optional_half_match) {
     ASSERT_TRUE(tm.match(pattern_relu1, model_relu));
 }
 
-TEST(pattern, optional_new_test) {
+TEST(pattern, optional_testing) {
     Shape shape{};
     auto model_input1 = std::make_shared<op::v0::Parameter>(element::i32, shape);
     auto model_input2 = std::make_shared<op::v0::Parameter>(element::i32, shape);
@@ -548,10 +550,10 @@ TEST(pattern, optional_new_test) {
 
     TestMatcher tm;
 
-    ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v1::Divide, op::v0::Relu>(model_add), model_add));
+    ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v0::Exp, op::v0::Relu>(model_add), model_add));
     ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v0::Abs, op::v0::Relu>(model_add), model_add));
-    ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v0::Abs, op::v1::Multiply>(model_add), model_add));
-    ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v1::Divide, op::v1::Multiply>(model_add), model_add));
+    ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v0::Abs, op::v0::Exp>(model_add), model_add));
+    ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v0::Exp, op::v0::Cos>(model_add), model_add));
 
     ASSERT_TRUE(
         tm.match(ov::pass::pattern::optional<op::v0::Abs>(model_abs), std::make_shared<op::v0::Abs>(model_abs)));
@@ -560,8 +562,8 @@ TEST(pattern, optional_new_test) {
     ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v0::Abs, op::v0::Relu>(model_abs),
                          std::make_shared<op::v0::Relu>(model_abs)));
 
-    ASSERT_FALSE(tm.match(ov::pass::pattern::optional<op::v1::Divide>(model_add), model_abs));
-    ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v1::Divide, op::v0::Abs>(model_add), model_abs));
+    ASSERT_FALSE(tm.match(ov::pass::pattern::optional<op::v0::Exp>(model_add), model_abs));
+    ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v0::Exp, op::v0::Abs>(model_add), model_abs));
 
     ASSERT_TRUE(tm.match(ov::pass::pattern::optional<op::v0::Relu>(model_relu),
                          std::make_shared<op::v0::Relu>(std::make_shared<op::v0::Relu>(model_add))));


### PR DESCRIPTION
[TRANSFORMATIONS] Fix Optional to match even with no inputs

### Details:
The Optional pattern type may create a wrong pattern to match if no inputs are provided to the Optional node. If no inputs present to the Optional type, it will not create an alternative branch(es) to check against resulting in the incorrect matching.

Fix that by adding a check for the number of inputs being 0.

Do a minor refactoring/renaming for the readability purposes.

### Tickets:
 CSV-133523

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
