### PR TITLE
cmake: fix build when using sysroot

### DIFF
--- a/src/cmake/ov_parallel.cmake
+++ b/src/cmake/ov_parallel.cmake
@@ -296,7 +296,7 @@ function(ov_set_threading_interface_for TARGET_NAME)
                 if(include_directories)
                     foreach(include_directory IN LISTS include_directories)
                         # cannot include /usr/include headers as SYSTEM
-                        if(NOT "${include_directory}" MATCHES "^/usr.*$")
+                        if(NOT "${include_directory}" MATCHES ".*/usr/include.*$")
                             target_include_directories(${TARGET_NAME} SYSTEM
                                 ${LINK_TYPE} $<BUILD_INTERFACE:${include_directory}>)
                         else()


### PR DESCRIPTION
When cross-compiling against a sysroot, system headers will not be at a place that starts with /usr. Update conditional check to exclude directories which have "/usr/include" in them to not add <sysroot>/usr/include as well.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
