### PR TITLE
[TF FE] Fixed getting model signature for HF models.

### DIFF
--- a/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
@@ -405,6 +405,9 @@ def extract_model_graph(argv):
             raise Exception("Unknown checkpoint format.")
 
     if isinstance(model, (tf.keras.layers.Layer, tf.Module, tf.keras.Model)):
+        if hasattr(model, "model") and model.model is not None and \
+                isinstance(model.model, (tf.keras.layers.Layer, tf.Module, tf.keras.Model)):
+            argv["input_model"] = model.model
         return True
     if trackable_is_imported and isinstance(model, Trackable):
         if hasattr(model, "signatures") and len(model.signatures.items()):

--- a/tests/model_hub_tests/tensorflow/model_lists/precommit
+++ b/tests/model_hub_tests/tensorflow/model_lists/precommit
@@ -33,3 +33,4 @@ google/vit-base-patch16-224,hf_transformers
 sentence-transformers/paraphrase-mpnet-base-v2,hf_transformers
 facebook/sam-vit-base,hf_transformers
 distilbert/distilgpt2,hf_transformers
+clips/mfaq,hf_sentence-transformers


### PR DESCRIPTION
### Details:
Some HF models have model in "model" attribute, which causes problems with getting model signature in tests. Tracing wraps such model in EagerPyFunc TF operation, which causes conversion error.

These problems can be fixed if model from "model" attribute is converted, which contains actual model.

### Tickets:
 - 134420
