### PR TITLE
[CPU]Fix GPT-J RoPE fusion

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/rotary_pos_emb.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/rotary_pos_emb.cpp
@@ -457,5 +457,130 @@ TEST_F(RoPECPUTestQwen7b, smoke_CompareWithRefs) {
     CheckNumberOfNodesWithType(compiledModel, "RoPE", 1);
 }
 
+class RoPECPUTestGPTJ : public SubgraphBaseTest {
+public:
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        const auto& funcInputs = function->inputs();
+
+        auto& input_shape = targetInputStaticShapes[0];
+        auto& sincos_shape = targetInputStaticShapes[1];
+        ov::Tensor t_input =
+            utils::create_and_fill_tensor(funcInputs[0].get_element_type(), input_shape, 2, -1.0f, 32768);
+        ov::Tensor t_cos_sin_cache =
+            utils::create_and_fill_tensor(funcInputs[1].get_element_type(), sincos_shape, 2, -1.0f, 32768);
+
+        inputs.clear();
+        inputs.insert({funcInputs[0].get_node_shared_ptr(), t_input});
+        inputs.insert({funcInputs[1].get_node_shared_ptr(), t_cos_sin_cache});
+    }
+
+protected:
+    std::shared_ptr<ov::Model> buildROPE_GPTJ(const int num_head,
+                                              const int hidden_dims,
+                                              const int rotary_dims) {
+        auto int32_max = std::numeric_limits<std::int32_t>::max();
+        auto input =
+            std::make_shared<ov::opset1::Parameter>(ov::element::f32, PartialShape{-1, -1, num_head, hidden_dims});
+        auto sincos = std::make_shared<ov::opset1::Parameter>(ov::element::f32, PartialShape{-1, -1, rotary_dims});
+
+        auto slice_Slice_965 =
+            makeOP<ov::op::v1::StridedSlice>({input, {0, 0, 0, 0}, {0, 0, 0, rotary_dims}, {1, 1, 1, 1}},
+                                             {{"begin_mask", {1, 1, 1, 0}},
+                                              {"end_mask", {1, 1, 1, 0}},
+                                              {"new_axis_mask", {}},
+                                              {"shrink_axis_mask", {}},
+                                              {"ellipsis_mask", {}}});
+        slice_Slice_965->set_friendly_name("slice_Slice_965");
+
+        auto varsplit = makeOP<ov::op::v1::VariadicSplit>({sincos, -1, {rotary_dims / 2, -1}});
+        varsplit->set_output_size(2);
+        varsplit->set_friendly_name("varsplit");
+        auto unsqueeze_sin = makeOP<opset1::Unsqueeze>({varsplit->output(0), 2});
+        auto unsqueeze_cos = makeOP<opset1::Unsqueeze>({varsplit->output(1), 2});
+        std::vector<int32_t> gather_idx(rotary_dims, 1);
+        int32_t v = 0;
+        for (size_t i = 0; i < gather_idx.size(); i += 2, v++) {
+            gather_idx[i] = v;
+            gather_idx[i + 1] = v;
+        }
+
+        auto const_idx = makeConst(ov::element::i32, ov::Shape({static_cast<size_t>(rotary_dims)}), gather_idx);
+        auto constant_155588 = makeConst(element::f32,
+                                         ov::Shape({
+                                             1,
+                                             1,
+                                             1,
+                                             1,
+                                         }),
+                                         {-1.000000f});
+        auto repeat_interleave_sin = makeOP<opset8::Gather>({unsqueeze_sin, const_idx, 3}, {{"batch_dims", 0}});
+        auto repeat_interleave_cos = makeOP<opset8::Gather>({unsqueeze_cos, const_idx, 3}, {{"batch_dims", 0}});
+        repeat_interleave_sin->set_friendly_name("repeat_interleave_sin");
+        repeat_interleave_cos->set_friendly_name("repeat_interleave_cos");
+        // x interleave (-x[:,:,:, 1::2], x[:,:,:, 0::2])
+        auto slice_Slice_1174 =
+            makeOP<ov::op::v1::StridedSlice>({slice_Slice_965, {0, 0, 0, 1}, {0, 0, 0, int32_max}, {1, 1, 1, 2}},
+                                             {{"begin_mask", {1, 1, 1, 0}},
+                                              {"end_mask", {1, 1, 1, 0}},
+                                              {"new_axis_mask", {}},
+                                              {"shrink_axis_mask", {}},
+                                              {"ellipsis_mask", {}}});
+        auto neg_Multiply_1177 =
+            makeOP<opset1::Multiply>({slice_Slice_1174, constant_155588}, {{"auto_broadcast", "numpy"}});
+        auto Unsqueeze_65524 = makeOP<opset1::Unsqueeze>({neg_Multiply_1177, -1});
+
+        auto slice_Slice_1168 =
+            makeOP<ov::op::v1::StridedSlice>({slice_Slice_965, {0, 0, 0, 0}, {0, 0, 0, int32_max}, {1, 1, 1, 2}},
+                                             {{"begin_mask", {1, 1, 1, 0}},
+                                              {"end_mask", {1, 1, 1, 0}},
+                                              {"new_axis_mask", {}},
+                                              {"shrink_axis_mask", {}},
+                                              {"ellipsis_mask", {}}});
+        auto Unsqueeze_65525 = makeOP<opset1::Unsqueeze>({slice_Slice_1168, -1});
+        auto stack_1182 = makeOP<opset1::Concat>({Unsqueeze_65524, Unsqueeze_65525}, {{"axis", -1}});
+        auto flatten_Reshape_1198 =
+            makeOP<opset1::Reshape>({stack_1182, {0, 0, num_head, rotary_dims}}, {{"special_zero", true}});
+        // x*cos [B,L,H,ndims]
+        auto mul_cos =
+            makeOP<opset1::Multiply>({slice_Slice_965, repeat_interleave_cos}, {{"auto_broadcast", "numpy"}});
+        mul_cos->set_friendly_name("mul_cos");
+        auto mul_sin =
+            makeOP<opset1::Multiply>({flatten_Reshape_1198, repeat_interleave_sin}, {{"auto_broadcast", "numpy"}});
+        // *cos + *sin
+        auto rotary_emb = makeOP<opset1::Add>({mul_cos, mul_sin}, {{"auto_broadcast", "numpy"}});
+
+        auto slice_Slice_971 =
+            makeOP<ov::op::v1::StridedSlice>({input, {0, 0, 0, rotary_dims}, {0, 0, 0, int32_max}, {1, 1, 1, 1}},
+                                             {{"begin_mask", {1, 1, 1, 0}},
+                                              {"end_mask", {1, 1, 1, 0}},
+                                              {"new_axis_mask", {}},
+                                              {"shrink_axis_mask", {}},
+                                              {"ellipsis_mask", {}}});
+        auto cat_Concat_1211 = makeOP<opset1::Concat>({rotary_emb, slice_Slice_971}, {{"axis", -1}});
+        auto permute_Transpose_1213 = makeOP<opset1::Transpose>({cat_Concat_1211, {0, 2, 1, 3}});
+
+        return std::make_shared<ov::Model>(ov::NodeVector{permute_Transpose_1213}, ov::ParameterVector{input, sincos});
+    }
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_CPU;
+
+        const int batch = 2;
+        const int seq_length = 7;
+        const int num_head = 16;
+        const int hidden_dims = 256;
+        const int rotary_dims = 64;
+
+        InputShape input = {{batch, seq_length, num_head, hidden_dims}, {{batch, seq_length, num_head, hidden_dims}}};
+        InputShape sincos = {{batch, seq_length, rotary_dims}, {{batch, seq_length, rotary_dims}}};
+        init_input_shapes({input, sincos});
+        function = buildROPE_GPTJ(num_head, hidden_dims, rotary_dims);
+    }
+};
+
+TEST_F(RoPECPUTestGPTJ, smoke_CompareWithRefs) {
+    run();
+    CheckNumberOfNodesWithType(compiledModel, "RoPE", 1);
+}
+
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - *Support new RoPE pattern of GPT-J*
 - *Local test shows 17 % improvement for 2nd token latency for BF16 in `Intel(R) Xeon(R) Platinum 8468`*

### Tickets:
 - *CVS-134949*
