### PR TITLE
[TRANSFORMATIONS] Fix ReshapeAMatMul pattern to work with shared node as reshape input

### DIFF
--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -37,9 +37,12 @@ bool relax_hc_reshape_followed_by_matmul(const ov::pass::pattern::PatternValueMa
         return false;
 
     const auto idx = reshape_is_A_input ? (matmul->get_transpose_b() ? -1 : -2) : (matmul->get_transpose_a() ? -2 : -1);
-    const auto C = std::make_shared<ov::op::v8::Gather>(std::make_shared<ov::op::v3::ShapeOf>(shape_source),
-                                                        ov::op::v0::Constant::create(ov::element::i64, {1}, {idx}),
-                                                        ov::op::v0::Constant::create(ov::element::i64, {}, {0}));
+    const auto in_C_0 = std::make_shared<ov::op::v3::ShapeOf>(shape_source);
+    const auto in_C_1 = ov::op::v0::Constant::create(ov::element::i64, {1}, {idx});
+    const auto in_C_2 = ov::op::v0::Constant::create(ov::element::i64, {}, {0});
+    const auto C = std::make_shared<ov::op::v8::Gather>(in_C_0,
+                                                        in_C_1,
+                                                        in_C_2);
     const auto N = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
     const auto pattern_vector = reshape_is_A_input
                                     ? (matmul->get_transpose_a() ? ov::OutputVector({C, N}) : ov::OutputVector({N, C}))
@@ -47,9 +50,12 @@ bool relax_hc_reshape_followed_by_matmul(const ov::pass::pattern::PatternValueMa
     const auto new_reshape_pattern = std::make_shared<ov::op::v0::Concat>(pattern_vector, 0);
 
     auto reshape_pattern = pattern_to_output.at(reshape_pattern_label).get_node_shared_ptr();
-    new_reshape_pattern->set_friendly_name(reshape_pattern->get_friendly_name());
-    copy_runtime_info(reshape_pattern, new_reshape_pattern);
-    replace_node(reshape_pattern, new_reshape_pattern);
+    ov::NodeVector nodes_to_copy_rt_info{new_reshape_pattern, C, N, in_C_0, in_C_1, in_C_2};
+    copy_runtime_info(reshape_pattern, nodes_to_copy_rt_info);
+
+    auto reshape_input = pattern_to_output.at(reshape_label).get_node_shared_ptr()->input(1);
+    reshape_input.replace_source_output(new_reshape_pattern);
+
     return true;
 }
 

--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -40,9 +40,7 @@ bool relax_hc_reshape_followed_by_matmul(const ov::pass::pattern::PatternValueMa
     const auto in_C_0 = std::make_shared<ov::op::v3::ShapeOf>(shape_source);
     const auto in_C_1 = ov::op::v0::Constant::create(ov::element::i64, {1}, {idx});
     const auto in_C_2 = ov::op::v0::Constant::create(ov::element::i64, {}, {0});
-    const auto C = std::make_shared<ov::op::v8::Gather>(in_C_0,
-                                                        in_C_1,
-                                                        in_C_2);
+    const auto C = std::make_shared<ov::op::v8::Gather>(in_C_0, in_C_1, in_C_2);
     const auto N = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
     const auto pattern_vector = reshape_is_A_input
                                     ? (matmul->get_transpose_a() ? ov::OutputVector({C, N}) : ov::OutputVector({N, C}))

--- a/src/inference/tests/functional/matmul_sr_tests.cpp
+++ b/src/inference/tests/functional/matmul_sr_tests.cpp
@@ -12,11 +12,15 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/gather.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/reduce_max.hpp"
 #include "openvino/op/reshape.hpp"
+#include "openvino/op/shape_of.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/manager.hpp"
@@ -389,4 +393,52 @@ TEST_F(TransformationTestsF, SmartReshapeReshapeBMatMulSeveralConsumers) {
     auto matmul = std::make_shared<ov::op::v0::MatMul>(sum, reshape);
     model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
     manager.register_pass<ov::pass::ReshapeBMatMul>();
+}
+
+TEST_F(TransformationTestsF, SmartReshape_ReshapeAMatMul_ReshapeInputSeveralConsumers) {
+    // Const will be reused as shared input for reshape and add operation
+    // param      param        const
+    //   |          |           | |
+    //   |          +-----------+ |
+    //   |                 |      |
+    //   |              Reshape   |
+    //   |                 |      |
+    //   +-----------------+      |
+    //             |              |
+    //           MatMul           |
+    //             |              |
+    //             +--------------+
+    //            Add
+    //             |
+    //           Result
+    std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
+    {
+        auto reshape_const = ov::op::v0::Constant::create(ov::element::i32, {2}, {1, 10});
+        auto data_reshape = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{2, 5});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(data_reshape, reshape_const, false);
+        auto data_matmul = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{10, 1});
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, data_matmul);
+        auto add = std::make_shared<ov::op::v1::Add>(matmul, reshape_const);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{data_matmul, data_reshape});;
+        manager.register_pass<ov::pass::ReshapeAMatMul>();
+    }
+    {
+        auto reshape_param = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{2, 5});
+        auto shape_of_param = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{10, 1});
+        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(shape_of_param, ov::element::i64);
+        auto const_gather_1 = ov::op::v0::Constant::create(ov::element::i64, {1}, {-2});
+        auto const_gather_2 = ov::op::v0::Constant::create(ov::element::i64, {}, {0});
+        auto gather = std::make_shared<ov::op::v8::Gather>(shape_of, const_gather_1, const_gather_2);
+        auto const_concat_1 = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{const_concat_1, gather}, 0);
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(reshape_param, concat, false);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, shape_of_param);
+        auto const_add_1 = ov::op::v0::Constant::create(ov::element::i32, {2}, {1, 10});
+        auto add = std::make_shared<ov::op::v1::Add>(matmul, const_add_1);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{reshape_param, shape_of_param});
+        ov::pass::Manager m;
+        m.run_passes(model_ref);
+    }
 }

--- a/src/inference/tests/functional/matmul_sr_tests.cpp
+++ b/src/inference/tests/functional/matmul_sr_tests.cpp
@@ -12,7 +12,6 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "openvino/op/add.hpp"
-#include "openvino/op/broadcast.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/gather.hpp"
@@ -420,7 +419,8 @@ TEST_F(TransformationTestsF, SmartReshape_ReshapeAMatMul_ReshapeInputSeveralCons
         auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, data_matmul);
         auto add = std::make_shared<ov::op::v1::Add>(matmul, reshape_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{data_matmul, data_reshape});;
+        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{data_matmul, data_reshape});
+        ;
         manager.register_pass<ov::pass::ReshapeAMatMul>();
     }
     {
@@ -437,7 +437,8 @@ TEST_F(TransformationTestsF, SmartReshape_ReshapeAMatMul_ReshapeInputSeveralCons
         auto const_add_1 = ov::op::v0::Constant::create(ov::element::i32, {2}, {1, 10});
         auto add = std::make_shared<ov::op::v1::Add>(matmul, const_add_1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{reshape_param, shape_of_param});
+        model_ref =
+            std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{reshape_param, shape_of_param});
         ov::pass::Manager m;
         m.run_passes(model_ref);
     }


### PR DESCRIPTION
### Details:
 - *`ReshapeAMatMul` worked incorrect in case of using shared nodes as reshape input* 
 - *Fix: to reconnect reshape input to new `shape_of` pattern*

### Tickets:
 - *[CVS-134625](https://jira.devtools.intel.com/browse/CVS-134625)*
