### PR TITLE
[TF FE] Test TextVectorization on white-space string input and Equal on empty string tensor

### DIFF
--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_text_vectorization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_text_vectorization.py
@@ -18,7 +18,7 @@ class TestTextVectorization(CommonTF2LayerTest):
         input_shape = inputs_info['text_input']
         inputs_data = {}
         strings_dictionary = ['hi OpenVINO here  ', '  hello OpenVINO there', 'hello PyTorch here  ',
-                              '  hi TensorFlow here', '  hi JAX here \t']
+                              '  hi TensorFlow here', '  hi JAX here \t', '   ']
         inputs_data['text_input'] = rng.choice(strings_dictionary, input_shape)
         return inputs_data
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_text_vectorization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_text_vectorization.py
@@ -18,7 +18,7 @@ class TestTextVectorization(CommonTF2LayerTest):
         input_shape = inputs_info['text_input']
         inputs_data = {}
         strings_dictionary = ['hi OpenVINO here  ', '  hello OpenVINO there', 'hello PyTorch here  ',
-                              '  hi TensorFlow here', '  hi JAX here \t', '   ']
+                              '  hi TensorFlow here', '  hi JAX here \t']
         inputs_data['text_input'] = rng.choice(strings_dictionary, input_shape)
         return inputs_data
 

--- a/tests/layer_tests/tensorflow_tests/test_tf_Equal.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Equal.py
@@ -241,8 +241,8 @@ class TestEqualStr(CommonTFLayerTest):
 
         return tf_net, ref_net
 
-    @pytest.mark.parametrize('x_shape', [[1], [5]])
-    @pytest.mark.parametrize('y_shape', [[1], [5]])
+    @pytest.mark.parametrize('x_shape', [[], [1], [5]])
+    @pytest.mark.parametrize('y_shape', [[], [1], [5]])
     @pytest.mark.precommit_tf_fe
     @pytest.mark.nightly
     @pytest.mark.xfail(condition=platform.system() in ('Darwin', 'Linux') and platform.machine() in ['arm', 'armv7l',


### PR DESCRIPTION
**Details:** Test `tf.keras.TextVectorization` on white-space string input and Equal on empty string tensor.

**Ticket:** 135749
