### PR TITLE
[GPU] Optimize gemm kernels for dynamic shape 

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -261,9 +261,6 @@ KERNEL(gemm_tiled_opt)(
             else
             #endif // INDIRECT_INPUT1
             {
-            #if HAS_DYNAMIC_N_PADDING || INPUT1_HAS_PADDING
-                b_tile[b_load_id] = b_raw_global_id > N - 1 ? 0 : b_ptr[sglid];
-            #else
                 #if B_VEC_SIZE == 1
                 b_tile[b_load_id] = b_raw_global_id > N - 1 ? 0 : b_ptr[sglid];
                 #else // B_VEC_SIZE == 1
@@ -279,7 +276,6 @@ KERNEL(gemm_tiled_opt)(
                 b_tile[b_load_id] = BLOCK_READ_B(b_ptr, 0);
                     #endif // TILE_N_NOT_DIVISIBLE
                 #endif // B_VEC_SIZE == 1
-            #endif // HAS_DYNAMIC_N_PADDING || INPUT1_HAS_PADDING
                 b_ptr += input1_offset;
             }
         #elif TRANSPOSE_INPUT1 == TRANSPOSE_OTHER // TRANSPOSE_INPUT1 == TRANSPOSE_X_LAST
@@ -436,9 +432,9 @@ KERNEL(gemm_tiled_opt)(
     #if IS_DYNAMIC && !INDIRECT_INPUT0 && !HAS_DYNAMIC_K_PADDING && !HAS_DYNAMIC_N_PADDING
         // Read A for next dot_id
         #if TILE_K_NOT_DIVISIBLE
-            a_read = TILE_K_NOT_DIVISIBLE_CALC ? a_ptr[sglid] : BLOCK_READ_A(a_ptr, 0);
+            a_read = (dot_id + 1 < tile_m_iterations) ? TILE_K_NOT_DIVISIBLE_CALC ? a_ptr[sglid] : BLOCK_READ_A(a_ptr, 0) : 0;
         #else
-            a_read = BLOCK_READ_A(a_ptr, 0);
+            a_read = (dot_id + 1 < tile_m_iterations) ? BLOCK_READ_A(a_ptr, 0) : 0;
         #endif
     #endif
 #elif TRANSPOSE_INPUT0 == TRANSPOSE_OTHER // TRANSPOSE_INPUT0
@@ -512,9 +508,6 @@ KERNEL(gemm_tiled_opt)(
                 else
             #endif // INDIRECT_INPUT1
                 {
-            #if HAS_DYNAMIC_N_PADDING || INPUT1_HAS_PADDING
-                    b_tile[b_load_id] = b_raw_global_id > N - 1 ? 0 : b_ptr[sglid];
-            #else
                 #if B_VEC_SIZE == 1
                     b_tile[b_load_id] = b_raw_global_id > N - 1 ? 0 : b_ptr[sglid];
                 #else // B_VEC_SIZE == 1
@@ -530,7 +523,6 @@ KERNEL(gemm_tiled_opt)(
                     b_tile[b_load_id] = BLOCK_READ_B(b_ptr, 0);
                     #endif // TILE_N_NOT_DIVISIBLE
                 #endif // B_VEC_SIZE == 1
-            #endif // HAS_DYNAMIC_N_PADDING || INPUT1_HAS_PADDING
                     b_ptr += input1_offset;
                 }
         #elif TRANSPOSE_INPUT1 == TRANSPOSE_OTHER // TRANSPOSE_INPUT1 == 0

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -263,10 +263,10 @@ KERNEL(gemm_tiled_opt)(
                         b_tile[b_load_id][0] = b_ptr[sglid];
                         b_tile[b_load_id][1] = b_ptr[sglid + 16];
                     } else {
-                        BLOCK_READ_B(b_ptr, 0);
+                        b_tile[b_load_id] = BLOCK_READ_B(b_ptr, 0);
                     }
                 #else
-                    BLOCK_READ_B(b_ptr, 0);
+                    b_tile[b_load_id] = BLOCK_READ_B(b_ptr, 0);
                 #endif
             #endif // HAS_DYNAMIC_N_PADDING || INPUT1_HAS_PADDING
                 b_ptr += input1_offset;
@@ -489,10 +489,10 @@ KERNEL(gemm_tiled_opt)(
                         b_tile[b_load_id][0] = b_ptr[sglid];
                         b_tile[b_load_id][1] = b_ptr[sglid + 16];
                     } else {
-                        BLOCK_READ_B(b_ptr, 0);
+                        b_tile[b_load_id] = BLOCK_READ_B(b_ptr, 0);
                     }
                 #else
-                    BLOCK_READ_B(b_ptr, 0);
+                    b_tile[b_load_id] = BLOCK_READ_B(b_ptr, 0);
                 #endif // TILE_N_NOT_DIVISIBLE
             #endif // HAS_DYNAMIC_N_PADDING || INPUT1_HAS_PADDING
                     b_ptr += input1_offset;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -215,11 +215,6 @@ KERNEL(gemm_tiled_opt)(
 #if TRANSPOSE_INPUT0 != TRANSPOSE_X_LAST
     MAKE_VECTOR_TYPE(INPUT0_TYPE, SIMD_WIDTH) a_tile;
 #endif // TRANSPOSE_INPUT0 != TRANSPOSE_X_LAST
-//#if TRANSPOSE_INPUT1 != TRANSPOSE_Y_LAST
-//    B_FLOATN b_tile[TILE_K];
-//#else // TRANSPOSE_INPUT1 != TRANSPOSE_Y_LAST
-//    MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile;
-//#endif // TRANSPOSE_INPUT1 != TRANSPOSE_Y_LAST
     B_FLOATN c_tile[TILE_M];
 
     unroll_for (uint i = 0; i < TILE_M; i++) {
@@ -233,7 +228,9 @@ KERNEL(gemm_tiled_opt)(
     #else // TRANSPOSE_INPUT1 != TRANSPOSE_Y_LAST
         MAKE_VECTOR_TYPE(INPUT1_TYPE, SIMD_WIDTH) b_tile;
     #endif // TRANSPOSE_INPUT1 != TRANSPOSE_Y_LAST
-        // Loading B tile
+
+    // Loading B tile
+#if (TRANSPOSE_INPUT1 != TRANSPOSE_Y_LAST)
         unroll_for (uint b_load_id = 0; b_load_id < TILE_K; b_load_id++) {
 #if INDIRECT_INPUT1
             uint b_load_offset = (k * TILE_K) + b_load_id;
@@ -312,8 +309,8 @@ KERNEL(gemm_tiled_opt)(
             }
     #endif // TRANSPOSE_INPUT1 == TRANSPOSE_X_LAST
 #endif // IS_DYNAMIC
-        } // Loading B tile end
-#if TRANSPOSE_INPUT1 == TRANSPOSE_Y_LAST
+    } // Loading B tile end
+#else if TRANSPOSE_INPUT1 == TRANSPOSE_Y_LAST
     #if INDIRECT_INPUT1
         if (do_indirect_load)
         {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -2121,7 +2121,7 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
     if (desc.GetType() == KernelType::ELTWISE &&
         conf.load_type == FusedOpsConfiguration::LoadType::LT_ALIGNED_READ &&
         ((input_tensor.SimpleLayout() && input_tensor.GetLayout() != orig_output_layout) || f_axis_broadcast) &&
-        (input_tensor.SameDimsSizes(prim_output) || f_axis_broadcast) &&
+        (!input_tensor.SimpleLayout() && (input_tensor.SameDimsSizes(prim_output) || f_axis_broadcast)) &&
         input_tensor.LogicalSize() != 1) {
         std::string sub_group_local_id_str = "get_sub_group_local_id";
         size_t found_sub = conf.bfzyx_idx_order[1].rfind(sub_group_local_id_str);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -106,7 +106,7 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.simd_size = 16;
         tuning_data.tile_k_size = tuning_data.simd_size;
         tuning_data.tile_m_size = tuning_data.simd_size;
-        bool output_ndim_transposed = (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1));
+        bool output_ndim_transposed = (params.output_order.size() > 0 && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
         if ((params.transpose_input0 == 0)
             && !params.inputs[0].X().pad.is_dynamic && !params.inputs[1].Y().pad.is_dynamic
             && !params.inputs[1].X().pad.is_dynamic && (!output_ndim_transposed || params.fused_ops.empty())

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -109,7 +109,7 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         bool output_ndim_transposed = (params.output_order.size() > 0 && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
         if ((params.transpose_input0 == 0 /*X_LAST*/) && (params.transpose_input1 == 0 /*X_LAST*/ || params.transpose_input1 == 1 /*Y_LAST*/)
             && !params.indirect_input0
-            && (!params.inputs[0].has_dynamic_pad() && !params.inputs[1].has_dynamic_pad())
+            && (!params.inputs[0].has_dynamic_pad())
             && (!output_ndim_transposed || params.fused_ops.empty())) {
             // - Not supports dynamic padding / indirect gemm / transposed input0 / transposed input1 for OTHER mode yet
             // - If output X dim (= N) is transposed, cannot read eltwise as aligned data

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -110,7 +110,10 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
 //        auto k_size = params.transpose_input0 ? params.inputs[0].Y().v : params.inputs[0].X().v;
 //        if (k_size == 128) // && also not support indirected input yet && FUSED_OPS_CAN_USE_PRELOAD is not supported && TILE_K == SIMD
         // no dynamic padding
-        tuning_data.tile_n_size = 32;
+        if (!params.transpose_input0)
+            tuning_data.tile_n_size = 32;
+        else
+            tuning_data.tile_n_size = 16;
     }
 
     GPU_DEBUG_LOG << params.layerID << ": tile_m_size: " << tuning_data.tile_m_size

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -107,10 +107,12 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.tile_k_size = tuning_data.simd_size;
         tuning_data.tile_m_size = tuning_data.simd_size;
         bool output_ndim_transposed = (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1));
-        if (!params.transpose_input0 && !params.inputs[0].X().pad.is_dynamic && !params.inputs[1].Y().pad.is_dynamic &&
-            !params.inputs[1].X().pad.is_dynamic && (!output_ndim_transposed || params.fused_ops.empty())) {
-            // Not supports dynamic padding / indirect gemm yet
-            // If output X dim (= N) is transposed, cannot read eltwise as aligned data
+        if ((params.transpose_input0 == 0)
+            && !params.inputs[0].X().pad.is_dynamic && !params.inputs[1].Y().pad.is_dynamic
+            && !params.inputs[1].X().pad.is_dynamic && (!output_ndim_transposed || params.fused_ops.empty())
+            && (params.transpose_input0 != 2)) {
+            // - Not supports dynamic padding / indirect gemm / transposed input0 / transposed input1 for OTHER mode yet
+            // - If output X dim (= N) is transposed, cannot read eltwise as aligned data
             tuning_data.tile_n_size = 32;
         } else {
             tuning_data.tile_n_size = 16;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -108,9 +108,10 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.tile_m_size = tuning_data.simd_size;
         bool output_ndim_transposed = (params.output_order.size() > 0 && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
         if ((params.transpose_input0 == 0)
-            && !params.inputs[0].X().pad.is_dynamic && !params.inputs[1].Y().pad.is_dynamic
-            && !params.inputs[1].X().pad.is_dynamic && (!output_ndim_transposed || params.fused_ops.empty())
-            && (params.transpose_input0 != 2)) {
+            && !params.indirect_input0 && !params.indirect_input1
+            && (!output_ndim_transposed || params.fused_ops.empty())
+            && (params.transpose_input0 != 2)
+            && (!params.inputs[0].is_dynamic() && !params.inputs[1].is_dynamic())) {
             // - Not supports dynamic padding / indirect gemm / transposed input0 / transposed input1 for OTHER mode yet
             // - If output X dim (= N) is transposed, cannot read eltwise as aligned data
             tuning_data.tile_n_size = 32;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -110,7 +110,7 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
 //        auto k_size = params.transpose_input0 ? params.inputs[0].Y().v : params.inputs[0].X().v;
 //        if (k_size == 128) // && also not support indirected input yet && FUSED_OPS_CAN_USE_PRELOAD is not supported && TILE_K == SIMD
         // no dynamic padding
-        if (!params.transpose_input0)
+        if (!params.transpose_input0 && !params.inputs[0].X().pad.is_dynamic && !params.inputs[1].Y().pad.is_dynamic && !params.inputs[1].X().pad.is_dynamic)
             tuning_data.tile_n_size = 32;
         else
             tuning_data.tile_n_size = 16;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -108,10 +108,9 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.tile_m_size = tuning_data.simd_size;
         bool output_ndim_transposed = (params.output_order.size() > 0 && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
         if ((params.transpose_input0 == 0 /*X_LAST*/) && (params.transpose_input1 == 0 /*X_LAST*/ || params.transpose_input1 == 1 /*Y_LAST*/)
-            && !params.indirect_input0
-            && (!params.inputs[0].has_dynamic_pad())
+            && (!params.indirect_input0 && !params.inputs[0].has_dynamic_pad())
             && (!output_ndim_transposed || params.fused_ops.empty())) {
-            // - Not supports dynamic padding / indirect gemm / transposed input0 / transposed input1 for OTHER mode yet
+            // - Not supports transposed input0 / transposed input1 for OTHER mode yet
             // - If output X dim (= N) is transposed, cannot read eltwise as aligned data
             tuning_data.tile_n_size = 32;
         } else {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -145,7 +145,12 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
         const std::string not_divisible_n = "(" + leftover_n + "!=0)";
         const std::string not_divisible_k = "(" + leftover_k + "!=0)";
         const std::string full_iteration_k = "(" + k_size + "/" + std::to_string(tuning_data.tile_k_size) + ")";
-
+        bool tile_k_may_have_leftover = false;
+        if (k_size.find("shape_info") == std::string::npos) {
+            tile_k_may_have_leftover = ((std::stoi(k_size) % tuning_data.tile_k_size) != 0);
+        } else {
+            tile_k_may_have_leftover = true;
+        }
         jit.AddConstants({
             MakeJitConstant("M", m_size),
             MakeJitConstant("K", k_size),
@@ -158,7 +163,8 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
             MakeJitConstant("TILE_N", tuning_data.tile_n_size),
             MakeJitConstant("K_FULL_ITERATIONS", full_iteration_k),
             MakeJitConstant("TILE_M_NOT_DIVISIBLE", not_divisible_m),
-            MakeJitConstant("TILE_K_NOT_DIVISIBLE", not_divisible_k),
+            MakeJitConstant("TILE_K_NOT_DIVISIBLE", tile_k_may_have_leftover),
+            MakeJitConstant("TILE_K_NOT_DIVISIBLE_CALC", not_divisible_k), // if tile_k is constant no need to add this
             MakeJitConstant("TILE_N_NOT_DIVISIBLE", not_divisible_n),
             MakeJitConstant("TILE_M_LEFTOVER", leftover_m),
             MakeJitConstant("TILE_K_LEFTOVER", leftover_k),

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -111,7 +111,7 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
             && !params.indirect_input0 && !params.indirect_input1
             && (!output_ndim_transposed || params.fused_ops.empty())
             && (params.transpose_input0 != 2)
-            && (!params.inputs[0].is_dynamic() && !params.inputs[1].is_dynamic())) {
+            && (!params.inputs[0].has_dynamic_pad() && !params.inputs[1].has_dynamic_pad())) {
             // - Not supports dynamic padding / indirect gemm / transposed input0 / transposed input1 for OTHER mode yet
             // - If output X dim (= N) is transposed, cannot read eltwise as aligned data
             tuning_data.tile_n_size = 32;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -107,6 +107,10 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.tile_n_size = tuning_data.simd_size;
         tuning_data.tile_k_size = tuning_data.simd_size;
         tuning_data.tile_m_size = tuning_data.simd_size;
+        auto k_size = params.transpose_input0 ? params.inputs[0].Y().v : params.inputs[0].X().v;
+        if (k_size == 128) // && also not support indirected input yet && FUSED_OPS_CAN_USE_PRELOAD is not supported && TILE_K == SIMD
+            // no dynamic padding
+            tuning_data.tile_n_size = 32;
     }
 
     GPU_DEBUG_LOG << params.layerID << ": tile_m_size: " << tuning_data.tile_m_size

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -104,12 +104,8 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         // In shape agnostic kernel case, the vector size of FusedOpsConfiguration cannot be specified at build time,
         // so the tile sizes must be the same as simd_size
         tuning_data.simd_size = 16;
-//        tuning_data.tile_n_size = tuning_data.simd_size;
         tuning_data.tile_k_size = tuning_data.simd_size;
         tuning_data.tile_m_size = tuning_data.simd_size;
-//        auto k_size = params.transpose_input0 ? params.inputs[0].Y().v : params.inputs[0].X().v;
-//        if (k_size == 128) // && also not support indirected input yet && FUSED_OPS_CAN_USE_PRELOAD is not supported && TILE_K == SIMD
-        // no dynamic padding
         if (!params.transpose_input0 && !params.inputs[0].X().pad.is_dynamic && !params.inputs[1].Y().pad.is_dynamic && !params.inputs[1].X().pad.is_dynamic)
             tuning_data.tile_n_size = 32;
         else

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -107,11 +107,10 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.tile_k_size = tuning_data.simd_size;
         tuning_data.tile_m_size = tuning_data.simd_size;
         bool output_ndim_transposed = (params.output_order.size() > 0 && (params.output_order.back() != (static_cast<int>(params.output_order.size()) - 1)));
-        if ((params.transpose_input0 == 0)
-            && !params.indirect_input0 && !params.indirect_input1
-            && (!output_ndim_transposed || params.fused_ops.empty())
-            && (params.transpose_input0 != 2)
-            && (!params.inputs[0].has_dynamic_pad() && !params.inputs[1].has_dynamic_pad())) {
+        if ((params.transpose_input0 == 0 /*X_LAST*/) && (params.transpose_input1 == 0 /*X_LAST*/ || params.transpose_input1 == 1 /*Y_LAST*/)
+            && !params.indirect_input0
+            && (!params.inputs[0].has_dynamic_pad() && !params.inputs[1].has_dynamic_pad())
+            && (!output_ndim_transposed || params.fused_ops.empty())) {
             // - Not supports dynamic padding / indirect gemm / transposed input0 / transposed input1 for OTHER mode yet
             // - If output X dim (= N) is transposed, cannot read eltwise as aligned data
             tuning_data.tile_n_size = 32;

--- a/src/plugins/intel_gpu/src/kernel_selector/tensor_type.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/tensor_type.h
@@ -462,6 +462,10 @@ public:
         return std::any_of(dims.begin(), dims.end(), [](const Dim& d) { return d.is_dynamic; });
     }
 
+    bool has_dynamic_pad() const {
+        return std::any_of(dims.begin(), dims.end(), [](const Dim& d) { return d.pad.is_dynamic; });
+    }
+
     virtual ~TensorBase() = default;
 };
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -1117,161 +1117,6 @@ public:
         }
     }
 
-    void test_transpose_matmul(size_t num_dims, bool is_input_dynamic, bool is_caching_test) {
-        tests::random_generator rg;
-        rg.set_seed(GET_SUITE_NAME);
-
-        const unsigned long BATCH_SIZE = 19;
-        const unsigned long M_SIZE = 37;
-        const unsigned long K_SIZE = 23;
-        const unsigned long N_SIZE = 29;
-
-        auto fill_mem = [&](cldnn::memory_ptr mem, std::vector<float>& data) {
-            cldnn::mem_lock<float> mem_ptr(mem, get_test_stream());
-            auto&& l = mem->get_layout();
-            auto data_idx = 0;
-            for (cldnn::tensor::value_type b = 0; b < l.batch(); ++b) {
-                for (cldnn::tensor::value_type f = 0; f < l.feature(); ++f) {
-                    for (cldnn::tensor::value_type y = 0; y < l.spatial(1); ++y) {
-                        for (cldnn::tensor::value_type x = 0; x < l.spatial(0); ++x) {
-                            auto tensor_coord = cldnn::tensor{{b, f, x, y}, 0};
-                            auto buffer_idx = l.get_linear_offset(tensor_coord);
-                            mem_ptr[buffer_idx] = data[data_idx++];
-                        }
-                    }
-                }
-            }
-        };
-
-        auto& engine = get_test_engine();
-        ov::Shape input0_shape;
-        ov::Shape input1_shape;
-        std::vector<int64_t> input0_order;
-        std::vector<int64_t> input1_order;
-        ov::Shape beam_table_shape;
-        cldnn::layout input0_layout;
-        cldnn::layout input1_layout;
-
-        if (num_dims == 1) {
-            input0_shape = { K_SIZE };
-            input1_shape = { N_SIZE, K_SIZE };
-            input0_order = { 0 };
-            input1_order = { 1, 0 };
-        } else if (num_dims == 2) {
-            input0_shape = { K_SIZE, M_SIZE };
-            input1_shape = { N_SIZE, K_SIZE };
-            input0_order = { 1, 0 };
-            input1_order = { 1, 0 };
-        } else if (num_dims == 3) {
-            input0_shape = { BATCH_SIZE, K_SIZE, M_SIZE };
-            input1_shape = { N_SIZE, BATCH_SIZE, K_SIZE };
-            input0_order = { 0, 2, 1 };
-            input1_order = { 1, 2, 0 };
-        } else if (num_dims == 4) {
-            input0_shape = { BATCH_SIZE, K_SIZE, 1, M_SIZE };
-            input1_shape = { N_SIZE, BATCH_SIZE, 1, K_SIZE };
-            input0_order = { 0, 2, 3, 1 };
-            input1_order = { 1, 2, 3, 0 };
-        }
-
-        if (is_input_dynamic) {
-            input0_layout = layout{ov::PartialShape::dynamic(input0_shape.size()), data_types::f32, format::bfyx};
-            input1_layout = layout{ov::PartialShape::dynamic(input1_shape.size()), data_types::f32, format::bfyx};
-        } else {
-            input0_layout = layout{ov::PartialShape(input0_shape), data_types::f32, format::bfyx};
-            input1_layout = layout{ov::PartialShape(input1_shape), data_types::f32, format::bfyx};
-        }
-
-        auto input0_mem = engine.allocate_memory(layout{ov::PartialShape(input0_shape), data_types::f32, format::bfyx});
-        auto input1_mem = engine.allocate_memory(layout{ov::PartialShape(input1_shape), data_types::f32, format::bfyx});
-
-        auto input_0_data = rg.generate_random_1d<float>(ov::shape_size(input0_shape), -2, 2);
-        auto input_1_data = rg.generate_random_1d<float>(ov::shape_size(input1_shape), -2, 2);
-
-        fill_mem(input0_mem, input_0_data);
-        fill_mem(input1_mem, input_1_data);
-
-        topology topology;
-        topology.add(input_layout("input0", input0_layout),
-                     input_layout("input1", input1_layout),
-                     gemm("gemm", { input_info("input0"), input_info("input1") }, data_types::f32, {}, {}, {}, {}, input0_order, input1_order)
-        );
-
-        ExecutionConfig config = get_test_default_config(engine);
-        config.set_property(ov::intel_gpu::optimize_data(true));
-        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
-        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
-        network->set_input_data("input0", input0_mem);
-        network->set_input_data("input1", input1_mem);
-
-        auto inst = network->get_primitive("gemm");
-        auto impl = inst->get_impl();
-        ASSERT_TRUE(impl != nullptr);
-        ASSERT_TRUE(impl->is_dynamic() == is_input_dynamic);
-
-        auto outputs = network->execute();
-
-        auto output_mem = outputs.at("gemm").get_memory();
-        cldnn::mem_lock<float> output_ptr(output_mem, get_test_stream());
-
-        ov::Shape ref_input0_shape;
-        ov::Shape ref_input1_shape;
-        ov::Shape ref_output_shape;
-        if (num_dims == 1) {
-            ref_input0_shape = { K_SIZE };
-            ref_input1_shape = { K_SIZE, N_SIZE };
-            ref_output_shape = { 1, N_SIZE };
-        } else if (num_dims == 2) {
-            ref_input0_shape = { M_SIZE, K_SIZE };
-            ref_input1_shape = { K_SIZE, N_SIZE };
-            ref_output_shape = { M_SIZE, N_SIZE };
-        } else if (num_dims == 3) {
-            ref_input0_shape = { BATCH_SIZE, M_SIZE, K_SIZE };
-            ref_input1_shape = { BATCH_SIZE, K_SIZE, N_SIZE };
-            ref_output_shape = { BATCH_SIZE, M_SIZE, N_SIZE };
-        } else if (num_dims == 4) {
-            ref_input0_shape = { BATCH_SIZE, 1, M_SIZE, K_SIZE };
-            ref_input1_shape = { BATCH_SIZE, 1, K_SIZE, N_SIZE };
-            ref_output_shape = { BATCH_SIZE, 1, M_SIZE, N_SIZE };
-        }
-
-        std::vector<float> ref_out_data;
-        ref_out_data.resize(ov::shape_size(ref_output_shape));
-
-        std::vector<float> ref_input_0_data(input_0_data.size());
-        std::vector<float> ref_input_1_data(input_1_data.size());
-
-        ov::reference::transpose((const char *)(input_0_data.data()),
-                                 (char *)(ref_input_0_data.data()),
-                                 input0_shape,
-                                 sizeof(float),
-                                 input0_order,
-                                 ref_input0_shape);
-
-        ov::reference::transpose((const char *)(input_1_data.data()),
-                                 (char *)(ref_input_1_data.data()),
-                                 input1_shape,
-                                 sizeof(float),
-                                 input1_order,
-                                 ref_input1_shape);
-
-        ov::reference::matmul<float>(ref_input_0_data.data(),
-                                     ref_input_1_data.data(),
-                                     ref_out_data.data(),
-                                     ref_input0_shape,
-                                     ref_input1_shape,
-                                     ref_output_shape,
-                                     false,
-                                     false);
-
-        ASSERT_EQ(output_ptr.size(), ref_out_data.size());
-
-        const auto abs_error = 0.0001;
-        for (uint32_t i = 0; i < ref_out_data.size(); ++i) {
-            ASSERT_NEAR(output_ptr[i], ref_out_data[i], abs_error) << "at " << i;
-        }
-    }
-
     void test_transpose_matmul_transpose(size_t num_dims, bool is_input_dynamic, bool is_caching_test) {
         tests::random_generator rg;
         rg.set_seed(GET_SUITE_NAME);
@@ -1443,6 +1288,282 @@ public:
             ASSERT_NEAR(output_ptr[i], transposed_out_data[i], abs_error);
         }
     }
+
+    void test_transpose_matmul_f32(size_t num_dims, bool is_input_dynamic, bool is_caching_test) {
+        tests::random_generator rg;
+        rg.set_seed(GET_SUITE_NAME);
+
+        const unsigned long BATCH_SIZE = 19;
+        const unsigned long M_SIZE = 37;
+        const unsigned long K_SIZE = 23;
+        const unsigned long N_SIZE = 29;
+
+        auto& engine = get_test_engine();
+        ov::Shape input0_shape;
+        ov::Shape input1_shape;
+        std::vector<int64_t> input0_order;
+        std::vector<int64_t> input1_order;
+        ov::Shape beam_table_shape;
+        cldnn::layout input0_layout;
+        cldnn::layout input1_layout;
+
+        if (num_dims == 1) {
+            input0_shape = { K_SIZE };
+            input1_shape = { N_SIZE, K_SIZE };
+            input0_order = { 0 };
+            input1_order = { 1, 0 };
+        } else if (num_dims == 2) {
+            input0_shape = { K_SIZE, M_SIZE };
+            input1_shape = { N_SIZE, K_SIZE };
+            input0_order = { 1, 0 };
+            input1_order = { 1, 0 };
+        } else if (num_dims == 3) {
+            input0_shape = { BATCH_SIZE, K_SIZE, M_SIZE };
+            input1_shape = { N_SIZE, BATCH_SIZE, K_SIZE };
+            input0_order = { 0, 2, 1 };
+            input1_order = { 1, 2, 0 };
+        } else if (num_dims == 4) {
+            input0_shape = { BATCH_SIZE, K_SIZE, 1, M_SIZE };
+            input1_shape = { N_SIZE, BATCH_SIZE, 1, K_SIZE };
+            input0_order = { 0, 2, 3, 1 };
+            input1_order = { 1, 2, 3, 0 };
+        }
+
+        if (is_input_dynamic) {
+            input0_layout = layout{ov::PartialShape::dynamic(input0_shape.size()), data_types::f32, format::bfyx};
+            input1_layout = layout{ov::PartialShape::dynamic(input1_shape.size()), data_types::f32, format::bfyx};
+        } else {
+            input0_layout = layout{ov::PartialShape(input0_shape), data_types::f32, format::bfyx};
+            input1_layout = layout{ov::PartialShape(input1_shape), data_types::f32, format::bfyx};
+        }
+
+        auto input0_mem = engine.allocate_memory(layout{ov::PartialShape(input0_shape), data_types::f32, format::bfyx});
+        auto input1_mem = engine.allocate_memory(layout{ov::PartialShape(input1_shape), data_types::f32, format::bfyx});
+
+        auto input_0_data = rg.generate_random_1d<float>(ov::shape_size(input0_shape), -2, 2);
+        auto input_1_data = rg.generate_random_1d<float>(ov::shape_size(input1_shape), -2, 2);
+
+        set_values(input0_mem, input_0_data);
+        set_values(input1_mem, input_1_data);
+
+        topology topology;
+        topology.add(input_layout("input0", input0_layout),
+                     input_layout("input1", input1_layout),
+                     gemm("gemm", { input_info("input0"), input_info("input1") }, data_types::f32, {}, {}, {}, {}, input0_order, input1_order)
+        );
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
+        network->set_input_data("input0", input0_mem);
+        network->set_input_data("input1", input1_mem);
+
+        auto inst = network->get_primitive("gemm");
+        auto impl = inst->get_impl();
+        ASSERT_TRUE(impl != nullptr);
+        ASSERT_TRUE(impl->is_dynamic() == is_input_dynamic);
+
+        auto outputs = network->execute();
+
+        auto output_mem = outputs.at("gemm").get_memory();
+        cldnn::mem_lock<float> output_ptr(output_mem, get_test_stream());
+
+        ov::Shape ref_input0_shape;
+        ov::Shape ref_input1_shape;
+        ov::Shape ref_output_shape;
+        if (num_dims == 1) {
+            ref_input0_shape = { K_SIZE };
+            ref_input1_shape = { K_SIZE, N_SIZE };
+            ref_output_shape = { 1, N_SIZE };
+        } else if (num_dims == 2) {
+            ref_input0_shape = { M_SIZE, K_SIZE };
+            ref_input1_shape = { K_SIZE, N_SIZE };
+            ref_output_shape = { M_SIZE, N_SIZE };
+        } else if (num_dims == 3) {
+            ref_input0_shape = { BATCH_SIZE, M_SIZE, K_SIZE };
+            ref_input1_shape = { BATCH_SIZE, K_SIZE, N_SIZE };
+            ref_output_shape = { BATCH_SIZE, M_SIZE, N_SIZE };
+        } else if (num_dims == 4) {
+            ref_input0_shape = { BATCH_SIZE, 1, M_SIZE, K_SIZE };
+            ref_input1_shape = { BATCH_SIZE, 1, K_SIZE, N_SIZE };
+            ref_output_shape = { BATCH_SIZE, 1, M_SIZE, N_SIZE };
+        }
+
+        std::vector<float> ref_out_data;
+        ref_out_data.resize(ov::shape_size(ref_output_shape));
+
+        std::vector<float> ref_input_0_data(input_0_data.size());
+        std::vector<float> ref_input_1_data(input_1_data.size());
+
+        ov::reference::transpose((const char *)(input_0_data.data()),
+                                 (char *)(ref_input_0_data.data()),
+                                 input0_shape,
+                                 sizeof(float),
+                                 input0_order,
+                                 ref_input0_shape);
+
+        ov::reference::transpose((const char *)(input_1_data.data()),
+                                 (char *)(ref_input_1_data.data()),
+                                 input1_shape,
+                                 sizeof(float),
+                                 input1_order,
+                                 ref_input1_shape);
+
+        ov::reference::matmul<float>(ref_input_0_data.data(),
+                                     ref_input_1_data.data(),
+                                     ref_out_data.data(),
+                                     ref_input0_shape,
+                                     ref_input1_shape,
+                                     ref_output_shape,
+                                     false,
+                                     false);
+
+        ASSERT_EQ(output_ptr.size(), ref_out_data.size());
+
+        const auto abs_error = 0.0001;
+        for (uint32_t i = 0; i < ref_out_data.size(); ++i) {
+            ASSERT_NEAR(output_ptr[i], ref_out_data[i], abs_error) << "at " << i;
+        }
+    }
+
+    void test_transpose_matmul_f16(size_t num_dims, bool is_input_dynamic, bool is_caching_test) {
+        tests::random_generator rg;
+        rg.set_seed(GET_SUITE_NAME);
+
+        const unsigned long BATCH_SIZE = 19;
+        const unsigned long M_SIZE = 37;
+        const unsigned long K_SIZE = 23;
+        const unsigned long N_SIZE = 29;
+
+        auto& engine = get_test_engine();
+        ov::Shape input0_shape;
+        ov::Shape input1_shape;
+        std::vector<int64_t> input0_order;
+        std::vector<int64_t> input1_order;
+        ov::Shape beam_table_shape;
+        cldnn::layout input0_layout;
+        cldnn::layout input1_layout;
+
+        if (num_dims == 1) {
+            input0_shape = { K_SIZE };
+            input1_shape = { N_SIZE, K_SIZE };
+            input0_order = { 0 };
+            input1_order = { 1, 0 };
+        } else if (num_dims == 2) {
+            input0_shape = { K_SIZE, M_SIZE };
+            input1_shape = { N_SIZE, K_SIZE };
+            input0_order = { 1, 0 };
+            input1_order = { 1, 0 };
+        } else if (num_dims == 3) {
+            input0_shape = { BATCH_SIZE, K_SIZE, M_SIZE };
+            input1_shape = { N_SIZE, BATCH_SIZE, K_SIZE };
+            input0_order = { 0, 2, 1 };
+            input1_order = { 1, 2, 0 };
+        } else if (num_dims == 4) {
+            input0_shape = { BATCH_SIZE, K_SIZE, 1, M_SIZE };
+            input1_shape = { N_SIZE, BATCH_SIZE, 1, K_SIZE };
+            input0_order = { 0, 2, 3, 1 };
+            input1_order = { 1, 2, 3, 0 };
+        }
+
+        if (is_input_dynamic) {
+            input0_layout = layout{ov::PartialShape::dynamic(input0_shape.size()), data_types::f16, format::bfyx};
+            input1_layout = layout{ov::PartialShape::dynamic(input1_shape.size()), data_types::f16, format::bfyx};
+        } else {
+            input0_layout = layout{ov::PartialShape(input0_shape), data_types::f16, format::bfyx};
+            input1_layout = layout{ov::PartialShape(input1_shape), data_types::f16, format::bfyx};
+        }
+
+        auto input0_mem = engine.allocate_memory(layout{ov::PartialShape(input0_shape), data_types::f16, format::bfyx});
+        auto input1_mem = engine.allocate_memory(layout{ov::PartialShape(input1_shape), data_types::f16, format::bfyx});
+
+        auto input_0_data = rg.generate_random_1d<ov::float16>(ov::shape_size(input0_shape), -2, 2);
+        auto input_1_data = rg.generate_random_1d<ov::float16>(ov::shape_size(input1_shape), -2, 2);
+
+        set_values(input0_mem, input_0_data);
+        set_values(input1_mem, input_1_data);
+
+        topology topology;
+        topology.add(input_layout("input0", input0_layout),
+                     input_layout("input1", input1_layout),
+                     gemm("gemm", { input_info("input0"), input_info("input1") }, data_types::f16, {}, {}, {}, {}, input0_order, input1_order)
+        );
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
+        network->set_input_data("input0", input0_mem);
+        network->set_input_data("input1", input1_mem);
+
+        auto inst = network->get_primitive("gemm");
+        auto impl = inst->get_impl();
+        ASSERT_TRUE(impl != nullptr);
+        ASSERT_TRUE(impl->is_dynamic() == is_input_dynamic);
+
+        auto outputs = network->execute();
+
+        auto output_mem = outputs.at("gemm").get_memory();
+        cldnn::mem_lock<ov::float16> output_ptr(output_mem, get_test_stream());
+
+        ov::Shape ref_input0_shape;
+        ov::Shape ref_input1_shape;
+        ov::Shape ref_output_shape;
+        if (num_dims == 1) {
+            ref_input0_shape = { K_SIZE };
+            ref_input1_shape = { K_SIZE, N_SIZE };
+            ref_output_shape = { 1, N_SIZE };
+        } else if (num_dims == 2) {
+            ref_input0_shape = { M_SIZE, K_SIZE };
+            ref_input1_shape = { K_SIZE, N_SIZE };
+            ref_output_shape = { M_SIZE, N_SIZE };
+        } else if (num_dims == 3) {
+            ref_input0_shape = { BATCH_SIZE, M_SIZE, K_SIZE };
+            ref_input1_shape = { BATCH_SIZE, K_SIZE, N_SIZE };
+            ref_output_shape = { BATCH_SIZE, M_SIZE, N_SIZE };
+        } else if (num_dims == 4) {
+            ref_input0_shape = { BATCH_SIZE, 1, M_SIZE, K_SIZE };
+            ref_input1_shape = { BATCH_SIZE, 1, K_SIZE, N_SIZE };
+            ref_output_shape = { BATCH_SIZE, 1, M_SIZE, N_SIZE };
+        }
+
+        std::vector<ov::float16> ref_out_data;
+        ref_out_data.resize(ov::shape_size(ref_output_shape));
+
+        std::vector<ov::float16> ref_input_0_data(input_0_data.size());
+        std::vector<ov::float16> ref_input_1_data(input_1_data.size());
+
+        ov::reference::transpose((const char *)(input_0_data.data()),
+                                 (char *)(ref_input_0_data.data()),
+                                 input0_shape,
+                                 sizeof(ov::float16),
+                                 input0_order,
+                                 ref_input0_shape);
+
+        ov::reference::transpose((const char *)(input_1_data.data()),
+                                 (char *)(ref_input_1_data.data()),
+                                 input1_shape,
+                                 sizeof(ov::float16),
+                                 input1_order,
+                                 ref_input1_shape);
+
+        ov::reference::matmul<ov::float16>(ref_input_0_data.data(),
+                                     ref_input_1_data.data(),
+                                     ref_out_data.data(),
+                                     ref_input0_shape,
+                                     ref_input1_shape,
+                                     ref_output_shape,
+                                     false,
+                                     false);
+
+        ASSERT_EQ(output_ptr.size(), ref_out_data.size());
+
+        const auto abs_error = 0.0001;
+        for (uint32_t i = 0; i < ref_out_data.size(); ++i) {
+            ASSERT_NEAR(output_ptr[i], ref_out_data[i], abs_error) << "at " << i;
+        }
+    }
 };
 
 TEST_F(gemm_gpu_tests, basic_bfyx_t2_inplace_crop_with_pad) {
@@ -1465,36 +1586,68 @@ TEST_F(gemm_gpu_tests, dynamic_multi_inference_different_shape) {
     this->test_dynamic_multi_inference_different_shape(false);
 }
 
-TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_1d) {
-    this->test_transpose_matmul(1, true, false);
+TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_1d_f16) {
+    this->test_transpose_matmul_f16(1, true, false);
 }
 
-TEST_F(gemm_gpu_tests, transpose_matmul_static_1d) {
-    this->test_transpose_matmul(1, false, false);
+TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_1d_f32) {
+    this->test_transpose_matmul_f32(1, true, false);
 }
 
-TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_2d) {
-    this->test_transpose_matmul(2, true, false);
+TEST_F(gemm_gpu_tests, transpose_matmul_static_1d_f16) {
+    this->test_transpose_matmul_f16(1, false, false);
 }
 
-TEST_F(gemm_gpu_tests, transpose_matmul_static_2d) {
-    this->test_transpose_matmul(2, false, false);
+TEST_F(gemm_gpu_tests, transpose_matmul_static_1d_f32) {
+    this->test_transpose_matmul_f32(1, false, false);
 }
 
-TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_3d) {
-    this->test_transpose_matmul(3, true, false);
+TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_2d_f16) {
+    this->test_transpose_matmul_f16(2, true, false);
 }
 
-TEST_F(gemm_gpu_tests, transpose_matmul_static_3d) {
-    this->test_transpose_matmul(3, false, false);
+TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_2d_f32) {
+    this->test_transpose_matmul_f32(2, true, false);
 }
 
-TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_4d) {
-    this->test_transpose_matmul(4, true, false);
+TEST_F(gemm_gpu_tests, transpose_matmul_static_2d_f16) {
+    this->test_transpose_matmul_f16(2, false, false);
 }
 
-TEST_F(gemm_gpu_tests, transpose_matmul_static_4d) {
-    this->test_transpose_matmul(4, false, false);
+TEST_F(gemm_gpu_tests, transpose_matmul_static_2d_f32) {
+    this->test_transpose_matmul_f32(2, false, false);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_3d_f16) {
+    this->test_transpose_matmul_f16(3, true, false);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_3d_f32) {
+    this->test_transpose_matmul_f32(3, true, false);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_static_3d_f16) {
+    this->test_transpose_matmul_f16(3, false, false);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_static_3d_f32) {
+    this->test_transpose_matmul_f32(3, false, false);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_4d_f16) {
+    this->test_transpose_matmul_f16(4, true, false);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_4d_f32) {
+    this->test_transpose_matmul_f32(4, true, false);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_static_4d_f16) {
+    this->test_transpose_matmul_f16(4, false, false);
+}
+
+TEST_F(gemm_gpu_tests, transpose_matmul_static_4d_f32) {
+    this->test_transpose_matmul_f32(4, false, false);
 }
 
 TEST_F(gemm_gpu_tests, transpose_matmul_in0_indirect) {
@@ -2968,7 +3121,7 @@ TEST_F(gemm_gpu_tests, basic_bfyx_t2_inplace_crop_with_pad_cached) {
 }
 
 TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_4d_cached) {
-    this->test_transpose_matmul(4, true, true);
+    this->test_transpose_matmul_f16(4, true, true);
 }
 
 TEST_F(gemm_gpu_tests, transpose_matmul_transpose_dynamic_4d_cached) {


### PR DESCRIPTION
### Details:
 -  Optimize gemm_tiled_opt kernel for large matmul in dynamic shape execution by 1) increase n tile size and 2) apply manual software pipelining with A matrix prefetch. 
 - Also fixed issues in fused eltwise input data loading for vector data.  

### Tickets:
 - 133445
