### PR TITLE
[GPU] Extend pattern for ClampFP16Output

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/clamp_fp16_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/clamp_fp16_output.cpp
@@ -10,6 +10,10 @@
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/softmax.hpp"
 #include "openvino/op/reshape.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/divide.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
@@ -28,7 +32,12 @@ ClampFP16Output::ClampFP16Output() {
     auto in1 = any_input(as_value_predicate(class_other_than<v0::Constant>()));
     auto matmul_m = wrap_type<v0::MatMul>({in0, in1}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
     auto reshape_m = wrap_type<v1::Reshape>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
-    auto softmax_input_m = std::make_shared<Or>(ov::OutputVector{reshape_m, matmul_m});
+    auto add_m = wrap_type<v1::Add>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
+    auto multiply_m = wrap_type<v1::Multiply>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
+    auto subtract_m = wrap_type<v1::Subtract>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
+    auto divide_m = wrap_type<v1::Divide>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
+    auto eltwise_m = std::make_shared<Or>(ov::OutputVector{add_m, multiply_m, subtract_m, divide_m});
+    auto softmax_input_m = std::make_shared<Or>(ov::OutputVector{eltwise_m, reshape_m, matmul_m});
     auto softmax_m = wrap_type<v8::Softmax>({softmax_input_m}, type_matches(ov::element::f16));
 
     ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/clamp_fp16_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/clamp_fp16_output.cpp
@@ -33,10 +33,8 @@ ClampFP16Output::ClampFP16Output() {
     auto matmul_m = wrap_type<v0::MatMul>({in0, in1}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
     auto reshape_m = wrap_type<v1::Reshape>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
     auto add_m = wrap_type<v1::Add>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
-    auto multiply_m = wrap_type<v1::Multiply>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
-    auto subtract_m = wrap_type<v1::Subtract>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
-    auto divide_m = wrap_type<v1::Divide>({matmul_m, any_input()}, all_of({type_matches(ov::element::f16), consumers_count(1)}));
-    auto eltwise_m = std::make_shared<Or>(ov::OutputVector{add_m, multiply_m, subtract_m, divide_m});
+    auto eltwise_m = wrap_type<v1::Divide, v1::Add, v1::Multiply, v1::Subtract>({matmul_m, any_input()},
+                                                                                all_of({type_matches(ov::element::f16), consumers_count(1)}));
     auto softmax_input_m = std::make_shared<Or>(ov::OutputVector{eltwise_m, reshape_m, matmul_m});
     auto softmax_m = wrap_type<v8::Softmax>({softmax_input_m}, type_matches(ov::element::f16));
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/clamp_fp16_output_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/clamp_fp16_output_test.cpp
@@ -15,6 +15,8 @@
 #include <openvino/op/constant.hpp>
 #include "openvino/op/clamp.hpp"
 #include "openvino/op/reshape.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/maximum.hpp"
 #include <plugin/transformations/clamp_fp16_output.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
@@ -92,7 +94,6 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest3) {
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
 
-
 TEST_F(TransformationTestsF, ClampFp16OutputTest4) {
     {
         auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 3, 2, 2 });
@@ -105,6 +106,52 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest4) {
     }
     {
         model_ref = model->clone(); // Not changed due to const input2
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, ClampFp16OutputTest5) {
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 3, 2, 2 });
+        auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 1, 2, 2 });
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input1, input2, true, false);
+        auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 3, 2, 2 });
+        auto add = std::make_shared<ov::op::v1::Add>(matmul, data);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(add, 1);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2, data });
+        manager.register_pass<ClampFP16Output>();
+    }
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 3, 2, 2 });
+        auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 1, 2, 2 });
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input1, input2, true, false);
+        auto min = static_cast<double>(std::numeric_limits<ov::float16>::lowest());
+        auto max = static_cast<double>(std::numeric_limits<ov::float16>::max());
+        auto clamp = std::make_shared<ov::op::v0::Clamp>(matmul, min, max);
+        auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 3, 2, 2 });
+        auto add = std::make_shared<ov::op::v1::Add>(clamp, data);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(add, 1);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2, data });
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, ClampFp16OutputTest6) {
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 3, 2, 2 });
+        auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 1, 2, 2 });
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input1, input2, true, false);
+        auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{ 3, 2, 2 });
+        auto maximum = std::make_shared<ov::op::v1::Maximum>(matmul, data);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(maximum, 1);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2, data });
+        manager.register_pass<ClampFP16Output>();
+    }
+    {
+        model_ref = model->clone(); // Not changed due to types for eltwise not supporting fusion to gemm
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }


### PR DESCRIPTION
### Details:
 - By PR(https://github.com/openvinotoolkit/openvino/pull/22245), `clamp_fp16_output` opt pass was moved to ngraph
 - Because nodes such as eltwise(`Add`, `Subtract`, `Multiply`, `Divide`) that were fused into target node `gemm` are not supported in pattern, corresponding pattern was extended for this purpose

### Tickets:
 - 135060
