### PR TITLE
[GPU] Fix count non zero for empty input

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -34,6 +34,15 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
         }
     }
 
+    event::ptr execute_impl(const std::vector<event::ptr>& events, count_nonzero_inst& instance) override {
+        if (instance.get_impl_params()->input_layouts[0].count() == 0) {
+            // set count of non-zero elements to 0 in case if input tensor is empty to have correct memory alloc for gather_nonzero
+            return instance.output_memory(0).fill(instance.get_network().get_stream(), 0);
+        } else {
+            return parent::execute_impl(events, instance);
+        }
+    }
+
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, bool is_shape_agnostic = false) {
         return get_default_params<kernel_selector::count_nonzero_params>(impl_param, is_shape_agnostic);
     }


### PR DESCRIPTION
### Details:
 - Adds buffer reset to 0 in `count_nonzero` impl in case of empty input tensor as currently we may try to allocate random amount of memory in subsequent `gather_nonzero` call
