### PR TITLE
[GPU] Re-enable memory reuse for gemm

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -33,6 +33,12 @@ struct gemm_impl : multi_stage_primitive<gemm> {
         return make_unique<gemm_impl>(*this);
     }
 
+    gemm_impl() = default;
+
+    gemm_impl(const std::vector<kernel_selector::kernel_data>& kd) : parent(kd) {
+        this->can_reuse_memory = true;
+    }
+
     void load(BinaryInputBuffer& ib) override {
         parent::load(ib);
         if (is_dynamic()) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
@@ -51,7 +51,7 @@ struct multi_stage_primitive : public typed_primitive_impl<PType> {
         for (size_t k = 0; k < other._kernels.size(); ++k) {
             _kernels.emplace_back(other._kernels[k]->clone());
         }
-        this->can_reuse_memory = false;
+        this->can_reuse_memory = other.can_reuse_memory;
         this->_kernel_name = other._kernel_name;
         this->_is_dynamic = other._is_dynamic;
     }


### PR DESCRIPTION
### Details:
 - Since #22726 gemm is derived from multi-stage impl which had memory reuse flag enforced to false for all sub-classes.
 - This patch enables memory reuse back for gemm kernel to reduce memory consumption.

### Tickets:
 - *135361*
