### PR TITLE
Calculate model weights hash in parallel

### DIFF
--- a/src/inference/src/compilation_context.cpp
+++ b/src/inference/src/compilation_context.cpp
@@ -12,6 +12,7 @@
 #endif
 
 #include "itt.hpp"
+#include "openvino/core/parallel.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/xml_parse_utils.hpp"
@@ -121,8 +122,32 @@ std::string ModelCache::compute_hash(const std::string& modelStr,
 
         auto ptr = static_cast<size_t*>(tensor.data());
         size_t size = tensor.get_size() / sizeof(size_t);
-        for (size_t i = 0; i < size; i++)
-            seed = hash_combine(seed, ptr[i]);
+
+        size_t block_size = 100000000;
+        size_t blocks_num = size / block_size;
+        std::vector<uint64_t> block_hashes(blocks_num + 1);
+
+        ov::parallel_for(blocks_num, [&](size_t block_idx) {
+            auto& block_hash = block_hashes[block_idx];
+            auto local_ptr = ptr + block_size * block_idx;
+            for (size_t i = 0; i < block_size; i++) {
+                block_hash = hash_combine(block_hash, local_ptr[i]);
+            }
+        });
+
+        {
+            auto& block_hash = block_hashes[blocks_num];
+            auto local_ptr = ptr + block_size * blocks_num;
+            auto elements_left = size - block_size * blocks_num;
+            for (size_t i = 0; i < elements_left; i++) {
+                block_hash = hash_combine(block_hash, local_ptr[i]);
+            }
+        }
+
+        for (auto hash : block_hashes) {
+            seed = hash_combine(seed, hash);
+        }
+
         auto size_done = size * sizeof(size_t);
         auto ptr_left = static_cast<uint8_t*>(tensor.data()) + size_done;
         size_t size_left = tensor.get_size() - size_done;

--- a/src/inference/src/compilation_context.cpp
+++ b/src/inference/src/compilation_context.cpp
@@ -123,25 +123,28 @@ std::string ModelCache::compute_hash(const std::string& modelStr,
         auto ptr = static_cast<size_t*>(tensor.data());
         size_t size = tensor.get_size() / sizeof(size_t);
 
-        size_t block_size = 100000000;
+        // 1MB block size in size_t
+        const size_t block_size = 1000000 / sizeof(size_t);
         size_t blocks_num = size / block_size;
-        std::vector<uint64_t> block_hashes(blocks_num + 1);
+        std::vector<uint64_t> block_hashes(blocks_num + 1, 0);
 
         ov::parallel_for(blocks_num, [&](size_t block_idx) {
-            auto& block_hash = block_hashes[block_idx];
+            uint64_t local_hash = 0;
             auto local_ptr = ptr + block_size * block_idx;
             for (size_t i = 0; i < block_size; i++) {
-                block_hash = hash_combine(block_hash, local_ptr[i]);
+                local_hash = hash_combine(local_hash, local_ptr[i]);
             }
+            block_hashes[block_idx] = local_hash;
         });
 
         {
-            auto& block_hash = block_hashes[blocks_num];
+            uint64_t local_hash = 0;
             auto local_ptr = ptr + block_size * blocks_num;
             auto elements_left = size - block_size * blocks_num;
             for (size_t i = 0; i < elements_left; i++) {
-                block_hash = hash_combine(block_hash, local_ptr[i]);
+                local_hash = hash_combine(local_hash, local_ptr[i]);
             }
+            block_hashes[blocks_num] = local_hash;
         }
 
         for (auto hash : block_hashes) {

--- a/src/inference/src/compilation_context.cpp
+++ b/src/inference/src/compilation_context.cpp
@@ -123,8 +123,8 @@ std::string ModelCache::compute_hash(const std::string& modelStr,
         auto ptr = static_cast<size_t*>(tensor.data());
         size_t size = tensor.get_size() / sizeof(size_t);
 
-        // 1MB block size in size_t
-        const size_t block_size = 1000000 / sizeof(size_t);
+        // 10MB block size in size_t
+        const size_t block_size = 10000000 / sizeof(size_t);
         size_t blocks_num = size / block_size;
         std::vector<uint64_t> block_hashes(blocks_num + 1, 0);
 


### PR DESCRIPTION
### Details:
 - Calculate model weights hash in parallel in case of reading model from buffer

### Tickets:
 - CVS-134771
