### PR TITLE
[GPU] Optimize softmax kernels

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
@@ -37,28 +37,35 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     const uint in_data_set_idx = get_global_id(0);  // this WI's id in group of items processing single data set
     const uint data_set_size = DATA_SET_SIZE;       // how many elements are in one data set
     const uint data_sets_count = DATA_SETS_COUNT;   // how many data sets are in the processing payload
-#if !IS_DYNAMIC
-    const uint items_num = ITEMS_NUM;               // how many elements are processed per one WI
-    const uint leftovers = LEFTOVERS;
-#else
-    // since workers_per_data_set is calculated by power of 2
-    // items_num can be calculated by dividing data_set_size by power of 2
-    const uint power = CALC_POWER(workers_per_data_set);
-    const uint items_num = data_set_size>>power;
-    const uint leftovers = data_set_size-(items_num<<power);
-#endif
 
     // To use subgroup block write functions, offset should be 16 bytes aligned.
     // ************************************************************************
     // | aligned_offset | 16 bytes aligned data offset | actual leftovers
     // ************************************************************************
     // leftover = aligned_offset + actual_leftovers
+
+#if !IS_DYNAMIC
+    const uint origin_items_num = ITEMS_NUM;               // how many elements are processed per one WI
+    const uint origin_leftovers = LEFTOVERS;
+#else
+    // since workers_per_data_set is calculated by power of 2
+    // items_num can be calculated by dividing data_set_size by power of 2
+    const uint power = CALC_POWER(workers_per_data_set);
+    const uint origin_items_num = data_set_size>>power;
+    const uint origin_leftovers = data_set_size-(origin_items_num<<power);
+#endif
+
     const uint data_set_offset = data_set_idx * data_set_size;
-    const uint aligned_offset = (workers_per_data_set > SUB_GROUP_SIZE)?
-                    (((SUBGROUP_BLOCK_WRITE_BYTE_BOUNDARY - data_set_offset * sizeof(INPUT0_TYPE) % SUBGROUP_BLOCK_WRITE_BYTE_BOUNDARY) % SUBGROUP_BLOCK_WRITE_BYTE_BOUNDARY) / sizeof(INPUT0_TYPE)) : 0;
+    const uint data_set_offset_byte_counts = data_set_offset * sizeof(INPUT0_TYPE);
+    const uint aligned_offset = ((workers_per_data_set > SUB_GROUP_SIZE) && (data_set_offset_byte_counts % SUBGROUP_BLOCK_WRITE_BYTE_BOUNDARY != 0))
+                ? ((((data_set_offset_byte_counts >> 4) + 1) << 4) / sizeof(INPUT0_TYPE) - data_set_offset) : 0;
+    const uint items_num = (origin_leftovers < aligned_offset) ? (origin_items_num - 1) : origin_items_num;
+    const uint leftovers = (origin_leftovers < aligned_offset) ? (origin_leftovers + workers_per_data_set) : origin_leftovers;
+
     const uint subgroup_offset = get_sub_group_id() * get_sub_group_size() * items_num;
-    const uint leftover_idx = (data_set_offset + in_data_set_idx) + ((in_data_set_idx < aligned_offset) ? 0 : (workers_per_data_set * items_num));
     const uint aligned_data_offset = data_set_offset + subgroup_offset + aligned_offset;
+    const uint actual_leftovers = leftovers - aligned_offset;
+    const uint leftover_idx = data_set_offset + aligned_offset + workers_per_data_set * items_num + in_data_set_idx;
 
     INPUT0_TYPE my_chunk[STACK_SIZE];
     INPUT0_TYPE my_maximum = -UNIT_VAL_MAX;
@@ -67,38 +74,47 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     __local INPUT0_TYPE lg_storage[SLM_SIZE];
 
     // Read inputs and Get maximum value from data set
-    uint i=0;
+    uint input_idx=0;
     if (workers_per_data_set > SUB_GROUP_SIZE)
     {
-        unroll_for (; i<items_num - (items_num % SUBGROUP_BLOCK_SIZE); i+=SUBGROUP_BLOCK_SIZE)
+        unroll_for (; input_idx<items_num - (items_num % SUBGROUP_BLOCK_SIZE); input_idx+=SUBGROUP_BLOCK_SIZE)
         {
-            BLOCK_TYPE vec_tmp = BLOCK_READ(input, aligned_data_offset + i * get_sub_group_size());
+            BLOCK_TYPE vec_tmp = BLOCK_READ(input, aligned_data_offset + input_idx * get_sub_group_size());
 #if SUBGROUP_BLOCK_SIZE == 1
             my_maximum = max(my_maximum, vec_tmp);
-            my_chunk[i] = vec_tmp;
+            my_chunk[input_idx] = vec_tmp;
 #else
             for (int j = 0; j < SUBGROUP_BLOCK_SIZE; j++)
             {
                 INPUT0_TYPE tmp = vec_tmp[j];
                 my_maximum = max(my_maximum, tmp);
-                my_chunk[i+j] = tmp;
+                my_chunk[input_idx+j] = tmp;
             }
 #endif
         }
     }
 
-    unroll_for (; i<items_num; i++)
+    unroll_for (; input_idx < items_num; input_idx++)
     {
-        INPUT0_TYPE tmp = input[aligned_data_offset + get_sub_group_local_id() + i * get_sub_group_size()];
+        INPUT0_TYPE tmp = input[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()];
         my_maximum = max(my_maximum, tmp);
-        my_chunk[i] = tmp;
+        my_chunk[input_idx] = tmp;
     }
-    if (in_data_set_idx < leftovers)
+
+    if (in_data_set_idx < aligned_offset)
+    {
+        INPUT0_TYPE tmp = input[data_set_offset + in_data_set_idx];
+        my_maximum = max(my_maximum, tmp);
+        my_chunk[input_idx++] = tmp;
+    }
+
+    if (in_data_set_idx < actual_leftovers)
     {
         INPUT0_TYPE tmp = input[leftover_idx];
         my_maximum = max(my_maximum, tmp);
-        my_chunk[items_num] = tmp;
+        my_chunk[input_idx++] = tmp;
     }
+
     my_maximum = sub_group_reduce_max(my_maximum);
 
     if (get_sub_group_local_id() == 0)
@@ -107,8 +123,8 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     barrier(CLK_LOCAL_MEM_FENCE);
     if (in_data_set_idx == 0)
     {
-        unroll_for (uint i=1; i<get_num_sub_groups(); ++i)
-            my_maximum = max(my_maximum, lg_storage[i]);
+        unroll_for (uint j=1; j<get_num_sub_groups(); ++j)
+            my_maximum = max(my_maximum, lg_storage[j]);
 
         lg_storage[0] = my_maximum;
     }
@@ -119,22 +135,13 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 
     // Get exp(x-max) and sum of exp(x-max)
     barrier(CLK_LOCAL_MEM_FENCE);
-    {
-        float tmp_sum = 0.f;
-        unroll_for (uint i=0; i<items_num; ++i)
-        {
-            INPUT0_TYPE tmp = native_exp(my_chunk[i] - my_maximum);
-            tmp_sum += convert_float(tmp);
-            my_chunk[i] = tmp;
-        }
 
-        if (in_data_set_idx < leftovers)
-        {
-            INPUT0_TYPE tmp = native_exp(my_chunk[items_num] - my_maximum);
-            tmp_sum += convert_float(tmp);
-            my_chunk[items_num] = tmp;
-        }
-        my_sum = TO_OUTPUT_TYPE(tmp_sum);
+    const uint num_iters = input_idx;
+    unroll_for (uint j=0; j<num_iters; ++j)
+    {
+        INPUT0_TYPE tmp = native_exp(my_chunk[j] - my_maximum);
+        my_sum += tmp;
+        my_chunk[j] = tmp;
     }
 
     my_sum = sub_group_reduce_add(my_sum);
@@ -145,71 +152,84 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     barrier(CLK_LOCAL_MEM_FENCE);
     if (in_data_set_idx == 0)
     {
-        float tmp_sum = lg_storage[0];
-        unroll_for (uint i=1; i<get_num_sub_groups(); ++i)
-            tmp_sum += convert_float(lg_storage[i]);
-        lg_storage[0] = TO_OUTPUT_TYPE(tmp_sum);
+        unroll_for (uint j=1; j<get_num_sub_groups(); ++j)
+            my_sum += lg_storage[j];
+
+        lg_storage[0] = my_sum;
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 
     my_sum = lg_storage[0];
 
     // Write outputs
-    i=0;
+    uint output_idx = 0;
 #if HAS_FUSED_OPS
     if (workers_per_data_set > SUB_GROUP_SIZE)
     {
-        unroll_for (; i < items_num - (items_num % SUBGROUP_BLOCK_SIZE); i+=SUBGROUP_BLOCK_SIZE)
+        unroll_for (; output_idx < items_num - (items_num % SUBGROUP_BLOCK_SIZE); output_idx+=SUBGROUP_BLOCK_SIZE)
         {
             BLOCK_TYPE vec_tmp;
 #if SUBGROUP_BLOCK_SIZE == 1
-            ACTIVATION_TYPE dequantized = my_chunk[i] / my_sum;
+            ACTIVATION_TYPE dequantized = my_chunk[output_idx] / my_sum;
             FUSED_OPS_MAIN;
             vec_tmp = FUSED_OPS_RESULT_MAIN;
 #else
             unroll_for (int j = 0; j < SUBGROUP_BLOCK_SIZE; j++)
             {
-                ACTIVATION_TYPE dequantized = my_chunk[i + j] / my_sum;
+                ACTIVATION_TYPE dequantized = my_chunk[output_idx + j] / my_sum;
                 FUSED_OPS_MAIN;
                 vec_tmp[j] = FUSED_OPS_RESULT_MAIN;
             }
 #endif
-            BLOCK_WRITE(output, aligned_data_offset + i * get_sub_group_size(), vec_tmp);
+            BLOCK_WRITE(output, aligned_data_offset + output_idx * get_sub_group_size(), vec_tmp);
         }
     }
-    unroll_for (; i<items_num; i++)
+    unroll_for (; output_idx < items_num; output_idx++)
     {
-        ACTIVATION_TYPE dequantized = my_chunk[i] / my_sum;
+        ACTIVATION_TYPE dequantized = my_chunk[output_idx] / my_sum;
         FUSED_OPS_MAIN;
         output[aligned_data_offset + get_sub_group_local_id() + i * get_sub_group_size()] = FUSED_OPS_RESULT_MAIN;
     }
-    if (in_data_set_idx < leftovers)
+
+    if (in_data_set_idx < aligned_offset)
     {
-        ACTIVATION_TYPE dequantized = my_chunk[items_num] / my_sum;
+        ACTIVATION_TYPE dequantized = my_chunk[output_idx++] / my_sum;
+        FUSED_OPS_LEFTOVERS;
+        output[data_set_offset + in_data_set_idx] = FUSED_OPS_RESULT_LEFTOVERS;
+    }
+
+    if (in_data_set_idx < actual_leftovers)
+    {
+        ACTIVATION_TYPE dequantized = my_chunk[output_idx++] / my_sum;
         FUSED_OPS_LEFTOVERS;
         output[leftover_idx] = FUSED_OPS_RESULT_LEFTOVERS;
     }
 #else
     if (workers_per_data_set > SUB_GROUP_SIZE)
     {
-        unroll_for (; i<items_num - (items_num % SUBGROUP_BLOCK_SIZE); i+=SUBGROUP_BLOCK_SIZE)
+        unroll_for (; output_idx<items_num - (items_num % SUBGROUP_BLOCK_SIZE); output_idx+=SUBGROUP_BLOCK_SIZE)
         {
             BLOCK_TYPE vec_tmp;
 #if SUBGROUP_BLOCK_SIZE == 1
-            vec_tmp = ACTIVATION(my_chunk[i] / my_sum, ACTIVATION_PARAMS);
+            vec_tmp = ACTIVATION(my_chunk[output_idx] / my_sum, ACTIVATION_PARAMS);
 #else
             unroll_for (int j = 0; j < SUBGROUP_BLOCK_SIZE; j++)
-                vec_tmp[j] = ACTIVATION(my_chunk[i + j] / my_sum, ACTIVATION_PARAMS);
+                vec_tmp[j] = ACTIVATION(my_chunk[output_idx + j] / my_sum, ACTIVATION_PARAMS);
 #endif
-            BLOCK_WRITE(output, aligned_data_offset + i * get_sub_group_size(), vec_tmp);
+            BLOCK_WRITE(output, aligned_data_offset + output_idx * get_sub_group_size(), vec_tmp);
         }
     }
-    unroll_for (; i < items_num; i++)
+
+    unroll_for (; output_idx < items_num; output_idx++)
     {
-        output[aligned_data_offset + get_sub_group_local_id() + i * get_sub_group_size()] = ACTIVATION(my_chunk[i] / my_sum, ACTIVATION_PARAMS);
+        output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] = ACTIVATION(my_chunk[output_idx] / my_sum, ACTIVATION_PARAMS);
     }
-    if (in_data_set_idx < leftovers)
-        output[leftover_idx] = ACTIVATION(my_chunk[items_num] / my_sum, ACTIVATION_PARAMS);
+
+    if (in_data_set_idx < aligned_offset)
+        output[data_set_offset + in_data_set_idx] = ACTIVATION(my_chunk[output_idx++] / my_sum, ACTIVATION_PARAMS);
+
+    if (in_data_set_idx < actual_leftovers)
+        output[leftover_idx] = ACTIVATION(my_chunk[output_idx++] / my_sum, ACTIVATION_PARAMS);
 #endif
 }
 #ifdef CALC_POWER

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
@@ -134,8 +134,8 @@ JitConstants SoftmaxKernel_bf::GetJitConstants(const softmax_params& params, Dis
         }
 
         // It can be expected that the maximum possible itemsNum will not exceed 32
-        // Therefore, in dynamic shape, stack_size including additional buffer is set to 33
-        constexpr size_t stack_size = 33; // The size of stack for my_chunk
+        // Therefore, in dynamic shape, stack_size including additional buffer is set to 35 32 + 3 (aligned offset + leftovers)
+        constexpr size_t stack_size = 35; // The size of stack for my_chunk
         jit.AddConstants({
             MakeJitConstant("LWS", lws_0),
             MakeJitConstant("SLM_SIZE", dispatchData.maxSlmSize),
@@ -151,7 +151,7 @@ JitConstants SoftmaxKernel_bf::GetJitConstants(const softmax_params& params, Dis
             MakeJitConstant("DATA_SETS_COUNT", dispatchData.dataSetsCount),
             MakeJitConstant("DATA_SET_SIZE", dispatchData.dataSetSize),
             MakeJitConstant("LEFTOVERS", dispatchData.leftovers),
-            MakeJitConstant("STACK_SIZE", dispatchData.itemsNum + 1),
+            MakeJitConstant("STACK_SIZE", dispatchData.itemsNum + 2), // (aligned offset + leftovers)
         });
     }
     jit.AddConstant(MakeJitConstant("SUB_GROUP_SIZE", subgroup_size));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
@@ -134,8 +134,8 @@ JitConstants SoftmaxKernel_bf::GetJitConstants(const softmax_params& params, Dis
         }
 
         // It can be expected that the maximum possible itemsNum will not exceed 32
-        // Therefore, in dynamic shape, stack_size including additional buffer is set to 35 32 + 3 (aligned offset + leftovers)
-        constexpr size_t stack_size = 35; // The size of stack for my_chunk
+        // Therefore, in dynamic shape, stack_size including additional buffer is set to 34(32 + 2(aligned offset + leftovers))
+        constexpr size_t stack_size = 34; // The size of stack for my_chunk
         jit.AddConstants({
             MakeJitConstant("LWS", lws_0),
             MakeJitConstant("SLM_SIZE", dispatchData.maxSlmSize),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/softmax_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/softmax_gpu_test.cpp
@@ -1205,7 +1205,7 @@ TEST(softmax_gpu_bfyx_f32, bf_opt_normalize_f_dynamic) {
     }
 }
 
-static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t y, const int64_t x) {
+static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t y, const int64_t x, const uint64_t axis) {
     tests::random_generator rg(GET_SUITE_NAME);
     auto& engine = get_test_engine();
     auto config = get_test_default_config(engine);
@@ -1222,7 +1222,7 @@ static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t
     std::string softmax_id = "softmax";
     topology topology;
     topology.add(input_layout("input", input_layout_dynamic));
-    topology.add(softmax(softmax_id, input_info("input"), 3));
+    topology.add(softmax(softmax_id, input_info("input"), axis));
 
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
 
@@ -1240,15 +1240,15 @@ static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t
     ASSERT_NE(output, nullptr);
 
     std::vector<ov::float16> output_ref(buf_size);
-    ov::reference::softmax<ov::float16>(input_data.data(), output_ref.data(), input_layout_static.get_shape(), ov::AxisSet{3});
+    ov::reference::softmax<ov::float16>(input_data.data(), output_ref.data(), input_layout_static.get_shape(), ov::AxisSet{axis});
     ASSERT_NE(output, nullptr);
     const float threshold_fp16 = 1e-1;
     cldnn::mem_lock<ov::float16> output_ptr(output, get_test_stream());
     for (size_t idx = 0; idx < static_cast<size_t>(buf_size); idx++) {
-         ASSERT_NEAR(float(output_ptr[idx]), float(output_ref[idx]), threshold_fp16) << std::fixed << setprecision(8) << output_ptr[idx] << " vs " << output_ref[idx];
+        ASSERT_NEAR(float(output_ptr[idx]), float(output_ref[idx]), threshold_fp16) << idx << ", " << std::fixed << setprecision(8) << output_ptr[idx] << " vs " << output_ref[idx];
     }
 }
 
-TEST(softmax_gpu_bfyx_f16, opt_softmax_bf) {
-    run_softmax_bfyx_opt(1, 2, 2, 267);
+TEST(softmax_gpu_bfyx_f16, opt_softmax_bf_axis_3) {
+    run_softmax_bfyx_opt(1, 2, 2, 3083, 3);
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/softmax_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/softmax_gpu_test.cpp
@@ -1250,5 +1250,5 @@ static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t
 }
 
 TEST(softmax_gpu_bfyx_f16, opt_softmax_bf_axis_3) {
-    run_softmax_bfyx_opt(1, 2, 2, 3083, 3);
+    run_softmax_bfyx_opt(1, 4, 2, 3083, 3);
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/softmax_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/softmax_gpu_test.cpp
@@ -3,6 +3,9 @@
 //
 
 #include "test_utils.h"
+#include "random_generator.hpp"
+
+#include "openvino/reference/softmax.hpp"
 
 #include <intel_gpu/primitives/input_layout.hpp>
 #include <intel_gpu/primitives/softmax.hpp>
@@ -1200,4 +1203,52 @@ TEST(softmax_gpu_bfyx_f32, bf_opt_normalize_f_dynamic) {
             }
         }
     }
+}
+
+static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t y, const int64_t x) {
+    tests::random_generator rg(GET_SUITE_NAME);
+    auto& engine = get_test_engine();
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    ov::intel_gpu::ImplementationDesc softmax_bf_kernel = {format::bfyx, "softmax_gpu_bf"};
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"softmax", softmax_bf_kernel}}));
+
+    const int64_t buf_size = b * f * y * x;
+    auto input_layout_dynamic = layout{ov::PartialShape{ov::Dimension::dynamic(), f, ov::Dimension::dynamic(), ov::Dimension::dynamic()},
+                                        data_types::f16, format::bfyx};
+    auto input_layout_static = layout{ov::PartialShape{b, f, y, x}, data_types::f16, format::bfyx};
+
+    std::string softmax_id = "softmax";
+    topology topology;
+    topology.add(input_layout("input", input_layout_dynamic));
+    topology.add(softmax(softmax_id, input_info("input"), 3));
+
+    cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+
+    auto input_mem = engine.allocate_memory(input_layout_static);
+
+    auto input_data = rg.generate_random_1d<ov::float16>(buf_size, -20, 20);
+    set_values(input_mem, input_data);
+
+    std::map<cldnn::primitive_id, cldnn::network_output> outputs;
+    cldnn::memory::ptr output = nullptr;
+
+    network->set_input_data("input", input_mem);
+    outputs = network->execute();
+    output = outputs.at(softmax_id).get_memory();
+    ASSERT_NE(output, nullptr);
+
+    std::vector<ov::float16> output_ref(buf_size);
+    ov::reference::softmax<ov::float16>(input_data.data(), output_ref.data(), input_layout_static.get_shape(), ov::AxisSet{3});
+    ASSERT_NE(output, nullptr);
+    const float threshold_fp16 = 1e-1;
+    cldnn::mem_lock<ov::float16> output_ptr(output, get_test_stream());
+    for (size_t idx = 0; idx < static_cast<size_t>(buf_size); idx++) {
+         ASSERT_NEAR(float(output_ptr[idx]), float(output_ref[idx]), threshold_fp16) << std::fixed << setprecision(8) << output_ptr[idx] << " vs " << output_ref[idx];
+    }
+}
+
+TEST(softmax_gpu_bfyx_f16, opt_softmax_bf) {
+    run_softmax_bfyx_opt(1, 2, 2, 267);
 }


### PR DESCRIPTION
### Details:
 - *Support sub_group_read for the case with SUB_GROUP_BLOCK_SIZE 1*
 - *Rearrange leftovers to support 16 bytes aligned for sub group block write*
 - *Use float value for summation in softmax kernel for accuracy issue*
 - *Increase STACK_SIZE of my_chunk to support aligned_offset and leftovers*
 - *Add unit test" 

### Tickets:
 - *133443*
