### PR TITLE
[chore] Use debug loglevel for github metrics script

### DIFF
--- a/.github/scripts/collect_github_metrics.py
+++ b/.github/scripts/collect_github_metrics.py
@@ -112,6 +112,7 @@ def main():
     repo = g.get_repo(repo_name)
 
     run = repo.get_workflow_run(int(run_id))
+    logger.debug('Processing run ID %s - %s', run_id, run.name)
     if run.status != 'completed':
         logger.error('Run %s is not completed! Only completed runs should be in the database', run_id)
         raise SystemExit(1)
@@ -144,6 +145,7 @@ def main():
 
     for job in run.jobs():
         job_id = job.id
+        logger.debug('Processing job %s', job.name)
         queued_duration_seconds = 0
         duration_seconds = 0
 
@@ -178,6 +180,7 @@ def main():
         logger.debug('Job query: %s', job_data_query)
         cur.execute(job_data_query)
         for step in job.steps:
+            logger.debug('Processing step %s', step.name)
             duration_seconds_timedelta = step.completed_at - step.started_at
             duration_seconds = round(duration_seconds_timedelta.total_seconds())
 

--- a/.github/workflows/send_workflows_to_opentelemetry.yml
+++ b/.github/workflows/send_workflows_to_opentelemetry.yml
@@ -62,7 +62,8 @@ jobs:
           PGPASSWORD: ${{ secrets.METRICS_DATABASE_PASSWORD }}
           PGDATABASE: ${{ secrets.METRICS_DATABASE_NAME }}
           PGPORT: 5432
-          LOGLEVEL: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
+          # LOGLEVEL: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
+          LOGLEVEL: DEBUG
         run: |
           python3 .github/scripts/collect_github_metrics.py \
           --run-id ${{ github.event.workflow_run.id }} \

--- a/.github/workflows/send_workflows_to_opentelemetry.yml
+++ b/.github/workflows/send_workflows_to_opentelemetry.yml
@@ -62,6 +62,7 @@ jobs:
           PGPASSWORD: ${{ secrets.METRICS_DATABASE_PASSWORD }}
           PGDATABASE: ${{ secrets.METRICS_DATABASE_NAME }}
           PGPORT: 5432
+          LOGLEVEL: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
         run: |
           python3 .github/scripts/collect_github_metrics.py \
           --run-id ${{ github.event.workflow_run.id }} \


### PR DESCRIPTION
### Details:
We can switch log level for GitHub metrics script only when the workflow is restarted with debug logging
