### PR TITLE
[GPU] Fix checking that convolution supports fusings in onednn case

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -432,8 +432,10 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
         };
 
         auto conv_supports_fusings = [&](convolution_node& node) -> bool {
-            if (_lo.get_optimization_attributes().use_onednn_impls == 1)
+            if (_lo.get_optimization_attributes().use_onednn_impls == 1 &&
+                _lo.get_preferred_impl_type(node, format::any) == impl_types::onednn) {
                 return true;
+            }
 
             if (node.get_output_layout().is_dynamic() || node.get_input_layout().is_dynamic()) {
                 return true;

--- a/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
@@ -770,7 +770,7 @@ TEST_P(conv_fp32_wrong_bias, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_fp32_wrong_bias, ::testing::ValuesIn(std::vector<convolution_test_params>{
-    convolution_test_params{ CASE_CONV_FP32_15, 3, 2, 3 },
+    convolution_test_params{ CASE_CONV_FP32_15, 3, 3, 3 },
 }));
 
 class conv_fp32_add_per_element_planar_const : public ConvFusingTest {};
@@ -1819,7 +1819,7 @@ TEST_P(conv_fp32_group_conv_eltwise_sum, basic) {
 #define CASE_GROUP_CONV_ELTW_FP32_1 { 1, 48, 3, 3 }, { 1, 48, 3, 3 }, { 1, 48, 3, 3 }, { 16, 3, 3, 3, 3 }, { 1, 1 }, { 1, 1 }, { 1, 1 }, 16, data_types::f32, format::bfyx, data_types::f32, format::g_os_iyx_osv16, data_types::f32, format::bfyx
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_fp32_group_conv_eltwise_sum, ::testing::ValuesIn(std::vector<conv_eltw_test_params>{
-    conv_eltw_test_params{ CASE_GROUP_CONV_ELTW_FP32_1, 3, 2, 3 },
+    conv_eltw_test_params{ CASE_GROUP_CONV_ELTW_FP32_1, 3, 3, 3 },
 }));
 
 class conv_swap_xy_with_eltwise_diff_sizes : public ConvEltwTest {};
@@ -4335,7 +4335,7 @@ TEST_P(onednn_replace_full_tensor_sum_to_binary_add, basic) {
 #define CASE_CONV_ELTW_SUM_TO_BINARY_ADD { 1, 32, 4, 4 }, { 1, 32, 2, 2 }, { 32, 32, 3, 3 }, { 1, 1 }, { 0, 0 }, { 1, 1 }, 1, data_types::f16, format::bfyx, data_types::f16, format::bfyx, data_types::f16, format::b_fs_yx_fsv16, data_types::f16, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
 
 INSTANTIATE_TEST_SUITE_P(eltwise_sum_fusings_gpu, onednn_replace_full_tensor_sum_to_binary_add, ::testing::ValuesIn(std::vector<convolution_eltw_sum_test_params>{
-    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_TO_BINARY_ADD, 2, 2, 3 },
+    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_TO_BINARY_ADD, 3, 3, 3 },
 }));
 
 #endif  // ENABLE_ONEDNN_FOR_GPU

--- a/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
@@ -493,7 +493,7 @@ TEST_P(deconv_actv_eltw_actv, basic_cached) {
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, deconv_actv_eltw_actv, ::testing::ValuesIn(std::vector<deconv_test_params>{
     // Some fusings disabled under deconvolution -> convolution optimization
-    deconv_test_params{ CASE_DECONV_FP32_1, 3, 2, 5 },
+    deconv_test_params{ CASE_DECONV_FP32_1, 3, 3, 5 },
     deconv_test_params{ CASE_DECONV_FP32_2, 2, 2, 5 },
     deconv_test_params{ CASE_DECONV_FP32_3, 2, 2, 5 },
     deconv_test_params{ CASE_DECONV_FP32_4, 2, 2, 5 },
@@ -502,7 +502,7 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, deconv_actv_eltw_actv, ::testing::ValuesIn
     deconv_test_params{ CASE_DECONV_FP32_7, 2, 2, 5 },
     deconv_test_params{ CASE_DECONV_FP32_8, 2, 2, 5 },
 
-    deconv_test_params{ CASE_DECONV_FP16_1, 3, 2, 5 },
+    deconv_test_params{ CASE_DECONV_FP16_1, 3, 3, 5 },
     deconv_test_params{ CASE_DECONV_FP16_2, 2, 2, 5 },
     deconv_test_params{ CASE_DECONV_FP16_3, 2, 2, 5 },
     deconv_test_params{ CASE_DECONV_FP16_4, 2, 2, 5 },


### PR DESCRIPTION
### Details:
 - *Fixed the cause of sporadic accuracy drops on several models on dGPU*

### Tickets:
 - [*CVS-134878*](https://jira.devtools.intel.com/browse/CVS-134878)
