### PR TITLE
[CPU] Prohibit fc avx2_vnni_2 decompression for bf16 input

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/precision_translation.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/precision_translation.cpp
@@ -21,12 +21,14 @@ InOutTypes getTypeConfiguration(const MemoryDescArgs& descriptors, const TypeMap
     });
 
     for (const auto& entry : mapping) {
-        const auto& pattern = entry.first;
+        if (!entry.enabled())
+            continue;
+
+        const auto& pattern = entry.mask();
         if (!match(pattern, types))
             continue;
 
-        const auto& translator = entry.second;
-        return translator(types);
+        return entry.translate(types);
     }
 
     OPENVINO_THROW("Failed to create a type configuration for the provided memory descriptors");


### PR DESCRIPTION
### Details:
 - The FC changes made in scope of #20486 were missed when rebasing #20718
 - The context is: Even the system and the node does support bf16 precision we have to fall back to f32 in/out precision
 due to lack of support for decompression with bf16 avx2_vnni_2 in oneDNN fork.
 - To cover this limitation an additional type mapping parameter in form of std::function was introduced for disabling particular type mapping entry using a runtime check (isa support in this case)

### Tickets:
 - 122347
 - 136163