### PR TITLE
[GPU] Remove heavy Reorder in target pattern(Conv - Reorder - Reshape -MVN)

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -47,6 +47,15 @@
 
 using namespace cldnn;
 
+int get_env(std::string key, int &val);
+int get_env(std::string key, int &val) {
+        if (const auto env_var = std::getenv(key.c_str())) {
+            val = std::atoi(env_var);
+            return true;
+        }
+        return false;
+}
+
 static size_t get_post_ops_count(const program_node& node) {
     size_t onednn_post_ops_count = 0;
     for (auto& fo : node.get_fused_primitives()) {
@@ -701,9 +710,31 @@ bool layout_optimizer::should_select_b_fs_yx_fsv16_layout(convolution_node const
     auto current_conv_partially_supports_layout = convolution_b_fs_yx_fsv16_opt(input_layout, output_layout, weights_layout, prim, true);
     auto may_use_weak_restrictions = is_prev_conv_node_supports_layout || weak_restriction_cond;
 
-    return ((_optimization_attributes.b_fs_yx_fsv16_network) &&
+    std::function<bool(const program_node&, size_t, size_t)> need_heavy_reorder = [&](const program_node& node, size_t cur_depth, size_t max_depth) {
+        if (cur_depth > max_depth) return false;
+        // vae_decoder target list{2097152, 8388608, 16777216, 33554432, 67108864}
+        if (node.is_type<reorder>()) {
+            for (auto& reorder_user : node.get_users()) {
+                if (reorder_user->is_type<reshape>()) {
+                    for (auto& reshape_user : reorder_user->get_users()) {
+                        if (reshape_user->is_type<mvn>() && node.get_output_layout().get_linear_size() > 2000000) {
+                            GPU_DEBUG_LOG << node.id() << ": " << node.get_output_layout().to_short_string() << " -> heavy reorder" << std::endl;
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        bool res = false;
+        for (const auto& usr : node.get_users()) {
+            res |= need_heavy_reorder(*usr, cur_depth + 1, max_depth);
+        }
+        return res;
+    };
+
+    return (((_optimization_attributes.b_fs_yx_fsv16_network) &&
             (current_conv_supports_layout || (may_use_weak_restrictions && current_conv_partially_supports_layout))) ||
-           input_layout.format == format::b_fs_yx_fsv16;
+           input_layout.format == format::b_fs_yx_fsv16) && !need_heavy_reorder(reinterpret_cast<program_node const&>(node), 0, 3);
 }
 
 bool layout_optimizer::convolution_b_fs_zyx_fsv16_opt(const layout& input_layout,
@@ -1804,7 +1835,12 @@ format layout_optimizer::get_preferred_format(program_node& node) {
     if (!_forcing_map.empty() && _forcing_map.count(node.id()) != 0) {
         expected = _forcing_map.at(node.id()).first;
     } else if (node.is_type<convolution>()) {
-        expected = get_expected_format(node.as<convolution>());
+        int val = 0;
+        get_env("CONV_TEST", val);
+        if (val)
+            expected = format::bfyx;
+        else
+            expected = get_expected_format(node.as<convolution>());
     } else if (node.is_type<quantize>()) {
         expected = get_expected_format(node.as<quantize>());
     } else if (node.is_type<reorder>() || node.is_type<input_layout>()) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -709,7 +709,7 @@ bool layout_optimizer::should_select_b_fs_yx_fsv16_layout(convolution_node const
                     for (auto& reshape_user : reorder_user->get_users()) {
                         // Meteor Lake showed planar format Convolution without Reorder is better than
                         // blocked format Convolution in case Reorder is larger than [1, 512, 128, 128].
-                        if (reshape_user->is_type<mvn>() && node.get_output_layout().get_linear_size() > 33000000) {
+                        if (reshape_user->is_type<mvn>() && node.get_output_layout().get_linear_size() > 8300000) {
                             GPU_DEBUG_LOG << node.id() << ": " << node.get_output_layout().to_short_string() << " -> heavy reorder" << std::endl;
                             return true;
                         }


### PR DESCRIPTION
Reorder is main bottle-neck(roughly 40%) in SD1.5(vae_decoder) on MTL.

Reorder in target pattern is always added at Reshape primitive creation, because of Reshape's in/out dimens are different.
We can get huge improvement to remove heavy Reorders from Using planner format in Conv.

Target pattern(Conv - Reorder - Reshape -MVN) repeats 14times  in vae_decoder.


### Tickets:
 - *134278*