### PR TITLE
[GPU] add reorder between mvn and conv.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
@@ -242,7 +242,7 @@ void prepare_padding::run(program& p) {
         }
 
         auto& input = node.get_dependency(0);
-        if (!node.is_dynamic() && node.get_preferred_impl_type() == impl_types::ocl && input.is_type<mvn>()) {
+        if (node.get_preferred_impl_type() == impl_types::ocl && input.is_type<mvn>()) {
             auto new_reorder = std::make_shared<reorder>(node.id() + "_padding_reorder_for_" + input.id(), input.id(), input.get_output_layout());
             auto& new_reorder_node = p.get_or_create(new_reorder);
             p.add_intermediate(new_reorder_node, node, input);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
@@ -6,6 +6,7 @@
 #include "program_node.h"
 #include "pass_manager.h"
 #include "convolution_inst.h"
+#include "mvn_inst.h"
 #include "sliding_window_utils.hpp"
 #include <algorithm>
 
@@ -240,6 +241,13 @@ void prepare_padding::run(program& p) {
             padding_end_z = std::max<tensor::value_type>(input_limit_z - prev_prim_output_layout.spatial(2), 0);
         }
 
+        auto& input = node.get_dependency(0);
+        if (!node.is_dynamic() && node.get_preferred_impl_type() == impl_types::ocl && input.is_type<mvn>()) {
+            auto new_reorder = std::make_shared<reorder>(node.id() + "_padding_reorder_for_" + input.id(), input.id(), input.get_output_layout());
+            auto& new_reorder_node = p.get_or_create(new_reorder);
+            p.add_intermediate(new_reorder_node, node, input);
+        }
+
         // Adjust right padding, so entire buffer size in X dimension is properly aligned.
         // TODO: NOTE: Will be reenabled with next check-in once heuristic for line-aligned algorithm will be added.
         // auto needed_buffer_size_x = static_cast<cldnn::tensor::value_type>(
@@ -248,6 +256,6 @@ void prepare_padding::run(program& p) {
 
         cldnn::padding needed_padding({0, 0, padding_begin_x, padding_begin_y, padding_begin_z}, {0, 0, padding_end_x, padding_end_y, padding_end_z}, 0);
         needed_padding = padding::max(prev_prim_output_layout.data_padding, needed_padding);
-        p.apply_needed_padding(node, conv_input_node, needed_padding);
+        p.apply_needed_padding(node, node.get_dependency(0), needed_padding);
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_padding_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_padding_test.cpp
@@ -8,6 +8,7 @@
 #include "intel_gpu/runtime/engine.hpp"
 #include "intel_gpu/graph/program.hpp"
 #include "data_inst.h"
+#include "mvn_inst.h"
 #include "convolution_inst.h"
 #include "pass_manager.h"
 #include "program_wrapper.h"
@@ -39,4 +40,31 @@ TEST(prepare_padding, groupconv_with_output) {
     const auto& node = prog->get_node("reorder_input_conv");
     auto params = node.get_kernel_impl_params();
     ASSERT_EQ(params->get_output_layout().data_padding.upper_size().spatial[2], 0);
+}
+
+TEST(prepare_padding, mvn_conv) {
+    tests::random_generator rg(GET_SUITE_NAME);
+    auto& engine = get_test_engine();
+    auto in_layout = layout{{1, 3, 512, 512}, data_types::f16, format::bfyx};
+    auto input = engine.allocate_memory(in_layout);
+    auto weights_data = rg.generate_random_4d<ov::float16>(3, 3, 3, 3, -1, 1);
+    auto weights_mem = engine.allocate_memory({ {3, 3, 3, 3}, data_types::f16, format::bfyx});
+    set_values(weights_mem, weights_data);
+
+    topology topo;
+    topo.add(input_layout("input", in_layout));
+    topo.add(mvn("mvn", input_info("input"), true, 1e-10f, true, { 2 }));
+    topo.add(data("weight", weights_mem));
+    topo.add(convolution("conv", input_info("mvn"), "weight", "", 1, {1, 1}, {1, 1}, {1, 1}, {1, 1}, false));
+    topo.add(reorder("reorder_output", input_info("conv"), format::bfyx, data_types::f16));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    auto prog = program::build_program(engine, topo, config, false, true);
+    network network(engine, topo, config);
+    network.set_input_data("input", input);
+    EXPECT_NO_THROW(network.execute());
+
+    ASSERT_TRUE(has_node(*network.get_program(), "conv_padding_reorder_for_mvn"));
 }

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_padding_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_padding_test.cpp
@@ -66,8 +66,10 @@ TEST(prepare_padding, mvn_conv) {
     network.set_input_data("input", input);
     EXPECT_NO_THROW(network.execute());
 
-    const auto& node = prog->get_node("conv");
-    if (!node.get_selected_impl()->is_onednn()) {
-        ASSERT_TRUE(has_node(*network.get_program(), "conv_padding_reorder_for_mvn"));
+    for (auto& item : network.get_executed_primitives()) {
+        auto prim = network.get_primitive(item.first);
+        if (prim->get_node().is_type<convolution>() && !prim->get_impl()->is_onednn()) {
+            ASSERT_TRUE(has_node(*network.get_program(), "conv_padding_reorder_for_mvn"));
+        }
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_padding_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_padding_test.cpp
@@ -66,5 +66,8 @@ TEST(prepare_padding, mvn_conv) {
     network.set_input_data("input", input);
     EXPECT_NO_THROW(network.execute());
 
-    ASSERT_TRUE(has_node(*network.get_program(), "conv_padding_reorder_for_mvn"));
+    const auto& node = prog->get_node("conv");
+    if (!node.get_selected_impl()->is_onednn()) {
+        ASSERT_TRUE(has_node(*network.get_program(), "conv_padding_reorder_for_mvn"));
+    }
 }


### PR DESCRIPTION
- add reorder to avoid inserting padding to mvn before ocl conv.
- mvn does not support padding.

### Tickets:
 - 136385