### PR TITLE
[Tests] Fixed Error update in output comparison

### DIFF
--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -445,7 +445,7 @@ void compare(const ov::Tensor& expected, const ov::Tensor& actual, double abs_th
             continue;
         }
 
-        bool status = error.update(expected_value, actual_value, i);
+        bool status = error.update(actual_value, expected_value, i);
 #ifdef NDEBUG
         if (!status) {
             break;


### PR DESCRIPTION
### Details:
 - *Fixed the order of parameters in `error.update` call to avoid misunderstanding in error message.*

### Tickets:
 - *N/A*
