### PR TITLE
[DOCS] Update code examples with imports and save_model for 24.0

### DIFF
--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-convert-models-as-python-objects.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-convert-models-as-python-objects.rst
@@ -15,7 +15,11 @@ Model conversion API is represented by ``convert_model()`` method in openvino.to
 
 .. note::
 
-   Model conversion can be performed by the ``convert_model()`` method and MO command line tool. The functionality from this article is applicable for ``convert_model()`` only and it is not present in command line tool.
+   Model conversion can be performed only when you install
+   :doc:`the development tools <../../../legacy-features/install-dev-tools>`, which provide
+   both the ``convert_model()`` method and ``mo`` command-line tool.
+   The functionality from this article is applicable for ``convert_model()`` only and it is
+   not present in command-line tool.
 
 
 ``convert_model()`` returns an openvino.runtime.Model object which can be compiled and inferred or serialized to IR.
@@ -26,6 +30,7 @@ Example of converting a PyTorch model directly from memory:
    :force:
 
    import torchvision
+   from openvino.tools.mo import convert_model
 
    model = torchvision.models.resnet50(weights='DEFAULT')
    ov_model = convert_model(model)
@@ -43,6 +48,7 @@ Example of using native Python classes to set ``input_shape``, ``mean_values`` a
    :force:
 
    from openvino.runtime import PartialShape, Layout
+   from openvino.tools.mo import convert_model
 
    ov_model = convert_model(model, input_shape=PartialShape([1,3,100,100]), mean_values=[127, 127, 127], layout=Layout("NCHW"))
 
@@ -50,6 +56,9 @@ Example of using strings for setting ``input_shape``, ``mean_values`` and ``layo
 
 .. code-block:: py
    :force:
+
+   from openvino.runtime import Layout
+   from openvino.tools.mo import convert_model
 
    ov_model = convert_model(model, input_shape="[1,3,100,100]", mean_values="[127,127,127]", layout="NCHW")
 
@@ -61,6 +70,8 @@ Example of using a tuple in the ``input`` parameter to cut a model:
 
 .. code-block:: py
    :force:
+
+   from openvino.tools.mo import convert_model
 
    ov_model = convert_model(model, input=("input_name", [3], np.float32))
 
@@ -100,6 +111,9 @@ Example of using lists to set shapes, types and layout for multiple inputs:
 .. code-block:: py
    :force:
 
+   from openvino.runtime import Layout
+   from openvino.tools.mo import convert_model, LayoutMap
+
    ov_model = convert_model(model, input=[("input1", [1,3,100,100], np.float32), ("input2", [1,3,100,100], np.float32)], layout=[Layout("NCHW"), LayoutMap("NCHW", "NHWC")])
 
 ``layout``, ``source_layout`` and ``dest_layout`` accept an ``openvino.runtime.Layout`` object or ``string``.
@@ -126,4 +140,13 @@ Example of using the ``LayoutMap`` class to change the layout of a model input:
    from openvino.tools.mo import convert_model, LayoutMap
 
    ov_model = convert_model(model, layout=LayoutMap("NCHW", "NHWC"))
+
+Example of using the ``serialize`` method to save the converted model to OpenVINO IR:
+
+.. code-block:: py
+   :force:
+
+   from openvino.runtime import serialize
+
+   serialize(ov_model, "model.xml")
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats.rst
@@ -65,6 +65,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 import torchvision
+                 from openvino.tools.mo import convert_model
+                 core = openvino.Core()
+
                  model = torchvision.models.resnet50(weights='DEFAULT')
                  ov_model = convert_model(model)
                  compiled_model = core.compile_model(ov_model, "AUTO")
@@ -108,6 +113,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 from openvino.tools.mo import convert_model
+                 
+                 core = openvino.Core()
                  ov_model = convert_model("saved_model.pb")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -209,6 +218,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 from openvino.tools.mo import convert_model
+
+                 core = openvino.Core()
                  ov_model = convert_model("<INPUT_MODEL>.tflite")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -229,7 +242,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.tflite")
+                 import openvino
+
+                 core = openvino.Core()
+                 ov_model = core.read_model("<INPUT_MODEL>.tflite")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
@@ -243,6 +259,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 
+                 core = openvino.Core()
                  compiled_model = core.compile_model("<INPUT_MODEL>.tflite", "AUTO")
 
               For a guide on how to run inference, see how to
@@ -327,6 +346,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 from openvino.tools.mo import convert_model
+
+                 core = openvino.Core()
                  ov_model = convert_model("<INPUT_MODEL>.onnx")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -347,7 +370,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.onnx")
+                 import openvino
+                 core = openvino.Core()
+
+                 ov_model = core.read_model("<INPUT_MODEL>.onnx")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
@@ -360,6 +386,9 @@ Here are code examples of how to use these methods with different model formats:
 
               .. code-block:: py
                  :force:
+
+                 import openvino
+                 core = openvino.Core()
 
                  compiled_model = core.compile_model("<INPUT_MODEL>.onnx", "AUTO")
 
@@ -448,6 +477,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 from openvino.tools.mo import convert_model
+
+                 core = openvino.Core()
                  ov_model = convert_model("<INPUT_MODEL>.pdmodel")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -467,6 +500,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 core = openvino.Core()
+
                  ov_model = read_model("<INPUT_MODEL>.pdmodel")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -480,6 +516,9 @@ Here are code examples of how to use these methods with different model formats:
 
               .. code-block:: py
                  :force:
+
+                 import openvino
+                 core = openvino.Core()
 
                  compiled_model = core.compile_model("<INPUT_MODEL>.pdmodel", "AUTO")
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-convert-onnx.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-convert-onnx.rst
@@ -4,7 +4,7 @@
 =============================================
 
 .. meta::
-   :description: Learn how to convert a model from the 
+   :description: Learn how to convert a model from the
                  ONNX format to the OpenVINO Intermediate Representation.
 
 
@@ -12,7 +12,7 @@
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Converting an ONNX Model <../../../../../openvino-workflow/model-preparation/convert-model-onnx>` article. 
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Converting an ONNX Model <../../../../../openvino-workflow/model-preparation/convert-model-onnx>` article.
 
 
 .. note:: ONNX models are supported via FrontEnd API. You may skip conversion to IR and read models directly by OpenVINO runtime API. Refer to the :doc:`inference example <../../../../../openvino-workflow/running-inference/integrate-openvino-with-your-application>` for more details. Using ``convert_model`` is still necessary in more complex cases, such as new custom inputs/outputs in model pruning, adding pre-processing, or using Python conversion extensions.
@@ -32,6 +32,10 @@ The model conversion process assumes you have an ONNX model that was directly do
       .. code-block:: py
          :force:
 
+         import openvino
+         from openvino.tools.mo import convert_model
+
+         core = openvino.Core()
          ov_model = convert_model("<INPUT_MODEL>.onnx")
          compiled_model = core.compile_model(ov_model, "AUTO")
 

--- a/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-convert-tensorflow.rst
+++ b/docs/articles_en/documentation/legacy-features/transition-legacy-conversion-api/legacy-conversion-api/[legacy]-supported-model-formats/[legacy]-convert-tensorflow.rst
@@ -208,6 +208,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
   .. code-block:: py
      :force:
 
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
+
      model = tf.keras.applications.ResNet50(weights="imagenet")
      ov_model = convert_model(model)
 
@@ -218,6 +221,7 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
      :force:
 
      import tensorflow_hub as hub
+     from openvino.tools.mo import convert_model
 
      model = hub.KerasLayer("https://tfhub.dev/google/imagenet/mobilenet_v1_100_224/classification/5")
      ov_model = convert_model(model, input_shape=[-1, 224, 224, 3])
@@ -226,6 +230,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
 
   .. code-block:: py
      :force:
+
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
 
      class MyModule(tf.Module):
         def __init__(self, name=None):
@@ -243,6 +250,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
   .. code-block:: py
      :force:
 
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
+
      with tf.compat.v1.Session() as sess:
         inp1 = tf.compat.v1.placeholder(tf.float32, [100], 'Input1')
         inp2 = tf.compat.v1.placeholder(tf.float32, [100], 'Input2')
@@ -256,6 +266,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
 
   .. code-block:: py
      :force:
+
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
 
      with tf.compat.v1.Session() as sess:
         inp1 = tf.compat.v1.placeholder(tf.float32, [100], 'Input1')
@@ -271,6 +284,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
   .. code-block:: py
      :force:
 
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
+
      @tf.function(
         input_signature=[tf.TensorSpec(shape=[1, 2, 3], dtype=tf.float32),
                          tf.TensorSpec(shape=[1, 2, 3], dtype=tf.float32)])
@@ -284,6 +300,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
   .. code-block:: py
      :force:
 
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
+
      with tf.compat.v1.Session() as sess:
         inp1 = tf.compat.v1.placeholder(tf.float32, [100], 'Input1')
         inp2 = tf.compat.v1.placeholder(tf.float32, [100], 'Input2')
@@ -296,6 +315,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
 
   .. code-block:: py
      :force:
+
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
 
      model = tf.keras.Model(...)
      checkpoint = tf.train.Checkpoint(model)

--- a/docs/articles_en/openvino-workflow/model-preparation/convert-model-to-ir.rst
+++ b/docs/articles_en/openvino-workflow/model-preparation/convert-model-to-ir.rst
@@ -51,9 +51,12 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import torchvision
+                 import openvino as ov
+
                  model = torchvision.models.resnet50(weights='DEFAULT')
-                 ov_model = convert_model(model)
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 ov_model = ov.convert_model(model)
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <convert-model-pytorch>`
@@ -94,8 +97,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = convert_model("saved_model.pb")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 ov_model = ov.convert_model("saved_model.pb")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <convert-model-tensorflow>`
@@ -115,8 +120,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("saved_model.pb")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 core = ov.Core()
+                 ov_model = core.read_model("saved_model.pb")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For a guide on how to run inference, see how to
               :doc:`Integrate OpenVINO™ with Your Application <../running-inference/integrate-openvino-with-your-application>`.
@@ -195,8 +203,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = convert_model("<INPUT_MODEL>.tflite")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 ov_model = ov.convert_model("<INPUT_MODEL>.tflite")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <convert-model-tensorflow-lite>`
@@ -215,8 +225,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.tflite")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 core = ov.Core()
+                 ov_model = core.read_model("<INPUT_MODEL>.tflite")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
 
@@ -229,7 +242,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 compiled_model = core.compile_model("<INPUT_MODEL>.tflite", "AUTO")
+                 import openvino as ov
+
+                 compiled_model = ov.compile_model("<INPUT_MODEL>.tflite", "AUTO")
 
               For a guide on how to run inference, see how to
               :doc:`Integrate OpenVINO™ with Your Application <../running-inference/integrate-openvino-with-your-application>`.
@@ -313,8 +328,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = convert_model("<INPUT_MODEL>.onnx")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 ov_model = ov.convert_model("<INPUT_MODEL>.onnx")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <convert-model-onnx>`
@@ -333,8 +350,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.onnx")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 core = ov.Core()
+                 ov_model = core.read_model("<INPUT_MODEL>.onnx")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
 
@@ -347,7 +367,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 compiled_model = core.compile_model("<INPUT_MODEL>.onnx", "AUTO")
+                 import openvino as ov
+
+                 compiled_model = ov.compile_model("<INPUT_MODEL>.onnx", "AUTO")
 
               For a guide on how to run inference, see how to :doc:`Integrate OpenVINO™ with Your Application <../running-inference/integrate-openvino-with-your-application>`.
 
@@ -434,8 +456,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = convert_model("<INPUT_MODEL>.pdmodel")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 ov_model = ov.convert_model("<INPUT_MODEL>.pdmodel")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <convert-model-paddle>`
@@ -453,8 +477,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.pdmodel")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 core = ov.Core()
+                 ov_model = core.read_model("<INPUT_MODEL>.pdmodel")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
 
@@ -467,7 +494,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 compiled_model = core.compile_model("<INPUT_MODEL>.pdmodel", "AUTO")
+                 import openvino as ov
+
+                 compiled_model = ov.compile_model("<INPUT_MODEL>.pdmodel", "AUTO")
 
               For a guide on how to run inference, see how to
               :doc:`Integrate OpenVINO™ with Your Application <../running-inference/integrate-openvino-with-your-application>`.
@@ -580,7 +609,7 @@ An example showing how to take advantage of OpenVINO IR, saving a model in OpenV
    ov_model = core.read_model("model.xml")
 
    # 4. Compile model from memory
-   compiled_model = core.compile_model(ov_model)
+   compiled_model = ov.compile_model(ov_model)
 
 Additional Resources
 ####################


### PR DESCRIPTION
Updating code examples with imports for convert_model and adding an example of how to save a converted model. This PR addresses the 120254 ticket. 
Porting: https://github.com/openvinotoolkit/openvino/pull/23654
