### PR TITLE
[DOCS] Update code examples with imports and save_model for for 23.3

### DIFF
--- a/docs/articles_en/documentation/openvino_legacy_features/mo_ovc_transition/legacy_conversion_api/convert_python_model_objects.rst
+++ b/docs/articles_en/documentation/openvino_legacy_features/mo_ovc_transition/legacy_conversion_api/convert_python_model_objects.rst
@@ -7,7 +7,7 @@
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Model Preparation <openvino_docs_model_processing_introduction>` article. 
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Model Preparation <openvino_docs_model_processing_introduction>` article.
 
 Model conversion API is represented by ``convert_model()`` method in openvino.tools.mo namespace. ``convert_model()`` is compatible with types from openvino.runtime, like PartialShape, Layout, Type, etc.
 
@@ -15,7 +15,11 @@ Model conversion API is represented by ``convert_model()`` method in openvino.to
 
 .. note::
 
-   Model conversion can be performed by the ``convert_model()`` method and MO command line tool. The functionality from this article is applicable for ``convert_model()`` only and it is not present in command line tool.
+   Model conversion can be performed only when you install
+   :doc:`the development tools <openvino_docs_install_guides_install_dev_tools>`, which provide
+   both the ``convert_model()`` method and ``mo`` command-line tool.
+   The functionality from this article is applicable for ``convert_model()`` only and it is
+   not present in command-line tool.
 
 
 ``convert_model()`` returns an openvino.runtime.Model object which can be compiled and inferred or serialized to IR.
@@ -26,6 +30,7 @@ Example of converting a PyTorch model directly from memory:
    :force:
 
    import torchvision
+   from openvino.tools.mo import convert_model
 
    model = torchvision.models.resnet50(weights='DEFAULT')
    ov_model = convert_model(model)
@@ -43,6 +48,7 @@ Example of using native Python classes to set ``input_shape``, ``mean_values`` a
    :force:
 
    from openvino.runtime import PartialShape, Layout
+   from openvino.tools.mo import convert_model
 
    ov_model = convert_model(model, input_shape=PartialShape([1,3,100,100]), mean_values=[127, 127, 127], layout=Layout("NCHW"))
 
@@ -50,6 +56,9 @@ Example of using strings for setting ``input_shape``, ``mean_values`` and ``layo
 
 .. code-block:: py
    :force:
+
+   from openvino.runtime import Layout
+   from openvino.tools.mo import convert_model
 
    ov_model = convert_model(model, input_shape="[1,3,100,100]", mean_values="[127,127,127]", layout="NCHW")
 
@@ -62,9 +71,11 @@ Example of using a tuple in the ``input`` parameter to cut a model:
 .. code-block:: py
    :force:
 
+   from openvino.tools.mo import convert_model
+
    ov_model = convert_model(model, input=("input_name", [3], np.float32))
 
-For complex cases, when a value needs to be set in the ``input`` parameter, the ``InputCutInfo`` class can be used. ``InputCutInfo`` accepts four parameters: ``name``, ``shape``, ``type``, and ``value``. 
+For complex cases, when a value needs to be set in the ``input`` parameter, the ``InputCutInfo`` class can be used. ``InputCutInfo`` accepts four parameters: ``name``, ``shape``, ``type``, and ``value``.
 
 ``InputCutInfo("input_name", [3], np.float32, [0.5, 2.1, 3.4])`` is equivalent of ``InputCutInfo(name="input_name", shape=[3], type=np.float32, value=[0.5, 2.1, 3.4])``.
 
@@ -85,11 +96,11 @@ Example of using ``InputCutInfo`` to freeze an input with value:
    ov_model = convert_model(model, input=InputCutInfo("input_name", [3], np.float32, [0.5, 2.1, 3.4]))
 
 To set parameters for models with multiple inputs, use ``list`` of parameters.
-Parameters supporting ``list``: 
+Parameters supporting ``list``:
 
 * input
 * input_shape
-* layout 
+* layout
 * source_layout
 * dest_layout
 * mean_values
@@ -99,6 +110,9 @@ Example of using lists to set shapes, types and layout for multiple inputs:
 
 .. code-block:: py
    :force:
+
+   from openvino.runtime import Layout
+   from openvino.tools.mo import convert_model, LayoutMap
 
    ov_model = convert_model(model, input=[("input1", [1,3,100,100], np.float32), ("input2", [1,3,100,100], np.float32)], layout=[Layout("NCHW"), LayoutMap("NCHW", "NHWC")])
 
@@ -127,3 +141,11 @@ Example of using the ``LayoutMap`` class to change the layout of a model input:
 
    ov_model = convert_model(model, layout=LayoutMap("NCHW", "NHWC"))
 
+Example of using the ``serialize`` method to save the converted model to OpenVINO IR:
+
+.. code-block:: py
+   :force:
+
+   from openvino.runtime import serialize
+
+   serialize(ov_model, "model.xml")

--- a/docs/articles_en/documentation/openvino_legacy_features/mo_ovc_transition/legacy_conversion_api/supported_model_formats.rst
+++ b/docs/articles_en/documentation/openvino_legacy_features/mo_ovc_transition/legacy_conversion_api/supported_model_formats.rst
@@ -7,7 +7,7 @@
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Supported Model Formats <openvino_docs_model_processing_introduction>` article. 
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Supported Model Formats <openvino_docs_model_processing_introduction>` article.
 
 .. toctree::
    :maxdepth: 1
@@ -26,16 +26,16 @@
 
 **OpenVINO IR (Intermediate Representation)** - the proprietary and default format of OpenVINO, benefiting from the full extent of its features. All other supported model formats, as listed below, are converted to :doc:`OpenVINO IR <openvino_ir>` to enable inference. Consider storing your model in this format to minimize first-inference latency, perform model optimization, and, in some cases, save space on your drive.
 
-**PyTorch, TensorFlow, ONNX, and PaddlePaddle** - can be used with OpenVINO Runtime API directly, 
+**PyTorch, TensorFlow, ONNX, and PaddlePaddle** - can be used with OpenVINO Runtime API directly,
 which means you do not need to save them as OpenVINO IR before including them in your application.
 OpenVINO can read, compile, and convert them automatically, as part of its pipeline.
 
-In the Python API, these options are provided as three separate methods: 
+In the Python API, these options are provided as three separate methods:
 ``read_model()``, ``compile_model()``, and ``convert_model()``.
-The ``convert_model()`` method enables you to perform additional adjustments 
-to the model, such as setting shapes, changing model input types or layouts, 
-cutting parts of the model, freezing inputs, etc. For a detailed description 
-of the conversion process, see the 
+The ``convert_model()`` method enables you to perform additional adjustments
+to the model, such as setting shapes, changing model input types or layouts,
+cutting parts of the model, freezing inputs, etc. For a detailed description
+of the conversion process, see the
 :doc:`model conversion guide <openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide>`.
 
 Here are code examples of how to use these methods with different model formats:
@@ -64,6 +64,11 @@ Here are code examples of how to use these methods with different model formats:
 
               .. code-block:: py
                  :force:
+
+                 import openvino
+                 import torchvision
+                 from openvino.tools.mo import convert_model
+                 core = openvino.Core()
 
                  model = torchvision.models.resnet50(weights='DEFAULT')
                  ov_model = convert_model(model)
@@ -108,6 +113,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 from openvino.tools.mo import convert_model
+
+                 core = openvino.Core()
                  ov_model = convert_model("saved_model.pb")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -210,6 +219,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 from openvino.tools.mo import convert_model
+
+                 core = openvino.Core()
                  ov_model = convert_model("<INPUT_MODEL>.tflite")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -230,7 +243,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.tflite")
+                 import openvino
+
+                 core = openvino.Core()
+                 ov_model = core.read_model("<INPUT_MODEL>.tflite")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
@@ -244,6 +260,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+
+                 core = openvino.Core()
                  compiled_model = core.compile_model("<INPUT_MODEL>.tflite", "AUTO")
 
               For a guide on how to run inference, see how to
@@ -328,6 +347,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 from openvino.tools.mo import convert_model
+
+                 core = openvino.Core()
                  ov_model = convert_model("<INPUT_MODEL>.onnx")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -348,7 +371,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.onnx")
+                 import openvino
+                 core = openvino.Core()
+
+                 ov_model = core.read_model("<INPUT_MODEL>.onnx")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
@@ -361,6 +387,9 @@ Here are code examples of how to use these methods with different model formats:
 
               .. code-block:: py
                  :force:
+
+                 import openvino
+                 core = openvino.Core()
 
                  compiled_model = core.compile_model("<INPUT_MODEL>.onnx", "AUTO")
 
@@ -449,6 +478,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 from openvino.tools.mo import convert_model
+                 core = openvino.Core()
+
                  ov_model = convert_model("<INPUT_MODEL>.pdmodel")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -468,6 +501,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import openvino
+                 core = openvino.Core()
+
                  ov_model = read_model("<INPUT_MODEL>.pdmodel")
                  compiled_model = core.compile_model(ov_model, "AUTO")
 
@@ -481,6 +517,9 @@ Here are code examples of how to use these methods with different model formats:
 
               .. code-block:: py
                  :force:
+
+                 import openvino
+                 core = openvino.Core()
 
                  compiled_model = core.compile_model("<INPUT_MODEL>.pdmodel", "AUTO")
 
@@ -551,10 +590,10 @@ converting them to ONNX for use with OpenVINO should be considered the default p
 
 .. note::
 
-   If you want to keep working with the legacy formats the old way, refer to a previous 
+   If you want to keep working with the legacy formats the old way, refer to a previous
    `OpenVINO LTS version and its documentation <https://docs.openvino.ai/2022.3/Supported_Model_Formats.html>`__ .
-    
-   OpenVINO versions of 2023 are mostly compatible with the old instructions, 
+
+   OpenVINO versions of 2023 are mostly compatible with the old instructions,
    through a deprecated MO tool, installed with the deprecated OpenVINO Developer Tools package.
 
    `OpenVINO 2023.0 <https://docs.openvino.ai/2023.3/Supported_Model_Formats_MO_DG.html>`__ is the last

--- a/docs/articles_en/documentation/openvino_legacy_features/mo_ovc_transition/legacy_conversion_api/supported_model_formats/Convert_Model_From_ONNX.rst
+++ b/docs/articles_en/documentation/openvino_legacy_features/mo_ovc_transition/legacy_conversion_api/supported_model_formats/Convert_Model_From_ONNX.rst
@@ -4,7 +4,7 @@
 =============================================
 
 .. meta::
-   :description: Learn how to convert a model from the 
+   :description: Learn how to convert a model from the
                  ONNX format to the OpenVINO Intermediate Representation.
 
 
@@ -12,7 +12,7 @@
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Converting an ONNX Model <openvino_docs_OV_Converter_UG_prepare_model_convert_model_Convert_Model_From_ONNX>` article. 
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Converting an ONNX Model <openvino_docs_OV_Converter_UG_prepare_model_convert_model_Convert_Model_From_ONNX>` article.
 
 
 .. note:: ONNX models are supported via FrontEnd API. You may skip conversion to IR and read models directly by OpenVINO runtime API. Refer to the :doc:`inference example <openvino_docs_OV_UG_Integrate_OV_with_your_application>` for more details. Using ``convert_model`` is still necessary in more complex cases, such as new custom inputs/outputs in model pruning, adding pre-processing, or using Python conversion extensions.
@@ -31,6 +31,10 @@ The model conversion process assumes you have an ONNX model that was directly do
 
       .. code-block:: py
          :force:
+
+         import openvino
+         from openvino.tools.mo import convert_model
+         core = openvino.Core()
 
          ov_model = convert_model("<INPUT_MODEL>.onnx")
          compiled_model = core.compile_model(ov_model, "AUTO")

--- a/docs/articles_en/documentation/openvino_legacy_features/mo_ovc_transition/legacy_conversion_api/supported_model_formats/Convert_Model_From_TensorFlow.rst
+++ b/docs/articles_en/documentation/openvino_legacy_features/mo_ovc_transition/legacy_conversion_api/supported_model_formats/Convert_Model_From_TensorFlow.rst
@@ -4,14 +4,14 @@
 ============================================
 
 .. meta::
-   :description: Learn how to convert a model from a 
+   :description: Learn how to convert a model from a
                  TensorFlow format to the OpenVINO Intermediate Representation.
 
 .. danger::
 
    The code described here has been **deprecated!** Do not use it to avoid working with a legacy solution. It will be kept for some time to ensure backwards compatibility, but **you should not use** it in contemporary applications.
 
-   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Converting a TensorFlow Model <openvino_docs_OV_Converter_UG_prepare_model_convert_model_Convert_Model_From_TensorFlow>` article. 
+   This guide describes a deprecated conversion method. The guide on the new and recommended method can be found in the :doc:`Converting a TensorFlow Model <openvino_docs_OV_Converter_UG_prepare_model_convert_model_Convert_Model_From_TensorFlow>` article.
 
 
 .. note:: TensorFlow models are supported via :doc:`FrontEnd API <openvino_docs_MO_DG_TensorFlow_Frontend>`. You may skip conversion to IR and read models directly by OpenVINO runtime API. Refer to the :doc:`inference example <openvino_docs_OV_UG_Integrate_OV_with_your_application>` for more details. Using ``convert_model`` is still necessary in more complex cases, such as new custom inputs/outputs in model pruning, adding pre-processing, or using Python conversion extensions.
@@ -125,7 +125,7 @@ TensorFlow 2 SavedModel format has a specific graph structure due to eager execu
 pruning, find custom input nodes in the ``StatefulPartitionedCall/*`` subgraph.
 
 Since the 2023.0 release, direct pruning of models in SavedModel format is not supported.
-It is essential to freeze the model before pruning. Use the following code snippet for model freezing: 
+It is essential to freeze the model before pruning. Use the following code snippet for model freezing:
 
 .. code-block:: py
    :force:
@@ -208,6 +208,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
   .. code-block:: py
      :force:
 
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
+
      model = tf.keras.applications.ResNet50(weights="imagenet")
      ov_model = convert_model(model)
 
@@ -218,6 +221,7 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
      :force:
 
      import tensorflow_hub as hub
+     from openvino.tools.mo import convert_model
 
      model = hub.KerasLayer("https://tfhub.dev/google/imagenet/mobilenet_v1_100_224/classification/5")
      ov_model = convert_model(model, input_shape=[-1, 224, 224, 3])
@@ -226,6 +230,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
 
   .. code-block:: py
      :force:
+
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
 
      class MyModule(tf.Module):
         def __init__(self, name=None):
@@ -243,6 +250,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
   .. code-block:: py
      :force:
 
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
+
      with tf.compat.v1.Session() as sess:
         inp1 = tf.compat.v1.placeholder(tf.float32, [100], 'Input1')
         inp2 = tf.compat.v1.placeholder(tf.float32, [100], 'Input2')
@@ -256,6 +266,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
 
   .. code-block:: py
      :force:
+
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
 
      with tf.compat.v1.Session() as sess:
         inp1 = tf.compat.v1.placeholder(tf.float32, [100], 'Input1')
@@ -271,6 +284,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
   .. code-block:: py
      :force:
 
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
+
      @tf.function(
         input_signature=[tf.TensorSpec(shape=[1, 2, 3], dtype=tf.float32),
                          tf.TensorSpec(shape=[1, 2, 3], dtype=tf.float32)])
@@ -284,6 +300,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
   .. code-block:: py
      :force:
 
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
+
      with tf.compat.v1.Session() as sess:
         inp1 = tf.compat.v1.placeholder(tf.float32, [100], 'Input1')
         inp2 = tf.compat.v1.placeholder(tf.float32, [100], 'Input2')
@@ -296,6 +315,9 @@ Model conversion API supports passing TensorFlow/TensorFlow2 models directly fro
 
   .. code-block:: py
      :force:
+
+     import tensorflow as tf
+     from openvino.tools.mo import convert_model
 
      model = tf.keras.Model(...)
      checkpoint = tf.train.Checkpoint(model)

--- a/docs/articles_en/openvino_workflow/model_preparation/Convert_Model_IR.rst
+++ b/docs/articles_en/openvino_workflow/model_preparation/Convert_Model_IR.rst
@@ -51,9 +51,12 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
+                 import torchvision
+                 import openvino as ov
+
                  model = torchvision.models.resnet50(weights='DEFAULT')
-                 ov_model = convert_model(model)
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 ov_model = ov.convert_model(model)
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <openvino_docs_MO_DG_prepare_model_convert_model_Convert_Model_From_PyTorch>`
@@ -94,8 +97,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = convert_model("saved_model.pb")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 ov_model = ov.convert_model("saved_model.pb")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <openvino_docs_MO_DG_prepare_model_convert_model_Convert_Model_From_TensorFlow>`
@@ -115,8 +120,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("saved_model.pb")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 core = ov.Core()
+                 ov_model = core.read_model("saved_model.pb")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For a guide on how to run inference, see how to
               :doc:`Integrate OpenVINO™ with Your Application <openvino_docs_OV_UG_Integrate_OV_with_your_application>`.
@@ -196,8 +204,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = convert_model("<INPUT_MODEL>.tflite")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 ov_model = ov.convert_model("<INPUT_MODEL>.tflite")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <openvino_docs_MO_DG_prepare_model_convert_model_Convert_Model_From_TensorFlow>`
@@ -216,8 +226,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.tflite")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 core = ov.Core()
+                 ov_model = core.read_model("<INPUT_MODEL>.tflite")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
 
@@ -230,7 +243,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 compiled_model = core.compile_model("<INPUT_MODEL>.tflite", "AUTO")
+                 import openvino as ov
+
+                 compiled_model = ov.compile_model("<INPUT_MODEL>.tflite", "AUTO")
 
               For a guide on how to run inference, see how to
               :doc:`Integrate OpenVINO™ with Your Application <openvino_docs_OV_UG_Integrate_OV_with_your_application>`.
@@ -314,8 +329,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = convert_model("<INPUT_MODEL>.onnx")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 ov_model = ov.convert_model("<INPUT_MODEL>.onnx")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <openvino_docs_MO_DG_prepare_model_convert_model_Convert_Model_From_ONNX>`
@@ -334,8 +351,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.onnx")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 core = ov.Core()
+                 ov_model = core.read_model("<INPUT_MODEL>.onnx")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
 
@@ -348,7 +368,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 compiled_model = core.compile_model("<INPUT_MODEL>.onnx", "AUTO")
+                 import openvino as ov
+
+                 compiled_model = ov.compile_model("<INPUT_MODEL>.onnx", "AUTO")
 
               For a guide on how to run inference, see how to :doc:`Integrate OpenVINO™ with Your Application <openvino_docs_OV_UG_Integrate_OV_with_your_application>`.
 
@@ -435,8 +457,10 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = convert_model("<INPUT_MODEL>.pdmodel")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 ov_model = ov.convert_model("<INPUT_MODEL>.pdmodel")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
               For more details on conversion, refer to the
               :doc:`guide <openvino_docs_MO_DG_prepare_model_convert_model_Convert_Model_From_Paddle>`
@@ -454,8 +478,11 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 ov_model = read_model("<INPUT_MODEL>.pdmodel")
-                 compiled_model = core.compile_model(ov_model, "AUTO")
+                 import openvino as ov
+
+                 core = ov.Core()
+                 ov_model = core.read_model("<INPUT_MODEL>.pdmodel")
+                 compiled_model = ov.compile_model(ov_model, "AUTO")
 
             * The ``compile_model()`` method:
 
@@ -468,7 +495,9 @@ Here are code examples of how to use these methods with different model formats:
               .. code-block:: py
                  :force:
 
-                 compiled_model = core.compile_model("<INPUT_MODEL>.pdmodel", "AUTO")
+                 import openvino as ov
+
+                 compiled_model = ov.compile_model("<INPUT_MODEL>.pdmodel", "AUTO")
 
               For a guide on how to run inference, see how to
               :doc:`Integrate OpenVINO™ with Your Application <openvino_docs_OV_UG_Integrate_OV_with_your_application>`.
@@ -581,7 +610,7 @@ An example showing how to take advantage of OpenVINO IR, saving a model in OpenV
    ov_model = core.read_model("model.xml")
 
    # 4. Compile model from memory
-   compiled_model = core.compile_model(ov_model)
+   compiled_model = ov.compile_model(ov_model)
 
 Additional Resources
 ####################


### PR DESCRIPTION
Updating code examples with imports for ``convert_model`` and adding an example of how to save a converted model. This PR addresses the 120254 ticket.
Porting: https://github.com/openvinotoolkit/openvino/pull/23654
