### PR TITLE
[GPU] Added padding propagation logic for reshape primitive

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/common_optimizations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/common_optimizations.cpp
@@ -127,15 +127,6 @@ bool ov::pass::CommonOptimizations::run_on_model(const std::shared_ptr<ov::Model
     // before CommonOptimization pipeline execution
     REGISTER_PASS(manager, MOCTransformations, true, false)
 
-    // The transformations below have to be a part of MOC transformations.
-    // They delete StridedSlices which do nothing, just return the same data tensor to output.
-    // But in some plugins, deletion of these "useless" StridedSlices can cause functional issues.
-    // tickets: 135242, 135241
-    auto strided_slice_elimination = manager.register_pass<GraphRewrite>();
-    ADD_MATCHER(strided_slice_elimination, NopStridedSlice)
-    ADD_MATCHER(strided_slice_elimination, NopStridedSliceByShape)
-    strided_slice_elimination->set_name("ov::pass::StridedSliceElimination");
-
     // Enabling conversion of FP16 IR to legacy representation, each plugin have to disable it
     // after support for FP16 IR is implemented
     REGISTER_PASS(manager, ConvertCompressedOnlyToLegacy)

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -1016,6 +1016,7 @@ ov::pass::NopElimination::NopElimination(bool use_shape_for_elimination) {
     ADD_MATCHER_FOR_THIS(EliminateEltwise)
     using namespace ov::pass;
     ADD_MATCHER_FOR_THIS(EliminateSplitConcat)
+    ADD_MATCHER_FOR_THIS(NopStridedSlice)
 
     // shape-dependent transformations
     if (use_shape_for_elimination) {
@@ -1027,6 +1028,7 @@ ov::pass::NopElimination::NopElimination(bool use_shape_for_elimination) {
         ADD_MATCHER_FOR_THIS(EliminateBroadcast)
         ADD_MATCHER_FOR_THIS(EliminateNopBroadcast)
         ADD_MATCHER_FOR_THIS(NopSliceBeforeGatherElements)
+        ADD_MATCHER_FOR_THIS(NopStridedSliceByShape)
         ADD_MATCHER_FOR_THIS(EliminateGather)
     }
 }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
@@ -336,6 +336,10 @@ struct layout {
     /// Modify padding in layout
     layout with_padding(padding const& padd) const;
 
+    bool has_dynamic_pad() const {
+        return data_padding.get_dynamic_pad_dims() != tensor(0);
+    }
+
     /// Data type stored in @ref memory (see. @ref data_types)
     ov::element::Type_t data_type;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -344,6 +344,11 @@ void concat_in_place_optimization::update_in_place_concat_paddings(
 }  // namespace cldnn
 
 static bool can_reshape_be_optimized(const reshape_node& node) {
+    // In case if pad is not propagated, the primitive can't be optimized out
+    if (node.get_input_layout(0).has_dynamic_pad() && !node.get_output_layout(0).has_dynamic_pad()) {
+        return false;
+    }
+
     if (node.has_fused_primitives())
         return false;
 

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -4,12 +4,16 @@
 
 #pragma once
 #include "intel_gpu/primitives/reshape.hpp"
+#include "intel_gpu/runtime/tensor_accessor.hpp"
+#include "openvino/core/partial_shape.hpp"
 #include "primitive_inst.h"
 
 #include <string>
 #include <memory>
 
 namespace cldnn {
+
+padding propagate_padding(const layout& in_layout, const ov::PartialShape& out_shape, reshape::reshape_mode mode, const ov::ITensorAccessor& ta);
 
 template <>
 struct typed_program_node<reshape> : public typed_program_node_base<reshape> {
@@ -24,7 +28,7 @@ public:
     program_node& input() const { return get_dependency(0); }
 
     bool has_padding() const {
-        return (this->get_output_layout().data_padding || input().get_output_layout(false).data_padding);
+        return (this->get_output_layout().data_padding || input().get_output_layout(false).data_padding || input().get_output_layout(false).has_dynamic_pad());
     }
 
     bool has_outer_padding_offset() const {
@@ -56,6 +60,10 @@ public:
         if (this->is_output() || this->has_fused_primitives())
             return false;
 
+        if (input().get_output_layout(false).has_dynamic_pad()) {
+            return typed_desc()->mode != reshape::reshape_mode::base;
+        }
+
         if (has_padding())
             return false;
 
@@ -68,6 +76,22 @@ public:
 
         auto input_layout = input().get_output_layout(false);
         auto output_layout = this->get_output_layout();
+        if (input_layout.has_dynamic_pad()) {
+            auto prim = typed_desc();
+
+            ov::PartialShape pattern_shape = { static_cast<int64_t>(prim->output_pattern.size()) };
+            if (pattern_shape.size() == 0)
+                pattern_shape = {};
+
+            auto pattern_data = prim->output_pattern;
+            auto pattern_tensor = make_tensor({pattern_shape, data_types::i64, format::bfyx}, static_cast<void*>(pattern_data.data()));
+            std::unordered_map<size_t, ov::Tensor> const_data {{1, pattern_tensor}};
+            const auto ta = ov::make_tensor_accessor(const_data);
+
+            this->set_output_padding(propagate_padding(input_layout, output_layout.get_partial_shape(), prim->mode, ta));
+            return;
+        }
+
         if (input_layout.batch() != output_layout.batch()) {
             // adjust output padding if Reshape has an outer padding exists in an input
             auto input_pitches = input_layout.get_pitches();

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -401,8 +401,10 @@ void primitive_inst::update_shape() {
     _impl_params->memory_deps = memory_deps;
 
     auto update_output_layout = [&](layout& layout, size_t idx) {
-        auto data_padding = padding::max(_impl_params->get_output_layout(idx).data_padding, layout.data_padding);
-        layout.data_padding = padding::max(_node->get_primitive()->get_output_padding(idx), data_padding);
+        if (!_node->is_type<reshape>()) {
+            auto data_padding = padding::max(_impl_params->get_output_layout(idx).data_padding, layout.data_padding);
+            layout.data_padding = padding::max(_node->get_primitive()->get_output_padding(idx), data_padding);
+        }
         if (_impl_params->get_output_layout(idx) != layout) {
             GPU_DEBUG_TRACE_DETAIL << id() << ": update shape: was: " << _impl_params->get_output_layout(idx).to_short_string()
                                    << " now: " << layout.to_short_string() << std::endl;

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -1,11 +1,14 @@
 // Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <iterator>
 #include <string>
 
 #include "intel_gpu/runtime/error_handler.hpp"
 #include "intel_gpu/runtime/memory.hpp"
 #include "json_object.h"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "primitive_type_base.h"
 #include "reshape_inst.h"
 #include "reshape_shape_inference.hpp"
@@ -14,6 +17,90 @@
 
 namespace cldnn {
 GPU_DEFINE_PRIMITIVE_TYPE_ID(reshape)
+
+padding propagate_padding(const layout& in_layout, const ov::PartialShape& out_shape, reshape::reshape_mode mode, const ov::ITensorAccessor& ta) {
+    if (mode == reshape::reshape_mode::base)
+        return padding();
+
+    auto in_pad = in_layout.data_padding;
+    if (in_pad.get_dynamic_pad_dims() == tensor(0)) {
+        return padding();
+    }
+
+    std::vector<int64_t> axes;
+    if (auto t = ta(1)) {
+        axes = ov::get_tensor_data_as<int64_t, std::vector<int64_t>>(t);
+    } else {
+        OPENVINO_THROW("[GPU] Can't propagate padding for reshape op as axes data is not available");
+    }
+
+    auto rank = in_layout.get_partial_shape().size();
+
+    auto default_format = format::get_default_format(rank);
+
+    auto pad_lower = in_pad.lower_size().sizes(default_format);
+    auto pad_upper = in_pad.upper_size().sizes(default_format);
+    auto pad_mask = in_pad.get_dynamic_pad_dims().sizes(default_format);
+
+    std::vector<int32_t> update_pad_lower;
+    std::vector<int32_t> update_pad_upper;
+    std::vector<int32_t> update_pad_mask;
+
+    if (mode == reshape::reshape_mode::unsqueeze) {
+        update_pad_lower = pad_lower;
+        update_pad_upper = pad_upper;
+        update_pad_mask = pad_mask;
+
+        std::unordered_set<int64_t> tmp(axes.begin(), axes.end());
+        std::vector<int64_t> unique_axes;
+        const auto expanded_rank = rank + tmp.size();
+        std::transform(axes.begin(), axes.end(), std::back_inserter(unique_axes), [=](int64_t axis) {
+            return ov::util::normalize(axis, expanded_rank);
+        });
+
+        // Normalize then remove repeated axes after normalization.
+        for (const auto& axis : axes) {
+            if (static_cast<size_t>(axis) <= out_shape.size()) {
+                pad_lower.insert(std::next(std::begin(pad_lower), axis), 0);
+                pad_upper.insert(std::next(std::begin(pad_upper), axis), 0);
+                pad_mask.insert(std::next(std::begin(pad_mask), axis), 0);
+            } else {
+                pad_lower.push_back(0);
+                pad_upper.push_back(0);
+                pad_mask.push_back(0);
+            }
+        }
+    } else {
+        std::unordered_set<int64_t> unique_axes;
+        std::transform(axes.begin(), axes.end(), std::inserter(unique_axes, unique_axes.end()), [=](int64_t axis) {
+            return ov::util::normalize(axis, rank);
+        });
+
+        for (size_t i = 0; i < pad_lower.size(); i++) {
+            auto rm_iter = unique_axes.find(i);
+            if (rm_iter == unique_axes.end()) {
+                update_pad_lower.push_back(pad_lower[i]);
+                update_pad_upper.push_back(pad_upper[i]);
+                update_pad_mask.push_back(pad_mask[i]);
+            } else {
+                // If we have a non-squeezable case (pad along removed axis), then out padding is reset
+                // and kernel must be executed
+                auto rm_axis = *rm_iter;
+                if (pad_lower[rm_axis] != 0 || pad_upper[rm_axis] != 0 || pad_mask[rm_axis] != 0 )
+                    return padding();
+            }
+        }
+    }
+
+    auto convert_pad = [](const std::vector<int32_t> pad) {
+        return tensor(format::get_default_format(pad.size()), pad, 0);
+    };
+
+    return padding(convert_pad(update_pad_lower).sizes(),
+                   convert_pad(update_pad_upper).sizes(),
+                   0.0f,
+                   convert_pad(update_pad_mask));
+}
 
 layout reshape_inst::calc_output_layout(reshape_node const& node, kernel_impl_params const& impl_param) {
     assert(static_cast<bool>(impl_param.desc->output_data_types[0]) == false &&
@@ -87,10 +174,12 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& node, 
 
     std::unordered_map<size_t, ov::Tensor> const_data;
     const auto ta = ov::make_tensor_accessor(const_data);
+    padding out_pad = padding();
 
     auto run_shape_infer = [&](reshape::reshape_mode mode) {
          switch (mode) {
             case reshape::reshape_mode::base: {
+                OPENVINO_ASSERT(!input_layout.has_dynamic_pad());
                 ov::op::v1::Reshape op;
                 op.set_special_zero(prim->special_zero);
                 op.set_friendly_name(prim->id.c_str());
@@ -101,12 +190,14 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& node, 
                 ov::op::v0::Squeeze op;
                 op.set_friendly_name(prim->id.c_str());
                 output_shapes = shape_infer(&op, input_shapes, ta);
+                out_pad = propagate_padding(input_layout, output_shapes[0], prim->mode, ta);
                 break;
             }
             case reshape::reshape_mode::unsqueeze: {
                 ov::op::v0::Unsqueeze op;
                 op.set_friendly_name(prim->id.c_str());
                 output_shapes = shape_infer(&op, input_shapes, ta);
+                out_pad = propagate_padding(input_layout, output_shapes[0], prim->mode, ta);
                 break;
             }
             default:
@@ -137,7 +228,7 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& node, 
         output_format = node.get_preferred_output_fmt();
     }
 
-    return { layout {output_shapes[0], input_layout.data_type, format::adjust_to_rank(output_format, output_shapes[0].size())} };
+    return { layout {output_shapes[0], input_layout.data_type, format::adjust_to_rank(output_format, output_shapes[0].size()), out_pad} };
 }
 
 template std::vector<layout> reshape_inst::calc_output_layouts<ov::PartialShape>(reshape_node const& node, const kernel_impl_params& impl_param);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/broadcast_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/broadcast_gpu_ref.cl
@@ -17,7 +17,47 @@
 
 #if OUTPUT_DIMS == 6
 inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, uint out_w, uint out_z, uint out_y, uint out_x) {
+#if defined(INPUT0_LAYOUT_BFWZYX) && defined(OUTPUT_LAYOUT_BFWZYX) && BROADCAST_ORDER_DEFAULT
+    const uint size_x = INPUT0_SIZE_X;
+    const uint size_y = INPUT0_SIZE_Y;
+    const uint size_z = INPUT0_SIZE_Z;
+    const uint size_w = INPUT0_SIZE_W;
+    const uint size_f = INPUT0_FEATURE_NUM;
+    const uint size_b = INPUT0_BATCH_NUM;
 
+    const uint idx_b = out_b % size_b;
+    const uint idx_f = out_f % size_f;
+    const uint idx_w = out_w % size_w;
+    const uint idx_z = out_z % size_z;
+    const uint idx_y = out_y % size_y;
+    const uint idx_x = out_x % size_x;
+
+    const uint pad_before_x = INPUT0_PAD_BEFORE_SIZE_X;
+    const uint pad_after_x = INPUT0_PAD_AFTER_SIZE_X;
+    const uint pad_before_y = INPUT0_PAD_BEFORE_SIZE_Y;
+    const uint pad_after_y = INPUT0_PAD_AFTER_SIZE_Y;
+    const uint pad_before_z = INPUT0_PAD_BEFORE_SIZE_Z;
+    const uint pad_after_z = INPUT0_PAD_AFTER_SIZE_Z;
+    const uint pad_before_w = INPUT0_PAD_BEFORE_SIZE_W;
+    const uint pad_after_w = INPUT0_PAD_AFTER_SIZE_W;
+    const uint pad_before_f = INPUT0_PAD_BEFORE_FEATURE_NUM;
+    const uint pad_after_f = INPUT0_PAD_AFTER_FEATURE_NUM;
+    const uint pad_before_b = INPUT0_PAD_BEFORE_BATCH_NUM;
+    const uint pad_after_b = INPUT0_PAD_AFTER_BATCH_NUM;
+
+    const uint x_pitch = 1;
+    const uint y_pitch = (size_x + pad_before_x + pad_after_x) * x_pitch;
+    const uint z_pitch = (size_y + pad_before_y + pad_after_y) * y_pitch;
+    const uint w_pitch = (size_z + pad_before_z + pad_after_z) * z_pitch;
+    const uint f_pitch = (size_w + pad_before_w + pad_after_w) * w_pitch;
+    const uint b_pitch = (size_f + pad_before_f + pad_after_f) * f_pitch;
+    const uint idx_pos = (pad_before_b + idx_b) * b_pitch +
+                         (pad_before_f + idx_f) * f_pitch +
+                         (pad_before_w + idx_w) * w_pitch +
+                         (pad_before_z + idx_z) * z_pitch +
+                         (pad_before_y + idx_y) * y_pitch +
+                         (pad_before_x + idx_x) * x_pitch;
+#else  // defined(INPUT0_LAYOUT_BFWZYX) && defined(OUTPUT_LAYOUT_BFWZYX)
     uint8 input_indices;
 
     input_indices[0] = INPUT0_BATCH_NUM;
@@ -58,11 +98,47 @@ inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, ui
     const uint idx_x = idx[5];
 
     const uint idx_pos = GET_UPDATES_INDEX(INPUT0, IDX_ORDER);
+#endif  // defined(INPUT0_LAYOUT_BFWZYX) && defined(OUTPUT_LAYOUT_BFWZYX)
+
     return idx_pos;
 }
 #elif OUTPUT_DIMS == 5
 inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, uint out_z, uint out_y, uint out_x) {
+#if defined(INPUT0_LAYOUT_BFZYX) && defined(OUTPUT_LAYOUT_BFZYX) && BROADCAST_ORDER_DEFAULT
+    const uint size_x = INPUT0_SIZE_X;
+    const uint size_y = INPUT0_SIZE_Y;
+    const uint size_z = INPUT0_SIZE_Z;
+    const uint size_f = INPUT0_FEATURE_NUM;
+    const uint size_b = INPUT0_BATCH_NUM;
 
+    const uint idx_b = out_b % size_b;
+    const uint idx_f = out_f % size_f;
+    const uint idx_z = out_z % size_z;
+    const uint idx_y = out_y % size_y;
+    const uint idx_x = out_x % size_x;
+
+    const uint pad_before_x = INPUT0_PAD_BEFORE_SIZE_X;
+    const uint pad_after_x = INPUT0_PAD_AFTER_SIZE_X;
+    const uint pad_before_y = INPUT0_PAD_BEFORE_SIZE_Y;
+    const uint pad_after_y = INPUT0_PAD_AFTER_SIZE_Y;
+    const uint pad_before_z = INPUT0_PAD_BEFORE_SIZE_Z;
+    const uint pad_after_z = INPUT0_PAD_AFTER_SIZE_Z;
+    const uint pad_before_f = INPUT0_PAD_BEFORE_FEATURE_NUM;
+    const uint pad_after_f = INPUT0_PAD_AFTER_FEATURE_NUM;
+    const uint pad_before_b = INPUT0_PAD_BEFORE_BATCH_NUM;
+    const uint pad_after_b = INPUT0_PAD_AFTER_BATCH_NUM;
+    const uint x_pitch = 1;
+    const uint y_pitch = (size_x + pad_before_x + pad_after_x) * x_pitch;
+    const uint z_pitch = (size_y + pad_before_y + pad_after_y) * y_pitch;
+    const uint f_pitch = (size_z + pad_before_z + pad_after_z) * z_pitch;
+    const uint b_pitch = (size_f + pad_before_f + pad_after_f) * f_pitch;
+    const uint idx_pos = (pad_before_b + idx_b) * b_pitch +
+                         (pad_before_f + idx_f) * f_pitch +
+                         (pad_before_z + idx_z) * z_pitch +
+                         (pad_before_y + idx_y) * y_pitch +
+                         (pad_before_x + idx_x) * x_pitch;
+
+#else  // defined(INPUT0_LAYOUT_BFZYX) && defined(OUTPUT_LAYOUT_BFZYX)
     uint8 input_indices;
 
     input_indices[0] = INPUT0_BATCH_NUM;
@@ -97,12 +173,43 @@ inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, ui
     const uint idx_z = idx[2];
     const uint idx_y = idx[3];
     const uint idx_x = idx[4];
+
     const uint idx_pos = GET_UPDATES_INDEX(INPUT0, IDX_ORDER);
+#endif  // defined(INPUT0_LAYOUT_BFZYX) && defined(OUTPUT_LAYOUT_BFZYX)
 
     return idx_pos;
 }
 #else
 inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, uint out_y, uint out_x) {
+#if defined(INPUT0_LAYOUT_BFYX) && defined(OUTPUT_LAYOUT_BFYX) && BROADCAST_ORDER_DEFAULT
+    const uint size_x = INPUT0_SIZE_X;
+    const uint size_y = INPUT0_SIZE_Y;
+    const uint size_f = INPUT0_FEATURE_NUM;
+    const uint size_b = INPUT0_BATCH_NUM;
+
+    const uint idx_b = out_b % size_b;
+    const uint idx_f = out_f % size_f;
+    const uint idx_y = out_y % size_y;
+    const uint idx_x = out_x % size_x;
+
+    const uint pad_before_x = INPUT0_PAD_BEFORE_SIZE_X;
+    const uint pad_after_x = INPUT0_PAD_AFTER_SIZE_X;
+    const uint pad_before_y = INPUT0_PAD_BEFORE_SIZE_Y;
+    const uint pad_after_y = INPUT0_PAD_AFTER_SIZE_Y;
+    const uint pad_before_f = INPUT0_PAD_BEFORE_FEATURE_NUM;
+    const uint pad_after_f = INPUT0_PAD_AFTER_FEATURE_NUM;
+    const uint pad_before_b = INPUT0_PAD_BEFORE_BATCH_NUM;
+    const uint pad_after_b = INPUT0_PAD_AFTER_BATCH_NUM;
+    const uint x_pitch = 1;
+    const uint y_pitch = (size_x + pad_before_x + pad_after_x) * x_pitch;
+    const uint f_pitch = (size_y + pad_before_y + pad_after_y) * y_pitch;
+    const uint b_pitch = (size_f + pad_before_f + pad_after_f) * f_pitch;
+    const uint idx_pos = (pad_before_b + idx_b) * b_pitch +
+                         (pad_before_f + idx_f) * f_pitch +
+                         (pad_before_y + idx_y) * y_pitch +
+                         (pad_before_x + idx_x) * x_pitch;
+
+#else  // defined(INPUT0_LAYOUT_BFYX) && defined(OUTPUT_LAYOUT_BFYX)
 
     uint4 input_indices;
 
@@ -135,7 +242,9 @@ inline uint FUNC(get_idx_pos)(OPTIONAL_SHAPE_INFO_ARG uint out_b, uint out_f, ui
     const uint idx_f = idx[1];
     const uint idx_y = idx[2];
     const uint idx_x = idx[3];
+
     const uint idx_pos = GET_UPDATES_INDEX(INPUT0, IDX_ORDER);
+#endif  // defined(INPUT0_LAYOUT_BFYX) && defined(OUTPUT_LAYOUT_BFYX)
 
     return idx_pos;
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/broadcast/broadcast_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/broadcast/broadcast_kernel_base.cpp
@@ -25,6 +25,10 @@ JitConstants BroadcastKernelBase::GetJitConstants(const broadcast_params& params
     JitConstants jit = MakeBaseParamsJitConstants(params);
 
     jit.AddConstants({MakeJitConstant("BROADCAST_ORDER", params.input_order)});
+    std::vector<uint16_t> default_order(params.input_order.size());
+    std::iota(default_order.begin(), default_order.end(), 0);
+    jit.AddConstants({MakeJitConstant("BROADCAST_ORDER_DEFAULT", default_order == params.input_order ? 1 : 0)});
+
     jit.AddConstants({MakeJitConstant("VEC_SIZE", VEC_SIZE)});
     jit.AddConstants({MakeJitConstant("Y_BLOCKS", Y_BLOCKS)});
     jit.AddConstants({MakeJitConstant("SAME_RANK_PLAIN_FORMAT", is_same_planar_format(in_layout, out_layout))});

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -134,7 +134,6 @@
 #include "transformations/rt_info/fused_names_attribute.hpp"
 #include "transformations/rt_info/keep_const_precision.hpp"
 #include "transformations/smart_reshape/matmul_sr.hpp"
-#include "transformations/common_optimizations/nop_elimination.hpp"
 
 namespace {
 template<typename T>

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -560,8 +560,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         pass_config->disable<ov::pass::ConvertGather8ToGather7>();
         pass_config->disable<ov::pass::ConvertGather7ToGather1>();
         pass_config->disable<ov::pass::ConvertTopK11ToTopK3>();
-        pass_config->disable<ov::pass::NopStridedSlice>();
-        pass_config->disable<ov::pass::NopStridedSliceByShape>();
 
         pass_config->enable<ov::pass::ConvertInterpolate1ToInterpolate4>();
 


### PR DESCRIPTION
### Details:
 - Dynamic padding produced by kv_cache prim was omitted by reshape w/o memory copy (prim was marked as optimized) which caused accuracy issues.
 - This patch adds propagation logic for unsqueeze/squeeze cases and disables optimization for generic reshape if input tensor has dynamic pad. 
 - Reverted https://github.com/openvinotoolkit/openvino/pull/23385
 - Added func test for grouped query attention subgraph
 - Added perf improvement for some broadcast cases to speedup unfused version of GQA

### Tickets:
 - *135242*, *135241*
