### PR TITLE
Restrict cmake on Android build

### DIFF
--- a/.github/workflows/android_arm64.yml
+++ b/.github/workflows/android_arm64.yml
@@ -116,7 +116,7 @@ jobs:
           apt --assume-yes install ccache scons ninja-build build-essential python3-pip
 
           # vcpkg requires cmake 3.19 or later
-          python3 -m pip install -U pip cmake<3.29.0
+          python3 -m pip install -U pip cmake==3.28.4
           # vcpkg's tool dependencies
           apt --assume-yes install curl zip unzip tar
           # vcpkg 'python3' port dependencies

--- a/.github/workflows/android_arm64.yml
+++ b/.github/workflows/android_arm64.yml
@@ -116,7 +116,7 @@ jobs:
           apt --assume-yes install ccache scons ninja-build build-essential python3-pip
 
           # vcpkg requires cmake 3.19 or later
-          python3 -m pip install -U pip cmake
+          python3 -m pip install -U pip cmake<3.29.0
           # vcpkg's tool dependencies
           apt --assume-yes install curl zip unzip tar
           # vcpkg 'python3' port dependencies

--- a/.github/workflows/android_arm64.yml
+++ b/.github/workflows/android_arm64.yml
@@ -116,7 +116,7 @@ jobs:
           apt --assume-yes install ccache scons ninja-build build-essential python3-pip
 
           # vcpkg requires cmake 3.19 or later
-          python3 -m pip install -U pip cmake==3.28.4
+          python3 -m pip install -U pip cmake~=3.28.0
           # vcpkg's tool dependencies
           apt --assume-yes install curl zip unzip tar
           # vcpkg 'python3' port dependencies


### PR DESCRIPTION
New cmake fails to be imported in our Android environment