### PR TITLE
[ IE TESTS ] Extend tensor comparation

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/nms_rotated.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/nms_rotated.cpp
@@ -267,6 +267,7 @@ void NmsRotatedLayerTestGPU::compare(const std::vector<ov::Tensor> &expectedOutp
 
     ASSERT_EQ(expected.size(), actual.size());
     for (size_t i = 0; i < expected.size(); ++i) {
+        abs_threshold = ov::test::utils::get_eps_by_ov_type(ov::element::f32) * expected[i].score;
         ASSERT_EQ(expected[i], actual[i]) << ", i=" << i;
         ASSERT_NEAR(expected[i].score, actual[i].score, abs_threshold) << ", i=" << i;
     }

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -73,8 +73,12 @@ protected:
 
     std::function<void(const std::exception& exp)> callback_exception = nullptr;
 
-    constexpr static const double disable_threshold = std::numeric_limits<double>::max();
-    double abs_threshold = disable_threshold, rel_threshold = disable_threshold;
+    constexpr static const double disable_threshold = -1;
+    constexpr static const double disable_tensor_metrics = 1.f;
+    double abs_threshold = disable_threshold,
+           rel_threshold = disable_threshold,
+           topk_threshold = disable_tensor_metrics,
+           mvn_threshold = disable_tensor_metrics;
 
     ov::test::utils::OpSummary& summary = ov::test::utils::OpSummary::getInstance();
     bool is_report_stages = false;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/utils/compare_results.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/utils/compare_results.hpp
@@ -12,10 +12,13 @@ namespace utils {
 using CompareMap = std::map<ov::NodeTypeInfo, std::function<void(
         const std::shared_ptr<ov::Node> &node,
         size_t port,
+        const ov::element::Type& inference_precision,
         const ov::Tensor &expected,
         const ov::Tensor &actual,
         double absThreshold,
-        double relThreshold)>>;
+        double relThreshold,
+        double topk_threshold,
+        double mvn_threshold)>>;
 
 CompareMap getCompareMap();
 

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -256,6 +256,12 @@ void SubgraphBaseTest::compare(const std::vector<ov::Tensor>& expected,
                                const std::vector<ov::Tensor>& actual) {
     ASSERT_EQ(expected.size(), actual.size());
     ASSERT_EQ(expected.size(), function->get_results().size());
+    ov::element::Type inference_precision = ov::element::undefined;
+    try {
+        inference_precision = core->get_property(targetDevice, ov::hint::inference_precision);
+    } catch (std::exception& e) {
+        std::cout << "[ WARNING ] Impossible to get Inference Precision with exception: " << e.what() << std::endl;
+    }
     auto compareMap = utils::getCompareMap();
     const auto& results = function->get_results();
     for (size_t j = 0; j < results.size(); j++) {
@@ -264,7 +270,9 @@ void SubgraphBaseTest::compare(const std::vector<ov::Tensor>& expected,
             std::shared_ptr<ov::Node> inputNode = result->get_input_node_shared_ptr(i);
             auto it = compareMap.find(inputNode->get_type_info());
             ASSERT_NE(it, compareMap.end());
-            it->second(inputNode, i, expected[j], actual[j], abs_threshold, rel_threshold);
+            it->second(inputNode, i, inference_precision,
+                       expected[j], actual[j],
+                       abs_threshold, rel_threshold, topk_threshold, mvn_threshold);
         }
     }
 }

--- a/src/tests/functional/shared_test_classes/src/base/utils/compare_results.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/compare_results.cpp
@@ -18,19 +18,25 @@ namespace utils {
 namespace {
 void compare(const std::shared_ptr<ov::Node> &node,
              size_t port,
+             const ov::element::Type& inference_precision,
              const ov::Tensor &expected,
              const ov::Tensor &actual,
-             double absThreshold,
-             double relThreshold) {
-    ov::test::utils::compare(expected, actual, absThreshold, relThreshold);
+             double abs_threshold,
+             double rel_threshold,
+             double topk_threshold,
+             double mvn_threshold) {
+    ov::test::utils::compare(expected, actual, inference_precision, abs_threshold, rel_threshold, topk_threshold, mvn_threshold);
 }
 
 void compare(const std::shared_ptr<ov::op::v0::DetectionOutput> &node,
              size_t port,
+             const ov::element::Type& inference_precision,
              const ov::Tensor &expected,
              const ov::Tensor &actual,
-             double absThreshold,
-             double relThreshold) {
+             double abs_threshold,
+             double rel_threshold,
+             double topk_threshold,
+             double mvn_threshold) {
         ASSERT_EQ(expected.get_size(), actual.get_size());
 
         size_t expSize = 0;
@@ -52,7 +58,7 @@ void compare(const std::shared_ptr<ov::op::v0::DetectionOutput> &node,
             actSize += 7;
         }
         ASSERT_EQ(expSize, actSize);
-        ov::test::utils::compare(expected, actual, 1e-2f, relThreshold);
+        ov::test::utils::compare(expected, actual, inference_precision, 1e-2f, rel_threshold, topk_threshold, mvn_threshold);
 }
 
 namespace color_conversion {
@@ -103,11 +109,14 @@ inline void validate_colors(const ov::Tensor& expected, const ov::Tensor& actual
 
 void compare(const std::shared_ptr<ov::op::v8::I420toRGB> &node,
              size_t port,
+             const ov::element::Type& inference_precision,
              const ov::Tensor &expected,
              const ov::Tensor &actual,
-             double absThreshold,
-             double relThreshold) {
-    ov::test::utils::compare(expected, actual, absThreshold, relThreshold);
+             double abs_threshold,
+             double rel_threshold,
+             double topk_threshold,
+             double mvn_threshold) {
+    ov::test::utils::compare(expected, actual, inference_precision, abs_threshold, rel_threshold, topk_threshold, mvn_threshold);
 
     // Allow less than 2% of deviations with 1 color step. 2% is experimental value
     // For different calculation methods - 1.4% deviation is observed
@@ -116,11 +125,14 @@ void compare(const std::shared_ptr<ov::op::v8::I420toRGB> &node,
 
 void compare(const std::shared_ptr<ov::op::v8::I420toBGR> &node,
              size_t port,
+             const ov::element::Type& inference_precision,
              const ov::Tensor &expected,
              const ov::Tensor &actual,
-             double absThreshold,
-             double relThreshold) {
-    ov::test::utils::compare(expected, actual, absThreshold, relThreshold);
+             double abs_threshold,
+             double rel_threshold,
+             double topk_threshold,
+             double mvn_threshold) {
+    ov::test::utils::compare(expected, actual, inference_precision, abs_threshold, rel_threshold, topk_threshold, mvn_threshold);
 
     // Allow less than 2% of deviations with 1 color step. 2% is experimental value
     // For different calculation methods - 1.4% deviation is observed
@@ -129,11 +141,14 @@ void compare(const std::shared_ptr<ov::op::v8::I420toBGR> &node,
 
 void compare(const std::shared_ptr<ov::op::v8::NV12toRGB> &node,
              size_t port,
+             const ov::element::Type& inference_precision,
              const ov::Tensor &expected,
              const ov::Tensor &actual,
-             double absThreshold,
-             double relThreshold) {
-    ov::test::utils::compare(expected, actual, absThreshold, relThreshold);
+             double abs_threshold,
+             double rel_threshold,
+             double topk_threshold,
+             double mvn_threshold) {
+    ov::test::utils::compare(expected, actual, inference_precision, abs_threshold, rel_threshold, topk_threshold, mvn_threshold);
 
     // Allow less than 2% of deviations with 1 color step. 2% is experimental value
     // For different calculation methods - 1.4% deviation is observed
@@ -142,11 +157,14 @@ void compare(const std::shared_ptr<ov::op::v8::NV12toRGB> &node,
 
 void compare(const std::shared_ptr<ov::op::v8::NV12toBGR> &node,
              size_t port,
+             const ov::element::Type& inference_precision,
              const ov::Tensor &expected,
              const ov::Tensor &actual,
-             double absThreshold,
-             double relThreshold) {
-    ov::test::utils::compare(expected, actual, absThreshold, relThreshold);
+             double abs_threshold,
+             double rel_threshold,
+             double topk_threshold,
+             double mvn_threshold) {
+    ov::test::utils::compare(expected, actual, inference_precision, abs_threshold, rel_threshold, topk_threshold, mvn_threshold);
 
     // Allow less than 2% of deviations with 1 color step. 2% is experimental value
     // For different calculation methods - 1.4% deviation is observed
@@ -156,11 +174,14 @@ void compare(const std::shared_ptr<ov::op::v8::NV12toBGR> &node,
 template<typename T>
 void compareResults(const std::shared_ptr<ov::Node> &node,
                     size_t port,
+                    const ov::element::Type& inference_precision,
                     const ov::Tensor &expected,
                     const ov::Tensor &actual,
-                    double absThreshold,
-                    double relThreshold) {
-    return compare(ov::as_type_ptr<T>(node), port, expected, actual, absThreshold, relThreshold);
+                    double abs_threshold,
+                    double rel_threshold,
+             double topk_threshold,
+             double mvn_threshold) {
+    return compare(ov::as_type_ptr<T>(node), port, inference_precision, expected, actual, abs_threshold, rel_threshold, topk_threshold, mvn_threshold);
 }
 
 } // namespace

--- a/src/tests/functional/shared_test_classes/src/single_op/generate_proposals.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/generate_proposals.cpp
@@ -116,6 +116,9 @@ void GenerateProposalsLayerTest::compare(const std::vector<ov::Tensor>& expected
         const auto expectedBuffer = static_cast<uint8_t*>(expected[i].data());
         const auto outputSize = i == 0 ? 4 : 1;
 
+        rel_threshold = ov::test::utils::tensor_comparation::calculate_default_rel_threshold(
+            expected[i].get_element_type(), actual[i].get_element_type());
+
         if (outType == ov::element::f32) {
             ov::test::utils::compare_raw_data(reinterpret_cast<const float*>(expectedBuffer),
                                               reinterpret_cast<const float*>(actualBuffer),

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/ov_tensor_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/ov_tensor_utils.hpp
@@ -54,7 +54,7 @@ struct InputGenerateData {
 
 // Pre-defaned eps based on mantissa bit depth
 inline double get_eps_by_ov_type(const ov::element::Type& elem_type) {
-    if (elem_type.is_integral()) {
+    if (elem_type.is_integral() || elem_type == ov::element::undefined) {
         return 0.f;
     }
     switch (elem_type) {
@@ -127,12 +127,44 @@ ov::Tensor create_and_fill_tensor_real_distribution(const ov::element::Type elem
                                                     const float min,
                                                     const float max,
                                                     const int seed);
+namespace tensor_comparation {
+double calculate_threshold(const double abs_threshold, const double rel_threshold, const double ref_value);
 
+double calculate_default_abs_threshold(const ov::element::Type& expected_type,
+                                       const ov::element::Type& actual_type = ov::element::undefined,
+                                       const ov::element::Type& inference_precision = ov::element::undefined);
+
+double calculate_default_rel_threshold(const ov::element::Type& expected_type,
+                                       const ov::element::Type& actual_type = ov::element::undefined,
+                                       const ov::element::Type& inference_precision = ov::element::undefined);
+}  // namespace tensor_comparation
+
+// function to compare tensors using different metrics:
+// `expected` : reference tensor
+// `actual` : plugin/calculated tensor
+// `inference_precision` : real plugin calculation precision. Default abs and rel thresholds will be calculated using
+// this value `abs_threshold` : abs difference between reference and calculated value `rel_threshold` : define first
+// incorrect element rank in mantissa `topk_threshold` : percentage of incorrect values in tensor. The value is
+// [0.f, 1.f] `mvn_threshold` : avg value of `std::diff(ref_value - calculated_value) / threshold`. The value is
+// [0.f, 1.f]. Shows tensor jitter relative to treshold
 void compare(const ov::Tensor& expected,
              const ov::Tensor& actual,
-             const double abs_threshold = std::numeric_limits<double>::max(),
-             const double rel_threshold = std::numeric_limits<double>::max());
+             const ov::element::Type& inference_precision,
+             const double abs_threshold = -1,
+             const double rel_threshold = -1,
+             const double topk_threshold = 1.f,
+             const double mvn_threshold = 1.f);
 
+inline void compare(const ov::Tensor& expected,
+                    const ov::Tensor& actual,
+                    const double abs_threshold = -1,
+                    const double rel_threshold = -1,
+                    const double topk_threshold = 1.f,
+                    const double mvn_threshold = 1.f) {
+    compare(expected, actual, ov::element::undefined, abs_threshold, rel_threshold, topk_threshold, mvn_threshold);
+}
+
+// todo: replace this function by `compare(expected, actual)`
 void compare_str(const ov::Tensor& expected, const ov::Tensor& actual);
 }  // namespace utils
 }  // namespace test

--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -312,32 +312,43 @@ ov::Tensor create_and_fill_tensor_consistently(const ov::element::Type element_t
     return tensor;
 }
 
+namespace tensor_comparation {
 constexpr double eps = std::numeric_limits<double>::epsilon();
 
-template <typename aT, typename bT>
-inline double less(aT a, bT b) {
+inline double less(double a, double b) {
+    if (std::isnan(a) || std::isnan(b)) {
+        return false;
+    } else if (std::isinf(b) && std::isinf(b)) {
+        return true;
+    } else if (std::isinf(b) && b > 0) {
+        // b is greater than any number or eq the +Inf
+        return true;
+    } else if (std::isinf(a) && a > 0) {
+        return false;
+    }
     return std::fabs(a - b) > eps && a < b;
 }
 
-inline double less_or_equal(double a, double b) {
-    bool res = true;
+inline double equal(double a, double b) {
     if (std::isnan(a) || std::isnan(b)) {
-        res = false;
+        return false;
     } else if (std::isinf(b) && std::isinf(b)) {
-        res = true;
+        return true;
     } else if (std::isinf(b) && b > 0) {
         // b is greater than any number or eq the +Inf
-        res = true;
+        return true;
     } else if (std::isinf(a) && a > 0) {
-        res = false;
-    } else {
-        res = std::fabs(b - a) <= eps || a <= b;
+        return false;
     }
-    return res;
+    return std::fabs(b - a) <= eps;
+}
+
+inline double less_or_equal(double a, double b) {
+    return less(a, b) || equal(a, b);
 }
 
 template <typename T1, typename T2>
-inline bool check_values_suitable_for_comparison(double value1, double value2) {
+inline bool is_value_suitable_for_comparation(double value1, double value2) {
     bool res = true;
     auto max_val1 = std::numeric_limits<T1>::max();
     auto min_val1 = std::numeric_limits<T1>::lowest();
@@ -350,7 +361,6 @@ inline bool check_values_suitable_for_comparison(double value1, double value2) {
     } else if ((std::isinf(value1) || value1 <= min_val1) && std::isinf(value2) || value2 <= min_val2) {
         res = false;
     }
-
     return res;
 }
 
@@ -368,33 +378,43 @@ protected:
     };
 
     std::vector<IncorrectValue> incorrect_values_abs;
-    double abs_threshold, rel_threshold;
-    int tensor_size;
+    double abs_threshold, rel_threshold, mvn_threshold, topk_threshold, mvn_results, topk_results;
+    size_t tensor_size;
 
     void emplace_back(double in_actual_value, double in_expected_value, double in_threshold, size_t in_coordinate) {
         incorrect_values_abs.push_back(IncorrectValue(in_actual_value, in_expected_value, in_threshold, in_coordinate));
     }
 
 public:
-    Error(const double in_abs_threshold, const double in_rel_threshold, int in_tensor_size = 0)
+    Error(const double in_abs_threshold,
+          const double in_rel_threshold,
+          const double in_topk_threshold,
+          const double in_mvn_threshold,
+          int in_tensor_size)
         : abs_threshold(in_abs_threshold),
           rel_threshold(in_rel_threshold),
-          tensor_size(in_tensor_size) {}
+          mvn_threshold(in_mvn_threshold),
+          topk_threshold(in_topk_threshold),
+          tensor_size(in_tensor_size),
+          mvn_results(0.f),
+          topk_results(0.f) {}
 
     bool update(double actual, double expected, size_t coordinate) {
         const auto diff = std::fabs(expected - actual);
-
-        const auto calculated_abs_threshold = std::abs(abs_threshold) + std::abs(rel_threshold * expected);
-        if (less_or_equal(diff, calculated_abs_threshold)) {
+        const auto threshold = calculate_threshold(abs_threshold, rel_threshold, expected);
+        mvn_results += equal(threshold, 0.f) ? diff : (diff / threshold);
+        if (less_or_equal(diff, threshold)) {
             return true;
         }
-        emplace_back(actual, expected, calculated_abs_threshold, coordinate);
-
+        emplace_back(actual, expected, threshold, coordinate);
         return false;
     }
 
     void check_results() {
-        if (!incorrect_values_abs.empty()) {
+        topk_results = static_cast<double>(incorrect_values_abs.size()) / (tensor_size ? tensor_size : 1);
+        mvn_results /= tensor_size ? tensor_size : 1;
+        if (!incorrect_values_abs.empty() && equal(1.f, topk_threshold) ||
+            incorrect_values_abs.size() > static_cast<int>(std::floor(topk_threshold * tensor_size))) {
 #ifdef NDEBUG
             std::string msg = "[ COMPARATION ] COMPARATION IS FAILED!";
             msg += "  Use DEBUG mode to print `incorrect_values_abs` and get detailed information!";
@@ -412,12 +432,79 @@ public:
             }
 #endif
             throw std::runtime_error(msg);
+        } else if (!less_or_equal(mvn_results, mvn_threshold)) {
+            std::string msg = "[ COMPARATION ] COMPARATION IS FAILED due to MVN THRESHOLD: ";
+            msg += std::to_string(mvn_threshold);
+            msg += ". Actual MVN value is ";
+            msg += std::to_string(mvn_results);
+            throw std::runtime_error(msg);
         }
     }
 };
 
+double calculate_threshold(const double abs_threshold, const double rel_threshold, const double ref_value) {
+    return abs_threshold + rel_threshold * std::fabs(ref_value);
+}
+
+double calculate_default_abs_threshold(const ov::element::Type& expected_type,
+                                       const ov::element::Type& actual_type,
+                                       const ov::element::Type& inference_precision) {
+    const std::vector<ov::element::Type> element_types{expected_type, actual_type, inference_precision};
+    std::vector<double> values;
+#define CASE(X)                                                                               \
+    case X:                                                                                   \
+        values.push_back(std::numeric_limits<element_type_traits<X>::value_type>::epsilon()); \
+        break;
+
+    for (const auto& elem_type : element_types) {
+        switch (elem_type) {
+            CASE(ov::element::Type_t::boolean)
+            CASE(ov::element::Type_t::bf16)
+            CASE(ov::element::Type_t::f16)
+            CASE(ov::element::Type_t::f32)
+            CASE(ov::element::Type_t::f64)
+            CASE(ov::element::Type_t::i4)
+            CASE(ov::element::Type_t::i8)
+            CASE(ov::element::Type_t::i16)
+            CASE(ov::element::Type_t::i32)
+            CASE(ov::element::Type_t::i64)
+            CASE(ov::element::Type_t::u1)
+            CASE(ov::element::Type_t::u4)
+            CASE(ov::element::Type_t::u8)
+            CASE(ov::element::Type_t::u16)
+            CASE(ov::element::Type_t::u32)
+            CASE(ov::element::Type_t::u64)
+        default:
+            break;
+        }
+    }
+#undef CASE
+
+    double threshold = *std::max_element(values.begin(), values.end());
+    return threshold;
+}
+
+double calculate_default_rel_threshold(const ov::element::Type& expected_type,
+                                       const ov::element::Type& actual_type,
+                                       const ov::element::Type& inference_precision) {
+    std::vector<double> values{get_eps_by_ov_type(expected_type),
+                               get_eps_by_ov_type(actual_type),
+                               get_eps_by_ov_type(inference_precision)};
+    double threshold = *std::max_element(values.begin(), values.end());
+    return threshold;
+}
+
+}  // namespace tensor_comparation
+
 template <typename ExpectedT, typename ActualT>
-void compare(const ov::Tensor& expected, const ov::Tensor& actual, double abs_threshold, double rel_threshold) {
+void compare(const ov::Tensor& expected,
+             const ov::Tensor& actual,
+             const ov::element::Type& inference_precision,
+             double abs_threshold,
+             double rel_threshold,
+             double topk_threshold,
+             double mvn_threshold) {
+    // check shapes
     auto expected_shape = expected.get_shape();
     auto actual_shape = actual.get_shape();
     if (expected_shape != actual_shape) {
@@ -428,30 +515,43 @@ void compare(const ov::Tensor& expected, const ov::Tensor& actual, double abs_th
         return;
     }
 
-    if (abs_threshold == std::numeric_limits<double>::max()) {
-        abs_threshold = std::max((double)std::numeric_limits<ExpectedT>::epsilon(),
-                                 (double)std::numeric_limits<ActualT>::epsilon());
+    // Set default values in case threshold values are incorrect
+    const auto expected_type = expected.get_element_type();
+    const auto actual_type = actual.get_element_type();
+    if (abs_threshold < 0) {
+        abs_threshold =
+            tensor_comparation::calculate_default_abs_threshold(expected_type, actual_type, inference_precision);
+    }
+    if (rel_threshold < 0) {
+        rel_threshold =
+            tensor_comparation::calculate_default_rel_threshold(expected_type, actual_type, inference_precision);
+    }
+    if (topk_threshold < 0.f || topk_threshold > 1.f) {
+        topk_threshold = 1.f;
+        std::cout << "[ WARNING ] Incorrect value: " << topk_threshold
+                  << " for Topk_threshold. It should be [0.f, 1.f]. Reset default value is 1.f" << std::endl;
+    }
+    if (mvn_threshold < 0.f || mvn_threshold > 1.f) {
+        mvn_threshold = 1.f;
+        std::cout << "[ WARNING ] Incorrect value: " << mvn_threshold
+                  << " for MVN_threshold. It should be [0.f, 1.f]. Reset default value is 1.f" << std::endl;
     }
 
-    if (rel_threshold == std::numeric_limits<double>::max()) {
-        rel_threshold = get_eps_by_ov_type(expected.get_element_type());
-    }
-
+    // error is a place with whole data related to incorrect element in tensor
     size_t shape_size_cnt = shape_size(expected_shape);
-    Error error(abs_threshold, rel_threshold, shape_size_cnt);
+    tensor_comparation::Error error(abs_threshold, rel_threshold, topk_threshold, mvn_threshold, shape_size_cnt);
     const auto expected_data = expected.data<ExpectedT>();
     const auto actual_data = actual.data<ActualT>();
     for (size_t i = 0; i < shape_size_cnt; ++i) {
         double expected_value = expected_data[i];
         double actual_value = actual_data[i];
-
-        if (!check_values_suitable_for_comparison<ExpectedT, ActualT>(expected_value, actual_value)) {
+        if (!tensor_comparation::is_value_suitable_for_comparation<ExpectedT, ActualT>(expected_value, actual_value)) {
             continue;
         }
 
         bool status = error.update(actual_value, expected_value, i);
 #ifdef NDEBUG
-        if (!status) {
+        if (!status && tensor_comparation::equal(topk_threshold, 1.f)) {
             break;
         }
 #endif
@@ -471,14 +571,20 @@ void compare_str(const ov::Tensor& expected, const ov::Tensor& actual) {
 
 void compare(const ov::Tensor& expected,
              const ov::Tensor& actual,
+             const ov::element::Type& inference_precision,
              const double abs_threshold,
-             const double rel_threshold) {
-#define CASE0(X, Y)                                                                                     \
-    case Y:                                                                                             \
-        compare<element_type_traits<X>::value_type, element_type_traits<Y>::value_type>(expected,       \
-                                                                                        actual,         \
-                                                                                        abs_threshold,  \
-                                                                                        rel_threshold); \
+             const double rel_threshold,
+             const double topk_threshold,
+             const double mvn_threshold) {
+#define CASE0(X, Y)                                                                                          \
+    case Y:                                                                                                  \
+        compare<element_type_traits<X>::value_type, element_type_traits<Y>::value_type>(expected,            \
+                                                                                        actual,              \
+                                                                                        inference_precision, \
+                                                                                        abs_threshold,       \
+                                                                                        rel_threshold,       \
+                                                                                        topk_threshold,      \
+                                                                                        mvn_threshold);      \
         break;
 
 #define CASE(X)                                          \


### PR DESCRIPTION
### Details:
 - *Inference precision is added as an argument to tensor comparation for calculation of default values for `abs_threshold` and `rel_threshold`*
 - *Extend tensor comparation by `topk_threshold`*
 -  - *Extend tensor comparation by `mvn_threshold`*

### Tickets:
 - *[136679](https://jira.devtools.intel.com/browse/CVS-136679)*
