### PR TITLE
[LPT] ConvolutionTransformatin: mixed precision fix

### DIFF
--- a/src/common/low_precision_transformations/src/convolution.cpp
+++ b/src/common/low_precision_transformations/src/convolution.cpp
@@ -58,7 +58,7 @@ bool ConvolutionTransformation::isQuantizedStatic(const std::shared_ptr<const No
 
 size_t ConvolutionTransformation::getInputChannels(const std::shared_ptr<ov::Node> conv) const {
     const auto channels = conv->get_input_partial_shape(1)[1];
-    assert(channels.is_static());
+    OPENVINO_ASSERT(channels.is_static());
     return channels.get_length();
 }
 
@@ -193,6 +193,7 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ov::pa
         }
         NetworkHelper::copyInfo(convolution, relaxedNewConvolution);
 
+        newMultiplyAfterConst = foldConvert(newMultiplyAfterConst, deqPrecision);
         newMultiplyAfter = std::make_shared<ov::op::TypeRelaxed<ov::opset1::Multiply>>(
             std::vector<element::Type>{ deqPrecision, deqPrecision },
             std::vector<element::Type>{ dequantization.multiply->get_output_element_type(0) },
@@ -223,7 +224,7 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ov::pa
         dequantization = reshapeFromWeights == nullptr ?
             NetworkHelper::getDequantization(convolution, defaultPrecisions, 1ul) :
             NetworkHelper::getDequantization(reshapeFromWeights, defaultPrecisions);
-        assert(!dequantization.empty());
+        OPENVINO_ASSERT(!dequantization.empty());
         if (const auto fq = ov::as_type_ptr<ov::opset1::FakeQuantize>(dequantization.data.get_node_shared_ptr())) {
             const auto newFQ = NetworkHelper::fold_fake_quantize(fq, true);
             NetworkHelper::copyInfo(fq, newFQ);
@@ -261,14 +262,17 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ov::pa
                 return new_shape;
             }();
 
-            newMultiplyAfter = std::make_shared<ov::opset1::Multiply>(
-                newConvolution,
-                foldConvert(
-                    fold_reshape<ov::opset1::Reshape>(
-                        multiplyFromWeights->input_value(1),
-                        std::make_shared<ov::opset1::Constant>(element::i32, Shape{ newScaleShape.size() }, newScaleShape),
-                        false),
-                    convolution->get_output_element_type(0)));
+            const auto newMultiplyAfterConst = foldConvert(
+                fold_reshape<ov::opset1::Reshape>(
+                    multiplyFromWeights->input_value(1),
+                    std::make_shared<ov::opset1::Constant>(element::i32, Shape{newScaleShape.size()}, newScaleShape),
+                    false),
+                deqPrecision);
+            newMultiplyAfter = std::make_shared<ov::op::TypeRelaxed<ov::opset1::Multiply>>(
+                std::vector<element::Type>{deqPrecision, deqPrecision},
+                std::vector<element::Type>{dequantization.multiply->get_output_element_type(0)},
+                ov::op::TemporaryReplaceOutputType(newConvolution, deqPrecision).get(),
+                ov::op::TemporaryReplaceOutputType(newMultiplyAfterConst, deqPrecision).get());
             NetworkHelper::insertDequantizationAfter(convolution, newMultiplyAfter, newConvolution);
             convolution = newMultiplyAfter->input_value(0).get_node_shared_ptr();
         }
@@ -284,7 +288,7 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ov::pa
                 subtractFromWeights = ov::as_type_ptr<ov::opset1::Subtract>(optimizedSubtract);
 
                 const auto weightsPShape = subtractFromWeights->get_input_partial_shape(0);
-                assert(weightsPShape.is_static());
+                OPENVINO_ASSERT(weightsPShape.is_static());
 
                 const size_t weightsRankValue = weightsPShape.rank().get_length();
                 Shape zeroPointShape(weightsRankValue, 1ul);

--- a/src/common/low_precision_transformations/src/convolution_backprop_data.cpp
+++ b/src/common/low_precision_transformations/src/convolution_backprop_data.cpp
@@ -70,7 +70,7 @@ bool ConvolutionBackpropDataTransformation::isQuantizedStatic(const std::shared_
 
 size_t ConvolutionBackpropDataTransformation::getInputChannels(const std::shared_ptr<ov::Node> conv) const {
     const auto channels = conv->get_input_partial_shape(1)[0];
-    assert(channels.is_static());
+    OPENVINO_ASSERT(channels.is_static());
     return channels.get_length();
 }
 
@@ -113,11 +113,6 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
         if (dequantization.subtract != nullptr) {
             NetworkHelper::optimizeSubtract(dequantization.subtract);
         }
-
-        std::shared_ptr<Node> newMultiplyAfterConst = std::make_shared<ov::opset1::Constant>(
-            dequantization.multiplyConstant->get_element_type(),
-            Shape{ 1 },
-            dequantization.multiplyConstant->cast_vector<float>()[0]);
         auto inputs = convolutionBackpropData->input_values();
         inputs[0] = dequantization.multiply->input_value(0);
         const auto copyNode = convolutionBackpropData->clone_with_new_inputs(inputs);
@@ -126,6 +121,12 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
             *ov::as_type_ptr<ov::opset1::ConvolutionBackpropData>(copyNode),
             std::vector<element::Type>{deqPrecision, deqPrecision},
             std::vector<element::Type>{deqPrecision});
+
+        const auto newMultiplyAfterConst = foldConvert(
+            std::make_shared<ov::opset1::Constant>(dequantization.multiplyConstant->get_element_type(),
+                                                   Shape{1},
+                                                   dequantization.multiplyConstant->cast_vector<float>()[0]),
+            deqPrecision);
 
         newMultiplyAfter = std::make_shared<ov::op::TypeRelaxed<ov::opset1::Multiply>>(
             std::vector<element::Type>{ deqPrecision, deqPrecision },
@@ -163,21 +164,24 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
 
         {
             const auto newScalePShape = multiplyFromWeights->get_input_partial_shape(1);
-            assert(newScalePShape.is_static());
+            OPENVINO_ASSERT(newScalePShape.is_static());
             Shape newScaleShape = newScalePShape.to_shape();
 
             auto inputs = convolutionBackpropData->input_values();
             inputs[1] = multiplyFromWeights->input_value(0);
 
             const auto newconvolutionBackpropData = convolutionBackpropData->copy_with_new_inputs(inputs);
-            newMultiplyAfter = std::make_shared<ov::opset1::Multiply>(
-                newconvolutionBackpropData,
-                foldConvert(
-                    fold_reshape<ov::opset1::Reshape>(
-                        multiplyFromWeights->input_value(1),
-                        std::make_shared<ov::opset1::Constant>(element::u64, Shape{ newScaleShape.size() }, newScaleShape),
-                        false),
-                    convolutionBackpropData->get_output_element_type(0)));
+            const auto newMultiplyAfterConst = foldConvert(
+                fold_reshape<ov::opset1::Reshape>(
+                    multiplyFromWeights->input_value(1),
+                    std::make_shared<ov::opset1::Constant>(element::u64, Shape{newScaleShape.size()}, newScaleShape),
+                    false),
+                deqPrecision);
+            newMultiplyAfter = std::make_shared<ov::op::TypeRelaxed<ov::opset1::Multiply>>(
+                std::vector<element::Type>{deqPrecision, deqPrecision},
+                std::vector<element::Type>{dequantization.multiply->get_output_element_type(0)},
+                ov::op::TemporaryReplaceOutputType(newconvolutionBackpropData, deqPrecision).get(),
+                ov::op::TemporaryReplaceOutputType(newMultiplyAfterConst, deqPrecision).get());
             NetworkHelper::insertDequantizationAfter(convolutionBackpropData, newMultiplyAfter, newconvolutionBackpropData);
             convolutionBackpropData = newMultiplyAfter->get_input_node_shared_ptr(0);
         }
@@ -191,7 +195,7 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
                 subtractFromWeights = ov::as_type_ptr<ov::opset1::Subtract>(optimizedSubtract);
 
                 const auto weightsPShape = subtractFromWeights->get_input_partial_shape(0);
-                assert(weightsPShape.is_static());
+                OPENVINO_ASSERT(weightsPShape.is_static());
 
                 const size_t weightsRankValue = weightsPShape.rank().get_length();
                 Shape zeroPointShape(weightsRankValue, 1ul);

--- a/src/common/low_precision_transformations/tests/convolution_backprop_data_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_backprop_data_transformation.cpp
@@ -373,6 +373,26 @@ const std::vector<ConvolutionBackpropDataTransformationTestValues> testValues = 
             true
         }
     },
+    // mixed precision: f16 dequantization constants, f32 dequantization precision
+    {
+        LayerTransformation::createParamsU8I8(),
+        // ActualValues
+        {
+            ov::element::u8,
+            {{ov::element::f16}, {}, { 0.02f }},
+            {{ov::element::f16}, {}, { 0.03f }},
+            op::v0::Constant::create(ov::element::i8, ov::Shape{}, std::vector<float>{ 2.f })
+        },
+        // ExpectedValues
+        {
+            ov::element::u8,
+            {},
+            {},
+            {{}, {}, {{ 0.0006f }, ov::element::f16, {}, false, 1, ov::element::f32}},
+            op::v0::Constant::create(ov::element::i8, ov::Shape{}, std::vector<float>{ 2.f }),
+            true
+        }
+    },
     // per-channel dequantization with the same values
     {
         LayerTransformation::createParamsU8I8(),

--- a/src/common/low_precision_transformations/tests/convolution_qdq_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/convolution_qdq_transformation.cpp
@@ -429,6 +429,30 @@ const std::vector<ConvolutionQDqTransformationTestValues> testValues = {
             {{}, {}, {{ 0.0006f }, ov::element::f32, {}}}
         }
     },
+    // mixed precision: f16 dequantization constants, f32 dequantization precision
+    {
+        LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),
+        // ActualValues
+        {
+            ov::element::u8,
+            {{ov::element::f16}, {}, {0.02f}},
+            {{ov::element::f16}, {}, {0.03f}},
+            {std::vector<float>{ 2.f }, ov::element::i8},
+            {},
+            ov::element::f16,
+            {}
+        },
+        // ExpectedValues
+        {
+            ov::element::u8,
+            {{}, {}, {}},
+            {{}, {}, {}},
+            {std::vector<float>{ 2.f }, ov::element::i8},
+            {},
+            ov::element::f32,
+            {{}, {}, {{ 0.0006f }, ov::element::f16, {}, false, 1, ov::element::f32}}
+        }
+    },
     // incorrect zero point on activations [not transformed]
     {
         LayerTransformation::createParamsU8I8().setSupportAsymmetricQuantization(true),


### PR DESCRIPTION
### Details:
 `ConvolutionTransformation` propagates multiplies from data and weights paths, and then fuses these 2 scales into one.

The bug was In mixed precision scenario (which is used on GPU device) when data dequantization was not produced by LPT but existed in the model. The propagated scales from data and weights had different precisions: scale from data did not change precision (f16), whereas precision of scale from weights was set to `deqPrecision=f32` - this led to element type inconsistency error at the scales fusion stage. In this PR, both scales are converted to `deqPrecision` to align scales element types and avoid precisions incosistency.

The same issue existed in `ConvolutionBackpropDataTransformation`: it was fixed too.

### Tickets:
 - *CVS-130598*
