### PR TITLE
Align reducel1 behavior 20559

### DIFF
--- a/src/frontends/onnx/frontend/src/op/reduce.cpp
+++ b/src/frontends/onnx/frontend/src/op/reduce.cpp
@@ -152,7 +152,7 @@ ov::OutputVector reduce_log_sum_exp(const ov::frontend::onnx::Node& node) {
 }
 
 ov::OutputVector reduce_l1(const ov::frontend::onnx::Node& node) {
-    return {make_ov_reduction_op<v4::ReduceL1>(node, node.get_ov_inputs().at(0), supported_types_v1)};
+    return {make_ov_reduction_op<v4::ReduceL1>(node, node.get_ov_inputs().at(0), supported_types_v2)};
 }
 
 ov::OutputVector reduce_l2(const ov::frontend::onnx::Node& node) {
@@ -185,6 +185,7 @@ ov::OutputVector reduce_sum_square(const ov::frontend::onnx::Node& node) {
     return {make_ov_reduction_op<v1::ReduceSum>(node, square_node, supported_types_v1)};
 }
 }  // namespace set_1
+
 /*
     Opset 11 is skipped because there are no significant difference between opset1 and opset 11.
     Found difference is:
@@ -211,6 +212,9 @@ ov::OutputVector reduce_log_sum(const ov::frontend::onnx::Node& node) {
     const ov::Output<ov::Node> sum_node =
         make_ov_reduction_op<v1::ReduceSum>(node, node.get_ov_inputs().at(0), supported_types_v2, false);
     return {std::make_shared<v0::Log>(sum_node)};
+}
+ov::OutputVector reduce_l1(const ov::frontend::onnx::Node& node) {
+    return {make_ov_reduction_op<v4::ReduceL1>(node, node.get_ov_inputs().at(0), supported_types_v2, false)};
 }
 }  // namespace set_18
 

--- a/src/frontends/onnx/frontend/src/op/reduce.hpp
+++ b/src/frontends/onnx/frontend/src/op/reduce.hpp
@@ -24,6 +24,9 @@ ov::OutputVector reduce_log_sum_exp(const ov::frontend::onnx::Node& node);
 namespace set_1 {
 ov::OutputVector reduce_l1(const ov::frontend::onnx::Node& node);
 }  // namespace set_1
+namespace set_18 {
+ov::OutputVector reduce_l1(const ov::frontend::onnx::Node& node);
+}  // namespace set_18
 
 namespace set_1 {
 ov::OutputVector reduce_l2(const ov::frontend::onnx::Node& node);

--- a/src/frontends/onnx/frontend/src/ops_bridge.cpp
+++ b/src/frontends/onnx/frontend/src/ops_bridge.cpp
@@ -483,7 +483,8 @@ OperatorsBridge::OperatorsBridge() {
     register_operator("ReduceLogSum", VersionRange{1, 17}, op::set_1::reduce_log_sum);
     register_operator("ReduceLogSum", VersionRange::since(18), op::set_18::reduce_log_sum);
     REGISTER_OPERATOR("ReduceLogSumExp", 1, reduce_log_sum_exp);
-    REGISTER_OPERATOR("ReduceL1", 1, reduce_l1);
+    REGISTER_OPERATOR("ReduceL1", VersionRange{1, 17}, op::set_1::reduce_l1);
+    REGISTER_OPERATOR("ReduceL1", VersionRange::since(18), op::set_18::reduce_l1);
     REGISTER_OPERATOR("ReduceL2", 1, reduce_l2);
     REGISTER_OPERATOR("ReduceMax", 1, reduce_max);
     REGISTER_OPERATOR("ReduceMax", 13, reduce_max);

--- a/src/frontends/onnx/tests/models/reduce_l1_18.prototxt
+++ b/src/frontends/onnx/tests/models/reduce_l1_18.prototxt
@@ -1,0 +1,48 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "A"
+    output: "B"
+    op_type: "ReduceL1"
+  }
+  name: "compute_graph"
+  input {
+    name: "A"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 18
+}

--- a/src/frontends/onnx/tests/models/reduce_l1_18_axes_as_input.prototxt
+++ b/src/frontends/onnx/tests/models/reduce_l1_18_axes_as_input.prototxt
@@ -1,0 +1,71 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "A"
+    input: "axes"
+    output: "B"
+    op_type: "ReduceL1"
+  }
+  name: "compute_graph"
+  input {
+    name: "A"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "axes"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 18
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -971,6 +971,36 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_reduce_l1) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_reduce_l1_18) {
+    auto model = convert_model("reduce_l1_18.onnx");
+
+    // input data shape (1, 1, 4, 4)
+    Inputs inputs{
+        ov::test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
+
+    // output data shape (1,)
+    auto expected_output = ov::test::NDArray<float, 4>({{{{16}}}}).get_vector();
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_multiple_inputs(inputs);
+    test_case.add_expected_output(expected_output);
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_reduce_l1_18_axes_as_input) {
+    auto model = convert_model("reduce_l1_18_axes_as_input.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_input<float>(Shape{1, 1, 4, 4}, {2, 1, 4, 2, 3, 1, 3, 2, 4, 2, 4, 2, 2, 2, 1, 4});
+    test_case.add_input<int64_t>({3});
+
+    test_case.add_expected_output(Shape{1, 1, 4, 1},
+                                  std::vector<float>{2.19722458f, 2.19722458f, 2.48490665f, 2.19722458f});
+
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_reduce_l2) {
     auto model = convert_model("reduce_l2.onnx");
 

--- a/src/frontends/onnx/tests/tests_python/test_backend.py
+++ b/src/frontends/onnx/tests/tests_python/test_backend.py
@@ -470,12 +470,6 @@ tests_expected_to_fail = [
     ),
     (
         xfail_issue_99968,
-        "OnnxBackendNodeModelTest.test_reduce_l1_do_not_keepdims_example_cpu",
-        "OnnxBackendNodeModelTest.test_reduce_l1_do_not_keepdims_random_cpu",
-        "OnnxBackendNodeModelTest.test_reduce_l1_keep_dims_example_cpu",
-        "OnnxBackendNodeModelTest.test_reduce_l1_keep_dims_random_cpu",
-        "OnnxBackendNodeModelTest.test_reduce_l1_negative_axes_keep_dims_example_cpu",
-        "OnnxBackendNodeModelTest.test_reduce_l1_negative_axes_keep_dims_random_cpu",
         "OnnxBackendNodeModelTest.test_reduce_l2_do_not_keepdims_example_cpu",
         "OnnxBackendNodeModelTest.test_reduce_l2_do_not_keepdims_random_cpu",
         "OnnxBackendNodeModelTest.test_reduce_l2_keep_dims_example_cpu",
@@ -488,7 +482,6 @@ tests_expected_to_fail = [
         "OnnxBackendNodeModelTest.test_reduce_log_sum_desc_axes_expanded_cpu",
         "OnnxBackendNodeModelTest.test_reduce_log_sum_exp_do_not_keepdims_example_cpu",
         "OnnxBackendNodeModelTest.test_reduce_log_sum_exp_do_not_keepdims_random_cpu",
-        "OnnxBackendNodeModelTest.test_reduce_l1_do_not_keepdims_example_cpu",
         "OnnxBackendNodeModelTest.test_reduce_log_sum_exp_keepdims_example_cpu",
         "OnnxBackendNodeModelTest.test_reduce_log_sum_exp_negative_axes_keepdims_example_cpu",
         "OnnxBackendNodeModelTest.test_reduce_log_sum_exp_keepdims_random_cpu",
@@ -705,7 +698,6 @@ tests_expected_to_fail = [
     ),
     (
         xfail_issue_125493,
-        "OnnxBackendNodeModelTest.test_reduce_l1_empty_set_cpu",
         "OnnxBackendNodeModelTest.test_reduce_l2_empty_set_cpu",
         "OnnxBackendNodeModelTest.test_reduce_log_sum_exp_empty_set_cpu",
         "OnnxBackendNodeModelTest.test_reduce_min_empty_set_cpu",


### PR DESCRIPTION
### Details:
 - I've aligned the ReduceL1 operation with opset 11, 13, and 18. I've registered the function inside the ops_bridge.cpp, created test models, and added them inside onnx_import.in.cpp.

### Tickets:
 - Closes *https://github.com/openvinotoolkit/openvino/issues/20559*
