### PR TITLE
[IE TESTS] Skip Import/Export/QueryModel tests for SW plugin from API Conformance

### DIFF
--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/query_model.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/query_model.hpp
@@ -76,6 +76,9 @@ TEST_P(OVClassQueryModelTest, QueryModelWithMatMul) {
 }
 
 TEST_P(OVClassQueryModelTest, QueryModelHETEROWithDeviceIDNoThrow) {
+    if (sw_plugin_in_target_device(target_device)) {
+        return;
+    }
     ov::Core ie = ov::test::utils::create_core();
 
     auto deviceIDs = ie.get_property(target_device, ov::available_devices);

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/life_time.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/life_time.cpp
@@ -148,6 +148,9 @@ void OVHoldersTestOnImportedNetwork::TearDown() {
 }
 
 TEST_P(OVHoldersTestOnImportedNetwork, LoadedTensor) {
+    if (sw_plugin_in_target_device(target_device)) {
+        return;
+    }
     ov::Core core = ov::test::utils::create_core();
     std::stringstream stream;
     {
@@ -160,6 +163,9 @@ TEST_P(OVHoldersTestOnImportedNetwork, LoadedTensor) {
 }
 
 TEST_P(OVHoldersTestOnImportedNetwork, CreateRequestWithCoreRemoved) {
+    if (sw_plugin_in_target_device(target_device)) {
+        return;
+    }
     ov::Core core = ov::test::utils::create_core();
     std::stringstream stream;
     {

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
@@ -474,6 +474,9 @@ TEST_P(OVCheckGetSupportedROMetricsPropsTests, ChangeCorrectProperties) {
 }
 
 TEST_P(OVCheckChangePropComplieModleGetPropTests_DEVICE_ID, ChangeCorrectDeviceProperties) {
+    if (sw_plugin_in_target_device(target_device)) {
+        return;
+    }
     std::vector<ov::PropertyName> supported_properties;
     OV_ASSERT_NO_THROW(supported_properties = core->get_property(target_device, ov::supported_properties));
     auto supported = util::contains(supported_properties, ov::device::id);
@@ -667,6 +670,9 @@ TEST_P(OVSpecificDeviceGetConfigTest, GetConfigSpecificDeviceNoThrow) {
 }
 
 TEST_P(OVGetAvailableDevicesPropsTest, GetAvailableDevicesNoThrow) {
+    if (sw_plugin_in_target_device(target_device)) {
+        return;
+    }
     ov::Core ie = ov::test::utils::create_core();
     std::vector<std::string> devices;
 
@@ -719,6 +725,9 @@ TEST_P(OVClassSetDevicePriorityConfigPropsTest, SetConfigAndCheckGetConfigNoThro
 }
 
 TEST_P(OVGetMetricPropsTest, GetMetricAndPrintNoThrow_AVAILABLE_DEVICES) {
+    if (sw_plugin_in_target_device(target_device)) {
+        return;
+    }
     ov::Core ie = ov::test::utils::create_core();
     std::vector<std::string> device_ids;
 
@@ -727,12 +736,7 @@ TEST_P(OVGetMetricPropsTest, GetMetricAndPrintNoThrow_AVAILABLE_DEVICES) {
 
     for (auto&& device_id : device_ids) {
         std::string full_name;
-        // sw plugins are not requested to support `ov::device::id` property
-        if (sw_plugin_in_target_device(target_device)) {
-            OV_ASSERT_NO_THROW(full_name = ie.get_property(target_device, ov::device::full_name));
-        } else {
-            OV_ASSERT_NO_THROW(full_name = ie.get_property(target_device, ov::device::full_name, ov::device::id(device_id)));
-        }
+        OV_ASSERT_NO_THROW(full_name = ie.get_property(target_device, ov::device::full_name, ov::device::id(device_id)));
         ASSERT_FALSE(full_name.empty());
     }
 


### PR DESCRIPTION
### Details:
 - *Skip some tests  based on  Import/Export/QueryModel in API conformance*

### Tickets:
 - *[136558](https://jira.devtools.intel.com/browse/CVS-136558)*
