### PR TITLE
[GPU] add u8 support in evaluate of logical_not

### DIFF
--- a/src/core/src/op/logical_not.cpp
+++ b/src/core/src/op/logical_not.cpp
@@ -55,7 +55,7 @@ bool LogicalNot::evaluate(TensorVector& outputs, const TensorVector& inputs) con
                                       this,
                                       outputs,
                                       inputs,
-                                      OV_PP_ET_LIST(boolean, i32, i64, u32, u64, f32),
+                                      OV_PP_ET_LIST(boolean, u8, i32, i64, u32, u64, f32),
                                       logical_not::Evaluate,
                                       inputs[0].get_element_type(),
                                       inputs[0],
@@ -67,6 +67,7 @@ bool LogicalNot::has_evaluate() const {
     OV_OP_SCOPE(v1_LogicalNot_has_evaluate);
     switch (get_input_element_type(0)) {
     case element::boolean:
+    case element::u8:
     case element::f16:
     case element::f32:
     case element::i32:

--- a/src/plugins/template/tests/functional/op_reference/logical_not.cpp
+++ b/src/plugins/template/tests/functional/op_reference/logical_not.cpp
@@ -23,8 +23,7 @@ std::vector<RefLogicalParams> generateLogicalParams() {
         Builder{}
             .opType(LogicalTypes::LOGICAL_NOT)
             .inputs({{{2, 2}, element::u8, std::vector<uint8_t>{1, 0, 1, 0}}})
-            .expected({{2, 2}, element::u8, std::vector<uint8_t>{0, 1, 0, 1}}),
-            };
+            .expected({{2, 2}, element::u8, std::vector<uint8_t>{0, 1, 0, 1}})};
     return logicalParams;
 }
 

--- a/src/plugins/template/tests/functional/op_reference/logical_not.cpp
+++ b/src/plugins/template/tests/functional/op_reference/logical_not.cpp
@@ -19,7 +19,12 @@ std::vector<RefLogicalParams> generateLogicalParams() {
         Builder{}
             .opType(LogicalTypes::LOGICAL_NOT)
             .inputs({{{2, 2}, element::boolean, std::vector<char>{true, false, true, false}}})
-            .expected({{2, 2}, element::boolean, std::vector<char>{false, true, false, true}})};
+            .expected({{2, 2}, element::boolean, std::vector<char>{false, true, false, true}}),
+        Builder{}
+            .opType(LogicalTypes::LOGICAL_NOT)
+            .inputs({{{2, 2}, element::u8, std::vector<uint8_t>{1, 0, 1, 0}}})
+            .expected({{2, 2}, element::u8, std::vector<uint8_t>{0, 1, 0, 1}}),
+            };
     return logicalParams;
 }
 


### PR DESCRIPTION
### Details:
 - Add u8 support in op evaluate of logical_not. It is called in cpu_impl of GPU plugin and GPU plugin is using u8 as boolean from transformed graph.

### Tickets:
 - 124503
