### PR TITLE
[core] Fix segfault in Constant when destroy not initialized string buffer

### DIFF
--- a/src/common/transformations/include/ov_ops/gather_compressed.hpp
+++ b/src/common/transformations/include/ov_ops/gather_compressed.hpp
@@ -18,22 +18,22 @@ public:
 
     GatherCompressed() = default;
 
-    GatherCompressed(const ov::Output<Node> &data,
-                     const ov::Output<Node> &indices,
-                     const ov::Output<Node> &axis,
+    GatherCompressed(const ov::Output<Node>& data,
+                     const ov::Output<Node>& indices,
+                     const ov::Output<Node>& axis,
                      const int64_t batch_dims,
-                     const ov::Output<Node> &decompression_scale,
-                     const ov::Output<Node> &decompression_zero_point,
+                     const ov::Output<Node>& decompression_scale,
+                     const ov::Output<Node>& decompression_zero_point,
                      const ov::element::Type output_type = ov::element::undefined);
 
-    GatherCompressed(const ov::Output<Node> &data,
-                     const ov::Output<Node> &indices,
-                     const ov::Output<Node> &axis,
+    GatherCompressed(const ov::Output<Node>& data,
+                     const ov::Output<Node>& indices,
+                     const ov::Output<Node>& axis,
                      const int64_t batch_dims,
-                     const ov::Output<Node> &decompression_scale,
+                     const ov::Output<Node>& decompression_scale,
                      const ov::element::Type output_type = ov::element::undefined);
 
-    bool visit_attributes(ov::AttributeVisitor &visitor) override;
+    bool visit_attributes(ov::AttributeVisitor& visitor) override;
 
     void validate_and_infer_types() override;
 

--- a/src/core/dev_api/openvino/runtime/string_aligned_buffer.hpp
+++ b/src/core/dev_api/openvino/runtime/string_aligned_buffer.hpp
@@ -27,7 +27,7 @@ private:
     StringAlignedBuffer& operator=(const StringAlignedBuffer&) = delete;
 
 protected:
-    size_t m_num_elements;
+    size_t m_num_elements{};
 };
 
 /// \brief SharedStringAlignedBuffer class to store pointer to shared pre-allocated buffer with std::string objects
@@ -36,12 +36,7 @@ class OPENVINO_API SharedStringAlignedBuffer : public ov::StringAlignedBuffer {
 public:
     SharedStringAlignedBuffer(char* ptr, size_t size);
 
-    virtual ~SharedStringAlignedBuffer() {
-        m_allocated_buffer = nullptr;
-        m_aligned_buffer = nullptr;
-        m_byte_size = 0;
-        m_num_elements = 0;
-    }
+    virtual ~SharedStringAlignedBuffer();
 };
 
 template <>

--- a/src/core/include/openvino/op/constant.hpp
+++ b/src/core/include/openvino/op/constant.hpp
@@ -648,6 +648,7 @@ private:
               typename StorageDataType = fundamental_type_for<Type>,
               typename std::enable_if<Type == element::Type_t::string, bool>::type = true>
     void fill_data(const T& value) {
+        fill_data<element::string>(std::string());
         std::string type_name(typeid(value).name());
         OPENVINO_THROW("fill_data does not support to fill ov::Tensor of string type with value of " + type_name);
     }
@@ -724,6 +725,7 @@ private:
               typename T,
               typename std::enable_if<Type == element::Type_t::string, bool>::type = true>
     void write_buffer(const std::vector<T>& source) {
+        fill_data<element::string>(std::string());
         if (source.size() > 0) {
             auto source_type = std::string(typeid(source[0]).name());
             OPENVINO_THROW("write_buffer does not support writing elements of type " + source_type +

--- a/src/core/src/runtime/string_aligned_buffer.cpp
+++ b/src/core/src/runtime/string_aligned_buffer.cpp
@@ -82,12 +82,12 @@ namespace ov {
 StringAlignedBuffer::StringAlignedBuffer(size_t num_elements, size_t byte_size, size_t alignment, bool initialize)
     : AlignedBuffer(byte_size, alignment),
       m_num_elements(num_elements) {
-    const auto has_enough_size = (sizeof(std::string) * num_elements) <= (byte_size + alignment);
+    const auto has_enough_size = (sizeof(std::string) * m_num_elements) <= size();
     OPENVINO_ASSERT(has_enough_size,
                     "Allocated memory of size ",
-                    byte_size,
+                    size(),
                     " bytes is not enough to store ",
-                    num_elements,
+                    m_num_elements,
                     " std::string objects");
     if (initialize) {
         std::uninitialized_fill_n(get_ptr<std::string>(), m_num_elements, std::string{});

--- a/src/core/src/runtime/string_aligned_buffer.cpp
+++ b/src/core/src/runtime/string_aligned_buffer.cpp
@@ -95,7 +95,7 @@ StringAlignedBuffer::StringAlignedBuffer(size_t num_elements, size_t byte_size, 
 }
 
 StringAlignedBuffer::~StringAlignedBuffer() {
-    if (m_aligned_buffer) {
+    if (m_allocated_buffer) {
         const auto first = get_ptr<std::string>();
         for_each(first, first + m_num_elements, [](std::string& s) {
             using std::string;
@@ -113,7 +113,6 @@ SharedStringAlignedBuffer::SharedStringAlignedBuffer(char* ptr, size_t size) {
 
 SharedStringAlignedBuffer::~SharedStringAlignedBuffer() {
     // to prevent deallocation in parent dtors.
-    m_aligned_buffer = nullptr;
     m_allocated_buffer = nullptr;
 }
 

--- a/src/core/src/runtime/string_aligned_buffer.cpp
+++ b/src/core/src/runtime/string_aligned_buffer.cpp
@@ -72,7 +72,7 @@ void aux_get_raw_string_by_index(const std::shared_ptr<ov::StringAlignedBuffer>&
     OPENVINO_ASSERT(string_aligned_buffer_ptr, "StringAlignedBuffer pointer is nullptr");
     OPENVINO_ASSERT(string_ind < string_aligned_buffer_ptr->get_num_elements(),
                     "Incorrect packed string tensor format: no batch size in the packed string tensor");
-    const std::string* strings = reinterpret_cast<const std::string*>(string_aligned_buffer_ptr->get_ptr());
+    const auto strings = string_aligned_buffer_ptr->get_ptr<const std::string>();
     raw_string_ptr = strings[string_ind].data();
     raw_string_size = strings[string_ind].size();
 }
@@ -82,22 +82,25 @@ namespace ov {
 StringAlignedBuffer::StringAlignedBuffer(size_t num_elements, size_t byte_size, size_t alignment, bool initialize)
     : AlignedBuffer(byte_size, alignment),
       m_num_elements(num_elements) {
-    OPENVINO_ASSERT(sizeof(std::string) * num_elements <= byte_size + alignment,
-                    "Allocated memory of size " + std::to_string(byte_size) + " bytes is not enough to store " +
-                        std::to_string(num_elements) + " std::string objects");
+    const auto has_enough_size = (sizeof(std::string) * num_elements) <= (byte_size + alignment);
+    OPENVINO_ASSERT(has_enough_size,
+                    "Allocated memory of size ",
+                    byte_size,
+                    " bytes is not enough to store ",
+                    num_elements,
+                    " std::string objects");
     if (initialize) {
-        auto strings = reinterpret_cast<std::string*>(m_aligned_buffer);
-        std::uninitialized_fill_n(strings, m_num_elements, std::string());
+        std::uninitialized_fill_n(get_ptr<std::string>(), m_num_elements, std::string{});
     }
 }
 
 StringAlignedBuffer::~StringAlignedBuffer() {
     if (m_aligned_buffer) {
-        auto strings = reinterpret_cast<std::string*>(m_aligned_buffer);
-        for (size_t ind = 0; ind < m_num_elements; ++ind) {
+        const auto first = get_ptr<std::string>();
+        for_each(first, first + m_num_elements, [](std::string& s) {
             using std::string;
-            strings[ind].~string();
-        }
+            s.~string();
+        });
     }
 }
 
@@ -106,6 +109,12 @@ SharedStringAlignedBuffer::SharedStringAlignedBuffer(char* ptr, size_t size) {
     m_aligned_buffer = ptr;
     m_byte_size = size;
     m_num_elements = size / ov::element::string.size();
+}
+
+SharedStringAlignedBuffer::~SharedStringAlignedBuffer() {
+    // to prevent deallocation in parent dtors.
+    m_aligned_buffer = nullptr;
+    m_allocated_buffer = nullptr;
 }
 
 AttributeAdapter<std::shared_ptr<ov::StringAlignedBuffer>>::AttributeAdapter(

--- a/src/core/tests/constant.cpp
+++ b/src/core/tests/constant.cpp
@@ -1499,6 +1499,15 @@ TEST(constant, ov_string_shared_data) {
     EXPECT_EQ(p1, p2);
 }
 
+TEST(constant, ov_string_broadcast_from_non_string) {
+    EXPECT_THROW(std::ignore = op::v0::Constant::create(element::string, Shape{4}, std::vector<int>{10}), Exception);
+}
+
+TEST(constant, ov_string_from_non_string_vector) {
+    EXPECT_THROW(std::ignore = op::v0::Constant::create(element::string, Shape{4}, std::vector<int>{10, 1, 3, 2}),
+                 Exception);
+}
+
 template <typename T1, typename T2>
 ::testing::AssertionResult test_convert() {
     Shape shape{5};

--- a/src/core/tests/string_align_buffer_test.cpp
+++ b/src/core/tests/string_align_buffer_test.cpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "openvino/runtime/string_aligned_buffer.hpp"
+
+namespace ov {
+namespace test {
+
+using StringAlignedBufferTest = testing::Test;
+
+TEST_F(StringAlignedBufferTest, default_ctor) {
+    StringAlignedBuffer buffer;
+
+    ASSERT_EQ(buffer.get_ptr(), nullptr);
+    EXPECT_EQ(buffer.get_num_elements(), 0);
+    EXPECT_EQ(buffer.size(), 0);
+}
+
+TEST_F(StringAlignedBufferTest, create_not_initialized_but_init_before_destruction) {
+    StringAlignedBuffer buffer{4, 100, 64, false};
+
+    ASSERT_NE(buffer.get_ptr(), nullptr);
+    EXPECT_EQ(buffer.get_num_elements(), 4);
+    EXPECT_EQ(buffer.size(), 100);
+
+    // uninitialized buffer must be initialized by user before dtor call to avoid segfault
+    std::uninitialized_fill_n(buffer.get_ptr<std::string>(), buffer.get_num_elements(), std::string{});
+}
+
+TEST_F(StringAlignedBufferTest, create_initialized) {
+    constexpr size_t exp_size = sizeof(std::string) * 5;
+
+    StringAlignedBuffer buffer(5, exp_size, 8, true);
+
+    ASSERT_NE(buffer.get_ptr(), nullptr);
+    EXPECT_EQ(buffer.get_num_elements(), 5);
+    EXPECT_EQ(buffer.size(), exp_size);
+}
+
+class SharedStringAlignedBufferTest : public testing::Test {
+protected:
+    const size_t exp_size = 11 * sizeof(std::string);
+    const std::string msg_at_0 = "test input message at index 0";
+
+    StringAlignedBuffer buffer{11, exp_size, 0, true};
+};
+
+TEST_F(SharedStringAlignedBufferTest, dtor_not_destroy_input_buffer) {
+    *buffer.get_ptr<std::string>() = msg_at_0;
+
+    {
+        SharedStringAlignedBuffer shared_buffer{buffer.get_ptr<char>(), buffer.size()};
+
+        ASSERT_EQ(shared_buffer.get_ptr(), buffer.get_ptr());
+        EXPECT_EQ(shared_buffer.get_num_elements(), buffer.get_num_elements());
+        EXPECT_EQ(shared_buffer.size(), exp_size);
+        EXPECT_EQ(shared_buffer.get_ptr<const std::string>()[0], msg_at_0);
+    }
+
+    ASSERT_NE(buffer.get_ptr(), nullptr);
+    EXPECT_EQ(buffer.get_num_elements(), 11);
+    EXPECT_EQ(buffer.size(), exp_size);
+    EXPECT_EQ(buffer.get_ptr<const std::string>()[0], msg_at_0);
+}
+
+TEST_F(SharedStringAlignedBufferTest, create_with_smaller_size_than_input_buffer) {
+    buffer.get_ptr<std::string>()[0] = msg_at_0;
+
+    const SharedStringAlignedBuffer shared_buffer{buffer.get_ptr<char>(), sizeof(std::string)};
+
+    ASSERT_EQ(shared_buffer.get_ptr(), buffer.get_ptr());
+    EXPECT_EQ(shared_buffer.get_num_elements(), 1);
+    EXPECT_EQ(shared_buffer.size(), sizeof(std::string));
+    EXPECT_EQ(shared_buffer.get_ptr<std::string>()[0], msg_at_0);
+
+    ASSERT_NE(buffer.get_ptr(), nullptr);
+    EXPECT_EQ(*buffer.get_ptr<const std::string>(), msg_at_0);
+}
+
+}  // namespace test
+}  // namespace ov

--- a/src/core/tests/string_align_buffer_test.cpp
+++ b/src/core/tests/string_align_buffer_test.cpp
@@ -22,14 +22,6 @@ TEST_F(StringAlignedBufferTest, default_ctor) {
     EXPECT_EQ(buffer.size(), 0);
 }
 
-TEST_F(StringAlignedBufferTest, create_not_initialized) {
-    StringAlignedBuffer buffer{4, 100, 64, false};
-
-    ASSERT_NE(buffer.get_ptr(), nullptr);
-    EXPECT_EQ(buffer.get_num_elements(), 4);
-    EXPECT_EQ(buffer.size(), 100);
-}
-
 TEST_F(StringAlignedBufferTest, create_not_initialized_but_init_before_destruction) {
     constexpr size_t exp_size = 4 * sizeof(std::string) + 1;
     StringAlignedBuffer buffer{4, exp_size, 64, false};
@@ -80,7 +72,7 @@ TEST_F(SharedStringAlignedBufferTest, dtor_not_destroy_input_buffer) {
     *buffer.get_ptr<std::string>() = msg_at_0;
 
     {
-        SharedStringAlignedBuffer shared_buffer{buffer.get_ptr<char>(), buffer.size()};
+        SharedStringAlignedBuffer shared_buffer(buffer.get_ptr<char>(), buffer.size());
 
         ASSERT_EQ(shared_buffer.get_ptr(), buffer.get_ptr());
         EXPECT_EQ(shared_buffer.get_num_elements(), buffer.get_num_elements());


### PR DESCRIPTION
### Details:
Fix segfault in Constant when destroy not initialized string buffer:
- Initialize buffer in Constant before exception throw to avoid segfault.
- Improve default ctor of` StringAlignedBuffer`.
- Set only required members in `SharedStringAlignedBuffer`'s dtor.
- Add unit test for `StringAlignedBuffer`.
- Use template `get_ptr` instead cast.
- Optimize assertion error message.

### Tickets:
 - Relate to [CVS-119224](https://jira.devtools.intel.com/browse/CVS-119224)
