### PR TITLE
Fix Python linter errors introduced by new `flake8-pytest-style` version

### DIFF
--- a/src/bindings/python/tests/test_graph/test_dyn_attributes.py
+++ b/src/bindings/python/tests/test_graph/test_dyn_attributes.py
@@ -7,7 +7,7 @@ import openvino.runtime.opset8 as ov
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def proposal_node():
     attributes = {
         "base_size": np.uint16(1),

--- a/src/bindings/python/tests/test_graph/test_manager.py
+++ b/src/bindings/python/tests/test_graph/test_manager.py
@@ -49,7 +49,7 @@ def test_constant_folding():
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-@pytest.fixture()
+@pytest.fixture
 def prepare_ir_paths(request, tmp_path):
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
 

--- a/src/bindings/python/tests/test_graph/test_node_factory.py
+++ b/src/bindings/python/tests/test_graph/test_node_factory.py
@@ -98,8 +98,8 @@ def test_node_factory_validate_missing_arguments():
         raise AssertionError("Validation of missing arguments has unexpectedly passed.")
 
 
-@pytest.mark.template_extension()
-@pytest.mark.dynamic_library()
+@pytest.mark.template_extension
+@pytest.mark.dynamic_library
 @pytest.mark.xfail(condition=platform == "darwin", reason="Ticket - 132696")
 def test_extension_added_from_library():
     if platform == "win32":

--- a/src/bindings/python/tests/test_runtime/test_core.py
+++ b/src/bindings/python/tests/test_runtime/test_core.py
@@ -90,12 +90,12 @@ def test_compile_model(request, tmp_path, device_name):
     assert isinstance(compiled_model, CompiledModel)
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_model():
     return get_relu_model()
 
 
-@pytest.fixture()
+@pytest.fixture
 def get_model_path(request, tmp_path):
     xml_path, _ = create_filename_for_test(request.node.name, tmp_path, True)
     serialize(get_relu_model(), xml_path)
@@ -309,7 +309,7 @@ def test_query_model(device):
     assert device in next(iter(set(query_model.values()))), "Wrong device for some layers"
 
 
-@pytest.mark.dynamic_library()
+@pytest.mark.dynamic_library
 def test_register_plugin():
     device = "TEST_DEVICE"
     lib_name = "test_plugin"
@@ -322,7 +322,7 @@ def test_register_plugin():
     assert f"Cannot load library '{full_lib_name}'" in str(e.value)
 
 
-@pytest.mark.dynamic_library()
+@pytest.mark.dynamic_library
 def test_register_plugins():
     device = "TEST_DEVICE"
     lib_name = "test_plugin"
@@ -346,8 +346,8 @@ def test_unload_plugin(device):
     core.unload_plugin(device)
 
 
-@pytest.mark.template_extension()
-@pytest.mark.dynamic_library()
+@pytest.mark.template_extension
+@pytest.mark.dynamic_library
 @pytest.mark.xfail(condition=sys.platform == "darwin", reason="Ticket - 132696")
 def test_add_extension_template_extension(device):
     core, model = get_model_with_template_extension()


### PR DESCRIPTION
### Details:
 - Fix new linter errors introduced with newly released [flake8-pytest-style](https://pypi.org/project/flake8-pytest-style/#history)

### Tickets:
 - N/A
