### PR TITLE
[Layer tests] Use legacy MO API only for legacy tests and optimize imports

### DIFF
--- a/tests/layer_tests/common/mo_convert_test_class.py
+++ b/tests/layer_tests/common/mo_convert_test_class.py
@@ -3,12 +3,8 @@
 
 from pathlib import Path
 
-from openvino.runtime import serialize, save_model
-from openvino.tools.ovc import convert_model
-from openvino.tools.mo import convert_model as legacy_convert_model
-from openvino.test_utils import compare_functions
-
 from common.utils.common_utils import generate_ir
+from openvino.test_utils import compare_functions
 
 
 class CommonMOConvertTest:
@@ -19,11 +15,14 @@ class CommonMOConvertTest:
         del kwargs['output_dir']
         del kwargs['model_name']
         if 'use_legacy_frontend' in kwargs or 'use_convert_model_from_mo' in kwargs:
+            from openvino.tools.mo import convert_model as legacy_convert_model
+            from openvino.runtime import serialize
             if 'use_convert_model_from_mo' in kwargs:
                 del kwargs['use_convert_model_from_mo']
             model = legacy_convert_model(**kwargs)
             serialize(model, str(Path(output_dir, model_name + '.xml')))
         else:
+            from openvino import convert_model, save_model
             # ovc.convert_model does not have 'compress_to_fp16' arg, it's moved into save model
             compress_to_fp16 = True
             if 'compress_to_fp16' in kwargs:
@@ -37,7 +36,7 @@ class CommonMOConvertTest:
         Generates two IRs using MO Python API and using cmd tool.
         Then two IRs are compared.
         """
-        from openvino.runtime import Core
+        from openvino import Core
         core = Core()
 
         test_params.update({"model_name": 'model_test', "output_dir": temp_dir})
@@ -59,7 +58,7 @@ class CommonMOConvertTest:
         """
         Generates IR using MO Python API, reads it and compares with reference graph.
         """
-        from openvino.runtime import Core
+        from openvino import Core
         core = Core()
 
         test_params.update({"model_name": 'model_test', "output_dir": temp_dir})

--- a/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
+++ b/tests/layer_tests/ovc_python_api_tests/test_pytorch.py
@@ -1,18 +1,15 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
+import unittest
 from typing import Tuple, List
-import numpy
+
 import numpy as np
 import openvino.runtime as ov
 import pytest
 import torch
-import unittest
-from openvino.runtime import PartialShape, Dimension, Model, Type
-from openvino.tools.mo import InputCutInfo
 from common.mo_convert_test_class import CommonMOConvertTest
+from openvino.runtime import PartialShape, Dimension, Model, Type
 
 
 class MyTorchOp(torch.autograd.Function):
@@ -981,13 +978,13 @@ def create_pytorch_module_with_nested_list_and_single_input(tmp_dir):
             x0 = x[0]
             x0 = torch.cat([x0, torch.zeros(1, 1)], 1)
             return x0 + torch.ones((1, 1))
-    
+
     net = PTModel()
     constant_one = ov.opset10.constant(np.ones((1, 1)), dtype=np.float32)
     const_zero = ov.opset10.constant(0, dtype=np.int64)
     constant_zeros1 = ov.opset10.constant(np.zeros((1, 1), dtype=np.float32), dtype=np.float32)
 
-    param =  ov.opset10.parameter(PartialShape([-1, -1, -1]), dtype=np.float32)
+    param = ov.opset10.parameter(PartialShape([-1, -1, -1]), dtype=np.float32)
     gather = ov.opset10.gather(param, const_zero, const_zero)
     concat1 = ov.opset10.concat([gather, constant_zeros1], 1)
     add = ov.opset10.add(concat1, constant_one)
@@ -996,19 +993,20 @@ def create_pytorch_module_with_nested_list_and_single_input(tmp_dir):
         "example_input": [torch.ones((1, 11))],
         "compress_to_fp16": False}
 
+
 def create_pytorch_module_with_single_input_as_list(tmp_dir):
     class PTModel(torch.nn.Module):
         def forward(self, x):
             x0 = x[0]
             x0 = torch.cat([x0, torch.zeros(1)], 0)
             return x0 + torch.ones(1)
-    
+
     net = PTModel()
     constant_one = ov.opset10.constant(np.ones((1,)), dtype=np.float32)
     const_zero = ov.opset10.constant(0, dtype=np.int64)
-    constant_zeros1 = ov.opset10.constant(np.zeros((1, ), dtype=np.float32), dtype=np.float32)
+    constant_zeros1 = ov.opset10.constant(np.zeros((1,), dtype=np.float32), dtype=np.float32)
 
-    param =  ov.opset10.parameter(PartialShape([-1, -1]), dtype=np.float32)
+    param = ov.opset10.parameter(PartialShape([-1, -1]), dtype=np.float32)
     gather = ov.opset10.gather(param, const_zero, const_zero)
     concat1 = ov.opset10.concat([gather, constant_zeros1], 0)
     add = ov.opset10.add(concat1, constant_one)
@@ -1016,6 +1014,7 @@ def create_pytorch_module_with_single_input_as_list(tmp_dir):
     return net, ref_model, {
         "example_input": [torch.ones((1, 11))],
         "compress_to_fp16": False}
+
 
 class TestMoConvertPyTorch(CommonMOConvertTest):
     test_data = [
@@ -1180,6 +1179,7 @@ def create_model_three_inputs():
         def forward(self, x, y, z):
             out = self.linear_relu_stack(x + y + z),
             return out
+
     return NeuralNetwork()
 
 
@@ -1206,13 +1206,12 @@ def make_ref_model_three_inputs(shape, dtype=np.float32):
 
 
 class TestPytorchConversionParams(CommonMOConvertTest):
-
     test_data = [
         {'params_test': {'input': [(torch.Size([2, 3, 4]), torch.float32),
                                    (torch.empty(2, 3, 4).size(), torch.float32),
                                    (torch.empty(2, 3, 4).shape, torch.float32)]},
          'fw_model': create_model_three_inputs(),
-         'ref_model': make_ref_model_three_inputs([2,3,4], np.float32)},
+         'ref_model': make_ref_model_three_inputs([2, 3, 4], np.float32)},
         {'params_test': {'input': [(torch.Size([5, 2]), torch.int32),
                                    (torch.empty(5, 2).size(), torch.int32),
                                    (torch.empty(5, 2).shape, torch.int32)]},
@@ -1229,7 +1228,7 @@ class TestPytorchConversionParams(CommonMOConvertTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_conversion_params(self, params, ie_device, precision, ir_version,
-                                 temp_dir, use_legacy_frontend):
+                               temp_dir, use_legacy_frontend):
         fw_model = params['fw_model']
         test_params = params['params_test']
         ref_model = params['ref_model']

--- a/tests/layer_tests/py_frontend_tests/test_torchvision_preprocessor.py
+++ b/tests/layer_tests/py_frontend_tests/test_torchvision_preprocessor.py
@@ -2,21 +2,19 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 import copy
-import pytest
 import platform
-from PIL import Image
 
+import numpy as np
+import pytest
 import torch
 import torch.nn.functional as f
 import torchvision.transforms as transforms
-
+from PIL import Image
 from openvino import Type, Core
-from openvino.tools.mo import convert_model
-from openvino.properties.hint import inference_precision
-
+from openvino import convert_model
 from openvino.preprocess.torchvision import PreprocessConverter
+from openvino.properties.hint import inference_precision
 
 
 class Convnet(torch.nn.Module):
@@ -61,7 +59,8 @@ def _infer_pipelines(test_input, preprocess_pipeline, input_channels=3):
 
 def test_normalize():
     test_input = np.random.randint(255, size=(224, 224, 3), dtype=np.uint8)
-    preprocess_pipeline = transforms.Compose([transforms.ToTensor(), transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])])
+    preprocess_pipeline = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])])
     torch_result, ov_result = _infer_pipelines(test_input, preprocess_pipeline)
     assert np.max(np.absolute(torch_result - ov_result)) < 4e-05
 
@@ -110,67 +109,67 @@ def test_convertimagedtype():
     ("test_input", "preprocess_pipeline"),
     [
         (
-            np.random.randint(255, size=(220, 220, 3), dtype=np.uint8),
-            transforms.Compose(
-                [
-                    transforms.Pad((2)),
-                    transforms.ToTensor(),
-                ],
-            ),
+                np.random.randint(255, size=(220, 220, 3), dtype=np.uint8),
+                transforms.Compose(
+                    [
+                        transforms.Pad((2)),
+                        transforms.ToTensor(),
+                    ],
+                ),
         ),
         (
-            np.random.randint(255, size=(218, 220, 3), dtype=np.uint8),
-            transforms.Compose(
-                [
-                    transforms.Pad((2, 3)),
-                    transforms.ToTensor(),
-                ],
-            ),
+                np.random.randint(255, size=(218, 220, 3), dtype=np.uint8),
+                transforms.Compose(
+                    [
+                        transforms.Pad((2, 3)),
+                        transforms.ToTensor(),
+                    ],
+                ),
         ),
         (
-            np.random.randint(255, size=(216, 218, 3), dtype=np.uint8),
-            transforms.Compose(
-                [
-                    transforms.Pad((2, 3, 4, 5)),
-                    transforms.ToTensor(),
-                ],
-            ),
+                np.random.randint(255, size=(216, 218, 3), dtype=np.uint8),
+                transforms.Compose(
+                    [
+                        transforms.Pad((2, 3, 4, 5)),
+                        transforms.ToTensor(),
+                    ],
+                ),
         ),
         (
-            np.random.randint(255, size=(216, 218, 3), dtype=np.uint8),
-            transforms.Compose(
-                [
-                    transforms.Pad((2, 3, 4, 5), fill=3),
-                    transforms.ToTensor(),
-                ],
-            ),
+                np.random.randint(255, size=(216, 218, 3), dtype=np.uint8),
+                transforms.Compose(
+                    [
+                        transforms.Pad((2, 3, 4, 5), fill=3),
+                        transforms.ToTensor(),
+                    ],
+                ),
         ),
         (
-            np.random.randint(255, size=(218, 220, 3), dtype=np.uint8),
-            transforms.Compose(
-                [
-                    transforms.Pad((2, 3), padding_mode="edge"),
-                    transforms.ToTensor(),
-                ],
-            ),
+                np.random.randint(255, size=(218, 220, 3), dtype=np.uint8),
+                transforms.Compose(
+                    [
+                        transforms.Pad((2, 3), padding_mode="edge"),
+                        transforms.ToTensor(),
+                    ],
+                ),
         ),
         (
-            np.random.randint(255, size=(218, 220, 3), dtype=np.uint8),
-            transforms.Compose(
-                [
-                    transforms.Pad((2, 3), padding_mode="reflect"),
-                    transforms.ToTensor(),
-                ],
-            ),
+                np.random.randint(255, size=(218, 220, 3), dtype=np.uint8),
+                transforms.Compose(
+                    [
+                        transforms.Pad((2, 3), padding_mode="reflect"),
+                        transforms.ToTensor(),
+                    ],
+                ),
         ),
         (
-            np.random.randint(255, size=(218, 220, 3), dtype=np.uint8),
-            transforms.Compose(
-                [
-                    transforms.Pad((2, 3), padding_mode="symmetric"),
-                    transforms.ToTensor(),
-                ],
-            ),
+                np.random.randint(255, size=(218, 220, 3), dtype=np.uint8),
+                transforms.Compose(
+                    [
+                        transforms.Pad((2, 3), padding_mode="symmetric"),
+                        transforms.ToTensor(),
+                    ],
+                ),
         ),
     ],
 )

--- a/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_FakeQuantize.py
@@ -3,12 +3,7 @@
 
 import numpy as np
 import pytest
-from common.layer_test_class import check_ir_version
 from common.tf_layer_test_class import CommonTFLayerTest
-from openvino.tools.mo.front.common.partial_infer.utils import int64_array
-
-from unit_tests.utils.graph import build_graph, regular_op_with_shaped_data, connect, \
-    shaped_data, connect_front, regular_op
 
 
 class TestFakeQuantize(CommonTFLayerTest):
@@ -52,38 +47,6 @@ class TestFakeQuantize(CommonTFLayerTest):
 
         # reference graph to compare with IR
         ref_net = None
-        if check_ir_version(10, None, ir_version) and not use_legacy_frontend:
-            levels = 2 ** num_bits - int(narrow_range)
-
-            # data (shape, value) -> const (shape, vale) -> data (shape, no value)
-            const_for_layer_tests = lambda name, value: {
-                **{name + '_dd': {'kind': 'data', 'value': value, 'shape': value.shape}},
-                **{name: {'kind': 'op', 'type': 'Const'}},
-                **shaped_data(name + '_d', int64_array(value.shape))}
-
-            connect_const_for_layer_tests = lambda first_tensor_name, second_tensor_name: [
-                *connect_front(first_tensor_name + '_dd', first_tensor_name),
-                *connect(first_tensor_name, second_tensor_name)]
-
-            nodes = {
-                **regular_op_with_shaped_data('parameter', [11], {'type': 'Parameter'}),
-                **const_for_layer_tests('il', np.array([nudged_il], dtype=np.float32)),
-                **const_for_layer_tests('ih', np.array([nudged_ih], dtype=np.float32)),
-                **const_for_layer_tests('ol', np.array([nudged_il], dtype=np.float32)),
-                **const_for_layer_tests('oh', np.array([nudged_ih], dtype=np.float32)),
-                **regular_op_with_shaped_data('fq', [11],
-                                              {'type': 'FakeQuantize', 'levels': levels}),
-                **regular_op('result', {'type': 'Result'}),
-            }
-            edges = [
-                *connect('parameter', '0:fq'),
-                *connect_const_for_layer_tests('il', '1:fq'),
-                *connect_const_for_layer_tests('ih', '2:fq'),
-                *connect_const_for_layer_tests('ol', '3:fq'),
-                *connect_const_for_layer_tests('oh', '4:fq'),
-                *connect('fq', 'result'),
-            ]
-            ref_net = build_graph(nodes, edges)
 
         return tf_net, ref_net
 

--- a/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
@@ -5,12 +5,7 @@ import platform
 
 import pytest
 import tensorflow as tf
-from common.layer_test_class import check_ir_version
 from common.tf_layer_test_class import CommonTFLayerTest
-
-from openvino.tools.mo.front.common.partial_infer.utils import int64_array
-from unit_tests.utils.graph import build_graph, regular_op_with_shaped_data, connect, \
-    shaped_data, connect_front
 
 
 class TestRandomUniform(CommonTFLayerTest):
@@ -32,50 +27,6 @@ class TestRandomUniform(CommonTFLayerTest):
             tf_net = sess.graph_def
 
         ref_net = None
-        if check_ir_version(10, None, ir_version):
-            const_for_layer_tests = lambda name, value, shape, shape1: {
-                **{name + '_dd': {'kind': 'data', 'value': value, 'shape': shape1}},
-                **{name: {'kind': 'op', 'type': 'Const'}},
-                **shaped_data(name + '_d', shape)}
-
-            connect_const_for_layer_tests = lambda first_tensor_name, second_tensor_name: [
-                *connect_front(first_tensor_name + '_dd', first_tensor_name),
-                *connect(first_tensor_name, second_tensor_name)]
-
-            nodes_attributes = {
-                **regular_op_with_shaped_data('input', x_shape, {'type': 'Parameter'}),
-                **const_for_layer_tests('shape', x_shape, int64_array([len(x_shape)]),
-                                        int64_array([len(x_shape)])),
-                **const_for_layer_tests('min_val', min_val, int64_array([]), int64_array([1])),
-                **const_for_layer_tests('max_val', max_val, int64_array([]), int64_array([1])),
-                **regular_op_with_shaped_data('random_uniform', x_shape, {'type': 'RandomUniform'}),
-                **regular_op_with_shaped_data('convert', x_shape, {'type': 'Convert'}),
-                **regular_op_with_shaped_data('add', x_shape, {'type': 'Add'}),
-                **regular_op_with_shaped_data('result', x_shape, {'type': 'Result'}),
-
-            }
-
-            if precision == 'FP16' and input_type == tf.float32:
-                ref_net = build_graph(nodes_attributes,
-                                      [*connect_const_for_layer_tests('shape', '0:random_uniform'),
-                                       *connect_const_for_layer_tests('min_val',
-                                                                      '1:random_uniform'),
-                                       *connect_const_for_layer_tests('max_val',
-                                                                      '2:random_uniform'),
-                                       *connect('random_uniform', 'convert'),
-                                       *connect('convert', '0:add'),
-                                       *connect('input', '1:add'),
-                                       *connect('add', 'result')])
-            else:
-                ref_net = build_graph(nodes_attributes,
-                                      [*connect_const_for_layer_tests('shape', '0:random_uniform'),
-                                       *connect_const_for_layer_tests('min_val',
-                                                                      '1:random_uniform'),
-                                       *connect_const_for_layer_tests('max_val',
-                                                                      '2:random_uniform'),
-                                       *connect('random_uniform', '0:add'),
-                                       *connect('input', '1:add'),
-                                       *connect('add', 'result')])
 
         return tf_net, ref_net
 


### PR DESCRIPTION
**Details:** Use legacy MO API only for legacy tests and optimize imports

**Ticket:** TBD
