### PR TITLE
Move driver version to backend and create getDriverExtVersion method

### DIFF
--- a/src/plugins/intel_npu/src/al/include/npu.hpp
+++ b/src/plugins/intel_npu/src/al/include/npu.hpp
@@ -27,6 +27,10 @@ public:
     virtual const std::shared_ptr<IDevice> getDevice(const ov::AnyMap& paramMap) const;
     /** @brief Provide a list of names of all devices, with which user can work directly */
     virtual const std::vector<std::string> getDeviceNames() const;
+    /** @brief Provide driver version */
+    virtual uint32_t getDriverVersion() const;
+    /** @brief Provide driver extension version */
+    virtual uint32_t getDriverExtVersion() const;
     /** @brief Get name of backend */
     virtual const std::string getName() const = 0;
     /** @brief Register backend-specific options */
@@ -60,7 +64,6 @@ public:
     virtual uint32_t getMaxNumSlices() const;
     virtual uint64_t getAllocMemSize() const;
     virtual uint64_t getTotalMemSize() const;
-    virtual uint32_t getDriverVersion() const;
 
     virtual std::shared_ptr<SyncInferRequest> createInferRequest(
         const std::shared_ptr<const ICompiledModel>& compiledModel,

--- a/src/plugins/intel_npu/src/al/src/npu.cpp
+++ b/src/plugins/intel_npu/src/al/src/npu.cpp
@@ -21,6 +21,12 @@ const std::shared_ptr<IDevice> IEngineBackend::getDevice(const ov::AnyMap&) cons
 const std::vector<std::string> IEngineBackend::getDeviceNames() const {
     OPENVINO_THROW("Get all device names not implemented");
 }
+uint32_t IEngineBackend::getDriverVersion() const {
+    OPENVINO_THROW("Get NPU driver version is not supported with this backend");
+}
+uint32_t IEngineBackend::getDriverExtVersion() const {
+    OPENVINO_THROW("Get NPU driver extension version is not supported with this backend");
+}
 
 void IEngineBackend::registerOptions(OptionsDesc&) const {}
 
@@ -42,10 +48,6 @@ uint64_t IDevice::getAllocMemSize() const {
 
 uint64_t IDevice::getTotalMemSize() const {
     OPENVINO_THROW("Get TotalMemSize is not supported");
-}
-
-uint32_t IDevice::getDriverVersion() const {
-    OPENVINO_THROW("Get NPU driver version is not supported with this backend");
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
@@ -21,6 +21,8 @@ public:
         return "LEVEL0";
     }
     const std::vector<std::string> getDeviceNames() const override;
+    uint32_t getDriverVersion() const override;
+    uint32_t getDriverExtVersion() const override;
 
 private:
     std::shared_ptr<ZeroInitStructsHolder> _instance;

--- a/src/plugins/intel_npu/src/backend/include/zero_device.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_device.hpp
@@ -29,7 +29,6 @@ public:
     uint32_t getMaxNumSlices() const override;
     uint64_t getAllocMemSize() const override;
     uint64_t getTotalMemSize() const override;
-    uint32_t getDriverVersion() const override;
 
     std::shared_ptr<SyncInferRequest> createInferRequest(const std::shared_ptr<const ICompiledModel>& compiledModel,
                                                          const std::shared_ptr<IExecutor>& executor,
@@ -44,7 +43,6 @@ private:
     ze_graph_dditable_ext_curr_t* _graph_ddi_table_ext = nullptr;
 
     ze_device_properties_t device_properties = {};
-    ze_driver_properties_t driver_properties = {};
 
     uint32_t _group_ordinal;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -42,6 +42,12 @@ public:
     inline ze_graph_profiling_dditable_ext_t* getProfilingDdiTable() const {
         return _graph_profiling_ddi_table_ext;
     }
+    inline uint32_t getDriverVersion() const {
+        return driver_properties.driverVersion;
+    }
+    inline uint32_t getDriverExtVersion() const {
+        return driver_ext_version;
+    }
 
 private:
     static const ze_driver_uuid_t uuid;
@@ -52,6 +58,9 @@ private:
     ze_context_handle_t context = nullptr;
     std::unique_ptr<ze_graph_dditable_ext_decorator> graph_dditable_ext_decorator;
     ze_graph_profiling_dditable_ext_t* _graph_profiling_ddi_table_ext = nullptr;
+
+    ze_driver_properties_t driver_properties = {};
+    uint32_t driver_ext_version = 0;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
@@ -20,6 +20,14 @@ ZeroEngineBackend::ZeroEngineBackend(const Config& config) {
     _devices.emplace(std::make_pair(device->getName(), device));
 }
 
+uint32_t ZeroEngineBackend::getDriverVersion() const {
+    return _instance->getDriverVersion();
+}
+
+uint32_t ZeroEngineBackend::getDriverExtVersion() const {
+    return _instance->getDriverExtVersion();
+}
+
 ZeroEngineBackend::~ZeroEngineBackend() = default;
 
 const std::shared_ptr<IDevice> ZeroEngineBackend::getDevice() const {

--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -19,9 +19,6 @@ ZeroDevice::ZeroDevice(const std::shared_ptr<ZeroInitStructsHolder>& initStructs
     device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     zeroUtils::throwOnFail("zeDeviceGetProperties",
                            zeDeviceGetProperties(_initStructs->getDevice(), &device_properties));
-    driver_properties.stype = ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES;
-    zeroUtils::throwOnFail("zeDriverGetProperties",
-                           zeDriverGetProperties(_initStructs->getDriver(), &driver_properties));
 
     std::vector<ze_command_queue_group_properties_t> command_group_properties;
     uint32_t command_queue_group_count = 0;
@@ -87,10 +84,6 @@ IDevice::Uuid ZeroDevice::getUuid() const {
     std::copy(std::begin(device_properties.uuid.id), std::end(device_properties.uuid.id), std::begin(uuid.uuid));
 
     return uuid;
-}
-
-uint32_t ZeroDevice::getDriverVersion() const {
-    return driver_properties.driverVersion;
 }
 
 uint32_t ZeroDevice::getSubDevId() const {

--- a/src/plugins/intel_npu/src/plugin/include/backends.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/backends.hpp
@@ -29,6 +29,8 @@ public:
     std::shared_ptr<IDevice> getDevice(const ov::AnyMap& paramMap) const;
     std::vector<std::string> getAvailableDevicesNames() const;
     std::string getBackendName() const;
+    uint32_t getDriverVersion() const;
+    uint32_t getDriverExtVersion() const;
     void registerOptions(OptionsDesc& options) const;
     std::string getCompilationPlatform(const std::string_view platform, const std::string& deviceId) const;
 

--- a/src/plugins/intel_npu/src/plugin/include/metrics.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metrics.hpp
@@ -33,7 +33,8 @@ public:
     std::string GetBackendName() const;
     uint64_t GetDeviceAllocMemSize(const std::string& specifiedDeviceName) const;
     uint64_t GetDeviceTotalMemSize(const std::string& specifiedDeviceName) const;
-    uint32_t GetDriverVersion(const std::string& specifiedDeviceName) const;
+    uint32_t GetDriverVersion() const;
+    uint32_t GetDriverExtVersion() const;
 
     std::vector<ov::PropertyName> GetCachingProperties() const;
     std::vector<ov::PropertyName> GetInternalSupportedProperties() const;

--- a/src/plugins/intel_npu/src/plugin/src/backends.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/backends.cpp
@@ -139,6 +139,22 @@ std::string NPUBackends::getBackendName() const {
     return "";
 }
 
+uint32_t NPUBackends::getDriverVersion() const {
+    if (_backend != nullptr) {
+        return _backend->getDriverVersion();
+    }
+
+    OPENVINO_THROW("No available backend");
+}
+
+uint32_t NPUBackends::getDriverExtVersion() const {
+    if (_backend != nullptr) {
+        return _backend->getDriverExtVersion();
+    }
+
+    OPENVINO_THROW("No available backend");
+}
+
 std::shared_ptr<IDevice> NPUBackends::getDevice(const std::string& specificName) const {
     _logger.debug("Searching for device %s to use started...", specificName.c_str());
     // TODO iterate over all available backends

--- a/src/plugins/intel_npu/src/plugin/src/metrics.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/metrics.cpp
@@ -103,6 +103,22 @@ std::string Metrics::GetBackendName() const {
     return _backends->getBackendName();
 }
 
+uint32_t Metrics::GetDriverVersion() const {
+    if (_backends == nullptr) {
+        OPENVINO_THROW("No available backends");
+    }
+
+    return _backends->getDriverVersion();
+}
+
+uint32_t Metrics::GetDriverExtVersion() const {
+    if (_backends == nullptr) {
+        OPENVINO_THROW("No available backends");
+    }
+
+    return _backends->getDriverExtVersion();
+}
+
 uint64_t Metrics::GetDeviceAllocMemSize(const std::string& specifiedDeviceName) const {
     const auto devName = getDeviceName(specifiedDeviceName);
     auto device = _backends->getDevice(devName);
@@ -117,15 +133,6 @@ uint64_t Metrics::GetDeviceTotalMemSize(const std::string& specifiedDeviceName) 
     auto device = _backends->getDevice(devName);
     if (device) {
         return device->getTotalMemSize();
-    }
-    OPENVINO_THROW("No device with name '", specifiedDeviceName, "' is available");
-}
-
-uint32_t Metrics::GetDriverVersion(const std::string& specifiedDeviceName) const {
-    const auto devName = getDeviceName(specifiedDeviceName);
-    auto device = _backends->getDevice(devName);
-    if (device) {
-        return device->getDriverVersion();
     }
     OPENVINO_THROW("No device with name '", specifiedDeviceName, "' is available");
 }

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -329,7 +329,7 @@ Plugin::Plugin()
          {true,
           ov::PropertyMutability::RO,
           [&](const Config& config) {
-              return _metrics->GetDriverVersion(get_specified_device_name(config));
+              return _metrics->GetDriverVersion();
           }}},
         // NPU Private
         // =========


### PR DESCRIPTION
### Details:
 - *Moving getDriverVersion to the backend makes more sense, and creating a new helper, getDriverExtVersion that would be used for plugin batching feature to decide when to use batching on auto mode or only on compile.*
- *Because of E-117498 we need to decide when Compiler or Auto mode for batching to be used.*
- *DriverExtVersion should be also updated by the driver team for this to work as expected.*

### Tickets:
 - *E-117498*
