### PR TITLE
[CPU] FC executor config fix for INT8 case

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -59,7 +59,7 @@ static const TypeMapping dnnlFCTypeMapping {
     // quantization configuration
     // int8 inner_product does not support f16 output and bias
     {{_u8 | _i8, _i8, _any, _f16},                            pt(bypass(), bypass(), just<f32>(), just<f32>())},
-    {{_u8 | _i8, _i8, _any, _u8 | _i8 | _i32 | _bf16 | _f32}, pt(bypass(), bypass(), use<3>(), bypass())},
+    {{_u8 | _i8, _i8, _any, _u8 | _i8 | _i32 | _bf16 | _f32}, pt(bypass(), bypass(), bypass(), use<3>())},
     // compresses int weights (@todo more strict requrements for output precision?)
     {{_bf16, _u8 | _nf4 | _u4 | _i4, _any, _any},             pt(bypass(), bypass(), use<0>(), use<0>()),
      Require<dnnl::impl::cpu::x64::avx512_core_bf16>()}, // Ticket 122347


### PR DESCRIPTION
### Details:
 - *dnnlFCTypeMapping: fixed output precision for INT8 case*

### Tickets:
 - *CVS-137666*
