### PR TITLE
[PT FE] Fix GHA model tests

### DIFF
--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -26,3 +26,4 @@ pytest-timeout==2.2.0
 jax<=0.4.14
 jaxlib<=0.4.14
 torch>=1.13,<2.3
+kornia==0.7.0

--- a/tests/model_hub_tests/pytorch/hf_transformers_models
+++ b/tests/model_hub_tests/pytorch/hf_transformers_models
@@ -74,7 +74,7 @@ facebook/encodec_24khz,encodec
 facebook/esm2_t6_8M_UR50D,esm
 facebook/flava-full,flava,xfail,Tracing problem
 facebook/flava-image-codebook,flava_image_codebook,skip,Load problem
-facebook/levit-128S,levit,xfail,Tracing problem
+facebook/levit-128S,levit
 facebook/m2m100_418M,m2m_100
 facebook/mask2former-swin-base-coco-panoptic,mask2former
 facebook/maskformer-swin-base-coco,maskformer

--- a/tests/model_hub_tests/pytorch/hf_transformers_models
+++ b/tests/model_hub_tests/pytorch/hf_transformers_models
@@ -367,7 +367,7 @@ thomwolf/vqgan_imagenet_f16_1024,vqgan_model,skip,Load problem
 thu-ml/zh-clip-vit-roberta-large-patch14,zhclip,skip,Load problem
 tifa-benchmark/promptcap-coco-vqa,ofa,skip,Load problem
 tli8hf/robertabase_snli,transformerfornli,skip,Load problem
-transfo-xl-wt103,transfo-xl,xfail,Unsupported op aten::index_copy_
+# transfo-xl/transfo-xl-wt103,transfo-xl - deprecated by transformers due to security vulnerability, not inferable in latest transformers
 transZ/BART_shared_clean,shared_bart,skip,Load problem
 transZ/BART_shared_v2,shared_bart_v2,skip,Load problem
 transZ/misecom,misecom,skip,Load problem

--- a/tests/model_hub_tests/pytorch/requirements.txt
+++ b/tests/model_hub_tests/pytorch/requirements.txt
@@ -24,4 +24,4 @@ torchvision
 transformers
 wheel
 PyYAML
-kornia==0.7.0
+kornia

--- a/tests/model_hub_tests/pytorch/requirements.txt
+++ b/tests/model_hub_tests/pytorch/requirements.txt
@@ -24,3 +24,4 @@ torchvision
 transformers
 wheel
 PyYAML
+kornia==0.7.0

--- a/tests/model_hub_tests/pytorch/test_gfpgan.py
+++ b/tests/model_hub_tests/pytorch/test_gfpgan.py
@@ -8,6 +8,8 @@ import tempfile
 
 import pytest
 import torch
+import torchvision
+from packaging import version
 
 from torch_utils import TestTorchConvertModel
 from openvino import convert_model
@@ -76,6 +78,7 @@ class TestGFPGANConvertModel(TestTorchConvertModel):
         # remove all downloaded files from cache
         self.repo_dir.cleanup()
 
-    @pytest.mark.nightly
+    @pytest.mark.skipif(version.parse(torchvision.__version__) >= version.parse("0.17"),
+                        reason="torchvision==0.17 have removed module torchvision.transforms.functional_tensor which is required by GFPGAN")
     def test_convert_model(self, ie_device):
         self.run("GFPGAN", None, ie_device)

--- a/tests/model_hub_tests/pytorch/test_lightglue.py
+++ b/tests/model_hub_tests/pytorch/test_lightglue.py
@@ -44,6 +44,5 @@ class TestLightGlueModel(TestTorchConvertModel):
         self.repo_dir.cleanup()
 
     @pytest.mark.nightly
-    @pytest.mark.precommit
     def test_convert_model(self, ie_device):
         self.run("lightglue", "superpoint", ie_device)

--- a/tests/model_hub_tests/pytorch/test_lightglue.py
+++ b/tests/model_hub_tests/pytorch/test_lightglue.py
@@ -44,5 +44,6 @@ class TestLightGlueModel(TestTorchConvertModel):
         self.repo_dir.cleanup()
 
     @pytest.mark.nightly
+    @pytest.mark.precommit
     def test_convert_model(self, ie_device):
         self.run("lightglue", "superpoint", ie_device)


### PR DESCRIPTION
### Details:
 - *Added `kornia` dependency for lightglue model*
 - *Disable GFPGAN since it doesn't support latest `torchvision`*
 - *Remove `transfo-xl-wt103` as not supported on latest `transformers`*
 - *Remove XFAIL from `facebook/levit-128S`*

### Tickets:
 - *ticket-id*
