### PR TITLE
[CPU] Do not assign Numa id to a node with zero shape input

### DIFF
--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -907,6 +907,13 @@ MemoryPtr Node::prepareWeightMemory(DnnlMemoryDescPtr dstWeightDesc, DnnlMemoryD
 }
 
 void Node::toNumaNode(int numaNodeID) {
+    if (!isExecutable())
+        return;
+
+    return toNumaNodeImpl(numaNodeID);
+}
+
+void Node::toNumaNodeImpl(int numaNodeID) {
     if (curNumaNode == numaNodeID)
         return;
 

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -659,7 +659,9 @@ protected:
 
     std::vector <NodePtr> parallelWith;
     int curNumaNode = -1;
-    virtual void toNumaNode(int numaID);
+
+    void toNumaNode(int numaID);
+    virtual void toNumaNodeImpl(int numaID);
 
     std::string primitivesPriority;
     std::vector <impl_desc_type> customImplPriorities;

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -109,7 +109,7 @@ bool FullyConnected::created() const {
     return getType() == Type::FullyConnected;
 }
 
-void FullyConnected::toNumaNode(int numaID) {
+void FullyConnected::toNumaNodeImpl(int numaID) {
     executor->moveMemToNumaNode(numaID);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -63,7 +63,7 @@ public:
     void fuseDecompressionSubtract(const MemoryCPtr& memory);
 
 protected:
-    void toNumaNode(int numaID) override;
+    void toNumaNodeImpl(int numaID) override;
 
 private:
     static const size_t DATA_ID = 0;


### PR DESCRIPTION
### Details:
 - Shapes inference can result into an appearance of the zero shape memory on the node inputs. Such nodes are considered as non-executable, so no prepareParams are called for them, thus no
 executors are created. So, it is necessary to avoid setting numa id for non-executable nodes.
 - Currently seg fault happens when node gets zero shape memory on the inputs.
 
Issue introduced in scope of:
- https://github.com/openvinotoolkit/openvino/pull/23593

### Tickets:
 - *CVS-137763*