### PR TITLE
[DOCS] Typo fix in Conversion Parameters article for 2024

### DIFF
--- a/docs/articles_en/openvino-workflow/model-preparation/conversion-parameters.rst
+++ b/docs/articles_en/openvino-workflow/model-preparation/conversion-parameters.rst
@@ -57,7 +57,7 @@ Providing just a path to the model or model object as ``openvino.convert_model``
           import openvino as ov
 
           ov_model = ov.convert_model(original_model)
-          ov.save_model(ov_model, 'model.xml' compress_to_fp16=False)
+          ov.save_model(ov_model, 'model.xml', compress_to_fp16=False)
 
     .. tab-item:: CLI
        :sync: cli


### PR DESCRIPTION
Port from https://github.com/openvinotoolkit/openvino/pull/23864

Added missing comma in Python code in the Conversion Parameters article.

Jira: 137610