### PR TITLE
[RISCV64] Added SHL submodule support and T-Head toolchain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -84,3 +84,6 @@
 [submodule "src/plugins/intel_cpu/thirdparty/libxsmm"]
 	path = src/plugins/intel_cpu/thirdparty/libxsmm
 	url = https://github.com/libxsmm/libxsmm.git
+[submodule "src/plugins/intel_cpu/thirdparty/shl"]
+	path = src/plugins/intel_cpu/thirdparty/shl
+	url = https://github.com/openvinotoolkit/shl.git

--- a/cmake/toolchains/riscv64-071-thead-gnu.toolchain.cmake
+++ b/cmake/toolchains/riscv64-071-thead-gnu.toolchain.cmake
@@ -1,0 +1,46 @@
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# NOTE: use T-Head compiler:
+#    git clone https://github.com/T-head-Semi/xuantie-gnu-toolchain.git
+#    ./configure --prefix=/opt/riscv
+#    make linux
+#    -DRISCV_TOOLCHAIN_ROOT=/opt/riscv
+
+# To enable cross-compilation with python (for example, on Ubuntu 22.04):
+# $ echo deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports/ jammy main >> riscv64-sources.list
+# $ echo deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports/ jammy universe >> riscv64-sources.list
+# $ echo deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main >> riscv64-sources.list
+# $ echo deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main >> riscv64-sources.list
+# $ mv riscv64-sources.list /etc/apt/sources.list.d/
+# $ dpkg --add-architecture riscv64
+# $ apt-get update -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/riscv64-sources.list
+# $ apt-get install -y --no-install-recommends libpython3-dev:riscv64
+# $ ln -s /usr/include/riscv64-linux-gnu/ /usr/include/python3.10/
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+set(RISCV64_THEAD ON)
+set(RISCV64_RVV0p7 ON)
+
+set(RISCV_TOOLCHAIN_ROOT $ENV{RISCV_TOOLCHAIN_ROOT} CACHE PATH "Path to CLANG for RISC-V cross compiler build directory")
+set(CMAKE_SYSROOT "${RISCV_TOOLCHAIN_ROOT}/sysroot" CACHE PATH "RISC-V sysroot")
+
+set(CMAKE_C_COMPILER ${RISCV_TOOLCHAIN_ROOT}/bin/riscv64-unknown-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER ${RISCV_TOOLCHAIN_ROOT}/bin/riscv64-unknown-linux-gnu-g++)
+set(CMAKE_STRIP ${RISCV_TOOLCHAIN_ROOT}/bin/riscv64-unknown-linux-gnu-strip)
+set(PKG_CONFIG_EXECUTABLE "NOT-FOUND" CACHE PATH "Path to RISC-V pkg-config")
+
+# Don't run the linker on compiler check
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -march=rv64gcv0p7_zfh_xtheadc -mabi=lp64d")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -march=rv64gcv0p7_zfh_xtheadc -mabi=lp64d")
+
+# system libc provides pthread functions (as detected by FindThreads.cmake), but not all functions are available
+# WA: use pthread explicitly, since we know it's available in current toolchain
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-pthread")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "-pthread")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-pthread")

--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -87,6 +87,13 @@ else()
 endif()
 ov_option(ENABLE_MLAS_FOR_CPU "Enable MLAS for OpenVINO CPU Plugin" ${ENABLE_MLAS_FOR_CPU_DEFAULT})
 
+if(RISCV64_THEAD)
+    set(ENABLE_SHL_FOR_CPU_DEFAULT ON)
+else()
+    set(ENABLE_SHL_FOR_CPU_DEFAULT OFF)
+endif()
+ov_dependent_option(ENABLE_SHL_FOR_CPU "Enable SHL for OpenVINO CPU Plugin" ${ENABLE_SHL_FOR_CPU_DEFAULT} "RISCV64" OFF)
+
 add_subdirectory(thirdparty)
 
 if(WIN32)
@@ -195,6 +202,9 @@ if (ENABLE_SNIPPETS_LIBXSMM_TPP)
     target_link_libraries(${TARGET_NAME} PRIVATE xsmm)
     target_include_directories(${TARGET_NAME} SYSTEM PRIVATE $<TARGET_PROPERTY:xsmm,INCLUDE_DIRECTORIES>)
 endif ()
+if(ENABLE_SHL_FOR_CPU)
+    target_link_libraries(${TARGET_NAME} PRIVATE shl)
+endif()
 target_include_directories(${TARGET_NAME} SYSTEM PRIVATE $<TARGET_PROPERTY:dnnl,INCLUDE_DIRECTORIES>)
 
 # Temporal solution to use template reference implementations in cases where optimizied implementation
@@ -292,6 +302,10 @@ if(BUILD_SHARED_LIBS)
 
     if(ENABLE_MLAS_FOR_CPU)
         target_include_directories(${TARGET_NAME}_obj SYSTEM PUBLIC $<TARGET_PROPERTY:mlas,INCLUDE_DIRECTORIES>)
+    endif()
+
+    if(ENABLE_SHL_FOR_CPU)
+        target_include_directories(${TARGET_NAME}_obj SYSTEM PUBLIC $<TARGET_PROPERTY:shl,INTERFACE_INCLUDE_DIRECTORIES>)
     endif()
 
     ov_set_threading_interface_for(${TARGET_NAME}_obj)

--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
@@ -158,4 +158,9 @@ if(ENABLE_MLAS_FOR_CPU)
     ov_install_static_lib(mlas ${OV_CPACK_COMP_CORE})
 endif()
 
+if(ENABLE_SHL_FOR_CPU)
+    add_subdirectory(shl)
+    ov_install_static_lib(shl ${OV_CPACK_COMP_CORE})
+endif()
+
 ov_add_onednn()


### PR DESCRIPTION
### Details:
 - *Support THead C910v (`rv64gcv0p7_zfh_xtheadc`)*
 - *Added the separate cmake toolchain for T-Head CPUs with rvv071*

### Tickets:
 - *N/A*
