### PR TITLE
Add openvino-telemetry to debian / rpm package

### DIFF
--- a/.github/workflows/job_debian_packages.yml
+++ b/.github/workflows/job_debian_packages.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install debian packages & check conflicts
         run: |
           apt-get update -y
-          
+
           if [[ "${{ runner.arch }}" == "X64" ]]; then
             # Install debian packages from previous release
             apt-get install --no-install-recommends -y gnupg wget ca-certificates
@@ -66,21 +66,26 @@ jobs:
         run: |
           /usr/share/openvino/samples/cpp/build_samples.sh
           /usr/share/openvino/samples/c/build_samples.sh
-          
+
           [[ "${{ runner.arch }}" == "X64" ]] && path_by_arch="intel64" || path_by_arch="aarch64"
           ~/openvino_cpp_samples_build/$path_by_arch/Release/hello_query_device
-          
+
+          # check integrity of OpenVINO Python API installation
+          apt-get install python3-pip -y
+          python3 -m pip check
+
           python3 /usr/share/openvino/samples/python/hello_query_device/hello_query_device.py
           python3 -c 'from openvino import Core; Core().get_property("CPU", "AVAILABLE_DEVICES")'
-          
+
           if [[ "${{ runner.arch }}" == "X64" ]]; then
             python3 -c 'from openvino import Core; Core().get_property("GPU", "AVAILABLE_DEVICES")'
           fi
-          
+
           python3 -c 'from openvino import Core; Core().get_property("AUTO", "SUPPORTED_PROPERTIES")'
           python3 -c 'from openvino import Core; Core().get_property("MULTI", "SUPPORTED_PROPERTIES")'
           python3 -c 'from openvino import Core; Core().get_property("HETERO", "SUPPORTED_PROPERTIES")'
           python3 -c 'from openvino import Core; Core().get_property("BATCH", "SUPPORTED_PROPERTIES")'
           python3 -c 'from openvino.frontend import FrontEndManager; assert len(FrontEndManager().get_available_front_ends()) == 6'
           benchmark_app --help
+          opt_in_out --help
           ovc --help

--- a/.gitmodules
+++ b/.gitmodules
@@ -78,3 +78,6 @@
 [submodule "src/plugins/intel_npu/thirdparty/level-zero-ext"]
 	path = src/plugins/intel_npu/thirdparty/level-zero-ext
 	url = https://github.com/intel/level-zero-npu-extensions.git
+[submodule "thirdparty/telemetry"]
+	path = thirdparty/telemetry
+	url = https://github.com/openvinotoolkit/telemetry.git

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -317,12 +317,14 @@ if(ENABLE_PYTHON_PACKAGING)
         set(ov_site_packages "site-packages")
     endif()
 
+    # install OpenVINO Python API
+
     set(python_package_prefix "${CMAKE_CURRENT_BINARY_DIR}/install_${pyversion}")
     set(install_lib "${python_package_prefix}/lib/${python_versioned_folder}/${ov_site_packages}")
-    set(meta_info_subdir "openvino-${OpenVINO_VERSION}-py${python_xy}.egg-info")
-    set(meta_info_file "${install_lib}/${meta_info_subdir}/PKG-INFO")
+    set(openvino_meta_info_subdir "openvino-${OpenVINO_VERSION}-py${python_xy}.egg-info")
+    set(openvino_meta_info_file "${install_lib}/${openvino_meta_info_subdir}/PKG-INFO")
 
-    add_custom_command(OUTPUT ${meta_info_file}
+    add_custom_command(OUTPUT ${openvino_meta_info_file}
         COMMAND ${CMAKE_COMMAND} -E remove_directory
             "${python_package_prefix}"
         COMMAND ${setup_py_env}
@@ -344,9 +346,36 @@ if(ENABLE_PYTHON_PACKAGING)
                     --record=installed.txt
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
         DEPENDS ${ov_setup_py_deps}
-        COMMENT "Create python package with ${meta_info_subdir} folder")
+        COMMENT "Create python package with ${openvino_meta_info_subdir} folder")
 
-    add_custom_target(_python_api_package ALL DEPENDS ${meta_info_file})
+    # Install OpenVINO Telemetry
+
+    set(OpenVINO_Telemetry_SOURCE_DIR "${OpenVINO_SOURCE_DIR}/thirdparty/telemetry")
+    file(GLOB_RECURSE telemetry_files ${OpenVINO_Telemetry_SOURCE_DIR}/*)
+
+    set(openvino_telemetry_meta_info_subdir "openvino-telemetry-${OpenVINO_VERSION}-py${python_xy}.egg-info")
+    set(openvino_telemetry_meta_info_file "${install_lib}/${openvino_telemetry_meta_info_subdir}/PKG-INFO")
+
+    add_custom_command(OUTPUT ${openvino_telemetry_meta_info_file}
+        COMMAND "${Python3_EXECUTABLE}" "${OpenVINO_Telemetry_SOURCE_DIR}/setup.py"
+                    --no-user-cfg
+                    --quiet
+                    build
+                        --executable "/usr/bin/python3"
+                    install
+                        --no-compile
+                        --prefix "${python_package_prefix}"
+                        --install-lib "${install_lib}"
+                        --install-scripts "${python_package_prefix}/bin"
+                        --single-version-externally-managed
+                        --record=installed.txt
+        WORKING_DIRECTORY "${OpenVINO_Telemetry_SOURCE_DIR}"
+        DEPENDS ${telemetry_files}
+        COMMENT "Create python package with ${openvino_telemetry_meta_info_subdir} folder")
+
+    # create custom target
+
+    add_custom_target(_python_api_package ALL DEPENDS ${openvino_meta_info_file} ${openvino_telemetry_meta_info_file})
 
     # install python package, which will be later packed into DEB | RPM
     ov_cpack_add_component(${OV_CPACK_COMP_PYTHON_OPENVINO}_package_${pyversion} HIDDEN)


### PR DESCRIPTION
### Details:
 - Install openvino-telementry as part of `python3-openvino` debian package
 - Ported https://github.com/openvinotoolkit/openvino/pull/23913

### Tickets:
 - Closes https://github.com/openvinotoolkit/openvino/issues/23876
