### PR TITLE
[GPU] Change acceptable filter x size of convolution_bfyx_gemm_like kernel to avoid kernel build error and slower performance than ref kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_gemm_like_fp16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_gemm_like_fp16.cl
@@ -110,7 +110,6 @@ KERNEL(convolution_f16)(
         _result.se = mad( _rowA, sub_group_broadcast( colB, 14 ), _result.se );  \
         _result.sf = mad( _rowA, sub_group_broadcast( colB, 15 ), _result.sf );  \
     }
-    typedef CAT( half, FILTER_SIZE_X ) half_t;
     // Walk DOWN src0 (patch 0, 1, 2, ...) and DOWN src1.
     // Inner loop loads and FMADs one row (FILTER_SIZE_X) of each input patch
     // and FILTER_SIZE_X/2 rows of interleaved filter.
@@ -158,6 +157,7 @@ KERNEL(convolution_f16)(
             #elif !defined(INPUT_BUFFER_WIDTH_PADDED) && !defined(INPUT_BUFFER_HEIGHT_PADDED)
             // TODO: Fixed vload issue in this path.
             #pragma error
+            typedef CAT( half, FILTER_SIZE_X ) half_t;
             half_t blockA00;
             half*  pblockA00 = (half*)(&blockA00);
             #if (PADDING_SIZE_X == 1) && (INPPUT_PADDING_Y == 1) && (FILTER_SIZE_X == 3) && (FILTER_SIZE_Y == 3)

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_gemm_like.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_gemm_like.cpp
@@ -110,10 +110,8 @@ bool ConvolutionKernel_bfyx_GEMMLike::Validate(const Params& p) const {
         return false;
     }
 
-    // Limit filter_x_size to 32 becasue...
-    // 1. convolution_gpu_bfyx_gemm_like_fp16.cl has vecter data type of "typedef CAT( half, FILTER_SIZE_X ) half_t;"
-    //    OpenCL supports up to half32
-    // 2. convolution ref kernel is faster than GEMMLike kernel when filter size is bigger
+    // Limit filter_x_size to 32 becasue convolution ref kernel is faster than GEMMLike kernel when filter size is bigger.
+    // 32 is chosen from filter size of customer model. May need to more measurement to pick optimal value
     const size_t acceptable_filter_x_size = 32;
     if (params.filterSize.x > acceptable_filter_x_size) {
         return false;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_gemm_like.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_gemm_like.cpp
@@ -110,8 +110,11 @@ bool ConvolutionKernel_bfyx_GEMMLike::Validate(const Params& p) const {
         return false;
     }
 
-    // To prevent big sized filter which causes lots of CL build time.
-    const size_t acceptable_filter_x_size = 64;     // This acceptable size was decided by heuristics
+    // Limit filter_x_size to 32 becasue...
+    // 1. convolution_gpu_bfyx_gemm_like_fp16.cl has vecter data type of "typedef CAT( half, FILTER_SIZE_X ) half_t;"
+    //    OpenCL supports up to half32
+    // 2. convolution ref kernel is faster than GEMMLike kernel when filter size is bigger
+    const size_t acceptable_filter_x_size = 32;
     if (params.filterSize.x > acceptable_filter_x_size) {
         return false;
     }

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/convolution.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/convolution.cpp
@@ -19,6 +19,7 @@ typedef std::tuple<
         ov::element::Type,     // Input precision
         ov::element::Type,     // Output precision
         InputShape,            // Input shape
+        bool,                  // ReduceSum replacement test
         std::string            // Device name
 > convLayerTestParamsSet;
 
@@ -30,8 +31,9 @@ public:
         ov::element::Type netType;
         ov::element::Type inType, outType;
         InputShape inputShape;
+        bool is_ReduceSum_test;
         std::string targetDevice;
-        std::tie(convParams, netType, inType, outType, inputShape, targetDevice) = obj.param;
+        std::tie(convParams, netType, inType, outType, inputShape, is_ReduceSum_test, targetDevice) = obj.param;
 
         ov::op::PadType padType;
         std::vector<size_t> kernel, stride, dilation;
@@ -47,7 +49,10 @@ public:
             result << ov::test::utils::vec2str(shape) << "_";
         }
         result << ")_";
-        result << "K" << ov::test::utils::vec2str(kernel) << "_";
+        if (is_ReduceSum_test)
+            result << "K" << ov::test::utils::vec2str(std::vector<size_t>{inputShape.second[0].at(-2), inputShape.second[0].at(-1)}) << "_";
+        else
+            result << "K" << ov::test::utils::vec2str(kernel) << "_";
         result << "S" << ov::test::utils::vec2str(stride) << "_";
         result << "PB" << ov::test::utils::vec2str(padBegin) << "_";
         result << "PE" << ov::test::utils::vec2str(padEnd) << "_";
@@ -57,6 +62,7 @@ public:
         result << "netPRC=" << netType << "_";
         result << "inPRC=" << inType << "_";
         result << "outPRC=" << outType << "_";
+        result << "is_ReduceSum_test=" << is_ReduceSum_test << "_";
         result << "trgDev=" << targetDevice;
 
         return result.str();
@@ -67,7 +73,8 @@ protected:
         convSpecificParams convParams;
         InputShape inputShape;
         auto netType = ov::element::undefined;
-        std::tie(convParams, netType, inType, outType, inputShape, targetDevice) = this->GetParam();
+        bool is_ReduceSum_test;
+        std::tie(convParams, netType, inType, outType, inputShape, is_ReduceSum_test, targetDevice) = this->GetParam();
 
         init_input_shapes({inputShape});
 
@@ -81,6 +88,12 @@ protected:
         for (auto&& shape : inputDynamicShapes)
             inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(inType, shape));
 
+        if (is_ReduceSum_test) {
+            auto input_static_shape = inputDynamicShapes[0].to_shape();
+            kernel.clear();
+            kernel.push_back(input_static_shape.at(-2));
+            kernel.push_back(input_static_shape.at(-1));
+        }
         auto convolutionNode = ov::test::utils::make_convolution(inputParams.front(), netType, kernel, stride, padBegin,
                                                                  padEnd, dilation, padType, convOutChannels);
 
@@ -111,6 +124,30 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_3D_tensor_basic, Convolut
                 ::testing::Values(ov::element::f16),
                 ::testing::Values(ov::element::undefined),
                 ::testing::Values(InputShape{{}, {{1, 13, 30}}}),
+                ::testing::Values(false),
+                ::testing::Values<std::string>(ov::test::utils::DEVICE_GPU)),
+                ConvolutionLayerGPUTest::getTestCaseName);
+
+// Customer model input/filter shape
+std::vector<InputShape> input_shape_reducesum_test = {
+    {{}, {{1, 1, 36, 64}}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_4D_tensor_ReduceSum, ConvolutionLayerGPUTest,
+        ::testing::Combine(
+                ::testing::Combine(
+                        ::testing::Values(std::vector<size_t>{36, 64}),
+                        ::testing::Values(std::vector<size_t>{1, 1}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0, 0}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0, 0}),
+                        ::testing::Values(std::vector<size_t>{1, 1}),
+                        ::testing::Values(1),
+                        ::testing::Values(ov::op::PadType::EXPLICIT)),
+                ::testing::Values(ov::element::f16),
+                ::testing::Values(ov::element::f16),
+                ::testing::Values(ov::element::undefined),
+                ::testing::ValuesIn(input_shape_reducesum_test),
+                ::testing::Values(true),
                 ::testing::Values<std::string>(ov::test::utils::DEVICE_GPU)),
                 ConvolutionLayerGPUTest::getTestCaseName);
 }  // namespace


### PR DESCRIPTION
### Details:
 - Change acceptable filter x size of convolution_bfyx_gemm_like kernel to avoid kernel build error and slower performance than ref kernel from 64 to 32

### Tickets:
 - 137837
