### PR TITLE
[core] Split autobroadcast_binop function to dedicated functions

### DIFF
--- a/src/core/reference/include/openvino/reference/autobroadcast_binop.hpp
+++ b/src/core/reference/include/openvino/reference/autobroadcast_binop.hpp
@@ -106,15 +106,12 @@ void numpy_broadcast_binop(const T* arg0,
                            const Shape& arg0_shape,
                            const Shape& arg1_shape,
                            Functor f) {
-    // We'll be using CoordinateTransformBasic to handle the broadcasting. The general
-    // procedure is as follows:
+    // We'll be using CoordinateTransformBasic to handle the broadcasting. The general procedure is as follows:
     //
     // (1) Left pad the shorter of the two shapes with ones.
-    // (2) Squeeze (remove ones from) both shapes, and record the squeezed axis
-    //     indices.
-    // (3) Using CoordinateTransformBasic, broadcast both args to the final output
-    //     shape. The "broadcasted axes" will be those that were squeezed in step
-    //     2.
+    // (2) Squeeze (remove ones from) both shapes, and record the squeezed axis indices.
+    // (3) Using CoordinateTransformBasic, broadcast both args to the final output shape. The "broadcasted axes" will be
+    //     those that were squeezed in step 2.
     //
     // Example:
     //
@@ -226,18 +223,14 @@ void pdpd_broadcast_binop(const T* arg0,
                           const Shape& arg1_shape,
                           int64_t axis,
                           Functor f) {
-    // We'll be using CoordinateTransformBasic to handle the broadcasting. No need to
-    // process arg0 and output shape will be the same as arg0. We need to process
-    // arg1 and the general procedure is as follows:
+    // We'll be using CoordinateTransformBasic to handle the broadcasting. No need to process arg0 and output shape will
+    // be the same as arg0. We need to process arg1 and the general procedure is as follows:
     //
     // (1) Trim trailing ones from arg1 shape.
-    // (2) Left and right pad arg1 to match arg0 shape. Axis is the index start
-    //     to align between arg0 and arg1.
-    // (3) Squeeze (remove ones from) arg1 shape, and record the squeezed axis
-    //     indices.
-    // (3) Using CoordinateTransformBasic, broadcast arg1 to the final output
-    //     shape. The "broadcasted axes" will be those that were squeezed in step
-    //     23.
+    // (2) Left and right pad arg1 to match arg0 shape. Axis is the index start to align between arg0 and arg1.
+    // (3) Squeeze (remove ones from) arg1 shape, and record the squeezed axis indices.
+    // (3) Using CoordinateTransformBasic, broadcast arg1 to the final output shape. The "broadcasted axes" will be
+    //     those that were squeezed in step 23.
     //
     // Example:
     //
@@ -296,19 +289,16 @@ void pdpd_broadcast_binop(const T* arg0,
  *
  * @tparam T Element type of the input tensors.
  * @tparam U Element type of the output tensor.
- * @tparam Functor Type of the functor for the elementwise operation. Must support
- *                 operator()(T,T), and operator()(T,T) must return a value of type
- *                 U.
+ * @tparam Functor Type of the functor for the elementwise operation. Must support operator()(T,T), and operator()(T,T)
+ *         must return a value of type U.
  *
  * @param arg0 Pointer to the buffer for left operand input tensor.
  * @param arg1 Pointer to the buffer for right operand input tensor.
- * @param out Pointer to the buffer for output tensor. This must be pre-allocated by
- *            the caller, and must be large enough to hold a tensor of the correct
- *            shape.
+ * @param out Pointer to the buffer for output tensor. This must be pre-allocated by the caller, and must be large
+ *            enough to hold a tensor of the correct shape.
  * @param broadcast_spec Specification of the auto-broadcasting scheme.
- * @param elementwise_functor Functor implementing the elementwise operation to be
- *                            applied across the input tensors. Must accept two
- *                            arguments of type T, and return a value of type U.
+ * @param elementwise_functor Functor implementing the elementwise operation to be applied across the input tensors.
+ *                            Must accept two arguments of type T, and return a value of type U.
  */
 template <typename T, typename U, typename Functor>
 void autobroadcast_binop(const T* arg0,
@@ -338,20 +328,17 @@ void autobroadcast_binop(const T* arg0,
  * \brief Helper function to implement auto broadcasting elementwise ternary op references.
  * \tparam U Element type of the selector tensor.
  * \tparam T Element type of the input tensors.
- * \tparam Functor Type of the functor for the elementwise operation. Must support
- *                 operator()(U,T,T), and operator()(U,T,T) must return a value of type
- *                 T.
+ * \tparam Functor Type of the functor for the elementwise operation. Must support operator()(U,T,T), and
+ * operator()(U,T,T) must return a value of type T.
+ *
  * \param arg0 Pointer to the buffer for selector tensor.
  * \param arg1 Pointer to the buffer for left operand input tensor.
  * \param arg2 Pointer to the buffer for right operand input tensor.
- * \param out Pointer to the buffer for output tensor. This must be pre-allocated by
- *            the caller, and must be large enough to hold a tensor of the correct
- *            shape.
+ * \param out  Pointer to the buffer for output tensor. This must be pre-allocated by the caller, and must be large
+ *             enough to hold a tensor of the correct shape.
  * \param broadcast_spec Specification of the auto-broadcasting scheme.
- * \param elementwise_functor Functor implementing the elementwise operation to be
- *                            applied across the input tensors. Must accept an argument
- *                            of
- *                            type U and two of type T, and return a value of type T.
+ * \param elementwise_functor Functor implementing the elementwise operation to be applied across the input tensors Must
+ *                            accept an argument of type U and two of type T, and return a value of type T.
  */
 template <typename T, typename U, typename Functor>
 void autobroadcast_select(const U* arg0,

--- a/src/core/reference/include/openvino/reference/autobroadcast_binop.hpp
+++ b/src/core/reference/include/openvino/reference/autobroadcast_binop.hpp
@@ -19,7 +19,7 @@ namespace internal {
 inline void row_major_strides(const Shape& shape, size_t* strides, size_t size) noexcept {
     size_t* st = strides + size - 1;
     size_t s = 1;
-    for (auto d = shape.rbegin(); d != shape.rend(); d++) {
+    for (auto d = shape.rbegin(), last = shape.rend(); d != last; ++d) {
         *st-- = s;
         s *= *d;
     }
@@ -44,10 +44,11 @@ inline void numpy_autobroadcast_binop(const T* arg0,
                                       const Shape& output_shape,
                                       const size_t axis,
                                       const size_t stride,
-                                      Functor elementwise_functor) {
+                                      Functor&& elementwise_functor) {
     for (CoordinateIterator it(output_shape), ite = CoordinateIterator::end();;) {
-        for (size_t i = 0; i < stride; ++i)
-            *out++ = elementwise_functor(arg0[i * A0], arg1[i * A1]);
+        for (size_t i = 0; i < stride; ++i, ++out) {
+            *out = elementwise_functor(arg0[i * A0], arg1[i * A1]);
+        }
 
         arg0 += A0 ? stride : 1;
         arg1 += A1 ? stride : 1;
@@ -72,23 +73,243 @@ inline size_t calculate_fixed_axis(size_t axis, const size_t* strides) {
 }
 }  // namespace internal
 
-/// \brief Helper function to implement autobroadcasting elementwise binop references.
-///
-/// \tparam T Element type of the input tensors.
-/// \tparam U Element type of the output tensor.
-/// \tparam Functor Type of the functor for the elementwise operation. Must support
-///                 operator()(T,T), and operator()(T,T) must return a value of type
-///                 U.
-///
-/// \param arg0 Pointer to the buffer for left operand input tensor.
-/// \param arg1 Pointer to the buffer for right operand input tensor.
-/// \param out Pointer to the buffer for output tensor. This must be pre-allocated by
-///            the caller, and must be large enough to hold a tensor of the correct
-///            shape.
-/// \param broadcast_spec Specification of the auto-broadcasting scheme.
-/// \param elementwise_functor Functor implementing the elementwise operation to be
-///                            applied across the input tensors. Must accept two
-///                            arguments of type T, and return a value of type U.
+/**
+ * @brief Apply elementwise function for 2 inputs of same size.
+ *
+ * @param arg0  Pointer to input 0 data.
+ * @param arg1  Pointer to input 1 data.
+ * @param out   Pointer to output data.
+ * @param count Number of elements in inputs
+ * @param f     Binary elementwise functions.
+ */
+template <typename T, typename U, class Functor>
+void no_broadcast_binop(const T* arg0, const T* arg1, U* out, const size_t count, Functor f) {
+    for (auto last = arg0 + count; arg0 != last; ++arg0, ++arg1, ++out) {
+        *out = f(*arg0, *arg1);
+    }
+}
+
+/**
+ * @brief Apply elementwise function for 2 inputs and apply NUMPY broadcasting.
+ *
+ * @param arg0       Pointer to input 0 data.
+ * @param arg1       Pointer to input 1 data.
+ * @param out        Pointer to output data.
+ * @param arg0_shape Shape of input 0.
+ * @param arg1_shape Shape of input 1.
+ * @param f          Binary elementwise functions.
+ */
+template <typename T, typename U, class Functor>
+void numpy_broadcast_binop(const T* arg0,
+                           const T* arg1,
+                           U* out,
+                           const Shape& arg0_shape,
+                           const Shape& arg1_shape,
+                           Functor f) {
+    // We'll be using CoordinateTransformBasic to handle the broadcasting. The general
+    // procedure is as follows:
+    //
+    // (1) Left pad the shorter of the two shapes with ones.
+    // (2) Squeeze (remove ones from) both shapes, and record the squeezed axis
+    //     indices.
+    // (3) Using CoordinateTransformBasic, broadcast both args to the final output
+    //     shape. The "broadcasted axes" will be those that were squeezed in step
+    //     2.
+    //
+    // Example:
+    //
+    //    Input shape->Padded shape->Squeezed Shape/Squeezed Axes
+    //    -----------  ------------  ----------------------------
+    // a: [ 3, 2, 1]   [ 3, 2, 1]    [ 3, 2   ]     {2}
+    // b: [    1, 6]   [ 1, 1, 6]    [       6]     {0,1}
+    //                   |  |  |
+    //                   v  v  v
+    //                 Output shape
+    //                 ------------
+    //                 [ 3, 2, 6]
+    using namespace internal;
+
+    size_t const shape_rank = std::max(arg0_shape.size(), arg1_shape.size()) + 1;
+
+    // TODO: Use compiler-specific alloca() or variable-length array
+    std::vector<size_t> tmp(shape_rank * 2);
+
+    size_t* strides0 = tmp.data();
+    size_t* strides1 = tmp.data() + shape_rank;
+
+    row_major_strides(arg0_shape, strides0, shape_rank);
+    row_major_strides(arg1_shape, strides1, shape_rank);
+
+    size_t const padding0 = shape_rank - arg0_shape.size();
+    size_t const padding1 = shape_rank - arg1_shape.size();
+
+    Shape output_shape(shape_rank, 0);
+
+    size_t axis = 0;
+
+    for (size_t i = 0; i < shape_rank; ++i) {
+        auto const dim0 = value_with_padding_or(arg0_shape, padding0, i, 1);
+        auto const dim1 = value_with_padding_or(arg1_shape, padding1, i, 1);
+
+        output_shape[i] = std::max(dim0, dim1);
+
+        if (dim0 != dim1)
+            axis = std::max(axis, i);
+    }
+
+    if (axis == 0) {
+        no_broadcast_binop(arg0, arg1, out, strides0[0], f);
+    } else if (strides0[axis] == 1 && value_with_padding_or(arg0_shape, padding0, axis, 1) == 1) {
+        axis = calculate_fixed_axis(axis, strides0);
+
+        internal::numpy_autobroadcast_binop<0, 1>(arg0,
+                                                  arg1,
+                                                  out,
+                                                  arg0_shape,
+                                                  arg1_shape,
+                                                  strides0,
+                                                  strides1,
+                                                  padding0,
+                                                  padding1,
+                                                  output_shape,
+                                                  axis,
+                                                  strides1[axis],
+                                                  f);
+    } else if (strides1[axis] == 1 && value_with_padding_or(arg1_shape, padding1, axis, 1) == 1) {
+        axis = calculate_fixed_axis(axis, strides1);
+
+        internal::numpy_autobroadcast_binop<1, 0>(arg0,
+                                                  arg1,
+                                                  out,
+                                                  arg0_shape,
+                                                  arg1_shape,
+                                                  strides0,
+                                                  strides1,
+                                                  padding0,
+                                                  padding1,
+                                                  output_shape,
+                                                  axis,
+                                                  strides0[axis],
+                                                  f);
+    } else
+        internal::numpy_autobroadcast_binop<1, 1>(arg0,
+                                                  arg1,
+                                                  out,
+                                                  arg0_shape,
+                                                  arg1_shape,
+                                                  strides0,
+                                                  strides1,
+                                                  padding0,
+                                                  padding1,
+                                                  output_shape,
+                                                  axis,
+                                                  strides0[axis],
+                                                  f);
+}
+
+/**
+ * @brief Apply elementwise function for 2 inputs and apply PDPP broadcasting.
+ *
+ * @param arg0       Pointer to input 0 data.
+ * @param arg1       Pointer to input 1 data.
+ * @param out        Pointer to output data.
+ * @param arg0_shape Shape of input 0.
+ * @param arg1_shape Shape of input 1.
+ * @param axis       Start dimension index for broadcast arg1 shape into arg0.
+ * @param f          Binary elementwise functions.
+ */
+template <typename T, typename U, class Functor>
+void pdpd_broadcast_binop(const T* arg0,
+                          const T* arg1,
+                          U* out,
+                          const Shape& arg0_shape,
+                          const Shape& arg1_shape,
+                          int64_t axis,
+                          Functor f) {
+    // We'll be using CoordinateTransformBasic to handle the broadcasting. No need to
+    // process arg0 and output shape will be the same as arg0. We need to process
+    // arg1 and the general procedure is as follows:
+    //
+    // (1) Trim trailing ones from arg1 shape.
+    // (2) Left and right pad arg1 to match arg0 shape. Axis is the index start
+    //     to align between arg0 and arg1.
+    // (3) Squeeze (remove ones from) arg1 shape, and record the squeezed axis
+    //     indices.
+    // (3) Using CoordinateTransformBasic, broadcast arg1 to the final output
+    //     shape. The "broadcasted axes" will be those that were squeezed in step
+    //     23.
+    //
+    // Example:
+    //
+    //    Input shape->   Padded shape->   Squeezed Shape/Squeezed Axes
+    //    -----------  ------------  ----------------------------
+    // a: [ 3, 4, 5, 6]   [ 3, 4, 5, 6]    [ 3, 4, 5, 6]
+    // b: [    4, 5,  ]   [ 1, 4, 5, 1]    [    4, 5   ]     {0,3}
+    //                      |  |  |
+    //                      v  v  v
+    //                     Output shape
+    //                     ------------
+    //                    [ 3, 4, 5, 6]
+
+    if (axis == -1) {
+        axis = arg0_shape.size() - arg1_shape.size();
+    }
+
+    Shape arg1_padded_shape = arg1_shape;
+    // Trim trailing ones
+    while (arg1_padded_shape.size() > 0 && arg1_padded_shape.back() == 1) {
+        arg1_padded_shape.pop_back();
+    }
+
+    for (int64_t i = 0; i < axis; ++i) {
+        arg1_padded_shape.insert(arg1_padded_shape.begin(), 1);
+    }
+
+    while (arg1_padded_shape.size() < arg0_shape.size()) {
+        arg1_padded_shape.insert(arg1_padded_shape.end(), 1);
+    }
+
+    Shape arg1_squeezed_shape;
+    AxisSet arg1_squeezed_axes;
+
+    for (size_t i = 0, size = arg0_shape.size(); i < size; i++) {
+        if (arg1_padded_shape[i] == 1) {
+            arg1_squeezed_axes.insert(i);
+        } else {
+            arg1_squeezed_shape.push_back(arg1_padded_shape[i]);
+        }
+    }
+
+    const CoordinateTransformBasic output_transform{arg0_shape};
+
+    for (const Coordinate& output_coord : output_transform) {
+        const auto arg1_coord = util::reduce(output_coord, arg1_squeezed_axes);
+        const auto out_index = coordinate_index(output_coord, arg0_shape);
+        const auto arg0_index = coordinate_index(output_coord, arg0_shape);
+        const auto arg1_index = coordinate_index(arg1_coord, arg1_squeezed_shape);
+        out[out_index] = f(arg0[arg0_index], arg1[arg1_index]);
+    }
+}
+
+/**
+ * @brief Helper function to implement auto broadcasting elementwise binop references.
+ *
+ * @tparam T Element type of the input tensors.
+ * @tparam U Element type of the output tensor.
+ * @tparam Functor Type of the functor for the elementwise operation. Must support
+ *                 operator()(T,T), and operator()(T,T) must return a value of type
+ *                 U.
+ *
+ * @param arg0 Pointer to the buffer for left operand input tensor.
+ * @param arg1 Pointer to the buffer for right operand input tensor.
+ * @param out Pointer to the buffer for output tensor. This must be pre-allocated by
+ *            the caller, and must be large enough to hold a tensor of the correct
+ *            shape.
+ * @param broadcast_spec Specification of the auto-broadcasting scheme.
+ * @param elementwise_functor Functor implementing the elementwise operation to be
+ *                            applied across the input tensors. Must accept two
+ *                            arguments of type T, and return a value of type U.
+ */
 template <typename T, typename U, typename Functor>
 void autobroadcast_binop(const T* arg0,
                          const T* arg1,
@@ -99,203 +320,39 @@ void autobroadcast_binop(const T* arg0,
                          Functor elementwise_functor) {
     switch (broadcast_spec.m_type) {
     case op::AutoBroadcastType::NONE:
-        for (size_t i = 0; i < shape_size(arg0_shape); i++) {
-            out[i] = static_cast<U>(elementwise_functor(arg0[i], arg1[i]));
-        }
+        no_broadcast_binop(arg0, arg1, out, shape_size(arg0_shape), elementwise_functor);
         break;
     case op::AutoBroadcastType::NUMPY:
-        // We'll be using CoordinateTransformBasic to handle the broadcasting. The general
-        // procedure is as follows:
-        //
-        // (1) Left pad the shorter of the two shapes with ones.
-        // (2) Squeeze (remove ones from) both shapes, and record the squeezed axis
-        //     indices.
-        // (3) Using CoordinateTransformBasic, broadcast both args to the final output
-        //     shape. The "broadcasted axes" will be those that were squeezed in step
-        //     2.
-        //
-        // Example:
-        //
-        //    Input shape->Padded shape->Squeezed Shape/Squeezed Axes
-        //    -----------  ------------  ----------------------------
-        // a: [ 3, 2, 1]   [ 3, 2, 1]    [ 3, 2   ]     {2}
-        // b: [    1, 6]   [ 1, 1, 6]    [       6]     {0,1}
-        //                   |  |  |
-        //                   v  v  v
-        //                 Output shape
-        //                 ------------
-        //                 [ 3, 2, 6]
-        {
-            using namespace internal;
-
-            size_t const shape_rank = std::max(arg0_shape.size(), arg1_shape.size()) + 1;
-
-            // TODO: Use compiler-specific alloca() or variable-length array
-            std::vector<size_t> tmp(shape_rank * 2);
-
-            size_t* strides0 = tmp.data();
-            size_t* strides1 = tmp.data() + shape_rank;
-
-            row_major_strides(arg0_shape, strides0, shape_rank);
-            row_major_strides(arg1_shape, strides1, shape_rank);
-
-            size_t const padding0 = shape_rank - arg0_shape.size();
-            size_t const padding1 = shape_rank - arg1_shape.size();
-
-            Shape output_shape(shape_rank, 0);
-
-            size_t axis = 0;
-
-            for (size_t i = 0; i < shape_rank; i++) {
-                auto const dim0 = value_with_padding_or(arg0_shape, padding0, i, 1);
-                auto const dim1 = value_with_padding_or(arg1_shape, padding1, i, 1);
-
-                output_shape[i] = std::max(dim0, dim1);
-
-                if (dim0 != dim1)
-                    axis = std::max(axis, i);
-            }
-
-            if (axis == 0) {
-                for (size_t i = 0, end = strides0[0]; i < end; ++i)
-                    out[i] = elementwise_functor(arg0[i], arg1[i]);
-            } else if (strides0[axis] == 1 && value_with_padding_or(arg0_shape, padding0, axis, 1) == 1) {
-                axis = calculate_fixed_axis(axis, strides0);
-
-                numpy_autobroadcast_binop<0, 1>(arg0,
-                                                arg1,
-                                                out,
-                                                arg0_shape,
-                                                arg1_shape,
-                                                strides0,
-                                                strides1,
-                                                padding0,
-                                                padding1,
-                                                output_shape,
-                                                axis,
-                                                strides1[axis],
-                                                elementwise_functor);
-            } else if (strides1[axis] == 1 && value_with_padding_or(arg1_shape, padding1, axis, 1) == 1) {
-                axis = calculate_fixed_axis(axis, strides1);
-
-                numpy_autobroadcast_binop<1, 0>(arg0,
-                                                arg1,
-                                                out,
-                                                arg0_shape,
-                                                arg1_shape,
-                                                strides0,
-                                                strides1,
-                                                padding0,
-                                                padding1,
-                                                output_shape,
-                                                axis,
-                                                strides0[axis],
-                                                elementwise_functor);
-            } else
-                numpy_autobroadcast_binop<1, 1>(arg0,
-                                                arg1,
-                                                out,
-                                                arg0_shape,
-                                                arg1_shape,
-                                                strides0,
-                                                strides1,
-                                                padding0,
-                                                padding1,
-                                                output_shape,
-                                                axis,
-                                                strides0[axis],
-                                                elementwise_functor);
-        }
+        numpy_broadcast_binop(arg0, arg1, out, arg0_shape, arg1_shape, elementwise_functor);
         break;
     case op::AutoBroadcastType::PDPD:
-        // We'll be using CoordinateTransformBasic to handle the broadcasting. No need to
-        // process arg0 and output shape will be the same as arg0. We need to process
-        // arg1 and the general procedure is as follows:
-        //
-        // (1) Trim trailing ones from arg1 shape.
-        // (2) Left and right pad arg1 to match arg0 shape. Axis is the index start
-        //     to align between arg0 and arg1.
-        // (3) Squeeze (remove ones from) arg1 shape, and record the squeezed axis
-        //     indices.
-        // (3) Using CoordinateTransformBasic, broadcast arg1 to the final output
-        //     shape. The "broadcasted axes" will be those that were squeezed in step
-        //     23.
-        //
-        // Example:
-        //
-        //    Input shape->   Padded shape->   Squeezed Shape/Squeezed Axes
-        //    -----------  ------------  ----------------------------
-        // a: [ 3, 4, 5, 6]   [ 3, 4, 5, 6]    [ 3, 4, 5, 6]
-        // b: [    4, 5,  ]   [ 1, 4, 5, 1]    [    4, 5   ]     {0,3}
-        //                      |  |  |
-        //                      v  v  v
-        //                     Output shape
-        //                     ------------
-        //                    [ 3, 4, 5, 6]
-        {
-            int64_t axis = broadcast_spec.m_axis;
-            if (axis == -1) {
-                axis = arg0_shape.size() - arg1_shape.size();
-            }
-
-            Shape arg1_padded_shape = arg1_shape;
-            // Trim trailing ones
-            while (arg1_padded_shape.size() > 0 && arg1_padded_shape.back() == 1) {
-                arg1_padded_shape.pop_back();
-            }
-
-            for (int64_t i = 0; i < axis; ++i) {
-                arg1_padded_shape.insert(arg1_padded_shape.begin(), 1);
-            }
-
-            while (arg1_padded_shape.size() < arg0_shape.size()) {
-                arg1_padded_shape.insert(arg1_padded_shape.end(), 1);
-            }
-
-            Shape arg1_squeezed_shape;
-            AxisSet arg1_squeezed_axes;
-
-            for (size_t i = 0; i < arg0_shape.size(); i++) {
-                if (arg1_padded_shape[i] == 1) {
-                    arg1_squeezed_axes.insert(i);
-                } else {
-                    arg1_squeezed_shape.push_back(arg1_padded_shape[i]);
-                }
-            }
-
-            const CoordinateTransformBasic output_transform{arg0_shape};
-
-            for (const Coordinate& output_coord : output_transform) {
-                const auto arg1_coord = util::reduce(output_coord, arg1_squeezed_axes);
-                const auto out_index = coordinate_index(output_coord, arg0_shape);
-                const auto arg0_index = coordinate_index(output_coord, arg0_shape);
-                const auto arg1_index = coordinate_index(arg1_coord, arg1_squeezed_shape);
-                out[out_index] = elementwise_functor(arg0[arg0_index], arg1[arg1_index]);
-            }
-        }
+        pdpd_broadcast_binop(arg0, arg1, out, arg0_shape, arg1_shape, broadcast_spec.m_axis, elementwise_functor);
+        break;
+    default:
+        break;
     }
 }
 
-/// \brief Helper function to implement autobroadcasting elementwise ternaryop
-/// references.
-///
-/// \tparam U Element type of the selector tensor.
-/// \tparam T Element type of the input tensors.
-/// \tparam Functor Type of the functor for the elementwise operation. Must support
-///                 operator()(U,T,T), and operator()(U,T,T) must return a value of type
-///                 T.
-///
-/// \param arg0 Pointer to the buffer for selector tensor.
-/// \param arg1 Pointer to the buffer for left operand input tensor.
-/// \param arg2 Pointer to the buffer for right operand input tensor.
-/// \param out Pointer to the buffer for output tensor. This must be pre-allocated by
-///            the caller, and must be large enough to hold a tensor of the correct
-///            shape.
-/// \param broadcast_spec Specification of the auto-broadcasting scheme.
-/// \param elementwise_functor Functor implementing the elementwise operation to be
-///                            applied across the input tensors. Must accept an argument
-///                            of
-///                            type U and two of type T, and return a value of type T.
+/**
+ *
+ * \brief Helper function to implement auto broadcasting elementwise ternary op references.
+ * \tparam U Element type of the selector tensor.
+ * \tparam T Element type of the input tensors.
+ * \tparam Functor Type of the functor for the elementwise operation. Must support
+ *                 operator()(U,T,T), and operator()(U,T,T) must return a value of type
+ *                 T.
+ * \param arg0 Pointer to the buffer for selector tensor.
+ * \param arg1 Pointer to the buffer for left operand input tensor.
+ * \param arg2 Pointer to the buffer for right operand input tensor.
+ * \param out Pointer to the buffer for output tensor. This must be pre-allocated by
+ *            the caller, and must be large enough to hold a tensor of the correct
+ *            shape.
+ * \param broadcast_spec Specification of the auto-broadcasting scheme.
+ * \param elementwise_functor Functor implementing the elementwise operation to be
+ *                            applied across the input tensors. Must accept an argument
+ *                            of
+ *                            type U and two of type T, and return a value of type T.
+ */
 template <typename T, typename U, typename Functor>
 void autobroadcast_select(const U* arg0,
                           const T* arg1,
@@ -308,8 +365,8 @@ void autobroadcast_select(const U* arg0,
                           Functor elementwise_functor) {
     switch (broadcast_spec.m_type) {
     case op::AutoBroadcastType::NONE:
-        for (size_t i = 0; i < shape_size(arg0_shape); i++) {
-            out[i] = elementwise_functor(arg0[i], arg1[i], arg2[i]);
+        for (auto last = arg0 + shape_size(arg0_shape); arg0 != last; ++arg0, ++arg1, ++arg2, ++out) {
+            *out = elementwise_functor(*arg0, *arg1, *arg2);
         }
         break;
     case op::AutoBroadcastType::NUMPY:
@@ -422,7 +479,7 @@ void autobroadcast_select(const U* arg0,
         Shape arg2_squeezed_shape;
         AxisSet arg2_squeezed_axes;
 
-        for (size_t i = 0; i < arg1_shape.size(); i++) {
+        for (size_t i = 0, size = arg1_shape.size(); i < size; ++i) {
             if (arg0_padded_shape[i] == 1) {
                 arg0_squeezed_axes.insert(i);
             } else {


### PR DESCRIPTION
### Details:
 - Split `autobroadcast_binop` to dedicated broadcast functions.
 - Minor size optimizations.

### Tickets:
 -[CVS-127056](https://jira.devtools.intel.com/browse/CVS-127056)
