### PR TITLE
[GHA] Possible workaround for the latest h5py issue on arm

### DIFF
--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -125,6 +125,9 @@ jobs:
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 30
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 30
 
+          # For building the latest h5py
+          apt install --assume-yes --no-install-recommends libhdf5-dev
+
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.4
         with:


### PR DESCRIPTION
After the latest release https://pypi.org/project/h5py/#history stopped being installed as a Python module on arm - it tries to be built from sources and there is a missing dependency for this. Trying to fix it without restricting the module version...