### PR TITLE
[CI] [GHA] Introduce external PR labeller

### DIFF
--- a/.github/scripts/external_pr_labeller.py
+++ b/.github/scripts/external_pr_labeller.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     LOGGER.info(f'CONTEXT: PR #{pr_number}. USER: {pr.user.login}. ALL PR LABELS: {list(pr.get_labels())}')
 
     if not gh_repo.has_in_collaborators(pr.user.login):
-        LOGGER.info(f'THE {pr.user.login} IS NOT COLLABORATOR')
+        LOGGER.info(f'THE {pr.user.login} IS NOT A COLLABORATOR')
         
         for label in pr.get_labels():
             if label.name == EXTERNAL_PR_LABEL_NAME:

--- a/.github/scripts/external_pr_labeller.py
+++ b/.github/scripts/external_pr_labeller.py
@@ -61,3 +61,5 @@ if __name__ == '__main__':
         LOGGER.info(
             f'THE {pr.user.login} IS A COLLABORATOR, NO NEED TO ADD THE "{EXTERNAL_PR_LABEL_NAME}" LABEL'
         )
+
+    github.close()

--- a/.github/scripts/external_pr_labeller.py
+++ b/.github/scripts/external_pr_labeller.py
@@ -44,10 +44,12 @@ if __name__ == '__main__':
     gh_repo = github.get_repo(full_name_or_id=repository_name)
 
     pr = gh_repo.get_pull(number=pr_number)
+    
+    LOGGER.info(f'CONTEXT: PR #{pr_number}. USER: {pr.user.login}. ALL PR LABELS: {list(pr.get_labels())}')
 
     if not gh_repo.has_in_collaborators(pr.user.login):
         LOGGER.info(f'THE {pr.user.login} IS NOT COLLABORATOR')
-        LOGGER.info(f'ALL PR LABELS: {list(pr.get_labels())}')
+        
         for label in pr.get_labels():
             if label.name == EXTERNAL_PR_LABEL_NAME:
                 LOGGER.info(f'THE PR ALREADY HAS THE "{EXTERNAL_PR_LABEL_NAME}" LABEL')

--- a/.github/scripts/external_pr_labeller/labeller.py
+++ b/.github/scripts/external_pr_labeller/labeller.py
@@ -1,0 +1,61 @@
+from github import Github, Auth
+import os
+import logging
+
+import argparse
+
+
+def get_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-r',
+        '--repository-name',
+        type=str,
+        required=True,
+        help='Repository name in the OWNER/REPOSITORY format',
+    )
+    parser.add_argument(
+        '--pr-number', type=int, required=True, help='PR number to label'
+    )
+    return parser.parse_args()
+
+
+def init_logger():
+    LOGLEVEL = os.environ.get('LOGLEVEL', 'INFO').upper()
+    logging.basicConfig(
+        level=LOGLEVEL,
+        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        datefmt='%m-%d-%Y %H:%M:%S',
+    )
+
+
+if __name__ == '__main__':
+
+    init_logger()
+
+    LOGGER = logging.getLogger('labeller')
+    EXTERNAL_PR_LABEL_NAME = 'ExternalPR'
+
+    args = get_arguments()
+    pr_number = args.pr_number
+    repository_name = args.repository_name
+
+    github = Github(auth=Auth.Token(token=os.environ.get('GITHUB_TOKEN')))
+    gh_repo = github.get_repo(full_name_or_id=repository_name)
+
+    pr = gh_repo.get_pull(number=pr_number)
+
+    if not gh_repo.has_in_collaborators(pr.user.login):
+        LOGGER.info(f'THE {pr.user.login} IS NOT COLLABORATOR')
+        LOGGER.info(f'ALL PR LABELS: {list(pr.get_labels())}')
+        for label in pr.get_labels():
+            if label.name == EXTERNAL_PR_LABEL_NAME:
+                LOGGER.info(f'THE PR ALREADY HAS THE "{EXTERNAL_PR_LABEL_NAME}" LABEL')
+                break
+        else:
+            pr.add_to_labels(EXTERNAL_PR_LABEL_NAME)
+            LOGGER.info(f'THE "{EXTERNAL_PR_LABEL_NAME}" LABEL WAS ADDED TO THE PR')
+    else:
+        LOGGER.info(
+            f'THE {pr.user.login} IS A COLLABORATOR, NO NEED TO ADD THE "{EXTERNAL_PR_LABEL_NAME}" LABEL'
+        )

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
         dot: 'true'
         non-matching-label: 'no-match-files'
   
-  external_pr_labeler:
+  external_pr_labeller:
     name: Label External PR
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,3 +16,27 @@ jobs:
         sync-labels: 'true'
         dot: 'true'
         non-matching-label: 'no-match-files'
+  
+  external_pr_labeler:
+    name: Label External PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Labeller Script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github'
+
+      - name: Install deps
+        run: pip3 install PyGithub==2.2.0
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Label External PR
+        env:
+          GITHUB_TOKEN: "${{ secrets.EXTERNAL_LABELLER_TOKEN }}"
+        run: |
+          python3 ${{ github.workspace }}/.github/scripts/external_pr_labeller/labeller.py \
+          --repository-name ${GITHUB_REPOSITORY} --pr-number ${{ github.event.number }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -38,5 +38,5 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.EXTERNAL_LABELLER_TOKEN }}"
         run: |
-          python3 ${{ github.workspace }}/.github/scripts/external_pr_labeller/labeller.py \
+          python3 ${{ github.workspace }}/.github/scripts/external_pr_labeller.py \
           --repository-name ${GITHUB_REPOSITORY} --pr-number ${{ github.event.number }}


### PR DESCRIPTION
### Details:
 - This PR introduces a PR labeller for external PRs. It will add the `ExternalPR` label to a PR whose author is not in the `openvino` collaborator list.

It will not work from a PR as it has a `pull_request_target` trigger for the secrets. I've tested it locally.

### Tickets:
 - *135090*
