### PR TITLE
[GHA] Freeze h5py version

### DIFF
--- a/src/frontends/tensorflow/tests/requirements.txt
+++ b/src/frontends/tensorflow/tests/requirements.txt
@@ -2,4 +2,4 @@
 numpy
 tensorflow
 # limit h5py version for Linux arm64, 3.11 version failed
-h5py~=3.10.0; sys_platform == 'linux' and platform_machine == 'aarch64'
+h5py<3.11.0; sys_platform == 'linux' and platform_machine == 'aarch64'

--- a/src/frontends/tensorflow/tests/requirements.txt
+++ b/src/frontends/tensorflow/tests/requirements.txt
@@ -1,4 +1,5 @@
 -c ../../../bindings/python/constraints.txt
 numpy
 tensorflow
-h5py<3.11.0 # w/a for Linux arm64, 3.11 version failed
+# limit h5py version for Linux arm64, 3.11 version failed
+h5py~=3.10.0; sys_platform == 'linux' and platform_machine == 'aarch64'

--- a/src/frontends/tensorflow/tests/requirements.txt
+++ b/src/frontends/tensorflow/tests/requirements.txt
@@ -1,4 +1,5 @@
 -c ../../../bindings/python/constraints.txt
 numpy
 tensorflow
-h5py~=3.10.0 # w/a for Linux arm64, 3.11 version failed
+# limit h5py version for Linux arm64, 3.11 version failed
+h5py~=3.10.0; sys_platform == 'linux' and platform_machine == 'aarch64'

--- a/src/frontends/tensorflow/tests/requirements.txt
+++ b/src/frontends/tensorflow/tests/requirements.txt
@@ -1,3 +1,4 @@
 -c ../../../bindings/python/constraints.txt
 numpy
 tensorflow
+h5py~=3.10.0 # w/a for Linux arm64, 3.11 version failed

--- a/src/frontends/tensorflow/tests/requirements.txt
+++ b/src/frontends/tensorflow/tests/requirements.txt
@@ -1,5 +1,4 @@
 -c ../../../bindings/python/constraints.txt
 numpy
 tensorflow
-# limit h5py version for Linux arm64, 3.11 version failed
-h5py~=3.10.0; sys_platform == 'linux' and platform_machine == 'aarch64'
+h5py<3.11.0 # w/a for Linux arm64, 3.11 version failed


### PR DESCRIPTION
### Details:
 - tensorflow package depends on h5py and starting from 3.11 version this package could not be installed on linux arm64 systems due to absent libraries (libhdf5-dev), see https://github.com/openvinotoolkit/openvino/actions/runs/8631731088/job/23660776687?pr=23909
 - 
### Tickets:
 - *ticket-id*
