### PR TITLE
[RISCV64][SHL] Added FC FP32 executor

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -123,12 +123,21 @@ if(OV_CPU_WITH_ACL)
     set(CMAKE_CXX_STANDARD 14)
 endif()
 
+if (ENABLE_SHL_FOR_CPU)
+    add_definitions(-DOV_CPU_WITH_SHL)
+    set(OV_CPU_WITH_SHL ON)
+endif()
+
 file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h
                           ${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp)
 
 if(NOT OV_CPU_WITH_ACL)
     list(APPEND EXCLUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src/nodes/executors/acl/*)
+endif()
+
+if(NOT OV_CPU_WITH_SHL)
+    list(APPEND EXCLUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src/nodes/executors/shl/*)
 endif()
 
 if(NOT X86_64)

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -949,6 +949,10 @@ void GraphOptimizer::FuseFCAndConvertOnWeights(Graph& graph) {
 }
 
 void GraphOptimizer::FuseFCAndTransposeOnWeights(Graph& graph) {
+#if defined(OV_CPU_WITH_SHL)
+    return;
+#endif
+
     // This optimization allows us to avoid transposing the weights in Transpose node and do it directly along with reordering in FC node
     auto& graphNodes = graph.GetNodes();
 

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -456,6 +456,7 @@ std::string Node::getPrimitiveDescriptorType() const {
     SEARCH_TYPE(winograd);
     SEARCH_TYPE(sparse);
     SEARCH_TYPE(acl);
+    SEARCH_TYPE(shl);
     SEARCH_TYPE(_dw);
     SEARCH_TYPE(_1x1);
 

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.cpp
@@ -20,6 +20,7 @@ std::string ExecutorTypeToString(const ExecutorType type) {
         CASE(Acl);
         CASE(Mlas);
         CASE(jit_aarch64);
+        CASE(Shl);
     }
 #undef CASE
     return "Undefined";
@@ -35,6 +36,7 @@ ExecutorType ExecutorTypeFromString(const std::string& typeStr) {
     CASE(Acl);
     CASE(Mlas);
     CASE(jit_aarch64);
+    CASE(Shl);
 #undef CASE
     return ExecutorType::Undefined;
 }

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -47,6 +47,12 @@ namespace intel_cpu {
 #    define OV_CPU_INSTANCE_MLAS_X64(...)
 #endif
 
+#if defined(OV_CPU_WITH_SHL)
+#    define OV_CPU_INSTANCE_SHL(...) {__VA_ARGS__},
+#else
+#    define OV_CPU_INSTANCE_SHL(...)
+#endif
+
 #define OV_CPU_INSTANCE_COMMON(...) {__VA_ARGS__},
 
 // @todo another option is to determine shape relation by executor type
@@ -63,7 +69,8 @@ enum class ExecutorType {
     Dnnl,
     Acl,
     Mlas,
-    jit_aarch64
+    jit_aarch64,
+    Shl
 };
 
 enum class OperationType {

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl.hpp
@@ -1,0 +1,199 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "shl_utils.hpp"
+#include "csinn/csinn_data_structure.h"
+#include "csinn/csinn_runtime.h"
+
+#include "memory_desc/cpu_memory_desc.h"
+
+#include <memory>
+
+
+namespace ov {
+namespace intel_cpu {
+
+
+template <typename T>
+struct ShlStructureTraits {};
+
+template <typename T, typename traits = ShlStructureTraits<T>>
+struct ShlStructure {
+public:
+    ShlStructure() = default;
+    ShlStructure(const ShlStructure<T, traits>&) = default;
+    ShlStructure(ShlStructure<T, traits>&&) = default;
+    explicit ShlStructure(T t) { reset(t); }
+
+    ShlStructure<T, traits> &operator=(const ShlStructure<T, traits>&) = default;
+    ShlStructure<T, traits> &operator=(ShlStructure<T, traits>&&) = default;
+
+    void reset(T t) {
+        m_ptr.reset(t, traits::destructor);
+    }
+
+    T get(bool allow_empty = false) const {
+        T result = m_ptr.get();
+        OPENVINO_ASSERT(allow_empty || result != nullptr, "ShlStructure is not initialized");
+        return result;
+    }
+
+    explicit operator T() const {
+        return get(true);
+    }
+
+    explicit operator bool() const {
+        return get(true) != nullptr;
+    }
+
+    bool operator==(const ShlStructure<T, traits> &other) const {
+        return other.m_ptr.get() == m_ptr.get();
+    }
+    bool operator!=(const ShlStructure &other) const {
+        return !(*this == other);
+    }
+
+private:
+    std::shared_ptr<typename std::remove_pointer<T>::type> m_ptr = nullptr;
+
+protected:
+    bool operator==(const T other) const { return other == m_ptr.get(); }
+    bool operator!=(const T other) const { return !(*this == other); }
+};
+
+template <>
+struct ShlStructureTraits<csinn_session*> {
+    static void destructor(csinn_session* p) {
+        return csinn_free_session(p);
+    }
+};
+struct ShlSession : public ShlStructure<csinn_session*> {
+    ShlSession() {
+        csinn_session* session = csinn_alloc_session();
+        OPENVINO_ASSERT(session != nullptr, "Failed to create csinn_session");
+        reset(session);
+    }
+
+    ShlSession(csinn_rmode_enum base_run_mode) : ShlSession() {
+        setBaseRunMode(base_run_mode);
+    }
+
+    void setBaseRunMode(csinn_rmode_enum base_run_mode) {
+        get()->base_run_mode = base_run_mode;
+    }
+};
+
+template <>
+struct ShlStructureTraits<csinn_tensor*> {
+    static void destructor(csinn_tensor* p) {
+        return csinn_free_tensor(p);
+    }
+};
+struct ShlTensor : public ShlStructure<csinn_tensor*> {
+    ShlTensor() {
+        csinn_tensor* tensor = csinn_alloc_tensor(nullptr);
+        OPENVINO_ASSERT(tensor != nullptr, "Failed to create csinn_tensor");
+        reset(tensor);
+    }
+
+    ShlTensor(const ShlSession& session) {
+        csinn_tensor* tensor = csinn_alloc_tensor(session.get());
+        OPENVINO_ASSERT(tensor != nullptr, "Failed to create csinn_tensor");
+        reset(tensor);
+    }
+
+    ShlTensor(const ShlSession& session, csinn_dtype_enum data_type, csinn_layout_enum layout)
+        : ShlTensor(session) {
+        setPrecision(data_type);
+        setLayout(layout);
+    }
+
+    ShlTensor(const ShlSession& session, const VectorDims& shape, csinn_dtype_enum data_type, csinn_layout_enum layout, void* data = nullptr)
+        : ShlTensor(session) {
+        setShape(shape);
+        setPrecision(data_type);
+        setLayout(layout);
+        setData(data);
+    }
+
+    void setLayout(csinn_layout_enum layout) {
+        get()->layout = layout;
+    }
+
+    void setPrecision(csinn_dtype_enum data_type) {
+        get()->dtype = data_type;
+    }
+
+    void setShape(const VectorDims& shape) {
+        get()->dim_count = shape.size();
+        OPENVINO_ASSERT(get()->dim_count < MAX_DIM, "Shl supports shapes with rank less or equal to 8");
+        for (int i = 0; i < get()->dim_count; ++i)
+            get()->dim[i] = static_cast<int32_t>(shape[i]);
+    }
+
+    void setData(void* data) {
+        get()->data = data;
+    }
+
+    csinn_layout_enum getLayout() const {
+        // csinn_tensor contains `layout` as int32_t
+        return static_cast<csinn_layout_enum>(get()->layout);
+    }
+
+    csinn_dtype_enum getPrecision() const {
+        return get()->dtype;
+    }
+
+    VectorDims getShape() const {
+        VectorDims shape(get()->dim_count);
+        for (size_t i = 0; i < shape.size(); ++i)
+            shape[i] = static_cast<size_t>(get()->dim[i]);
+        return shape;
+    }
+
+    void* getData() const {
+        return get()->data;
+    }
+
+#ifdef CPU_DEBUG_CAPS
+    void print() const {
+        std::cout << "Shape: " << ov::Shape(getShape()) << " "
+                  << "DataType: " << getPrecision() << " "
+                  << "Layout: " << getLayout() << " "
+                  << "Ptr: " << getData() << std::endl;
+    }
+#endif
+};
+
+template <>
+struct ShlStructureTraits<csinn_fc_params*> {
+    static void destructor(csinn_fc_params* p) {
+        return csinn_free_params(p);
+    }
+};
+struct ShlFCParams : public ShlStructure<csinn_fc_params*> {
+    ShlFCParams() {
+        csinn_fc_params* params = static_cast<csinn_fc_params*>(csinn_alloc_params(sizeof(csinn_fc_params), nullptr));
+        OPENVINO_ASSERT(params != nullptr, "Failed to create csinn_fc_params");
+        reset(params);
+    }
+
+    ShlFCParams(const ShlSession& session) {
+        csinn_fc_params* params = static_cast<csinn_fc_params*>(csinn_alloc_params(sizeof(csinn_fc_params), session.get()));
+        OPENVINO_ASSERT(params != nullptr, "Failed to create csinn_fc_params");
+        reset(params);
+    }
+
+    ShlFCParams(const ShlSession& session, csinn_api_enum api) : ShlFCParams(session) {
+        setAPI(api);
+    }
+
+    void setAPI(csinn_api_enum api) {
+        get()->base.api = api;
+    }
+};
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl.hpp
@@ -98,16 +98,16 @@ struct ShlTensor : public ShlStructure<csinn_tensor*> {
         reset(tensor);
     }
 
-    ShlTensor(const ShlSession& session, csinn_dtype_enum data_type, csinn_layout_enum layout)
+    ShlTensor(const ShlSession& session, csinn_dtype_enum data_type, csinn_layout_enum layout, const VectorDims& shape = {}, void* data = nullptr)
         : ShlTensor(session) {
         setPrecision(data_type);
         setLayout(layout);
-    }
-
-    ShlTensor(const ShlSession& session, const VectorDims& shape, csinn_dtype_enum data_type, csinn_layout_enum layout, void* data = nullptr)
-        : ShlTensor(session, data_type, layout) {
         setShape(shape);
         setData(data);
+    }
+
+    ShlTensor(const ShlTensor& another) : ShlTensor() {
+        csinn_tensor_copy(get(), another.get());
     }
 
     csinn_layout_enum getLayout() const {
@@ -132,6 +132,12 @@ struct ShlTensor : public ShlStructure<csinn_tensor*> {
 
     void setData(void* data) {
         get()->data = data;
+    }
+
+    ShlTensor cloneWithNewShape(const VectorDims& shape) const {
+        ShlTensor cloned(*this);
+        cloned.setShape(shape);
+        return cloned;
     }
 
 #ifdef CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
@@ -1,0 +1,103 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shl_fullyconnected.hpp"
+
+#include "csinn/csi_nn.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/memory_arguments.hpp"
+#include "utils/debug_capabilities.h"
+
+namespace ov {
+namespace intel_cpu {
+
+bool ShlFCExecutor::supports(const FCConfig& config) {
+    if (config.attrs.weightsNonTransposed) {
+        DEBUG_LOG("ShlFCExecutor: weightsNonTransposed is not supported!");
+        return false;
+    }
+
+    if (!config.postOps.empty()) {
+        DEBUG_LOG("ShlFCExecutor: PostOps are not supported");
+        return false;
+    }
+
+    const auto& srcDesc = config.descs.at(ARG_SRC);
+    const auto& weiDesc = config.descs.at(ARG_WEI);
+    const auto& dstDesc = config.descs.at(ARG_DST);
+    if (!everyone_is(ov::element::f32, srcDesc->getPrecision(), weiDesc->getPrecision(), dstDesc->getPrecision())) {
+        DEBUG_LOG("ShlFCExecutor: supports only f32");
+        return false;
+    }
+
+    if (config.attrs.withBias) {
+        const auto& biaDesc = config.descs.at(ARG_BIAS);
+        if (biaDesc->getPrecision() != ov::element::f32) {
+            DEBUG_LOG("ShlFCExecutor: supports only f32 bias");
+            return false;
+        }
+
+        const auto& biasDims = biaDesc->getShape().getStaticDims();
+        const auto& outDims = dstDesc->getShape().getDims();
+        const bool isByChannel = biasDims.back() == outDims.back();
+        if (!isByChannel || !std::all_of(biasDims.begin(), biasDims.end() - 1, [](const Dim dim) { return dim == 1; })) {
+            DEBUG_LOG("ShlFCExecutor: only 'by channel' bias is supported");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+ShlFCExecutor::ShlFCExecutor(const FCAttrs& attrs,
+                             const PostOps& postOps,
+                             const MemoryArgs& memory,
+                             const ExecutorContext::CPtr context) {
+    const auto& srcDesc = memory.at(ARG_SRC)->getDescPtr();
+    const auto& weiDesc = memory.at(ARG_WEI)->getDescPtr();
+    const auto& dstDesc = memory.at(ARG_DST)->getDescPtr();
+
+    // Allocate Shl session
+    sess = ShlSession(CSINN_RM_LAYER);
+
+    // Allocate Shl tensors
+    src = ShlTensor(sess, precisionToShlDataType(srcDesc->getPrecision()), getShlDataLayoutByMemoryDesc(srcDesc));
+    wei = ShlTensor(sess, precisionToShlDataType(weiDesc->getPrecision()), getShlDataLayoutByMemoryDesc(weiDesc, true));
+    dst = ShlTensor(sess, precisionToShlDataType(dstDesc->getPrecision()), getShlDataLayoutByMemoryDesc(dstDesc));
+    bias = ShlTensor(sess);
+
+    if (attrs.withBias) {
+        const auto& biasDesc = memory.at(ARG_BIAS)->getDescPtr();
+        bias = ShlTensor(sess, memory.at(ARG_BIAS)->getDescPtr()->getShape().getStaticDims(),
+                        precisionToShlDataType(biasDesc->getPrecision()),
+                        getShlDataLayoutByMemoryDesc(biasDesc), memory.at(ARG_BIAS)->getData());
+    } else {
+        bias = ShlTensor(sess);
+    }
+
+    // Init FC params
+    params = ShlFCParams(sess, CSINN_RVV);
+
+    OPENVINO_ASSERT(csinn_fullyconnected_init(src.get(), dst.get(), wei.get(), bias.get(), params.get()) == CSINN_TRUE,
+                    "ShlFCExecutor: failed to init FC");
+}
+
+bool ShlFCExecutor::update(const MemoryArgs& memory) {
+    src.setShape(memory.at(ARG_SRC)->getDescPtr()->getShape().getStaticDims());
+    wei.setShape(memory.at(ARG_WEI)->getDescPtr()->getShape().getStaticDims());
+    dst.setShape(memory.at(ARG_DST)->getDescPtr()->getShape().getStaticDims());
+    return true;
+}
+
+void ShlFCExecutor::execute(const MemoryArgs& memory) {
+    src.setData(memory.at(ARG_SRC)->getData());
+    wei.setData(memory.at(ARG_WEI)->getData());
+    dst.setData(memory.at(ARG_DST)->getData());
+
+    OPENVINO_ASSERT(csinn_fullyconnected(src.get(), dst.get(), wei.get(), bias.get(), params.get()) == CSINN_TRUE,
+                    "ShlFCExecutor: failed to execute");
+}
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
@@ -35,6 +35,8 @@ private:
     ShlTensor bias = {};
     ShlSession sess = {};
     ShlFCParams params = {};
+
+    bool with_bias = false;
 };
 using ShlFCExecutorPtr = std::shared_ptr<ShlFCExecutor>;
 

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "shl.hpp"
+#include "cpu_memory.h"
+#include "nodes/executors/fullyconnected_config.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+class ShlFCExecutor : public Executor {
+public:
+    ShlFCExecutor(const FCAttrs& attrs,
+                  const PostOps& postOps,
+                  const MemoryArgs& memory,
+                  const ExecutorContext::CPtr context);
+
+    void execute(const MemoryArgs& memory) override;
+
+    impl_desc_type implType() const override {
+        return impl_desc_type::gemm_shl;
+    }
+
+    // offloads execution data preparation from the exec call
+    bool update(const MemoryArgs& memory) override;
+
+    static bool supports(const FCConfig& config);
+
+private:
+    ShlTensor src = {};
+    ShlTensor wei = {};
+    ShlTensor dst = {};
+    ShlTensor bias = {};
+    ShlSession sess = {};
+    ShlFCParams params = {};
+};
+using ShlFCExecutorPtr = std::shared_ptr<ShlFCExecutor>;
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_utils.hpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "csinn/csinn_data_structure.h"
+#include "csinn/csinn_runtime.h"
+#include "memory_desc/cpu_memory_desc.h"
+
+
+namespace ov {
+namespace intel_cpu {
+
+/**
+* @brief Return Shl DataType that corresponds to the given precision
+* @param precision precision to be converted
+* @return Shl DataType
+*/
+inline csinn_dtype_enum precisionToShlDataType(ov::element::Type precision) {
+    switch (precision) {
+        case ov::element::i8:   return CSINN_DTYPE_INT8;
+        case ov::element::u8:   return CSINN_DTYPE_UINT8;
+        case ov::element::i16:  return CSINN_DTYPE_INT16;
+        case ov::element::u16:  return CSINN_DTYPE_UINT16;
+        case ov::element::i32:  return CSINN_DTYPE_INT32;
+        case ov::element::u32:  return CSINN_DTYPE_UINT32;
+        case ov::element::f16:  return CSINN_DTYPE_FLOAT16;
+        case ov::element::f32:  return CSINN_DTYPE_FLOAT32;
+        case ov::element::f64:  return CSINN_DTYPE_FLOAT64;
+        case ov::element::i64:  return CSINN_DTYPE_INT64;
+        case ov::element::bf16: return CSINN_DTYPE_BFLOAT16;
+        default:
+            OPENVINO_THROW("Unknown data type for Shl");
+    }
+}
+
+/**
+* @brief Return Shl DataLayout that corresponds to MemoryDecs layout
+* @param desc MemoryDecs from which layout is retrieved
+* @param is_weights True if it's a layout of weights
+* @return Shl DataLayout or CSINN_LAYOUT_NULL if the layout is unknown
+*/
+inline csinn_layout_enum getShlDataLayoutByMemoryDesc(const MemoryDescPtr& desc, bool is_weights = false) {
+    if (desc->hasLayoutType(LayoutType::ncsp)) {
+        switch (desc->getShape().getRank()) {
+            case 1: return is_weights ? CSINN_LAYOUT_O     : CSINN_LAYOUT_N;
+            case 2: return is_weights ? CSINN_LAYOUT_OI    : CSINN_LAYOUT_NC;
+            case 3: return is_weights ? CSINN_LAYOUT_OIW   : CSINN_LAYOUT_NCW;
+            case 4: return is_weights ? CSINN_LAYOUT_OIHW  : CSINN_LAYOUT_NCHW;
+            case 5: return is_weights ? CSINN_LAYOUT_OIDHW : CSINN_LAYOUT_NCDHW;
+        }
+    } else if (desc->hasLayoutType(LayoutType::nspc)) {
+        switch (desc->getShape().getRank()) {
+            case 3: return is_weights ? CSINN_LAYOUT_OWI   : CSINN_LAYOUT_NWC;
+            case 4: return is_weights ? CSINN_LAYOUT_OHWI  : CSINN_LAYOUT_NHWC;
+            case 5: return is_weights ? CSINN_LAYOUT_ODHWI : CSINN_LAYOUT_NDHWC;
+        }
+    }
+    return CSINN_LAYOUT_NULL;
+}
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -106,6 +106,7 @@ const std::vector<impl_desc_type>& FullyConnected::getDefaultImplPriority() {
     static const std::vector<impl_desc_type> priorities = {
         impl_desc_type::unknown,
         impl_desc_type::acl,
+        impl_desc_type::shl,
         impl_desc_type::brgemm_sparse_avx512_amx,
         impl_desc_type::brgemm_avx512_amx,
         impl_desc_type::brgemm_avx512,

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -91,6 +91,9 @@ void FullyConnected::executeDynamicImpl(dnnl::stream strm) {
 }
 
 bool FullyConnected::canFuse(const NodePtr& node) const {
+#if defined(OV_CPU_WITH_SHL)
+    return false;
+#endif
     return canFuseSimpleOperation(node);
 }
 

--- a/src/plugins/intel_cpu/src/onednn/iml_type_mapper.cpp
+++ b/src/plugins/intel_cpu/src/onednn/iml_type_mapper.cpp
@@ -44,6 +44,7 @@ impl_desc_type parse_impl_name(std::string impl_desc_name) {
     SEARCH_WORD(reorder);
     SEARCH_WORD(sparse);
     SEARCH_WORD(acl);
+    SEARCH_WORD(shl);
     SEARCH_WORD(asimd);
     if ((res & impl_desc_type::avx2) != impl_desc_type::avx2 &&
         (res & impl_desc_type::avx512) != impl_desc_type::avx512)
@@ -130,6 +131,8 @@ const char* impl_type_to_string(impl_desc_type type) {
     CASE(jit_sve256);
     CASE(jit_sve384);
     CASE(jit_sve512);
+    CASE(shl);
+    CASE(gemm_shl);
 
 #undef CASE
     return "unknown";

--- a/src/plugins/intel_cpu/src/onednn/iml_type_mapper.h
+++ b/src/plugins/intel_cpu/src/onednn/iml_type_mapper.h
@@ -10,7 +10,7 @@
 namespace ov {
 namespace intel_cpu {
 
-enum impl_desc_type {
+enum impl_desc_type : int64_t {
     unknown = 0x00000000,
     undef,
     // Optimization approach
@@ -47,6 +47,9 @@ enum impl_desc_type {
     sve256 = 1<<29,
     sve384 = 1<<30,
     sve512 = 1<<31,
+
+    // shl backend
+    shl = 1ll<<32,
 
     // real types
     ref_any             = ref  | any,
@@ -112,7 +115,9 @@ enum impl_desc_type {
     jit_sve128        = jit | sve128,
     jit_sve256        = jit | sve256,
     jit_sve384        = jit | sve384,
-    jit_sve512        = jit | sve512
+    jit_sve512        = jit | sve512,
+
+    gemm_shl          = gemm | shl
 };
 
 std::vector<std::string> extractTypeAndImplName(const std::string& priority);

--- a/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
@@ -40,6 +40,9 @@ endif()
 if(NOT RISCV64)
     list(APPEND EXCLUDED_SOURCE_PATHS
          ${CMAKE_CURRENT_SOURCE_DIR}/custom/single_layer_tests/instances/riscv64)
+elseif(NOT OV_CPU_WITH_SHL)
+    list(APPEND EXCLUDED_SOURCE_PATHS
+         ${CMAKE_CURRENT_SOURCE_DIR}/custom/single_layer_tests/instances/riscv64/shl)
 endif()
 if(NOT (ARM OR AARCH64))
     list(APPEND EXCLUDED_SOURCE_PATHS

--- a/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
@@ -37,6 +37,10 @@ else()
     set(EXCLUDED_SOURCE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/custom/extension ${CMAKE_CURRENT_SOURCE_DIR}/shared_tests_instances/onnx)
 endif()
 
+if(NOT RISCV64)
+    list(APPEND EXCLUDED_SOURCE_PATHS
+         ${CMAKE_CURRENT_SOURCE_DIR}/custom/single_layer_tests/instances/riscv64)
+endif()
 if(NOT (ARM OR AARCH64))
     list(APPEND EXCLUDED_SOURCE_PATHS
          ${CMAKE_CURRENT_SOURCE_DIR}/custom/single_layer_tests/instances/arm

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/riscv64/shl/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/riscv64/shl/matmul.cpp
@@ -12,7 +12,6 @@ namespace ov {
 namespace test {
 namespace MatMul {
 namespace {
-#ifdef OV_CPU_WITH_SHL
 std::vector<CPUSpecificParams> filterSpecificParams_SHL() {
     // replace with shl primitive type
     std::vector<CPUSpecificParams> specificParams;
@@ -95,7 +94,6 @@ const auto testParams2D_SHL_smoke = ::testing::Combine(::testing::Combine(::test
                                              ::testing::Values(emptyFusingSpec),
                                              ::testing::ValuesIn(filterSpecificParams_SHL()));
 INSTANTIATE_TEST_SUITE_P(smoke_FC_2D_SHL, MatMulLayerCPUTest, testParams2D_SHL_smoke, MatMulLayerCPUTest::getTestCaseName);
-#endif
 }  // namespace
 }  // namespace MatMul
 }  // namespace test

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/riscv64/shl/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/riscv64/shl/matmul.cpp
@@ -1,0 +1,102 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "custom/single_layer_tests/classes/matmul.hpp"
+#include "utils/cpu_test_utils.hpp"
+#include "utils/fusing_test_utils.hpp"
+
+using namespace CPUTestUtils;
+
+namespace ov {
+namespace test {
+namespace MatMul {
+namespace {
+#ifdef OV_CPU_WITH_SHL
+std::vector<CPUSpecificParams> filterSpecificParams_SHL() {
+    // replace with shl primitive type
+    std::vector<CPUSpecificParams> specificParams;
+    specificParams.push_back(CPUSpecificParams{{}, {}, {"gemm_shl"}, "gemm_shl"});
+    return specificParams;
+}
+
+const std::vector<ShapeRelatedParams>& FC_2DParams() {
+    static const std::vector<ShapeRelatedParams> params = {
+        {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {false, true}},
+        {static_shapes_to_test_representation({{59, 120}, {120, 1}}), {false, true}},
+        {static_shapes_to_test_representation({{1, 120}, {120, 59}}), {false, true}},
+        {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {false, true}},
+
+        {
+            {
+                {{-1, -1}, {{20, 60}, {20, 60}}},
+                {{60, 120}, {{60, 120}, {60, 120}}}
+            },
+            {false, true}
+        },
+        {
+            {
+                {{{0, 100}, {0, 12}}, {{20, 1}, {14, 1}, {20, 1}, {14, 1}}},
+                {{1, 120}, {{1, 120}, {1, 120}, {1, 120}, {1, 120}}}
+            },
+            {false, true}
+        },
+    };
+    return params;
+}
+
+
+const auto testParams3D_SHL_smoke = ::testing::Combine(::testing::Combine(::testing::ValuesIn(FC_2DParams()),
+                                                        ::testing::Values(ElementType::f32),
+                                                        ::testing::Values(ElementType::undefined),
+                                                        ::testing::Values(ElementType::undefined),
+                                                        ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                                        ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                                        ::testing::Values(emptyAdditionalConfig())),
+                                             ::testing::Values(MatMulNodeType::FullyConnected),
+                                             ::testing::Values(emptyFusingSpec),
+                                             ::testing::ValuesIn(filterSpecificParams_SHL()));
+INSTANTIATE_TEST_SUITE_P(smoke_FC_3D_SHL, MatMulLayerCPUTest, testParams3D_SHL_smoke, MatMulLayerCPUTest::getTestCaseName);
+
+const std::vector<ShapeRelatedParams>& FC_3DParams() {
+    static const std::vector<ShapeRelatedParams> params = {
+        {static_shapes_to_test_representation({{1, 32, 120}, {120, 5}}), {false, true}},
+        {static_shapes_to_test_representation({{1, 1, 120}, {120, 120}}), {false, true}},
+        {static_shapes_to_test_representation({{3, 1, 120}, {120, 120}}), {false, true}},
+        {static_shapes_to_test_representation({{2, 32, 1}, {1, 50}}), {false, true}},
+
+        {
+            {
+                {{1, 5, 32}, {{1, 5, 32}, {1, 5, 32}}},
+                {{32, 3}, {{32, 3}, {32, 3}}}
+            },
+            {false, true}
+        },
+
+        {
+            {
+                {{{0, 60}, {0, 60}, {0, 60}}, {{1, 3, 14}, {1, 7, 14}}},
+                {{14, 10}, {{14, 10}, {14, 10}}}
+            },
+            {false, true}
+        },
+    };
+    return params;
+}
+
+const auto testParams2D_SHL_smoke = ::testing::Combine(::testing::Combine(::testing::ValuesIn(FC_3DParams()),
+                                                                ::testing::Values(ElementType::f32),
+                                                                ::testing::Values(ElementType::undefined),
+                                                                ::testing::Values(ElementType::undefined),
+                                                                ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                                                ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                                                ::testing::Values(emptyAdditionalConfig())),
+                                             ::testing::Values(MatMulNodeType::FullyConnected),
+                                             ::testing::Values(emptyFusingSpec),
+                                             ::testing::ValuesIn(filterSpecificParams_SHL()));
+INSTANTIATE_TEST_SUITE_P(smoke_FC_2D_SHL, MatMulLayerCPUTest, testParams2D_SHL_smoke, MatMulLayerCPUTest::getTestCaseName);
+#endif
+}  // namespace
+}  // namespace MatMul
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - *Reused FC RVV from SHL*
 - *The PR  to SHL dev branch with accuracy fix for FC f32: https://github.com/openvinotoolkit/shl/pull/3*

### Tickets:
 - *N/A*

### TODO:
- [x] Fix `execType: gemm_f32`
- [x] Added wrapper for `csinn_tensor` and `csinn_session` to allocate these structures and deallocate them


### Prerequisites:
- [x] https://github.com/openvinotoolkit/openvino/pull/23901
