### PR TITLE
[CI] [GHA] Fix GPU job display name if the job is skipped

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -761,7 +761,7 @@ jobs:
           if-no-files-found: 'error'
 
   GPU:
-    name: GPU ${{ matrix.TEST_TYPE }} Tests
+    name: GPU Tests
     needs: [ Build, Smart_CI ]
     if: fromJSON(needs.smart_ci.outputs.affected_components).GPU
     timeout-minutes: 80


### PR DESCRIPTION
### Details:
 - If the GPU job is skipped, the UI shows:
![image](https://github.com/openvinotoolkit/openvino/assets/65596953/6c8c8142-d12e-4f80-a2c3-ab17ff9e3b1f)

The jobs created by `matrix` will have the necessary distinguishable properties in the `()` after the job name, e.g., for `Conformance`:
![image](https://github.com/openvinotoolkit/openvino/assets/65596953/d9104eda-3c33-4cee-ab33-4df0e41cc6f3)
so we do not need `matrix`.