### PR TITLE
[CPU] Fix issue on depthwise fusion for Reduce node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -90,6 +90,7 @@ size_t ReduceKey::hash() const {
     seed = hash_combine(seed, jcp.layout);
     seed = hash_combine(seed, jcp.reduce_mode);
     seed = hash_combine(seed, jcp.fuse_low_precision);
+    seed = hash_combine(seed, jcp.fuse_broadcast);
     seed = hash_combine(seed, jcp.src_dt);
     seed = hash_combine(seed, jcp.dst_dt);
     seed = get_post_op_hash(seed, *postOps.get());
@@ -1164,6 +1165,7 @@ struct jit_uni_reduce_post_kernel_f32 : public jit_uni_reduce_post_kernel, publi
         post_reduce = jcp_.reduce_mode == Algorithm::ReduceL2 || jcp_.reduce_mode == Algorithm::ReduceMean ||
                       jcp_.reduce_mode == Algorithm::ReduceLogSum || jcp_.reduce_mode == Algorithm::ReduceLogSumExp;
         post_ops_fusing = attr_.post_ops_.len() != 0;
+        increase_oc_off = !jcp_.fuse_broadcast && jcp_.layout != ReduceLayoutType::reduce_blocked;
 
         mov(reg_dst, ptr[reg_params + GET_OFF_POST(dst)]);
         mov(reg_work_amount, ptr[reg_params + GET_OFF_POST(work_amount)]);
@@ -1227,6 +1229,7 @@ private:
     bool planar_layout = false;
     bool post_reduce = true;
     bool post_ops_fusing = false;
+    bool increase_oc_off = false;
 
     Xbyak::Reg64 reg_src = rbp;
     Xbyak::Reg64 reg_dst = r8;
@@ -1337,7 +1340,7 @@ private:
                     wrap_load_vector(vmm_dst, 0);
                     reduce_map_kernel(vmm_dst);
                     if (post_ops_fusing)
-                        apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                        apply_post_ops(jcp_.dst_dt, jcp_.fuse_broadcast);
                     store_vector(ptr[reg_dst], vmm_dst, jcp_.dst_dt);
 
                     if (isa == cpu::x64::sse41) {
@@ -1346,7 +1349,7 @@ private:
                         if (post_ops_fusing) {
                             if (jcp_.layout != ReduceLayoutType::reduce_ncsp)
                                 add(reg_oc_off, 4 * sizeof(float));
-                            apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                            apply_post_ops(jcp_.dst_dt, jcp_.fuse_broadcast);
                             if (jcp_.layout != ReduceLayoutType::reduce_ncsp)
                                 sub(reg_oc_off, 4 * sizeof(float));
                         }
@@ -1356,7 +1359,7 @@ private:
                     add(reg_dst, step * jcp_.dst_data_size);
                     if (jcp_.fuse_low_precision)
                         add(reg_src, step * sizeof(float));
-                    if (jcp_.layout == ReduceLayoutType::reduce_nspc && post_ops_fusing)
+                    if (post_ops_fusing && increase_oc_off)
                         add(reg_oc_off, step * sizeof(float));
                     sub(reg_work_amount, step);
 
@@ -1375,14 +1378,14 @@ private:
                         jl(reduce_loop_end_label, T_NEAR);
 
                         wrap_load_vector(vmm_dst, 0);
-                        apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                        apply_post_ops(jcp_.dst_dt, jcp_.fuse_broadcast);
                         store_vector(ptr[reg_dst], vmm_dst, jcp_.dst_dt);
 
                         if (isa == cpu::x64::sse41) {
                             wrap_load_vector(vmm_dst, 4);
                             if (jcp_.layout != ReduceLayoutType::reduce_ncsp)
                                 add(reg_oc_off, 4 * sizeof(float));
-                            apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                            apply_post_ops(jcp_.dst_dt, jcp_.fuse_broadcast);
                             if (jcp_.layout != ReduceLayoutType::reduce_ncsp)
                                 sub(reg_oc_off, 4 * sizeof(float));
                             store_vector(ptr[reg_dst + 4 * jcp_.dst_data_size], vmm_dst, jcp_.dst_dt);
@@ -1391,7 +1394,7 @@ private:
                         add(reg_dst, step * jcp_.dst_data_size);
                         if (jcp_.fuse_low_precision)
                             add(reg_src, step * sizeof(float));
-                        if (jcp_.layout == ReduceLayoutType::reduce_nspc && post_ops_fusing)
+                        if (post_ops_fusing && increase_oc_off)
                             add(reg_oc_off, step * sizeof(float));
                         sub(reg_work_amount, step);
 
@@ -1427,13 +1430,13 @@ private:
 
                 // store
                 if (post_ops_fusing)
-                    apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                    apply_post_ops(jcp_.dst_dt, jcp_.fuse_broadcast);
                 store_scalar(ptr[reg_dst], xmm_dst, jcp_.dst_dt);
 
                 add(reg_dst, step * jcp_.dst_data_size);
                 if (jcp_.fuse_low_precision)
                     add(reg_src, step * sizeof(float));
-                if (jcp_.layout == ReduceLayoutType::reduce_nspc && post_ops_fusing)
+                if (post_ops_fusing && increase_oc_off)
                     add(reg_oc_off, step * sizeof(float));
                 sub(reg_work_amount, step);
 
@@ -1455,13 +1458,13 @@ private:
                     wrap_load_scalar(xmm_dst, 0);
 
                     // store
-                    apply_post_ops(jcp_.dst_dt, jcp_.layout == ReduceLayoutType::reduce_ncsp);
+                    apply_post_ops(jcp_.dst_dt, jcp_.fuse_broadcast);
                     store_scalar(ptr[reg_dst], xmm_dst, jcp_.dst_dt);
 
                     add(reg_dst, step * jcp_.dst_data_size);
                     if (jcp_.fuse_low_precision)
                         add(reg_src, step * sizeof(float));
-                    if (jcp_.layout == ReduceLayoutType::reduce_nspc && post_ops_fusing)
+                    if (post_ops_fusing && increase_oc_off)
                         add(reg_oc_off, step * sizeof(float));
                     sub(reg_work_amount, step);
 
@@ -3060,6 +3063,10 @@ inline void Reduce::set_reduce_dim_flags() {
         SET_SRC_DIM_VALUE(1, src_dims[0], 1, 1, 1);
         SET_DST_DIM_VALUE(1, process_dst_dims[0], 1, 1, 1);
     }
+
+    // Depthwise fusion can be computed like eltwise fusion without broadcast, if is_depthwise_compatible is true.
+    bool is_depthwise_compatible = dims_size > 1 && process_dst_dims[1] == OB * OC * OD * OH * OW;
+    jcp.fuse_broadcast = jcp.layout == ReduceLayoutType::reduce_ncsp && !is_depthwise_compatible;
 
     // must be done before the following dimension change
     if (is_hybrid_layout) {

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -3065,7 +3065,7 @@ inline void Reduce::set_reduce_dim_flags() {
     }
 
     // Depthwise fusion can be computed like eltwise fusion without broadcast, if is_depthwise_compatible is true.
-    bool is_depthwise_compatible = dims_size > 1 && process_dst_dims[1] == OB * OC * OD * OH * OW;
+    bool is_depthwise_compatible = dims_size > 1 && process_dst_dims[1] == OC * OD * OH * OW;
     jcp.fuse_broadcast = jcp.layout == ReduceLayoutType::reduce_ncsp && !is_depthwise_compatible;
 
     // must be done before the following dimension change

--- a/src/plugins/intel_cpu/src/nodes/reduce.h
+++ b/src/plugins/intel_cpu/src/nodes/reduce.h
@@ -21,6 +21,7 @@ struct jit_reduce_config_params {
     ReduceLayoutType layout;
     Algorithm reduce_mode;
     bool fuse_low_precision;
+    bool fuse_broadcast;    // if post ops fusion needs broadcast
     dnnl::memory::data_type src_dt;
     dnnl::memory::data_type dst_dt;
     int src_data_size;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
@@ -19,6 +19,10 @@ std::vector<std::vector<ov::test::InputShape>> inputShapes_dyn = {
     {{{{1, 5}, 19, {1, 5}, {1, 10}}, {{2, 19, 2, 2}, {2, 19, 2, 9}}}},
 };
 
+std::vector<std::vector<ov::test::InputShape>> inputShapes_3D_fuse_dyn = {
+    {{{{1, 5}, 19, {1, 10}}, {{1, 19, 2}, {1, 19, 9}}}},
+};
+
 std::vector<std::vector<ov::test::InputShape>> inputShapes_5D_dyn = {
     {{{{1, 5}, 19, {1, 5}, {1, 5}, {1, 5}}, {{2, 19, 2, 2, 2}, {2, 19, 3, 2, 2}}}},
 };
@@ -37,6 +41,10 @@ std::vector<std::vector<ov::test::InputShape>> inputShapes_SmallChannel_dyn = {
 
 std::vector<std::vector<ov::test::InputShape>> inputShapes_SingleBatch_dyn = {
     {{{{1, 5}, 19, {1, 5}, {1, 10}}, {{1, 19, 2, 2}, {1, 19, 2, 9}}}},
+};
+
+std::vector<CPUSpecificParams> cpuParams_3D = {
+        CPUSpecificParams({ncw}, {ncw}, {}, {}),
 };
 
 std::vector<CPUSpecificParams> cpuParams_4D = {
@@ -480,6 +488,20 @@ const auto params_OneAxis_fusing = testing::Combine(
         testing::ValuesIn(fusingParamsSet),
         testing::ValuesIn(additionalConfig()));
 
+const auto params_MultiAxis_3D_fusing = testing::Combine(
+        testing::Combine(
+                testing::Values(axes()[2]),
+                testing::Values(ov::test::utils::OpType::VECTOR),
+                testing::Values(true),
+                testing::Values(ov::test::utils::ReductionType::Sum),
+                testing::ValuesIn(inpOutPrc()),
+                testing::Values(ElementType::undefined),
+                testing::Values(ElementType::undefined),
+                testing::ValuesIn(inputShapes_3D_fuse_dyn)),
+        testing::ValuesIn(filterCPUSpecificParams(cpuParams_3D)),
+        testing::Values(fusingFakeQuantizePerChannelRelu),
+        testing::ValuesIn(additionalConfig()));
+
 const auto params_MultiAxis_4D_fusing = testing::Combine(
         testing::Combine(
                 testing::ValuesIn(axesND()),
@@ -526,6 +548,13 @@ INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_OneAxis_fusing_CPU,
         ReduceCPULayerTest,
         params_OneAxis_fusing,
+        ReduceCPULayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        smoke_Reduce_MultiAxis_3D_fusing_CPU,
+        ReduceCPULayerTest,
+        params_MultiAxis_3D_fusing,
         ReduceCPULayerTest::getTestCaseName
 );
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
@@ -20,7 +20,7 @@ std::vector<std::vector<ov::test::InputShape>> inputShapes_dyn = {
 };
 
 std::vector<std::vector<ov::test::InputShape>> inputShapes_3D_fuse_dyn = {
-    {{{{1, 5}, 19, {1, 10}}, {{1, 19, 2}, {1, 19, 9}}}},
+    {{{{1, 5}, 19, {1, 10}}, {{1, 19, 2}, {1, 19, 9}, {1, 19, 2}}}},
 };
 
 std::vector<std::vector<ov::test::InputShape>> inputShapes_5D_dyn = {


### PR DESCRIPTION
### Details:
 - *Avoid broadcast for depthwise fusion with a shape pattern where channel is the only non-one dimension, e.g., [1, C], [1, C, 1, ..., 1].*
 - *Add test cases that can reproduce this issue beforehand.*

### Tickets:
 - *[CVS-138063](https://jira.devtools.intel.com/browse/CVS-138063)*
