### PR TITLE
[Tmpl test] ExperimentalDetectron DO & GP : enable whole Tensor comparison

### DIFF
--- a/src/plugins/template/tests/functional/op_reference/experimental_detectron_detection_output.cpp
+++ b/src/plugins/template/tests/functional/op_reference/experimental_detectron_detection_output.cpp
@@ -34,14 +34,16 @@ struct ExperimentalDOParams {
           deltasData(CreateTensor(iType, deltasValues)),
           scoresData(CreateTensor(iType, scoresValues)),
           imageSizeInfoData(CreateTensor(iType, imageSizeInfoValues)),
-          refBoxesData(CreateTensor(iType, refBoxesValues)),
-          refClassesData(CreateTensor(ov::element::i32, refClassesValues)),
-          refScoresData(CreateTensor(iType, refScoresValues)),
           testcaseName(testcaseName) {
         roisShape = Shape{num_rois, 4};
         deltasShape = Shape{num_rois, static_cast<size_t>(attrs.num_classes * 4)};
         scoresShape = Shape{num_rois, static_cast<size_t>(attrs.num_classes)};
         imageSizeInfoShape = Shape{1, 3};
+
+        const auto max_d = attrs.max_detections_per_image;
+        refBoxesData = CreateTensor(Shape{max_d, 4}, iType, refBoxesValues);
+        refClassesData = CreateTensor(Shape{max_d}, ov::element::i32, refClassesValues);
+        refScoresData = CreateTensor(Shape{max_d}, iType, refScoresValues);
     }
 
     Attrs attrs;
@@ -65,14 +67,13 @@ class ReferenceExperimentalDOLayerTest : public testing::TestWithParam<Experimen
                                          public CommonReferenceTest {
 public:
     void SetUp() override {
-        legacy_compare = true;
-        auto params = GetParam();
+        const auto& params = GetParam();
         function = CreateFunction(params);
         inputData = {params.roisData, params.deltasData, params.scoresData, params.imageSizeInfoData};
         refOutData = {params.refBoxesData, params.refClassesData, params.refScoresData};
     }
     static std::string getTestCaseName(const testing::TestParamInfo<ExperimentalDOParams>& obj) {
-        auto param = obj.param;
+        const auto& param = obj.param;
         std::ostringstream result;
         result << "roisShape=" << param.roisShape << "_";
         result << "deltasShape=" << param.deltasShape << "_";

--- a/src/plugins/template/tests/functional/op_reference/experimental_detectron_generate_proposals.cpp
+++ b/src/plugins/template/tests/functional/op_reference/experimental_detectron_generate_proposals.cpp
@@ -35,13 +35,15 @@ struct ExperimentalGPParams {
           anchorsData(CreateTensor(iType, anchorsValues)),
           deltasData(CreateTensor(iType, deltasValues)),
           scoresData(CreateTensor(iType, scoresValues)),
-          refRoisData(CreateTensor(iType, refRoisValues)),
-          refScoresData(CreateTensor(iType, refScoresValues)),
           testcaseName(testcaseName) {
         imageSizeInfoShape = Shape{3};
         anchorsShape = Shape{height * width * number_of_channels, 4};
         deltasShape = Shape{number_of_channels * 4, height, width};
         scoresShape = Shape{number_of_channels, height, width};
+
+        const auto post_nms = static_cast<size_t>(attrs.post_nms_count);
+        refRoisData = CreateTensor(Shape{post_nms, 4}, iType, refRoisValues);
+        refScoresData = CreateTensor(Shape{post_nms}, iType, refScoresValues);
     }
 
     Attrs attrs;
@@ -64,14 +66,13 @@ class ReferenceExperimentalGPLayerTest : public testing::TestWithParam<Experimen
                                          public CommonReferenceTest {
 public:
     void SetUp() override {
-        legacy_compare = true;
-        auto params = GetParam();
+        const auto& params = GetParam();
         function = CreateFunction(params);
         inputData = {params.imageSizeInfoData, params.anchorsData, params.deltasData, params.scoresData};
         refOutData = {params.refRoisData, params.refScoresData};
     }
     static std::string getTestCaseName(const testing::TestParamInfo<ExperimentalGPParams>& obj) {
-        auto param = obj.param;
+        const auto& param = obj.param;
         std::ostringstream result;
         result << "imageSizeInfoShape=" << param.imageSizeInfoShape << "_";
         result << "anchorsShape=" << param.anchorsShape << "_";


### PR DESCRIPTION
### Details:
 - Used actual shape in expected output tensor for `ExperimentalDetectronDetectionOutput` and `ExperimentalDetectronGenerateProposalsSingleImage` tests.

### Tickets:
 - CVS-137158, CVS-137161
