### PR TITLE
[intel-npu] Unpublishing ov::internal properties

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -263,10 +263,16 @@ void CompiledModel::initialize_properties() {
           [](const Config& config) {
               return config.get<ENABLE_CPU_PINNING>();
           }}},
+        {ov::hint::model_priority.name(),
+         {true,
+          ov::PropertyMutability::RO,
+          [](const Config& config) {
+              return config.get<MODEL_PRIORITY>();
+          }}},
         // OV Internals
         // =========
         {ov::internal::supported_properties.name(),
-         {true,
+         {false,
           ov::PropertyMutability::RO,
           [&](const Config&) {
               static const std::vector<ov::PropertyName> supportedProperty{
@@ -276,12 +282,6 @@ void CompiledModel::initialize_properties() {
           }}},
         // NPU Private
         // =========
-        {ov::hint::model_priority.name(),
-         {false,
-          ov::PropertyMutability::RO,
-          [](const Config& config) {
-              return config.get<MODEL_PRIORITY>();
-          }}},
         {ov::intel_npu::tiles.name(),
          {false,
           ov::PropertyMutability::RO,

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -291,22 +291,28 @@ Plugin::Plugin()
               const auto specifiedDeviceName = get_specified_device_name(config);
               return _metrics->GetFullDeviceName(specifiedDeviceName);
           }}},
+        {ov::hint::model_priority.name(),
+         {true,
+          ov::PropertyMutability::RW,
+          [](const Config& config) {
+              return config.get<MODEL_PRIORITY>();
+          }}},
         // OV Internals
         // =========
         {ov::internal::caching_properties.name(),
-         {true,
+         {false,
           ov::PropertyMutability::RO,
           [&](const Config&) {
               return _metrics->GetCachingProperties();
           }}},
         {ov::internal::exclusive_async_requests.name(),
-         {true,
+         {false,
           ov::PropertyMutability::RW,
           [](const Config& config) {
               return config.get<EXCLUSIVE_ASYNC_REQUESTS>();
           }}},
         {ov::internal::supported_properties.name(),
-         {true,
+         {false,
           ov::PropertyMutability::RO,
           [&](const Config&) {
               return _metrics->GetInternalSupportedProperties();
@@ -333,12 +339,6 @@ Plugin::Plugin()
           }}},
         // NPU Private
         // =========
-        {ov::hint::model_priority.name(),
-         {false,
-          ov::PropertyMutability::RW,
-          [](const Config& config) {
-              return config.get<MODEL_PRIORITY>();
-          }}},
         {ov::intel_npu::dma_engines.name(),
          {false,
           ov::PropertyMutability::RW,


### PR DESCRIPTION
### Details:
Changes in intel-npu plugin:
- Removing ov::internal properties from public supported_properties list
- publishing model_priority property in supported_properties
