### PR TITLE
Correct the CPU pinning on platforms which P/E Cores are in interleave sequence

### DIFF
--- a/src/inference/src/dev/threading/cpu_streams_executor_internal.cpp
+++ b/src/inference/src/dev/threading/cpu_streams_executor_internal.cpp
@@ -84,7 +84,8 @@ void reserve_cpu_by_streams_info(const std::vector<std::vector<int>> _streams_in
                                  std::vector<std::vector<int>>& _stream_processors,
                                  const int _cpu_status) {
     std::vector<std::vector<int>> streams_table;
-    std::vector<std::vector<std::string>> stream_conditions;
+    std::vector<std::vector<std::pair<std::string, int>>> stream_conditions;
+    std::vector<std::vector<int>> threads_status;  // used to count the number of threads
     std::vector<int> stream_pos;
     std::vector<int> stream_num;
     int num_streams = 0;
@@ -100,13 +101,14 @@ void reserve_cpu_by_streams_info(const std::vector<std::vector<int>> _streams_in
     }
     num_conditions = static_cast<int>(stream_pos.size());
     _stream_processors.assign(num_streams, std::vector<int>());
-    stream_conditions.assign(num_conditions, std::vector<std::string>());
+    stream_conditions.assign(num_conditions, std::vector<std::pair<std::string, int>>());
+    threads_status.assign(num_conditions, std::vector<int>());
     stream_num.assign(num_conditions, 0);
 
     for (size_t i = 0; i < _streams_info_table.size(); i++) {
-        std::vector<std::string> proc_types;
-        std::vector<std::string> numa_nodes;
-        std::vector<std::string> sockets;
+        std::string proc_type = "";
+        std::string numa_node = "";
+        std::string socket = "";
         if (_streams_info_table[i][NUMBER_OF_STREAMS] != 0) {
             streams_table.push_back(_streams_info_table[i]);
             if (_streams_info_table[i][NUMBER_OF_STREAMS] < 0) {
@@ -118,22 +120,20 @@ void reserve_cpu_by_streams_info(const std::vector<std::vector<int>> _streams_in
             condition_idx++;
         }
         if (_streams_info_table[i][PROC_TYPE] > ALL_PROC) {
-            proc_types.push_back(std::to_string(_streams_info_table[i][PROC_TYPE]));
+            proc_type = std::to_string(_streams_info_table[i][PROC_TYPE]);
         } else {
             last_all_proc = true;
         }
         if (_streams_info_table[i][STREAM_NUMA_NODE_ID] >= 0) {
-            numa_nodes.push_back(std::to_string(_streams_info_table[i][STREAM_NUMA_NODE_ID]));
+            numa_node = std::to_string(_streams_info_table[i][STREAM_NUMA_NODE_ID]);
         }
         if (_streams_info_table[i][STREAM_SOCKET_ID] >= 0) {
-            sockets.push_back(std::to_string(_streams_info_table[i][STREAM_SOCKET_ID]));
+            socket = std::to_string(_streams_info_table[i][STREAM_SOCKET_ID]);
         }
-        for (auto t : proc_types) {
-            for (auto n : numa_nodes) {
-                for (auto s : sockets) {
-                    stream_conditions[condition_idx].push_back(t + n + s);
-                }
-            }
+        if (proc_type != "") {
+            stream_conditions[condition_idx].push_back(
+                std::make_pair(proc_type + numa_node + socket, _streams_info_table[i][THREADS_PER_STREAM]));
+            threads_status[condition_idx].push_back(0);
         }
         if (_streams_info_table[i][PROC_TYPE] > ALL_PROC && _streams_info_table[i][NUMBER_OF_STREAMS] > 0) {
             condition_idx++;
@@ -146,8 +146,20 @@ void reserve_cpu_by_streams_info(const std::vector<std::vector<int>> _streams_in
                                      std::to_string(_cpu_mapping_table[i][CPU_MAP_NUMA_NODE_ID]) +
                                      std::to_string(_cpu_mapping_table[i][CPU_MAP_SOCKET_ID]);
             for (size_t j = 0; j < stream_conditions.size(); j++) {
-                if (std::find(stream_conditions[j].begin(), stream_conditions[j].end(), cpu_string) !=
-                    stream_conditions[j].end()) {
+                auto iter = std::find_if(stream_conditions[j].begin(),
+                                         stream_conditions[j].end(),
+                                         [&](std::pair<std::string, int> item) {
+                                             return cpu_string == item.first;
+                                         });
+                if (iter != stream_conditions[j].end()) {
+                    // process the situation of proc_type = ALL_PROC
+                    if (stream_conditions[j].size() > 1) {
+                        int idx = iter - stream_conditions[j].begin();
+                        threads_status[j][idx]++;
+                        if (threads_status[j][idx] >= stream_conditions[j][idx].second) {
+                            stream_conditions[j][idx] = std::make_pair("", 0);
+                        }
+                    }
                     _stream_processors[stream_pos[j]].push_back(_cpu_mapping_table[i][CPU_MAP_PROCESSOR_ID]);
                     _cpu_mapping_table[i][CPU_MAP_USED_FLAG] = _cpu_status;
                     if (static_cast<int>(_stream_processors[stream_pos[j]].size()) ==

--- a/src/inference/src/dev/threading/cpu_streams_executor_internal.cpp
+++ b/src/inference/src/dev/threading/cpu_streams_executor_internal.cpp
@@ -154,7 +154,7 @@ void reserve_cpu_by_streams_info(const std::vector<std::vector<int>> _streams_in
                 if (iter != stream_conditions[j].end()) {
                     // process the situation of proc_type = ALL_PROC
                     if (stream_conditions[j].size() > 1) {
-                        int idx = iter - stream_conditions[j].begin();
+                        size_t idx = iter - stream_conditions[j].begin();
                         threads_status[j][idx]++;
                         if (threads_status[j][idx] >= stream_conditions[j][idx].second) {
                             stream_conditions[j][idx] = std::make_pair("", 0);

--- a/src/inference/src/os/cpu_map_info.hpp
+++ b/src/inference/src/os/cpu_map_info.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "dev/threading/parallel_custom_arena.hpp"
+#include "openvino/util/log.hpp"
 
 namespace ov {
 
@@ -20,6 +21,24 @@ class CPU {
 public:
     CPU();
     ~CPU(){};
+    void cpu_debug() {
+        OPENVINO_DEBUG << "[ threading ] cpu_mapping_table:";
+        for (size_t i = 0; i < _cpu_mapping_table.size(); i++) {
+            OPENVINO_DEBUG << _cpu_mapping_table[i][CPU_MAP_PROCESSOR_ID] << " "
+                           << _cpu_mapping_table[i][CPU_MAP_NUMA_NODE_ID] << " "
+                           << _cpu_mapping_table[i][CPU_MAP_SOCKET_ID] << " " << _cpu_mapping_table[i][CPU_MAP_CORE_ID]
+                           << " " << _cpu_mapping_table[i][CPU_MAP_CORE_TYPE] << " "
+                           << _cpu_mapping_table[i][CPU_MAP_GROUP_ID] << " "
+                           << _cpu_mapping_table[i][CPU_MAP_USED_FLAG];
+        }
+        OPENVINO_DEBUG << "[ threading ] org_proc_type_table:";
+        for (size_t i = 0; i < _proc_type_table.size(); i++) {
+            OPENVINO_DEBUG << _proc_type_table[i][ALL_PROC] << " " << _proc_type_table[i][MAIN_CORE_PROC] << " "
+                           << _proc_type_table[i][EFFICIENT_CORE_PROC] << " "
+                           << _proc_type_table[i][HYPER_THREADING_PROC] << " " << _proc_type_table[i][PROC_NUMA_NODE_ID]
+                           << " " << _proc_type_table[i][PROC_SOCKET_ID];
+        }
+    }
     int _processors = 0;
     int _numa_nodes = 0;
     int _sockets = 0;

--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -14,7 +14,6 @@
 #include "dev/threading/parallel_custom_arena.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/runtime/system_conf.hpp"
-#include "openvino/util/log.hpp"
 #include "os/cpu_map_info.hpp"
 
 namespace ov {
@@ -279,20 +278,7 @@ CPU::CPU() {
 
     _org_proc_type_table = _proc_type_table;
 
-    OPENVINO_DEBUG << "[ threading ] cpu_mapping_table:";
-    for (size_t i = 0; i < _cpu_mapping_table.size(); i++) {
-        OPENVINO_DEBUG << _cpu_mapping_table[i][CPU_MAP_PROCESSOR_ID] << " "
-                       << _cpu_mapping_table[i][CPU_MAP_NUMA_NODE_ID] << " " << _cpu_mapping_table[i][CPU_MAP_SOCKET_ID]
-                       << " " << _cpu_mapping_table[i][CPU_MAP_CORE_ID] << " "
-                       << _cpu_mapping_table[i][CPU_MAP_CORE_TYPE] << " " << _cpu_mapping_table[i][CPU_MAP_GROUP_ID]
-                       << " " << _cpu_mapping_table[i][CPU_MAP_USED_FLAG];
-    }
-    OPENVINO_DEBUG << "[ threading ] org_proc_type_table:";
-    for (size_t i = 0; i < _proc_type_table.size(); i++) {
-        OPENVINO_DEBUG << _proc_type_table[i][ALL_PROC] << " " << _proc_type_table[i][MAIN_CORE_PROC] << " "
-                       << _proc_type_table[i][EFFICIENT_CORE_PROC] << " " << _proc_type_table[i][HYPER_THREADING_PROC]
-                       << " " << _proc_type_table[i][PROC_NUMA_NODE_ID] << " " << _proc_type_table[i][PROC_SOCKET_ID];
-    }
+    cpu_debug();
 }
 
 void parse_node_info_linux(const std::vector<std::string> node_info_table,

--- a/src/inference/src/os/mac/mac_system_conf.cpp
+++ b/src/inference/src/os/mac/mac_system_conf.cpp
@@ -31,6 +31,8 @@ CPU::CPU() {
 
     parse_processor_info_macos(system_info_table, _processors, _numa_nodes, _sockets, _cores, _proc_type_table);
     _org_proc_type_table = _proc_type_table;
+
+    cpu_debug();
 }
 
 void parse_processor_info_macos(const std::vector<std::pair<std::string, uint64_t>>& system_info_table,

--- a/src/inference/src/os/win/win_system_conf.cpp
+++ b/src/inference/src/os/win/win_system_conf.cpp
@@ -51,6 +51,8 @@ CPU::CPU() {
             _socketid_mapping_table.insert({socket_id, socket_id});
         }
     }
+
+    cpu_debug();
 }
 
 void parse_processor_info_win(const char* base_ptr,

--- a/src/inference/tests/unit/cpu_reserve_test.cpp
+++ b/src/inference/tests/unit/cpu_reserve_test.cpp
@@ -1182,21 +1182,22 @@ LinuxCpuReserveTestCase _1socket_32cores_hyper_1streams = {
     NOT_USED,
 };
 
-LinuxCpuReserveTestCase _1socket_20cores_MTL_1streams_6threads = {
-    20,
+LinuxCpuReserveTestCase _1socket_22cores_MTL_1streams_6threads = {
+    22,
     1,
-    {{20, 6, 8, 6, 0, 0}},
+    {{22, 6, 10, 6, 0, 0}},
     {
-        {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 0, MAIN_CORE_PROC, 0, -1},
-        {2, 0, 0, 1, EFFICIENT_CORE_PROC, 1, -1},     {3, 0, 0, 1, EFFICIENT_CORE_PROC, 2, -1},
-        {4, 0, 0, 2, EFFICIENT_CORE_PROC, 3, -1},     {5, 0, 0, 2, EFFICIENT_CORE_PROC, 4, -1},
-        {6, 0, 0, 3, EFFICIENT_CORE_PROC, 5, -1},     {7, 0, 0, 3, EFFICIENT_CORE_PROC, 6, -1},
-        {8, 0, 0, 4, EFFICIENT_CORE_PROC, 7, -1},     {9, 0, 0, 4, EFFICIENT_CORE_PROC, 8, -1},
-        {10, 0, 0, 5, HYPER_THREADING_PROC, 9, -1},   {11, 0, 0, 5, MAIN_CORE_PROC, 9, -1},
-        {12, 0, 0, 6, HYPER_THREADING_PROC, 10, -1},  {13, 0, 0, 6, MAIN_CORE_PROC, 10, -1},
-        {14, 0, 0, 7, HYPER_THREADING_PROC, 11, -1},  {15, 0, 0, 7, MAIN_CORE_PROC, 11, -1},
-        {16, 0, 0, 8, HYPER_THREADING_PROC, 12, -1},  {17, 0, 0, 9, MAIN_CORE_PROC, 12, -1},
-        {18, 0, 0, 10, HYPER_THREADING_PROC, 13, -1}, {19, 0, 0, 11, MAIN_CORE_PROC, 13, -1},
+        {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},       {1, 0, 0, 0, MAIN_CORE_PROC, 0, -1},
+        {2, 0, 0, 1, EFFICIENT_CORE_PROC, 1, -1},        {3, 0, 0, 2, EFFICIENT_CORE_PROC, 1, -1},
+        {4, 0, 0, 3, EFFICIENT_CORE_PROC, 1, -1},        {5, 0, 0, 4, EFFICIENT_CORE_PROC, 1, -1},
+        {6, 0, 0, 5, EFFICIENT_CORE_PROC, 2, -1},        {7, 0, 0, 6, EFFICIENT_CORE_PROC, 2, -1},
+        {8, 0, 0, 7, EFFICIENT_CORE_PROC, 2, -1},        {9, 0, 0, 8, EFFICIENT_CORE_PROC, 2, -1},
+        {10, 0, 0, 9, HYPER_THREADING_PROC, 3, -1},      {11, 0, 0, 9, MAIN_CORE_PROC, 3, -1},
+        {12, 0, 0, 10, HYPER_THREADING_PROC, 4, -1},     {13, 0, 0, 10, MAIN_CORE_PROC, 4, -1},
+        {14, 0, 0, 11, HYPER_THREADING_PROC, 5, -1},     {15, 0, 0, 11, MAIN_CORE_PROC, 5, -1},
+        {16, 0, 0, 12, HYPER_THREADING_PROC, 6, -1},     {17, 0, 0, 12, MAIN_CORE_PROC, 6, -1},
+        {18, 0, 0, 13, HYPER_THREADING_PROC, 7, -1},     {19, 0, 0, 13, MAIN_CORE_PROC, 7, -1},
+        {20, 0, 0, 14, EFFICIENT_CORE_PROC, -100, -100}, {21, 0, 0, 15, EFFICIENT_CORE_PROC, -100, -100},
     },
     {{1, MAIN_CORE_PROC, 6, 0, 0}},
     {
@@ -1205,21 +1206,22 @@ LinuxCpuReserveTestCase _1socket_20cores_MTL_1streams_6threads = {
     NOT_USED,
 };
 
-LinuxCpuReserveTestCase _1socket_20cores_MTL_1streams_7threads = {
-    20,
+LinuxCpuReserveTestCase _1socket_22cores_MTL_1streams_7threads = {
+    22,
     1,
-    {{20, 6, 8, 6, 0, 0}},
+    {{22, 6, 10, 6, 0, 0}},
     {
-        {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 0, MAIN_CORE_PROC, 0, -1},
-        {2, 0, 0, 1, EFFICIENT_CORE_PROC, 1, -1},     {3, 0, 0, 1, EFFICIENT_CORE_PROC, 2, -1},
-        {4, 0, 0, 2, EFFICIENT_CORE_PROC, 3, -1},     {5, 0, 0, 2, EFFICIENT_CORE_PROC, 4, -1},
-        {6, 0, 0, 3, EFFICIENT_CORE_PROC, 5, -1},     {7, 0, 0, 3, EFFICIENT_CORE_PROC, 6, -1},
-        {8, 0, 0, 4, EFFICIENT_CORE_PROC, 7, -1},     {9, 0, 0, 4, EFFICIENT_CORE_PROC, 8, -1},
-        {10, 0, 0, 5, HYPER_THREADING_PROC, 9, -1},   {11, 0, 0, 5, MAIN_CORE_PROC, 9, -1},
-        {12, 0, 0, 6, HYPER_THREADING_PROC, 10, -1},  {13, 0, 0, 6, MAIN_CORE_PROC, 10, -1},
-        {14, 0, 0, 7, HYPER_THREADING_PROC, 11, -1},  {15, 0, 0, 7, MAIN_CORE_PROC, 11, -1},
-        {16, 0, 0, 8, HYPER_THREADING_PROC, 12, -1},  {17, 0, 0, 9, MAIN_CORE_PROC, 12, -1},
-        {18, 0, 0, 10, HYPER_THREADING_PROC, 13, -1}, {19, 0, 0, 11, MAIN_CORE_PROC, 13, -1},
+        {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},       {1, 0, 0, 0, MAIN_CORE_PROC, 0, -1},
+        {2, 0, 0, 1, EFFICIENT_CORE_PROC, 1, -1},        {3, 0, 0, 2, EFFICIENT_CORE_PROC, 1, -1},
+        {4, 0, 0, 3, EFFICIENT_CORE_PROC, 1, -1},        {5, 0, 0, 4, EFFICIENT_CORE_PROC, 1, -1},
+        {6, 0, 0, 5, EFFICIENT_CORE_PROC, 2, -1},        {7, 0, 0, 6, EFFICIENT_CORE_PROC, 2, -1},
+        {8, 0, 0, 7, EFFICIENT_CORE_PROC, 2, -1},        {9, 0, 0, 8, EFFICIENT_CORE_PROC, 2, -1},
+        {10, 0, 0, 9, HYPER_THREADING_PROC, 3, -1},      {11, 0, 0, 9, MAIN_CORE_PROC, 3, -1},
+        {12, 0, 0, 10, HYPER_THREADING_PROC, 4, -1},     {13, 0, 0, 10, MAIN_CORE_PROC, 4, -1},
+        {14, 0, 0, 11, HYPER_THREADING_PROC, 5, -1},     {15, 0, 0, 11, MAIN_CORE_PROC, 5, -1},
+        {16, 0, 0, 12, HYPER_THREADING_PROC, 6, -1},     {17, 0, 0, 12, MAIN_CORE_PROC, 6, -1},
+        {18, 0, 0, 13, HYPER_THREADING_PROC, 7, -1},     {19, 0, 0, 13, MAIN_CORE_PROC, 7, -1},
+        {20, 0, 0, 14, EFFICIENT_CORE_PROC, -100, -100}, {21, 0, 0, 15, EFFICIENT_CORE_PROC, -100, -100},
     },
     {{1, ALL_PROC, 7, 0, 0}, {0, MAIN_CORE_PROC, 6, 0, 0}, {0, EFFICIENT_CORE_PROC, 1, 0, 0}},
     {
@@ -1256,7 +1258,7 @@ INSTANTIATE_TEST_SUITE_P(CPUReserve,
                                          _1socket_18cores_hyper_2streams,
                                          _1socket_18cores_hyper_plugin_reserve_2threads,
                                          _1socket_32cores_hyper_1streams,
-                                         _1socket_20cores_MTL_1streams_6threads,
-                                         _1socket_20cores_MTL_1streams_7threads));
+                                         _1socket_22cores_MTL_1streams_6threads,
+                                         _1socket_22cores_MTL_1streams_7threads));
 #endif
 }  // namespace

--- a/src/inference/tests/unit/cpu_reserve_test.cpp
+++ b/src/inference/tests/unit/cpu_reserve_test.cpp
@@ -1182,6 +1182,52 @@ LinuxCpuReserveTestCase _1socket_32cores_hyper_1streams = {
     NOT_USED,
 };
 
+LinuxCpuReserveTestCase _1socket_20cores_MTL_1streams_6threads = {
+    20,
+    1,
+    {{20, 6, 8, 6, 0, 0}},
+    {
+        {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 0, MAIN_CORE_PROC, 0, -1},
+        {2, 0, 0, 1, EFFICIENT_CORE_PROC, 1, -1},     {3, 0, 0, 1, EFFICIENT_CORE_PROC, 2, -1},
+        {4, 0, 0, 2, EFFICIENT_CORE_PROC, 3, -1},     {5, 0, 0, 2, EFFICIENT_CORE_PROC, 4, -1},
+        {6, 0, 0, 3, EFFICIENT_CORE_PROC, 5, -1},     {7, 0, 0, 3, EFFICIENT_CORE_PROC, 6, -1},
+        {8, 0, 0, 4, EFFICIENT_CORE_PROC, 7, -1},     {9, 0, 0, 4, EFFICIENT_CORE_PROC, 8, -1},
+        {10, 0, 0, 5, HYPER_THREADING_PROC, 9, -1},   {11, 0, 0, 5, MAIN_CORE_PROC, 9, -1},
+        {12, 0, 0, 6, HYPER_THREADING_PROC, 10, -1},  {13, 0, 0, 6, MAIN_CORE_PROC, 10, -1},
+        {14, 0, 0, 7, HYPER_THREADING_PROC, 11, -1},  {15, 0, 0, 7, MAIN_CORE_PROC, 11, -1},
+        {16, 0, 0, 8, HYPER_THREADING_PROC, 12, -1},  {17, 0, 0, 9, MAIN_CORE_PROC, 12, -1},
+        {18, 0, 0, 10, HYPER_THREADING_PROC, 13, -1}, {19, 0, 0, 11, MAIN_CORE_PROC, 13, -1},
+    },
+    {{1, MAIN_CORE_PROC, 6, 0, 0}},
+    {
+        {1, 11, 13, 15, 17, 19},
+    },
+    NOT_USED,
+};
+
+LinuxCpuReserveTestCase _1socket_20cores_MTL_1streams_7threads = {
+    20,
+    1,
+    {{20, 6, 8, 6, 0, 0}},
+    {
+        {0, 0, 0, 0, HYPER_THREADING_PROC, 0, -1},    {1, 0, 0, 0, MAIN_CORE_PROC, 0, -1},
+        {2, 0, 0, 1, EFFICIENT_CORE_PROC, 1, -1},     {3, 0, 0, 1, EFFICIENT_CORE_PROC, 2, -1},
+        {4, 0, 0, 2, EFFICIENT_CORE_PROC, 3, -1},     {5, 0, 0, 2, EFFICIENT_CORE_PROC, 4, -1},
+        {6, 0, 0, 3, EFFICIENT_CORE_PROC, 5, -1},     {7, 0, 0, 3, EFFICIENT_CORE_PROC, 6, -1},
+        {8, 0, 0, 4, EFFICIENT_CORE_PROC, 7, -1},     {9, 0, 0, 4, EFFICIENT_CORE_PROC, 8, -1},
+        {10, 0, 0, 5, HYPER_THREADING_PROC, 9, -1},   {11, 0, 0, 5, MAIN_CORE_PROC, 9, -1},
+        {12, 0, 0, 6, HYPER_THREADING_PROC, 10, -1},  {13, 0, 0, 6, MAIN_CORE_PROC, 10, -1},
+        {14, 0, 0, 7, HYPER_THREADING_PROC, 11, -1},  {15, 0, 0, 7, MAIN_CORE_PROC, 11, -1},
+        {16, 0, 0, 8, HYPER_THREADING_PROC, 12, -1},  {17, 0, 0, 9, MAIN_CORE_PROC, 12, -1},
+        {18, 0, 0, 10, HYPER_THREADING_PROC, 13, -1}, {19, 0, 0, 11, MAIN_CORE_PROC, 13, -1},
+    },
+    {{1, ALL_PROC, 7, 0, 0}, {0, MAIN_CORE_PROC, 6, 0, 0}, {0, EFFICIENT_CORE_PROC, 1, 0, 0}},
+    {
+        {1, 2, 11, 13, 15, 17, 19},
+    },
+    NOT_USED,
+};
+
 TEST_P(LinuxCpuReserveTests, LinuxCpuReserve) {}
 
 INSTANTIATE_TEST_SUITE_P(CPUReserve,
@@ -1209,6 +1255,8 @@ INSTANTIATE_TEST_SUITE_P(CPUReserve,
                                          _1socket_18cores_hyper_1streams,
                                          _1socket_18cores_hyper_2streams,
                                          _1socket_18cores_hyper_plugin_reserve_2threads,
-                                         _1socket_32cores_hyper_1streams));
+                                         _1socket_32cores_hyper_1streams,
+                                         _1socket_20cores_MTL_1streams_6threads,
+                                         _1socket_20cores_MTL_1streams_7threads));
 #endif
 }  // namespace


### PR DESCRIPTION
### Details:
 - Fix wrong binding to 6E+1P cores on MTL windows with command "-pin HYBRID_AWARE -nthreads 7"
 - Correct binding cores: 6P+1E
 - Add test case
 - Add CPU debug on Windows and Mac

### Tickets:
 - *CVS-138630*
