### PR TITLE
[Python][Wheel] Added RISCV64 support for wheel setup

### DIFF
--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -38,6 +38,8 @@ elif machine == "arm" or machine == "armv7l":
     ARCH = "arm"
 elif machine == "aarch64" or machine == "arm64" or machine == "ARM64":
     ARCH = "arm64"
+elif machine == "riscv64":
+    ARCH = "riscv64"
 
 # The following variables can be defined in environment or .env file
 SCRIPT_DIR = Path(__file__).resolve().parents[0]


### PR DESCRIPTION
### Details:
 - *The PR adds RISCV64 arch for python wheel setup to fix the following error during build on the target machine:*
 ```
[100%] Building Python wheel openvino-2024.2.0-14978-cp310-cp310-manylinux_2_36_riscv64.whl
Processing /home/sipeed/openvino/openvino/src/bindings/python/wheel
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/sipeed/openvino/openvino/src/bindings/python/wheel/setup.py", line 50, in <module>
          OV_RUNTIME_LIBS_DIR = os.getenv("OV_RUNTIME_LIBS_DIR", f"runtime/{LIBS_DIR}/{ARCH}/{CONFIG}")
      NameError: name 'ARCH' is not defined
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
make[2]: *** [src/bindings/python/wheel/CMakeFiles/ie_wheel.dir/build.make:177: wheels/openvino-2024.2.0-14978-cp310-cp310-manylinux_2_36_riscv64.whl] Error 1
make[1]: *** [CMakeFiles/Makefile2:2841: src/bindings/python/wheel/CMakeFiles/ie_wheel.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

### Tickets:
 - *N/A*
