### PR TITLE
[JS API] Add config param to Core.import_model()

### DIFF
--- a/src/bindings/js/node/include/helper.hpp
+++ b/src/bindings/js/node/include/helper.hpp
@@ -172,6 +172,8 @@ bool acceptableType(const Napi::Value& val, const std::vector<napi_types>& accep
 
 Napi::Value any_to_js(const Napi::CallbackInfo& info, ov::Any value);
 
-ov::Any js_to_any(const Napi::CallbackInfo& info, Napi::Value value);
+ov::Any js_to_any(const Napi::Env& env, const Napi::Value& value);
 
-bool is_napi_value_int(const Napi::CallbackInfo& info, Napi::Value& num);
+bool is_napi_value_int(const Napi::Env& env, const Napi::Value& num);
+
+ov::AnyMap to_anyMap(const Napi::Env&, const Napi::Value&);

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -27,7 +27,6 @@ std::tuple<ov::AnyMap, std::string> try_get_set_property_parameters(const Napi::
     validate_set_property_args(info);
 
     std::string device_name;
-    ov::AnyMap properties;
 
     const size_t args_length = info.Length();
 
@@ -35,16 +34,7 @@ std::tuple<ov::AnyMap, std::string> try_get_set_property_parameters(const Napi::
         device_name = info[0].ToString();
 
     const size_t parameters_position_index = device_name.empty() ? 0 : 1;
-    Napi::Object parameters = info[parameters_position_index].ToObject();
-    const auto& keys = parameters.GetPropertyNames();
-
-    for (uint32_t i = 0; i < keys.Length(); ++i) {
-        auto property_name = static_cast<Napi::Value>(keys[i]).ToString().Utf8Value();
-
-        ov::Any any_value = js_to_any(info.Env(), parameters.Get(property_name));
-
-        properties.insert(std::make_pair(property_name, any_value));
-    }
+    const auto& properties = to_anyMap(info.Env(), info[parameters_position_index]);
 
     return std::make_tuple(properties, device_name);
 }

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -510,7 +510,7 @@ Napi::Value any_to_js(const Napi::CallbackInfo& info, ov::Any value) {
     return info.Env().Undefined();
 }
 
-ov::Any js_to_any(const Napi::CallbackInfo& info, Napi::Value value) {
+ov::Any js_to_any(const Napi::Env& env, const Napi::Value& value) {
     if (value.IsString()) {
         return ov::Any(value.ToString().Utf8Value());
     } else if (value.IsBigInt()) {
@@ -526,7 +526,7 @@ ov::Any js_to_any(const Napi::CallbackInfo& info, Napi::Value value) {
     } else if (value.IsNumber()) {
         Napi::Number num = value.ToNumber();
 
-        if (is_napi_value_int(info, value)) {
+        if (is_napi_value_int(env, value)) {
             return ov::Any(num.Int32Value());
         } else {
             return ov::Any(num.DoubleValue());
@@ -538,14 +538,22 @@ ov::Any js_to_any(const Napi::CallbackInfo& info, Napi::Value value) {
     }
 }
 
-bool is_napi_value_int(const Napi::CallbackInfo& info, Napi::Value& num) {
-    return info.Env()
-        .Global()
-        .Get("Number")
-        .ToObject()
-        .Get("isInteger")
-        .As<Napi::Function>()
-        .Call({num})
-        .ToBoolean()
-        .Value();
+bool is_napi_value_int(const Napi::Env& env, const Napi::Value& num) {
+    return env.Global().Get("Number").ToObject().Get("isInteger").As<Napi::Function>().Call({num}).ToBoolean().Value();
+}
+
+ov::AnyMap to_anyMap(const Napi::Env& env, const Napi::Value& val) {
+    ov::AnyMap properties;
+    const auto& parameters = val.ToObject();
+    const auto& keys = parameters.GetPropertyNames();
+
+    for (uint32_t i = 0; i < keys.Length(); ++i) {
+        const auto& property_name = static_cast<Napi::Value>(keys[i]).ToString().Utf8Value();
+
+        ov::Any any_value = js_to_any(env, parameters.Get(property_name));
+
+        properties.insert(std::make_pair(property_name, any_value));
+    }
+
+    return properties;
 }

--- a/src/bindings/js/node/tests/basic.test.js
+++ b/src/bindings/js/node/tests/basic.test.js
@@ -193,6 +193,7 @@ describe('Test exportModel()/importModel()', () => {
   const tensor = Float32Array.from({ length: 3072 }, () => (Math.random() + epsilon));
   const inferRequest = compiledModel.createInferRequest();
   const res1 = inferRequest.infer([tensor]);
+
   it('Test importModel(stream, device)', () => {
     const newCompiled = core.importModelSync(userStream, 'CPU');
     const newInferRequest = newCompiled.createInferRequest();
@@ -205,7 +206,21 @@ describe('Test exportModel()/importModel()', () => {
     const newCompiled = core.importModelSync(userStream, 'CPU', { 'NUM_STREAMS': 1 });
     const newInferRequest = newCompiled.createInferRequest();
     const res2 = newInferRequest.infer([tensor]);
-    
+
     assert.deepStrictEqual(res1['fc_out'].data[0], res2['fc_out'].data[0]);
+  });
+
+  it('Test importModel(stream, device)', () => {
+    assert.throws(
+      () => core.importModelSync(epsilon, 'CPU'),
+      /The first argument must be of type Buffer./
+    );
+  });
+
+  it('Test importModel(stream, device)', () => {
+    assert.throws(
+      () => core.importModelSync(userStream, tensor),
+      /The second argument must be of type String./
+    );
   });
 });

--- a/src/bindings/js/node/tests/basic.test.js
+++ b/src/bindings/js/node/tests/basic.test.js
@@ -14,10 +14,10 @@ const compiledModel = core.compileModelSync(model, 'CPU');
 const modelLike = [[model],
   [compiledModel]];
 
-it('Core.getAvailableDevices()', () => {    
-    const devices = core.getAvailableDevices();
-    
-    assert.ok(devices.includes('CPU'));
+it('Core.getAvailableDevices()', () => {
+  const devices = core.getAvailableDevices();
+
+  assert.ok(devices.includes('CPU'));
 });
 
 it('CompiledModel type', () => {
@@ -187,16 +187,25 @@ describe('Input class for ov::Input<const ov::Node>', () => {
 
 });
 
-it('Test exportModel()/importModel()', () => {
+describe('Test exportModel()/importModel()', () => {
   const userStream = compiledModel.exportModelSync();
-  const newCompiled = core.importModelSync(userStream, 'CPU');
   const epsilon = 0.5;
   const tensor = Float32Array.from({ length: 3072 }, () => (Math.random() + epsilon));
-
   const inferRequest = compiledModel.createInferRequest();
   const res1 = inferRequest.infer([tensor]);
-  const newInferRequest = newCompiled.createInferRequest();
-  const res2 = newInferRequest.infer([tensor]);
+  it('Test importModel(stream, device)', () => {
+    const newCompiled = core.importModelSync(userStream, 'CPU');
+    const newInferRequest = newCompiled.createInferRequest();
+    const res2 = newInferRequest.infer([tensor]);
 
-  assert.deepStrictEqual(res1['fc_out'].data[0], res2['fc_out'].data[0]);
+    assert.deepStrictEqual(res1['fc_out'].data[0], res2['fc_out'].data[0]);
+  });
+
+  it('Test importModel(stream, device, config)', () => {
+    const newCompiled = core.importModelSync(userStream, 'CPU', { 'NUM_STREAMS': 1 });
+    const newInferRequest = newCompiled.createInferRequest();
+    const res2 = newInferRequest.infer([tensor]);
+    
+    assert.deepStrictEqual(res1['fc_out'].data[0], res2['fc_out'].data[0]);
+  });
 });


### PR DESCRIPTION
### Details:
 - add `Core.import_model(stream, device_name, config[optional})
 - add ` ov::AnyMap to_anyMap(const Napi::Env&, const Napi::Value&)` helper for conversion from Napi::Value to ov::AnyMap and reuse it in other methods 

### Tickets:
 - *136460*
