### PR TITLE
[CPU] Reduce overhead of moving to a numa node

### DIFF
--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -576,8 +576,17 @@ void Node::updateDynamicParams() {
         }
     }
 }
-void Node::executeDynamic(dnnl::stream strm) {
+
+void Node::executeStatic(const dnnl::stream strm, int numaId) {
+    if (numaId >= 0)
+        toNumaNode(numaId);
+    execute(strm);
+}
+
+void Node::executeDynamic(dnnl::stream strm, int numaId) {
     if (isExecutable()) {
+        if (numaId >= 0)
+            toNumaNode(numaId);
         executeDynamicImpl(strm);
     }
     updateLastInputDims();
@@ -907,9 +916,6 @@ MemoryPtr Node::prepareWeightMemory(DnnlMemoryDescPtr dstWeightDesc, DnnlMemoryD
 }
 
 void Node::toNumaNode(int numaNodeID) {
-    if (!isExecutable())
-        return;
-
     return toNumaNodeImpl(numaNodeID);
 }
 

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -435,10 +435,13 @@ public:
 
     virtual void resolveInPlaceEdges(Edge::LOOK look = Edge::LOOK_BOTH);
 
-    virtual void execute(dnnl::stream strm) = 0;
+    // @todo this supposed to be 'execute + executeImpl' instead of 'executeStatic + execute'
+    // but this requires changes in all the nodes. Since moving to a numa node right before an execute
+    // is a temprorary solution, do it this way for now.
+    void executeStatic(const dnnl::stream strm, int numaId = -1);
     void updateShapes();
     void updateDynamicParams();
-    void executeDynamic(dnnl::stream strm);
+    void executeDynamic(dnnl::stream strm, int numaId = -1);
     virtual void redefineOutputMemory(const std::vector<VectorDims> &newShapes);
     void redefineOutputMemory(const size_t port, const VectorDims& new_output_shape);
     bool outputShapeDataDependency() const;
@@ -759,6 +762,7 @@ protected:
     virtual bool needShapeInfer() const;
     std::vector<VectorDims> shapeInferGeneric(const std::vector<Shape>& inputDims) const;
     IShapeInfer::Result shapeInfer() const;
+    virtual void execute(dnnl::stream strm) = 0;
     // TODO [DS] : make pure after all nodes will be support dynamic shapes
     virtual void executeDynamicImpl(dnnl::stream strm) {
         OPENVINO_THROW_NOT_IMPLEMENTED("[DS] executeDynamicImpl not implemented for node with type: ", getTypeStr());


### PR DESCRIPTION
### Details:
 - By combining move and execute into single function, so
isExecutable() check is performed only once
 - It turned out isExecutable() check is not that lightweight. For some models it adds noticeable (about 5%+) latency overhead. So, the solution is to group 'execute' and 'toNumaNode' into a single function and perform the check only once.
 - fixes overhead introduced by another fix:
 https://github.com/openvinotoolkit/openvino/pull/23849

### Tickets:
 - 138220