### PR TITLE
[GPU] Optimize FC kernels for INT4 vector * matrix with short output size

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/format.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/format.hpp
@@ -143,6 +143,7 @@ struct format {
         o_is_yx_isv16,                                ///< format used only for convolution weights
         os_is_yx_osv16_isv16,                         ///< format used for convolution i8 weights
         os_is_zyx_osv32_isv16,
+        os_is_yx_osv32_isv2,                          ///< format used only for fully connected weights compressed for i4
         os_is_zyx_osv64_isv16,
         os_zyxi_osv16,                                ///< format used for weights for 3D convolution
         os_is_yx_isv16_osv16,                         ///< format used for blocked convolution

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -498,6 +498,8 @@ kernel_selector::weights_layout to_weights_layout(format f, bool is_grouped) {
             return kernel_selector::weights_layout::os_i_osv16__ai8;
         case format::os_i_osv16:
             return kernel_selector::weights_layout::os_i_osv16;
+        case format::os_is_yx_osv32_isv2:
+            return kernel_selector::weights_layout::os_is_yx_osv32_isv2;
         case format::os_is_zyx_isv16_osv16:
             return kernel_selector::weights_layout::os_is_zyx_isv16_osv16;
         case format::is_os_zyx_isv16_osv16:
@@ -620,6 +622,8 @@ cldnn::format::type from_weights_layout(kernel_selector::weights_layout l) {
             return cldnn::format::os_iyx_osv64;
         case kernel_selector::weights_layout::os_i_osv16:
             return cldnn::format::os_i_osv16;
+        case kernel_selector::weights_layout::os_is_yx_osv32_isv2:
+            return cldnn::format::os_is_yx_osv32_isv2;
         case kernel_selector::weights_layout::os_i_osv8__ai8:
             return cldnn::format::os_i_osv8__ai8;
         case kernel_selector::weights_layout::os_i_osv16__ai8:

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
@@ -287,6 +287,12 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
 
             unroll_for(uint load_iter = 0; load_iter < FILTER_LOAD_ITERS; ++load_iter) {
                 SLM_FILTER_PACKED_VEC wei_packed = BLOCK_READN(FILTER_TYPE, FILTER_LOAD_BLOCK_SIZE, weights, weights_idx);
+                #if TILE_K == 4 && COMPRESSED_WEIGHTS_INT4
+                    // TODO: fix
+                    uchar tmp = wei_packed[1];
+                    wei_packed[1] = wei_packed[2];
+                    wei_packed[2] = tmp;
+                #endif
                 SLM_FILTER_UNPACKED_VEC wei_unpacked = UNPACK_INT4x2(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE_PRELOAD*)&wei_packed));
 
                 ACCUMULATOR_TYPE* w = (ACCUMULATOR_TYPE*)(&wei_unpacked);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
@@ -576,7 +576,7 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
                     }
                 }
             #endif
-            #if TILE_OFM == 1
+            #if TILE_OFM == 1 && FILTER_LAYOUT_OS_IYX_OSV32
             weights_offset += TILE_K_OFM_PACKED * SIMD * 2;
             #else
             weights_offset += TILE_K_OFM_PACKED * SIMD;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/fetch_weights.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/fetch_weights.cl
@@ -405,7 +405,7 @@ inline uint get_os_zyxi_osv16_index(uint o, uint i, uint z, uint y, uint x, uint
         ((o) / (sub_group_size))*CAT(prefix, _OFM_PITCH)                 \
     )
 
-#define GET_FILTER_OS_IYX_OSV_INDEX_INT4_PACKED(prefix, o, i, y, x, sub_group_size) \
+#define GET_FILTER_OS_IS_YX_OSV_ISV_INDEX_INT4_PACKED(prefix, o, i, y, x, sub_group_size) \
     CAT(prefix, _OFFSET) +                                               \
     ((o) % (sub_group_size)) +                                           \
     (sub_group_size)*(                                                   \
@@ -414,7 +414,6 @@ inline uint get_os_zyxi_osv16_index(uint o, uint i, uint z, uint y, uint x, uint
         (i)*CAT(prefix, _IFM_PITCH) +                                    \
         ((o) / (sub_group_size))*(CAT(prefix, _OFM_PITCH)/2)                 \
     )
-
 
 #define GET_FILTER_OS_IYX_OSV_ROTATE_180_INDEX(prefix, o, i, y, x, sub_group_size) \
     CAT(prefix, _OFFSET) +                                                          \

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/fetch_weights.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/fetch_weights.cl
@@ -405,6 +405,17 @@ inline uint get_os_zyxi_osv16_index(uint o, uint i, uint z, uint y, uint x, uint
         ((o) / (sub_group_size))*CAT(prefix, _OFM_PITCH)                 \
     )
 
+#define GET_FILTER_OS_IYX_OSV_INDEX_INT4_PACKED(prefix, o, i, y, x, sub_group_size) \
+    CAT(prefix, _OFFSET) +                                               \
+    ((o) % (sub_group_size)) +                                           \
+    (sub_group_size)*(                                                   \
+        (x)*CAT(prefix, _X_PITCH) +                                      \
+        (y)*CAT(prefix, _Y_PITCH) +                                      \
+        (i)*CAT(prefix, _IFM_PITCH) +                                    \
+        ((o) / (sub_group_size))*(CAT(prefix, _OFM_PITCH)/2)                 \
+    )
+
+
 #define GET_FILTER_OS_IYX_OSV_ROTATE_180_INDEX(prefix, o, i, y, x, sub_group_size) \
     CAT(prefix, _OFFSET) +                                                          \
     ((o) % (sub_group_size)) +                                                      \

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/int4_utils.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/int4_utils.cl
@@ -93,6 +93,14 @@ inline half8 unpack_to_half(uint4x8_t v) __attribute__((overloadable)) {
     return (half8)(f0.s0, f0.s1, f1.s0, f1.s1, f2.s0, f2.s1, f3.s0, f3.s1);
 }
 
+inline half8 unpack_to_half_osv32_isv2(uint4x8_t v) __attribute__((overloadable)) {
+    half2 f0 = unpack_to_half(v.s0);
+    half2 f1 = unpack_to_half(v.s2);
+    half2 f2 = unpack_to_half(v.s1);
+    half2 f3 = unpack_to_half(v.s3);
+    return (half8)(f0.s0, f0.s1, f1.s0, f1.s1, f2.s0, f2.s1, f3.s0, f3.s1);
+}
+
 inline half8 unpack_to_half(int4x8_t v) __attribute__((overloadable)) {
     half2 f0 = unpack_to_half(v.s0);
     half2 f1 = unpack_to_half(v.s1);
@@ -100,6 +108,15 @@ inline half8 unpack_to_half(int4x8_t v) __attribute__((overloadable)) {
     half2 f3 = unpack_to_half(v.s3);
     return (half8)(f0.s0, f0.s1, f1.s0, f1.s1, f2.s0, f2.s1, f3.s0, f3.s1);
 }
+
+inline half8 unpack_to_half_osv32_isv2(int4x8_t v) __attribute__((overloadable)) {
+    half2 f0 = unpack_to_half(v.s0);
+    half2 f1 = unpack_to_half(v.s2);
+    half2 f2 = unpack_to_half(v.s1);
+    half2 f3 = unpack_to_half(v.s3);
+    return (half8)(f0.s0, f0.s1, f1.s0, f1.s1, f2.s0, f2.s1, f3.s0, f3.s1);
+}
 #endif  // defined(cl_khr_fp16)
 
 #define UNPACK_INT4x2(target_type, value) CAT(unpack_to_, target_type)(value)
+#define UNPACK_INT4x2_OSV32_ISV2(target_type, value) CAT(CAT(unpack_to_, target_type), _osv32_isv2)(value)

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/fully_connected_gpu_bf_tiled_common.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/fully_connected_gpu_bf_tiled_common.cl
@@ -131,13 +131,7 @@ inline void (FUNC_NAME)(
         unroll_for(uint ki = 0; ki < (TILE_IFM * SIMD) / TILE_K; ++ki) {
             #if COMPRESSED_WEIGHTS_INT4
                 FILTER_PACKED_VEC_TYPE wei_packed = FILTER_BLOCK_READ(weights, weights_offset);
-                #if TILE_K == 4
-                // TODO : fix
-                    uchar tmp = wei_packed[1];
-                    wei_packed[1] = wei_packed[2];
-                    wei_packed[2] = tmp; 
-                #endif
-                wei = UNPACK_INT4x2(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE*)&wei_packed));
+                wei = UNPACK_INT4(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE*)&wei_packed));
             #else
                 wei = TO_FILTER_VEC_TYPE(FILTER_BLOCK_READ(weights, weights_offset));
             #endif
@@ -147,9 +141,9 @@ inline void (FUNC_NAME)(
                 unroll_for(uint kii = 0; kii < TILE_K; ++kii) {
                     unroll_for(uint fi = 0; fi < TILE_OFM; ++fi) {
                         #if COMPRESSED_WEIGHTS_INT4
-                        const uint w_idx = kii * TILE_OFM + fi;
-                        #else
                         const uint w_idx = fi * TILE_K + kii;
+                        #else
+                        const uint w_idx = kii * TILE_OFM + fi;
                         #endif
                         const uint offset_ofm = out_f + fi*SIMD + sglid;
                         #if !DECOMPRESSION_SCALE_POST_OP
@@ -182,7 +176,11 @@ inline void (FUNC_NAME)(
                     }
                 }
             #endif
+            #if TILE_OFM == 1 && FILTER_LAYOUT_OS_IS_YX_OSV32_ISV2
+            weights_offset += TILE_K_OFM_PACKED * 2 * SIMD;
+            #else
             weights_offset += TILE_K_OFM_PACKED * SIMD;
+            #endif
 
             unroll_for (uint kii = 0; kii < TILE_K; ++kii) {
                 const uint total_k = ki * TILE_K + kii;
@@ -190,14 +188,14 @@ inline void (FUNC_NAME)(
                     INPUT0_TYPE in_val = _sub_group_shuffle(((INPUT0_TYPE*)(&in_0[bi]))[total_k / SIMD], total_k % SIMD);
                     unroll_for (uint fi = 0; fi < TILE_OFM; ++fi) {
                         #if COMPRESSED_WEIGHTS_INT4
-                        int weight_idx = fi * TILE_K + kii;
+                        int w_idx = fi * TILE_K + kii;
                         #else
-                        int weight_idx = kii * TILE_OFM + fi;
+                        int w_idx = kii * TILE_OFM + fi;
                         #endif
 #if DECOMPRESSION_SCALE_POST_OP
-                        ((ACCUMULATOR_TYPE*)(&acc_tmp[bi]))[fi] += in_val * ((ACCUMULATOR_TYPE*)(&wei))[weight_idx];
+                        ((ACCUMULATOR_TYPE*)(&acc_tmp[bi]))[fi] += in_val * ((ACCUMULATOR_TYPE*)(&wei))[w_idx];
 #else
-                        ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += in_val * ((ACCUMULATOR_TYPE*)(&wei))[weight_idx];
+                        ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += in_val * ((ACCUMULATOR_TYPE*)(&wei))[w_idx];
 #endif
                     }
                 }
@@ -254,7 +252,7 @@ inline void (FUNC_NAME)(
         unroll_for(uint ki = 0; ki < CEIL_DIV(LEFTOVER_IFM, TILE_K); ++ki) {
             #if COMPRESSED_WEIGHTS_INT4
                 FILTER_PACKED_VEC_TYPE wei_packed = FILTER_BLOCK_READ(weights, weights_offset);
-                wei = UNPACK_INT4x2(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE*)&wei_packed));
+                wei = UNPACK_INT4(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE*)&wei_packed));
             #else
                 wei = TO_FILTER_VEC_TYPE(FILTER_BLOCK_READ(weights, weights_offset));
             #endif
@@ -263,7 +261,11 @@ inline void (FUNC_NAME)(
                 ACCUMULATOR_TYPE* w = (ACCUMULATOR_TYPE*)(&wei);
                 unroll_for(uint kii = 0; kii < TILE_K; ++kii) {
                     unroll_for(uint fi = 0; fi < TILE_OFM; ++fi) {
+                        #if COMPRESSED_WEIGHTS_INT4
                         const uint w_idx = kii * TILE_OFM + fi;
+                        #else
+                        const uint w_idx = kii * TILE_OFM + fi;
+                        #endif
                         uint offset_ofm = out_f + fi*SIMD + get_sub_group_local_id();
                         #if DECOMPRESSION_SCALE_GROUPS_NUM > 1
                             const uint scale_offset = (offset_ofm % DECOMPRESSION_SCALE_BATCH_NUM) * DECOMPRESSION_SCALE_BATCH_PITCH +
@@ -290,8 +292,11 @@ inline void (FUNC_NAME)(
                     }
                 }
             #endif
+            #if TILE_OFM == 1 && FILTER_LAYOUT_OS_IS_YX_OSV32_ISV2
+            weights_offset += TILE_K_OFM_PACKED * 2 * SIMD;
+            #else
             weights_offset += TILE_K_OFM_PACKED * SIMD;
-
+            #endif
             unroll_for (uint kii = 0; kii < TILE_K; ++kii) {
                 unroll_for (uint fi = 0; fi < TILE_OFM; ++fi) {
                     unroll_for (uint bi = 0; bi < FORCED_TILE_B; ++bi) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
@@ -29,6 +29,7 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
     OUTPUT_TYPE out = in0 | (in1 << 4);
     output[out_byte_offset] = out;
 #elif defined(OUTPUT_LAYOUT_OS_IYX_OSV32)
+#if 0
     const unsigned o = (uint)get_global_id(0);
     const unsigned i = (uint)get_global_id(1);
 
@@ -48,6 +49,31 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
 
     const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX(OUTPUT, o, i, 0, 0, 32 / 2); // Calculate offset as osv16 due to packing
     output[output_idx] = packed_out_channels;
+    // osv32 layout
+    // k0_f0f16 | k0_f1f17 | .... | k0_f15f31 || k1_f0f16 | k1_f1f17 | ... | k1_f15f31
+    // k2_f0f16 | k2_f1f17 | .... | k2_f15f31 || k3_f0f16 | k3_f1f17 | ... | k3_f15f31
+    // ...
+    // kn-2_f0f16 | kn-2_f1f17 | .... | kn-2_f15f31 || kn-1_f0f16 | kn-1_f1f17 | ... | kn-1_f15f31
+
+#else
+    // osv32 layout
+    // f0_k0k1 | f1_k0k1 | .... | f31_k0k1
+    // f0_k2k3 | f1_k2k3 | ....  | f32_k2k3
+    // ...
+    // f0_kn-1kn | f1_kn-1kn|.... |f32_kn-1kn
+    const unsigned o = (uint)get_global_id(0);
+    const unsigned i = (uint)get_global_id(1) * 2;
+
+    const uint input0_offset = GET_FILTER_INDEX(INPUT0, 0, o, i, 0, 0);
+
+    INPUT0_TYPE in1 = input[input0_offset / 2] & 0xFF;
+
+    INPUT0_TYPE packed_out_channels = in1;
+
+    const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX_INT4_PACKED(OUTPUT, o, i/2, 0, 0, 32); // Calculate offset as osv16 due to packing
+    //printf("Input) o:%d i:%d input_idx : %d => Output) output_idx:%d\n", o, i, input0_offset / 2, output_idx);
+    output[output_idx] = packed_out_channels;
+#endif
 #else
 #error "reorder_weights_int4: unsupported layouts combination"
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
@@ -29,7 +29,10 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
     OUTPUT_TYPE out = in0 | (in1 << 4);
     output[out_byte_offset] = out;
 #elif defined(OUTPUT_LAYOUT_OS_IYX_OSV32)
-#if 0
+    // os_iyx osv32 layout for int4 packed weight
+    // k0_f0f16 | k0_f1f17 | .... | k0_f15f31 || k1_f0f16 | k1_f1f17 | ... | k1_f15f31
+    // k2_f0f16 | k2_f1f17 | .... | k2_f15f31 || k3_f0f16 | k3_f1f17 | ... | k3_f15f31
+    // ...
     const unsigned o = (uint)get_global_id(0);
     const unsigned i = (uint)get_global_id(1);
 
@@ -49,18 +52,12 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
 
     const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX(OUTPUT, o, i, 0, 0, 32 / 2); // Calculate offset as osv16 due to packing
     output[output_idx] = packed_out_channels;
-    // osv32 layout
-    // k0_f0f16 | k0_f1f17 | .... | k0_f15f31 || k1_f0f16 | k1_f1f17 | ... | k1_f15f31
-    // k2_f0f16 | k2_f1f17 | .... | k2_f15f31 || k3_f0f16 | k3_f1f17 | ... | k3_f15f31
-    // ...
-    // kn-2_f0f16 | kn-2_f1f17 | .... | kn-2_f15f31 || kn-1_f0f16 | kn-1_f1f17 | ... | kn-1_f15f31
 
-#else
-    // osv32 layout
-    // f0_k0k1 | f1_k0k1 | .... | f31_k0k1
-    // f0_k2k3 | f1_k2k3 | ....  | f32_k2k3
+#elif defined(OUTPUT_LAYOUT_OS_IS_YX_OSV32_ISV2)
+    // osv32_isv2 layout for int4 packed weight
+    // f0_k0k1 | f1_k0k1 | ....  | f15_k0k1|| f16_k0k1 | f17_k0k1 | ... | f31_k0k1
+    // f0_k2k3 | f1_k2k3 | ....  | f15_k2k3|| f16_k2k3 | f17_k2k3 | ... | f31_k2k3
     // ...
-    // f0_kn-1kn | f1_kn-1kn|.... |f32_kn-1kn
     const unsigned o = (uint)get_global_id(0);
     const unsigned i = (uint)get_global_id(1) * 2;
 
@@ -70,10 +67,8 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
 
     INPUT0_TYPE packed_out_channels = in1;
 
-    const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX_INT4_PACKED(OUTPUT, o, i/2, 0, 0, 32); // Calculate offset as osv16 due to packing
-    //printf("Input) o:%d i:%d input_idx : %d => Output) output_idx:%d\n", o, i, input0_offset / 2, output_idx);
+    const uint output_idx = GET_FILTER_OS_IS_YX_OSV_ISV_INDEX_INT4_PACKED(OUTPUT, o, i/2, 0, 0, 32); // Calculate offset as osv16 due to packing
     output[output_idx] = packed_out_channels;
-#endif
 #else
 #error "reorder_weights_int4: unsupported layouts combination"
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
@@ -345,6 +345,7 @@ std::string toString(WeightsLayout layout) {
         case WeightsLayout::os_is_yx_osv16_isv4:                         return "OS_IS_YX_OSV16_ISV4";
         case WeightsLayout::os_is_yx_osv32_isv4_swizzled_by_2:           return "OS_IS_YX_OSV32_ISV4_SWIZZLED_BY_2";
         case WeightsLayout::os_is_yx_osv32_isv4:                         return "OS_IS_YX_OSV32_ISV4";
+        case WeightsLayout::os_is_yx_osv32_isv2:                         return "OS_IS_YX_OSV32_ISV2";
         case WeightsLayout::os_is_zyx_osv32_isv4:                        return "OS_IS_ZYX_OSV32_ISV4";
         case WeightsLayout::oizyx:                                       return "OIZYX";
         case WeightsLayout::iozyx:                                       return "IOZYX";

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -402,6 +402,9 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
         // Do not use SCALE_POST_OP for SLM kernel, since it demonstrates worse performance
         if (scale_group_size % simd == 0 && !dispatchData.use_slm)
             jit.AddConstant(MakeJitConstant("DECOMPRESSION_SCALE_POST_OP", 1));
+        jit.AddConstant(MakeJitConstant("W_IDX", "fi * TILE_K + kii"));
+    } else {
+        jit.AddConstant(MakeJitConstant("W_IDX", "kii * TILE_OFM + fi"));
     }
 
     if (dispatchData.use_slm) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -245,8 +245,10 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
     if (params.weights.GetDType() == WeightsType::UINT4 || params.weights.GetDType() == WeightsType::INT4) {
         if (!params.is_shape_agnostic && batch == 1) {
             // Tuning for Meteor Lake
-            size_t ideal_num_threads = 128 /*# EUs*/* 8 /*# hw threads*/* 16/*SIMD*/;
+            size_t ideal_num_threads = params.engineInfo.maxThreadsPerDevice * simd;
             if (output_f / 2 < ideal_num_threads * 0.8) {
+                GPU_DEBUG_TRACE_DETAIL << "FC bf tiled: Set ofm_tile 1. (output_f : " << output_f
+                                       << ", ideal threads : " << ideal_num_threads << ")" << std::endl;
                 return selector.Default(tune_params(1, 1, 4, 2, 1, 1, EXE_MODE_DEFAULT));
             } else {
                 return selector.Default(tune_params(1, 2, 4, 2, 1, 1, EXE_MODE_DEFAULT));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -245,11 +245,11 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
     if (params.weights.GetDType() == WeightsType::UINT4 || params.weights.GetDType() == WeightsType::INT4) {
         if (!params.is_shape_agnostic && batch == 1) {
             // Tuning for Meteor Lake
-//            return selector.Default(tune_params(1, 2, 4, 2, 1, 1, EXE_MODE_DEFAULT));
-            if (getenv("ORIG") != nullptr) {
-                return selector.Default(tune_params(1, 2, 4, 2, 1, 1, EXE_MODE_DEFAULT));
-            } else {
+            size_t ideal_num_threads = 128 /*# EUs*/* 8 /*# hw threads*/* 16/*SIMD*/;
+            if (output_f / 2 < ideal_num_threads * 0.8) {
                 return selector.Default(tune_params(1, 1, 4, 2, 1, 1, EXE_MODE_DEFAULT));
+            } else {
+                return selector.Default(tune_params(1, 2, 4, 2, 1, 1, EXE_MODE_DEFAULT));
             }
         } else {
             // Try to use SLM kernels if possible

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
@@ -18,6 +18,7 @@ ParamsKey ReorderWeightsKernelInt4::GetSupportedKey() const {
     k.EnableInputWeightsLayout(WeightsLayout::oiyx);
     k.EnableInputWeightsLayout(WeightsLayout::ioyx);
     k.EnableOutputWeightsLayout(WeightsLayout::os_iyx_osv32);
+    k.EnableOutputWeightsLayout(WeightsLayout::os_is_yx_osv32_isv2);
     k.EnableOutputWeightsLayout(WeightsLayout::oiyx);
     k.EnableTensorOffset();
     k.EnableTensorPitches();
@@ -36,7 +37,8 @@ ReorderWeightsKernelInt4::DispatchData ReorderWeightsKernelInt4::SetDefault(cons
 
     // Divide one of the dimensions by 2 to save with byte granularity
     if (output.GetLayout() == WeightsLayout::os_iyx_osv32) {
-//        dispatchData.gws = { Align(output.OFM().v, 32) / 2, output.IFM().v, 1 };
+        dispatchData.gws = { Align(output.OFM().v, 32) / 2, output.IFM().v, 1 };
+    } else if (output.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
         dispatchData.gws = { Align(output.OFM().v, 32), output.IFM().v / 2, 1 };
     } else {
         dispatchData.gws = { CeilDiv(output.LogicalSize(), 2), 1, 1 };
@@ -57,9 +59,9 @@ bool ReorderWeightsKernelInt4::Validate(const Params& params) const {
     }
 
     bool supported_case = input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv32;
+    supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::oiyx;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::os_iyx_osv32;
-
     return supported_case;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
@@ -36,7 +36,8 @@ ReorderWeightsKernelInt4::DispatchData ReorderWeightsKernelInt4::SetDefault(cons
 
     // Divide one of the dimensions by 2 to save with byte granularity
     if (output.GetLayout() == WeightsLayout::os_iyx_osv32) {
-        dispatchData.gws = { Align(output.OFM().v, 32) / 2, output.IFM().v, 1 };
+//        dispatchData.gws = { Align(output.OFM().v, 32) / 2, output.IFM().v, 1 };
+        dispatchData.gws = { Align(output.OFM().v, 32), output.IFM().v / 2, 1 };
     } else {
         dispatchData.gws = { CeilDiv(output.LogicalSize(), 2), 1, 1 };
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/tensor_type.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/tensor_type.cpp
@@ -117,6 +117,7 @@ WeightsTensor::WeightsChannelArray WeightsTensor::weightsChannelArray {{
     { WeightsLayout::os_is_yx_osv16_isv4,                         {  0,  1, -1,   2,   3, -1 } },
     { WeightsLayout::os_is_yx_osv32_isv4_swizzled_by_2,           {  0,  1, -1,   2,   3, -1 } },
     { WeightsLayout::os_is_yx_osv32_isv4,                         {  0,  1, -1,   2,   3, -1 } },
+    { WeightsLayout::os_is_yx_osv32_isv2,                         {  0,  1, -1,   2,   3, -1 } },
     { WeightsLayout::os_is_zyx_osv32_isv4,                        {  0,  1,  2,   3,   4, -1 } },
     { WeightsLayout::oizyx,                                       {  0,  1,  2,   3,   4, -1 } },
     { WeightsLayout::iozyx,                                       {  0,  1,  2,   4,   3, -1 } },

--- a/src/plugins/intel_gpu/src/kernel_selector/tensor_type.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/tensor_type.h
@@ -112,6 +112,7 @@ enum WeightsLayout {
     os_i_osv16__ai8,
     os_i_osv16,
     os_is_yx_osv16_isv16,           // weights for int8 blocked conv
+    os_is_yx_osv32_isv2,            // weights for fully connected kernels with int4 compressed data type
     os_is_zyx_osv16_isv16,
     os_is_zyx_osv32_isv16,
     os_is_zyx_osv64_isv16,

--- a/src/plugins/intel_gpu/src/runtime/format.cpp
+++ b/src/plugins/intel_gpu/src/runtime/format.cpp
@@ -119,6 +119,7 @@ static const std::map<format::type, format_traits> format_traits_map {
         FMT_TRAITS(os_zyxi_osv16,                                1, 1, 3, 0, {0, 2, 3, 4, 1}, "ozyxi",  "oixyz", {{0, 16}}),
         FMT_TRAITS(os_is_yx_isv8_osv16_isv2,                     1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{1, 8}, {0, 16}, {1, 2}}),
         FMT_TRAITS(os_is_yx_osv16_isv16,                         1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{0, 16}, {1, 16}}),
+        FMT_TRAITS(os_is_yx_osv32_isv2,                          1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{0, 32}}),
         FMT_TRAITS(os_is_zyx_osv32_isv16,                        1, 1, 3, 0, {0, 1, 2, 3, 4}, "oizyx",  "oixyz", {{0, 32}, {1, 16}}),
         FMT_TRAITS(os_is_zyx_osv64_isv16,                        1, 1, 3, 0, {0, 1, 2, 3, 4}, "oizyx",  "oixyz", {{0, 64}, {1, 16}}),
         FMT_TRAITS(os_iyx_osv8,                                  1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{0, 8}}),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1145,23 +1145,20 @@ public:
         tests::random_generator rg(GET_SUITE_NAME);
         auto& engine = get_test_engine();
 
-       if (engine.get_device_info().dev_type == device_type::discrete_gpu)
-            GTEST_SKIP();
-
-        long int ifm_num = 1024;
-        long int ofm_num = 2048;
+        long int ifm_num = 256;
+        long int ofm_num = 256;
 
         auto input_mem = engine.allocate_memory({ { batch_num, ifm_num}, data_types::f16, format::bfyx });
-        auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::i4, format::bfyx });
+        auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u4, format::bfyx });
         auto scale_mem = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
 
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<int8_t>(ofm_num * ifm_num / 2, -2, 2);
+        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
         set_values(weights_mem, weigths_data);
 
-        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -2.0f, 2.0f);
+        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
         set_values(scale_mem, scale_data);
 
         auto in_layout = is_dynamic ? layout{ {-1, ifm_num}, data_types::f16, format::bfyx }
@@ -2926,6 +2923,10 @@ TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_cached) {
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_b1g32) {
     this->test_compressed_int4_scale(false, true, 1, 32);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_b42g32) {
+    this->test_compressed_int4_scale(false, true, 48, 32);
 }
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_b1g64) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -2925,7 +2925,7 @@ TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_b1g32) {
     this->test_compressed_int4_scale(false, true, 1, 32);
 }
 
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_b42g32) {
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_b48g32) {
     this->test_compressed_int4_scale(false, true, 48, 32);
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1145,20 +1145,23 @@ public:
         tests::random_generator rg(GET_SUITE_NAME);
         auto& engine = get_test_engine();
 
-        long int ifm_num = 256;
-        long int ofm_num = 256;
+       if (engine.get_device_info().dev_type == device_type::discrete_gpu)
+            GTEST_SKIP();
+
+        long int ifm_num = 1024;
+        long int ofm_num = 2048;
 
         auto input_mem = engine.allocate_memory({ { batch_num, ifm_num}, data_types::f16, format::bfyx });
-        auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u4, format::bfyx });
+        auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::i4, format::bfyx });
         auto scale_mem = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
 
         auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -2.0f, 2.0f);
         set_values(input_mem, input_data);
 
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+        auto weigths_data = rg.generate_random_1d<int8_t>(ofm_num * ifm_num / 2, -2, 2);
         set_values(weights_mem, weigths_data);
 
-        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
+        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -2.0f, 2.0f);
         set_values(scale_mem, scale_data);
 
         auto in_layout = is_dynamic ? layout{ {-1, ifm_num}, data_types::f16, format::bfyx }


### PR DESCRIPTION
### Details:
 - Currently, in dynamic shape, ofm size is fixed as 2 because it is is tightly coupled by weight layout (i.e., tile_ofm == 2 requires os_iyx_osv32 weight format)
 - For Vec*Mat case (b==1, used for 2nd+ token generation in LLMs) with small output size N, this configuration is not good because of the limited # of gpu threads. 
 - To increase GPU threads, needed to 1) reduce the ofm size to 1 2) But still share the weight format with first token case where ofm=2 is good. 
- Previously the os_iyx_osv32 weight format was packing int4 weight with the following order:
  k0_f0f16 | k0_f1f17 | .... | k0_f15f31 || k1_f0f16 | k1_f1f17 | ... | k1_f15f31
- To use common weight format for ofm=1 and ofm=2, implemented a new weight format for int4 dtype,  where the weight is stored int the following order: 
  f0_k0k1 | f1_k0k1 | .... | f15_k0k1|| f16_k0k1 | f17_k0k1 | ... | f31_k0k1

### Tickets:
 - 138296
