### PR TITLE
[GPU] Fix wrong dynamic convolution selection in SD1.5 dynamic dpas platform

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1140,8 +1140,12 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
         return format::adjust_to_rank(format::bfyx, output_layout.get_partial_shape().size());
     }
 
+    bool onednn_valid_post_ops = get_post_ops_count(node) <= 32;
+    bool use_onednn_impls = _optimization_attributes.use_onednn_impls && input_layout.data_type != data_types::f32;
+    bool use_onednn_preferred_format = (use_onednn_impls && onednn_valid_post_ops && node.get_preferred_output_fmt() != format::any);
+
     // Use planar bfyx format for dynamic convolutions with explicit padding
-    if (node.is_dynamic() && output_layout.get_partial_shape().size() == 4 && node.use_explicit_padding() && !i8_u8_input)
+    if (node.is_dynamic() && output_layout.get_partial_shape().size() == 4 && node.use_explicit_padding() && !i8_u8_input && !use_onednn_preferred_format)
         return format::bfyx;
 
     if (input_layout.is_dynamic() || output_layout.is_dynamic()) {
@@ -1154,10 +1158,7 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
 
     const float cond_denom = _total_conv > 0 ? 1.0f / static_cast<float>(_total_conv) : 1.0f;
 
-    bool onednn_valid_post_ops = get_post_ops_count(node) <= 32;
-    bool use_onednn_impls = _optimization_attributes.use_onednn_impls && input_layout.data_type != data_types::f32;
-
-    if (use_onednn_impls && onednn_valid_post_ops && node.get_preferred_output_fmt() != format::any) {
+    if (use_onednn_preferred_format) {
         expected_format = node.get_preferred_output_fmt();
     } else {
         /* *************************** Native impls format selection part ************************** */


### PR DESCRIPTION
_Dynamic convolutions with explicit padding run planar bfyx format in clDNN.
But this limitation is only for clDNN NOT oneDNN. Because unexpected format selection in dynamic convolution, SD1.5 in platform used dpas always run clDNN and it caused bad performance._

### Tickets:
 - *138632*
