### PR TITLE
[CPU] Avoid extra copy of const inputs to the weights cache

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -375,15 +375,23 @@ void Input::cloneBlobIfRequired() {
 
     auto weightCache = context->getWeightsCache();
 
-    if (weightCache) {
-        MemoryPtr ptr = *weightCache->findOrCreate(blobKey(), cloneBlob);
-        memoryPtr = std::const_pointer_cast<const IMemory>(ptr);
-    // IRs already have all subnormals flushed to zero, but in
-    // read_model scenario with directly loaded original model still can have subnormals
-    } else if (prec != element::string && isBlobAligned() && (!needFlushDenormalsToZero || !hasSubnormals()) && !isWA()) {
+    // if (weightCache) {
+    //     MemoryPtr ptr = *weightCache->findOrCreate(blobKey(), cloneBlob);
+    //     memoryPtr = std::const_pointer_cast<const IMemory>(ptr);
+    // // IRs already have all subnormals flushed to zero, but in
+    // // read_model scenario with directly loaded original model still can have subnormals
+    // } else
+    if (prec != element::string && isBlobAligned() && (!needFlushDenormalsToZero || !hasSubnormals()) && !isWA()) {
         memoryPtr = std::make_shared<Memory>(getEngine(), memDesc, constOp->get_data_ptr());
     } else {
-        memoryPtr = std::const_pointer_cast<const IMemory>(cloneBlob());
+        if (weightCache) {
+            MemoryPtr ptr = *weightCache->findOrCreate(blobKey(), cloneBlob);
+            memoryPtr = std::const_pointer_cast<const IMemory>(ptr);
+            // IRs already have all subnormals flushed to zero, but in
+            // read_model scenario with directly loaded original model still can have subnormals
+        } else {
+            memoryPtr = std::const_pointer_cast<const IMemory>(cloneBlob());
+        }
     }
 }
 


### PR DESCRIPTION
### Details:
 - TODO: more "smart" logic is required. I.e. do copy for multi-socket and avoid copy for within single socket.
 - Extra validation is required
### Ticket:
- 138902