### PR TITLE
[CPU] Refactor binary PReLU avx2 post op

### DIFF
--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
@@ -222,50 +222,6 @@ const char* DnnlExtensionUtils::query_pd_info(const_dnnl_primitive_desc_t pd) {
     return pd->info();
 }
 
-dnnl::algorithm DnnlExtensionUtils::convertToDnnlAlgorithm(Algorithm alg) {
-    switch (alg) {
-        case Algorithm::EltwiseRelu: return dnnl::algorithm::eltwise_relu;
-        case Algorithm::EltwiseTanh: return dnnl::algorithm::eltwise_tanh;
-        case Algorithm::EltwiseElu: return dnnl::algorithm::eltwise_elu;
-        case Algorithm::EltwiseAbs: return dnnl::algorithm::eltwise_abs;
-        case Algorithm::EltwiseSqrt: return dnnl::algorithm::eltwise_sqrt;
-        case Algorithm::EltwiseSwish: return dnnl::algorithm::eltwise_swish;
-        case Algorithm::EltwiseHswish: return dnnl::algorithm::eltwise_hardswish;
-        case Algorithm::EltwiseSoftRelu: return dnnl::algorithm::eltwise_soft_relu;
-        case Algorithm::EltwiseMish: return dnnl::algorithm::eltwise_mish;
-        case Algorithm::EltwiseExp: return dnnl::algorithm::eltwise_exp;
-        case Algorithm::EltwiseGeluErf: return dnnl::algorithm::eltwise_gelu_erf;
-        case Algorithm::EltwiseGeluTanh: return dnnl::algorithm::eltwise_gelu_tanh;
-        case Algorithm::EltwiseSigmoid: return dnnl::algorithm::eltwise_logistic;
-        case Algorithm::EltwiseClamp: return dnnl::algorithm::eltwise_clip;
-        case Algorithm::EltwisePowerStatic: return dnnl::algorithm::eltwise_pow;
-        case Algorithm::EltwiseHsigmoid: return dnnl::algorithm::eltwise_hsigmoid;
-        case Algorithm::EltwiseRoundHalfToEven: return dnnl::algorithm::eltwise_round_half_to_even;
-        case Algorithm::EltwiseRoundHalfAwayFromZero: return dnnl::algorithm::eltwise_round_half_away_from_zero;
-        case Algorithm::EltwiseAdd: return dnnl::algorithm::binary_add;
-        case Algorithm::EltwiseMultiply: return dnnl::algorithm::binary_mul;
-        case Algorithm::EltwiseSubtract: return dnnl::algorithm::binary_sub;
-        case Algorithm::EltwiseDivide: return dnnl::algorithm::binary_div;
-        case Algorithm::EltwiseMaximum: return dnnl::algorithm::binary_max;
-        case Algorithm::EltwiseMinimum: return dnnl::algorithm::binary_min;
-        case Algorithm::EltwiseEqual: return dnnl::algorithm::binary_eq;
-        case Algorithm::EltwiseNotEqual: return dnnl::algorithm::binary_ne;
-        case Algorithm::EltwiseGreater: return dnnl::algorithm::binary_gt;
-        case Algorithm::EltwiseGreaterEqual: return dnnl::algorithm::binary_ge;
-        case Algorithm::EltwiseLess: return dnnl::algorithm::binary_lt;
-        case Algorithm::EltwiseLessEqual: return dnnl::algorithm::binary_le;
-        case Algorithm::EltwisePrelu: return dnnl::algorithm::binary_prelu;
-        case Algorithm::ReduceMax: return dnnl::algorithm::reduction_max;
-        case Algorithm::ReduceMin: return dnnl::algorithm::reduction_min;
-        case Algorithm::ReduceSum: return dnnl::algorithm::reduction_sum;
-        case Algorithm::ReduceMean: return dnnl::algorithm::reduction_mean;
-        case Algorithm::FQCommon: return dnnl::algorithm::quantization_quantize_dequantize;
-        case Algorithm::FQQuantization: return dnnl::algorithm::quantization_quantize;
-        case Algorithm::FQBinarization: return dnnl::algorithm::binarization_depthwise;
-        default: return dnnl::algorithm::undef;
-    }
-}
-
 bool DnnlExtensionUtils::isUnarySupportedAsPostOp(Algorithm alg) {
 #if defined(OV_CPU_WITH_ACL)
     return one_of(alg, Algorithm::EltwiseRelu,

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.h
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.h
@@ -100,7 +100,6 @@ public:
     static dnnl_primitive_desc_t clone_primitive_desc(const_dnnl_primitive_desc_t cprim_desc);
     static dnnl_memory_desc_t clone_desc(const_dnnl_memory_desc_t cdesc);
     static const char* query_pd_info(const_dnnl_primitive_desc_t pd);
-    static dnnl::algorithm convertToDnnlAlgorithm(Algorithm alg);
     static bool isUnarySupportedAsPostOp(Algorithm alg);
 };
 

--- a/src/plugins/intel_cpu/src/nodes/executors/executor_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor_config.hpp
@@ -17,8 +17,6 @@ struct Config {
     MemoryDescArgs descs;
     Attrs attrs;
     PostOps postOps;
-
-    CPU_DEBUG_CAP_ENABLE(friend std::ostream& operator<< <>(std::ostream& os, const Config& key));
 };
 
 }  // namespace executor

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/matmul.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/matmul.hpp
@@ -49,6 +49,7 @@ protected:
     void transpose(T& shape);
 
     void SetUp() override;
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
 };
 
 namespace MatMul {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/convolution.cpp
@@ -31,10 +31,10 @@ std::vector<CPUSpecificParams> filterCPUInfoForDevice_BF16(std::vector<CPUSpecif
 
 const std::vector<fusingSpecificParams> fusingParamsSetWithoutEmpty{
         // eltwise
-        fusingRelu,
         fusingPRelu1DScaleShift,
         // depthwise
         fusingReluScaleShift,
+        fusingPReluPerChannel,
         // fake quantize
         fusingFakeQuantizePerTensorRelu,
         fusingFakeQuantizePerChannelRelu,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/matmul.cpp
@@ -26,6 +26,7 @@ std::vector<fusingSpecificParams> fusingParamsSet2D_nightly {
         fusingScaleShift, //covered by MLAS
 #endif
         fusingPReluPerTensor,
+        fusingPReluPerChannel,
         fusingFakeQuantizePerChannelRelu,
 };
 
@@ -44,6 +45,15 @@ std::vector<fusingSpecificParams> fusingParamsSet2DBF16 {
         fusingBias,
         fusingRelu,
         fusingPReluPerTensor,
+};
+
+const std::vector<fusingSpecificParams> matmulFusingParamsNightly {
+        emptyFusingSpec,
+        fusingElu,
+        fusingSqrt,
+        fusingPReluPerTensor,
+        fusingPReluPerChannel,
+        fusingMultiplyPerChannel,
 };
 
 const auto matMulParams_x64 = ::testing::Combine(::testing::ValuesIn(IS_x64),
@@ -104,7 +114,7 @@ std::vector<ov::AnyMap> filterAdditionalConfig_Brgemm() {
         ov::AnyMap{/* empty config */}
     };
 #else
-    std::vector<ov::AnyMap> additionalConfig = {};
+    std::vector<ov::AnyMap> additionalConfig = {{}};
 #endif
     if (with_cpu_x86_bfloat16()) {
         additionalConfig.push_back({ov::hint::inference_precision(ov::element::bf16)});
@@ -262,7 +272,7 @@ const auto matMulBrgemmParams_nightly = ::testing::Combine(::testing::ValuesIn(I
 
 const auto testBrgemmParams_nightly = ::testing::Combine(matMulBrgemmParams_nightly,
                                                        ::testing::Values(MatMulNodeType::MatMul),
-                                                       ::testing::ValuesIn(matmulFusingParams()),
+                                                       ::testing::ValuesIn(matmulFusingParamsNightly),
                                                        ::testing::ValuesIn(filterSpecificParams_Brgemm()));
 
 INSTANTIATE_TEST_SUITE_P(nightly_MM_Brgemm_Static, MatMulLayerCPUTest, testBrgemmParams_nightly, MatMulLayerCPUTest::getTestCaseName);
@@ -445,11 +455,11 @@ const std::vector<ShapeRelatedParams> IS_brgemm_Amx_smoke = {
         {static_shapes_to_test_representation({{7, 32, 128}, {3, 7, 128, 5}}), {false, true}},
         {static_shapes_to_test_representation({{7, 32, 128}, {3, 7, 128, 5}}), {true, true}},
 
-        {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {false, false}},
-        {static_shapes_to_test_representation({{10, 10, 10}, {10, 10, 10}}), {true, false}},
+        {static_shapes_to_test_representation({{10, 10, 100}, {10, 100, 10}}), {false, false}},
+        {static_shapes_to_test_representation({{10, 10, 100}, {10, 100, 10}}), {true, false}},
 
-        {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {false, true}},
-        {static_shapes_to_test_representation({{55, 12}, {12, 55}}), {true, true}},
+        {static_shapes_to_test_representation({{55, 120}, {120, 55}}), {false, true}},
+        {static_shapes_to_test_representation({{55, 120}, {120, 55}}), {true, true}},
 };
 
 const auto matMulBrgemmAmxParams_smoke = ::testing::Combine(::testing::ValuesIn(IS_brgemm_Amx_smoke),
@@ -463,6 +473,7 @@ const auto matMulBrgemmAmxParams_smoke = ::testing::Combine(::testing::ValuesIn(
 std::vector<fusingSpecificParams> matmulBrgemmAmxFusingParams {
         emptyFusingSpec,
         fusingPReluPerTensor,
+        fusingPReluPerChannel,
         fusingAddPerTensor,
         fusingBias,
 };

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -287,6 +287,18 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_RDFT_2d/RDFTLayerTest.Inference/IS=\(100.16\)_modelType=f32_Axes=\((0.1|_2._1|1.0)\)_SignalSize=\(\).*)",
         // Issue: 134470
         R"(.*smoke.*StatefulModelStateInLoopBody.*)",
+        // Issue: 138520
+        R"(.*smoke_MM_Static/MatMulLayerCPUTest.CompareWithRefs/MatMul_IS=\[\]_\[\]_TS=\(\(55.12\)\)_\(\(12.55\)\)_.*\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*smoke_FC_3D_BF16/MatMulLayerCPUTest.CompareWithRefs/FullyConnected_IS=\[\]_\[\]_TS=\(\(1.32.120\)\)_\(\(120.5\)\).*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*smoke_FC_3D_BF16/MatMulLayerCPUTest.CompareWithRefs/FullyConnected_IS=\[\]_\[\]_TS=\(\(1.32.120\)\)_\(\(120.50\)\).*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*smoke_FC_3D_BF16/MatMulLayerCPUTest.CompareWithRefs/FullyConnected_IS=\[\]_\[\]_TS=\(\(1.1.120\)\)_\(\(120.120\)\).*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*smoke_FC_3D_BF16/MatMulLayerCPUTest.CompareWithRefs/FullyConnected_IS=\[\]_\[\]_TS=\(\(3.1.120\)\)_\(\(120.120\)\).*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*smoke_FC_3D_BF16/MatMulLayerCPUTest.CompareWithRefs/FullyConnected_IS=\[..60...60...60\]_\[14.10\]_TS=\(\(1.3.14\)_\(1.7.14\)\)_\(\(14.10\)_\(14.10\)\)_.*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*nightly_FC_3D_BF16/MatMulLayerCPUTest.CompareWithRefs/FullyConnected_IS=\[\]_\[\]_TS=\(\(1.32.120\)\)_\(\(120.5.*\)\)_.*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*nightly_FC_3D_BF16/MatMulLayerCPUTest.CompareWithRefs/FullyConnected_IS=\[\?.\?.50\]_\[50.7\]_TS=\(\(1.2.50\)_\(1.10.50\)_\(1.2.50\)_\(2.2.50\)\)_\(\(50.7\)_\(50.7\)_\(50.7\)_\(50.7\)\)_.*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*smoke_MM_Dynamic_Fusing/MatMulLayerCPUTest.CompareWithRefs/MatMul_IS=\[\?.\?\]_\[\?.33\]_TS=\(\(16.12\)_\(33.7\)_\(16.12\)\)_\(\(12.33\)_\(7.33\)_\(12.33\)\)_transpose_a=0_transpose_b=0_secondaryInputType=PARAMETER_.*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=jit_gemm.*)",
+        R"(.*(nightly|smoke)_MM_Brgemm_Static/MatMulLayerCPUTest.CompareWithRefs/MatMul_IS=\[\]_\[\]_TS=\(\(55.12\)\)_\(\(12.55\)\)_.*config=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=brgemm_avx512.*)",
+        R"(.*smoke_MM_Brgemm_Dynamic_Fusing/MatMulLayerCPUTest.CompareWithRefs/MatMul_IS=\[\?.\?\]_\[\?.33\]_TS=\(\(16.12\)_\(33.7\)_\(16.12\)\)_\(\(12.33\)_\(7.33\)_\(12.33\)\)_transpose_a=0_transpose_b=0_secondaryInputType=PARAMETER_netPRC=f32_inPRC=undefined_outPRC=undefined_trgDev=CPUconfig=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=brgemm_avx512.*)",
     };
 
 #if defined(OPENVINO_ARCH_X86)

--- a/src/plugins/intel_cpu/tests/functional/utils/cpu_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/cpu_test_utils.cpp
@@ -223,7 +223,9 @@ void CPUTestsBase::CheckPluginRelatedResultsImpl(const std::shared_ptr<const ov:
 }
 
 bool CPUTestsBase::primTypeCheck(std::string primType) const {
+#ifndef NDEBUG
     std::cout << "selectedType: " << selectedType << std::endl;
+#endif
     if (selectedType.find("FP") != std::string::npos)
         return selectedType.find(CPUTestsBase::any_type) != std::string::npos ||
                std::regex_match(primType,


### PR DESCRIPTION
### Details:
Refactor binary PReLU avx2 post op in order to reduce the amount of instructions for avx2 and fix the conflicting register indices issue for both avx2 and sse41. This is more advanced version of the previous fix ported only to the LTS branch https://github.com/openvinotoolkit/openvino/pull/23910. Also dedicated SL tests were introduced.

OneDNN fork PR https://github.com/openvinotoolkit/oneDNN/pull/242

### Tickets:
 - CVS-137492
