### PR TITLE
[PyOV] Limit numpy to major version

### DIFF
--- a/src/bindings/python/requirements.txt
+++ b/src/bindings/python/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.16.6
+numpy>=1.16.6,<2.0.0
 openvino-telemetry>=2023.2.1
 packaging

--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -1,5 +1,5 @@
 -c ../constraints.txt
-numpy>=1.16.6
+numpy>=1.16.6,<2.0.0
 importlib-metadata; python_version < "3.8" and sys_platform == "win32"
 networkx
 defusedxml


### PR DESCRIPTION
### Details:
 - Preparing to restrict OV to not use release of Numpy 2.0 which may introduce many breaking changes including:
     - required bump of `pybind` to 2.12+
     - API and namespaces clean-ups and deprecations
     - behavior changes of keywords such as `copy`
     - changes to existing and introduction of new dtypes (such as `StringDType` and possibility of adding custom ones)
     - more can be found here: https://numpy.org/devdocs/release/2.0.0-notes.html
     - and here: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-migration-guide
 
### Tickets:
 - CVS-138838
