### PR TITLE
[CPU] Shared compressed weights support

### DIFF
--- a/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
@@ -153,3 +153,38 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed4) {
         model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1});
     }
 }
+
+TEST_F(TransformationTestsF, ConvertGatherToCompressed5) {
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1, 16});
+        auto axis_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{32, 16}, {1});
+        auto convert = std::make_shared<ov::op::v0::Convert>(weights_const, ov::element::f32);
+        auto zp_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{32, 1}, {1});
+        auto zp_convert = std::make_shared<ov::op::v0::Convert>(zp_const, ov::element::f32);
+        auto sub = std::make_shared<ov::op::v1::Subtract>(convert, zp_convert);
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{32, 1}, {1});
+        auto scale = std::make_shared<ov::op::v1::Multiply>(sub, scale_const);
+        auto gather = std::make_shared<ov::op::v8::Gather>(scale, input1, axis_const);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1});
+        manager.register_pass<ConvertGatherToGatherCompressed>();
+    }
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1, 16});
+        auto axis_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{32, 16}, {1});
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{32, 1}, {1});
+        auto zp_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{32, 1}, {1});
+        auto zp_convert = std::make_shared<ov::op::v0::Convert>(zp_const, ov::element::f32);
+        auto gather_compressed = std::make_shared<ov::op::internal::GatherCompressed>(weights_const,
+                                                                                      input1,
+                                                                                      axis_const,
+                                                                                      0,
+                                                                                      scale_const,
+                                                                                      zp_convert,
+                                                                                      ov::element::f32);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1});
+    }
+}

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -295,12 +295,16 @@ void GraphOptimizer::FuseFCAndWeightsDecompression(Graph &graph) {
         return node->getType() == expectedType && node->getChildEdges().size() == 1;
     };
 
+#define SKIP_FUSION_FOR_NODE(node)                                                   \
+    DEBUG_LOG("FuseFCAndWeightsDecompression can't be applied for node ", node->getName()); \
+    continue
+
     if (!impl::cpu::x64::mayiuse(impl::cpu::x64::avx2))
         return;
 
     auto& graphNodes = graph.GetNodes();
     for (size_t i = 0; i < graphNodes.size(); i++) {
-        const auto fcNode = dynamic_cast<node::FullyConnected*>(graphNodes[i].get());
+        const auto fcNode = std::dynamic_pointer_cast<node::FullyConnected>(graphNodes[i]);
         if (fcNode == nullptr)
             continue;
 
@@ -309,6 +313,8 @@ void GraphOptimizer::FuseFCAndWeightsDecompression(Graph &graph) {
         const NodePtr transposeNode = withTranspose ? parent : nullptr;
         if (transposeNode)
             parent = transposeNode->getParentEdgeAt(0)->getParent();
+        // Compressed weights can be shared between several FC layers
+        const bool is_shared_decompression = parent->getChildEdges().size() > 1;
 
         const bool withReshape = parent->getType() == Type::Reshape;
         const auto reshapeNode = withReshape ? parent : nullptr;
@@ -317,76 +323,66 @@ void GraphOptimizer::FuseFCAndWeightsDecompression(Graph &graph) {
         }
 
         const auto multiplyNode = parent;
-        if (!expectedNode(multiplyNode, Type::Eltwise) || multiplyNode->getAlgorithm() != Algorithm::EltwiseMultiply ||
-            !multiplyNode->isConstant())
-            continue;
+        if (multiplyNode->getType() != Type::Eltwise || multiplyNode->getAlgorithm() != Algorithm::EltwiseMultiply ||
+            !multiplyNode->isConstant()) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
 
         CPU_GRAPH_OPTIMIZER_SCOPE(FuseFCAndWeightsDecompression);
         const auto multiplyConstNode = multiplyNode->getParentEdgeAt(1)->getParent();
-        if (!expectedNode(multiplyConstNode, Type::Input))
-            continue;
+        if (multiplyConstNode->getType() != Type::Input) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
 
         const auto mulParent = multiplyNode->getParentEdgeAt(0)->getParent();
         const bool withSubtract = mulParent->getAlgorithm() == Algorithm::EltwiseSubtract;
         NodePtr subtractNode, subtractConvertNode, subtractConstNode;
         if (withSubtract) {
             subtractNode = mulParent;
-            if (!expectedNode(subtractNode, Type::Eltwise))
-                continue;
+            if (!expectedNode(subtractNode, Type::Eltwise)) {
+                SKIP_FUSION_FOR_NODE(fcNode);
+            }
             auto subtractParent = subtractNode->getParentEdgeAt(1)->getParent();
-            if (expectedNode(subtractParent, Type::Convert)) {
+            if (subtractParent->getType() == Type::Convert) {
                 subtractConvertNode = subtractParent;
                 subtractParent = subtractConvertNode->getParentEdgeAt(0)->getParent();
             }
             subtractConstNode = subtractParent;
-            if (!expectedNode(subtractConstNode, Type::Input))
-                continue;
-        }
-
-        const bool withSubtractConvert = subtractConvertNode != nullptr;
-        const bool withPowerStatic = mulParent->getAlgorithm() == Algorithm::EltwisePowerStatic;
-        NodePtr powerStaticNode;
-        if (withPowerStatic) {
-            powerStaticNode = mulParent;
-            if (auto *eltwiseNode = dynamic_cast<node::Eltwise *>(powerStaticNode.get())) {
-                if (eltwiseNode->getAlpha() != 1 || eltwiseNode->getBeta() != 1)
-                    continue;
-            } else {
-                continue;
+            if (subtractConstNode->getType() != Type::Input) {
+                SKIP_FUSION_FOR_NODE(fcNode);
             }
         }
 
-        // Both operations fallbacks on IP zero-point attribute and cannot be combined
-        if (withSubtract && withPowerStatic)
-            continue;
-
-        auto convertNode = mulParent;
-        if (withSubtract)
-            convertNode = subtractNode->getParentEdgeAt(0)->getParent();
-        if (withPowerStatic)
-            convertNode = powerStaticNode->getParentEdgeAt(0)->getParent();
-
-        if (!expectedNode(convertNode, Type::Convert))
-            continue;
+        const bool withSubtractConvert = subtractConvertNode != nullptr;
+        const auto convertNode = withSubtract ? subtractNode->getParentEdgeAt(0)->getParent() : mulParent;
+        if (!expectedNode(convertNode, Type::Convert)) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
         const auto weightsNode = convertNode->getParentEdgeAt(0)->getParent();
-        if (!expectedNode(weightsNode, Type::Input))
-            continue;
+        if (weightsNode->getType() != Type::Input) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
 
         // Precision limitations
-        if (supportedDataPrecisions.find(fcNode->getOriginalInputPrecisionAtPort(0)) == supportedDataPrecisions.end())
-            continue;
-        if (supportedWeightsPrecisions.find(weightsNode->getOriginalOutputPrecisionAtPort(0)) == supportedWeightsPrecisions.end())
-            continue;
+        if (supportedDataPrecisions.find(fcNode->getOriginalInputPrecisionAtPort(0)) == supportedDataPrecisions.end()) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
+        if (supportedWeightsPrecisions.find(weightsNode->getOriginalOutputPrecisionAtPort(0)) == supportedWeightsPrecisions.end()) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
         if (withSubtract &&
-            !one_of(subtractConstNode->getOriginalOutputPrecisionAtPort(0), weightsNode->getOriginalOutputPrecisionAtPort(0), ov::element::f32))
-            continue;
+            !one_of(subtractConstNode->getOriginalOutputPrecisionAtPort(0), weightsNode->getOriginalOutputPrecisionAtPort(0), ov::element::f32)) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
 
         // Shape limitations
         const auto weightsShape = weightsNode->getOutputShapeAtPort(0);
-        if (weightsShape != multiplyNode->getOutputShapeAtPort(0))
-            continue;
-        if (reshapeNode && (reshapeNode->getInputShapeAtPort(0).getRank() != 3 || reshapeNode->getOutputShapeAtPort(0).getRank() != 2))
-            continue;
+        if (weightsShape != multiplyNode->getOutputShapeAtPort(0)) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
+        if (reshapeNode && (reshapeNode->getInputShapeAtPort(0).getRank() != 3 || reshapeNode->getOutputShapeAtPort(0).getRank() != 2)) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
 
         VectorDims decompressionConstShape;
         const auto fcInputWeightsShape = fcNode->getInputShapeAtPort(1);
@@ -413,93 +409,58 @@ void GraphOptimizer::FuseFCAndWeightsDecompression(Graph &graph) {
         auto check_decompression_shape = [&decompressionConstShape](const VectorDims& shape_to_check) {
             if (shape_to_check.size() > decompressionConstShape.size())
                 return false;
-            if (shape_to_check.size() == 1 && shape_to_check[0] == 1)
+            if (std::all_of(shape_to_check.begin(), shape_to_check.end(), [](Dim x) { return x == 1; }))
                 return true;
             const auto comparison_start_pos = decompressionConstShape.size() - shape_to_check.size();
             // in case of different ranks shapes are compared taking into account ranks numpy broadcasting
             return std::equal(shape_to_check.begin(), shape_to_check.end(), decompressionConstShape.begin() + comparison_start_pos);
         };
-        if (!check_decompression_shape(multiplyConstNode->getOutputShapeAtPort(0).getDims()))
-            continue;
-        if (withSubtract && !check_decompression_shape(subtractConstNode->getOutputShapeAtPort(0).getDims()))
-            continue;
+        if (!check_decompression_shape(multiplyConstNode->getOutputShapeAtPort(0).getDims())) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
+        if (withSubtract && !check_decompression_shape(subtractConstNode->getOutputShapeAtPort(0).getDims())) {
+            SKIP_FUSION_FOR_NODE(fcNode);
+        }
 
+        const size_t OC = fcInputWeightsShape.getDims()[0];
+        const size_t IC = fcInputWeightsShape.getDims()[1];
         // HW specific shape limitations
         if (impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx) &&
             fcNode->getOriginalInputPrecisionAtPort(0) == ov::element::bf16) {
             // OneDNN AMX IP implementation has limited shapes support due to performance considerations. As a current solution conditions below are copied
             // from OneDNN to make sure correct IP impl will be used since fallback one doesn't support weights decompression feature.
-            size_t OC = fcInputWeightsShape.getDims()[0];
-            size_t IC = fcInputWeightsShape.getDims()[1];
             size_t simdWidth = 16;
             size_t vnniFactor = 2;
             size_t maxSize = 512;
             auto amxRow = vnniFactor * simdWidth;
 
-            if ((IC <= amxRow && OC <= amxRow) || (IC <= maxSize && OC <= maxSize && IC % amxRow != 0))
-                continue;
+            if ((IC <= amxRow && OC <= amxRow) || (IC <= maxSize && OC <= maxSize && IC % amxRow != 0)) {
+                SKIP_FUSION_FOR_NODE(fcNode);
+            }
         }
 
-        size_t IC = fcInputWeightsShape.getDims()[1];
         // OneDNN IP primitive provides limited decompression params support
-        if (IC % groupNum != 0 || IC / groupNum < 4) {
-            continue;
+        if (IC % groupNum != 0 || IC / groupNum < 4 || OC == 1) {
+            SKIP_FUSION_FOR_NODE(fcNode);
         }
 
         // Fusion processing
         auto *multiplyInputNode = dynamic_cast<node::Input *>(multiplyConstNode.get());
-        if (!multiplyInputNode) {
-            OPENVINO_THROW("Cannot cast ", multiplyInputNode->getName(), " to Input node.");
-        }
+        OPENVINO_ASSERT(multiplyInputNode, "Cannot cast ", multiplyConstNode->getName(), " to Input node.");
         fcNode->fuseDecompressionMultiply(multiplyInputNode->getMemoryPtr());
 
         if (withSubtract) {
             auto *subtractInputNode = dynamic_cast<node::Input *>(subtractConstNode.get());
-            if (!subtractInputNode) {
-                OPENVINO_THROW("Cannot cast ", subtractInputNode->getName(), " to Input node.");
-            }
+            OPENVINO_ASSERT(multiplyInputNode, "Cannot cast ", subtractConstNode->getName(), " to Input node.");
             fcNode->fuseDecompressionSubtract(subtractInputNode->getMemoryPtr());
-        }
-        if (withPowerStatic) {
-            auto *eltwiseNode = dynamic_cast<node::Eltwise *>(powerStaticNode.get());
-            if (!eltwiseNode) {
-                OPENVINO_THROW("Cannot cast ", eltwiseNode->getName(), " to Eltwise node.");
-            }
-
-            CpuBlockedMemoryDesc memoryDesc(ov::element::f32, Shape({1}));
-            auto memory = std::make_shared<Memory>(graph.getEngine(), memoryDesc, nullptr, false);
-            (static_cast<float *>(memory->getData()))[0] = -1.f * eltwiseNode->getGamma();
-            fcNode->fuseDecompressionSubtract(memory);
         }
 
         fcNode->addOriginalLayer(multiplyNode->getOriginalLayers());
         fcNode->addOriginalLayer(convertNode->getOriginalLayers());
-
-        if (withSubtractConvert) {
-            fcNode->addOriginalLayer(subtractConvertNode->getOriginalLayers());
-            auto subtractConvertEdge = subtractConvertNode->getChildEdges()[0].lock();
-            graph.RemoveEdge(subtractConvertEdge);
-        }
-        if (withSubtract) {
-            fcNode->addOriginalLayer(subtractNode->getOriginalLayers());
-            auto subtractConstEdge = subtractConstNode->getChildEdges()[0].lock();
-            graph.RemoveEdge(subtractConstEdge);
-        }
-        if (withPowerStatic) {
-            fcNode->addOriginalLayer(powerStaticNode->getOriginalLayers());
-        }
-
-        auto multiplyConstEdge = multiplyConstNode->getChildEdges()[0].lock();
-        graph.RemoveEdge(multiplyConstEdge);
-
-        graph.DropNode(convertNode);
-        if (withSubtractConvert)
-            graph.DropNode(subtractConvertNode);
         if (withSubtract)
-            graph.DropNode(subtractNode);
-        if (withPowerStatic)
-            graph.DropNode(powerStaticNode);
-        graph.DropNode(multiplyNode);
+            fcNode->addOriginalLayer(subtractNode->getOriginalLayers());
+        if (withSubtractConvert)
+            fcNode->addOriginalLayer(subtractConvertNode->getOriginalLayers());
 
         const auto& weightsPrecision = weightsNode->getOriginalOutputPrecisionAtPort(0);
         if (withTranspose) {
@@ -511,7 +472,54 @@ void GraphOptimizer::FuseFCAndWeightsDecompression(Graph &graph) {
             reshapeNode->setOriginalOutputPrecisionAtPort(0, weightsPrecision);
         }
         fcNode->setOriginalInputPrecisionAtPort(1, weightsPrecision);
+
+        // If decompression subgraph is shared with other nodes, it mustn't be removed.
+        // In this case, the current FC is reconnected to the weights
+        if (is_shared_decompression) {
+            const auto weights_out_edge = weightsNode->getChildEdges()[0].lock();
+            const auto fc_weights_path_edge = withTranspose ? transposeNode->getParentEdgeAt(0)
+                                                            : fcNode->getParentEdgeAt(1);
+            const auto inNum = weights_out_edge->getInputNum();
+            const auto outNum = fc_weights_path_edge->getOutputNum();
+            graph.RemoveEdge(fc_weights_path_edge);
+            // In case of shared group decompression, Reshape node has to be copied for the current FC
+            if (withReshape) {
+                const auto& reshapeOutShape = reshapeNode->getOutputShapeAtPort(0).getStaticDims();
+                auto reshapeConst = std::make_shared<ov::opset1::Constant>(ov::element::i32,
+                                                                           ov::Shape{reshapeOutShape.size()},
+                                                                           reshapeOutShape);
+                auto reshapeDummyInput = std::make_shared<ov::opset1::Parameter>(reshapeNode->getOriginalInputPrecisionAtPort(0),
+                                                                                 reshapeNode->getInputShapeAtPort(0).toPartialShape());
+                const auto reshape = std::make_shared<ov::opset1::Reshape>(reshapeDummyInput, reshapeConst, false);
+                reshape->set_friendly_name(reshapeNode->getName() + "_copy");
+                const auto cpuReshape = std::make_shared<ov::intel_cpu::node::Reshape>(reshape, graph.getGraphContext());
+                graph.InsertNode(weightsNode, withTranspose ? transposeNode : fcNode, cpuReshape, inNum, outNum, false);
+                const auto cpuReshapeConst = std::make_shared<node::Input>(reshapeConst, graph.getGraphContext());
+                graph.AddNode(cpuReshapeConst);
+                graph.CreateEdge(cpuReshapeConst, cpuReshape, 0, 1);
+            } else {
+                graph.CreateEdge(weightsNode, withTranspose ? transposeNode : fcNode, inNum, outNum);
+            }
+        } else {
+            // If decompression subgraph is not shared with other nodes, it can be removed
+            if (withSubtract)
+                graph.RemoveEdge(subtractNode->getParentEdgeAt(1));
+            if (withSubtractConvert) {
+                // SubtractConvert is removed only if there are no other consumers (e.g. CompressedGather)
+                const auto& restChilds = subtractConvertNode->getChildEdges();
+                if (restChilds.empty())
+                    graph.RemoveEdge(subtractConvertNode->getParentEdgeAt(0));
+            }
+            graph.RemoveEdge(multiplyNode->getParentEdgeAt(1));
+
+            graph.DropNode(convertNode);
+            if (withSubtract)
+                graph.DropNode(subtractNode);
+            graph.DropNode(multiplyNode);
+        }
+        DEBUG_LOG("FuseFCAndWeightsDecompression finished for node ", fcNode->getName());
     }
+#undef SKIP_FUSION_FOR_NODE
 }
 
 void GraphOptimizer::FuseConvolutionMatMulDeconvAndBias(Graph &graph) {
@@ -914,25 +922,27 @@ void GraphOptimizer::FuseFCAndConvertOnWeights(Graph& graph) {
     // This optimization fuses Convert (fp16 -> bf16/fp32) on weights directly to FC input to allow precision conversion handling based on internal logic
     // (e.g. fuse conversion with weights reordering)
     auto& graphNodes = graph.GetNodes();
+    for (const auto& fullyConnected : graphNodes) {
+        if (fullyConnected->getType() != Type::FullyConnected) {
+            continue;
+        }
+        const auto convert = fullyConnected->getParentEdgeAt(1)->getParent();
+        if (convert->getType() != Type::Convert || convert->getOriginalInputPrecisionAtPort(0) != ov::element::f16 ||
+            !one_of(convert->getOriginalOutputPrecisionAtPort(0), ov::element::f32, ov::element::bf16) ||
+            !convert->isConstant()) {
+            continue;
+        }
 
-    auto isSuitablePattern = [](NodePtr parent) {
-        bool res = true && parent->getType() == Type::Convert
-                        && parent->getChildEdges().size() == 1
-                        && parent->getChildEdgeAt(0)->getOutputNum() == 1
-                        && parent->getChildEdgeAt(0)->getChild()->getType() == Type::FullyConnected
-                        && one_of(parent->getOriginalInputPrecisionAtPort(0), ov::element::f16)
-                        && one_of(parent->getOriginalOutputPrecisionAtPort(0), ov::element::f32, ov::element::bf16)
-                        && parent->isConstant();
-        return res;
-    };
-
-    for (auto parent : graphNodes) {
-        if (isSuitablePattern(parent)) {
-            CPU_GRAPH_OPTIMIZER_SCOPE(FuseFCAndConvertOnWeights);
-            auto childNode = parent->getChildEdgeAt(0)->getChild();
-            // set correct weight precision
-            childNode->setOriginalInputPrecisionAtPort(1, parent->getOriginalInputPrecisionAtPort(0));
-            graph.DropNode(parent);
+        const auto weights = convert->getParentEdgeAt(0)->getParent();
+        const auto weights_out_edge = weights->getChildEdges()[0].lock();
+        const auto fc_weights_path_edge = fullyConnected->getParentEdgeAt(1);
+        const auto inNum = weights_out_edge->getInputNum();
+        const auto outNum = fc_weights_path_edge->getOutputNum();
+        fullyConnected->setOriginalInputPrecisionAtPort(1, convert->getOriginalInputPrecisionAtPort(0));
+        graph.RemoveEdge(fc_weights_path_edge);
+        graph.CreateEdge(weights, fullyConnected, inNum, outNum);
+        if (convert->getChildEdges().empty()) {
+            graph.DropNode(convert);
         }
     }
 }

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -157,32 +157,37 @@ namespace intel_cpu {
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
 
 bool Transformations::is_decompression_multiply(const_node_ptr& node) const {
-    auto get_single_consumer = [](const_node_ptr& node) -> std::shared_ptr<ov::Node> {
-        const auto consumers = node->get_output_target_inputs(0);
-        if (consumers.size() != 1)
-            return nullptr;
-        return consumers.begin()->get_node()->shared_from_this();
+    auto all_has_type = [](const std::set<ov::Input<ov::Node>>& consumers, const ov::DiscreteTypeInfo& type) {
+        return std::all_of(consumers.begin(), consumers.end(), [&type](const ov::Input<ov::Node>& input) {
+            return input.get_node()->get_type_info() == type;
+        });
     };
 
-    auto consumer = get_single_consumer(node);
-    if (!consumer)
-        return false;
-
-    if (ov::is_type<ov::opset1::MatMul>(consumer)) {
+    const auto consumers = node->get_output_target_inputs(0);
+    if (all_has_type(consumers, ov::opset1::MatMul::get_type_info_static()))
         return true;
-    } else if (ov::is_type<ov::opset1::Reshape>(consumer)) {
-        consumer = get_single_consumer(consumer);
-        if (consumer != nullptr && ov::is_type<ov::opset1::MatMul>(consumer)) {
-            return true;
+
+    auto are_converts_from_decompression = [&all_has_type](const std::set<ov::Input<ov::Node>>& consumers) {
+        if (!all_has_type(consumers, ov::opset1::Convert::get_type_info_static()))
+            return false;
+        for (const auto& consumer : consumers) {
+            const auto child_consumers = consumer.get_node()->get_output_target_inputs(0);
+            if (!all_has_type(child_consumers, ov::opset1::MatMul::get_type_info_static()))
+                return false;
+        }
+        return true;
+    };
+
+    if (all_has_type(consumers, ov::opset1::Reshape::get_type_info_static())) {
+        for (const auto& consumer : consumers) {
+            const auto child_consumers = consumer.get_node()->get_output_target_inputs(0);
+            if (all_has_type(child_consumers, ov::opset1::MatMul::get_type_info_static()) ||
+                are_converts_from_decompression(child_consumers)) {
+                return true;
+            }
         }
     }
-    if (consumer != nullptr && ov::is_type<ov::opset1::Convert>(consumer)) {
-        consumer = get_single_consumer(consumer);
-        if (consumer != nullptr && ov::is_type<ov::opset1::MatMul>(consumer)) {
-            return true;
-        }
-    }
-    return false;
+    return are_converts_from_decompression(consumers);
 }
 
 bool Transformations::fuse_type_to_fq(const std::shared_ptr<ov::Node>& node, const precisions_map& precisions) {
@@ -376,8 +381,10 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::KeepConstAndDecompression);
     CPU_SET_CALLBACK_COMMON(manager,
         [](const_node_ptr &node) -> bool {
-            const auto outputs = node->get_output_target_inputs(0);
-            return outputs.size() != 1 || !is_type<ov::op::v0::MatMul>(outputs.begin()->get_node());
+            const auto consumers = node->get_output_target_inputs(0);
+            return std::all_of(consumers.begin(), consumers.end(), [](const ov::Input<ov::Node>& consumer) {
+                return !ov::is_type<ov::op::v0::MatMul>(consumer.get_node());
+            });
         },
         ov::pass::KeepConstAndDecompression);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/matmul_weights_decompression.cpp
@@ -1,12 +1,11 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "common_test_utils/node_builders/constant.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/fusing_test_utils.hpp"
-#include "transformations/rt_info/decompression.hpp"
 #include "openvino/runtime/intel_cpu/properties.hpp"
+#include "shared_test_classes/subgraph/weights_decompression_builders.hpp"
 
 using namespace CPUTestUtils;
 
@@ -16,13 +15,14 @@ namespace test {
  * WP - weights precision
  * DP - decompression precision
  * IP - input precision
+ * SP - scale precision
  * Opt - optional
  *                        Subtract_const(WP)
  *                           /
  *    Weights(WP)     Convert(DP)
- *       |               /
- *    Convert(DP)   Reshape (Opt)
- *            \        /          Multiply_const(DP)
+ *       |               /           Multiply_const(SP)
+ *    Convert(DP)   Reshape (Opt)      /
+ *            \        /          Convert(if SP != DP)
  *            Subtract(Opt)       /
  *                  \         Reshape (Opt)
  *                   \         /
@@ -38,60 +38,26 @@ namespace test {
  *               |
  *              Bias
  */
-
-enum class DecompressionSubtractType {
-    empty,  // no decompression subtract
-    scalar, // decompression subtract with scalar shape
-    full    // decompression subtract with per-channel or grouped shape
-};
-
-inline std::ostream& operator<<(std::ostream & os, DecompressionSubtractType type) {
-    switch (type) {
-        case DecompressionSubtractType::empty:
-            os << "empty";
-            break;
-        case DecompressionSubtractType::scalar:
-            os << "scalar";
-            break;
-        case DecompressionSubtractType::full:
-            os << "full";
-            break;
-        default:
-            OPENVINO_THROW("Not supported type for DecompressionSubtractType");
-    }
-    return os;
-}
-
-struct ShapeParams {
-    ShapeParams() = default;
-    ShapeParams(InputShape data_shape, ov::Shape weights_shape, int weights_group_size = -1)
-        : data_shape(std::move(data_shape)),
-          weights_shape(std::move(weights_shape)),
-          weights_group_size(weights_group_size) {}
-
-    InputShape data_shape;
-    ov::Shape weights_shape;
-    // Decompression group size. If the value is equal to -1, ordinary decompression is used
-    int weights_group_size;
-};
-using MatmulWeightsDecompressionParams = std::tuple<ShapeParams,
-                                                    ov::test::ElementType,     // weights precision
-                                                    ov::test::ElementType,     // decompression precision
-                                                    bool,                      // transpose on weights
-                                                    DecompressionSubtractType, // decompression subtract type
-                                                    bool,                      // reshape on decompression constants
-                                                    ov::AnyMap,                // additional config
+using MatmulWeightsDecompressionParams = std::tuple<MatMulDecompressionShapeParams,
+                                                    ov::test::ElementType,      // weights precision
+                                                    ov::test::ElementType,      // decompression precision
+                                                    ov::test::ElementType,      // scale precision
+                                                    bool,                       // transpose on weights
+                                                    DecompressionSubtractType,  // decompression subtract type
+                                                    bool,                       // reshape on decompression constants
+                                                    ov::AnyMap,                 // additional config
                                                     fusingSpecificParams,
-                                                    bool>;  // should use decompression implementation
+                                                    bool>;                      // should use decompression implementation
 
 class MatmulWeightsDecompression : public testing::WithParamInterface<MatmulWeightsDecompressionParams>,
-                                  virtual public SubgraphBaseTest,
-                                  public CpuTestWithFusing {
+                                   virtual public SubgraphBaseTest,
+                                   public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<MatmulWeightsDecompressionParams> obj) {
-        ShapeParams shape_params;
+        MatMulDecompressionShapeParams shape_params;
         ov::test::ElementType weights_precision;
         ov::test::ElementType decompression_precision;
+        ov::test::ElementType scale_precision;
         bool transpose;
         DecompressionSubtractType decompression_subtract_type;
         bool reshape_on_decompression;
@@ -102,6 +68,7 @@ public:
         std::tie(shape_params,
                  weights_precision,
                  decompression_precision,
+                 scale_precision,
                  transpose,
                  decompression_subtract_type,
                  reshape_on_decompression,
@@ -110,11 +77,10 @@ public:
                  should_fuse) = obj.param;
 
         std::ostringstream result;
-        result << "data_shape=" << shape_params.data_shape << "_";
-        result << "weights_shape=" << shape_params.weights_shape << "_";
-        result << "group_size=" << shape_params.weights_group_size << "_";
+        result << shape_params << "_";
         result << "weights_precision=" << weights_precision << "_";
         result << "decompression_precision=" << decompression_precision << "_";
+        result << "scale_precision=" << scale_precision << "_";
         result << "transpose_weights=" << transpose << "_";
         result << "decompression_subtract=" << decompression_subtract_type << "_";
         result << "reshape_on_decompression=" << reshape_on_decompression << "_";
@@ -130,129 +96,26 @@ public:
     }
 
 protected:
-    std::shared_ptr<ov::Node> initDecompressionWeights(const ov::Shape& weights_shape,
-                                                       const int group_size,
-                                                       const ov::element::Type data_precision,
-                                                       const ov::element::Type weights_precision,
-                                                       const ov::element::Type decompression_precision,
-                                                       const bool transpose_weights,
-                                                       const DecompressionSubtractType decompression_subtract_type,
-                                                       const bool reshape_on_decompression_constant) {
-        auto transpose_if_necessary = [&](const ov::Shape& shape) {
-            auto result_shape = shape;
-            if (transpose_weights)
-                std::swap(*result_shape.rbegin(), *(result_shape.rbegin() + 1));
-            return result_shape;
-        };
-
-        const bool group_decompression = group_size != -1;
-        // Weights has shape [I, O], where
-        // I - input channels
-        // O - output channels
-        // In case of group decompression, input channels dimension is split into 2: I -> [N, G], where
-        // N - number of groups
-        // G - group size
-        auto transformed_weights_shape = transpose_if_necessary(weights_shape);
-        if (group_decompression) {
-            OPENVINO_ASSERT(weights_shape[0] % group_size == 0,
-                            "Weights output channels count (",
-                            weights_shape[0],
-                            ") must be divisible by decompression group size (",
-                            group_size,
-                            ").");
-            auto in_channel_idx = transpose_weights ? transformed_weights_shape.size() - 1 : transformed_weights_shape.size() - 2;
-            transformed_weights_shape[in_channel_idx] = weights_shape[0] / group_size;
-            transformed_weights_shape.insert(transformed_weights_shape.begin() + in_channel_idx + 1, group_size);
-        }
-
-        auto up_to = weights_precision == ov::element::i4 ? 7 : 15;
-        auto weights_tensor =
-            ov::test::utils::create_and_fill_tensor(weights_precision, transformed_weights_shape, ov::test::utils::InputGenerateData(1, up_to));
-        auto weights = std::make_shared<ov::op::v0::Constant>(weights_tensor);
-        weights->set_friendly_name("Compressed_weights");
-        auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, decompression_precision);
-
-        std::shared_ptr<ov::Node> mul_parent = weights_convert;
-        auto output_channels = *weights_shape.rbegin();
-
-        // Decompression constants shape:
-        // Ordinary decompression: [O, 1]
-        // Group decompression: [O, N, 1]
-        ov::Shape scaleshift_target_shape{output_channels};
-        scaleshift_target_shape.insert(scaleshift_target_shape.begin(), group_decompression ? weights_shape[0] / group_size : 1);
-        scaleshift_target_shape = transpose_if_necessary(scaleshift_target_shape);
-        if (group_decompression) {
-            auto in_channel_idx = transpose_weights ? scaleshift_target_shape.size() - 1 : scaleshift_target_shape.size() - 2;
-            scaleshift_target_shape.insert(scaleshift_target_shape.begin() + in_channel_idx + 1, 1);
-        }
-
-        auto scaleshift_const_shape = scaleshift_target_shape;
-        if (reshape_on_decompression_constant)
-            scaleshift_const_shape.erase(std::remove(scaleshift_const_shape.begin(), scaleshift_const_shape.end(), 1), scaleshift_const_shape.end());
-        if (decompression_subtract_type != DecompressionSubtractType::empty) {
-            auto subtract_shape = decompression_subtract_type == DecompressionSubtractType::full ? scaleshift_const_shape : Shape({});
-            auto shift_const_tensor =
-                ov::test::utils::create_and_fill_tensor(weights_precision, subtract_shape, ov::test::utils::InputGenerateData(1, up_to));
-            auto shift_const = std::make_shared<ov::op::v0::Constant>(shift_const_tensor);
-
-            std::shared_ptr<ov::Node> shift_convert = std::make_shared<ov::op::v0::Convert>(shift_const, decompression_precision);
-            if (reshape_on_decompression_constant) {
-                auto subtract_target_shape = decompression_subtract_type == DecompressionSubtractType::full
-                    ? scaleshift_target_shape : ov::Shape(scaleshift_const_shape.size(), 1);
-                auto shift_reshape_const = ov::opset10::Constant::create(ov::element::i32, {subtract_target_shape.size()}, subtract_target_shape);
-                auto shift_reshape = std::make_shared<ov::opset10::Reshape>(shift_convert, shift_reshape_const, false);
-                shift_convert = shift_reshape;
-            }
-            mul_parent = std::make_shared<ov::opset10::Subtract>(weights_convert, shift_convert);
-        }
-
-        auto scale_const_tensor = ov::test::utils::create_and_fill_tensor_real_distribution(decompression_precision, scaleshift_const_shape, 0.001f, 0.01f, 1);
-        std::shared_ptr<ov::Node> scale_const = std::make_shared<ov::op::v0::Constant>(scale_const_tensor);
-        if (reshape_on_decompression_constant) {
-            auto scale_reshape_const = ov::opset10::Constant::create(ov::element::i32, {scaleshift_target_shape.size()}, scaleshift_target_shape);
-            auto scale_reshape = std::make_shared<ov::opset10::Reshape>(scale_const, scale_reshape_const, false);
-            scale_const = scale_reshape;
-        }
-        std::shared_ptr<ov::Node> last_node = std::make_shared<ov::opset10::Multiply>(mul_parent, scale_const);
-
-        if (group_decompression) {
-            auto reshape_target_shape = transpose_weights ? std::vector<int>{-1, static_cast<int>(weights_shape[0])}
-                                                          : std::vector<int>{static_cast<int>(weights_shape[0]), -1};
-            auto target_shape_node = ov::opset10::Constant::create(ov::element::i32, {reshape_target_shape.size()}, reshape_target_shape);
-            last_node = std::make_shared<ov::opset10::Reshape>(last_node, target_shape_node, false);
-        }
-        if (decompression_precision != data_precision) {
-            last_node = std::make_shared<ov::opset10::Convert>(last_node, data_precision);
-        }
-        if (transpose_weights) {
-            const size_t rank = last_node->get_output_partial_shape(0).size();
-            std::vector<int> order(rank);
-            std::iota(order.begin(), order.end(), 0);
-            std::swap(*order.rbegin(), *(order.rbegin() + 1));
-            auto transpose_constant = ov::opset10::Constant::create(ov::element::i32, {rank}, order);
-            last_node = std::make_shared<ov::opset10::Transpose>(last_node, transpose_constant);
-        }
-        return last_node;
-    }
-
     std::shared_ptr<ov::Model> initSubgraph(const ov::PartialShape& data_shape,
                                             const ov::Shape& weights_shape,
                                             const int group_size,
                                             const ov::element::Type data_precision,
                                             const ov::element::Type weights_precision,
                                             const ov::element::Type decompression_precision,
+                                            const ov::element::Type scale_precision,
                                             const bool transpose_weights,
                                             const DecompressionSubtractType decompression_subtract_type,
                                             const bool reshape_on_decompression) {
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(data_precision, data_shape)};
-        const auto weights_subgraph = initDecompressionWeights(weights_shape,
-                                                               group_size,
-                                                               data_precision,
-                                                               weights_precision,
-                                                               decompression_precision,
-                                                               transpose_weights,
-                                                               decompression_subtract_type,
-                                                               reshape_on_decompression);
+        const auto weights_subgraph = initMatMulDecompressionSubgraph(weights_shape,
+                                                                      group_size,
+                                                                      data_precision,
+                                                                      weights_precision,
+                                                                      decompression_precision,
+                                                                      scale_precision,
+                                                                      transpose_weights,
+                                                                      decompression_subtract_type,
+                                                                      reshape_on_decompression);
         auto matMul = std::make_shared<ov::op::v0::MatMul>(params[0], weights_subgraph);
         return makeNgraphFunction(data_precision, params, matMul, "MatmulWeightsDecompression");
     }
@@ -260,9 +123,10 @@ protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
 
-        ShapeParams shape_params;
+        MatMulDecompressionShapeParams shape_params;
         ov::test::ElementType weights_precision;
         ov::test::ElementType decompression_precision;
+        ov::test::ElementType scale_precision;
         bool transpose_weights;
         DecompressionSubtractType decompression_subtract_type;
         bool reshape_on_decompression;
@@ -273,6 +137,7 @@ protected:
         std::tie(shape_params,
                  weights_precision,
                  decompression_precision,
+                 scale_precision,
                  transpose_weights,
                  decompression_subtract_type,
                  reshape_on_decompression,
@@ -282,7 +147,7 @@ protected:
 
         configuration.insert(additional_config.begin(), additional_config.end());
         std::tie(postOpMgrPtr, fusedOps) = fusing_params;
-        init_input_shapes({shape_params.data_shape, {{}, {{shape_params.weights_shape}}}});
+        init_input_shapes({shape_params.data_shape});
 
         // if dynamic quantization is enabled
         if (configuration.count(ov::hint::dynamic_quantization_group_size.name()) &&
@@ -297,10 +162,11 @@ protected:
 
         function = initSubgraph(inputDynamicShapes[0],
                                 shape_params.weights_shape,
-                                shape_params.weights_group_size,
+                                shape_params.decompression_group_size,
                                 netType,
                                 weights_precision,
                                 decompression_precision,
+                                scale_precision,
                                 transpose_weights,
                                 decompression_subtract_type,
                                 reshape_on_decompression);
@@ -308,20 +174,19 @@ protected:
 
     void check_results() {
         const auto& test_param = GetParam();
-        const auto& weights_precision = std::get<1>(test_param);
+        const ov::element::Type compressed_weights_precision = std::get<1>(test_param);
+        const bool use_matmul_decompression_impl = std::get<9>(test_param);
 
-        for (const auto& n : compiledModel.get_runtime_model()->get_ordered_ops()) {
-            auto layer_type = n->get_rt_info().at(ov::exec_model_info::LAYER_TYPE).as<std::string>();
-            if (layer_type == "Constant") {
-                ASSERT_EQ(n->get_output_element_type(0), weights_precision);
-            }
-        }
+        const auto runtime_model = compiledModel.get_runtime_model();
+        const auto result = runtime_model->get_result();
+        const auto fc = result->get_input_node_shared_ptr(0);
+        const auto type = fc->get_rt_info().at(ov::exec_model_info::LAYER_TYPE).as<std::string>();
+        EXPECT_EQ(type, "FullyConnected");
 
-        const bool should_fuse = std::get<8>(test_param);
-        const size_t expected_count = should_fuse ? 0 : 1;
-        CheckNumberOfNodesWithType(compiledModel, "Convert", expected_count);
-        CheckNumberOfNodesWithType(compiledModel, "Eltwise", expected_count);
-        CheckNumberOfNodesWithType(compiledModel, "Subgraph", 0);
+        const auto& expected_weights_precision = use_matmul_decompression_impl
+                                                     ? compressed_weights_precision
+                                                     : fc->get_input_element_type(0);
+        EXPECT_EQ(fc->get_input_element_type(1), expected_weights_precision);
     }
 };
 
@@ -350,7 +215,7 @@ const std::vector<ov::test::ElementType> weights_precisions = {ov::element::u8,
                                                                ov::element::i4,
                                                                element::nf4};
 
-const std::vector<ShapeParams> input_shapes_basic = {
+const std::vector<MatMulDecompressionShapeParams> input_shapes_basic = {
     {{{-1, -1, -1}, {{1, 4, 16}, {10, 16, 16}}}, {16, 32}},
     {{{}, {{1, 8, 16}}}, {16, 32}, 4ul},
     {{{}, {{1, 4, 16}}}, {1, 16, 32}},
@@ -359,7 +224,7 @@ const std::vector<ShapeParams> input_shapes_basic = {
     {{{}, {{1, 11, 154}}}, {154, 77}, 154ul},
     {{{-1, -1, -1}, {{10, 40, 480}, {11, 40, 480}}}, {1, 480, 256}},
 };
-const std::vector<ShapeParams> input_shapes_amx = {
+const std::vector<MatMulDecompressionShapeParams> input_shapes_amx = {
     {{{-1, -1, -1}, {{10, 40, 480}, {11, 40, 480}}}, {1, 480, 256}},
     {{{}, {{1, 4, 32}}}, {32, 256}},
     {{{}, {{1, 16, 32}}}, {32, 64}},
@@ -375,6 +240,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_basic,
                          ::testing::Combine(::testing::ValuesIn(input_shapes_basic),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
                                             ::testing::Values(DecompressionSubtractType::full),
                                             // todo: zero points converted to fp32 for reshape == true case
@@ -389,6 +255,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_amx,
                          ::testing::Combine(::testing::ValuesIn(input_shapes_amx),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
                                             ::testing::Values(DecompressionSubtractType::full),
                                             // todo: zero points converted to fp32 for reshape == true case
@@ -398,13 +265,13 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_amx,
                                             ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);
 
-const std::vector<ShapeParams> input_shapes_corner_cases_basic = {
+const std::vector<MatMulDecompressionShapeParams> input_shapes_corner_cases_basic = {
     {{{-1, -1, -1}, {{1, 4, 16}}}, {1, 16, 32}},
     {{{-1, -1, -1}, {{1, 4, 16}}}, {16, 32}},
     {{{-1, -1, -1}, {{1, 5, 16}}}, {16, 32}, 4ul},
     {{{-1, -1, -1}, {{1, 1, 4096}}}, {4096, 4096}, 128ul},
 };
-const std::vector<ShapeParams> input_shapes_corner_cases_amx = {
+const std::vector<MatMulDecompressionShapeParams> input_shapes_corner_cases_amx = {
     {{{-1, -1, -1}, {{10, 40, 480}, {11, 40, 480}}}, {1, 480, 256}},
     {{{-1, -1, -1}, {{1, 1, 4096}}}, {4096, 4096}, 128ul},
 };
@@ -420,6 +287,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_basic,
                          ::testing::Combine(::testing::ValuesIn(input_shapes_corner_cases_basic),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions_corner_cases),
+                                            ::testing::Values(ov::element::undefined),
                                             ::testing::ValuesIn(transpose_weights),
                                             ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::ValuesIn(reshape_on_decompression),
@@ -428,11 +296,49 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_basic,
                                             ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);
 
+const std::vector<MatMulDecompressionShapeParams> input_shapes_f32_decompression_f16_scale = {
+    {{{}, {{1, 8, 16}}}, {16, 32}},
+    {{{}, {{1, 8, 16}}}, {16, 32}, 4ul},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_f32_decompression_f16_scale,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_f32_decompression_f16_scale),
+                                            ::testing::Values(ov::element::u8),
+                                            ::testing::Values(ov::element::f32),
+                                            ::testing::Values(ov::element::f16),
+                                            ::testing::ValuesIn(transpose_weights),
+                                            ::testing::Values(DecompressionSubtractType::full),
+                                            ::testing::ValuesIn(reshape_on_decompression),
+                                            ::testing::ValuesIn(filter_additional_config_basic()),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::Values(true)),
+                         MatmulWeightsDecompression::getTestCaseName);
+
+const std::vector<MatMulDecompressionShapeParams> input_shapes_corner_cases_negative = {
+    {{{-1, -1, -1}, {{1, 512, 512}}}, {512, 1}},
+    {{{-1, -1, -1}, {{1, 5, 32}}}, {32, 64}, 2ul},
+};
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_negative,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_corner_cases_negative),
+                                            ::testing::Values(ov::element::u8),
+                                            ::testing::Values(ov::element::f32),
+                                            ::testing::Values(ov::element::undefined),
+                                            ::testing::Values(true),
+                                            ::testing::Values(DecompressionSubtractType::empty),
+                                            ::testing::Values(false),
+                                            ::testing::ValuesIn(filter_additional_config_basic()),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::Values(false)),
+                         MatmulWeightsDecompression::getTestCaseName);
+
 INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_amx,
                          MatmulWeightsDecompression,
                          ::testing::Combine(::testing::ValuesIn(input_shapes_corner_cases_amx),
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions_corner_cases),
+                                            ::testing::Values(ov::element::undefined),
                                             ::testing::ValuesIn(transpose_weights),
                                             ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::ValuesIn(reshape_on_decompression),
@@ -441,7 +347,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_amx,
                                             ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);
 
-const std::vector<ShapeParams> input_shapes_basic_dyn_quant = {
+const std::vector<MatMulDecompressionShapeParams> input_shapes_basic_dyn_quant = {
     {{{}, {{1, 7, 256}}}, {256, 128}, 32lu},
     {{{}, {{1, 1, 128}}}, {128, 32}},
     {{{}, {{1, 3, 144}}}, {144, 64}, 16lu},
@@ -465,6 +371,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_non_default_dyn_quant_gro
                          ::testing::Combine(::testing::ValuesIn(input_shapes_basic_dyn_quant),
                                             ::testing::ValuesIn(weights_precisions_dyn_quant),
                                             ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
                                             ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::Values(false),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -298,6 +298,7 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_MM_Brgemm_Dynamic_Fusing/MatMulLayerCPUTest.CompareWithRefs/MatMul_IS=\[\?.\?\]_\[\?.33\]_TS=\(\(16.12\)_\(33.7\)_\(16.12\)\)_\(\(12.33\)_\(7.33\)_\(12.33\)\)_transpose_a=0_transpose_b=0_secondaryInputType=PARAMETER_netPRC=f32_inPRC=undefined_outPRC=undefined_trgDev=CPUconfig=\(INFERENCE_PRECISION_HINT=bf16_\)_Fused=Multiply\(PerChannel\)_primitive=brgemm_avx512.*)",
         // Issue: 140389
         R"(.*smoke_GatherCompressedWeights_basic/GatherWeightsDecompression.CompareWithRefs.*i4.*)",
+        R"(.*smoke_MatmulAndGatherSharedWeightsDecompression.*weights_precision=i4.*decompression_subtract=1.*)",
         R"(.*FQLayerDQBias.smoke_CompareWithRefs.*)",
         R"(.*smoke_matmulBrgemmInt8/MatmulBrgemmInt8Test.CompareWithRefs.*MatMul.*InputType=i8_OutputType=i8.*)",
         R"(.*smoke_Snippets_MHAWOTransposeOnInputs_4D/MHAWOTransposeOnInputs.CompareWithRefImpl.*)",
@@ -385,6 +386,10 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(MultipleLSTMCellTest/MultipleLSTMCellTest.CompareWithRefs.*)");
     // int8 / code-generation specific
     retVector.emplace_back(R"(smoke_LPT.*)");
+    // Compressed weights are not supported
+    retVector.emplace_back(R"(smoke_MatMulCompressedWeights.*)");
+    retVector.emplace_back(R"(smoke_MatMulSharedCompressedWeights.*)");
+    retVector.emplace_back(R"(smoke_MatmulAndGatherSharedWeightsDecompression.*)");
     // smoke_Snippets test cases are not supported on arm32 platforms
 #if !defined(OPENVINO_ARCH_ARM64)
     retVector.emplace_back(R"(smoke_Snippets.*)");
@@ -406,7 +411,7 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(.*smoke_LPT/MatMulTransformation.CompareWithRefImpl/f32_CPU_\[(1|8|1,1,1),4,12,2\]_level=256_shape=\[\]_input_low=\{ (0|-12.8) \}_input_high=\{ (25.5|12.7) \}_output_low=\{ (0|-12.8) \}_output_high\{ (25.5|12.7) \}_.*)");
     retVector.emplace_back(R"(.*smoke_LPT/MatMulTransformation.CompareWithRefImpl/f32_CPU_\[(1|8|1,1,1),4,12,2\]_level=256_shape=\[\]_input_low=\{ (0|-12.8) \}_input_high=\{ (25.5|12.7) \}_output_low=\{ (0|-12.8) \}_output_high\{ (25.5|12.7) \}_.*)");
     retVector.emplace_back(
-        R"(.*smoke_MatMulCompressedWeights_corner_cases_basic/MatmulWeightsDecompression.CompareWithRefs/data_shape=\[\?.\?.\?\]_\(\[1,1,4096\]\)_weights_shape=\[4096,4096\]_group_size=128_weights_precision=nf4_decompression_precision=f16_transpose_weights=0_decompression_subtract=full_reshape_on_decompression=1_config=\(\).*)");
+        R"(.*smoke_MatMulCompressedWeights_corner_cases_basic/MatmulWeightsDecompression.CompareWithRefs/data_shape=\[\?.\?.\?\]_\(\[1,1,4096\]\)_weights_shape=\[4096,4096\]_group_size=128_weights_precision=nf4_decompression_precision=f16_scale_precision=undefined_transpose_weights=0_decompression_subtract=full_reshape_on_decompression=1_config=\(\).*)");
     retVector.emplace_back(R"(.*smoke_RDFT_CPU_1D/RDFTTestCPU.CompareWithRefs/prec=f32_IS0=\[\]_TS0=\(\(126\)\)_constAxes=true_axes=\(\(0\)\)_isInverse=false.*)");
     retVector.emplace_back(R"(.*smoke_RDFT_CPU_2D/RDFTTestCPU.CompareWithRefs/prec=f32_IS0=\[\]_TS0=\(\(16.38\)\)_constAxes=true_axes=\(\(0.1\)\)_isInverse=false.*)");
 #endif

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/gather_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/gather_weights_decompression.cpp
@@ -21,7 +21,7 @@ const std::vector<ov::element::Type> weights_precisions = {ov::element::u8,
                                                            ov::element::i8,
                                                            ov::element::u4,
                                                            ov::element::i4};
-const std::vector<GWDShapeParams> input_shapes_basic = {
+const std::vector<GatherDecompressionShapeParams> input_shapes_basic = {
     {{2, 5}, {{-1, -1}, {{2, 3}}}, 0, 0},
     {{15, 32}, {{-1, -1}, {{2, 3}}}, 1, 0, 16},
     {{15, 32}, {{-1, -1}, {{2, 3}}}, 0, 0, 16},

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_gather_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_gather_weights_decompression.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/shared_matmul_gather_weights_decompression.hpp"
+
+#include "common_test_utils/test_constants.hpp"
+
+using namespace ov::test;
+
+namespace {
+TEST_P(SharedMatmulAndGatherWeightsDecompression, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    run();
+    check_results();
+}
+
+const std::vector<GatherDecompressionShapeParams> input_shapes = {
+    {{128, 256}, {{}, {{256, 256}}}, 1, 0},
+    {{128, 256}, {{}, {{256, 256}}}, 1, 0, 16},
+};
+const std::vector<ElementType> weights_precisions = {ov::element::u8, ov::element::u4, ov::element::i4};
+const std::vector<ElementType> decompression_precisions = {ov::element::f32};
+const std::vector<bool> decompression_subtract = {true, false};
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatmulAndGatherSharedWeightsDecompression,
+                         SharedMatmulAndGatherWeightsDecompression,
+                         ::testing::Combine(::testing::Values(utils::DEVICE_CPU),
+                                            ::testing::ValuesIn(input_shapes),
+                                            ::testing::ValuesIn(weights_precisions),
+                                            ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::ValuesIn(decompression_subtract),
+                                            ::testing::Values(true)),
+                         SharedMatmulAndGatherWeightsDecompression::getTestCaseName);
+
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_weights_decompression.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/shared_matmul_weights_decompression.hpp"
+
+#include "common_test_utils/test_constants.hpp"
+
+using namespace ov::test;
+
+namespace {
+TEST_P(SharedMatmulWeightsDecompression, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    run();
+    check_results();
+}
+const std::vector<MatMulDecompressionShapeParams> input_shapes = {
+    {{{}, {{1, 1, 256}}}, {256, 128}},
+    {{{}, {{1, 1, 256}}}, {256, 128}, 64ul},
+};
+const std::vector<ElementType> decompression_precisions = {ov::element::f16, ov::element::f32};
+const std::vector<ElementType> weights_precisions = {ov::element::u8, ov::element::u4};
+const std::vector<bool> transpose_weights = {true, false};
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulSharedCompressedWeights,
+                         SharedMatmulWeightsDecompression,
+                         ::testing::Combine(::testing::Values(utils::DEVICE_CPU),
+                                            ::testing::ValuesIn(input_shapes),
+                                            ::testing::ValuesIn(weights_precisions),
+                                            ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::ValuesIn(transpose_weights),
+                                            ::testing::Values(DecompressionSubtractType::full),
+                                            ::testing::Values(true)),
+                         SharedMatmulWeightsDecompression::getTestCaseName);
+
+}  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/gather_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/gather_weights_decompression.cpp
@@ -19,7 +19,7 @@ const std::vector<ov::element::Type> weights_precisions = {ov::element::u8,
                                                            ov::element::i8,
                                                            ov::element::u4,
                                                            ov::element::i4};
-const std::vector<GWDShapeParams> input_shapes_basic = {
+const std::vector<GatherDecompressionShapeParams> input_shapes_basic = {
     {{2, 5}, {{-1, -1}, {{2, 3}}}, 1, 1},
     {{15, 32}, {{-1, -1}, {{2, 3}}}, 1, 0, 16},
     {{15, 32}, {{-1, -1}, {{2, 3}}}, 0, 0, 16},

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/gather_weights_decompression.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/gather_weights_decompression.hpp
@@ -6,6 +6,7 @@
 
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
+#include "shared_test_classes/subgraph/weights_decompression_builders.hpp"
 
 namespace ov {
 namespace test {
@@ -25,29 +26,8 @@ namespace test {
  *             Gather
  */
 
-struct GWDShapeParams {
-    GWDShapeParams() = default;
-    GWDShapeParams(ov::Shape data_shape,
-                InputShape indices_shape,
-                int axis,
-                int64_t batch_dims,
-                int decompression_group_size = -1)
-        : data_shape(std::move(data_shape)),
-          indices_shape(std::move(indices_shape)),
-          axis(axis),
-          batch_dims(batch_dims),
-          decompression_group_size(decompression_group_size) {}
-
-    ov::Shape data_shape;
-    InputShape indices_shape;
-    int axis;
-    int64_t batch_dims;
-    // Decompression group size. If the value is equal to -1, ordinary decompression is used
-    int decompression_group_size;
-};
-
 using GatherWeightsDecompressionParams = std::tuple<std::string,        // Device name
-                                                    GWDShapeParams,     // input shapes
+                                                    GatherDecompressionShapeParams,
                                                     ov::element::Type,  // data type
                                                     ov::element::Type,  // output type
                                                     bool,               // decompression subtract
@@ -72,14 +52,6 @@ protected:
                                              const bool reshape_on_decompression,
                                              const bool per_tensor_zp,
                                              const bool per_tensor_scale);
-    std::shared_ptr<ov::Node> init_compressed_weights_subgraph(const ov::Shape& data_shape,
-                                                               const int group_size,
-                                                               const ov::element::Type data_precision,
-                                                               const ov::element::Type output_precision,
-                                                               const bool add_subtract,
-                                                               const bool reshape_on_decompression_constant,
-                                                               const bool per_tensor_zp,
-                                                               const bool per_tensor_scale);
     void generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) override;
     void check_results();
     void SetUp() override;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/shared_matmul_gather_weights_decompression.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/shared_matmul_gather_weights_decompression.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "shared_test_classes/subgraph/weights_decompression_builders.hpp"
+
+namespace ov {
+namespace test {
+/*
+ * WP - weights precision
+ * DP - decompression precision
+ * IP - input precision
+ * Opt - optional
+ *                 Weights(WP)     Subtract_const(WP)
+ *                    |               /
+ *                 Convert(DP)    Convert(DP)
+ *                         \        /
+ *                         Subtract(Opt)
+ *                               \          Multiply_const(DP)
+ *                                \         /
+ *                                 Multiply
+ *                                   |
+ *                                Reshape (in case of group decompression)
+ *                                   |
+ *                Data(IP)        Convert (if IP != DP)        Indices(I32)
+ *                        \      /                     \      /
+ *               Matmul(transpose_b = true)             Gather
+*/
+
+using SharedMatmulAndGatherWeightsDecompressionParams = std::tuple<std::string,                 // target device
+                                                                   GatherDecompressionShapeParams,
+                                                                   ElementType,                 // weights precision
+                                                                   ElementType,                 // decompression precision
+                                                                   bool,                        // decompression subtract
+                                                                   bool>;                       // use matmul decompression implementation
+
+class SharedMatmulAndGatherWeightsDecompression : public testing::WithParamInterface<SharedMatmulAndGatherWeightsDecompressionParams>,
+                                                  virtual public SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<SharedMatmulAndGatherWeightsDecompressionParams> obj);
+
+protected:
+    std::shared_ptr<ov::Model> initSubgraph(const ov::Shape& data_shape,
+                                            const ov::PartialShape& indices_shape,
+                                            const int axis,
+                                            const int64_t batch_dims,
+                                            const int group_size,
+                                            const ov::element::Type data_precision,
+                                            const ov::element::Type output_precision,
+                                            const bool add_subtract);
+    void SetUp() override;
+    void check_results();
+};
+
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/shared_matmul_weights_decompression.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/shared_matmul_weights_decompression.hpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "shared_test_classes/subgraph/weights_decompression_builders.hpp"
+
+namespace ov {
+namespace test {
+/*
+ * WP - weights precision
+ * DP - decompression precision
+ * IP - input precision
+ * Opt - optional
+ *                 Weights(WP)     Subtract_const(WP)
+ *                    |               /
+ *                 Convert(DP)    Convert(DP)
+ *                         \        /
+ *                         Subtract(Opt)
+ *                               \          Multiply_const(DP)
+ *                                \         /
+ *                                 Multiply
+ *                                   |
+ *                                Reshape (in case of group decompression)
+ *                                   |
+ *                                Convert (if IP != DP)
+ *                               /                    \
+ *      Data(IP)   Transpose(Opt)                      Transpose(Opt)     Data2(IP)
+ *            \     /                                               \     /
+ *             Matmul                                                Matmul
+ */
+
+using MatmulSharedWeightsDecompressionParams = std::tuple<std::string,                 // target device
+                                                          MatMulDecompressionShapeParams,
+                                                          ElementType,                 // weights precision
+                                                          ElementType,                 // decompression precision
+                                                          bool,                        // transpose on weights
+                                                          DecompressionSubtractType,   // decompression subtract type
+                                                          bool>;                       // use matmul decompression implementation
+
+class SharedMatmulWeightsDecompression : public testing::WithParamInterface<MatmulSharedWeightsDecompressionParams>,
+                                         virtual public SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<MatmulSharedWeightsDecompressionParams> obj);
+
+protected:
+    std::shared_ptr<ov::Model> initSubgraph(const ov::PartialShape& data_shape,
+                                            const ov::Shape& weights_shape,
+                                            const int group_size,
+                                            const ov::element::Type data_precision,
+                                            const ov::element::Type weights_precision,
+                                            const ov::element::Type decompression_precision,
+                                            const bool transpose_weights,
+                                            const DecompressionSubtractType decompression_subtract_type);
+    void SetUp() override;
+    void check_results();
+};
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/weights_decompression_builders.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/weights_decompression_builders.hpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include "openvino/core/node.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+struct MatMulDecompressionShapeParams {
+    MatMulDecompressionShapeParams() = default;
+    MatMulDecompressionShapeParams(InputShape data_shape, ov::Shape weights_shape, int decompression_group_size = -1)
+        : data_shape(std::move(data_shape)),
+          weights_shape(std::move(weights_shape)),
+          decompression_group_size(decompression_group_size) {}
+
+    InputShape data_shape;
+    ov::Shape weights_shape;
+    // Decompression group size. If the value is equal to -1, ordinary decompression is used
+    int decompression_group_size;
+};
+
+std::ostream& operator<<(std::ostream& os, MatMulDecompressionShapeParams type);
+
+struct GatherDecompressionShapeParams {
+    GatherDecompressionShapeParams() = default;
+    GatherDecompressionShapeParams(ov::Shape data_shape,
+                                   InputShape indices_shape,
+                                   int axis,
+                                   int64_t batch_dims,
+                                   int decompression_group_size = -1)
+        : data_shape(std::move(data_shape)),
+          indices_shape(std::move(indices_shape)),
+          axis(axis),
+          batch_dims(batch_dims),
+          decompression_group_size(decompression_group_size) {}
+
+    ov::Shape data_shape;
+    InputShape indices_shape;
+    int axis;
+    int64_t batch_dims;
+    // Decompression group size. If the value is equal to -1, ordinary decompression is used
+    int decompression_group_size;
+};
+
+std::ostream& operator<<(std::ostream& os, GatherDecompressionShapeParams type);
+
+enum class DecompressionSubtractType {
+    empty,  // no decompression subtract
+    scalar, // decompression subtract with scalar shape
+    full    // decompression subtract with per-channel or grouped shape
+};
+
+std::ostream& operator<<(std::ostream& os, DecompressionSubtractType type);
+
+std::shared_ptr<ov::Node> initMatMulDecompressionSubgraph(
+    const ov::Shape& weights_shape,
+    const int group_size,
+    const ov::element::Type data_precision,
+    const ov::element::Type weights_precision,
+    const ov::element::Type decompression_precision,
+    const ov::element::Type scale_precision,
+    const bool transpose_weights,
+    const DecompressionSubtractType decompression_subtract_type,
+    const bool reshape_on_decompression_constant);
+
+std::shared_ptr<ov::Node> initGatherDecompressionSubgraph(const ov::Shape& data_shape,
+                                                          const int group_size,
+                                                          const ov::element::Type data_precision,
+                                                          const ov::element::Type output_precision,
+                                                          const bool add_subtract,
+                                                          const bool reshape_on_decompression_constant,
+                                                          const bool per_tensor_zp,
+                                                          const bool per_tensor_scale);
+
+} // namespace test
+} // namespace ov

--- a/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_gather_weights_decompression.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_gather_weights_decompression.cpp
@@ -1,0 +1,109 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/shared_matmul_gather_weights_decompression.hpp"
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/runtime/exec_model_info.hpp"
+#include "shared_test_classes/subgraph/weights_decompression_builders.hpp"
+
+namespace ov {
+namespace test {
+std::string SharedMatmulAndGatherWeightsDecompression::getTestCaseName(testing::TestParamInfo<SharedMatmulAndGatherWeightsDecompressionParams> obj) {
+    std::string target_device;
+    GatherDecompressionShapeParams shape_params;
+    ov::test::ElementType weights_precision;
+    ov::test::ElementType decompression_precision;
+    bool decompression_subtract;
+    bool use_decompression_impl;
+
+    std::tie(target_device,
+             shape_params,
+             weights_precision,
+             decompression_precision,
+             decompression_subtract,
+             use_decompression_impl) = obj.param;
+
+    std::ostringstream result;
+    result << "device=" << target_device << "_";
+    result << shape_params << "_";
+    result << "weights_precision=" << weights_precision << "_";
+    result << "decompression_precision=" << decompression_precision << "_";
+    result << "decompression_subtract=" << decompression_subtract << "_";
+    result << "use_decompression_impl=" << use_decompression_impl;
+    return result.str();
+}
+
+std::shared_ptr<ov::Model> SharedMatmulAndGatherWeightsDecompression::initSubgraph(const ov::Shape& data_shape,
+                                                                                   const ov::PartialShape& indices_shape,
+                                                                                   const int axis,
+                                                                                   const int64_t batch_dims,
+                                                                                   const int group_size,
+                                                                                   const ov::element::Type data_precision,
+                                                                                   const ov::element::Type output_precision,
+                                                                                   const bool add_subtract) {
+    const auto indices_data = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, indices_shape);
+    const auto axis_const = ov::op::v0::Constant::create(ov::element::i32, {1}, {axis});
+    const auto decompression_subgraph = initGatherDecompressionSubgraph(data_shape,
+                                                                        group_size,
+                                                                        data_precision,
+                                                                        output_precision,
+                                                                        add_subtract,
+                                                                        false,
+                                                                        false,
+                                                                        false);
+    const auto gather = std::make_shared<ov::op::v8::Gather>(decompression_subgraph, indices_data, axis_const, batch_dims);
+
+    const auto fc_data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, indices_shape);
+    const auto matmul = std::make_shared<ov::op::v0::MatMul>(fc_data, decompression_subgraph, false, true);
+    const ov::OutputVector last_nodes{gather, matmul};
+    const ov::ParameterVector params{indices_data, fc_data};
+    return std::make_shared<ov::Model>(last_nodes, params, "SharedMatmulAndGatherWeightsDecompression");
+}
+
+void SharedMatmulAndGatherWeightsDecompression::SetUp() {
+    GatherDecompressionShapeParams shape_params;
+    ov::test::ElementType weights_precision;
+    ov::test::ElementType decompression_precision;
+    bool decompression_subtract;
+    bool use_decompression_impl;
+
+    std::tie(targetDevice,
+             shape_params,
+             weights_precision,
+             decompression_precision,
+             decompression_subtract,
+             use_decompression_impl) = GetParam();
+
+    init_input_shapes({shape_params.indices_shape, shape_params.indices_shape});
+
+    function = initSubgraph(shape_params.data_shape,
+                            inputDynamicShapes[0],
+                            shape_params.axis,
+                            shape_params.batch_dims,
+                            shape_params.decompression_group_size,
+                            weights_precision,
+                            decompression_precision,
+                            decompression_subtract);
+}
+
+void SharedMatmulAndGatherWeightsDecompression::check_results() {
+    const auto& test_param = GetParam();
+    const ov::element::Type compressed_weights_precision = std::get<2>(test_param);
+    const auto use_matmul_decompression_impl = std::get<5>(test_param);
+
+    const auto results = compiledModel.get_runtime_model()->get_results();
+    EXPECT_EQ(results.size(), 2);
+    const auto gather_node = results[0]->get_input_node_shared_ptr(0);
+    EXPECT_EQ(gather_node->get_input_element_type(0), compressed_weights_precision);
+
+    const auto matmul_node = results[1]->get_input_node_shared_ptr(0);
+    const auto& expected_mm_weights_precision = use_matmul_decompression_impl
+                                                    ? compressed_weights_precision
+                                                    : matmul_node->get_input_element_type(0);
+    EXPECT_EQ(matmul_node->get_input_element_type(1), expected_mm_weights_precision);
+}
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_weights_decompression.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_weights_decompression.cpp
@@ -1,0 +1,123 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/shared_matmul_weights_decompression.hpp"
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/runtime/exec_model_info.hpp"
+#include "shared_test_classes/subgraph/weights_decompression_builders.hpp"
+
+namespace ov {
+namespace test {
+std::string SharedMatmulWeightsDecompression::getTestCaseName(testing::TestParamInfo<MatmulSharedWeightsDecompressionParams> obj) {
+    std::string target_device;
+    MatMulDecompressionShapeParams shape_params;
+    ov::test::ElementType weights_precision;
+    ov::test::ElementType decompression_precision;
+    bool transpose;
+    DecompressionSubtractType decompression_subtract_type;
+    bool use_decompression_impl;
+
+    std::tie(target_device,
+             shape_params,
+             weights_precision,
+             decompression_precision,
+             transpose,
+             decompression_subtract_type,
+             use_decompression_impl) = obj.param;
+
+    std::ostringstream result;
+    result << "device=" << target_device << "_";
+    result << shape_params << "_";
+    result << "weights_precision=" << weights_precision << "_";
+    result << "decompression_precision=" << decompression_precision << "_";
+    result << "transpose_weights=" << transpose << "_";
+    result << "decompression_subtract=" << decompression_subtract_type << "_";
+    result << "use_decompression_impl=" << use_decompression_impl;
+    return result.str();
+}
+
+std::shared_ptr<ov::Model> SharedMatmulWeightsDecompression::initSubgraph(
+    const ov::PartialShape& data_shape,
+    const ov::Shape& weights_shape,
+    const int group_size,
+    const ov::element::Type data_precision,
+    const ov::element::Type weights_precision,
+    const ov::element::Type decompression_precision,
+    const bool transpose_weights,
+    const DecompressionSubtractType decompression_subtract_type) {
+    const auto weights_subgraph = initMatMulDecompressionSubgraph(weights_shape,
+                                                                  group_size,
+                                                                  data_precision,
+                                                                  weights_precision,
+                                                                  decompression_precision,
+                                                                  ov::element::undefined,
+                                                                  transpose_weights,
+                                                                  decompression_subtract_type,
+                                                                  false);
+    ov::ParameterVector params;
+    ov::OutputVector last_layers;
+    for (size_t i = 0; i < 2; ++i) {
+        const auto param = std::make_shared<ov::op::v0::Parameter>(data_precision, data_shape);
+        auto shared_weights_input = weights_subgraph;
+        // In real cases, transpose is not shared between MatMuls,
+        // so we recreate the own copy of transpose for each matmul
+        if (transpose_weights) {
+            OPENVINO_ASSERT(ov::is_type<ov::opset10::Transpose>(shared_weights_input));
+            shared_weights_input = weights_subgraph->clone_with_new_inputs(weights_subgraph->input_values());
+        }
+        const auto matMul = std::make_shared<ov::op::v0::MatMul>(param, shared_weights_input);
+        params.push_back(param);
+        last_layers.push_back(matMul);
+    }
+    return std::make_shared<ov::Model>(last_layers, params, "SharedMatmulWeightsDecompression");
+}
+
+void SharedMatmulWeightsDecompression::SetUp() {
+    MatMulDecompressionShapeParams shape_params;
+    ov::test::ElementType weights_precision;
+    ov::test::ElementType decompression_precision;
+    bool transpose_weights;
+    DecompressionSubtractType decompression_subtract_type;
+    bool use_decompression_impl;
+
+    std::tie(targetDevice,
+             shape_params,
+             weights_precision,
+             decompression_precision,
+             transpose_weights,
+             decompression_subtract_type,
+             use_decompression_impl) = GetParam();
+    init_input_shapes({shape_params.data_shape, shape_params.data_shape});
+
+    ElementType netType = ov::element::f32;
+    inType = outType = netType;
+
+    function = initSubgraph(inputDynamicShapes[0],
+                            shape_params.weights_shape,
+                            shape_params.decompression_group_size,
+                            netType,
+                            weights_precision,
+                            decompression_precision,
+                            transpose_weights,
+                            decompression_subtract_type);
+}
+
+void SharedMatmulWeightsDecompression::check_results() {
+    const auto& test_param = GetParam();
+    const ov::element::Type compressed_weights_precision = std::get<2>(test_param);
+    const auto use_matmul_decompression_impl = std::get<6>(test_param);
+
+    const auto results = compiledModel.get_runtime_model()->get_results();
+    for (const auto& result : results) {
+        const auto last_layer = result->get_input_node_shared_ptr(0);
+        const auto& expected_weights_precision = use_matmul_decompression_impl
+                                                     ? compressed_weights_precision
+                                                     : last_layer->get_input_element_type(0);
+        EXPECT_EQ(last_layer->get_input_element_type(1), expected_weights_precision);
+    }
+}
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/subgraph/weights_decompression_builders.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/weights_decompression_builders.cpp
@@ -1,0 +1,276 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/weights_decompression_builders.hpp"
+
+#include "openvino/opsets/opset10.hpp"
+#include "common_test_utils/node_builders/constant.hpp"
+#include "transformations/rt_info/decompression.hpp"
+
+namespace ov {
+namespace test {
+std::ostream& operator<<(std::ostream& os, MatMulDecompressionShapeParams shape_params) {
+    os << "data_shape=" << shape_params.data_shape << "_weights_shape=" << shape_params.weights_shape;
+    if (shape_params.decompression_group_size != -1)
+        os << "_group_size=" << shape_params.decompression_group_size;
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, GatherDecompressionShapeParams shape_params) {
+    os << "data_shape=" << shape_params.data_shape << "_indices_shape=" << shape_params.indices_shape;
+    if (shape_params.decompression_group_size != -1)
+        os << "_group_size=" << shape_params.decompression_group_size;
+    os << "_axis=" << shape_params.axis << "_batch_dims=" << shape_params.batch_dims;
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, DecompressionSubtractType type) {
+    switch (type) {
+    case DecompressionSubtractType::empty:
+        os << "empty";
+        break;
+    case DecompressionSubtractType::scalar:
+        os << "scalar";
+        break;
+    case DecompressionSubtractType::full:
+        os << "full";
+        break;
+    default:
+        OPENVINO_THROW("Not supported DecompressionSubtractType");
+    }
+    return os;
+}
+
+std::shared_ptr<ov::Node> initMatMulDecompressionSubgraph(
+    const ov::Shape& weights_shape,
+    const int group_size,
+    const ov::element::Type data_precision,
+    const ov::element::Type weights_precision,
+    const ov::element::Type decompression_precision,
+    const ov::element::Type scale_precision,
+    const bool transpose_weights,
+    const DecompressionSubtractType decompression_subtract_type,
+    const bool reshape_on_decompression_constant) {
+    auto transpose_if_necessary = [&](const ov::Shape& shape) {
+        auto result_shape = shape;
+        if (transpose_weights)
+            std::swap(*result_shape.rbegin(), *(result_shape.rbegin() + 1));
+        return result_shape;
+    };
+
+    const bool group_decompression = group_size != -1;
+    // Weights has shape [I, O], where
+    // I - input channels
+    // O - output channels
+    // In case of group decompression, input channels dimension is split into 2: I -> [N, G], where
+    // N - number of groups
+    // G - group size
+    auto transformed_weights_shape = transpose_if_necessary(weights_shape);
+    if (group_decompression) {
+        OPENVINO_ASSERT(weights_shape[0] % group_size == 0,
+                        "Weights output channels count (",
+                        weights_shape[0],
+                        ") must be divisible by decompression group size (",
+                        group_size,
+                        ").");
+        auto in_channel_idx =
+            transpose_weights ? transformed_weights_shape.size() - 1 : transformed_weights_shape.size() - 2;
+        transformed_weights_shape[in_channel_idx] = weights_shape[0] / group_size;
+        transformed_weights_shape.insert(transformed_weights_shape.begin() + in_channel_idx + 1, group_size);
+    }
+
+    auto up_to = weights_precision == ov::element::i4 ? 7 : 15;
+    auto weights_tensor = ov::test::utils::create_and_fill_tensor(weights_precision,
+                                                                  transformed_weights_shape,
+                                                                  ov::test::utils::InputGenerateData(1, up_to));
+    auto weights = std::make_shared<ov::op::v0::Constant>(weights_tensor);
+    auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, decompression_precision);
+
+    std::shared_ptr<ov::Node> mul_parent = weights_convert;
+    auto output_channels = *weights_shape.rbegin();
+
+    // Decompression constants shape:
+    // Ordinary decompression: [O, 1]
+    // Group decompression: [O, N, 1]
+    ov::Shape scaleshift_target_shape{output_channels};
+    scaleshift_target_shape.insert(scaleshift_target_shape.begin(),
+                                    group_decompression ? weights_shape[0] / group_size : 1);
+    scaleshift_target_shape = transpose_if_necessary(scaleshift_target_shape);
+    if (group_decompression) {
+        auto in_channel_idx =
+            transpose_weights ? scaleshift_target_shape.size() - 1 : scaleshift_target_shape.size() - 2;
+        scaleshift_target_shape.insert(scaleshift_target_shape.begin() + in_channel_idx + 1, 1);
+    }
+
+    auto scaleshift_const_shape = scaleshift_target_shape;
+    if (reshape_on_decompression_constant)
+        scaleshift_const_shape.erase(std::remove(scaleshift_const_shape.begin(), scaleshift_const_shape.end(), 1),
+                                        scaleshift_const_shape.end());
+    if (decompression_subtract_type != DecompressionSubtractType::empty) {
+        auto subtract_shape =
+            decompression_subtract_type == DecompressionSubtractType::full ? scaleshift_const_shape : ov::Shape({});
+        auto shift_const_tensor = ov::test::utils::create_and_fill_tensor(weights_precision,
+                                                                          subtract_shape,
+                                                                          ov::test::utils::InputGenerateData(1, up_to));
+        auto shift_const = std::make_shared<ov::op::v0::Constant>(shift_const_tensor);
+
+        std::shared_ptr<ov::Node> shift_convert =
+            std::make_shared<ov::op::v0::Convert>(shift_const, decompression_precision);
+        if (reshape_on_decompression_constant) {
+            auto subtract_target_shape = decompression_subtract_type == DecompressionSubtractType::full
+                                                ? scaleshift_target_shape
+                                                : ov::Shape(scaleshift_const_shape.size(), 1);
+            auto shift_reshape_const = ov::opset10::Constant::create(ov::element::i32,
+                                                                        {subtract_target_shape.size()},
+                                                                        subtract_target_shape);
+            auto shift_reshape = std::make_shared<ov::opset10::Reshape>(shift_convert, shift_reshape_const, false);
+            shift_convert = shift_reshape;
+        }
+        mul_parent = std::make_shared<ov::opset10::Subtract>(weights_convert, shift_convert);
+    }
+
+    const auto& scale_prc = scale_precision == ov::element::undefined ? decompression_precision : scale_precision;
+    auto scale_const_tensor = ov::test::utils::create_and_fill_tensor_real_distribution(scale_prc,
+                                                                                        scaleshift_const_shape,
+                                                                                        0.001f,
+                                                                                        0.01f,
+                                                                                        1);
+    std::shared_ptr<ov::Node> scale_const = std::make_shared<ov::op::v0::Constant>(scale_const_tensor);
+
+    if (scale_prc != decompression_precision) {
+        const auto scale_convert = std::make_shared<ov::op::v0::Convert>(scale_const, decompression_precision);
+        ov::mark_as_decompression(scale_convert);
+        scale_const = scale_convert;
+    }
+
+    if (reshape_on_decompression_constant) {
+        auto reshape_const = ov::opset10::Constant::create(ov::element::i32, {scaleshift_target_shape.size()}, scaleshift_target_shape);
+        auto scale_reshape = std::make_shared<ov::opset10::Reshape>(scale_const, reshape_const, false);
+        scale_const = scale_reshape;
+    }
+    std::shared_ptr<ov::Node> last_node = std::make_shared<ov::opset10::Multiply>(mul_parent, scale_const);
+
+    if (group_decompression) {
+        auto reshape_target_shape = transpose_weights ? std::vector<int>{-1, static_cast<int>(weights_shape[0])}
+                                                        : std::vector<int>{static_cast<int>(weights_shape[0]), -1};
+        auto target_shape_node =
+            ov::opset10::Constant::create(ov::element::i32, {reshape_target_shape.size()}, reshape_target_shape);
+        last_node = std::make_shared<ov::opset10::Reshape>(last_node, target_shape_node, false);
+    }
+    if (decompression_precision != data_precision) {
+        last_node = std::make_shared<ov::opset10::Convert>(last_node, data_precision);
+        ov::mark_as_decompression(last_node);
+    }
+    if (transpose_weights) {
+        const size_t rank = last_node->get_output_partial_shape(0).size();
+        std::vector<int> order(rank);
+        std::iota(order.begin(), order.end(), 0);
+        std::swap(*order.rbegin(), *(order.rbegin() + 1));
+        auto transpose_constant = ov::opset10::Constant::create(ov::element::i32, {rank}, order);
+        last_node = std::make_shared<ov::opset10::Transpose>(last_node, transpose_constant);
+    }
+    return last_node;
+}
+
+std::shared_ptr<ov::Node> initGatherDecompressionSubgraph(const ov::Shape& data_shape,
+                                                          const int group_size,
+                                                          const ov::element::Type data_precision,
+                                                          const ov::element::Type output_precision,
+                                                          const bool add_subtract,
+                                                          const bool reshape_on_decompression_constant,
+                                                          const bool per_tensor_zp,
+                                                          const bool per_tensor_scale) {
+    const bool group_decompression = group_size != -1;
+    // Weights has shape [I, D], where
+    // I - index
+    // D - data
+    // In case of group decompression, data dimension is split into 2: I -> [N, G], where
+    // N - number of groups
+    // G - group size
+    auto original_data_shape = data_shape;
+    if (group_decompression) {
+        OPENVINO_ASSERT(data_shape[1] % group_size == 0,
+                        "The last data dimension (",
+                        data_shape[1],
+                        ") must be divisible by decompression group size (",
+                        group_size,
+                        ").");
+        auto data_idx = data_shape.size() - 1;
+        original_data_shape[data_idx] = data_shape[1] / group_size;
+        original_data_shape.insert(original_data_shape.begin() + data_idx + 1, group_size);
+    }
+    ov::test::utils::InputGenerateData generate_data;
+    if (data_precision.is_signed())
+        generate_data.start_from = -5;
+    auto weights_tensor = ov::test::utils::create_and_fill_tensor(data_precision, original_data_shape, generate_data);
+    auto weights = std::make_shared<ov::op::v0::Constant>(weights_tensor);
+    weights->set_friendly_name("Compressed_weights");
+    auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, output_precision);
+
+    std::shared_ptr<ov::Node> mul_parent = weights_convert;
+
+    // Decompression constants shape:
+    // Ordinary decompression: [I, 1]
+    // Group decompression: [I, N, 1]
+    ov::Shape scaleshift_target_shape{data_shape[0]};
+    scaleshift_target_shape.insert(scaleshift_target_shape.end(), group_decompression ? data_shape[1] / group_size : 1);
+    if (group_decompression || scaleshift_target_shape.size() < original_data_shape.size()) {
+        auto data_idx = scaleshift_target_shape.size() - 1;
+        scaleshift_target_shape.insert(scaleshift_target_shape.begin() + data_idx + 1, 1);
+    }
+
+    auto scaleshift_const_shape = scaleshift_target_shape;
+    if (reshape_on_decompression_constant)
+        scaleshift_const_shape.erase(std::remove(scaleshift_const_shape.begin(), scaleshift_const_shape.end(), 1),
+                                     scaleshift_const_shape.end());
+    if (add_subtract) {
+        auto shift_tensor_shape = per_tensor_zp ? ov::Shape{1} : scaleshift_const_shape;
+        auto shift_tensor = ov::test::utils::create_and_fill_tensor(data_precision, shift_tensor_shape);
+        if (per_tensor_zp && data_precision.bitwidth() == 4) {
+            static_cast<uint8_t*>(shift_tensor.data())[0] = 0x88;
+        }
+        auto shift_const = std::make_shared<ov::op::v0::Constant>(shift_tensor);
+        std::shared_ptr<ov::Node> shift_convert = std::make_shared<ov::op::v0::Convert>(shift_const, output_precision);
+        if (reshape_on_decompression_constant && !per_tensor_zp) {
+            auto shift_reshape_const = ov::op::v0::Constant::create(ov::element::i32,
+                                                                    {scaleshift_target_shape.size()},
+                                                                    scaleshift_target_shape);
+            auto shift_reshape = std::make_shared<ov::op::v1::Reshape>(shift_convert, shift_reshape_const, false);
+            shift_convert = shift_reshape;
+        }
+        mul_parent = std::make_shared<ov::op::v1::Subtract>(weights_convert, shift_convert);
+    }
+
+    ov::test::utils::InputGenerateData in_data;
+    in_data.start_from = -0.5;
+    in_data.range = 1;
+    in_data.resolution = 30000;
+    auto scale_tensor_shape = per_tensor_scale ? ov::Shape{1} : scaleshift_const_shape;
+    auto scale_tensor = ov::test::utils::create_and_fill_tensor(output_precision, scale_tensor_shape, in_data);
+    for (size_t i = 0; i < scale_tensor.get_size(); i++) {
+        if (output_precision == ov::element::f16)
+            scale_tensor.data<ov::float16>()[i] /= ov::float16(16.f);
+        else if (output_precision == ov::element::f32)
+            scale_tensor.data<float>()[i] /= 16.f;
+    }
+    std::shared_ptr<ov::Node> scale_const = std::make_shared<ov::op::v0::Constant>(scale_tensor);
+    if (reshape_on_decompression_constant && !per_tensor_scale) {
+        auto scale_reshape_const =
+            ov::op::v0::Constant::create(ov::element::i32, {scaleshift_target_shape.size()}, scaleshift_target_shape);
+        auto scale_reshape = std::make_shared<ov::op::v1::Reshape>(scale_const, scale_reshape_const, false);
+        scale_const = scale_reshape;
+    }
+    std::shared_ptr<ov::Node> last_node = std::make_shared<ov::op::v1::Multiply>(mul_parent, scale_const);
+
+    if (group_decompression) {
+        auto reshape_target_shape = std::vector<int>{static_cast<int>(data_shape[0]), -1};
+        auto target_shape_node =
+            ov::op::v0::Constant::create(ov::element::i32, {reshape_target_shape.size()}, reshape_target_shape);
+        last_node = std::make_shared<ov::op::v1::Reshape>(last_node, target_shape_node, false);
+    }
+    return last_node;
+}
+
+} // namespace test
+} // namespace ov


### PR DESCRIPTION
### Details:
 - *Shared decompression between 2 Matmuls is supported for 8bits and 4bits weights*
 - *Shared decompression between Matmul and Gather is supported for 8bits and 4bits weights*
 - *Added CPU subgraph test*

### Tickets:
 - *CVS-140442* <= Validation results can be found there
 - *CVS-137591*
 - *CVS-136594*
