### PR TITLE
[Snippets] Added ExpandedLoopInfo and UnifiedLoopInfo support

### DIFF
--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -21,21 +21,16 @@ public:
     enum {UNDEFINED_DIM_IDX = std::numeric_limits<size_t>::max()};
 
     LoopInfo() = default;
-    LoopInfo(size_t work_amount, size_t increment,
-             const std::vector<LoopPort>& entries,
-             const std::vector<LoopPort>& exits,
-             const SpecificIterationHandlers& handlers = SpecificIterationHandlers());
-    LoopInfo(size_t work_amount, size_t increment,
-             const std::vector<ExpressionPort>& entries,
-             const std::vector<ExpressionPort>& exits,
-             const SpecificIterationHandlers& handlers = SpecificIterationHandlers());
+    LoopInfo(size_t work_amount, size_t increment, const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits);
+    LoopInfo(size_t work_amount, size_t increment, const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits);
+    virtual ~LoopInfo() = default;
 
     /**
      * @brief Clone LoopInfo with new expressions
      * @param expr_map map of new and old expressions
      * @return the copy
      */
-    std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const;
+    virtual std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const = 0;
 
     /**
      * @brief Returns dimension index if dimension indices for all entry and exit points are equal.
@@ -65,9 +60,9 @@ public:
     const std::vector<LoopPort>& get_exit_points() const;
     /**
      * @brief Returns handlers of loop specific iterations
-     * @return m_handlers
+     * @return handlers
      */
-    const SpecificIterationHandlers& get_handlers() const;
+    virtual const SpecificIterationHandlers& get_handlers() const = 0;
 
     /**
      * @brief Sets `dim_idx` to all entry and exit points
@@ -95,34 +90,64 @@ public:
      */
     void set_exit_points(std::vector<LoopPort> exit_points);
     /**
-     * @brief Set m_handlers value
+     * @brief Set handlers
      * @param handlers - transformations for loop specific iterations
      */
-    void set_handlers(SpecificIterationHandlers handlers);
-
-    /**
-     * @brief Register loop specific iteration handler
-     * @param Type - type of specific iteration
-     * @param T - transformation
-     * @param args - arguments of the transformation
-     */
-    template <SpecificIterationHandlers::HandlerType Type, typename T, class... Args>
-    void register_handler(Args&&... args) {
-        m_handlers.register_handler<Type, T>(args...);
-    }
+    virtual void set_handlers(SpecificIterationHandlers handlers) = 0;
 
     /**
      * @brief Update the parameters of existing loop input ports
      * @param updater - function that updates ports
      */
-    void update_entry_points(const std::function<void(LoopPort&)>& updater);
+    inline void update_entry_points(const std::function<void(LoopPort&)>& updater) {
+        std::for_each(m_entry_points.begin(), m_entry_points.end(), updater);
+    }
     /**
      * @brief Update the parameters of existing loop output ports
      * @param updater - function that updates ports
      */
-    void update_exit_points(const std::function<void(LoopPort&)>& updater);
+    inline void update_exit_points(const std::function<void(LoopPort&)>& updater) {
+        std::for_each(m_exit_points.begin(), m_exit_points.end(), updater);
+    }
+    /**
+     * @brief Calls `initializer` for each entry point
+     * @param initializer - function that address to entry point
+     */
+    inline void init_using_entry_points(const std::function<void(const LoopPort&)>& initializer) const {
+        std::for_each(m_entry_points.cbegin(), m_entry_points.cend(), initializer);
+    }
+    /**
+     * @brief Calls `initializer` for each exit point
+     * @param initializer - function that address to exit point
+     */
+    inline void init_using_exit_points(const std::function<void(const LoopPort&)>& initializer) const {
+        std::for_each(m_exit_points.cbegin(), m_exit_points.cend(), initializer);
+    }
 
-private:
+    /**
+     * @brief Returns vector with boolean values `is_incremented` of loop ports
+     * @return vector with boolean values
+     */
+    std::vector<bool> get_is_incremented() const;
+    /**
+     * @brief Returns vector with pointer increments of loop ports
+     * @return vector with ptr increments
+     */
+    std::vector<int64_t> get_ptr_increments() const;
+    /**
+     * @brief Returns vector with finalization offsets of loop ports
+     * @return vector with finalization offsets
+     */
+    std::vector<int64_t> get_finalization_offsets() const;
+    /**
+     * @brief Returns vector with data sizes of loop ports
+     * @return vector with data sizes
+     */
+    std::vector<int64_t> get_data_sizes() const;
+
+protected:
+    static std::vector<LoopPort> clone_loop_ports(const ExpressionMap& expr_map, const std::vector<LoopPort>& port_ports);
+
     size_t m_work_amount = 0;
     size_t m_increment = 0;
     // The order of entry and exit expressions is important:
@@ -131,9 +156,126 @@ private:
     // Note: Scalars aren't entry expressions but can be before first entry expr in Linear IR
     std::vector<LoopPort> m_entry_points = {};
     std::vector<LoopPort> m_exit_points = {};
-    SpecificIterationHandlers m_handlers = {};
 };
 using LoopInfoPtr = std::shared_ptr<LoopInfo>;
+
+class UnifiedLoopInfo : public LoopInfo {
+public:
+    UnifiedLoopInfo() = default;
+    UnifiedLoopInfo(size_t work_amount, size_t increment,
+                    const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
+                    const SpecificIterationHandlers& handlers = SpecificIterationHandlers());
+    UnifiedLoopInfo(size_t work_amount, size_t increment,
+                    const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits,
+                    const SpecificIterationHandlers& handlers = SpecificIterationHandlers());
+
+    /**
+     * @brief Clone LoopInfo with new expressions
+     * @param expr_map map of new and old expressions
+     * @return the copy
+     */
+    std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const override;
+
+    /**
+     * @brief Returns handlers of loop specific iterations
+     * @return m_handlers
+     */
+    const SpecificIterationHandlers& get_handlers() const override;
+    /**
+     * @brief Set m_handlers value
+     * @param handlers - transformations for loop specific iterations
+     */
+    void set_handlers(SpecificIterationHandlers handlers) override;
+
+    /**
+     * @brief Register loop specific iteration handler
+     * @param Type - type of specific iteration
+     * @param T - transformation
+     * @param args - arguments of the transformation
+     */
+    template <SpecificLoopIterType Type, typename T, class... Args>
+    void register_handler(Args&&... args) {
+        m_handlers.register_handler<Type, T>(args...);
+    }
+
+private:
+    SpecificIterationHandlers m_handlers = {};
+};
+using UnifiedLoopInfoPtr = std::shared_ptr<UnifiedLoopInfo>;
+
+class ExpandedLoopInfo : public LoopInfo {
+public:
+    ExpandedLoopInfo() = default;
+    ExpandedLoopInfo(size_t work_amount, size_t increment,
+                     const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
+                     SpecificLoopIterType type, std::shared_ptr<UnifiedLoopInfo> original_loop_info);
+    ExpandedLoopInfo(size_t work_amount, size_t increment,
+                     const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
+                     std::vector<int64_t> ptr_increments, std::vector<int64_t> final_offsets, std::vector<int64_t> data_sizes,
+                     SpecificLoopIterType type, std::shared_ptr<UnifiedLoopInfo> unified_loop_info);
+    /**
+     * @brief Clone LoopInfo with new expressions
+     * @param expr_map map of new and old expressions
+     * @return the copy
+     */
+    std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const override;
+
+    /**
+     * @brief Returns handlers of loop specific iterations
+     * @return handlers
+     */
+    const SpecificIterationHandlers& get_handlers() const override;
+    /**
+     * @brief Returns original unified LoopInfo from which this LoopInfo was created
+     * @return const reference of m_unified_loop_info
+     */
+    const std::shared_ptr<UnifiedLoopInfo>& get_unified_loop_info() const;
+    /**
+     * @brief Returns type of loop iterations
+     * @return SpecificLoopIterType
+     */
+    SpecificLoopIterType get_type() const;
+    /**
+     * @brief Returns passes of the corresponding halder
+     * @return pass pipeline
+     */
+    const pass::PassPipeline& get_handlers_by_type() const;
+
+    /**
+     * @brief Set m_handlers value
+     * @param handlers - transformations for loop specific iterations
+     */
+    void set_handlers(SpecificIterationHandlers handlers) override;
+
+    /**
+     * @brief Returns dense vector with pointer increments
+     * @return ref of `m_ptr_increments`
+     */
+    std::vector<int64_t>& get_dense_ptr_increments();
+    /**
+     * @brief Returns dense vector with finalization offsets
+     * @return ref of `m_finalization_offsets`
+     */
+    std::vector<int64_t>& get_dense_finalization_offsets();
+    /**
+     * @brief Returns dense vector with data sizes
+     * @return const ref of `m_data_sizes`
+     */
+    const std::vector<int64_t>& get_dense_data_sizes() const;
+
+private:
+    // ExpandedLoopInfo has LoopPorts to have opportunity to work with Loops
+    // in iter handlers in InsertSpecificIterations/ For example, in UpdateSubtensors.
+    // However, for faster work with data ptr shifts ExpandedLoopInfo has the separate dense attributes.
+    // Note: the first initialization of these attributes is in ctor from entry and exit loop ports
+    std::vector<int64_t> m_ptr_increments = {};
+    std::vector<int64_t> m_finalization_offsets = {};
+    std::vector<int64_t> m_data_sizes = {};
+
+    SpecificLoopIterType m_type = {};
+    std::shared_ptr<UnifiedLoopInfo> m_unified_loop_info = {};
+};
+using ExpandedLoopInfoPtr = std::shared_ptr<ExpandedLoopInfo>;
 
 } // namespace lowered
 } // namespace snippets

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -12,9 +12,11 @@ namespace ov {
 namespace snippets {
 namespace lowered {
 
-/* The structure contains the information about a Loop in Linear Intermediate IR (Linear IR):
- * work amount of the Loop, step of loop counter increment, entry and exit ports of the Loop,
- * passes for specific iterations.
+/**
+ * @interface LoopInfo
+ * @brief The base class that contains the base common information about a Loop in Linear Intermediate IR (Linear IR):
+ *        work amount of the Loop, step of loop counter increment, entry and exit ports of the Loop.
+ * @ingroup snippets
  */
 class LoopInfo {
 public:
@@ -58,11 +60,6 @@ public:
      * @return m_exit_points
      */
     const std::vector<LoopPort>& get_exit_points() const;
-    /**
-     * @brief Returns handlers of loop specific iterations
-     * @return handlers
-     */
-    virtual const SpecificIterationHandlers& get_handlers() const = 0;
 
     /**
      * @brief Sets `dim_idx` to all entry and exit points
@@ -89,11 +86,6 @@ public:
      * @param exit_points - vector of loop output ports
      */
     void set_exit_points(std::vector<LoopPort> exit_points);
-    /**
-     * @brief Set handlers
-     * @param handlers - transformations for loop specific iterations
-     */
-    virtual void set_handlers(SpecificIterationHandlers handlers) = 0;
 
     /**
      * @brief Update the parameters of existing loop input ports
@@ -159,6 +151,12 @@ protected:
 };
 using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 
+/**
+ * @interface UnifiedLoopInfo
+ * @brief The structure describes unified (entire) Loop before decomposition into specific loop iterations.
+ *        Contains passes for specific loop iterations that will be called in decomposition for each iteration (in `InsertSpecificIterations` pass).
+ * @ingroup snippets
+ */
 class UnifiedLoopInfo : public LoopInfo {
 public:
     UnifiedLoopInfo() = default;
@@ -180,12 +178,12 @@ public:
      * @brief Returns handlers of loop specific iterations
      * @return m_handlers
      */
-    const SpecificIterationHandlers& get_handlers() const override;
+    const SpecificIterationHandlers& get_handlers() const;
     /**
      * @brief Set m_handlers value
      * @param handlers - transformations for loop specific iterations
      */
-    void set_handlers(SpecificIterationHandlers handlers) override;
+    void set_handlers(SpecificIterationHandlers handlers);
 
     /**
      * @brief Register loop specific iteration handler
@@ -203,6 +201,12 @@ private:
 };
 using UnifiedLoopInfoPtr = std::shared_ptr<UnifiedLoopInfo>;
 
+/**
+ * @interface ExpandedLoopInfo
+ * @brief The structure describes expanded Loop (specific iterations) after unified loop decomposition into specific loop iterations.
+ *        Contains type of specific iteration, pointer to the original unified loop and dense data pointer shifts for quick recalculation.
+ * @ingroup snippets
+ */
 class ExpandedLoopInfo : public LoopInfo {
 public:
     ExpandedLoopInfo() = default;
@@ -221,11 +225,6 @@ public:
     std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const override;
 
     /**
-     * @brief Returns handlers of loop specific iterations
-     * @return handlers
-     */
-    const SpecificIterationHandlers& get_handlers() const override;
-    /**
      * @brief Returns original unified LoopInfo from which this LoopInfo was created
      * @return const reference of m_unified_loop_info
      */
@@ -240,12 +239,6 @@ public:
      * @return pass pipeline
      */
     const pass::PassPipeline& get_handlers_by_type() const;
-
-    /**
-     * @brief Set m_handlers value
-     * @param handlers - transformations for loop specific iterations
-     */
-    void set_handlers(SpecificIterationHandlers handlers) override;
 
     /**
      * @brief Returns dense vector with pointer increments

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -271,15 +271,15 @@ public:
     }
 
     /**
-     * @brief Sort ALL input Loop Ports by `new_order`: `m_input_ports[new_order[i]] = m_input_ports[i]`
+     * @brief Reorder ALL input Loop Ports by `new_order`: `m_input_ports[new_order[i]] = m_input_ports[i]`
      * @param new_order vector of new indexes
      */
-    void sort_input_ports(const std::vector<size_t>& new_order);
+    void reorder_input_ports(const std::vector<size_t>& new_order);
     /**
-     * @brief Sort ALL output Loop Ports by `new_order`: `m_output_ports[new_order[i]] = m_output_ports[i]`
+     * @brief Reorder ALL output Loop Ports by `new_order`: `m_output_ports[new_order[i]] = m_output_ports[i]`
      * @param new_order vector of new indexes
      */
-    void sort_output_ports(const std::vector<size_t>& new_order);
+    void reorder_output_ports(const std::vector<size_t>& new_order);
 
     /**
      * @brief Replace the current LoopPort `actual_port` with new `target_ports`

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -103,34 +103,48 @@ public:
     virtual void replace_with_new_ports(const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports);
 
     /**
-     * @brief Update the parameters of existing loop input ports
-     * @param updater - function that updates ports
+     * @brief Iterates through entry loop ports and call `caller` for each of them
+     * @param caller - function that called for each entry loop port
      */
-    inline void update_entry_points(const std::function<void(LoopPort&)>& updater) {
-        std::for_each(m_entry_points.begin(), m_entry_points.end(), updater);
+    inline void iterate_through_entry_points(const std::function<void(LoopPort&)>& caller) {
+        std::for_each(m_entry_points.begin(), m_entry_points.end(), caller);
     }
     /**
-     * @brief Update the parameters of existing loop input ports
-     * @param updater - function that updates ports and need index of the port
+     * @brief Iterates through entry loop ports and call `caller` for each of them
+     * @param caller - function that called for each entry loop port
      */
-    inline void update_entry_points(const std::function<void(LoopPort&, size_t idx)>& updater) {
-        for (size_t i = 0; i < m_entry_points.size(); ++i)
-            updater(m_entry_points[i], i);
+    inline void iterate_through_entry_points(const std::function<void(const LoopPort&)>& caller) const {
+        std::for_each(m_entry_points.cbegin(), m_entry_points.cend(), caller);
     }
     /**
-     * @brief Update the parameters of existing loop output ports
-     * @param updater - function that updates ports
+     * @brief Iterates through exit loop ports and call `caller` for each of them
+     * @param caller - function that called for each exit loop port
      */
-    inline void update_exit_points(const std::function<void(LoopPort&)>& updater) {
-        std::for_each(m_exit_points.begin(), m_exit_points.end(), updater);
+    inline void iterate_through_exit_points(const std::function<void(LoopPort&)>& caller) {
+        std::for_each(m_exit_points.begin(), m_exit_points.end(), caller);
     }
     /**
-     * @brief Update the parameters of existing loop output ports
-     * @param updater - function that updates ports and need index of the port
+     * @brief Iterates through exit loop ports and call `caller` for each of them
+     * @param caller - function that called for each exit loop port
      */
-    inline void update_exit_points(const std::function<void(LoopPort&, size_t idx)>& updater) {
-        for (size_t i = 0; i < m_exit_points.size(); ++i)
-            updater(m_exit_points[i], i);
+    inline void iterate_through_exit_points(const std::function<void(const LoopPort&)>& caller) const {
+        std::for_each(m_exit_points.cbegin(), m_exit_points.cend(), caller);
+    }
+    /**
+     * @brief Iterates through entry and exit loop ports and call `caller` for each of them
+     * @param caller - function that called for each exit loop port
+     */
+    inline void iterate_through_points(const std::function<void(LoopPort&)>& caller) {
+        iterate_through_entry_points(caller);
+        iterate_through_exit_points(caller);
+    }
+    /**
+     * @brief Iterates through entry and exit loop ports and call `caller` for each of them
+     * @param caller - function that called for each exit loop port
+     */
+    inline void iterate_through_points(const std::function<void(const LoopPort&)>& caller) const {
+        iterate_through_entry_points(caller);
+        iterate_through_exit_points(caller);
     }
 
     // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
@@ -157,11 +171,6 @@ protected:
      * @return vector with new cloned loop ports
      */
     static std::vector<LoopPort> clone_loop_ports(const ExpressionMap& expr_map, const std::vector<LoopPort>& loop_ports);
-    /**
-     * @brief Applies provided initializer function to entry and exit points
-     * @param initializer function that can access to LoopPort
-     */
-    void init_from_ports(const std::function<void(const LoopPort&)>& initializer) const;
 
     size_t m_work_amount = 0;
     size_t m_increment = 0;

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -293,7 +293,7 @@ public:
      * @brief Iterates through all LoopPortDesc and call `caller` for each of them
      * @param caller - function that called for each LoopPortDesc
      */
-    inline void iterate_through_ports(const std::function<void(LoopPortDesc&)>& caller) {
+    inline void iterate_through_descs(const std::function<void(LoopPortDesc&)>& caller) {
         std::for_each(m_entry_port_descs.begin(), m_entry_port_descs.end(), caller);
         std::for_each(m_exit_port_descs.begin(), m_exit_port_descs.end(), caller);
     }
@@ -301,7 +301,7 @@ public:
      * @brief Iterates through all loop ports and call `caller` for each of them
      * @param caller - function that called for each loop port
      */
-    inline void iterate_through_ports(const std::function<void(const LoopPortDesc&)>& caller) const {
+    inline void iterate_through_descs(const std::function<void(const LoopPortDesc&)>& caller) const {
         std::for_each(m_entry_port_descs.cbegin(), m_entry_port_descs.cend(), caller);
         std::for_each(m_exit_port_descs.cbegin(), m_exit_port_descs.cend(), caller);
     }
@@ -309,7 +309,7 @@ public:
      * @brief Iterates through all pairs <LoopPort, LoopPortDesc> and call `caller` for each of them
      * @param caller - function that called for each pair
      */
-    inline void iterate_through_ports(const std::function<void(LoopPort&, LoopPortDesc&)>& caller) {
+    inline void iterate_through_infos(const std::function<void(LoopPort&, LoopPortDesc&)>& caller) {
         OPENVINO_ASSERT(m_input_ports.size() == m_entry_port_descs.size(), "Incompatible count of input port and descs");
         OPENVINO_ASSERT(m_output_ports.size() == m_exit_port_descs.size(), "Incompatible count of exit port and descs");
         for (size_t i = 0; i < get_input_count(); ++i)
@@ -321,7 +321,7 @@ public:
      * @brief Iterates through all pairs <LoopPort, LoopPortDesc> and call `caller` for each of them
      * @param caller - function that called for each pair
      */
-    inline void iterate_through_ports(const std::function<void(const LoopPort&, const LoopPortDesc&)>& caller) const {
+    inline void iterate_through_infos(const std::function<void(const LoopPort&, const LoopPortDesc&)>& caller) const {
         OPENVINO_ASSERT(m_input_ports.size() == m_entry_port_descs.size(), "Incompatible count of input port and descs");
         OPENVINO_ASSERT(m_output_ports.size() == m_exit_port_descs.size(), "Incompatible count of exit port and descs");
         for (size_t i = 0; i < get_input_count(); ++i)

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -72,15 +72,35 @@ public:
      */
     void set_increment(size_t increment);
     /**
+     * @brief Sets `dim_idx` to all entry and exit points
+     * @param dim_idx - index
+     */
+    void set_dim_idx(size_t dim_idx);
+    /**
      * @brief Set m_entry_points value
      * @param entry_points - vector of loop input ports
      */
-    void set_entry_points(std::vector<LoopPort> entry_points);
+    virtual void set_entry_points(std::vector<LoopPort> entry_points);
     /**
      * @brief Set m_exit_points value
      * @param exit_points - vector of loop output ports
      */
-    void set_exit_points(std::vector<LoopPort> exit_points);
+    virtual void set_exit_points(std::vector<LoopPort> exit_points);
+
+    /**
+     * @brief Update the parameters of existing loop input ports
+     * @param updater - function that updates ports
+     */
+    inline void update_entry_points(const std::function<void(LoopPort&)>& updater) {
+        std::for_each(m_entry_points.begin(), m_entry_points.end(), updater);
+    }
+    /**
+     * @brief Update the parameters of existing loop output ports
+     * @param updater - function that updates ports
+     */
+    inline void update_exit_points(const std::function<void(LoopPort&)>& updater) {
+        std::for_each(m_exit_points.begin(), m_exit_points.end(), updater);
+    }
 
     // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
     // so the standard OPENVINO_RTTI(...) macros could be used in derived classes.
@@ -178,11 +198,6 @@ public:
      * @param handlers - transformations for loop specific iterations
      */
     void set_handlers(SpecificIterationHandlers handlers);
-    /**
-     * @brief Sets `dim_idx` to all entry and exit points
-     * @param dim_idx - index
-     */
-    void set_dim_idx(size_t dim_idx);
 
     /**
      * @brief Register loop specific iteration handler
@@ -193,21 +208,6 @@ public:
     template <SpecificLoopIterType Type, typename T, class... Args>
     void register_pass_to_handler(Args&&... args) {
         m_handlers.register_pass<Type, T>(args...);
-    }
-
-    /**
-     * @brief Update the parameters of existing loop input ports
-     * @param updater - function that updates ports
-     */
-    inline void update_entry_points(const std::function<void(LoopPort&)>& updater) {
-        std::for_each(m_entry_points.begin(), m_entry_points.end(), updater);
-    }
-    /**
-     * @brief Update the parameters of existing loop output ports
-     * @param updater - function that updates ports
-     */
-    inline void update_exit_points(const std::function<void(LoopPort&)>& updater) {
-        std::for_each(m_exit_points.begin(), m_exit_points.end(), updater);
     }
 
 private:
@@ -270,6 +270,17 @@ public:
      * @return const ref of `m_data_sizes`
      */
     const std::vector<int64_t>& get_data_sizes() const;
+
+    /**
+     * @brief Set m_entry_points value
+     * @param entry_points - vector of loop input ports
+     */
+    void set_entry_points(std::vector<LoopPort> entry_points) override;
+    /**
+     * @brief Set m_exit_points value
+     * @param exit_points - vector of loop output ports
+     */
+    void set_exit_points(std::vector<LoopPort> exit_points) override;
 
 private:
     // ExpandedLoopInfo has LoopPorts to have opportunity to work with Loops

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -274,12 +274,12 @@ public:
      * @brief Sort ALL input Loop Ports by `new_order`: `m_input_ports[new_order[i]] = m_input_ports[i]`
      * @param new_order vector of new indexes
      */
-    void sort_entry_ports(const std::vector<size_t>& new_order);
+    void sort_input_ports(const std::vector<size_t>& new_order);
     /**
      * @brief Sort ALL output Loop Ports by `new_order`: `m_output_ports[new_order[i]] = m_output_ports[i]`
      * @param new_order vector of new indexes
      */
-    void sort_exit_ports(const std::vector<size_t>& new_order);
+    void sort_output_ports(const std::vector<size_t>& new_order);
 
     /**
      * @brief Replace the current LoopPort `actual_port` with new `target_ports`
@@ -300,16 +300,16 @@ public:
      * @param caller - function that called for each LoopPortDesc
      */
     inline void iterate_through_descs(const std::function<void(LoopPortDesc&)>& caller) {
-        std::for_each(m_entry_port_descs.begin(), m_entry_port_descs.end(), caller);
-        std::for_each(m_exit_port_descs.begin(), m_exit_port_descs.end(), caller);
+        std::for_each(m_input_port_descs.begin(), m_input_port_descs.end(), caller);
+        std::for_each(m_output_port_descs.begin(), m_output_port_descs.end(), caller);
     }
     /**
      * @brief Iterates through all loop ports and call `caller` for each of them
      * @param caller - function that called for each loop port
      */
     inline void iterate_through_descs(const std::function<void(const LoopPortDesc&)>& caller) const {
-        std::for_each(m_entry_port_descs.cbegin(), m_entry_port_descs.cend(), caller);
-        std::for_each(m_exit_port_descs.cbegin(), m_exit_port_descs.cend(), caller);
+        std::for_each(m_input_port_descs.cbegin(), m_input_port_descs.cend(), caller);
+        std::for_each(m_output_port_descs.cbegin(), m_output_port_descs.cend(), caller);
     }
     /**
      * @brief Iterates through all pairs <LoopPort, LoopPortDesc> and call `caller` for each of them
@@ -317,9 +317,9 @@ public:
      */
     inline void iterate_through_infos(const std::function<void(LoopPort&, LoopPortDesc&)>& caller) {
         for (size_t i = 0; i < get_input_count(); ++i)
-            caller(m_input_ports[i], m_entry_port_descs[i]);
+            caller(m_input_ports[i], m_input_port_descs[i]);
         for (size_t i = 0; i < get_output_count(); ++i)
-            caller(m_output_ports[i], m_exit_port_descs[i]);
+            caller(m_output_ports[i], m_output_port_descs[i]);
     }
     /**
      * @brief Iterates through all pairs <LoopPort, LoopPortDesc> and call `caller` for each of them
@@ -327,9 +327,9 @@ public:
      */
     inline void iterate_through_infos(const std::function<void(const LoopPort&, const LoopPortDesc&)>& caller) const {
         for (size_t i = 0; i < get_input_count(); ++i)
-            caller(m_input_ports[i], m_entry_port_descs[i]);
+            caller(m_input_ports[i], m_input_port_descs[i]);
         for (size_t i = 0; i < get_output_count(); ++i)
-            caller(m_output_ports[i], m_exit_port_descs[i]);
+            caller(m_output_ports[i], m_output_port_descs[i]);
     }
 
 private:
@@ -347,8 +347,8 @@ private:
     void validate() const;
 
     SpecificIterationHandlers m_handlers = {};
-    std::vector<LoopPortDesc> m_entry_port_descs = {};
-    std::vector<LoopPortDesc> m_exit_port_descs = {};
+    std::vector<LoopPortDesc> m_input_port_descs = {};
+    std::vector<LoopPortDesc> m_output_port_descs = {};
 };
 using UnifiedLoopInfoPtr = std::shared_ptr<UnifiedLoopInfo>;
 

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -118,11 +118,27 @@ public:
         std::for_each(m_entry_points.begin(), m_entry_points.end(), updater);
     }
     /**
+     * @brief Update the parameters of existing loop input ports
+     * @param updater - function that updates ports and need index of the port
+     */
+    inline void update_entry_points(const std::function<void(LoopPort&, size_t idx)>& updater) {
+        for (size_t i = 0; i < m_entry_points.size(); ++i)
+            updater(m_entry_points[i], i);
+    }
+    /**
      * @brief Update the parameters of existing loop output ports
      * @param updater - function that updates ports
      */
     inline void update_exit_points(const std::function<void(LoopPort&)>& updater) {
         std::for_each(m_exit_points.begin(), m_exit_points.end(), updater);
+    }
+    /**
+     * @brief Update the parameters of existing loop output ports
+     * @param updater - function that updates ports and need index of the port
+     */
+    inline void update_exit_points(const std::function<void(LoopPort&, size_t idx)>& updater) {
+        for (size_t i = 0; i < m_exit_points.size(); ++i)
+            updater(m_exit_points[i], i);
     }
 
     // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -99,6 +99,16 @@ public:
      * @param target_ports new ports. Ther order of ports is important. Can contains `actual_port`
      */
     virtual void replace_with_new_ports(const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports);
+    /**
+     * @brief Sort ALL entry Loop Ports by `new_order`: `m_entry_points[new_order[i]] = m_entry_points[i]`
+     * @param new_order vector of new indexes
+     */
+    virtual void sort_entry_ports(const std::vector<size_t>& new_order);
+    /**
+     * @brief Sort ALL exit Loop Ports by `new_order`: `m_exit_points[new_order[i]] = m_exit_points[i]`
+     * @param new_order vector of new indexes
+     */
+    virtual void sort_exit_ports(const std::vector<size_t>& new_order);
 
     /**
      * @brief Update the parameters of existing loop input ports

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -86,6 +86,19 @@ public:
      * @param exit_points - vector of loop output ports
      */
     virtual void set_exit_points(std::vector<LoopPort> exit_points);
+    /**
+     * @brief Replace the current LoopPort `actual_port` with new `target_ports`
+     * @param actual_port actual port
+     * @param target_ports new ports. Ther order of ports is important. Can contains `actual_port`
+     */
+    virtual void replace_with_new_ports(const LoopPort& actual_port, const std::vector<LoopPort>& target_ports);
+    /**
+     * @brief Replace the current LoopPort that contains ExpressionPort `actual_port` with new `target_ports`
+     *        Note: If there is no LoopPort with this ExpressionPort `actual_port`, does nothing
+     * @param actual_port actual port
+     * @param target_ports new ports. Ther order of ports is important. Can contains `actual_port`
+     */
+    virtual void replace_with_new_ports(const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports);
 
     /**
      * @brief Update the parameters of existing loop input ports

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -35,6 +35,17 @@ public:
     virtual std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const = 0;
 
     /**
+     * @brief Returns count of entry points
+     * @return count
+     */
+    size_t get_entry_count() const;
+    /**
+     * @brief Returns count of exit points
+     * @return count
+     */
+    size_t get_exit_count() const;
+
+    /**
      * @brief Returns dimension index if dimension indices for all entry and exit points are equal.
      *        Otherwise returns UNDEFINED_DIM_IDX.
      * @return index
@@ -301,6 +312,19 @@ public:
      * @return const ref of `m_data_sizes`
      */
     const std::vector<int64_t>& get_data_sizes() const;
+
+    /**
+     * @brief Sort ALL entry Loop Ports by `new_order`: `m_entry_points[new_order[i]] = m_entry_points[i]`
+     *        Note: sorts the correspondings data pointer shifts parameters: `m_ptr_increments` etc
+     * @param new_order vector of new indexes
+     */
+    void sort_entry_ports(const std::vector<size_t>& new_order) override;
+    /**
+     * @brief Sort ALL exit Loop Ports by `new_order`: `m_exit_points[new_order[i]] = m_exit_points[i]`
+     *        Note: sorts the correspondings data pointer shifts parameters: `m_ptr_increments` etc
+     * @param new_order vector of new indexes
+     */
+    void sort_exit_ports(const std::vector<size_t>& new_order) override;
 
 private:
     // ExpandedLoopInfo has LoopPorts to have opportunity to work with Loops

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -76,16 +76,7 @@ public:
      * @param dim_idx - index
      */
     void set_dim_idx(size_t dim_idx);
-    /**
-     * @brief Set m_entry_points value
-     * @param entry_points - vector of loop input ports
-     */
-    virtual void set_entry_points(std::vector<LoopPort> entry_points);
-    /**
-     * @brief Set m_exit_points value
-     * @param exit_points - vector of loop output ports
-     */
-    virtual void set_exit_points(std::vector<LoopPort> exit_points);
+
     /**
      * @brief Replace the current LoopPort `actual_port` with new `target_ports`
      * @param actual_port actual port
@@ -99,6 +90,7 @@ public:
      * @param target_ports new ports. Ther order of ports is important. Can contains `actual_port`
      */
     virtual void replace_with_new_ports(const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports);
+
     /**
      * @brief Sort ALL entry Loop Ports by `new_order`: `m_entry_points[new_order[i]] = m_entry_points[i]`
      * @param new_order vector of new indexes
@@ -309,17 +301,6 @@ public:
      * @return const ref of `m_data_sizes`
      */
     const std::vector<int64_t>& get_data_sizes() const;
-
-    /**
-     * @brief Set m_entry_points value
-     * @param entry_points - vector of loop input ports
-     */
-    void set_entry_points(std::vector<LoopPort> entry_points) override;
-    /**
-     * @brief Set m_exit_points value
-     * @param exit_points - vector of loop output ports
-     */
-    void set_exit_points(std::vector<LoopPort> exit_points) override;
 
 private:
     // ExpandedLoopInfo has LoopPorts to have opportunity to work with Loops

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -103,17 +103,6 @@ public:
     virtual void replace_with_new_ports(const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports);
 
     /**
-     * @brief Sort ALL entry Loop Ports by `new_order`: `m_entry_points[new_order[i]] = m_entry_points[i]`
-     * @param new_order vector of new indexes
-     */
-    virtual void sort_entry_ports(const std::vector<size_t>& new_order);
-    /**
-     * @brief Sort ALL exit Loop Ports by `new_order`: `m_exit_points[new_order[i]] = m_exit_points[i]`
-     * @param new_order vector of new indexes
-     */
-    virtual void sort_exit_ports(const std::vector<size_t>& new_order);
-
-    /**
      * @brief Update the parameters of existing loop input ports
      * @param updater - function that updates ports
      */
@@ -252,6 +241,17 @@ public:
         m_handlers.register_pass<Type, T>(args...);
     }
 
+    /**
+     * @brief Sort ALL entry Loop Ports by `new_order`: `m_entry_points[new_order[i]] = m_entry_points[i]`
+     * @param new_order vector of new indexes
+     */
+    void sort_entry_ports(const std::vector<size_t>& new_order);
+    /**
+     * @brief Sort ALL exit Loop Ports by `new_order`: `m_exit_points[new_order[i]] = m_exit_points[i]`
+     * @param new_order vector of new indexes
+     */
+    void sort_exit_ports(const std::vector<size_t>& new_order);
+
 private:
     SpecificIterationHandlers m_handlers = {};
 };
@@ -314,17 +314,20 @@ public:
     const std::vector<int64_t>& get_data_sizes() const;
 
     /**
-     * @brief Sort ALL entry Loop Ports by `new_order`: `m_entry_points[new_order[i]] = m_entry_points[i]`
-     *        Note: sorts the correspondings data pointer shifts parameters: `m_ptr_increments` etc
-     * @param new_order vector of new indexes
+     * @brief Replace the current LoopPort `actual_port` with new `target_ports`
+     *        Attention: ExpandedLoopInfo supports only replace one port with one port!
+     * @param actual_port actual port
+     * @param target_ports vector with the single target port!
      */
-    void sort_entry_ports(const std::vector<size_t>& new_order) override;
+    void replace_with_new_ports(const LoopPort& actual_port, const std::vector<LoopPort>& target_ports) override;
     /**
-     * @brief Sort ALL exit Loop Ports by `new_order`: `m_exit_points[new_order[i]] = m_exit_points[i]`
-     *        Note: sorts the correspondings data pointer shifts parameters: `m_ptr_increments` etc
-     * @param new_order vector of new indexes
+     * @briefReplace the current LoopPort `actual_port` with new `target_ports`
+     *        Note: If there is no LoopPort with this ExpressionPort `actual_port`, does nothing
+     *        Attention: ExpandedLoopInfo supports only replace one port with one port!
+     * @param actual_port actual port
+     * @param target_ports vector with the single target port!
      */
-    void sort_exit_ports(const std::vector<size_t>& new_order) override;
+    void replace_with_new_ports(const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports) override;
 
 private:
     // ExpandedLoopInfo has LoopPorts to have opportunity to work with Loops

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -14,7 +14,7 @@ namespace lowered {
 
 /**
  * @interface LoopInfo
- * @brief The base class that contains the base common information about a Loop in Linear Intermediate IR (Linear IR):
+ * @brief The base class that contains the common information about a Loop in Linear Intermediate Representation (Linear IR):
  *        work amount of the Loop, step of loop counter increment, entry and exit ports of the Loop.
  * @ingroup snippets
  */
@@ -86,12 +86,12 @@ protected:
     /**
      * @brief Helper to clone Loop ports using `ExpressionMap`
      * @param expr_map expression map [the current expr -> the new expr]
-     * @param port_ports the loop ports that will be cloned
+     * @param loop_ports the loop ports that will be cloned
      * @return vector with new cloned loop ports
      */
-    static std::vector<LoopPort> clone_loop_ports(const ExpressionMap& expr_map, const std::vector<LoopPort>& port_ports);
+    static std::vector<LoopPort> clone_loop_ports(const ExpressionMap& expr_map, const std::vector<LoopPort>& loop_ports);
     /**
-     * @brief Helper to initialize some values from loop ports
+     * @brief Applies provided initializer function to entry and exit points
      * @param initializer function that can access to LoopPort
      */
     void init_from_ports(const std::function<void(const LoopPort&)>& initializer) const;
@@ -110,7 +110,7 @@ using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 /**
  * @interface UnifiedLoopInfo
  * @brief The structure describes unified (entire) Loop before decomposition into specific loop iterations.
- *        Contains passes for specific loop iterations that will be called in decomposition for each iteration (in `InsertSpecificIterations` pass).
+ *        Contains passes for specific loop iterations that will be called for each iteration during the decomposition stage (`InsertSpecificIterations` pass).
  * @ingroup snippets
  */
 class UnifiedLoopInfo : public LoopInfo {
@@ -232,7 +232,7 @@ public:
      */
     SpecificLoopIterType get_type() const;
     /**
-     * @brief Returns passes of the corresponding halder
+     * @brief Returns passes of the corresponding handler
      * @return pass pipeline
      */
     const pass::PassPipeline& get_handlers_by_type() const;

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -186,6 +186,8 @@ public:
         int64_t data_size = 0;
     };
     // The structure describes full information about port
+    // - TODO [140365] : UnifiedLoopInfo should have the map of LoopPorts and LoopDesc as class field
+    //                   instead of the separate vectors with descriptors.
     struct LoopPortInfo {
         LoopPort port;
         LoopPortDesc desc;

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -15,7 +15,7 @@ namespace lowered {
 /**
  * @interface LoopInfo
  * @brief The base class that contains the common information about a Loop in Linear Intermediate Representation (Linear IR):
- *        work amount of the Loop, step of loop counter increment, entry and exit ports of the Loop.
+ *        work amount of the Loop, step of loop counter increment, input and exit ports of the Loop.
  * @ingroup snippets
  */
 class LoopInfo {
@@ -35,18 +35,18 @@ public:
     virtual std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const = 0;
 
     /**
-     * @brief Returns count of entry points
+     * @brief Returns count of input ports
      * @return count
      */
-    size_t get_entry_count() const;
+    size_t get_input_count() const;
     /**
-     * @brief Returns count of exit points
+     * @brief Returns count of exit ports
      * @return count
      */
-    size_t get_exit_count() const;
+    size_t get_output_count() const;
 
     /**
-     * @brief Returns dimension index if dimension indices for all entry and exit points are equal.
+     * @brief Returns dimension index if dimension indices for all input and exit ports are equal.
      *        Otherwise returns UNDEFINED_DIM_IDX.
      * @return index
      */
@@ -68,14 +68,14 @@ public:
     std::vector<bool> get_is_incremented() const;
     /**
      * @brief Returns vector of loop input ports
-     * @return m_entry_points
+     * @return m_input_ports
      */
-    const std::vector<LoopPort>& get_entry_points() const;
+    const std::vector<LoopPort>& get_input_ports() const;
     /**
      * @brief Returns vector of loop outputs ports
-     * @return m_exit_points
+     * @return m_output_ports
      */
-    const std::vector<LoopPort>& get_exit_points() const;
+    const std::vector<LoopPort>& get_output_ports() const;
 
     /**
      * @brief Set m_work_amount value
@@ -88,7 +88,7 @@ public:
      */
     void set_increment(size_t increment);
     /**
-     * @brief Sets `dim_idx` to all entry and exit points
+     * @brief Sets `dim_idx` to all input and exit ports
      * @param dim_idx - index
      */
     void set_dim_idx(size_t dim_idx);
@@ -112,16 +112,16 @@ public:
      * @param caller - function that called for each loop port
      */
     inline void iterate_through_ports(const std::function<void(LoopPort&)>& caller) {
-        std::for_each(m_entry_points.begin(), m_entry_points.end(), caller);
-        std::for_each(m_exit_points.begin(), m_exit_points.end(), caller);
+        std::for_each(m_input_ports.begin(), m_input_ports.end(), caller);
+        std::for_each(m_output_ports.begin(), m_output_ports.end(), caller);
     }
     /**
      * @brief Iterates through all loop ports and call `caller` for each of them
      * @param caller - function that called for each loop port
      */
     inline void iterate_through_ports(const std::function<void(const LoopPort&)>& caller) const {
-        std::for_each(m_entry_points.cbegin(), m_entry_points.cend(), caller);
-        std::for_each(m_exit_points.cbegin(), m_exit_points.cend(), caller);
+        std::for_each(m_input_ports.cbegin(), m_input_ports.cend(), caller);
+        std::for_each(m_output_ports.cbegin(), m_output_ports.cend(), caller);
     }
 
     // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
@@ -149,7 +149,7 @@ protected:
      */
     static std::vector<LoopPort> clone_loop_ports(const ExpressionMap& expr_map, const std::vector<LoopPort>& loop_ports);
     /**
-     * @brief Find LoopPort in entry and exit ports
+     * @brief Find LoopPort in input and exit ports
      * @param loop_port target port
      * @return iterator of the corresponding collection
      */
@@ -158,12 +158,12 @@ protected:
 
     size_t m_work_amount = 0;
     size_t m_increment = 0;
-    // The order of entry and exit expressions is important:
-    //     - The position before first entry expr is Loop Begin position
+    // The order of input and exit expressions is important:
+    //     - The position before first input expr is Loop Begin position
     //     - The position after last exit expr is Loop End position
-    // Note: Scalars aren't entry expressions but can be before first entry expr in Linear IR
-    std::vector<LoopPort> m_entry_points = {};
-    std::vector<LoopPort> m_exit_points = {};
+    // Note: Scalars aren't input expressions but can be before first input expr in Linear IR
+    std::vector<LoopPort> m_input_ports = {};
+    std::vector<LoopPort> m_output_ports = {};
 };
 using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 
@@ -176,6 +176,8 @@ using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 class UnifiedLoopInfo : public LoopInfo {
 public:
     OPENVINO_RTTI("UnifiedLoopInfo", "0", LoopInfo)
+    // The structure describes data pointer shift parameters:
+    // pointer increment, finalization offset, element size of the port
     struct LoopPortDesc {
         LoopPortDesc(int64_t inc = 0, int64_t fo = 0, int64_t ds = 0)
             : ptr_increment(inc), finalization_offset(fo), data_size(ds) {}
@@ -188,7 +190,7 @@ public:
     UnifiedLoopInfo() = default;
     UnifiedLoopInfo(size_t work_amount, size_t increment,
                     const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
-                    const std::vector<LoopPortDesc>& in_shifts, const std::vector<LoopPortDesc>& out_shifts,
+                    const std::vector<LoopPortDesc>& in_descs, const std::vector<LoopPortDesc>& out_descs,
                     const SpecificIterationHandlers& handlers = SpecificIterationHandlers());
     UnifiedLoopInfo(size_t work_amount, size_t increment,
                     const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
@@ -225,25 +227,25 @@ public:
      */
     std::vector<int64_t> get_data_sizes() const;
     /**
-     * @brief Returns vector with data pointer shift params of entry loop ports
+     * @brief Returns vector with data pointer shift params of input loop ports
      * @return vector with params
      */
-    const std::vector<LoopPortDesc>& get_entry_port_descs() const;
+    const std::vector<LoopPortDesc>& get_input_port_descs() const;
     /**
      * @brief Returns vector with data pointer shift params of exit loop ports
      * @return vector with params
      */
-    const std::vector<LoopPortDesc>& get_exit_port_descs() const;
+    const std::vector<LoopPortDesc>& get_output_port_descs() const;
     /**
-     * @brief Returns vector with full LoopPort info [Port and descriptor] of entry loop ports
+     * @brief Returns vector with full LoopPort info [Port and descriptor] of input loop ports
      * @return vector with port information
      */
-    std::vector<LoopPortInfo> get_entry_ports_info() const;
+    std::vector<LoopPortInfo> get_input_ports_info() const;
     /**
-     * @brief Returns vector with full LoopPort info [Port and descriptor] of entry loop ports
+     * @brief Returns vector with full LoopPort info [Port and descriptor] of input loop ports
      * @return vector with port information
      */
-    std::vector<LoopPortInfo> get_exit_ports_info() const;
+    std::vector<LoopPortInfo> get_output_ports_info() const;
 
     /**
      * @brief Set m_handlers value
@@ -263,12 +265,12 @@ public:
     }
 
     /**
-     * @brief Sort ALL entry Loop Ports by `new_order`: `m_entry_points[new_order[i]] = m_entry_points[i]`
+     * @brief Sort ALL input Loop Ports by `new_order`: `m_input_ports[new_order[i]] = m_input_ports[i]`
      * @param new_order vector of new indexes
      */
     void sort_entry_ports(const std::vector<size_t>& new_order);
     /**
-     * @brief Sort ALL exit Loop Ports by `new_order`: `m_exit_points[new_order[i]] = m_exit_points[i]`
+     * @brief Sort ALL exit Loop Ports by `new_order`: `m_output_ports[new_order[i]] = m_output_ports[i]`
      * @param new_order vector of new indexes
      */
     void sort_exit_ports(const std::vector<size_t>& new_order);
@@ -291,7 +293,7 @@ public:
      * @brief Iterates through all LoopPortDesc and call `caller` for each of them
      * @param caller - function that called for each LoopPortDesc
      */
-    inline void iterate_through_port_descs(const std::function<void(LoopPortDesc&)>& caller) {
+    inline void iterate_through_ports(const std::function<void(LoopPortDesc&)>& caller) {
         std::for_each(m_entry_port_descs.begin(), m_entry_port_descs.end(), caller);
         std::for_each(m_exit_port_descs.begin(), m_exit_port_descs.end(), caller);
     }
@@ -299,7 +301,7 @@ public:
      * @brief Iterates through all loop ports and call `caller` for each of them
      * @param caller - function that called for each loop port
      */
-    inline void iterate_through_port_descs(const std::function<void(const LoopPortDesc&)>& caller) const {
+    inline void iterate_through_ports(const std::function<void(const LoopPortDesc&)>& caller) const {
         std::for_each(m_entry_port_descs.cbegin(), m_entry_port_descs.cend(), caller);
         std::for_each(m_exit_port_descs.cbegin(), m_exit_port_descs.cend(), caller);
     }
@@ -307,25 +309,25 @@ public:
      * @brief Iterates through all pairs <LoopPort, LoopPortDesc> and call `caller` for each of them
      * @param caller - function that called for each pair
      */
-    inline void iterate_through_port_info(const std::function<void(LoopPort&, LoopPortDesc&)>& caller) {
-        OPENVINO_ASSERT(m_entry_points.size() == m_entry_port_descs.size(), "Incompatible count of entry point and descs");
-        OPENVINO_ASSERT(m_exit_points.size() == m_exit_port_descs.size(), "Incompatible count of exit point and descs");
-        for (size_t i = 0; i < get_entry_count(); ++i)
-            caller(m_entry_points[i], m_entry_port_descs[i]);
-        for (size_t i = 0; i < get_exit_count(); ++i)
-            caller(m_exit_points[i], m_exit_port_descs[i]);
+    inline void iterate_through_ports(const std::function<void(LoopPort&, LoopPortDesc&)>& caller) {
+        OPENVINO_ASSERT(m_input_ports.size() == m_entry_port_descs.size(), "Incompatible count of input port and descs");
+        OPENVINO_ASSERT(m_output_ports.size() == m_exit_port_descs.size(), "Incompatible count of exit port and descs");
+        for (size_t i = 0; i < get_input_count(); ++i)
+            caller(m_input_ports[i], m_entry_port_descs[i]);
+        for (size_t i = 0; i < get_output_count(); ++i)
+            caller(m_output_ports[i], m_exit_port_descs[i]);
     }
     /**
      * @brief Iterates through all pairs <LoopPort, LoopPortDesc> and call `caller` for each of them
      * @param caller - function that called for each pair
      */
-    inline void iterate_through_port_info(const std::function<void(const LoopPort&, const LoopPortDesc&)>& caller) const {
-        OPENVINO_ASSERT(m_entry_points.size() == m_entry_port_descs.size(), "Incompatible count of entry point and descs");
-        OPENVINO_ASSERT(m_exit_points.size() == m_exit_port_descs.size(), "Incompatible count of exit point and descs");
-        for (size_t i = 0; i < get_entry_count(); ++i)
-            caller(m_entry_points[i], m_entry_port_descs[i]);
-        for (size_t i = 0; i < get_exit_count(); ++i)
-            caller(m_exit_points[i], m_exit_port_descs[i]);
+    inline void iterate_through_ports(const std::function<void(const LoopPort&, const LoopPortDesc&)>& caller) const {
+        OPENVINO_ASSERT(m_input_ports.size() == m_entry_port_descs.size(), "Incompatible count of input port and descs");
+        OPENVINO_ASSERT(m_output_ports.size() == m_exit_port_descs.size(), "Incompatible count of exit port and descs");
+        for (size_t i = 0; i < get_input_count(); ++i)
+            caller(m_input_ports[i], m_entry_port_descs[i]);
+        for (size_t i = 0; i < get_output_count(); ++i)
+            caller(m_output_ports[i], m_exit_port_descs[i]);
     }
 
 private:
@@ -410,9 +412,9 @@ private:
     // ExpandedLoopInfo has LoopPorts to have opportunity to work with Loops
     // in iter handlers in InsertSpecificIterations. For example, in UpdateSubtensors.
     // However, for faster work with data ptr shifts ExpandedLoopInfo has the separate dense attributes.
-    // Thus, LoopPorts of ExpandedLoopInfo are interpreted as entry and exit points of specific Loop iterations.
+    // Thus, LoopPorts of ExpandedLoopInfo are interpreted as input and exit ports of specific Loop iterations.
     // All needed informations about data pointer shifts are stored in attributes below!
-    // Note: the first initialization of these attributes is in ctor from entry and exit loop ports
+    // Note: the first initialization of these attributes is in ctor from input and exit loop ports
     std::vector<int64_t> m_ptr_increments = {};
     std::vector<int64_t> m_finalization_offsets = {};
     std::vector<int64_t> m_data_sizes = {};

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -174,8 +174,8 @@ public:
      * @param args - arguments of the transformation
      */
     template <SpecificLoopIterType Type, typename T, class... Args>
-    void register_handler(Args&&... args) {
-        m_handlers.register_handler<Type, T>(args...);
+    void register_pass_to_handler(Args&&... args) {
+        m_handlers.register_pass<Type, T>(args...);
     }
 
     /**
@@ -235,7 +235,7 @@ public:
      * @brief Returns passes of the corresponding handler
      * @return pass pipeline
      */
-    const pass::PassPipeline& get_handlers_by_type() const;
+    const pass::PassPipeline& get_handler_passes() const;
 
     /**
      * @brief Returns dense vector with pointer increments
@@ -264,7 +264,7 @@ private:
     std::vector<int64_t> m_finalization_offsets = {};
     std::vector<int64_t> m_data_sizes = {};
 
-    SpecificLoopIterType m_type = {};
+    const SpecificLoopIterType m_type = {};
     std::shared_ptr<UnifiedLoopInfo> m_unified_loop_info = {};
 };
 using ExpandedLoopInfoPtr = std::shared_ptr<ExpandedLoopInfo>;

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -82,6 +82,22 @@ public:
      */
     void set_exit_points(std::vector<LoopPort> exit_points);
 
+    // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
+    // so the standard OPENVINO_RTTI(...) macros could be used in derived classes.
+    _OPENVINO_HIDDEN_METHOD static const ::ov::DiscreteTypeInfo& get_type_info_static() {
+        static ::ov::DiscreteTypeInfo type_info_static {"PassBase"};
+        type_info_static.hash();
+        return type_info_static;
+    }
+
+    virtual const DiscreteTypeInfo& get_type_info() const {
+        return get_type_info_static();
+    }
+
+    const char* get_type_name() const {
+        return get_type_info().name;
+    }
+
 protected:
     /**
      * @brief Helper to clone Loop ports using `ExpressionMap`
@@ -115,6 +131,7 @@ using LoopInfoPtr = std::shared_ptr<LoopInfo>;
  */
 class UnifiedLoopInfo : public LoopInfo {
 public:
+    OPENVINO_RTTI("UnifiedLoopInfo", "0", LoopInfo)
     UnifiedLoopInfo() = default;
     UnifiedLoopInfo(size_t work_amount, size_t increment,
                     const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
@@ -206,6 +223,7 @@ using UnifiedLoopInfoPtr = std::shared_ptr<UnifiedLoopInfo>;
  */
 class ExpandedLoopInfo : public LoopInfo {
 public:
+    OPENVINO_RTTI("ExpandedLoopInfo", "0", LoopInfo)
     ExpandedLoopInfo() = default;
     ExpandedLoopInfo(size_t work_amount, size_t increment,
                      const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -96,14 +96,14 @@ public:
     /**
      * @brief Replace the current LoopPort `actual_port` with new `target_ports`
      * @param actual_port actual port
-     * @param target_ports new ports. Ther order of ports is important. Can contains `actual_port`
+     * @param target_ports new ports. The ports order is important. Can contain `actual_port`
      */
     virtual void replace_with_new_ports(const LoopPort& actual_port, const std::vector<LoopPort>& target_ports);
     /**
      * @brief Replace the current LoopPort that contains ExpressionPort `actual_port` with new `target_ports`
      *        Note: If there is no LoopPort with this ExpressionPort `actual_port`, does nothing
      * @param actual_port actual port
-     * @param target_ports new ports. Ther order of ports is important. Can contains `actual_port`
+     * @param target_ports new ports. The ports order is important. Can contain `actual_port`
      */
     virtual void replace_with_new_ports(const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports);
 
@@ -127,7 +127,7 @@ public:
     // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
     // so the standard OPENVINO_RTTI(...) macros could be used in derived classes.
     _OPENVINO_HIDDEN_METHOD static const ::ov::DiscreteTypeInfo& get_type_info_static() {
-        static ::ov::DiscreteTypeInfo type_info_static {"PassBase"};
+        static ::ov::DiscreteTypeInfo type_info_static {"LoopInfoBase"};
         type_info_static.hash();
         return type_info_static;
     }
@@ -412,7 +412,7 @@ public:
      */
     void replace_with_new_ports(const LoopPort& actual_port, const std::vector<LoopPort>& target_ports) override;
     /**
-     * @briefReplace the current LoopPort `actual_port` with new `target_ports`
+     * @brief Replace the current LoopPort `actual_port` with new `target_ports`
      *        Note: If there is no LoopPort with this ExpressionPort `actual_port`, does nothing
      *        Attention: ExpandedLoopInfo supports only replace one port with one port!
      * @param actual_port actual port

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -31,7 +31,15 @@ public:
      * @param index loop ID
      * @return the LoopInfo shared ptr
      */
-    LoopInfoPtr get_loop_info(size_t index) const;
+    template<typename T = LoopInfo>
+    std::shared_ptr<T> get_loop_info(size_t index) const {
+        static_assert(std::is_base_of<LoopInfo, T>::value, "LoopInfo not derived from lowered::LoopInfo");
+        const auto it = m_map.find(index);
+        OPENVINO_ASSERT(it != m_map.end(), "LoopInfo hasn't been found!");
+        const auto loop_info = std::dynamic_pointer_cast<T>(it->second);
+        OPENVINO_ASSERT(loop_info, "LoopInfo of specific type hasn't been found!");
+        return loop_info;
+    }
     /**
      * @brief Get count of loops
      * @return count of loops in the map
@@ -96,7 +104,7 @@ public:
         const auto handlers = set_default_handlers
                                   ? SpecificIterationHandlers(work_amount, normalized_increment)
                                   : SpecificIterationHandlers();
-        const auto loop_info = std::make_shared<LoopInfo>(work_amount, normalized_increment, entries, exits, handlers);
+        const auto loop_info = std::make_shared<UnifiedLoopInfo>(work_amount, normalized_increment, entries, exits, handlers);
         const auto loop_id = this->add_loop_info(loop_info);
         for (auto expr_it = loop_begin_pos; expr_it != loop_end_pos; ++expr_it) {
             insert_loop_id(*expr_it, loop_id);
@@ -137,21 +145,12 @@ public:
      *                       If there is explicit LoopBegin expressions in IR, loop_begin_pos must be the iterator of the LoopBegin
      * @param loop_end_pos the next iterator after last expression iterator. Must be the iterator of the `linear_ir`.
      *                     If there is explicit LoopEnd expressions in IR, loop_end_pos must be the next iterator of the LoopEnd
-     * @param work_amount work amount of the loop
-     * @param work_amount_increment increment of the loop
-     * @param entries input loop ports
-     * @param exits output loop ports
+     * @param loop_info information about new Loop
      * @param old_id loop ID of the previos loop
      * @return new loop ID
      */
-    size_t replace_with_new_loop(const LinearIR& linear_ir,
-                                 LinearIR::constExprIt loop_begin_pos,
-                                 LinearIR::constExprIt loop_end_pos,
-                                 size_t work_amount,
-                                 size_t increment,
-                                 const std::vector<LoopPort>& entries,
-                                 const std::vector<LoopPort>& exits,
-                                 const size_t old_id);
+    size_t replace_with_new_loop(const LinearIR& linear_ir, LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos,
+                                 const LoopInfoPtr& loop_info, const size_t old_id);
     /**
      * @brief Fuse two LoopInfos: fuse their informations to the one
      * @param linear_ir linear IR
@@ -230,6 +229,8 @@ public:
      */
     void expression_replacement(LinearIR::constExprIt new_expr_begin, LinearIR::constExprIt new_expr_end, const ExpressionPtr& decomposed_expr,
                                 size_t loop_id, const std::vector<ExpressionPort>& new_entries, const std::vector<ExpressionPort>& exits);
+
+    using LoopBounds = std::pair<LinearIR::constExprIt, LinearIR::constExprIt>;
     /**
      * @brief Find bounds of Loop:
      *        - If the explicit Loop exprs with the target `loop_id` have been inserted,
@@ -241,7 +242,7 @@ public:
      * @param loop_id target Loop ID
      * @return the pair of loop_begin_pos and loop_end_pos iterators
      */
-    std::pair<LinearIR::constExprIt, LinearIR::constExprIt> get_loop_bounds(const LinearIR& linear_ir, size_t loop_id) const;
+    LoopBounds get_loop_bounds(const LinearIR& linear_ir, size_t loop_id) const;
     /**
      * @brief Find bounds of Loop:
      *        - If the explicit Loop exprs with the target `loop_id` have been inserted,
@@ -255,8 +256,7 @@ public:
      * @param exits output loop ports
      * @return the pair of loop_begin_pos and loop_end_pos iterators
      */
-    static std::pair<LinearIR::constExprIt, LinearIR::constExprIt> get_loop_bounds(const LinearIR& linear_ir, size_t loop_id,
-                                                                                   const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits);
+    static LoopBounds get_loop_bounds(const LinearIR& linear_ir, size_t loop_id, const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits);
 
     /**
      * @brief Get LoopPort by ExpressionPort

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -267,12 +267,12 @@ public:
     LoopPort get_loop_port_by_expr_port(const ExpressionPort& expr_port, const size_t loop_id);
 
     /**
-     * @brief Blend loop map using `loop_id_map` and update LoopIDs of expressions and LoopEnd
+     * @brief Reassign Loop IDs in `m_map` using `loop_id_map` and update LoopIDs of expressions and LoopEnd
      * @param linear_ir linear IR
      * @param loop_id_map [ current Loop ID -> new target Loop ID ]
-     * @return True if loops have been mixed up. Otherwise returns False
+     * @return True if loops have been reassigned. Otherwise returns False
      */
-    bool blend(const LinearIR& linear_ir, const std::map<size_t, size_t>& loop_id_map);
+    bool reassign_identifiers(const LinearIR& linear_ir, const std::map<size_t, size_t>& loop_id_map);
 
 private:
     /**

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -266,6 +266,14 @@ public:
      */
     LoopPort get_loop_port_by_expr_port(const ExpressionPort& expr_port, const size_t loop_id);
 
+    /**
+     * @brief Blend loop map using `loop_id_map` and update LoopIDs of expressions and LoopEnd
+     * @param linear_ir linear IR
+     * @param loop_id_map [ current Loop ID -> new target Loop ID ]
+     * @return True if loops have been mixed up. Otherwise returns False
+     */
+    bool blend(const LinearIR& linear_ir, const std::map<size_t, size_t>& loop_id_map);
+
 private:
     /**
      * @brief Add new Loop Info to the map

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -178,22 +178,22 @@ public:
      * @param loop_id the target Loop ID
      * @param actual_port the current port
      * @param target_ports vector of the new ports (the order is important!)
-     * @param is_entry True if these ports are input, otherwise - output
      */
     template<typename T>
-    void update_loop_port(size_t loop_id, const T& actual_port, const std::vector<T>& target_ports, bool is_entry = true);
+    void update_loop_port(size_t loop_id, const T& actual_port, const std::vector<T>& target_ports) {
+        const auto& loop_info = get_loop_info(loop_id);
+        loop_info->replace_with_new_ports(actual_port, target_ports);
+    }
     /**
      * @brief Update Loop ports for several Loops.
      * @param loop_ids the target Loop IDs
      * @param actual_port the current port
      * @param target_ports vector of the new ports (the order is important!)
-     * @param is_entry True if these ports are input, otherwise - output
      */
     template<typename T>
-    void update_loops_port(const std::vector<size_t>& loop_ids, const T& actual_port,
-                           const std::vector<T>& target_ports, bool is_entry = true) {
+    void update_loops_port(const std::vector<size_t>& loop_ids, const T& actual_port, const std::vector<T>& target_ports) {
         for (auto loop_id : loop_ids) {
-            update_loop_port(loop_id, actual_port, target_ports, is_entry);
+            update_loop_port(loop_id, actual_port, target_ports);
         }
     }
     /**

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -152,7 +152,7 @@ public:
     size_t replace_with_new_loop(const LinearIR& linear_ir, LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos,
                                  const LoopInfoPtr& loop_info, const size_t old_id);
     /**
-     * @brief Fuse two LoopInfos: fuse their informations to the one
+     * @brief Fuse two UnifiedLoopInfos: fuse their informations to the one
      * @param linear_ir linear IR
      * @param loop_id_upper Loop ID of the Loop that is earlier in the linear IR
      * @param loop_id_lower Loop ID of the Loop that is later in the linear IR
@@ -160,7 +160,7 @@ public:
      */
     void fuse_loops(const LinearIR& linear_ir, size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper = true);
     /**
-     * @brief Fuse two loops: fuse their LoopInfos and update loop IDs in expressions
+     * @brief Fuse two Unified loops: fuse their UnifiedLoopInfos and update loop IDs in expressions
      * @param loop_begin_target the first expression iterator of the Loop that will be left after fusion
      * @param loop_end_target the next ietartor for the last expression of the Loop that will be left after fusion
      * @param loop_id_upper Loop ID of the Loop that is earlier in the linear IR
@@ -170,7 +170,7 @@ public:
     void fuse_loops(LinearIR::constExprIt loop_begin_target, LinearIR::constExprIt loop_end_target,
                     size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper = true);
     /**
-     * @brief Update Loop ports for one Loop. The method saves the order of ports since
+     * @brief Update Loop ports for one Unified Loop. The method saves the order of ports since
      *        the order of expression defines Loop bounds before explicit loop insertion (the most first and the most last expressions).
      *        Note:
      *         - Update LoopPort - insert new loop target ports instead of existing.

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -211,7 +211,7 @@ public:
      */
     void update_loop_ports(const ExpressionPtr& expr);
     /**
-     * @brief Sort Loop Ports by expression locations in Linear IR
+     * @brief Sort Unified Loop Ports by expression locations in Linear IR
      * @param loop_begin_pos the first expression iterator of the Loop
      * @param loop_end_pos the next iterator after the last expression
      * @param loop_id target Loop ID

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -82,7 +82,7 @@ public:
                    LinearIR::constExprIt loop_end_pos,
                    size_t loop_depth, size_t vector_size);
     /**
-     * @brief Create new LoopInfo and mark all expressions in loop bounds by new loop ID with more manual parameters
+     * @brief Create new UnifiedLoopInfo and mark all expressions in loop bounds by new loop ID with more manual parameters
      * @param loop_begin_pos the first expression iterator
      * @param loop_end_pos the next iterator after last expression
      * @param work_amount work amount of the loop
@@ -112,7 +112,7 @@ public:
         return loop_id;
     }
     /**
-     * @brief Create new LoopInfo and mark all expressions in loop bounds by new loop ID with more manual parameters
+     * @brief Create new UnifiedLoopInfo and mark all expressions in loop bounds by new loop ID with more manual parameters
      * @param loop_begin_pos the first expression iterator
      * @param loop_end_pos the next iterator after last expression
      * @param work_amount work amount of the loop
@@ -133,7 +133,7 @@ public:
                      const std::vector<T>& exits,
                      bool set_default_handlers = true) {
         const auto loop_id = mark_loop(loop_begin_pos, loop_end_pos, work_amount, increment, entries, exits, set_default_handlers);
-        const auto loop_info = get_loop_info(loop_id);
+        const auto loop_info = get_loop_info<UnifiedLoopInfo>(loop_id);
         loop_info->set_dim_idx(dim_idx);
         return loop_id;
     }

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -267,12 +267,12 @@ public:
     LoopPort get_loop_port_by_expr_port(const ExpressionPort& expr_port, const size_t loop_id);
 
     /**
-     * @brief Reassign Loop IDs in `m_map` using `loop_id_map` and update LoopIDs of expressions and LoopEnd
-     * @param linear_ir linear IR
-     * @param loop_id_map [ current Loop ID -> new target Loop ID ]
+     * @brief Reassign Loop IDs in `m_map` using `loop_id_map`
+     *        Note: the method don't update `loop_ids` of expressions!
+     * @param loop_id_map [ current Loop ID -> new target Loop ID ].
      * @return True if loops have been reassigned. Otherwise returns False
      */
-    bool reassign_identifiers(const LinearIR& linear_ir, const std::map<size_t, size_t>& loop_id_map);
+    bool reassign_identifiers(const std::map<size_t, size_t>& loop_id_map);
 
 private:
     /**

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -198,15 +198,15 @@ public:
     }
     /**
      * @brief The method checks the loops (LoopInfo) that the target expression is marked with and update the corresponding loop ports if needed:
-     *           - If parent of the target expression and this expression are marked by one Loop and the parent is an exit port of this Loop,
-     *             the method replace parent output port with the target expression output ports as new exit LoopPorts.
+     *           - If parent of the target expression and this expression are marked by one Loop and the parent is an output port of this Loop,
+     *             the method replace parent output port with the target expression output ports as new output LoopPorts.
      *             If there are other consumers of parent output port that are not by the same Loop (like in the example below),
-     *             the method just adds inserted expression output ports to existing parent output port as new exit LoopPorts.
+     *             the method just adds inserted expression output ports to existing parent output port as new output LoopPorts.
      *                     Parent [1, 0]
      *                    /              \                        <- Adds the target expression outputs to the existing LoopPort (parent output) of Loop[1]
      *               Another expr [2]   Target expression [1, 3]     (If Another expr is marked by Loop [1] too, the method will replace loop ports (not add))
-     *           - If the target expression and its consumers have the same outer loop ids and some of consumers are entry ports of these Loops,
-     *             the method just replace the existing entry loop ports (that contains consumer input ports) with the target expression input ports.
+     *           - If the target expression and its consumers have the same outer loop ids and some of consumers are input ports of these Loops,
+     *             the method just replace the existing input loop ports (that contains consumer input ports) with the target expression input ports.
      * @param expr the target expression
      */
     void update_loop_ports(const ExpressionPtr& expr);
@@ -235,8 +235,8 @@ public:
      * @brief Find bounds of Loop:
      *        - If the explicit Loop exprs with the target `loop_id` have been inserted,
      *          Loop bounds are these iterators of the corresponding LoopBegin and LoopEnd.
-     *        - Otherwise Loop bounds are iterators of the first entry loop port (or Scalar, VectorBuffer and another LoopBegin that
-     *          are in this Loop but have another `loop_id`) and the next iterator of the last exit loop port (or another LoopEnd that
+     *        - Otherwise Loop bounds are iterators of the first input loop port (or Scalar, VectorBuffer and another LoopBegin that
+     *          are in this Loop but have another `loop_id`) and the next iterator of the last output loop port (or another LoopEnd that
      *          are in this Loop but have another `loop_id`).
      * @param linear_ir linear IR
      * @param loop_id target Loop ID
@@ -247,8 +247,8 @@ public:
      * @brief Find bounds of Loop:
      *        - If the explicit Loop exprs with the target `loop_id` have been inserted,
      *          Loop bounds are these iterators of the corresponding LoopBegin and LoopEnd.
-     *        - Otherwise Loop bounds are iterators of the first entry loop port (or Scalar, VectorBuffer and another LoopBegin that
-     *          are in this Loop but have another `loop_id`) and the next iterator of the last exit loop port (or another LoopEnd that
+     *        - Otherwise Loop bounds are iterators of the first input loop port (or Scalar, VectorBuffer and another LoopBegin that
+     *          are in this Loop but have another `loop_id`) and the next iterator of the last output loop port (or another LoopEnd that
      *          are in this Loop but have another `loop_id`).
      * @param linear_ir linear IR
      * @param loop_id target Loop ID
@@ -298,12 +298,12 @@ private:
                                   std::vector<ExpressionPort>& entries,
                                   std::vector<ExpressionPort>& exits);
     /**
-     * @brief Fuse exit LoopPorts of upper Loop and entry LoopPorts of lower Loop
-     * @param exit_points ref of exit LoopPorts of upper Loop
-     * @param entry_points ref of entry LoopPorts of lower Loop
+     * @brief Fuse input LoopPorts of upper Loop and output LoopPorts of lower Loop
+     * @param output_ports ref of output LoopPorts of upper Loop
+     * @param input_ports ref of input LoopPorts of lower Loop
      * @param loop_id ID of the new Loop after fusion
      */
-    static void fuse_loop_ports(std::vector<LoopPort>& exit_points, std::vector<LoopPort>& entry_points, size_t loop_id);
+    static void fuse_loop_ports(std::vector<LoopPort>& output_ports, std::vector<LoopPort>& input_ports, size_t loop_id);
 
     /* ===== The methods for work with Loop IDs of Expression ===== */
     // Notes:

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -36,7 +36,7 @@ public:
     std::shared_ptr<T> get_loop_info(size_t index) const {
         const auto it = m_map.find(index);
         OPENVINO_ASSERT(it != m_map.end(), "LoopInfo hasn't been found!");
-        const auto loop_info = std::dynamic_pointer_cast<T>(it->second);
+        const auto loop_info = ov::as_type_ptr<T>(it->second);
         OPENVINO_ASSERT(loop_info, "LoopInfo of specific type hasn't been found!");
         return loop_info;
     }

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -267,12 +267,12 @@ public:
     LoopPort get_loop_port_by_expr_port(const ExpressionPort& expr_port, const size_t loop_id);
 
     /**
-     * @brief Reassign Loop IDs in `m_map` using `loop_id_map`
+     * @brief Reorder ALL Loop IDs in `m_map` using `loop_id_map`
      *        Note: the method don't update `loop_ids` of expressions!
      * @param loop_id_map [ current Loop ID -> new target Loop ID ].
-     * @return True if loops have been reassigned. Otherwise returns False
+     * @return True if loops have been reordered. Otherwise returns False
      */
-    bool reassign_identifiers(const std::map<size_t, size_t>& loop_id_map);
+    bool reorder_identifiers(const std::map<size_t, size_t>& loop_id_map);
 
 private:
     /**

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -31,9 +31,9 @@ public:
      * @param index loop ID
      * @return the LoopInfo shared ptr
      */
-    template<typename T = LoopInfo>
+    template<typename T = LoopInfo,
+             typename std::enable_if<std::is_base_of<LoopInfo, T>::value, bool>::type = true>
     std::shared_ptr<T> get_loop_info(size_t index) const {
-        static_assert(std::is_base_of<LoopInfo, T>::value, "LoopInfo not derived from lowered::LoopInfo");
         const auto it = m_map.find(index);
         OPENVINO_ASSERT(it != m_map.end(), "LoopInfo hasn't been found!");
         const auto loop_info = std::dynamic_pointer_cast<T>(it->second);
@@ -138,7 +138,7 @@ public:
         return loop_id;
     }
     /**
-     * @brief Create new Loop and replace with it: create new LoopInfo, update loop IDs in expressions and
+     * @brief Create new Loop and replace with it: add new LoopInfo, update loop IDs in expressions and
      *        remove the old LoopInfo from the map if no one expression isn't mark by this `old_id`
      * @param linear_ir linear IR
      * @param loop_begin_pos the first expression iterator. Must be the iterator of the `linear_ir`.

--- a/src/common/snippets/include/snippets/lowered/loop_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_port.hpp
@@ -24,15 +24,10 @@ struct LoopPort {
     friend bool operator!=(const LoopPort& lhs, const LoopPort& rhs);
     friend bool operator<(const LoopPort& lhs, const LoopPort& rhs);
 
-    bool is_dynamic() const;
-
     std::shared_ptr<ExpressionPort> expr_port = {};
     // True if after each Loop iteration the corresponding data pointer should be incremented.
     // Otherwise, the data pointer shift is skipped
     bool is_incremented = true;
-    int64_t ptr_increment = 0;
-    int64_t finalization_offset = 0;
-    int64_t data_size = 0;
     size_t dim_idx = 0; // The numeration starts from the end (dim_idx = 0 -> is the most inner dimension)
 };
 

--- a/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
@@ -15,7 +15,7 @@ namespace pass {
 
 /**
  * @interface FuseLoops
- * @brief The pass fuses marking Loops. The transformations support the following fusions of loops:
+ * @brief The pass fuses marking Unified Loops. The transformations support the following fusions of loops:
  *
  *        - Upper Loop is fused into the Current Loop
  *             Loop_0 (Upper)                 |
@@ -42,7 +42,7 @@ public:
     FuseLoops();
     bool run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, lowered::LinearIR::constExprIt end) override;
 
-    static bool can_be_fused(const LoopInfoPtr& loop_upper, const LoopInfoPtr& loop_lower);
+    static bool can_be_fused(const UnifiedLoopInfoPtr& loop_upper, const UnifiedLoopInfoPtr& loop_lower);
 
 private:
      // This method checks that all ports which connect lower and upper loops are incremented.

--- a/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
@@ -49,11 +49,11 @@ private:
     // This helps to avoid fusing for the ports with incompleted data
     static bool loop_ports_are_compatible(const LoopInfoPtr& loop_upper, const LoopInfoPtr& loop_lower);
     static bool fuse_upper_into_current(LinearIR& linear_ir, const LoopManagerPtr& loop_manager,
-                                        const std::shared_ptr<ExpressionPort>& current_entry_point,
+                                        const std::shared_ptr<ExpressionPort>& current_input_port,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
     static bool fuse_lower_into_current(LinearIR& linear_ir, const LoopManagerPtr& loop_manager,
-                                        const std::shared_ptr<ExpressionPort>& current_entry_point,
+                                        const std::shared_ptr<ExpressionPort>& current_input_port,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
     static void move(LinearIR& linear_ir, const LoopManagerPtr& loop_manager, size_t loop_id,

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -15,7 +15,7 @@ namespace pass {
 
 /**
  * @interface InitLoops
- * @brief The pass initializes scheduling information in LoopInfo
+ * @brief The pass initializes scheduling information in UnifiedLoopInfo
  * @ingroup snippets
  */
 class InitLoops : public Pass {
@@ -24,7 +24,7 @@ public:
     InitLoops() = default;
     bool run(LinearIR& linear_ir) override;
 
-    static void init_loop_info(const LoopInfoPtr& loop_info, size_t loop_id, bool only_runtime_args = false);
+    static void init_loop_info(const UnifiedLoopInfoPtr& loop_info, size_t loop_id, bool only_runtime_args = false);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
@@ -15,8 +15,8 @@ namespace pass {
 
 /**
  * @interface InsertBuffers
- * @brief The pass inserts Buffer between exit points of one loop (or Brgemm) and
- *        entry points of another loop (or Brgemm) to store intermediate data.
+ * @brief The pass inserts Buffer between output ports of one loop (or Brgemm) and
+ *        input ports of another loop (or Brgemm) to store intermediate data.
  *        The pass should be called after FuseLoops.
  * @param m_buffer_allocation_rank - rank of shape for memory allocation: shape[shape_rank - normalize(m_allocation_rank) : shape_rank]
  * @ingroup snippets

--- a/src/common/snippets/include/snippets/lowered/pass/insert_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_loops.hpp
@@ -16,7 +16,7 @@ namespace pass {
 
 /**
  * @interface InsertLoops
- * @brief The pass explicitly insert LoadBegin and LoadEnd in Linear IR using LoopInfo from Loop markup algorithm
+ * @brief The pass explicitly insert LoadBegin and LoadEnd in Linear IR using UnifiedLoopInfo from Loop markup algorithm
  * @ingroup snippets
  */
 class InsertLoops : public RangedPass {
@@ -26,7 +26,7 @@ public:
     bool run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, lowered::LinearIR::constExprIt end) override;
 private:
     static void insertion(LinearIR& linear_ir, const LoopManagerPtr& loop_manager, size_t loop_id);
-    static bool is_loop_dynamic(const LoopInfoPtr& loop_info);
+    static bool is_loop_dynamic(const UnifiedLoopInfoPtr& loop_info);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
@@ -10,8 +10,6 @@
 #include "snippets/lowered/loop_manager.hpp"
 #include "snippets/op/loop.hpp"
 
-#include <array>
-
 
 namespace ov {
 namespace snippets {
@@ -32,7 +30,7 @@ public:
 
     /**
      * @brief Check if specific Loop iterations needed
-     * @param unified_loop_info loop info of the original (solid) Loop
+     * @param unified_loop_info loop info of the original (unified) Loop
      * @param type type of the specific loop iterations
      * @param remaining_work_amount the work amount on the current moment (after applying of the previous loop decomposed parts)
      * @return True if needed otherwise - False
@@ -40,7 +38,7 @@ public:
     static bool is_decomposed_loop_needed(const UnifiedLoopInfoPtr& unified_loop_info, SpecificLoopIterType type, size_t remaining_work_amount);
     /**
      * @brief Calculate work amount of specific Loop iterations
-     * @param unified_loop_info loop info of the original (solid) Loop
+     * @param unified_loop_info loop info of the original (unified) Loop
      * @param type type of the specific loop iterations
      * @param remaining_work_amount the work amount on the current moment (after applying of the previous loop decomposed parts)
      * @return work amount
@@ -48,7 +46,7 @@ public:
     static size_t get_decomposed_loop_work_amount(const UnifiedLoopInfoPtr& unified_loop_info, SpecificLoopIterType type, size_t remaining_work_amount);
     /**
      * @brief Calculate increment of specific Loop iterations
-     * @param unified_loop_info loop info of the original (solid) Loop
+     * @param unified_loop_info loop info of the original (unified) Loop
      * @param type type of the specific loop iterations
      * @param remaining_work_amount the work amount on the current moment (after applying of the previous loop decomposed parts)
      * @return increment
@@ -82,11 +80,11 @@ private:
      * @param begin iterator of LoopBegin
      * @param end iterator of LoopEnd
      * @param decomposed_loop_info loop info of the corresponding decomposed loop
-     * @param solid_loop_id ID of the solid loop
+     * @param unified_loop_id ID of the unified loop
      * @param decomposed_loop_end LoopEnd of the decomposed loop
      */
     static void init_decomposed_loop(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end,
-                                     const ExpandedLoopInfoPtr& decomposed_loop_info, size_t solid_loop_id,
+                                     const ExpandedLoopInfoPtr& decomposed_loop_info, size_t unified_loop_id,
                                      const std::shared_ptr<op::LoopEnd>& decomposed_loop_end);
 
     static std::array<SpecificLoopIterType, 3> m_iterations;

--- a/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
@@ -6,6 +6,13 @@
 
 #include "pass.hpp"
 
+#include "snippets/lowered/specific_loop_iter_types.hpp"
+#include "snippets/lowered/loop_manager.hpp"
+#include "snippets/op/loop.hpp"
+
+#include <array>
+
+
 namespace ov {
 namespace snippets {
 namespace lowered {
@@ -20,18 +27,69 @@ namespace pass {
 class InsertSpecificIterations : public RangedPass {
 public:
     OPENVINO_RTTI("InsertSpecificIterations", "RangedPass")
+    InsertSpecificIterations() = default;
     bool run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, lowered::LinearIR::constExprIt end) override;
 
     /**
-     * @brief Makes a copy of a loop body with id 'loop_id' and inserts it to the LinearIR before the 'insert_pos' position
-     * @param linear_ir LinearIR which should be modified
-     * @param loop_id id of the loop which should be copied
-     * @param insert_pos position before which the loop body copy should be inserted
-     * @return iterator which points on the LoopBegin copy
+     * @brief Check if specific Loop iterations needed
+     * @param unified_loop_info loop info of the original (solid) Loop
+     * @param type type of the specific loop iterations
+     * @param remaining_work_amount the work amount on the current moment (after applying of the previous loop decomposed parts)
+     * @return True if needed otherwise - False
      */
-    static LinearIR::constExprIt insert_copy_loop(LinearIR& linear_ir,
-                                                  const size_t loop_id,
-                                                  const LinearIR::constExprIt& insert_pos);
+    static bool is_decomposed_loop_needed(const UnifiedLoopInfoPtr& unified_loop_info, SpecificLoopIterType type, size_t remaining_work_amount);
+    /**
+     * @brief Calculate work amount of specific Loop iterations
+     * @param unified_loop_info loop info of the original (solid) Loop
+     * @param type type of the specific loop iterations
+     * @param remaining_work_amount the work amount on the current moment (after applying of the previous loop decomposed parts)
+     * @return work amount
+     */
+    static size_t get_decomposed_loop_work_amount(const UnifiedLoopInfoPtr& unified_loop_info, SpecificLoopIterType type, size_t remaining_work_amount);
+    /**
+     * @brief Calculate increment of specific Loop iterations
+     * @param unified_loop_info loop info of the original (solid) Loop
+     * @param type type of the specific loop iterations
+     * @param remaining_work_amount the work amount on the current moment (after applying of the previous loop decomposed parts)
+     * @return increment
+     */
+    static size_t get_decomposed_loop_increment(const UnifiedLoopInfoPtr& unified_loop_info, SpecificLoopIterType type, size_t remaining_work_amount);
+
+private:
+    /**
+     * @brief Decomposes the original Loop to the several speicifc iterations
+     * @param linear_ir target Linear IR
+     * @param begin iterator of LoopBegin
+     * @param end iterator of LoopEnd
+     * @param loop_end the target LoopEnd
+     * @return True if the Loop has been successfully decomposed, otherwise returns False.
+     */
+    bool decompose(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end, const std::shared_ptr<op::LoopEnd>& loop_end);
+    /**
+     * @brief Make a copy of Loop with ID `loop_id` and insert to LinearIR before `insert_pos`
+     * @param linear_ir target Linear IR
+     * @param loop_id the target loop ID
+     * @param insert_pos insertion position iterator
+     * @param new_entry_ports reference of vector with Loop entry ports that will be updated after insertion
+     * @param new_exit_ports reference of vector with Loop exit ports that will be updated after insertion
+     * @return LoopBounds: iterators of new LoopBegin and LoopEnd
+     */
+    static LoopManager::LoopBounds insert_copy_loop(LinearIR& linear_ir, const size_t loop_id, const LinearIR::constExprIt& insert_pos,
+                                                    std::vector<LoopPort>& new_entry_ports, std::vector<LoopPort>& new_exit_ports);
+    /**
+     * @brief Initializes decomposed loop: update ptr arithmetic, work_amout, increment, ID
+     * @param linear_ir target Linear IR
+     * @param begin iterator of LoopBegin
+     * @param end iterator of LoopEnd
+     * @param decomposed_loop_info loop info of the corresponding decomposed loop
+     * @param solid_loop_id ID of the solid loop
+     * @param decomposed_loop_end LoopEnd of the decomposed loop
+     */
+    static void init_decomposed_loop(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end,
+                                     const ExpandedLoopInfoPtr& decomposed_loop_info, size_t solid_loop_id,
+                                     const std::shared_ptr<op::LoopEnd>& decomposed_loop_end);
+
+    static std::array<SpecificLoopIterType, 3> m_iterations;
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
@@ -55,7 +55,7 @@ public:
 
 private:
     /**
-     * @brief Decomposes the original Loop to the several speicifc iterations
+     * @brief Decomposes the original Loop to the several specific iterations
      * @param linear_ir target Linear IR
      * @param begin iterator of LoopBegin
      * @param end iterator of LoopEnd

--- a/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
@@ -86,8 +86,6 @@ private:
     static void init_decomposed_loop(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end,
                                      const ExpandedLoopInfoPtr& decomposed_loop_info, size_t unified_loop_id,
                                      const std::shared_ptr<op::LoopEnd>& decomposed_loop_end);
-
-    static std::array<SpecificLoopIterType, 3> m_iterations;
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
@@ -68,8 +68,8 @@ private:
      * @param linear_ir target Linear IR
      * @param loop_id the target loop ID
      * @param insert_pos insertion position iterator
-     * @param new_entry_ports reference of vector with Loop entry ports that will be updated after insertion
-     * @param new_exit_ports reference of vector with Loop exit ports that will be updated after insertion
+     * @param new_entry_ports reference of vector with Loop input ports that will be updated after insertion
+     * @param new_exit_ports reference of vector with Loop output ports that will be updated after insertion
      * @return LoopBounds: iterators of new LoopBegin and LoopEnd
      */
     static LoopManager::LoopBounds insert_copy_loop(LinearIR& linear_ir, const size_t loop_id, const LinearIR::constExprIt& insert_pos,

--- a/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_specific_iterations.hpp
@@ -62,7 +62,7 @@ private:
      * @param loop_end the target LoopEnd
      * @return True if the Loop has been successfully decomposed, otherwise returns False.
      */
-    bool decompose(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end, const std::shared_ptr<op::LoopEnd>& loop_end);
+    static bool decompose(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end, const std::shared_ptr<op::LoopEnd>& loop_end);
     /**
      * @brief Make a copy of Loop with ID `loop_id` and insert to LinearIR before `insert_pos`
      * @param linear_ir target Linear IR

--- a/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
@@ -22,7 +22,7 @@ namespace pass {
  *              Loop2 -> 1 -> 2
  *        Note: If the LinearIR contains Loop-specific iterations (`m_has_specific_loops` = true),
  *              loopEnd expressions in the LinearIR may have the same LoopIDs.
- *              Otherwise, when the LinearIR has Solid Loops, loopIDs must be unique!
+ *              Otherwise, when the LinearIR has unified Loops, loopIDs must be unique!
  * @ingroup snippets
  */
 
@@ -33,7 +33,7 @@ public:
     bool run(lowered::LinearIR& linear_ir) override;
 
 private:
-    bool m_has_specific_loops;
+    bool m_has_specific_loops = true;
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "pass.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+/**
+ * @interface NormalizeLoopIDs
+ * @brief Sort loop IDs in LoopEnd expressions order and make them dense with expression loop IDs updates.
+ *        After optimizations on Loops IDs might be unevenly: some numbers are missed and unsorted.
+ *        For example,
+ *             [Loop -> ID -> new ID]
+ *              Loop0 -> 3 -> 0
+ *              Loop1 -> 0 -> 1
+ *              Loop2 -> 1 -> 2
+ *        Note: If the LinearIR contains Loop-specific iterations (`m_has_specific_loops` = true),
+ *              loopEnd expressions in the LinearIR may have the same LoopIDs.
+ *              Otherwise, when the LinearIR has Solid Loops, loopIDs must be unique!
+ * @ingroup snippets
+ */
+
+class NormalizeLoopIDs : public Pass {
+public:
+    OPENVINO_RTTI("NormalizeLoopIDs", "Pass")
+    NormalizeLoopIDs(bool has_specific_loops = true) : m_has_specific_loops(has_specific_loops) {}
+    bool run(lowered::LinearIR& linear_ir) override;
+
+private:
+    bool m_has_specific_loops;
+};
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
@@ -34,6 +34,11 @@ public:
     bool run(lowered::LinearIR& linear_ir) override;
 
 private:
+    // [ original Loop ID -> new normalized and sorted ]
+    using IDMapper = std::map<size_t, size_t>;
+
+    static void update_linear_ir(lowered::LinearIR& linear_ir, const IDMapper& loop_ids);
+
     bool m_has_specific_loops = true;
 };
 

--- a/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
@@ -13,8 +13,9 @@ namespace pass {
 
 /**
  * @interface NormalizeLoopIDs
- * @brief Sort loop IDs in LoopEnd expressions order and make them dense with expression loop IDs updates.
- *        After optimizations on Loops IDs might be unevenly: some numbers are missed and unsorted.
+ * @brief Sort loop IDs in the order of LoopEnd expressions execution and set them evenly: without missed numbers in IDs.
+ *        Loops might have an arbitrary IDs ordering as a result of optimizations:
+ *        IDs can be unsorted or non-consecutive (some are missing).
  *        For example,
  *             [Loop -> ID -> new ID]
  *              Loop0 -> 3 -> 0

--- a/src/common/snippets/include/snippets/lowered/pass/propagate_subtensors.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/propagate_subtensors.hpp
@@ -14,7 +14,7 @@ namespace pass {
 /**
  * @interface UpdateSubtensors
  * @brief The pass updates subtensors of all operations in Loop based on tail size.
- * Firstly, the pass updates subtensors of all Loop entry points.
+ * Firstly, the pass updates subtensors of all Loop input ports.
  * After that, shape inference infrastructure is used to update subtensors of all ops in Loop body
  * @param m_offset - offset which must be set
  * @ingroup snippets

--- a/src/common/snippets/include/snippets/lowered/pass/split_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/split_loops.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 /**
  * @interface SplitLoops
- * @brief If loop_1 has larger increment but the same works amount of loop_2, that follows loop_1, then split loop_2
+ * @brief If Unified Loop `loop_1` has larger increment but the same works amount of Unified loop `loop_2`, that follows loop_1, then split loop_2
  *        into two loops so the outermost of the split loops could be fused with the loop_1 using the pass `FuseLoops`.
  * Example:
  *         Loop_1_begin                                Loop_1_begin                                  Loop_1_begin
@@ -36,7 +36,7 @@ public:
     bool run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, lowered::LinearIR::constExprIt end) override;
 
 private:
-    static bool can_be_split(const LoopInfoPtr& current, const LoopInfoPtr& target);
+    static bool can_be_split(const UnifiedLoopInfoPtr& current, const UnifiedLoopInfoPtr& target);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/validate_expanded_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/validate_expanded_loops.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "pass.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+/**
+ * @interface ValidateExpandedLoops
+ * @brief The pass validates loops after decomposition into specific iterations
+ * @ingroup snippets
+ */
+class ValidateExpandedLoops : public Pass {
+public:
+    OPENVINO_RTTI("ValidateExpandedLoops", "Pass")
+    ValidateExpandedLoops() = default;
+    bool run(LinearIR& linear_ir) override;
+};
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/lowered/pass/validate_expanded_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/validate_expanded_loops.hpp
@@ -21,6 +21,10 @@ public:
     OPENVINO_RTTI("ValidateExpandedLoops", "Pass")
     ValidateExpandedLoops() = default;
     bool run(LinearIR& linear_ir) override;
+
+private:
+    static void validate_loop_information(const LinearIR& linear_ir);
+    static void validate_loop_expressions(const LinearIR& linear_ir);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/validate_unified_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/validate_unified_loops.hpp
@@ -12,8 +12,8 @@ namespace lowered {
 namespace pass {
 
 /**
- * @interface ValidateLoops
- * @brief The pass validates LoopInfo that describes Loops:
+ * @interface ValidateUnifiedLoops
+ * @brief The pass validates UnifiedLoopInfo that describes entire Loops:
  *          - Verifies the correctness of nested Loops.
  *            The loops with the same dimension index (splitted dimension) should be successively nested
  *          - dim_idx are sorted in accordance with loop nesting
@@ -22,10 +22,10 @@ namespace pass {
  *          - TODO [112196] : probably, it's a temporary design. Need to investigate it and remove these limitations
  * @ingroup snippets
  */
-class ValidateLoops : public Pass {
+class ValidateUnifiedLoops : public Pass {
 public:
-    OPENVINO_RTTI("ValidateLoops", "Pass")
-    ValidateLoops();
+    OPENVINO_RTTI("ValidateUnifiedLoops", "Pass")
+    ValidateUnifiedLoops() = default;
     bool run(LinearIR& linear_ir) override;
 };
 

--- a/src/common/snippets/include/snippets/lowered/specific_loop_iter_handlers.hpp
+++ b/src/common/snippets/include/snippets/lowered/specific_loop_iter_handlers.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "snippets/lowered/pass/pass.hpp"
+#include "snippets/lowered/specific_loop_iter_types.hpp"
 
 
 namespace ov {
@@ -13,7 +14,6 @@ namespace lowered {
 
 class SpecificIterationHandlers {
 public:
-    enum class HandlerType { FIRST_ITER, MAIN_BODY, LAST_ITER };
     SpecificIterationHandlers() = default;
     SpecificIterationHandlers(size_t loop_work_amount, size_t loop_increment);
     SpecificIterationHandlers(pass::PassPipeline first_iter_handlers,
@@ -23,28 +23,30 @@ public:
     const pass::PassPipeline& get_first_iter_handlers() const;
     const pass::PassPipeline& get_main_iter_handlers() const;
     const pass::PassPipeline& get_last_iter_handlers() const;
+    const pass::PassPipeline& get_handlers_by_type(SpecificLoopIterType Type) const;
+
     static SpecificIterationHandlers merge_handlers(const SpecificIterationHandlers& lhs, const SpecificIterationHandlers& rhs);
 
-    template <HandlerType Type,
+    template <SpecificLoopIterType Type,
               typename T,
               class... Args,
-              typename std::enable_if<Type == HandlerType::FIRST_ITER, bool>::type = true>
+              typename std::enable_if<Type == SpecificLoopIterType::FIRST_ITER, bool>::type = true>
     void register_handler(Args&&... args) {
         m_first_iter_handlers.register_pass<T>(args...);
     }
 
-    template <HandlerType Type,
+    template <SpecificLoopIterType Type,
               typename T,
               class... Args,
-              typename std::enable_if<Type == HandlerType::MAIN_BODY, bool>::type = true>
+              typename std::enable_if<Type == SpecificLoopIterType::MAIN_BODY, bool>::type = true>
     void register_handler(Args&&... args) {
         m_main_body_handlers.register_pass<T>(args...);
     }
 
-    template <HandlerType Type,
+    template <SpecificLoopIterType Type,
               typename T,
               class... Args,
-              typename std::enable_if<Type == HandlerType::LAST_ITER, bool>::type = true>
+              typename std::enable_if<Type == SpecificLoopIterType::LAST_ITER, bool>::type = true>
     void register_handler(Args&&... args) {
         m_last_iter_handlers.register_pass<T>(args...);
     }

--- a/src/common/snippets/include/snippets/lowered/specific_loop_iter_handlers.hpp
+++ b/src/common/snippets/include/snippets/lowered/specific_loop_iter_handlers.hpp
@@ -20,32 +20,46 @@ public:
                               pass::PassPipeline main_body_handlers,
                               pass::PassPipeline last_iter_handlers);
 
-    template <SpecificLoopIterType Type>
+    template <SpecificLoopIterType Type,
+              typename std::enable_if<Type == SpecificLoopIterType::FIRST_ITER, bool>::type = true>
     const pass::PassPipeline& get_passes() const {
-        switch (Type) {
-            case SpecificLoopIterType::FIRST_ITER:
-                return m_first_iter_handlers;
-            case SpecificLoopIterType::MAIN_BODY:
-                return m_main_body_handlers;
-            case SpecificLoopIterType::LAST_ITER:
-                return m_last_iter_handlers;
-            default:
-                OPENVINO_THROW("Unknown SpecificLoopIterType");
-        }
+        return m_first_iter_handlers;
     }
 
-    template <SpecificLoopIterType Type, typename Pass, class... Args>
+    template <SpecificLoopIterType Type,
+              typename std::enable_if<Type == SpecificLoopIterType::MAIN_BODY, bool>::type = true>
+    const pass::PassPipeline& get_passes() const {
+        return m_main_body_handlers;
+    }
+
+    template <SpecificLoopIterType Type,
+              typename std::enable_if<Type == SpecificLoopIterType::LAST_ITER, bool>::type = true>
+    const pass::PassPipeline& get_passes() const {
+        return m_last_iter_handlers;
+    }
+
+    template <SpecificLoopIterType Type,
+              typename T,
+              class... Args,
+              typename std::enable_if<Type == SpecificLoopIterType::FIRST_ITER, bool>::type = true>
     void register_pass(Args&&... args) {
-        switch (Type) {
-            case SpecificLoopIterType::FIRST_ITER:
-                return m_first_iter_handlers.register_pass<Pass>(args...);
-            case SpecificLoopIterType::MAIN_BODY:
-                return m_main_body_handlers.register_pass<Pass>(args...);
-            case SpecificLoopIterType::LAST_ITER:
-                return m_last_iter_handlers.register_pass<Pass>(args...);
-            default:
-                OPENVINO_THROW("Unknown SpecificLoopIterType");
-        }
+        m_first_iter_handlers.register_pass<T>(args...);
+    }
+
+    template <SpecificLoopIterType Type,
+              typename T,
+              class... Args,
+              typename std::enable_if<Type == SpecificLoopIterType::MAIN_BODY, bool>::type = true>
+    void register_pass(Args&&... args) {
+        m_main_body_handlers.register_pass<T>(args...);
+    }
+
+    template <SpecificLoopIterType Type,
+              typename T,
+              class... Args,
+              typename std::enable_if<Type == SpecificLoopIterType::LAST_ITER, bool>::type = true>
+    void register_pass(Args&&... args) {
+        m_last_iter_handlers.register_pass<T>(args...);
     }
 
     static SpecificIterationHandlers merge_handlers(const SpecificIterationHandlers& lhs, const SpecificIterationHandlers& rhs);

--- a/src/common/snippets/include/snippets/lowered/specific_loop_iter_types.hpp
+++ b/src/common/snippets/include/snippets/lowered/specific_loop_iter_types.hpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+
+enum class SpecificLoopIterType {
+    FIRST_ITER, MAIN_BODY, LAST_ITER
+};
+
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -11,6 +11,7 @@
 #include "snippets/lowered/pass/cleanup_loop_offsets.hpp"
 #include "snippets/lowered/pass/insert_specific_iterations.hpp"
 #include "snippets/lowered/pass/optimize_loop_single_evaluation.hpp"
+#include "snippets/lowered/pass/normalize_loop_ids.hpp"
 #include "snippets/lowered/pass/pass.hpp"
 #include "snippets/op/kernel.hpp"
 #include "snippets/op/memory_access.hpp"
@@ -37,6 +38,7 @@ void Generator::generate(lowered::LinearIR& linear_ir, LoweringResult& result, c
     //       since CleanupLoopOffsets can't handle loops with evaluate_once = true
     lowered_pipeline.register_pass<lowered::pass::AssignRegisters>(reg_type_mapper);
     lowered_pipeline.register_pass<lowered::pass::InsertSpecificIterations>();
+    lowered_pipeline.register_pass<lowered::pass::NormalizeLoopIDs>();
     lowered_pipeline.register_pass<lowered::pass::CleanupLoopOffsets>();
     lowered_pipeline.register_pass<lowered::pass::OptimizeLoopSingleEvaluation>();
     lowered_pipeline.run(linear_ir);

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -12,6 +12,7 @@
 #include "snippets/lowered/pass/insert_specific_iterations.hpp"
 #include "snippets/lowered/pass/optimize_loop_single_evaluation.hpp"
 #include "snippets/lowered/pass/normalize_loop_ids.hpp"
+#include "snippets/lowered/pass/validate_expanded_loops.hpp"
 #include "snippets/lowered/pass/pass.hpp"
 #include "snippets/op/kernel.hpp"
 #include "snippets/op/memory_access.hpp"
@@ -41,6 +42,7 @@ void Generator::generate(lowered::LinearIR& linear_ir, LoweringResult& result, c
     lowered_pipeline.register_pass<lowered::pass::NormalizeLoopIDs>();
     lowered_pipeline.register_pass<lowered::pass::CleanupLoopOffsets>();
     lowered_pipeline.register_pass<lowered::pass::OptimizeLoopSingleEvaluation>();
+    lowered_pipeline.register_pass<lowered::pass::ValidateExpandedLoops>();
     lowered_pipeline.run(linear_ir);
     linear_ir.init_emitters(target);
 

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -40,9 +40,9 @@ void Generator::generate(lowered::LinearIR& linear_ir, LoweringResult& result, c
     lowered_pipeline.register_pass<lowered::pass::AssignRegisters>(reg_type_mapper);
     lowered_pipeline.register_pass<lowered::pass::InsertSpecificIterations>();
     lowered_pipeline.register_pass<lowered::pass::NormalizeLoopIDs>();
+    lowered_pipeline.register_pass<lowered::pass::ValidateExpandedLoops>();
     lowered_pipeline.register_pass<lowered::pass::CleanupLoopOffsets>();
     lowered_pipeline.register_pass<lowered::pass::OptimizeLoopSingleEvaluation>();
-    lowered_pipeline.register_pass<lowered::pass::ValidateExpandedLoops>();
     lowered_pipeline.run(linear_ir);
     linear_ir.init_emitters(target);
 

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -493,9 +493,9 @@ LinearIR::exprIt LinearIR::replace_with_expr(const std::vector<ExpressionPtr>& o
     const auto output_ports = new_expr_it->get()->get_output_ports();
     for (const auto& old_expr : old_exprs) {
         for (size_t i = 0; i < old_expr->get_input_count(); ++i)
-            m_loop_manager->update_loops_port(loop_ids, old_expr->get_input_port(i), input_ports, true);
+            m_loop_manager->update_loops_port(loop_ids, old_expr->get_input_port(i), input_ports);
         for (size_t i = 0; i < old_expr->get_input_count(); ++i)
-            m_loop_manager->update_loops_port(loop_ids, old_expr->get_output_port(i), output_ports, false);
+            m_loop_manager->update_loops_port(loop_ids, old_expr->get_output_port(i), output_ports);
         erase(find(old_expr));
     }
     return new_expr_it;

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -11,25 +11,11 @@ namespace ov {
 namespace snippets {
 namespace lowered {
 
-LoopInfo::LoopInfo(size_t work_amount,
-                   size_t increment,
-                   const std::vector<LoopPort>& entries,
-                   const std::vector<LoopPort>& exits,
-                   const SpecificIterationHandlers& handlers)
-    : m_work_amount(work_amount),
-      m_increment(increment),
-      m_entry_points(entries),
-      m_exit_points(exits),
-      m_handlers(handlers) {}
+LoopInfo::LoopInfo(size_t work_amount, size_t increment, const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits)
+    : m_work_amount(work_amount), m_increment(increment), m_entry_points(entries), m_exit_points(exits) {}
 
-LoopInfo::LoopInfo(size_t work_amount,
-                   size_t increment,
-                   const std::vector<ExpressionPort>& entries,
-                   const std::vector<ExpressionPort>& exits,
-                   const SpecificIterationHandlers& handlers)
-    : m_work_amount(work_amount),
-      m_increment(increment),
-      m_handlers(handlers) {
+LoopInfo::LoopInfo(size_t work_amount, size_t increment, const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits)
+    : m_work_amount(work_amount), m_increment(increment) {
     m_entry_points.reserve(entries.size());
     m_exit_points.reserve(exits.size());
     for (const auto& port : entries)
@@ -38,22 +24,17 @@ LoopInfo::LoopInfo(size_t work_amount,
         m_exit_points.emplace_back(port);
 }
 
-std::shared_ptr<LoopInfo> LoopInfo::clone_with_new_expr(const ExpressionMap& expr_map) const {
-    auto clone_loop_ports = [&expr_map](const std::vector<LoopPort>& port_points) {
-        std::vector<LoopPort> cloned_port_points;
-        cloned_port_points.reserve(port_points.size());
-        for (const auto& p : port_points) {
-            const auto& expr = p.expr_port->get_expr().get();
-            OPENVINO_ASSERT(expr_map.count(expr), "Can't clone LoopInfo: old expression is not in the map");
-            const auto& new_expr = expr_map.at(expr);
-            cloned_port_points.emplace_back(*p.clone_with_new_expr(new_expr));
-        }
-        return cloned_port_points;
+size_t LoopInfo::get_dim_idx() const {
+    OPENVINO_ASSERT(!m_entry_points.empty(), "Loop info must have at least one entry point");
+    auto equal_dim_idxes = [&](const LoopPort& p) {
+        return p.dim_idx == m_entry_points[0].dim_idx;
     };
-    const auto& new_entry_points = clone_loop_ports(m_entry_points);
-    const auto& new_exit_points = clone_loop_ports(m_exit_points);
-
-    return std::make_shared<LoopInfo>(m_work_amount, m_increment, new_entry_points, new_exit_points, m_handlers);
+    if (std::all_of(m_entry_points.begin(), m_entry_points.end(), equal_dim_idxes) &&
+        std::all_of(m_exit_points.begin(), m_exit_points.end(), equal_dim_idxes)) {
+        return m_entry_points[0].dim_idx;
+    } else {
+        return UNDEFINED_DIM_IDX;
+    }
 }
 
 size_t LoopInfo::get_work_amount() const {
@@ -72,21 +53,12 @@ const std::vector<LoopPort>& LoopInfo::get_exit_points() const {
     return m_exit_points;
 }
 
-const SpecificIterationHandlers& LoopInfo::get_handlers() const {
-    return m_handlers;
+void LoopInfo::set_work_amount(size_t work_amount) {
+    m_work_amount = work_amount;
 }
 
-size_t LoopInfo::get_dim_idx() const {
-    OPENVINO_ASSERT(!m_entry_points.empty(), "Loop info must have at least one entry point");
-    auto equal_dim_idxes = [&](const LoopPort& p) {
-        return p.dim_idx == m_entry_points[0].dim_idx;
-    };
-    if (std::all_of(m_entry_points.begin(), m_entry_points.end(), equal_dim_idxes) &&
-        std::all_of(m_exit_points.begin(), m_exit_points.end(), equal_dim_idxes)) {
-        return m_entry_points[0].dim_idx;
-    } else {
-        return UNDEFINED_DIM_IDX;
-    }
+void LoopInfo::set_increment(size_t increment) {
+    m_increment = increment;
 }
 
 void LoopInfo::set_dim_idx(size_t dim_idx) {
@@ -97,14 +69,6 @@ void LoopInfo::set_dim_idx(size_t dim_idx) {
     update_exit_points(set_common_dim_idx);
 }
 
-void LoopInfo::set_work_amount(size_t work_amount) {
-    m_work_amount = work_amount;
-}
-
-void LoopInfo::set_increment(size_t increment) {
-    m_increment = increment;
-}
-
 void LoopInfo::set_entry_points(std::vector<LoopPort> entry_points) {
     m_entry_points = std::move(entry_points);
 }
@@ -113,16 +77,156 @@ void LoopInfo::set_exit_points(std::vector<LoopPort> exit_points) {
     m_exit_points = std::move(exit_points);
 }
 
-void LoopInfo::set_handlers(SpecificIterationHandlers handlers) {
+std::vector<bool> LoopInfo::get_is_incremented() const {
+    std::vector<bool> values;
+    values.reserve(m_entry_points.size() + m_exit_points.size());
+    auto initializer = [&values](const LoopPort& port) {
+        values.push_back(port.is_incremented);
+    };
+    init_using_entry_points(initializer);
+    init_using_exit_points(initializer);
+    return values;
+}
+
+std::vector<int64_t> LoopInfo::get_ptr_increments() const {
+    std::vector<int64_t> values;
+    values.reserve(m_entry_points.size() + m_exit_points.size());
+    auto initializer = [&values](const LoopPort& port) {
+        values.push_back(port.ptr_increment);
+    };
+    init_using_entry_points(initializer);
+    init_using_exit_points(initializer);
+    return values;
+}
+
+std::vector<int64_t> LoopInfo::get_finalization_offsets() const {
+    std::vector<int64_t> values;
+    values.reserve(m_entry_points.size() + m_exit_points.size());
+    auto initializer = [&values](const LoopPort& port) {
+        values.push_back(port.finalization_offset);
+    };
+    init_using_entry_points(initializer);
+    init_using_exit_points(initializer);
+    return values;
+}
+
+std::vector<int64_t> LoopInfo::get_data_sizes() const {
+    std::vector<int64_t> values;
+    values.reserve(m_entry_points.size() + m_exit_points.size());
+    auto initializer = [&values](const LoopPort& port) {
+        values.push_back(port.data_size);
+    };
+    init_using_entry_points(initializer);
+    init_using_exit_points(initializer);
+    return values;
+}
+
+std::vector<LoopPort> LoopInfo::clone_loop_ports(const ExpressionMap& expr_map, const std::vector<LoopPort>& port_ports) {
+    std::vector<LoopPort> cloned_port_points;
+    cloned_port_points.reserve(port_ports.size());
+    for (const auto& p : port_ports) {
+        const auto& expr = p.expr_port->get_expr().get();
+        OPENVINO_ASSERT(expr_map.count(expr), "Can't clone LoopInfo: old expression is not in the map");
+        const auto& new_expr = expr_map.at(expr);
+        cloned_port_points.emplace_back(*p.clone_with_new_expr(new_expr));
+    }
+    return cloned_port_points;
+}
+
+UnifiedLoopInfo::UnifiedLoopInfo(size_t work_amount,
+                             size_t increment,
+                             const std::vector<LoopPort>& entries,
+                             const std::vector<LoopPort>& exits,
+                             const SpecificIterationHandlers& handlers)
+    : LoopInfo(work_amount, increment, entries, exits), m_handlers(handlers) {}
+
+UnifiedLoopInfo::UnifiedLoopInfo(size_t work_amount,
+                             size_t increment,
+                             const std::vector<ExpressionPort>& entries,
+                             const std::vector<ExpressionPort>& exits,
+                             const SpecificIterationHandlers& handlers)
+    : LoopInfo(work_amount, increment, entries, exits), m_handlers(handlers) {}
+
+std::shared_ptr<LoopInfo> UnifiedLoopInfo::clone_with_new_expr(const ExpressionMap& expr_map) const {
+    const auto& new_entry_points = clone_loop_ports(expr_map, m_entry_points);
+    const auto& new_exit_points = clone_loop_ports(expr_map, m_exit_points);
+
+    return std::make_shared<UnifiedLoopInfo>(m_work_amount, m_increment, new_entry_points, new_exit_points, m_handlers);
+}
+
+const SpecificIterationHandlers& UnifiedLoopInfo::get_handlers() const {
+    return m_handlers;
+}
+
+void UnifiedLoopInfo::set_handlers(SpecificIterationHandlers handlers) {
     m_handlers = std::move(handlers);
 }
 
-void LoopInfo::update_entry_points(const std::function<void(LoopPort&)>& updater) {
-    std::for_each(m_entry_points.begin(), m_entry_points.end(), updater);
+ExpandedLoopInfo::ExpandedLoopInfo(size_t work_amount, size_t increment,
+                                   const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
+                                   SpecificLoopIterType type, std::shared_ptr<UnifiedLoopInfo> unified_loop_info)
+    : LoopInfo(work_amount, increment, entries, exits), m_type(type) {
+    OPENVINO_ASSERT(unified_loop_info, "Failed to create ExpandedLoopInfo: unified loop info is nullptr!");
+    m_unified_loop_info = std::move(unified_loop_info);
+
+    m_ptr_increments = get_ptr_increments();
+    m_finalization_offsets = get_finalization_offsets();
+    m_data_sizes = get_data_sizes();
 }
 
-void LoopInfo::update_exit_points(const std::function<void(LoopPort&)>& updater) {
-    std::for_each(m_exit_points.begin(), m_exit_points.end(), updater);
+ExpandedLoopInfo::ExpandedLoopInfo(size_t work_amount, size_t increment,
+                                   const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
+                                   std::vector<int64_t> ptr_increments, std::vector<int64_t> final_offsets, std::vector<int64_t> data_sizes,
+                                   SpecificLoopIterType type, std::shared_ptr<UnifiedLoopInfo> unified_loop_info)
+    : LoopInfo(work_amount, increment, entries, exits), m_ptr_increments(std::move(ptr_increments)), m_finalization_offsets(std::move(final_offsets)),
+      m_data_sizes(std::move(data_sizes)), m_type(type) {
+    OPENVINO_ASSERT(unified_loop_info, "Failed to create ExpandedLoopInfo: unified loop info is nullptr!");
+    m_unified_loop_info = std::move(unified_loop_info);
+
+    const auto count = entries.size() + exits.size();
+    OPENVINO_ASSERT(utils::everyone_is(count, m_ptr_increments.size(), m_finalization_offsets.size(), m_data_sizes.size()),
+                    "Incompatible data ptr shifts!");
+}
+
+std::shared_ptr<LoopInfo> ExpandedLoopInfo::clone_with_new_expr(const ExpressionMap& expr_map) const {
+    const auto& new_entry_points = clone_loop_ports(expr_map, m_entry_points);
+    const auto& new_exit_points = clone_loop_ports(expr_map, m_exit_points);
+
+    return std::make_shared<ExpandedLoopInfo>(m_work_amount, m_increment, new_entry_points, new_exit_points,
+                                              m_ptr_increments, m_finalization_offsets, m_data_sizes, m_type, m_unified_loop_info);
+}
+
+const SpecificIterationHandlers& ExpandedLoopInfo::get_handlers() const {
+    OPENVINO_THROW("ExpandedLoopInfo doesn't support get_handlers");
+}
+
+const std::shared_ptr<UnifiedLoopInfo>& ExpandedLoopInfo::get_unified_loop_info() const {
+    OPENVINO_ASSERT(m_unified_loop_info, "Failed to get solid loop info: it's nullptr");
+    return m_unified_loop_info;
+}
+
+SpecificLoopIterType ExpandedLoopInfo::get_type() const {
+    return m_type;
+}
+
+void ExpandedLoopInfo::set_handlers(SpecificIterationHandlers handlers) {
+    OPENVINO_THROW("ExpandedLoopInfo doesn't support set_handlers");
+}
+
+const pass::PassPipeline& ExpandedLoopInfo::get_handlers_by_type() const {
+    return get_unified_loop_info()->get_handlers().get_handlers_by_type(m_type);
+}
+
+std::vector<int64_t>& ExpandedLoopInfo::get_dense_ptr_increments() {
+    return m_ptr_increments;
+}
+
+std::vector<int64_t>& ExpandedLoopInfo::get_dense_finalization_offsets() {
+    return m_finalization_offsets;
+}
+
+const std::vector<int64_t>& ExpandedLoopInfo::get_dense_data_sizes() const {
+    return m_data_sizes;
 }
 
 } // namespace lowered

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -196,21 +196,13 @@ std::shared_ptr<LoopInfo> ExpandedLoopInfo::clone_with_new_expr(const Expression
                                               m_ptr_increments, m_finalization_offsets, m_data_sizes, m_type, m_unified_loop_info);
 }
 
-const SpecificIterationHandlers& ExpandedLoopInfo::get_handlers() const {
-    OPENVINO_THROW("ExpandedLoopInfo doesn't support get_handlers");
-}
-
 const std::shared_ptr<UnifiedLoopInfo>& ExpandedLoopInfo::get_unified_loop_info() const {
-    OPENVINO_ASSERT(m_unified_loop_info, "Failed to get solid loop info: it's nullptr");
+    OPENVINO_ASSERT(m_unified_loop_info, "Failed to get unified loop info: it's nullptr");
     return m_unified_loop_info;
 }
 
 SpecificLoopIterType ExpandedLoopInfo::get_type() const {
     return m_type;
-}
-
-void ExpandedLoopInfo::set_handlers(SpecificIterationHandlers handlers) {
-    OPENVINO_THROW("ExpandedLoopInfo doesn't support set_handlers");
 }
 
 const pass::PassPipeline& ExpandedLoopInfo::get_handlers_by_type() const {

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -199,8 +199,17 @@ SpecificLoopIterType ExpandedLoopInfo::get_type() const {
     return m_type;
 }
 
-const pass::PassPipeline& ExpandedLoopInfo::get_handlers_by_type() const {
-    return get_unified_loop_info()->get_handlers().get_handlers_by_type(m_type);
+const pass::PassPipeline& ExpandedLoopInfo::get_handler_passes() const {
+    switch (m_type) {
+        case SpecificLoopIterType::FIRST_ITER:
+            return get_unified_loop_info()->get_handlers().get_passes<SpecificLoopIterType::FIRST_ITER>();
+        case SpecificLoopIterType::MAIN_BODY:
+            return get_unified_loop_info()->get_handlers().get_passes<SpecificLoopIterType::MAIN_BODY>();
+        case SpecificLoopIterType::LAST_ITER:
+            return get_unified_loop_info()->get_handlers().get_passes<SpecificLoopIterType::LAST_ITER>();
+        default:
+            OPENVINO_THROW("Unknown SpecificLoopIterType");
+    }
 }
 
 const std::vector<int64_t>& ExpandedLoopInfo::get_ptr_increments() const {

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -171,21 +171,21 @@ const SpecificIterationHandlers& UnifiedLoopInfo::get_handlers() const {
 std::vector<int64_t> UnifiedLoopInfo::get_ptr_increments() const {
     std::vector<int64_t> values;
     values.reserve(m_input_ports.size() + m_output_ports.size());
-    iterate_through_ports([&values](const LoopPortDesc& shift) { values.push_back(shift.ptr_increment); });
+    iterate_through_descs([&values](const LoopPortDesc& shift) { values.push_back(shift.ptr_increment); });
     return values;
 }
 
 std::vector<int64_t> UnifiedLoopInfo::get_finalization_offsets() const {
     std::vector<int64_t> values;
     values.reserve(m_input_ports.size() + m_output_ports.size());
-    iterate_through_ports([&values](const LoopPortDesc& shift) { values.push_back(shift.finalization_offset); });
+    iterate_through_descs([&values](const LoopPortDesc& shift) { values.push_back(shift.finalization_offset); });
     return values;
 }
 
 std::vector<int64_t> UnifiedLoopInfo::get_data_sizes() const {
     std::vector<int64_t> values;
     values.reserve(m_input_ports.size() + m_output_ports.size());
-    iterate_through_ports([&values](const LoopPortDesc& shift) { values.push_back(shift.data_size); });
+    iterate_through_descs([&values](const LoopPortDesc& shift) { values.push_back(shift.data_size); });
     return values;
 }
 

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -61,6 +61,14 @@ void LoopInfo::set_increment(size_t increment) {
     m_increment = increment;
 }
 
+void LoopInfo::set_dim_idx(size_t dim_idx) {
+    auto set_common_dim_idx = [dim_idx](LoopPort& port) {
+        port.dim_idx = dim_idx;
+    };
+    update_entry_points(set_common_dim_idx);
+    update_exit_points(set_common_dim_idx);
+}
+
 void LoopInfo::set_entry_points(std::vector<LoopPort> entry_points) {
     m_entry_points = std::move(entry_points);
 }
@@ -143,14 +151,6 @@ void UnifiedLoopInfo::set_handlers(SpecificIterationHandlers handlers) {
     m_handlers = std::move(handlers);
 }
 
-void UnifiedLoopInfo::set_dim_idx(size_t dim_idx) {
-    auto set_common_dim_idx = [dim_idx](LoopPort& port) {
-        port.dim_idx = dim_idx;
-    };
-    update_entry_points(set_common_dim_idx);
-    update_exit_points(set_common_dim_idx);
-}
-
 ExpandedLoopInfo::ExpandedLoopInfo(size_t work_amount, size_t increment,
                                    const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits,
                                    SpecificLoopIterType type, std::shared_ptr<UnifiedLoopInfo> unified_loop_info)
@@ -223,6 +223,19 @@ const std::vector<int64_t>& ExpandedLoopInfo::get_finalization_offsets() const {
 const std::vector<int64_t>& ExpandedLoopInfo::get_data_sizes() const {
     return m_data_sizes;
 }
+
+void ExpandedLoopInfo::set_entry_points(std::vector<LoopPort> entry_points) {
+    OPENVINO_ASSERT(m_entry_points.size() == entry_points.size(),
+                    "Failed to set entry points to ExpandedLoopInfo: count of new ports is not equal to the current port count");
+    m_entry_points = std::move(entry_points);
+}
+
+void ExpandedLoopInfo::set_exit_points(std::vector<LoopPort> exit_points) {
+    OPENVINO_ASSERT(m_exit_points.size() == exit_points.size(),
+                    "Failed to set exit points to ExpandedLoopInfo: count of new ports is not equal to the current port count");
+    m_exit_points = std::move(exit_points);
+}
+
 
 } // namespace lowered
 } // namespace snippets

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -85,7 +85,7 @@ std::vector<LoopPort>::iterator LoopInfo::find_loop_port(const LoopPort& loop_po
     auto& ports = loop_port.expr_port->get_type() == ExpressionPort::Input ? m_input_ports : m_output_ports;
     const auto it = std::find_if(ports.begin(), ports.end(),
                                  [&loop_port](const LoopPort& port) { return port == loop_port; });
-    OPENVINO_ASSERT(it != ports.end(), "Failed update_loop_port: existing loop ports has not been found");
+    OPENVINO_ASSERT(it != ports.end(), "Failed update_loop_port: existing loop port has not been found");
     return it;
 }
 
@@ -256,10 +256,10 @@ void UnifiedLoopInfo::sort_output_ports(const std::vector<size_t>& new_order) {
 }
 
 void UnifiedLoopInfo::replace_with_cloned_descs(size_t actual_port_idx, size_t new_count, bool is_input) {
-    auto& data_ptr_shifts = is_input ? m_input_port_descs : m_output_port_descs;
-    std::vector<LoopPortDesc> target_shifts(new_count, data_ptr_shifts[actual_port_idx]);
-    auto shift_it = data_ptr_shifts.erase(data_ptr_shifts.begin() + actual_port_idx);
-    data_ptr_shifts.insert(shift_it, target_shifts.cbegin(), target_shifts.cend());
+    auto& descs = is_input ? m_input_port_descs : m_output_port_descs;
+    std::vector<LoopPortDesc> target_shifts(new_count, descs[actual_port_idx]);
+    auto shift_it = descs.erase(descs.begin() + actual_port_idx);
+    descs.insert(shift_it, target_shifts.cbegin(), target_shifts.cend());
 }
 
 void UnifiedLoopInfo::replace_with_new_ports(const LoopPort& actual_port, const std::vector<LoopPort>& target_ports) {

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -74,10 +74,10 @@ void LoopInfo::init_from_ports(const std::function<void(const LoopPort&)>& initi
     std::for_each(m_exit_points.cbegin(), m_exit_points.cend(), initializer);
 }
 
-std::vector<LoopPort> LoopInfo::clone_loop_ports(const ExpressionMap& expr_map, const std::vector<LoopPort>& port_ports) {
+std::vector<LoopPort> LoopInfo::clone_loop_ports(const ExpressionMap& expr_map, const std::vector<LoopPort>& loop_ports) {
     std::vector<LoopPort> cloned_port_points;
-    cloned_port_points.reserve(port_ports.size());
-    for (const auto& p : port_ports) {
+    cloned_port_points.reserve(loop_ports.size());
+    for (const auto& p : loop_ports) {
         const auto& expr = p.expr_port->get_expr().get();
         OPENVINO_ASSERT(expr_map.count(expr), "Can't clone LoopInfo: old expression is not in the map");
         const auto& new_expr = expr_map.at(expr);

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -69,14 +69,6 @@ void LoopInfo::set_dim_idx(size_t dim_idx) {
     update_exit_points(set_common_dim_idx);
 }
 
-void LoopInfo::set_entry_points(std::vector<LoopPort> entry_points) {
-    m_entry_points = std::move(entry_points);
-}
-
-void LoopInfo::set_exit_points(std::vector<LoopPort> exit_points) {
-    m_exit_points = std::move(exit_points);
-}
-
 void LoopInfo::replace_with_new_ports(const LoopPort& actual_port, const std::vector<LoopPort>& target_ports) {
     auto& ports = actual_port.expr_port->get_type() == ExpressionPort::Input ? m_entry_points : m_exit_points;
     auto port_it = std::find_if(ports.begin(), ports.end(),
@@ -275,19 +267,6 @@ const std::vector<int64_t>& ExpandedLoopInfo::get_finalization_offsets() const {
 const std::vector<int64_t>& ExpandedLoopInfo::get_data_sizes() const {
     return m_data_sizes;
 }
-
-void ExpandedLoopInfo::set_entry_points(std::vector<LoopPort> entry_points) {
-    OPENVINO_ASSERT(m_entry_points.size() == entry_points.size(),
-                    "Failed to set entry points to ExpandedLoopInfo: count of new ports is not equal to the current port count");
-    m_entry_points = std::move(entry_points);
-}
-
-void ExpandedLoopInfo::set_exit_points(std::vector<LoopPort> exit_points) {
-    OPENVINO_ASSERT(m_exit_points.size() == exit_points.size(),
-                    "Failed to set exit points to ExpandedLoopInfo: count of new ports is not equal to the current port count");
-    m_exit_points = std::move(exit_points);
-}
-
 
 } // namespace lowered
 } // namespace snippets

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -107,6 +107,28 @@ void LoopInfo::replace_with_new_ports(const ExpressionPort& actual_port, const s
     ports.insert(port_it, target_loop_ports.cbegin(), target_loop_ports.cend());
 }
 
+namespace {
+void sort_ports(const std::vector<size_t>& new_order, std::vector<LoopPort>& ports) {
+    OPENVINO_ASSERT(new_order.size() == ports.size(),
+                    "Failed to sort ports: `new_order` must contain new indexes for ALL ports");
+    OPENVINO_ASSERT(std::set<size_t>(new_order.cbegin(), new_order.cend()).size() == new_order.size(),
+                    "Failed to sort ports: new order must contain unique indexes");
+    std::vector<LoopPort> ordered_ports(ports.size());
+    for (size_t i = 0; i < ports.size(); ++i) {
+        ordered_ports[new_order[i]] = ports[i];
+    }
+    ports = std::move(ordered_ports);
+}
+}  // namespace
+
+void LoopInfo::sort_entry_ports(const std::vector<size_t>& new_order) {
+    sort_ports(new_order, m_entry_points);
+}
+
+void LoopInfo::sort_exit_ports(const std::vector<size_t>& new_order) {
+    sort_ports(new_order, m_exit_points);
+}
+
 void LoopInfo::init_from_ports(const std::function<void(const LoopPort&)>& initializer) const {
     std::for_each(m_entry_points.cbegin(), m_entry_points.cend(), initializer);
     std::for_each(m_exit_points.cbegin(), m_exit_points.cend(), initializer);

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -264,11 +264,8 @@ void LoopManager::fuse_loops(const LinearIR& linear_ir, size_t loop_id_upper, si
 
 void LoopManager::fuse_loops(LinearIR::constExprIt loop_begin_target, LinearIR::constExprIt loop_end_target,
                              size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper) {
-    OPENVINO_ASSERT(m_map.count(loop_id_upper) == 1 && m_map.count(loop_id_lower) == 1,
-                    "Failed Loop Fusion: the Loop with the Loop ID isn't existed");
-
-    const auto& loop_info_upper = m_map[loop_id_upper];
-    const auto& loop_info_lower = m_map[loop_id_lower];
+    const auto& loop_info_upper = get_loop_info<UnifiedLoopInfo>(loop_id_upper);
+    const auto& loop_info_lower = get_loop_info<UnifiedLoopInfo>(loop_id_lower);
 
     auto entry_points_upper = loop_info_upper->get_entry_points();
     auto exit_points_upper = loop_info_upper->get_exit_points();
@@ -459,7 +456,7 @@ void LoopManager::sort_loop_ports(LinearIR::constExprIt& loop_begin_pos, LinearI
     loop_info->set_exit_points(exits);
 }
 
-bool LoopManager::blend(const LinearIR& linear_ir, const std::map<size_t, size_t>& loop_id_map) {
+bool LoopManager::reassign_identifiers(const LinearIR& linear_ir, const std::map<size_t, size_t>& loop_id_map) {
     // If all new IDs are the same as original - nothing to update
     if (std::all_of(loop_id_map.cbegin(), loop_id_map.cend(), [](const std::pair<size_t, size_t>& p) { return p.first == p.second; })) {
         return false;

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -418,8 +418,8 @@ void LoopManager::sort_loop_ports(LinearIR::constExprIt& loop_begin_pos, LinearI
         update_order(loop_entries, expr);
         update_order(loop_exits, expr);
     }
-    loop_info->sort_entry_ports(new_entry_order);
-    loop_info->sort_exit_ports(new_exit_order);
+    loop_info->sort_input_ports(new_entry_order);
+    loop_info->sort_output_ports(new_exit_order);
 }
 
 bool LoopManager::reassign_identifiers(const std::map<size_t, size_t>& loop_id_map) {

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -396,7 +396,7 @@ void LoopManager::expression_replacement(LinearIR::constExprIt new_expr_begin, L
 
 void LoopManager::sort_loop_ports(LinearIR::constExprIt& loop_begin_pos, LinearIR::constExprIt& loop_end_pos, size_t loop_id) {
     // [113536] Update this logic please, when expression numeration will be implemented
-    const auto& loop_info = get_loop_info(loop_id);
+    const auto& loop_info = get_loop_info<UnifiedLoopInfo>(loop_id);
     const auto& loop_entries = loop_info->get_entry_points();
     const auto& loop_exits = loop_info->get_exit_points();
 

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -236,7 +236,7 @@ size_t LoopManager::replace_with_new_loop(const LinearIR& linear_ir, LinearIR::c
     const auto explicit_loop_bounds = is_bound_explicit_loop_begin && is_bound_explicit_loop_end;
     OPENVINO_ASSERT(std::all_of(m_map.cbegin(), m_map.cend(),
                     [&loop_info](const std::pair<size_t, LoopInfoPtr>& p) { return loop_info != p.second; }),
-                    "Failed to replace with new Loop: this Loop is already existed!");
+                    "Failed to replace with new Loop: this Loop already exists!");
 
     // [137819] Should be before loop id replacing!!!
     // Check that other expression in LinearIR doesn't have the old loop ID - otherwise completely removed from loop manager

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -470,7 +470,7 @@ bool LoopManager::reassign_identifiers(const std::map<size_t, size_t>& loop_id_m
     OPENVINO_ASSERT(saved_loops.empty(), "Failed to reassign LoopIDs: not all Loops have been reassigned");
 
     // Update the next ID
-    next_id = *m_map.crbegin() + 1;
+    next_id = m_map.crbegin()->first + 1;
 
     return true;
 }

--- a/src/common/snippets/src/lowered/loop_port.cpp
+++ b/src/common/snippets/src/lowered/loop_port.cpp
@@ -27,10 +27,6 @@ std::shared_ptr<LoopPort> LoopPort::clone_with_new_expr(const ExpressionPtr& new
     return new_loop_port;
 }
 
-bool LoopPort::is_dynamic() const {
-    return utils::is_dynamic_value(ptr_increment) || utils::is_dynamic_value(finalization_offset);
-}
-
 bool operator==(const LoopPort& lhs, const LoopPort& rhs) {
     if (&lhs == &rhs)
         return true;

--- a/src/common/snippets/src/lowered/pass/assign_registers.cpp
+++ b/src/common/snippets/src/lowered/pass/assign_registers.cpp
@@ -216,7 +216,7 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
     }
 
     // define life intervals
-    // liveOut[i] - regs that are live on exit from i-th (topologically ordered) operation
+    // liveOut[i] - regs that are live on output from i-th (topologically ordered) operation
     // liveIn[i] - regs that are live on entering the i-th (topologically ordered) operation
     std::vector<std::set<Reg>> life_in_vec(std::move(used_vec)),
                                life_in_gpr(std::move(used_gpr));

--- a/src/common/snippets/src/lowered/pass/assign_registers.cpp
+++ b/src/common/snippets/src/lowered/pass/assign_registers.cpp
@@ -216,7 +216,7 @@ bool AssignRegisters::run(LinearIR& linear_ir) {
     }
 
     // define life intervals
-    // liveOut[i] - regs that are live on output from i-th (topologically ordered) operation
+    // liveOut[i] - regs that are live on exit from i-th (topologically ordered) operation
     // liveIn[i] - regs that are live on entering the i-th (topologically ordered) operation
     std::vector<std::set<Reg>> life_in_vec(std::move(used_vec)),
                                life_in_gpr(std::move(used_gpr));

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -101,10 +101,10 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
 
     const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     size_t loop_port_idx = 0;
-    loop_info->iterate_through_points([&resetting_data_indexes, &loop_port_idx](LoopPort& loop_port) {
+    loop_info->iterate_through_port_info([&resetting_data_indexes, &loop_port_idx](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& shifts) {
         if (resetting_data_indexes.count(loop_port_idx)) {
-            loop_port.ptr_increment = 0;
-            loop_port.finalization_offset = 0;
+            shifts.ptr_increment = 0;
+            shifts.finalization_offset = 0;
             loop_port.is_incremented = false;
         }
         ++loop_port_idx;

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -79,18 +79,12 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
     if (resetting_data_indexes.empty())
         return false;
 
-    const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
-
     // TODO [133463]: We have to update LoopEnd and LoopInfo since the both entities must be valid.
     //                To avoid the both changes, we have to insert Loop ops to LinearIR in the end of pipeline.
-    auto loop_entries = loop_info->get_entry_points();
-    auto loop_exits = loop_info->get_exit_points();
     auto new_is_incremented = loop_end->get_is_incremented();
     if (const auto loop_end_dynamic = ov::as_type_ptr<op::LoopEndDynamic>(loop_end_expr->get_node())) {
         for (auto idx_to_drop : resetting_data_indexes) {
             new_is_incremented[idx_to_drop] = false;
-            auto& loop_port = idx_to_drop < input_count ? loop_entries[idx_to_drop] : loop_exits[idx_to_drop - input_count];
-            loop_port.is_incremented = false;
         }
     } else if (const auto loop_end_static = ov::as_type_ptr<op::LoopEndStatic>(loop_end_expr->get_node())) {
         auto new_ptr_increments = loop_end_static->get_ptr_increments();
@@ -99,17 +93,25 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
             new_ptr_increments[idx_to_drop] = 0;
             new_finalization_offsets[idx_to_drop] = 0;
             new_is_incremented[idx_to_drop] = false;
-            auto& loop_port = idx_to_drop < input_count ? loop_entries[idx_to_drop] : loop_exits[idx_to_drop - input_count];
-            loop_port.ptr_increment = 0;
-            loop_port.finalization_offset = 0;
-            loop_port.is_incremented = false;
         }
         loop_end_static->set_ptr_increments(new_ptr_increments);
         loop_end_static->set_finalization_offsets(new_finalization_offsets);
     }
     loop_end->set_is_incremented(new_is_incremented);
-    loop_info->set_entry_points(loop_entries);
-    loop_info->set_exit_points(loop_exits);
+
+    auto loop_port_updater = [&resetting_data_indexes, input_count](LoopPort& loop_port, size_t idx) {
+        auto idx_shift = loop_port.expr_port->get_type() == ExpressionPort::Output ? input_count : 0;
+        if (resetting_data_indexes.count(idx + idx_shift)) {
+            loop_port.ptr_increment = 0;
+            loop_port.finalization_offset = 0;
+            loop_port.is_incremented = false;
+        }
+    };
+
+    const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
+    loop_info->update_entry_points(loop_port_updater);
+    loop_info->update_exit_points(loop_port_updater);
+
     return true;
 }
 

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -101,7 +101,7 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
 
     const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     size_t loop_port_idx = 0;
-    loop_info->iterate_through_ports([&resetting_data_indexes, &loop_port_idx](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& shifts) {
+    loop_info->iterate_through_infos([&resetting_data_indexes, &loop_port_idx](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& shifts) {
         if (resetting_data_indexes.count(loop_port_idx)) {
             shifts.ptr_increment = 0;
             shifts.finalization_offset = 0;

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -79,7 +79,7 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
     if (resetting_data_indexes.empty())
         return false;
 
-    const auto loop_info = loop_manager->get_loop_info(loop_end->get_id());
+    const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
 
     // TODO [133463]: We have to update LoopEnd and LoopInfo since the both entities must be valid.
     //                To avoid the both changes, we have to insert Loop ops to LinearIR in the end of pipeline.

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -101,7 +101,7 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
 
     const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     size_t loop_port_idx = 0;
-    loop_info->iterate_through_port_info([&resetting_data_indexes, &loop_port_idx](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& shifts) {
+    loop_info->iterate_through_ports([&resetting_data_indexes, &loop_port_idx](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& shifts) {
         if (resetting_data_indexes.count(loop_port_idx)) {
             shifts.ptr_increment = 0;
             shifts.finalization_offset = 0;

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -44,7 +44,8 @@ bool FuseLoops::loop_ports_are_compatible(const LoopInfoPtr& loop_upper,
     return true;
 }
 
-bool FuseLoops::can_be_fused(const LoopInfoPtr& loop_upper, const LoopInfoPtr& loop_lower) {
+bool FuseLoops::can_be_fused(const UnifiedLoopInfoPtr& loop_upper, const UnifiedLoopInfoPtr& loop_lower) {
+    OPENVINO_ASSERT(loop_upper != nullptr && loop_lower != nullptr, "LoopInfo is nullptr!");
     if (!loop_ports_are_compatible(loop_upper, loop_lower))
         return false;
     // Loop fusion is supported only if Loops have equal/broadcastable increments and work amounts.
@@ -106,8 +107,8 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LoopManagerPt
                                         const std::shared_ptr<ExpressionPort>& current_entry_point,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos) {
-    const auto& loop_current = loop_manager->get_loop_info(current_loop_id);
-    const auto& loop_target = loop_manager->get_loop_info(target_loop_id);
+    const auto& loop_current = loop_manager->get_loop_info<UnifiedLoopInfo>(current_loop_id);
+    const auto& loop_target = loop_manager->get_loop_info<UnifiedLoopInfo>(target_loop_id);
     if (!can_be_fused(loop_target, loop_current))
         return false;
 
@@ -150,8 +151,8 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LoopManagerPt
                                         const std::shared_ptr<ExpressionPort>& current_exit_point,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos) {
-    const auto& loop_current = loop_manager->get_loop_info(current_loop_id);
-    const auto& loop_target = loop_manager->get_loop_info(target_loop_id);
+    const auto& loop_current = loop_manager->get_loop_info<UnifiedLoopInfo>(current_loop_id);
+    const auto& loop_target = loop_manager->get_loop_info<UnifiedLoopInfo>(target_loop_id);
     if (!can_be_fused(loop_current, loop_target))
         return false;
 

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -220,7 +220,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                 // Loop_0 (Upper)                 |
                 //   |               =>           |
                 // Loop_1 (Current)     Loop_0 + Loop_1 => new `Loop_1`
-                auto input_ports = current_loop_info->get_input_ports();
+                const auto& input_ports = current_loop_info->get_input_ports();
                 bool was_fusion_up = false;
                 for (size_t in_port = 0; in_port < input_ports.size() && !was_fusion_up; ++in_port) {
                     const auto input_port = input_ports[in_port];
@@ -264,7 +264,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                 // Loop_0 (Current)    Loop_0 + Loop_1 => new `Loop_0`
                 //   |               =>           |
                 // Loop_1 (Lower)                 |
-                auto output_ports = current_loop_info->get_output_ports();
+                const auto& output_ports = current_loop_info->get_output_ports();
                 bool was_fusion_down = false;
                 for (size_t out_port = 0; out_port < output_ports.size() && !was_fusion_down; ++out_port) {
                     const auto output_port = output_ports[out_port];

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -208,15 +208,15 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
             if (prev_fused_loops.count(current_loop_id) != 0)
                 continue;
 
-            const auto current_loop_info = loop_manager->get_loop_info(current_loop_id);
-            LinearIR::constExprIt current_loop_begin_pos, current_loop_end_pos;
-            std::tie(current_loop_begin_pos, current_loop_end_pos) = loop_manager->get_loop_bounds(linear_ir, current_loop_id);
-
             // We fuse upper Loops into the current till we can do it.
             // After that we fuse lower Loops into the current till we can do it.
             // If we have fused on outputs we should verify possible fusions on inputs again because of new entry points
             bool need_fusion_checks = true;
             while (need_fusion_checks) {
+                const auto current_loop_info = loop_manager->get_loop_info(current_loop_id);
+                LinearIR::constExprIt current_loop_begin_pos, current_loop_end_pos;
+                std::tie(current_loop_begin_pos, current_loop_end_pos) = loop_manager->get_loop_bounds(linear_ir, current_loop_id);
+
                 // Loop_0 (Upper)                 |
                 //   |               =>           |
                 // Loop_1 (Current)     Loop_0 + Loop_1 => new `Loop_1`

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -68,8 +68,8 @@ bool FuseLoops::can_be_fused(const UnifiedLoopInfoPtr& loop_upper, const Unified
     // WA: we can't fuse 2 loops if one of them has first iteration handler but second hasn't,
     // because in this case Main/Tail body handlers of the loop wo first iter handler must be reset with new parameters
     // (e.g. tail size). This logic is not implemented for now, so fusion for such loops is skipped.
-    const bool first_iter_handlers_match = loop_upper->get_handlers().get_first_iter_handlers().empty() ==
-                                           loop_lower->get_handlers().get_first_iter_handlers().empty();
+    const bool first_iter_handlers_match = loop_upper->get_handlers().get_passes<SpecificLoopIterType::FIRST_ITER>().empty() ==
+                                           loop_lower->get_handlers().get_passes<SpecificLoopIterType::FIRST_ITER>().empty();
     return first_iter_handlers_match && (is_dynamic_case || equal_parameters || bcastable_upper || bcastable_lower);
 }
 

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -28,8 +28,8 @@ bool FuseLoops::loop_ports_are_compatible(const LoopInfoPtr& loop_upper,
         return std::find_if(loop_ports.cbegin(), loop_ports.cend(),
                             [&target_port](const LoopPort& loop_port) {return *(loop_port.expr_port.get()) == target_port; });
     };
-    const auto& upper_exit_ports = loop_upper->get_exit_points();
-    const auto& lower_entry_ports = loop_lower->get_entry_points();
+    const auto& upper_exit_ports = loop_upper->get_output_ports();
+    const auto& lower_entry_ports = loop_lower->get_input_ports();
     for (const auto& lower_entry_port : lower_entry_ports) {
         const auto& src_port = lower_entry_port.expr_port->get_port_connector_ptr()->get_source();
         const auto upper_exit_port_it = found_port(upper_exit_ports, src_port);
@@ -104,7 +104,7 @@ void FuseLoops::move(LinearIR& linear_ir, const LoopManagerPtr& loop_manager, si
 }
 
 bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LoopManagerPtr& loop_manager,
-                                        const std::shared_ptr<ExpressionPort>& current_entry_point,
+                                        const std::shared_ptr<ExpressionPort>& current_input_port,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos) {
     const auto& loop_current = loop_manager->get_loop_info<UnifiedLoopInfo>(current_loop_id);
@@ -115,12 +115,12 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LoopManagerPt
     // We can fuse Loop_up to Loop_down only in cases when other consumers of Loop_up are after Loop_down
     // Because Loop_up should be explicitly moved before Loop_down in linear IR, and we must save control dependency
     bool is_fusion_allowed = true;
-    for (size_t i = 0; i < loop_target->get_exit_points().size() && is_fusion_allowed; ++i) {
-        const auto target_exit_point = loop_target->get_exit_points()[i];
-        const auto consumer_inputs = target_exit_point.expr_port->get_connected_ports();
+    for (size_t i = 0; i < loop_target->get_output_ports().size() && is_fusion_allowed; ++i) {
+        const auto target_output_port = loop_target->get_output_ports()[i];
+        const auto consumer_inputs = target_output_port.expr_port->get_connected_ports();
         for (const auto& consumer_input : consumer_inputs) {
             const auto& consumer = consumer_input.get_expr();
-            if (ov::is_type<ov::op::v0::Result>(consumer->get_node()) || consumer == current_entry_point->get_expr())
+            if (ov::is_type<ov::op::v0::Result>(consumer->get_node()) || consumer == current_input_port->get_expr())
                 continue;
             // The fusing is only valid if target Loop consumer (the Consumer is outside of target Loop)
             // is after current Loop (after Loop_down).
@@ -148,7 +148,7 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LoopManagerPt
 }
 
 bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LoopManagerPtr& loop_manager,
-                                        const std::shared_ptr<ExpressionPort>& current_exit_point,
+                                        const std::shared_ptr<ExpressionPort>& current_output_port,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos) {
     const auto& loop_current = loop_manager->get_loop_info<UnifiedLoopInfo>(current_loop_id);
@@ -159,11 +159,11 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LoopManagerPt
     // We can fuse Loop_down to Loop_up only in cases when other parents of Loop_down are before Loop_up
     // Because Loop_down should be explicitly moved after Loop_up in linear IR, and we must save control dependency
     bool is_fusion_allowed = true;
-    for (size_t i = 0; i < loop_target->get_entry_points().size() && is_fusion_allowed; ++i) {
-        const auto target_entry_port = loop_target->get_entry_points()[i];
+    for (size_t i = 0; i < loop_target->get_input_ports().size() && is_fusion_allowed; ++i) {
+        const auto target_entry_port = loop_target->get_input_ports()[i];
         const auto parent_expr_output = *target_entry_port.expr_port->get_connected_ports().begin();
         const auto& parent_expr = parent_expr_output.get_expr();
-        if (ov::is_type<ov::op::v0::Parameter>(parent_expr->get_node()) || parent_expr == current_exit_point->get_expr())
+        if (ov::is_type<ov::op::v0::Parameter>(parent_expr->get_node()) || parent_expr == current_output_port->get_expr())
             continue;
         is_fusion_allowed = is_loop_id_found(parent_expr->get_loop_ids(), current_loop_id) ||  // The parent expr is from the same current Loop
                             std::find(linear_ir.cbegin(), current_loop_begin_pos, parent_expr) != current_loop_begin_pos; // The parent is before current Loop
@@ -210,7 +210,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
 
             // We fuse upper Loops into the current till we can do it.
             // After that we fuse lower Loops into the current till we can do it.
-            // If we have fused on outputs we should verify possible fusions on inputs again because of new entry points
+            // If we have fused on outputs we should verify possible fusions on inputs again because of new input ports
             bool need_fusion_checks = true;
             while (need_fusion_checks) {
                 const auto current_loop_info = loop_manager->get_loop_info(current_loop_id);
@@ -220,11 +220,11 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                 // Loop_0 (Upper)                 |
                 //   |               =>           |
                 // Loop_1 (Current)     Loop_0 + Loop_1 => new `Loop_1`
-                auto entry_points = current_loop_info->get_entry_points();
+                auto input_ports = current_loop_info->get_input_ports();
                 bool was_fusion_up = false;
-                for (size_t in_port = 0; in_port < entry_points.size() && !was_fusion_up; ++in_port) {
-                    const auto entry_point = entry_points[in_port];
-                    const auto parent_expr_output = *entry_point.expr_port->get_connected_ports().begin();
+                for (size_t in_port = 0; in_port < input_ports.size() && !was_fusion_up; ++in_port) {
+                    const auto input_port = input_ports[in_port];
+                    const auto parent_expr_output = *input_port.expr_port->get_connected_ports().begin();
                     const auto& parent_expr = parent_expr_output.get_expr();
                     const auto parent = parent_expr->get_node();
                     if (ov::is_type<ov::op::v0::Constant>(parent) ||
@@ -249,26 +249,26 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
 
                     const auto upper_loop_id = upper_loop_ids[loop_idx];
                     OPENVINO_ASSERT(current_loop_id != upper_loop_id,
-                                    "Loops cannot have parents of entry points with the same identifier (", upper_loop_id, ")");
-                    if (fuse_upper_into_current(linear_ir, loop_manager, entry_point.expr_port, current_loop_id, upper_loop_id,
+                                    "Loops cannot have parents of input ports with the same identifier (", upper_loop_id, ")");
+                    if (fuse_upper_into_current(linear_ir, loop_manager, input_port.expr_port, current_loop_id, upper_loop_id,
                                                 current_loop_begin_pos, current_loop_end_pos)) {
                         was_fusion_up = true;
                         prev_fused_loops.insert(current_loop_id);
                     }
                 }
 
-                // If Loops were fused and there are new entry_points, we should check for possible fusion again
-                if (was_fusion_up && entry_points != current_loop_info->get_entry_points())
+                // If Loops were fused and there are new input_ports, we should check for possible fusion again
+                if (was_fusion_up && input_ports != current_loop_info->get_input_ports())
                     continue;
 
                 // Loop_0 (Current)    Loop_0 + Loop_1 => new `Loop_0`
                 //   |               =>           |
                 // Loop_1 (Lower)                 |
-                auto exit_points = current_loop_info->get_exit_points();
+                auto output_ports = current_loop_info->get_output_ports();
                 bool was_fusion_down = false;
-                for (size_t out_port = 0; out_port < exit_points.size() && !was_fusion_down; ++out_port) {
-                    const auto exit_point = exit_points[out_port];
-                    const auto consumer_exprs_inputs = exit_point.expr_port->get_connected_ports();
+                for (size_t out_port = 0; out_port < output_ports.size() && !was_fusion_down; ++out_port) {
+                    const auto output_port = output_ports[out_port];
+                    const auto consumer_exprs_inputs = output_port.expr_port->get_connected_ports();
                     for (const auto& consumer_expr_input : consumer_exprs_inputs) {
                         const auto& consumer_expr = consumer_expr_input.get_expr();
                         const auto consumer = consumer_expr->get_node();
@@ -296,7 +296,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                         if (current_loop_id == lower_loop_id)
                             continue;
 
-                        if (fuse_lower_into_current(linear_ir, loop_manager, exit_point.expr_port, current_loop_id, lower_loop_id,
+                        if (fuse_lower_into_current(linear_ir, loop_manager, output_port.expr_port, current_loop_id, lower_loop_id,
                                                     current_loop_begin_pos, current_loop_end_pos)) {
                             was_fusion_down = true;
                             prev_fused_loops.insert(current_loop_id);
@@ -306,7 +306,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                     }
                 }
 
-                // We iterated by each exit point and didn't fuse new Loops -> we can finish check for possible fusions on outputs.
+                // We iterated by each output port and didn't fuse new Loops -> we can finish check for possible fusions on outputs.
                 if (!was_fusion_down)
                     need_fusion_checks = false;
             }

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -153,9 +153,9 @@ void InitLoops::init_loop_info(const UnifiedLoopInfoPtr& loop_info, const size_t
     };
 
     if (only_runtime_args) {
-        loop_info->iterate_through_ports(init_runtime_parameters);
+        loop_info->iterate_through_infos(init_runtime_parameters);
     } else {
-        loop_info->iterate_through_ports(init_all_parameters);
+        loop_info->iterate_through_infos(init_all_parameters);
     }
 }
 

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -40,7 +40,7 @@ inline void init_is_incremented(LoopPort& port, size_t loop_id) {
         //     Store; Loop ids [0,1,2,3]
         //     IntermediateMemoryBuffer; Loop ids [0,1]
         //     Load; Loop ids [0,1,4,5]
-        // Store is exit port of Loop-1, but it should be incremented only in Loop-2 and Loop-3. Similar with Load.
+        // Store is output port of Loop-1, but it should be incremented only in Loop-2 and Loop-3. Similar with Load.
         auto is_ignored = [=](const ExpressionPtr& target_expr) {
             if (ov::is_type<op::IntermediateMemoryBuffer>(target_expr->get_node())) {
                 const auto& target_loops = target_expr->get_loop_ids();
@@ -114,7 +114,7 @@ inline int64_t get_data_size(const LoopPort& loop_port) {
 
 inline void init_work_amount(const LoopInfoPtr& loop_info) {
     size_t work_amount = 1;
-    for (const auto& loop_port : loop_info->get_entry_points()) {
+    for (const auto& loop_port : loop_info->get_input_ports()) {
         if (loop_port.is_incremented) {
             const auto& desc = loop_port.expr_port->get_descriptor_ptr();
             const auto& shape = desc->get_shape();
@@ -122,7 +122,7 @@ inline void init_work_amount(const LoopInfoPtr& loop_info) {
             utils::broadcast_merge_dim(work_amount, work_amount, shape[utils::get_input_dim_idx(layout, loop_port.dim_idx)]);
         }
     }
-    for (const auto& loop_port : loop_info->get_exit_points()) {
+    for (const auto& loop_port : loop_info->get_output_ports()) {
         if (loop_port.is_incremented) {
             const auto& desc = loop_port.expr_port->get_descriptor_ptr();
             const auto& shape = desc->get_shape();
@@ -153,9 +153,9 @@ void InitLoops::init_loop_info(const UnifiedLoopInfoPtr& loop_info, const size_t
     };
 
     if (only_runtime_args) {
-        loop_info->iterate_through_port_info(init_runtime_parameters);
+        loop_info->iterate_through_ports(init_runtime_parameters);
     } else {
-        loop_info->iterate_through_port_info(init_all_parameters);
+        loop_info->iterate_through_ports(init_all_parameters);
     }
 }
 

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -135,7 +135,8 @@ inline void init_work_amount(const LoopInfoPtr& loop_info) {
 }
 }  // namespace
 
-void InitLoops::init_loop_info(const LoopInfoPtr& loop_info, const size_t loop_id, bool only_runtime_args) {
+void InitLoops::init_loop_info(const UnifiedLoopInfoPtr& loop_info, const size_t loop_id, bool only_runtime_args) {
+    OPENVINO_ASSERT(loop_info != nullptr, "UnifiedLoopInfo is nullptr, nothing to initialize");
     if (utils::is_dynamic_value(loop_info->get_work_amount()))
         init_work_amount(loop_info);
 
@@ -169,7 +170,7 @@ bool InitLoops::run(LinearIR& linear_ir) {
     const auto& loop_manager = linear_ir.get_loop_manager();
     const auto& loops = loop_manager->get_map();
     for (const auto& loop : loops) {
-        init_loop_info(loop.second, loop.first);
+        init_loop_info(std::dynamic_pointer_cast<UnifiedLoopInfo>(loop.second), loop.first);
     }
 
     return true;

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -170,7 +170,7 @@ bool InitLoops::run(LinearIR& linear_ir) {
     const auto& loop_manager = linear_ir.get_loop_manager();
     const auto& loops = loop_manager->get_map();
     for (const auto& loop : loops) {
-        init_loop_info(std::dynamic_pointer_cast<UnifiedLoopInfo>(loop.second), loop.first);
+        init_loop_info(ov::as_type_ptr<UnifiedLoopInfo>(loop.second), loop.first);
     }
 
     return true;

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -154,11 +154,11 @@ void InitLoops::init_loop_info(const UnifiedLoopInfoPtr& loop_info, const size_t
     };
 
     if (only_runtime_args) {
-        loop_info->update_entry_points(init_runtime_parameters);
-        loop_info->update_exit_points(init_runtime_parameters);
+        loop_info->iterate_through_entry_points(init_runtime_parameters);
+        loop_info->iterate_through_exit_points(init_runtime_parameters);
     } else {
-        loop_info->update_entry_points(init_all_parameters);
-        loop_info->update_exit_points(init_all_parameters);
+        loop_info->iterate_through_entry_points(init_all_parameters);
+        loop_info->iterate_through_exit_points(init_all_parameters);
     }
 }
 

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -17,8 +17,8 @@ namespace pass {
 
 void InsertLoops::insertion(LinearIR& linear_ir, const LoopManagerPtr& loop_manager, size_t loop_id) {
     const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
-    auto loop_entries = loop_info->get_entry_points();
-    auto loop_exits = loop_info->get_exit_points();
+    auto loop_entries = loop_info->get_input_ports();
+    auto loop_exits = loop_info->get_output_ports();
     const auto work_amount = loop_info->get_work_amount();
     const auto work_amount_increment = loop_info->get_increment();
 
@@ -64,8 +64,8 @@ bool InsertLoops::is_loop_dynamic(const UnifiedLoopInfoPtr& loop_info) {
     auto is_loop_port_dynamic = [](const UnifiedLoopInfo::LoopPortDesc& shifts) {
         return utils::is_dynamic_value(shifts.ptr_increment) || utils::is_dynamic_value(shifts.finalization_offset);
     };
-    const auto& entry_shifts = loop_info->get_entry_port_descs();
-    const auto& exit_shifts = loop_info->get_exit_port_descs();
+    const auto& entry_shifts = loop_info->get_input_port_descs();
+    const auto& exit_shifts = loop_info->get_output_port_descs();
     return utils::is_dynamic_value(loop_info->get_work_amount()) ||
            std::any_of(entry_shifts.cbegin(), entry_shifts.cend(), is_loop_port_dynamic) ||
            std::any_of(exit_shifts.cbegin(), exit_shifts.cend(), is_loop_port_dynamic);

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -16,7 +16,7 @@ namespace lowered {
 namespace pass {
 
 void InsertLoops::insertion(LinearIR& linear_ir, const LoopManagerPtr& loop_manager, size_t loop_id) {
-    const auto loop_info = loop_manager->get_loop_info(loop_id);
+    const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
     auto loop_entries = loop_info->get_entry_points();
     auto loop_exits = loop_info->get_exit_points();
     const auto work_amount = loop_info->get_work_amount();
@@ -29,8 +29,8 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LoopManagerPtr& loop_mana
     auto init_inputs = [&loop_end_inputs](const LoopPort& port) {
         loop_end_inputs.push_back(port.expr_port->get_port_connector_ptr());
     };
-    loop_info->init_using_entry_points(init_inputs);
-    loop_info->init_using_exit_points(init_inputs);
+    std::for_each(loop_entries.cbegin(), loop_entries.cend(), init_inputs);
+    std::for_each(loop_exits.cbegin(), loop_exits.cend(), init_inputs);
 
     const auto is_incremented = loop_info->get_is_incremented();
     const auto io_data_sizes = loop_info->get_data_sizes();
@@ -62,7 +62,7 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LoopManagerPtr& loop_mana
     linear_ir.insert_node(loop_end, loop_end_inputs, outer_loop_ids, false, loop_bounds.second);
 }
 
-bool InsertLoops::is_loop_dynamic(const LoopInfoPtr& loop_info) {
+bool InsertLoops::is_loop_dynamic(const UnifiedLoopInfoPtr& loop_info) {
     auto is_loop_port_dynamic = [](const LoopPort& port) {
         return port.is_dynamic();
     };

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -4,24 +4,85 @@
 
 #include "snippets/lowered/pass/insert_specific_iterations.hpp"
 
-#include "snippets/itt.hpp"
 #include "snippets/lowered/linear_ir.hpp"
-#include "snippets/lowered/loop_manager.hpp"
-#include "snippets/snippets_isa.hpp"
+#include "snippets/lowered/specific_loop_iter_types.hpp"
 #include "snippets/utils.hpp"
+#include "snippets/itt.hpp"
 
 namespace ov {
 namespace snippets {
 namespace lowered {
 namespace pass {
 
-LinearIR::constExprIt InsertSpecificIterations::insert_copy_loop(LinearIR& linear_ir, const size_t loop_id, const LinearIR::constExprIt& insert_pos) {
+std::array<SpecificLoopIterType, 3> InsertSpecificIterations::m_iterations = {
+    SpecificLoopIterType::FIRST_ITER,
+    SpecificLoopIterType::MAIN_BODY,
+    SpecificLoopIterType::LAST_ITER
+};
+
+bool InsertSpecificIterations::is_decomposed_loop_needed(const UnifiedLoopInfoPtr& unified_loop_info, SpecificLoopIterType type,
+                                                         size_t remaining_work_amount) {
+    OPENVINO_ASSERT(unified_loop_info, "UnifiedLoopInfo is missed!");
+    const auto increment = unified_loop_info->get_increment();
+    OPENVINO_ASSERT(!utils::is_dynamic_value(increment) && increment > 0, "Incorrect increment!");
+    const auto is_dynamic = utils::is_dynamic_value(remaining_work_amount);
+
+    switch (type) {
+        case (SpecificLoopIterType::FIRST_ITER):
+            return !unified_loop_info->get_handlers().get_first_iter_handlers().empty() && (is_dynamic || remaining_work_amount >= increment);
+        case (SpecificLoopIterType::MAIN_BODY):
+            return is_dynamic || remaining_work_amount >= increment;
+        case (SpecificLoopIterType::LAST_ITER):
+            return (is_dynamic && increment > 1) || (!is_dynamic && remaining_work_amount > 0);
+        default:
+            OPENVINO_THROW("Unknown SpecificLoopIterType!");
+    }
+    return false;
+}
+size_t InsertSpecificIterations::get_decomposed_loop_work_amount(const UnifiedLoopInfoPtr& unified_loop_info, SpecificLoopIterType type,
+                                                                 size_t remaining_work_amount) {
+    OPENVINO_ASSERT(unified_loop_info, "UnifiedLoopInfo is missed!");
+    const auto increment = unified_loop_info->get_increment();
+    const auto is_dynamic = utils::is_dynamic_value(remaining_work_amount);
+
+    switch (type) {
+        case (SpecificLoopIterType::FIRST_ITER):
+            return increment;
+        case (SpecificLoopIterType::MAIN_BODY):
+            return is_dynamic ? remaining_work_amount : (remaining_work_amount / increment) * increment;
+        case (SpecificLoopIterType::LAST_ITER):
+            return remaining_work_amount;
+        default:
+            OPENVINO_THROW("Unknown SpecificLoopIterType!");
+    }
+    return 0;
+}
+size_t InsertSpecificIterations::get_decomposed_loop_increment(const UnifiedLoopInfoPtr& unified_loop_info, SpecificLoopIterType type,
+                                                               size_t remaining_work_amount) {
+    OPENVINO_ASSERT(unified_loop_info, "UnifiedLoopInfo is missed!");
+    const auto increment = unified_loop_info->get_increment();
+    const auto is_dynamic = utils::is_dynamic_value(remaining_work_amount);
+
+    switch (type) {
+        case (SpecificLoopIterType::FIRST_ITER):
+        case (SpecificLoopIterType::MAIN_BODY):
+            return increment;
+        case(SpecificLoopIterType::LAST_ITER):
+            return is_dynamic ? 1 : remaining_work_amount;
+        default:
+            OPENVINO_THROW("Unknown SpecificLoopIterType!");
+    }
+    return 0;
+}
+
+LoopManager::LoopBounds InsertSpecificIterations::insert_copy_loop(LinearIR& linear_ir, const size_t loop_id, const LinearIR::constExprIt& insert_pos,
+                                                                   std::vector<LoopPort>& new_entry_ports, std::vector<LoopPort>& new_exit_ports) {
     const auto& loop_manager = linear_ir.get_loop_manager();
     const auto loop_bounds = loop_manager->get_loop_bounds(linear_ir, loop_id);
     ExpressionMap expression_map;
     const auto& loop_copy_range = LinearIR::deep_copy_range(loop_bounds.first, std::next(loop_bounds.second), expression_map);
     const auto new_loop_begin_pos = linear_ir.insert(insert_pos, loop_copy_range.begin(), loop_copy_range.end());
-    const auto new_loop_end_pos = insert_pos;
+    const auto new_loop_end_pos = std::prev(insert_pos);
 
     // Set the same pointers of Tensor Shape to the cloned loop
     for (LinearIR::constExprIt cloned_it = new_loop_begin_pos, original_it = loop_bounds.first; cloned_it != new_loop_end_pos; ++cloned_it, ++original_it) {
@@ -33,113 +94,103 @@ LinearIR::constExprIt InsertSpecificIterations::insert_copy_loop(LinearIR& linea
             cloned_expr->get_output_port_descriptor(i)->set_shape_ptr(original_expr->get_output_port_descriptor(i)->get_shape_ptr());
     }
 
+    auto clone_ports = [&expression_map](const std::vector<LoopPort>& ports, std::vector<LoopPort>& new_ports) {
+        new_ports.resize(ports.size());
+        for (size_t i = 0; i < ports.size(); ++i) {
+            const auto& entry = ports[i];
+            new_ports[i] = *entry.clone_with_new_expr(expression_map[entry.expr_port->get_expr().get()]);
+        }
+    };
     const auto original_loop_info = loop_manager->get_loop_info(loop_id);
-    std::vector<LoopPort> new_entry_points, new_exit_points;
-    // Clone loop ports from original loop info to new loop info
-    for (const auto& entry : original_loop_info->get_entry_points())
-        new_entry_points.push_back(*entry.clone_with_new_expr(expression_map[entry.expr_port->get_expr().get()]));
-    for (const auto& exit : original_loop_info->get_exit_points())
-        new_exit_points.push_back(*exit.clone_with_new_expr(expression_map[exit.expr_port->get_expr().get()]));
+    clone_ports(original_loop_info->get_entry_points(), new_entry_ports);
+    clone_ports(original_loop_info->get_exit_points(), new_exit_ports);
 
-    for (const auto& elem : expression_map) {
-        const auto expr = elem.first->shared_from_this();
-        const auto& new_expr = elem.second;
-        // Loop begin/end ops can't be loop ports
-        if (ov::is_type<op::LoopBase>(expr->get_node()))
-            continue;
-        // Update loop info of all outer loops with new loop ports
-        const auto outer_loop_ids = LoopManager::get_outer_expr_loops(expr, loop_id);
-        for (size_t i = 0; i < expr->get_input_count(); ++i)
-            loop_manager->update_loops_port(outer_loop_ids, expr->get_input_port(i), {expr->get_input_port(i), new_expr->get_input_port(i)}, true);
-        for (size_t i = 0; i < expr->get_output_count(); ++i)
-            loop_manager->update_loops_port(outer_loop_ids, expr->get_output_port(i), {expr->get_output_port(i), new_expr->get_output_port(i)}, false);
+    return { new_loop_begin_pos, new_loop_end_pos };
+}
+
+void InsertSpecificIterations::init_decomposed_loop(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end,
+                                                    const ExpandedLoopInfoPtr& decomposed_loop_info, size_t solid_loop_id,
+                                                    const std::shared_ptr<op::LoopEnd>& decomposed_loop_end) {
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    const auto new_id = loop_manager->replace_with_new_loop(linear_ir, begin, std::next(end), decomposed_loop_info, solid_loop_id);
+    decomposed_loop_end->set_id(new_id);
+    decomposed_loop_end->set_increment(decomposed_loop_info->get_increment());
+    if (const auto static_loop_end = ov::as_type_ptr<op::LoopEndStatic>(decomposed_loop_end)) {
+        static_loop_end->set_work_amount(decomposed_loop_info->get_work_amount());
+        static_loop_end->set_ptr_increments(decomposed_loop_info->get_ptr_increments());
+        static_loop_end->set_finalization_offsets(decomposed_loop_info->get_finalization_offsets());
+    }
+    // Note: handlers must be run on the range started with the first operation in the loop body.
+    const auto handlers = decomposed_loop_info->get_handlers_by_type();
+    handlers.run(linear_ir, std::next(begin), end);
+}
+
+bool InsertSpecificIterations::decompose(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end,
+                                         const std::shared_ptr<op::LoopEnd>& loop_end) {
+    const auto loop_id = loop_end->get_id();
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    const auto& unified_loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
+
+    auto remaining_work_amount = unified_loop_info->get_work_amount();
+    const auto is_wa_dynamic = utils::is_dynamic_value(remaining_work_amount);
+
+    auto decomposed = false;
+    for (const auto& iter_type : m_iterations) {
+        if (is_decomposed_loop_needed(unified_loop_info, iter_type, remaining_work_amount)) {
+            const auto work_amount = get_decomposed_loop_work_amount(unified_loop_info, iter_type, remaining_work_amount);
+            const auto increment = get_decomposed_loop_increment(unified_loop_info, iter_type, remaining_work_amount);
+            // Update remaining Loop work amount
+            // Note: if work_amount is unknown and increment = 1, it means that a loop will iterate by whole work_amount
+            if ((!is_wa_dynamic) || (increment == 1 && utils::is_dynamic_value(work_amount))) {
+                remaining_work_amount -= work_amount;
+            }
+
+            auto decomposed_loop_end = loop_end;
+            auto decomposed_loop_begin_it = begin, decomposed_loop_end_it = end;
+            auto decomposed_loop_entry_ports = unified_loop_info->get_entry_points();
+            auto decomposed_loop_exit_ports = unified_loop_info->get_exit_points();
+            // Need to copy body if there are other specific sup-loops
+            // Otherwise we should update the current body
+            if (remaining_work_amount > 0) {
+                std::tie(decomposed_loop_begin_it, decomposed_loop_end_it) =
+                    insert_copy_loop(linear_ir, loop_id, begin, decomposed_loop_entry_ports, decomposed_loop_exit_ports);
+                decomposed_loop_end = ov::as_type_ptr<op::LoopEnd>(decomposed_loop_end_it->get()->get_node());
+                OPENVINO_ASSERT(decomposed_loop_end, "Cloned Loop does not contain LoopEnd op at the expected place.");
+
+                // Only latest loop iterations must have summarized finalization offsets!
+                // Since we inserted copy before the latest iterations, these copis should have reseted offsets
+                auto nullify_finalization_offset = [](LoopPort& port) {
+                    if (!utils::is_dynamic_value(port.finalization_offset))
+                        port.finalization_offset = 0;
+                };
+                std::for_each(decomposed_loop_entry_ports.begin(), decomposed_loop_entry_ports.end(), nullify_finalization_offset);
+                std::for_each(decomposed_loop_exit_ports.begin(), decomposed_loop_exit_ports.end(), nullify_finalization_offset);
+            }
+
+            const auto decomposed_loop_info = std::make_shared<ExpandedLoopInfo>(work_amount, increment,
+                                                                                   decomposed_loop_entry_ports, decomposed_loop_exit_ports,
+                                                                                   iter_type, unified_loop_info);
+            init_decomposed_loop(linear_ir, decomposed_loop_begin_it, decomposed_loop_end_it, decomposed_loop_info, loop_id, decomposed_loop_end);
+
+            decomposed = true;
+        }
     }
 
-    const auto new_id = loop_manager->replace_with_new_loop(linear_ir, new_loop_begin_pos, new_loop_end_pos,
-                                                            original_loop_info->get_work_amount(), original_loop_info->get_increment(),
-                                                            new_entry_points, new_exit_points, loop_id);
-    const auto loop_end = ov::as_type_ptr<op::LoopEndStatic>(std::prev(new_loop_end_pos)->get()->get_node());
-    OPENVINO_ASSERT(loop_end, "Cloned Loop does not contain LoopEnd op at the expected place.");
-    loop_end->set_id(new_id);
-    return new_loop_begin_pos;
+    return decomposed;
 }
 
 bool InsertSpecificIterations::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, lowered::LinearIR::constExprIt end) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::InsertSpecificIterations")
-    const auto& loop_manager = linear_ir.get_loop_manager();
 
     bool modified = false;
     for (auto expr_it = begin; expr_it != end; ++expr_it) {
-        const auto& expr = *expr_it;
-        const auto node = expr->get_node();
-        const auto loop_end = ov::as_type_ptr<op::LoopEndStatic>(node);
-        if (!loop_end)
-            continue;
-
-        const auto& loop_info = loop_manager->get_loop_info(loop_end->get_id());
-        const auto work_amount = loop_info->get_work_amount();
-        const auto increment = loop_info->get_increment();
-        const auto& handlers = loop_info->get_handlers();
-
-        const auto main_loop_begin_it = linear_ir.find(linear_ir.get_expr_by_node(loop_end->get_loop_begin()));
-        const auto main_loop_end_it = linear_ir.find_after(main_loop_begin_it, linear_ir.get_expr_by_node(loop_end));
-        // Note: handlers must be run on the range started with the first operation in the loop body.
-        const auto main_first_body_op_it = std::next(main_loop_begin_it);
-
-        auto update_loop_params = [&loop_manager](const std::shared_ptr<op::LoopEndStatic>& loop_end_copy,
-                                                  size_t new_work_amount,
-                                                  size_t new_increment,
-                                                  bool zero_finalization_offsets) {
-            loop_end_copy->set_work_amount(new_work_amount);
-            loop_end_copy->set_increment(new_increment);
-
-            const auto& loop_info_copy = loop_manager->get_loop_info(loop_end_copy->get_id());
-            loop_info_copy->set_work_amount(new_work_amount);
-            loop_info_copy->set_increment(new_increment);
-
-            if (zero_finalization_offsets)
-                loop_end_copy->set_finalization_offsets(std::vector<int64_t>(loop_end_copy->get_finalization_offsets().size(), 0));
-        };
-
-        auto copy_and_run_specific_handlers = [&](const PassPipeline& handlers) {
-            const auto new_loop_begin_pos = insert_copy_loop(linear_ir, loop_end->get_id(), main_loop_begin_it);
-            const auto new_loop_begin = ov::as_type_ptr<op::LoopBeginStatic>(new_loop_begin_pos->get()->get_node());
-            OPENVINO_ASSERT(new_loop_begin, "Cloned Loop does not contain LoopBegin op at the expected place.");
-            const auto new_loop_end = ov::as_type_ptr<op::LoopEndStatic>(new_loop_begin->get_loop_end());
-            OPENVINO_ASSERT(new_loop_end, "Cloned Loop does not contain LoopEnd op at the expected place.");
-            const auto new_loop_end_pos = linear_ir.find_after(new_loop_begin_pos, linear_ir.get_expr_by_node(new_loop_end));
-
-            // Note: handlers must be run on the range started with the first operation in the loop body.
-            handlers.run(linear_ir, std::next(new_loop_begin_pos), new_loop_end_pos);
-            return new_loop_end;
-        };
-
-        const bool specific_first_iteration = !handlers.get_first_iter_handlers().empty();
-        if (work_amount == increment) {
-            handlers.get_first_iter_handlers().run(linear_ir, main_first_body_op_it, main_loop_end_it);
-        } else {
-            if (specific_first_iteration) {
-                const auto loop_end_copy = copy_and_run_specific_handlers(handlers.get_first_iter_handlers());
-                update_loop_params(loop_end_copy, increment, increment, true);
-            }
-
-            const auto tail_size = work_amount % increment;
-            if (tail_size != 0) {
-                if (!specific_first_iteration || work_amount > 2 * increment) {
-                    const auto loop_end_copy = copy_and_run_specific_handlers(handlers.get_main_iter_handlers());
-                    const auto reduce_value = specific_first_iteration ? tail_size + increment : tail_size;
-                    const auto new_work_amount = work_amount - reduce_value;
-                    update_loop_params(loop_end_copy, new_work_amount, increment, true);
-                }
-                handlers.get_last_iter_handlers().run(linear_ir, main_first_body_op_it, main_loop_end_it);
-                update_loop_params(loop_end, tail_size, tail_size, false);
-            } else if (specific_first_iteration) {
-                handlers.get_main_iter_handlers().run(linear_ir, main_first_body_op_it, main_loop_end_it);
-                update_loop_params(loop_end, work_amount - increment, increment, false);
-            }
+        if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr_it->get()->get_node())) {
+            const auto begin_it = linear_ir.find_before(expr_it, linear_ir.get_expr_by_node(loop_end->get_loop_begin())), end_it = expr_it;
+            OPENVINO_ASSERT(decompose(linear_ir, begin_it, end_it, loop_end), "Loop with ID ", loop_end->get_id(), " has not been decomposed!");
+            modified = true;
         }
-        modified = true;
     }
+
     return modified;
 }
 
@@ -147,4 +198,3 @@ bool InsertSpecificIterations::run(LinearIR& linear_ir, lowered::LinearIR::const
 } // namespace lowered
 } // namespace snippets
 } // namespace ov
-

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -161,11 +161,10 @@ bool InsertSpecificIterations::decompose(LinearIR& linear_ir, LinearIR::constExp
 
                 // Only latest loop iterations must have summarized finalization offsets!
                 // Since we inserted copy before the latest iterations, these copies should have reseted offsets
-                auto nullify_finalization_offset = [](int64_t& offset) {
+                std::for_each(decomposed_finalization_offsets.begin(), decomposed_finalization_offsets.end(), [](int64_t& offset) {
                     if (!utils::is_dynamic_value(offset))
                         offset = 0;
-                };
-                std::for_each(decomposed_finalization_offsets.begin(), decomposed_finalization_offsets.end(), nullify_finalization_offset);
+                });
             }
 
             const auto decomposed_loop_info = std::make_shared<ExpandedLoopInfo>(work_amount, increment,

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -42,7 +42,8 @@ size_t InsertSpecificIterations::get_decomposed_loop_work_amount(const UnifiedLo
 
     switch (type) {
         case (SpecificLoopIterType::FIRST_ITER):
-            return increment;
+            // We don't set always `increment` for first iterations since in dynamic `work_amount` can be less than `increment`
+            return is_dynamic ? remaining_work_amount : increment;
         case (SpecificLoopIterType::MAIN_BODY):
             return is_dynamic ? remaining_work_amount : (remaining_work_amount / increment) * increment;
         case (SpecificLoopIterType::LAST_ITER):
@@ -90,8 +91,8 @@ LoopManager::LoopBounds InsertSpecificIterations::insert_copy_loop(LinearIR& lin
     auto clone_ports = [&expression_map](const std::vector<LoopPort>& ports, std::vector<LoopPort>& new_ports) {
         new_ports.resize(ports.size());
         for (size_t i = 0; i < ports.size(); ++i) {
-            const auto& entry = ports[i];
-            new_ports[i] = *entry.clone_with_new_expr(expression_map[entry.expr_port->get_expr().get()]);
+            const auto& port = ports[i];
+            new_ports[i] = *port.clone_with_new_expr(expression_map[port.expr_port->get_expr().get()]);
         }
     };
     const auto original_loop_info = loop_manager->get_loop_info(loop_id);

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -140,7 +140,7 @@ bool InsertSpecificIterations::decompose(LinearIR& linear_ir, LinearIR::constExp
             const auto increment = get_decomposed_loop_increment(unified_loop_info, iter_type, remaining_work_amount);
             // Update remaining Loop work amount
             // Note: if work_amount is unknown and increment = 1, it means that a loop will iterate by whole work_amount
-            if ((!is_wa_dynamic) || (increment == 1 && utils::is_dynamic_value(work_amount))) {
+            if (!is_wa_dynamic || increment == 1) {
                 remaining_work_amount -= work_amount;
             }
 

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -25,7 +25,8 @@ bool InsertSpecificIterations::is_decomposed_loop_needed(const UnifiedLoopInfoPt
 
     switch (type) {
         case (SpecificLoopIterType::FIRST_ITER):
-            return !unified_loop_info->get_handlers().get_first_iter_handlers().empty() && (is_dynamic || remaining_work_amount >= increment);
+            return !unified_loop_info->get_handlers().get_passes<SpecificLoopIterType::FIRST_ITER>().empty() &&
+                   (is_dynamic || remaining_work_amount >= increment);
         case (SpecificLoopIterType::MAIN_BODY):
             return is_dynamic || remaining_work_amount >= increment;
         case (SpecificLoopIterType::LAST_ITER):
@@ -115,7 +116,7 @@ void InsertSpecificIterations::init_decomposed_loop(LinearIR& linear_ir, LinearI
         static_loop_end->set_finalization_offsets(decomposed_loop_info->get_finalization_offsets());
     }
     // Note: handlers must be run on the range started with the first operation in the loop body.
-    const auto handlers = decomposed_loop_info->get_handlers_by_type();
+    const auto handlers = decomposed_loop_info->get_handler_passes();
     handlers.run(linear_ir, std::next(begin), end);
 }
 

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -97,8 +97,8 @@ LoopManager::LoopBounds InsertSpecificIterations::insert_copy_loop(LinearIR& lin
         }
     };
     const auto original_loop_info = loop_manager->get_loop_info(loop_id);
-    clone_ports(original_loop_info->get_entry_points(), new_entry_ports);
-    clone_ports(original_loop_info->get_exit_points(), new_exit_ports);
+    clone_ports(original_loop_info->get_input_ports(), new_entry_ports);
+    clone_ports(original_loop_info->get_output_ports(), new_exit_ports);
 
     return { new_loop_begin_pos, new_loop_end_pos };
 }
@@ -146,8 +146,8 @@ bool InsertSpecificIterations::decompose(LinearIR& linear_ir, LinearIR::constExp
 
             auto decomposed_loop_end = loop_end;
             auto decomposed_loop_begin_it = begin, decomposed_loop_end_it = end;
-            auto decomposed_loop_entry_ports = unified_loop_info->get_entry_points();
-            auto decomposed_loop_exit_ports = unified_loop_info->get_exit_points();
+            auto decomposed_loop_entry_ports = unified_loop_info->get_input_ports();
+            auto decomposed_loop_exit_ports = unified_loop_info->get_output_ports();
             auto decomposed_ptr_increments = unified_loop_info->get_ptr_increments();
             auto decomposed_finalization_offsets = unified_loop_info->get_finalization_offsets();
             auto decomposed_data_sizes = unified_loop_info->get_data_sizes();

--- a/src/common/snippets/src/lowered/pass/iter_handler.cpp
+++ b/src/common/snippets/src/lowered/pass/iter_handler.cpp
@@ -100,7 +100,8 @@ bool TransformInnerSplitLoop::run(LinearIR& linear_ir, LinearIR::constExprIt beg
         const auto inner_loop_end = ov::as_type_ptr<op::LoopEndStatic>(expr->get_node());
         if (!inner_loop_end)
             continue;
-        const auto inner_loop_info = loop_manager->get_loop_info(inner_loop_end->get_id());
+        // There is already ExpandedLoopInfo
+        const auto inner_loop_info = loop_manager->get_loop_info<ExpandedLoopInfo>(inner_loop_end->get_id());
         const auto inner_dim_idx = inner_loop_info->get_dim_idx();
         if (inner_dim_idx != current_dim_idx)
             continue;
@@ -119,7 +120,7 @@ bool TransformInnerSplitLoop::run(LinearIR& linear_ir, LinearIR::constExprIt beg
         const auto inner_loop_begin_it = std::find(begin, it, linear_ir.get_expr_by_node(inner_loop_begin));
         const auto inner_loop_end_it = std::next(it);
         OPENVINO_ASSERT(inner_loop_begin_it != it, "LoopBegin has not been found!");
-        const auto& last_iter_handlers = inner_loop_info->get_handlers().get_last_iter_handlers();
+        const auto& last_iter_handlers = inner_loop_info->get_unified_loop_info()->get_handlers().get_last_iter_handlers();
         last_iter_handlers.run(linear_ir, std::next(inner_loop_begin_it), inner_loop_end_it);
         modified = true;
     }

--- a/src/common/snippets/src/lowered/pass/iter_handler.cpp
+++ b/src/common/snippets/src/lowered/pass/iter_handler.cpp
@@ -120,7 +120,7 @@ bool TransformInnerSplitLoop::run(LinearIR& linear_ir, LinearIR::constExprIt beg
         const auto inner_loop_begin_it = std::find(begin, it, linear_ir.get_expr_by_node(inner_loop_begin));
         const auto inner_loop_end_it = std::next(it);
         OPENVINO_ASSERT(inner_loop_begin_it != it, "LoopBegin has not been found!");
-        const auto& last_iter_handlers = inner_loop_info->get_unified_loop_info()->get_handlers().get_last_iter_handlers();
+        const auto& last_iter_handlers = inner_loop_info->get_unified_loop_info()->get_handlers().get_passes<SpecificLoopIterType::LAST_ITER>();
         last_iter_handlers.run(linear_ir, std::next(inner_loop_begin_it), inner_loop_end_it);
         modified = true;
     }

--- a/src/common/snippets/src/lowered/pass/normalize_loop_ids.cpp
+++ b/src/common/snippets/src/lowered/pass/normalize_loop_ids.cpp
@@ -28,12 +28,12 @@ bool NormalizeLoopIDs::run(lowered::LinearIR& linear_ir) {
                 loop_id_map[old_id] = new_id;
                 continue;
             }
-            OPENVINO_ASSERT(m_has_specific_loops, "NormalizeLoopIDs failed: LinearIR contains solid loops with the same IDs!");
+            OPENVINO_ASSERT(m_has_specific_loops, "NormalizeLoopIDs failed: LinearIR contains unified loops with the same IDs!");
         }
     }
 
     const auto& loop_manager = linear_ir.get_loop_manager();
-    return loop_manager->blend(linear_ir, loop_id_map);
+    return loop_manager->reassign_identifiers(linear_ir, loop_id_map);
 }
 
 } // namespace pass

--- a/src/common/snippets/src/lowered/pass/normalize_loop_ids.cpp
+++ b/src/common/snippets/src/lowered/pass/normalize_loop_ids.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/lowered/pass/normalize_loop_ids.hpp"
+
+#include "snippets/lowered/loop_manager.hpp"
+#include "snippets/op/loop.hpp"
+#include "snippets/itt.hpp"
+
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+bool NormalizeLoopIDs::run(lowered::LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::NormalizeLoopIDs");
+
+    // [ original Loop ID -> new normalized and sorted ]
+    std::map<size_t, size_t> loop_id_map;
+    for (const auto& expr : linear_ir) {
+        const auto& node = expr->get_node();
+        if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(node)) {
+            const auto old_id = loop_end->get_id();
+            if (loop_id_map.count(old_id) == 0) {
+                const auto new_id = loop_id_map.size();
+                loop_id_map[old_id] = new_id;
+                continue;
+            }
+            OPENVINO_ASSERT(m_has_specific_loops, "NormalizeLoopIDs failed: LinearIR contains solid loops with the same IDs!");
+        }
+    }
+
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    return loop_manager->blend(linear_ir, loop_id_map);
+}
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/lowered/pass/normalize_loop_ids.cpp
+++ b/src/common/snippets/src/lowered/pass/normalize_loop_ids.cpp
@@ -20,7 +20,7 @@ void NormalizeLoopIDs::update_linear_ir(lowered::LinearIR& linear_ir, const IDMa
         if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node())) {
             const auto current_id = loop_end->get_id();
             OPENVINO_ASSERT(loop_id_map.count(current_id) > 0, "ID of the LoopEnd has not been found in the map!");
-            loop_end->set_id(loop_id_map.at(loop_end->get_id()));
+            loop_end->set_id(loop_id_map.at(current_id));
         }
 
         auto expr_loop_ids = expr->get_loop_ids();

--- a/src/common/snippets/src/lowered/pass/normalize_loop_ids.cpp
+++ b/src/common/snippets/src/lowered/pass/normalize_loop_ids.cpp
@@ -60,7 +60,7 @@ bool NormalizeLoopIDs::run(lowered::LinearIR& linear_ir) {
     }
 
     // Secondly, we blend `LoopInfo` in the LoopManager::m_map by new Loop IDs
-    const auto updated = linear_ir.get_loop_manager()->reassign_identifiers(loop_id_map);
+    const auto updated = linear_ir.get_loop_manager()->reorder_identifiers(loop_id_map);
     if (!updated)
         return false;
 

--- a/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
+++ b/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
@@ -24,9 +24,9 @@ void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
     OPENVINO_ASSERT(snippets::utils::implication(most_outer_loop, new_dim_value != SIZE_MAX),
                     "if the updated subtensor propagation was called for the outer loop, new_dim_value must not be equal to default value");
     std::map<lowered::PortDescriptorPtr, snippets::VectorDims> original_shapes;
-    // First step: set new dim value to the corresponding entry_points' dimensions
+    // First step: set new dim value to the corresponding input_ports' dimensions
     if (most_outer_loop) {
-        for (const auto& port : loop_info->get_entry_points()) {
+        for (const auto& port : loop_info->get_input_ports()) {
             const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().type;
             if ((port.is_incremented && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
                 const auto& expr = port.expr_port->get_expr();
@@ -99,9 +99,9 @@ void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
             const auto inner_begin = std::next(expr_it);
             const auto inner_end = linear_ir.find_after(inner_begin, linear_ir.get_expr_by_node(loop_end));
 
-            // The corresponding shapes of inner loops entry points must be updated using existing subtensor values
+            // The corresponding shapes of inner loops input ports must be updated using existing subtensor values
             if (!most_outer_loop) {
-                for (const auto& port : loop_info->get_entry_points())
+                for (const auto& port : loop_info->get_input_ports())
                     update_only_dim_idx_with_subtensor_value(port);
             }
             propagate_updated_subtensor_through_loop(linear_ir, inner_loop_info, inner_begin, inner_end, false);

--- a/src/common/snippets/src/lowered/pass/reduce_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/reduce_decomposition.cpp
@@ -51,8 +51,6 @@ std::shared_ptr<ov::Node> get_horizon_node(const ov::Output<ov::Node>& input, co
 }
 }  // namespace
 
-using HandlerType = SpecificIterationHandlers::HandlerType;
-
 ReduceDecomposition::ReduceDecomposition(size_t vector_size) : RangedPass(), m_vector_size{vector_size} {}
 
 bool ReduceDecomposition::run(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end) {
@@ -100,7 +98,8 @@ bool ReduceDecomposition::run(LinearIR& linear_ir, LinearIR::constExprIt begin, 
             std::vector<ExpressionPort>{(*accumulation.first)->get_output_port(0)});
         const auto tail_size = utils::is_dynamic_value(work_amount) ? 1lu : work_amount % increment;
         if (tail_size != 0) {
-            loop_manager->get_loop_info(reduce_loop_id)->register_handler<HandlerType::LAST_ITER, SetFillOffset>(tail_size);
+            const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(reduce_loop_id);
+            loop_info->register_handler<SpecificLoopIterType::LAST_ITER, SetFillOffset>(tail_size);
         }
         const auto horizon = push_node(get_horizon_node(accumulation.second, reduce_type_info));
 

--- a/src/common/snippets/src/lowered/pass/reduce_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/reduce_decomposition.cpp
@@ -108,15 +108,15 @@ bool ReduceDecomposition::run(LinearIR& linear_ir, LinearIR::constExprIt begin, 
         replace_input_port_connectors(reduce_expr->get_output_port_connector(0)->get_consumers(), horizon.first->get()->get_output_port_connector(0));
 
         // Update Loop info for outer loops
-        const std::vector<ExpressionPort> entry_points{(*fill.first)->get_input_port(0)};
-        const std::vector<ExpressionPort> exit_points{(*horizon.first)->get_output_port(0)};
+        const std::vector<ExpressionPort> input_ports{(*fill.first)->get_input_port(0)};
+        const std::vector<ExpressionPort> output_ports{(*horizon.first)->get_output_port(0)};
         for (auto loop_id : reduce_expr->get_loop_ids()) {
             loop_manager->expression_replacement(vector_buffer.first,
                                                  expr_it,
                                                  reduce_expr,
                                                  loop_id,
-                                                 entry_points,
-                                                 exit_points);
+                                                 input_ports,
+                                                 output_ports);
         }
 
         expr_it = linear_ir.erase(expr_it);

--- a/src/common/snippets/src/lowered/pass/reduce_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/reduce_decomposition.cpp
@@ -99,7 +99,7 @@ bool ReduceDecomposition::run(LinearIR& linear_ir, LinearIR::constExprIt begin, 
         const auto tail_size = utils::is_dynamic_value(work_amount) ? 1lu : work_amount % increment;
         if (tail_size != 0) {
             const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(reduce_loop_id);
-            loop_info->register_handler<SpecificLoopIterType::LAST_ITER, SetFillOffset>(tail_size);
+            loop_info->register_pass_to_handler<SpecificLoopIterType::LAST_ITER, SetFillOffset>(tail_size);
         }
         const auto horizon = push_node(get_horizon_node(accumulation.second, reduce_type_info));
 

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -18,7 +18,8 @@ namespace pass {
 
 SplitLoops::SplitLoops() : RangedPass() {}
 
-bool SplitLoops::can_be_split(const LoopInfoPtr& loop_to_split, const LoopInfoPtr& loop_to_fuse) {
+bool SplitLoops::can_be_split(const UnifiedLoopInfoPtr& loop_to_split, const UnifiedLoopInfoPtr& loop_to_fuse) {
+    OPENVINO_ASSERT(loop_to_split != nullptr && loop_to_fuse != nullptr, "LoopInfo is nullptr!");
     const auto current_dim_idx = loop_to_split->get_dim_idx();
     const auto parent_dim_idx = loop_to_fuse->get_dim_idx();
     const auto& handlers = loop_to_split->get_handlers();
@@ -80,7 +81,7 @@ bool SplitLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, 
                                                                    loop_to_split->get_dim_idx(),
                                                                    loop_to_split->get_entry_points(),
                                                                    loop_to_split->get_exit_points());
-                const auto& new_loop_info = loop_manager->get_loop_info(split_loop_id);
+                const auto& new_loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(split_loop_id);
                 const auto work_amount = loop_to_fuse->get_work_amount();
                 const auto increment = loop_to_fuse->get_increment();
                 const auto tail_size = work_amount % increment;

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -43,7 +43,7 @@ bool SplitLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, 
         // Splitting could also be done in a more general case, but the splitted loop and its parent must always
         // be in the same set of outer loops. Otherwise they won't be fused.
         const auto& loop_id = loop_ids.front();
-        const auto loop = loop_manager->get_loop_info(loop_id);
+        const auto loop = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
         for (const auto& entry_point : loop->get_entry_points()) {
             const auto& parent_port = entry_point.expr_port->get_port_connector_ptr()->get_source();
             const auto& parent_expr = parent_port.get_expr();
@@ -52,11 +52,11 @@ bool SplitLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, 
                 continue;
 
             const auto& parent_loop_id = parent_loop_ids.front();
-            const auto parent_loop = loop_manager->get_loop_info(parent_loop_id);
+            const auto parent_loop = loop_manager->get_loop_info<UnifiedLoopInfo>(parent_loop_id);
 
             const bool split_parent = parent_loop->get_increment() < loop->get_increment();
-            const auto upper_loop = std::make_shared<LoopInfo>(*parent_loop);
-            const auto lower_loop = std::make_shared<LoopInfo>(*loop);
+            const auto upper_loop = std::make_shared<UnifiedLoopInfo>(*parent_loop);
+            const auto lower_loop = std::make_shared<UnifiedLoopInfo>(*loop);
             if (split_parent)
                 upper_loop->set_increment(loop->get_increment());
             else
@@ -86,7 +86,7 @@ bool SplitLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, 
                 const auto tail_size = work_amount % increment;
                 auto new_handlers = loop_to_split->get_handlers();
                 if (tail_size != 0) {
-                    new_handlers.register_handler<SpecificIterationHandlers::HandlerType::LAST_ITER, TransformInnerSplitLoop>(tail_size);
+                    new_handlers.register_handler<SpecificLoopIterType::LAST_ITER, TransformInnerSplitLoop>(tail_size);
                 }
                 new_loop_info->set_handlers(new_handlers);
                 break;

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -46,8 +46,8 @@ bool SplitLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, 
         // be in the same set of outer loops. Otherwise they won't be fused.
         const auto& loop_id = loop_ids.front();
         const auto loop = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
-        for (const auto& entry_point : loop->get_entry_points()) {
-            const auto& parent_port = entry_point.expr_port->get_port_connector_ptr()->get_source();
+        for (const auto& input_port : loop->get_input_ports()) {
+            const auto& parent_port = input_port.expr_port->get_port_connector_ptr()->get_source();
             const auto& parent_expr = parent_port.get_expr();
             const auto& parent_loop_ids = parent_expr->get_loop_ids();
             if (parent_loop_ids.empty())
@@ -73,15 +73,15 @@ bool SplitLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, 
 
                 const auto& loop_to_split_id = split_parent ? parent_loop_id : loop_id;
                 const auto loop_bounds = LoopManager::get_loop_bounds(linear_ir, loop_to_split_id,
-                                                                      loop_to_split->get_entry_points(),
-                                                                      loop_to_split->get_exit_points());
+                                                                      loop_to_split->get_input_ports(),
+                                                                      loop_to_split->get_output_ports());
                 const auto split_loop_id = loop_manager->mark_loop(loop_bounds.first,
                                                                    loop_bounds.second,
                                                                    loop_to_fuse->get_work_amount(),
                                                                    loop_to_fuse->get_increment(),
                                                                    loop_to_split->get_dim_idx(),
-                                                                   loop_to_split->get_entry_points(),
-                                                                   loop_to_split->get_exit_points());
+                                                                   loop_to_split->get_input_ports(),
+                                                                   loop_to_split->get_output_ports());
                 const auto& new_loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(split_loop_id);
                 const auto work_amount = loop_to_fuse->get_work_amount();
                 const auto increment = loop_to_fuse->get_increment();

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -24,7 +24,8 @@ bool SplitLoops::can_be_split(const UnifiedLoopInfoPtr& loop_to_split, const Uni
     const auto parent_dim_idx = loop_to_fuse->get_dim_idx();
     const auto& handlers = loop_to_split->get_handlers();
     const bool equal_dim_idxes = current_dim_idx != LoopInfo::UNDEFINED_DIM_IDX && current_dim_idx == parent_dim_idx;
-    const bool only_main_body = handlers.get_first_iter_handlers().empty() && handlers.get_last_iter_handlers().empty();
+    const bool only_main_body = handlers.get_passes<SpecificLoopIterType::FIRST_ITER>().empty() &&
+                                handlers.get_passes<SpecificLoopIterType::LAST_ITER>().empty();
     return loop_to_split->get_work_amount() == loop_to_fuse->get_work_amount() &&
            loop_to_split->get_increment() != loop_to_fuse->get_increment() && equal_dim_idxes && only_main_body;
 }
@@ -87,7 +88,7 @@ bool SplitLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, 
                 const auto tail_size = work_amount % increment;
                 auto new_handlers = loop_to_split->get_handlers();
                 if (tail_size != 0) {
-                    new_handlers.register_handler<SpecificLoopIterType::LAST_ITER, TransformInnerSplitLoop>(tail_size);
+                    new_handlers.register_pass<SpecificLoopIterType::LAST_ITER, TransformInnerSplitLoop>(tail_size);
                 }
                 new_loop_info->set_handlers(new_handlers);
                 break;

--- a/src/common/snippets/src/lowered/pass/validate.cpp
+++ b/src/common/snippets/src/lowered/pass/validate.cpp
@@ -106,9 +106,9 @@ void validate_loop_end_static(const ExpressionPtr& expr, const LinearIR& linear_
     const auto& final_offsets = loop_end->get_finalization_offsets();
     auto validate_loop_ports = [&](const std::vector<UnifiedLoopInfo::LoopPortInfo>& loop_port_infos, size_t shift = 0) {
         for (size_t i = 0; i < loop_port_infos.size(); ++i) {
-            OPENVINO_ASSERT(is_incremented[i + shift] == loop_port_infos[i].first.is_incremented &&
-                            ptr_increments[i + shift] == loop_port_infos[i].second.ptr_increment &&
-                            final_offsets[i + shift] == loop_port_infos[i].second.finalization_offset,
+            OPENVINO_ASSERT(is_incremented[i + shift] == loop_port_infos[i].port.is_incremented &&
+                            ptr_increments[i + shift] == loop_port_infos[i].desc.ptr_increment &&
+                            final_offsets[i + shift] == loop_port_infos[i].desc.finalization_offset,
                             "Incompatible data ptr shifts in LoopEndStatic and the corresponding LoopInfo");
         }
     };
@@ -127,10 +127,8 @@ void validate_loop_end_dynamic(const ExpressionPtr& expr, const LinearIR& linear
     OPENVINO_ASSERT(loop_info->get_increment() == loop_end->get_increment(),
                     "Incompatible LoopEndDynamic and the corresponding LoopInfo");
 
-    const auto& input_ports = loop_info->get_input_ports();
-    const auto& output_ports = loop_info->get_output_ports();
-    OPENVINO_ASSERT(input_ports.size() == loop_end->get_input_num() &&
-                    output_ports.size() == loop_end->get_output_num(),
+    OPENVINO_ASSERT(loop_info->get_input_count() == loop_end->get_input_num() &&
+                    loop_info->get_output_count() == loop_end->get_output_num(),
                     "Incompatible LoopEndStatic and the corresponding LoopInfo");
 
     const auto& is_incremented = loop_end->get_is_incremented();
@@ -141,8 +139,8 @@ void validate_loop_end_dynamic(const ExpressionPtr& expr, const LinearIR& linear
                         "Incompatible data ptr shifts in LoopEndStatic and the corresponding LoopInfo");
         }
     };
-    validate_loop_ports(input_ports);
-    validate_loop_ports(output_ports, loop_end->get_input_num());
+    validate_loop_ports(loop_info->get_input_ports());
+    validate_loop_ports(loop_info->get_output_ports(), loop_end->get_input_num());
 }
 } // namespace
 

--- a/src/common/snippets/src/lowered/pass/validate.cpp
+++ b/src/common/snippets/src/lowered/pass/validate.cpp
@@ -90,31 +90,30 @@ void validate_loop_end_static(const ExpressionPtr& expr, const LinearIR& linear_
                     "LoopEndStatic must be connected to the LoopBeginStatic");
 
     const auto& loop_manager = linear_ir.get_loop_manager();
-    const auto& loop_info = loop_manager->get_loop_info(loop_end->get_id());
+    const auto& loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     OPENVINO_ASSERT(loop_info->get_work_amount() == loop_end->get_work_amount() &&
                     loop_info->get_increment() == loop_end->get_increment(),
                     "Incompatible LoopEndStatic and the corresponding LoopInfo");
 
-    const auto& entry_points = loop_info->get_entry_points();
-    const auto& exit_points = loop_info->get_exit_points();
-    OPENVINO_ASSERT(entry_points.size() == loop_end->get_input_num() &&
-                    exit_points.size() == loop_end->get_output_num(),
+    const auto entry_point_infos = loop_info->get_entry_ports_info();
+    const auto exit_point_infos = loop_info->get_exit_ports_info();
+    OPENVINO_ASSERT(entry_point_infos.size() == loop_end->get_input_num() &&
+                    exit_point_infos.size() == loop_end->get_output_num(),
                     "Incompatible LoopEndStatic and the corresponding LoopInfo");
 
     const auto& is_incremented = loop_end->get_is_incremented();
     const auto& ptr_increments = loop_end->get_ptr_increments();
     const auto& final_offsets = loop_end->get_finalization_offsets();
-
-    auto validate_loop_ports = [&](const std::vector<LoopPort>& loop_ports, size_t shift = 0) {
-        for (size_t i = 0; i < loop_ports.size(); ++i) {
-        OPENVINO_ASSERT(is_incremented[i + shift] == loop_ports[i].is_incremented &&
-                        ptr_increments[i + shift] == loop_ports[i].ptr_increment &&
-                        final_offsets[i + shift] == loop_ports[i].finalization_offset,
-                        "Incompatible data ptr shifts in LoopEndStatic and the corresponding LoopInfo");
+    auto validate_loop_ports = [&](const std::vector<UnifiedLoopInfo::LoopPortInfo>& loop_port_infos, size_t shift = 0) {
+        for (size_t i = 0; i < loop_port_infos.size(); ++i) {
+            OPENVINO_ASSERT(is_incremented[i + shift] == loop_port_infos[i].first.is_incremented &&
+                            ptr_increments[i + shift] == loop_port_infos[i].second.ptr_increment &&
+                            final_offsets[i + shift] == loop_port_infos[i].second.finalization_offset,
+                            "Incompatible data ptr shifts in LoopEndStatic and the corresponding LoopInfo");
         }
     };
-    validate_loop_ports(entry_points);
-    validate_loop_ports(exit_points, loop_end->get_input_num());
+    validate_loop_ports(entry_point_infos);
+    validate_loop_ports(exit_point_infos, loop_end->get_input_num());
 }
 
 void validate_loop_end_dynamic(const ExpressionPtr& expr, const LinearIR& linear_ir) {
@@ -124,7 +123,7 @@ void validate_loop_end_dynamic(const ExpressionPtr& expr, const LinearIR& linear
                     "LoopEndDynamic must be connected to the LoopBeginDynamic");
 
     const auto& loop_manager = linear_ir.get_loop_manager();
-    const auto& loop_info = loop_manager->get_loop_info(loop_end->get_id());
+    const auto& loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     OPENVINO_ASSERT(loop_info->get_increment() == loop_end->get_increment(),
                     "Incompatible LoopEndDynamic and the corresponding LoopInfo");
 

--- a/src/common/snippets/src/lowered/pass/validate.cpp
+++ b/src/common/snippets/src/lowered/pass/validate.cpp
@@ -95,10 +95,10 @@ void validate_loop_end_static(const ExpressionPtr& expr, const LinearIR& linear_
                     loop_info->get_increment() == loop_end->get_increment(),
                     "Incompatible LoopEndStatic and the corresponding LoopInfo");
 
-    const auto entry_point_infos = loop_info->get_entry_ports_info();
-    const auto exit_point_infos = loop_info->get_exit_ports_info();
-    OPENVINO_ASSERT(entry_point_infos.size() == loop_end->get_input_num() &&
-                    exit_point_infos.size() == loop_end->get_output_num(),
+    const auto input_port_infos = loop_info->get_input_ports_info();
+    const auto output_port_infos = loop_info->get_output_ports_info();
+    OPENVINO_ASSERT(input_port_infos.size() == loop_end->get_input_num() &&
+                    output_port_infos.size() == loop_end->get_output_num(),
                     "Incompatible LoopEndStatic and the corresponding LoopInfo");
 
     const auto& is_incremented = loop_end->get_is_incremented();
@@ -112,8 +112,8 @@ void validate_loop_end_static(const ExpressionPtr& expr, const LinearIR& linear_
                             "Incompatible data ptr shifts in LoopEndStatic and the corresponding LoopInfo");
         }
     };
-    validate_loop_ports(entry_point_infos);
-    validate_loop_ports(exit_point_infos, loop_end->get_input_num());
+    validate_loop_ports(input_port_infos);
+    validate_loop_ports(output_port_infos, loop_end->get_input_num());
 }
 
 void validate_loop_end_dynamic(const ExpressionPtr& expr, const LinearIR& linear_ir) {
@@ -127,10 +127,10 @@ void validate_loop_end_dynamic(const ExpressionPtr& expr, const LinearIR& linear
     OPENVINO_ASSERT(loop_info->get_increment() == loop_end->get_increment(),
                     "Incompatible LoopEndDynamic and the corresponding LoopInfo");
 
-    const auto& entry_points = loop_info->get_entry_points();
-    const auto& exit_points = loop_info->get_exit_points();
-    OPENVINO_ASSERT(entry_points.size() == loop_end->get_input_num() &&
-                    exit_points.size() == loop_end->get_output_num(),
+    const auto& input_ports = loop_info->get_input_ports();
+    const auto& output_ports = loop_info->get_output_ports();
+    OPENVINO_ASSERT(input_ports.size() == loop_end->get_input_num() &&
+                    output_ports.size() == loop_end->get_output_num(),
                     "Incompatible LoopEndStatic and the corresponding LoopInfo");
 
     const auto& is_incremented = loop_end->get_is_incremented();
@@ -141,8 +141,8 @@ void validate_loop_end_dynamic(const ExpressionPtr& expr, const LinearIR& linear
                         "Incompatible data ptr shifts in LoopEndStatic and the corresponding LoopInfo");
         }
     };
-    validate_loop_ports(entry_points);
-    validate_loop_ports(exit_points, loop_end->get_input_num());
+    validate_loop_ports(input_ports);
+    validate_loop_ports(output_ports, loop_end->get_input_num());
 }
 } // namespace
 

--- a/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/lowered/pass/validate_expanded_loops.hpp"
+
+#include "snippets/lowered/loop_manager.hpp"
+#include "snippets/utils.hpp"
+#include "snippets/itt.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+bool ValidateExpandedLoops::run(LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ValidateExpandedLoops")
+
+    const auto& loop_manager = linear_ir.get_loop_manager();
+
+    std::set<size_t> unique_loop_ids;
+    for (const auto& expr : linear_ir) {
+        if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node())) {
+            const auto loop_id = loop_end->get_id();
+            unique_loop_ids.insert(loop_id);
+            OPENVINO_ASSERT(std::dynamic_pointer_cast<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id)),
+                            "ValidateExpandedLoops expects only ExpandedLoopInfo in LoopManager");
+        }
+    }
+    OPENVINO_ASSERT(unique_loop_ids.size() == loop_manager->get_map().size(),
+                    "ValidateExpandedLoops failed: incompatible loopIDs of inserted LoopEnd expressions and LoopInfo in LoopManager");
+
+    return true;
+}
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
@@ -13,9 +13,87 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 
-bool ValidateExpandedLoops::run(LinearIR& linear_ir) {
-    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ValidateExpandedLoops")
+#define INFORMATIVE_ASSERT(cond, ...) \
+    OPENVINO_ASSERT((cond), "Failed to validate ExpandedLoops: ", __VA_ARGS__)
 
+namespace {
+template<class T>
+void dynamic_save_add(T& lhs, const T& rhs) {
+    if (utils::is_dynamic_value(lhs) || utils::is_dynamic_value(rhs)) {
+        lhs = utils::get_dynamic_value<T>();
+        return;
+    }
+    lhs += rhs;
+}
+
+bool is_inner_splitted_tail(const ExpressionPtr& loop_expr, const LoopManagerPtr& loop_manager) {
+    const auto loop_end = ov::as_type_ptr<op::LoopEnd>(loop_expr->get_node());
+    INFORMATIVE_ASSERT(loop_end, "expects LoopEnd");
+    const auto loop_id = loop_end->get_id();
+    const auto expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id));
+    INFORMATIVE_ASSERT(expanded_loop_info, "expects only ExpandedLoopInfo in LoopManager");
+    // Inner Splitted Tail Loop has `MAIN_BODY` type for now after InsertSpecificIteration pass
+    if (expanded_loop_info->get_type() != SpecificLoopIterType::MAIN_BODY)
+        return false;
+    const auto outer_loops = loop_expr->get_loop_ids();
+    if (outer_loops.empty())
+        return false;
+    const auto outer_loop_id = outer_loops.front();
+    const auto outer_expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_manager->get_loop_info(outer_loop_id));
+    INFORMATIVE_ASSERT(outer_expanded_loop_info, "expects only ExpandedLoopInfo in LoopManager");
+    return outer_expanded_loop_info->get_type() == SpecificLoopIterType::LAST_ITER &&
+           expanded_loop_info->get_dim_idx() == outer_expanded_loop_info->get_dim_idx();
+}
+
+} // namespace
+
+void ValidateExpandedLoops::validate_loop_information(const LinearIR& linear_ir) {
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    const auto& loop_map = loop_manager->get_map();
+
+    UnifiedLoopInfoPtr current_unified_loop_info = nullptr;
+    std::vector<int64_t> total_finalization_offsets;
+    size_t current_work_amount = 0;
+    size_t num_ports = 0;
+
+    for (const auto& p : loop_map) {
+        const auto& expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(p.second);
+        INFORMATIVE_ASSERT(expanded_loop_info, "expects only ExpandedLoopInfo in LoopManager");
+
+        if (expanded_loop_info->get_unified_loop_info() != current_unified_loop_info) {
+            // If there is `current_unified_loop_info` - the previos loop is finished and need to validate total information
+            if (current_unified_loop_info) {
+                INFORMATIVE_ASSERT(current_work_amount == current_unified_loop_info->get_work_amount(),
+                                   "total work amount of expanded loops is not equal to work amount of undefined loop");
+                INFORMATIVE_ASSERT(total_finalization_offsets == current_unified_loop_info->get_finalization_offsets(),
+                                   "total finalization offsets are not equal to finalization offsets of unified loop");
+            }
+
+            current_unified_loop_info = expanded_loop_info->get_unified_loop_info();
+
+            INFORMATIVE_ASSERT(current_unified_loop_info->get_input_count() == expanded_loop_info->get_input_count() &&
+                               current_unified_loop_info->get_output_count() == expanded_loop_info->get_output_count(),
+                               "incompatible loop ports with UnifiedLoopInfo");
+
+            current_work_amount = 0;
+            num_ports = expanded_loop_info->get_input_count() + expanded_loop_info->get_output_count();
+            total_finalization_offsets.clear();
+            total_finalization_offsets.resize(num_ports, 0);
+        }
+
+        dynamic_save_add(current_work_amount, expanded_loop_info->get_work_amount());
+        INFORMATIVE_ASSERT(current_unified_loop_info->get_ptr_increments() == expanded_loop_info->get_ptr_increments(),
+                           "incompatible pointer increments with UnifiedLoopInfo");
+
+        const auto& finalization_offsets = expanded_loop_info->get_finalization_offsets();
+        INFORMATIVE_ASSERT(finalization_offsets.size() == total_finalization_offsets.size(),
+                           "incompatible finalization offset count");
+        for (size_t i = 0; i < num_ports; ++i)
+            dynamic_save_add(total_finalization_offsets[i], finalization_offsets[i]);
+    }
+}
+
+void ValidateExpandedLoops::validate_loop_expressions(const LinearIR& linear_ir) {
     const auto& loop_manager = linear_ir.get_loop_manager();
 
     std::set<size_t> unique_loop_ids;
@@ -23,15 +101,45 @@ bool ValidateExpandedLoops::run(LinearIR& linear_ir) {
         if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node())) {
             const auto loop_id = loop_end->get_id();
             unique_loop_ids.insert(loop_id);
-            OPENVINO_ASSERT(ov::as_type_ptr<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id)),
-                            "ValidateExpandedLoops expects only ExpandedLoopInfo in LoopManager");
+
+            // At the moment, InnerSpliitedTail LoopEnd is not compatible with ExpandedLoopInfo
+            // Validation is not supported
+            if (is_inner_splitted_tail(expr, loop_manager))
+                continue;
+
+            const auto expanded_loop_info = std::dynamic_pointer_cast<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id));
+            INFORMATIVE_ASSERT(expanded_loop_info, "expects only ExpandedLoopInfo in LoopManager");
+
+            INFORMATIVE_ASSERT(loop_end->get_increment() == expanded_loop_info->get_increment(),
+                               "incompatible increment of LoopEnd and ExpandedLoopInfo");
+            INFORMATIVE_ASSERT(loop_end->get_element_type_sizes() == expanded_loop_info->get_data_sizes(),
+                               "incompatible element sizes of LoopEnd and ExpandedLoopInfo");
+            if (const auto static_loop_end = ov::as_type_ptr<op::LoopEndStatic>(expr->get_node())) {
+                INFORMATIVE_ASSERT(static_loop_end->get_work_amount() == expanded_loop_info->get_work_amount(),
+                                   "incompatible work amount of LoopEnd and ExpandedLoopInfo");
+                INFORMATIVE_ASSERT(static_loop_end->get_ptr_increments() == expanded_loop_info->get_ptr_increments(),
+                                   "incompatible pointer increments of LoopEnd and ExpandedLoopInfo");
+                INFORMATIVE_ASSERT(static_loop_end->get_finalization_offsets() == expanded_loop_info->get_finalization_offsets(),
+                                   "incompatible finalization offsets of LoopEnd and ExpandedLoopInfo");
+            }
         }
     }
-    OPENVINO_ASSERT(unique_loop_ids.size() == loop_manager->get_map().size(),
-                    "ValidateExpandedLoops failed: incompatible loopIDs of inserted LoopEnd expressions and LoopInfo in LoopManager");
+    INFORMATIVE_ASSERT(unique_loop_ids.size() == loop_manager->get_map().size(),
+                      "incompatible loopIDs of inserted LoopEnd expressions and LoopInfo in LoopManager");
+}
+
+bool ValidateExpandedLoops::run(LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ValidateExpandedLoops")
+
+    // Firstly, validate mapping compatibility between ExpandedLoopInfo and original UnifiedLoopInfo
+    validate_loop_information(linear_ir);
+    // Secondly, validate that LoopEnd contains the information from ExpandedLoopInfo
+    validate_loop_expressions(linear_ir);
 
     return true;
 }
+
+#undef INFORMATIVE_ASSERT
 
 } // namespace pass
 } // namespace lowered

--- a/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
@@ -18,7 +18,7 @@ namespace pass {
 
 namespace {
 template<class T>
-void dynamic_save_add(T& lhs, const T& rhs) {
+void dynamic_safe_add(T& lhs, const T& rhs) {
     if (utils::is_dynamic_value(lhs) || utils::is_dynamic_value(rhs)) {
         lhs = utils::get_dynamic_value<T>();
         return;
@@ -81,7 +81,7 @@ void ValidateExpandedLoops::validate_loop_information(const LinearIR& linear_ir)
             total_finalization_offsets.resize(num_ports, 0);
         }
 
-        dynamic_save_add(current_work_amount, expanded_loop_info->get_work_amount());
+        dynamic_safe_add(current_work_amount, expanded_loop_info->get_work_amount());
         INFORMATIVE_ASSERT(current_unified_loop_info->get_ptr_increments() == expanded_loop_info->get_ptr_increments(),
                            "incompatible pointer increments with UnifiedLoopInfo");
 
@@ -89,7 +89,7 @@ void ValidateExpandedLoops::validate_loop_information(const LinearIR& linear_ir)
         INFORMATIVE_ASSERT(finalization_offsets.size() == total_finalization_offsets.size(),
                            "incompatible finalization offset count");
         for (size_t i = 0; i < num_ports; ++i)
-            dynamic_save_add(total_finalization_offsets[i], finalization_offsets[i]);
+            dynamic_safe_add(total_finalization_offsets[i], finalization_offsets[i]);
     }
 }
 

--- a/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
@@ -23,7 +23,7 @@ bool ValidateExpandedLoops::run(LinearIR& linear_ir) {
         if (const auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node())) {
             const auto loop_id = loop_end->get_id();
             unique_loop_ids.insert(loop_id);
-            OPENVINO_ASSERT(std::dynamic_pointer_cast<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id)),
+            OPENVINO_ASSERT(ov::as_type_ptr<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id)),
                             "ValidateExpandedLoops expects only ExpandedLoopInfo in LoopManager");
         }
     }

--- a/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
@@ -66,7 +66,7 @@ void ValidateExpandedLoops::validate_loop_information(const LinearIR& linear_ir)
                 INFORMATIVE_ASSERT(current_work_amount == current_unified_loop_info->get_work_amount(),
                                    "total work amount of expanded loops is not equal to work amount of undefined loop");
                 INFORMATIVE_ASSERT(total_finalization_offsets == current_unified_loop_info->get_finalization_offsets(),
-                                   "total finalization offsets are not equal to finalization offsets of unified loop");
+                                   "total finalization offsets are not equal to finalization offsets of undefined loop");
             }
 
             current_unified_loop_info = expanded_loop_info->get_unified_loop_info();
@@ -107,7 +107,7 @@ void ValidateExpandedLoops::validate_loop_expressions(const LinearIR& linear_ir)
             if (is_inner_splitted_tail(expr, loop_manager))
                 continue;
 
-            const auto expanded_loop_info = std::dynamic_pointer_cast<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id));
+            const auto expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id));
             INFORMATIVE_ASSERT(expanded_loop_info, "expects only ExpandedLoopInfo in LoopManager");
 
             INFORMATIVE_ASSERT(loop_end->get_increment() == expanded_loop_info->get_increment(),

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "snippets/lowered/pass/validate_loops.hpp"
+#include "snippets/lowered/pass/validate_unified_loops.hpp"
 
 #include "snippets/itt.hpp"
 #include "snippets/lowered/linear_ir.hpp"
@@ -14,10 +14,8 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 
-ValidateLoops::ValidateLoops() {}
-
-bool ValidateLoops::run(LinearIR& linear_ir) {
-    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ValidateLoops")
+bool ValidateUnifiedLoops::run(LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ValidateUnifiedLoops")
     if (linear_ir.empty())
         return false;
 
@@ -82,7 +80,9 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
     };
 
     for (const auto& pair : loops) {
-        const auto& loop_info = pair.second;
+        const auto& loop_info = std::dynamic_pointer_cast<UnifiedLoopInfo>(pair.second);
+        OPENVINO_ASSERT(loop_info,
+                        "ValidateUnifiedLoops expects only UnifiedLoopInfo in LoopManager");
         const auto& entry_points = loop_info->get_entry_points();
         const auto& exit_points = loop_info->get_exit_points();
         validate_loop_ports(entry_points);

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -37,60 +37,52 @@ bool ValidateUnifiedLoops::run(LinearIR& linear_ir) {
 
     std::vector<size_t> dim_indexes;
 
-    auto validate_loop_ports = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](const std::vector<LoopPort>& loop_ports) {
-        for (const auto& loop_port : loop_ports) {
-            const auto expr = loop_port.expr_port->get_expr();
-            const auto& loop_ids = expr->get_loop_ids();
-            // If loop_ids of the current port is subsequence of already validated IDs, skip
-            if (is_already_verified(loop_ids))
-                continue;
+    auto validate_loop_port = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](const LoopPort& loop_port) {
+        const auto expr = loop_port.expr_port->get_expr();
+        const auto& loop_ids = expr->get_loop_ids();
+        // If loop_ids of the current port is subsequence of already validated IDs, skip
+        if (is_already_verified(loop_ids))
+            return;
 
-            dim_indexes.clear();
-            dim_indexes.reserve(loop_ids.size());
-            // Outer Loop -> Inner Loop
-            for (size_t i = 0; i < loop_ids.size(); ++i) {
-                const auto id = loop_ids[i];
-                const auto dim_idx = loop_manager->get_loop_info(id)->get_dim_idx();
-                // if the loop has different dimension indexes, it don't have to meet the split loop related requirements
-                if (dim_idx == LoopInfo::UNDEFINED_DIM_IDX)
-                    continue;
-                if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) != dim_indexes.cend()) {
-                    OPENVINO_ASSERT(*dim_indexes.rbegin() == dim_idx,
-                                    "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
-                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->get_increment() == loop_manager->get_loop_info(id)->get_work_amount(),
-                                    "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
-                }
-                dim_indexes.push_back(dim_idx);
+        dim_indexes.clear();
+        dim_indexes.reserve(loop_ids.size());
+        // Outer Loop -> Inner Loop
+        for (size_t i = 0; i < loop_ids.size(); ++i) {
+            const auto id = loop_ids[i];
+            const auto dim_idx = loop_manager->get_loop_info(id)->get_dim_idx();
+            // if the loop has different dimension indexes, it don't have to meet the split loop related requirements
+            if (dim_idx == LoopInfo::UNDEFINED_DIM_IDX)
+                continue;
+            if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) != dim_indexes.cend()) {
+                OPENVINO_ASSERT(*dim_indexes.rbegin() == dim_idx,
+                                "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
+                OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->get_increment() == loop_manager->get_loop_info(id)->get_work_amount(),
+                                "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
             }
-            validated_nested_loops.insert(loop_ids);
+            dim_indexes.push_back(dim_idx);
         }
-    };
-
-    auto add_ports_dims_to_unique_dims = [](const std::vector<LoopPort>& loop_ports, std::set<size_t>& unique_dims, bool is_entry) {
-        for (const auto& loop_port : loop_ports) {
-            if (!loop_port.is_incremented)
-                continue;
-            const auto planar_shape = is_entry ? ov::snippets::utils::get_planar_vdims(*loop_port.expr_port)
-                                               : ov::snippets::utils::get_preordered_vdims(*loop_port.expr_port);
-            const auto& dim = *(planar_shape.rbegin() + loop_port.dim_idx);
-            // Since dim == 1 can be broadcasted to any value, it's not necessary to add it to unique dims
-            if (!utils::is_dynamic_value(dim) && dim != 1)
-                unique_dims.insert(dim);
-        }
+        validated_nested_loops.insert(loop_ids);
     };
 
     for (const auto& pair : loops) {
         const auto& loop_info = ov::as_type_ptr<UnifiedLoopInfo>(pair.second);
         OPENVINO_ASSERT(loop_info,
                         "ValidateUnifiedLoops expects only UnifiedLoopInfo in LoopManager");
-        const auto& input_ports = loop_info->get_input_ports();
-        const auto& output_ports = loop_info->get_output_ports();
-        validate_loop_ports(input_ports);
-        validate_loop_ports(output_ports);
+        loop_info->iterate_through_ports(validate_loop_port);
 
+        // Validate that iteration dimnsion is broadcastable
         std::set<size_t> unique_dimensions;
-        add_ports_dims_to_unique_dims(input_ports, unique_dimensions, true);
-        add_ports_dims_to_unique_dims(output_ports, unique_dimensions, false);
+        loop_info->iterate_through_ports([&unique_dimensions](const LoopPort& loop_port) {
+            if (loop_port.is_incremented) {
+                const auto is_input = loop_port.expr_port->get_type() == ExpressionPort::Input;
+                const auto planar_shape = is_input ? ov::snippets::utils::get_planar_vdims(*loop_port.expr_port)
+                                                   : ov::snippets::utils::get_preordered_vdims(*loop_port.expr_port);
+                const auto& dim = *(planar_shape.rbegin() + loop_port.dim_idx);
+                // Since dim == 1 can be broadcasted to any value, it's not necessary to add it to unique dims
+                if (!utils::is_dynamic_value(dim) && dim != 1)
+                    unique_dimensions.insert(dim);
+            }
+        });
         OPENVINO_ASSERT(unique_dimensions.size() <= 1,
                         "Loop ports have incompatible dimensions, by which the loop iterates");
     }

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -83,14 +83,14 @@ bool ValidateUnifiedLoops::run(LinearIR& linear_ir) {
         const auto& loop_info = ov::as_type_ptr<UnifiedLoopInfo>(pair.second);
         OPENVINO_ASSERT(loop_info,
                         "ValidateUnifiedLoops expects only UnifiedLoopInfo in LoopManager");
-        const auto& entry_points = loop_info->get_entry_points();
-        const auto& exit_points = loop_info->get_exit_points();
-        validate_loop_ports(entry_points);
-        validate_loop_ports(exit_points);
+        const auto& input_ports = loop_info->get_input_ports();
+        const auto& output_ports = loop_info->get_output_ports();
+        validate_loop_ports(input_ports);
+        validate_loop_ports(output_ports);
 
         std::set<size_t> unique_dimensions;
-        add_ports_dims_to_unique_dims(entry_points, unique_dimensions, true);
-        add_ports_dims_to_unique_dims(exit_points, unique_dimensions, false);
+        add_ports_dims_to_unique_dims(input_ports, unique_dimensions, true);
+        add_ports_dims_to_unique_dims(output_ports, unique_dimensions, false);
         OPENVINO_ASSERT(unique_dimensions.size() <= 1,
                         "Loop ports have incompatible dimensions, by which the loop iterates");
     }

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -80,7 +80,7 @@ bool ValidateUnifiedLoops::run(LinearIR& linear_ir) {
     };
 
     for (const auto& pair : loops) {
-        const auto& loop_info = std::dynamic_pointer_cast<UnifiedLoopInfo>(pair.second);
+        const auto& loop_info = ov::as_type_ptr<UnifiedLoopInfo>(pair.second);
         OPENVINO_ASSERT(loop_info,
                         "ValidateUnifiedLoops expects only UnifiedLoopInfo in LoopManager");
         const auto& entry_points = loop_info->get_entry_points();

--- a/src/common/snippets/src/lowered/specific_loop_iter_handlers.cpp
+++ b/src/common/snippets/src/lowered/specific_loop_iter_handlers.cpp
@@ -40,6 +40,19 @@ const pass::PassPipeline& SpecificIterationHandlers::get_last_iter_handlers() co
     return m_last_iter_handlers;
 }
 
+const pass::PassPipeline& SpecificIterationHandlers::get_handlers_by_type(SpecificLoopIterType Type) const {
+    switch (Type) {
+        case (SpecificLoopIterType::FIRST_ITER):
+            return get_first_iter_handlers();
+        case (SpecificLoopIterType::MAIN_BODY):
+            return get_main_iter_handlers();
+        case (SpecificLoopIterType::LAST_ITER):
+            return get_last_iter_handlers();
+        default:
+            OPENVINO_THROW("Unknown SpecificLoopIterType type!");
+    }
+}
+
 SpecificIterationHandlers SpecificIterationHandlers::merge_handlers(
     const SpecificIterationHandlers& lhs,
     const SpecificIterationHandlers& rhs) {

--- a/src/common/snippets/src/lowered/specific_loop_iter_handlers.cpp
+++ b/src/common/snippets/src/lowered/specific_loop_iter_handlers.cpp
@@ -28,38 +28,13 @@ SpecificIterationHandlers::SpecificIterationHandlers(lowered::pass::PassPipeline
       m_main_body_handlers(std::move(main_body_handlers)),
       m_last_iter_handlers(std::move(last_iter_handlers)) {}
 
-const pass::PassPipeline& SpecificIterationHandlers::get_first_iter_handlers() const {
-    return m_first_iter_handlers;
-}
-
-const pass::PassPipeline& SpecificIterationHandlers::get_main_iter_handlers() const {
-    return m_main_body_handlers;
-}
-
-const pass::PassPipeline& SpecificIterationHandlers::get_last_iter_handlers() const {
-    return m_last_iter_handlers;
-}
-
-const pass::PassPipeline& SpecificIterationHandlers::get_handlers_by_type(SpecificLoopIterType Type) const {
-    switch (Type) {
-        case (SpecificLoopIterType::FIRST_ITER):
-            return get_first_iter_handlers();
-        case (SpecificLoopIterType::MAIN_BODY):
-            return get_main_iter_handlers();
-        case (SpecificLoopIterType::LAST_ITER):
-            return get_last_iter_handlers();
-        default:
-            OPENVINO_THROW("Unknown SpecificLoopIterType type!");
-    }
-}
-
 SpecificIterationHandlers SpecificIterationHandlers::merge_handlers(
     const SpecificIterationHandlers& lhs,
     const SpecificIterationHandlers& rhs) {
     return SpecificIterationHandlers(
-        pass::PassPipeline::merge_pipelines(lhs.get_first_iter_handlers(), rhs.get_first_iter_handlers()),
-        pass::PassPipeline::merge_pipelines(lhs.get_main_iter_handlers(), rhs.get_main_iter_handlers()),
-        pass::PassPipeline::merge_pipelines(lhs.get_last_iter_handlers(), rhs.get_last_iter_handlers()));
+        pass::PassPipeline::merge_pipelines(lhs.m_first_iter_handlers, rhs.m_first_iter_handlers),
+        pass::PassPipeline::merge_pipelines(lhs.m_main_body_handlers, rhs.m_main_body_handlers),
+        pass::PassPipeline::merge_pipelines(lhs.m_last_iter_handlers, rhs.m_last_iter_handlers));
 }
 
 } // namespace lowered

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -37,7 +37,7 @@
 #include "snippets/lowered/pass/move_scalar_to_consumer.hpp"
 #include "snippets/lowered/pass/move_result_out_of_loop.hpp"
 #include "snippets/lowered/pass/clean_repeated_ptr_shifts.hpp"
-#include "snippets/lowered/pass/validate_loops.hpp"
+#include "snippets/lowered/pass/validate_unified_loops.hpp"
 #include "snippets/lowered/pass/insert_loops.hpp"
 #include "snippets/lowered/pass/optimize_domain.hpp"
 #include "snippets/lowered/pass/insert_perf_count.hpp"
@@ -442,7 +442,7 @@ void Subgraph::control_flow_transformations(lowered::LinearIR& linear_ir,
     pipeline.register_pass<lowered::pass::InsertBroadcastMove>();
     pipeline.register_pass<lowered::pass::LoadMoveBroadcastToBroadcastLoad>();
     pipeline.register_pass<lowered::pass::ValidateShapes>();
-    pipeline.register_pass<lowered::pass::ValidateLoops>();
+    pipeline.register_pass<lowered::pass::ValidateUnifiedLoops>();
     pipeline.register_pass<lowered::pass::InitLoops>();
     pipeline.register_pass<lowered::pass::InsertLoops>();
     pipeline.register_pass<lowered::pass::AllocateBuffers>(lowering_result.buffer_scratchpad_size, linear_ir.get_config().m_are_buffers_optimized);

--- a/src/common/snippets/tests/src/lowered/pass/buffer_allocation.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/buffer_allocation.cpp
@@ -10,7 +10,6 @@
 #include "snippets/lowered/pass/mark_loops.hpp"
 #include "snippets/lowered/pass/init_loops.hpp"
 #include "snippets/lowered/pass/insert_load_store.hpp"
-#include "snippets/lowered/pass/validate_loops.hpp"
 #include "snippets/lowered/pass/insert_loops.hpp"
 #include "snippets/lowered/pass/allocate_buffers.hpp"
 #include "snippets/lowered/pass/fuse_loops.hpp"

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -47,10 +47,10 @@ static void init_linear_ir(const std::vector<ov::PartialShape>& in_shapes, Linea
     loop_manager->mark_loop(expr_it, std::next(expr_it), inner_wa, inner_inc, 0, loop_entry_points, loop_exit_points);
     loop_manager->mark_loop(expr_it, std::next(expr_it), blocked_wa, blocked_inc, 1, loop_entry_points, loop_exit_points);
     const auto loop_id = loop_manager->mark_loop(expr_it, std::next(expr_it), outer_wa, outer_inc, 1, loop_entry_points, loop_exit_points);
-    const auto& outer_loop_info = loop_manager->get_loop_info(loop_id);
+    const auto& outer_loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
     const auto outer_tail_size = outer_wa % outer_inc;
     if (outer_tail_size != 0) {
-        outer_loop_info->register_handler<SpecificIterationHandlers::HandlerType::LAST_ITER, pass::TransformInnerSplitLoop>(outer_tail_size);
+        outer_loop_info->register_handler<SpecificLoopIterType::LAST_ITER, pass::TransformInnerSplitLoop>(outer_tail_size);
     }
 }
 

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -35,8 +35,8 @@ static void init_linear_ir(const std::vector<ov::PartialShape>& in_shapes, Linea
                                 [](const ExpressionPtr& expr) { return ov::is_type<ov::op::v1::Add>(expr->get_node()); });
     ASSERT_TRUE(expr_it != linear_ir.cend());
     const auto add = *expr_it;
-    const auto loop_entry_points = std::vector<ExpressionPort>{add->get_input_port(0), add->get_input_port(1)};
-    const auto loop_exit_points = std::vector<ExpressionPort>{add->get_output_port(0)};
+    const auto loop_input_ports = std::vector<ExpressionPort>{add->get_input_port(0), add->get_input_port(1)};
+    const auto loop_output_ports = std::vector<ExpressionPort>{add->get_output_port(0)};
     const auto loop_manager = linear_ir.get_loop_manager();
     const auto in_shape0 = in_shapes[0].get_shape();
     const auto in_shape1 = in_shapes[1].get_shape();
@@ -46,9 +46,9 @@ static void init_linear_ir(const std::vector<ov::PartialShape>& in_shapes, Linea
     const auto blocked_inc = 1;
     const auto outer_wa = std::max(*(in_shape0.rbegin() + 1), *(in_shape1.rbegin() + 1));
     const auto outer_inc = blocked_wa;
-    loop_manager->mark_loop(expr_it, std::next(expr_it), inner_wa, inner_inc, 0, loop_entry_points, loop_exit_points);
-    loop_manager->mark_loop(expr_it, std::next(expr_it), blocked_wa, blocked_inc, 1, loop_entry_points, loop_exit_points);
-    const auto loop_id = loop_manager->mark_loop(expr_it, std::next(expr_it), outer_wa, outer_inc, 1, loop_entry_points, loop_exit_points);
+    loop_manager->mark_loop(expr_it, std::next(expr_it), inner_wa, inner_inc, 0, loop_input_ports, loop_output_ports);
+    loop_manager->mark_loop(expr_it, std::next(expr_it), blocked_wa, blocked_inc, 1, loop_input_ports, loop_output_ports);
+    const auto loop_id = loop_manager->mark_loop(expr_it, std::next(expr_it), outer_wa, outer_inc, 1, loop_input_ports, loop_output_ports);
     const auto& outer_loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
     const auto outer_tail_size = outer_wa % outer_inc;
     if (outer_tail_size != 0) {

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -69,9 +69,9 @@ static void apply_transformations(LinearIR& linear_ir, const std::shared_ptr<pas
     pipeline.register_pass<pass::InsertLoops>();
     pipeline.register_pass<pass::InsertSpecificIterations>();
     pipeline.register_pass<pass::NormalizeLoopIDs>(!is_loop_decomp_disabled);
+    pipeline.register_pass<pass::ValidateExpandedLoops>();
     pipeline.register_pass<pass::CleanupLoopOffsets>();
     pipeline.register_pass<pass::OptimizeLoopSingleEvaluation>();
-    pipeline.register_pass<pass::ValidateExpandedLoops>();
     pipeline.run(linear_ir);
 }
 

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -52,7 +52,7 @@ static void init_linear_ir(const std::vector<ov::PartialShape>& in_shapes, Linea
     const auto& outer_loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
     const auto outer_tail_size = outer_wa % outer_inc;
     if (outer_tail_size != 0) {
-        outer_loop_info->register_handler<SpecificLoopIterType::LAST_ITER, pass::TransformInnerSplitLoop>(outer_tail_size);
+        outer_loop_info->register_pass_to_handler<SpecificLoopIterType::LAST_ITER, pass::TransformInnerSplitLoop>(outer_tail_size);
     }
 }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
@@ -169,8 +169,8 @@ bool BrgemmBlocking::run(LinearIR& linear_ir, LinearIR::constExprIt begin, Linea
                 LoopPort(brgemm_cpu && brgemm_cpu->is_with_data_repacking() ? copy_b_expr->get_input_port(0) : brgemm_expr->get_input_port(1), true, 1)};
             const std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), false)};
             const auto id = loop_manager->mark_loop(loop_begin_it, loop_end_it, k, block_size_k, entries, exits);
-            const auto loop_info = loop_manager->get_loop_info<ov::snippets::lowered::UnifiedLoopInfo>(id);
-            loop_info->register_handler<ov::snippets::lowered::SpecificLoopIterType::FIRST_ITER, SetBrgemmBeta>(0.f);
+            const auto& loop_info = loop_manager->get_loop_info<ov::snippets::lowered::UnifiedLoopInfo>(id);
+            loop_info->register_pass_to_handler<ov::snippets::lowered::SpecificLoopIterType::FIRST_ITER, SetBrgemmBeta>(0.f);
         };
 
         if (block_size_k != k) {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
@@ -169,7 +169,8 @@ bool BrgemmBlocking::run(LinearIR& linear_ir, LinearIR::constExprIt begin, Linea
                 LoopPort(brgemm_cpu && brgemm_cpu->is_with_data_repacking() ? copy_b_expr->get_input_port(0) : brgemm_expr->get_input_port(1), true, 1)};
             const std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), false)};
             const auto id = loop_manager->mark_loop(loop_begin_it, loop_end_it, k, block_size_k, entries, exits);
-            loop_manager->get_loop_info(id)->register_handler<SpecificIterationHandlers::HandlerType::FIRST_ITER, SetBrgemmBeta>(0.f);
+            const auto loop_info = loop_manager->get_loop_info<ov::snippets::lowered::UnifiedLoopInfo>(id);
+            loop_info->register_handler<ov::snippets::lowered::SpecificLoopIterType::FIRST_ITER, SetBrgemmBeta>(0.f);
         };
 
         if (block_size_k != k) {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
@@ -67,8 +67,8 @@ bool BrgemmBlocking::run(LinearIR& linear_ir, LinearIR::constExprIt begin, Linea
         const auto& loop_ids = brgemm_expr->get_loop_ids();
         for (const auto& id : loop_ids) {
             const auto loop = loop_manager->get_loop_info(id);
-            if (std::any_of(loop->get_entry_points().begin(), loop->get_entry_points().end(), check_port) ||
-                std::any_of(loop->get_exit_points().begin(), loop->get_exit_points().end(), check_port)) {
+            if (std::any_of(loop->get_input_ports().begin(), loop->get_input_ports().end(), check_port) ||
+                std::any_of(loop->get_output_ports().begin(), loop->get_output_ports().end(), check_port)) {
                 return true;
             }
         }

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/lowered/buffer_allocation.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/lowered/buffer_allocation.cpp
@@ -8,7 +8,6 @@
 #include "snippets/lowered/pass/mark_loops.hpp"
 #include "snippets/lowered/pass/init_loops.hpp"
 #include "snippets/lowered/pass/insert_load_store.hpp"
-#include "snippets/lowered/pass/validate_loops.hpp"
 #include "snippets/lowered/pass/insert_loops.hpp"
 #include "snippets/lowered/pass/allocate_buffers.hpp"
 #include "snippets/lowered/pass/fuse_loops.hpp"


### PR DESCRIPTION
### Details:
 - *Splitted `LoopInfo` into `ExpandedLoopInfo` and `UnifiedLoopInfo`. Now `UnifiedLoopInfo` is used for whole Loop before loop decomposition into specific iterations. `ExpandedLoopInfo` describes loop specific iterations that have been already inserted to `LinearIR`.*
 - *Added `NormalizeLoopIDs` pass to order IDs of expanded loops (specific loop iterations) by execution.*
 - *Added `ValidateExpandedLoops` pass for validation loops after decomposition.*

### Tickets:
 - *140419*


### Prerequisites:
- https://github.com/openvinotoolkit/openvino/pull/24115
- https://github.com/openvinotoolkit/openvino/pull/23710
