### PR TITLE
[CVS-132132][NPU] Move the model transformations to the "CompiledModel" constructor

### DIFF
--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -28,12 +28,12 @@ public:
      * "compiler" parameter inside the newly created "CompiledModel".
      * @param config Custom configuration object
      */
-    explicit CompiledModel(const std::shared_ptr<const ov::Model>& model,
-                           const std::shared_ptr<const ov::IPlugin>& plugin,
-                           const std::shared_ptr<IDevice>& device,
-                           const ov::SoPtr<ICompiler>& compiler,
-                           const bool profiling,
-                           const Config& config);
+    CompiledModel(const std::shared_ptr<const ov::Model>& model,
+                  const std::shared_ptr<const ov::IPlugin>& plugin,
+                  const std::shared_ptr<IDevice>& device,
+                  const ov::SoPtr<ICompiler>& compiler,
+                  const bool profiling,
+                  const Config& config);
 
     /**
      * @brief The constructor used by the "Plugin::import_model" method.
@@ -45,12 +45,12 @@ public:
      * @param compiler If set, the module will be stored inside the newly created "CompiledModel"
      * @param config Custom configuration object
      */
-    explicit CompiledModel(const std::shared_ptr<const ov::Model>& model,
-                           const std::shared_ptr<const ov::IPlugin>& plugin,
-                           const std::shared_ptr<const NetworkDescription>& networkDescription,
-                           const std::shared_ptr<IDevice>& device,
-                           const std::optional<ov::SoPtr<ICompiler>>& compiler,
-                           const Config& config);
+    CompiledModel(const std::shared_ptr<const ov::Model>& model,
+                  const std::shared_ptr<const ov::IPlugin>& plugin,
+                  const std::shared_ptr<const NetworkDescription>& networkDescription,
+                  const std::shared_ptr<IDevice>& device,
+                  const std::optional<ov::SoPtr<ICompiler>>& compiler,
+                  const Config& config);
 
     CompiledModel(const CompiledModel&) = delete;
 

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -15,6 +15,36 @@ namespace intel_npu {
 
 class CompiledModel final : public ICompiledModel {
 public:
+    /**
+     * @brief The constructor used by the "Plugin::compile_model" method.
+     * @note The compilation step has been placed inside this constructor instead of the originating call. This choice
+     * was motivated by the possibility of modifying the I/O identifiers via these passes which could potentially lead
+     * to bugs.
+     * @param model The IR of the model to be compiled
+     * @param plugin Pointer towards the NPU plugin instance
+     * @param device Backend specific object through which inference requests can be created
+     * @param compiler Module used for compiling the IR model.
+     * @param profiling Flag indicating if profiling was requested. Setting this to "true" will lead to storing the
+     * "compiler" parameter inside the newly created "CompiledModel".
+     * @param config Custom configuration object
+     */
+    explicit CompiledModel(const std::shared_ptr<const ov::Model>& model,
+                           const std::shared_ptr<const ov::IPlugin>& plugin,
+                           const std::shared_ptr<IDevice>& device,
+                           const ov::SoPtr<ICompiler>& compiler,
+                           const bool profiling,
+                           const Config& config);
+
+    /**
+     * @brief The constructor used by the "Plugin::import_model" method.
+     * @param model The IR of the already compiled model
+     * @param plugin Pointer towards the NPU plugin instance
+     * @param networkDescription Object holding the compiled model within a buffer along with distinct fields for its
+     * metadata
+     * @param device Backend specific object through which inference requests can be created
+     * @param compiler If set, the module will be stored inside the newly created "CompiledModel"
+     * @param config Custom configuration object
+     */
     explicit CompiledModel(const std::shared_ptr<const ov::Model>& model,
                            const std::shared_ptr<const ov::IPlugin>& plugin,
                            const std::shared_ptr<const NetworkDescription>& networkDescription,
@@ -48,6 +78,8 @@ private:
     void initialize_properties();
 
     void configure_stream_executors();
+
+    void create_executor();
 
     std::shared_ptr<const NetworkDescription> _networkPtr;
     const std::shared_ptr<const ov::Model> _model;

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -335,12 +335,7 @@ void CompiledModel::initialize_properties() {
 }
 
 void CompiledModel::create_executor() {
-    const bool configCreateExecutor = _config.get<CREATE_EXECUTOR>();
-    static const auto envVar = std::getenv("IE_NPU_CREATE_EXECUTOR");
-    const bool IE_NPU_CREATE_EXECUTOR =
-        envVar ? envVarStrToBool("IE_NPU_CREATE_EXECUTOR", envVar) : configCreateExecutor;
-
-    if (IE_NPU_CREATE_EXECUTOR) {
+    if (_config.get<CREATE_EXECUTOR>()) {
         _logger.info("Creating the executor inside the \"CompiledModel\" constructor");
 
         // If no device has been defined, the executor shall keep the default value of "nullptr". In this scenario,

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -42,6 +42,40 @@ using intel_npu::envVarStrToBool;
 
 CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
                              const std::shared_ptr<const ov::IPlugin>& plugin,
+                             const std::shared_ptr<IDevice>& device,
+                             const ov::SoPtr<ICompiler>& compiler,
+                             const bool profiling,
+                             const Config& config)
+    : ICompiledModel(model, plugin),
+      _model(model),
+      _config(config),
+      _logger("CompiledModel", config.get<LOG_LEVEL>()),
+      _device(device),
+      _compiler(profiling ? std::optional(compiler) : std::nullopt) {
+    OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "CompiledModel::CompiledModel");
+    OPENVINO_ASSERT(compiler != nullptr, "NPU CompiledModel: the pointer towards the compiler object is null");
+
+    try {
+        _networkPtr = std::make_shared<const NetworkDescription>(compiler->compile(model, config));
+    } catch (const std::exception& ex) {
+        OPENVINO_THROW(ex.what());
+    } catch (...) {
+        _logger.error("Unexpected exception");
+        OPENVINO_THROW("NPU CompiledModel: got an unexpected exception from compiler");
+    }
+
+    OV_ITT_TASK_CHAIN(COMPILED_MODEL, itt::domains::NPUPlugin, "CompiledModel::CompiledModel", "initialize_properties");
+    initialize_properties();
+    configure_stream_executors();
+
+    OV_ITT_TASK_NEXT(COMPILED_MODEL, "create_executor");
+    create_executor();
+
+    OV_ITT_TASK_SKIP(COMPILED_MODEL);
+}
+
+CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
+                             const std::shared_ptr<const ov::IPlugin>& plugin,
                              const std::shared_ptr<const NetworkDescription>& networkDescription,
                              const std::shared_ptr<IDevice>& device,
                              const std::optional<ov::SoPtr<ICompiler>>& compiler,
@@ -54,32 +88,15 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
       _device(device),
       _compiler(compiler) {
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "CompiledModel::CompiledModel");
-
-    if (_networkPtr == nullptr) {
-        OPENVINO_THROW("Network is null!");
-    }
+    OPENVINO_ASSERT(_networkPtr != nullptr,
+                    "NPU CompiledModel: the pointer towards the NetworkDescription object is null");
 
     OV_ITT_TASK_CHAIN(COMPILED_MODEL, itt::domains::NPUPlugin, "CompiledModel::CompiledModel", "initialize_properties");
     initialize_properties();
     configure_stream_executors();
 
     OV_ITT_TASK_NEXT(COMPILED_MODEL, "create_executor");
-    const bool configCreateExecutor = _config.get<CREATE_EXECUTOR>();
-    static const auto envVar = std::getenv("IE_NPU_CREATE_EXECUTOR");
-    const bool IE_NPU_CREATE_EXECUTOR =
-        envVar ? envVarStrToBool("IE_NPU_CREATE_EXECUTOR", envVar) : configCreateExecutor;
-
-    if (IE_NPU_CREATE_EXECUTOR) {
-        _logger.info("Creating the executor inside the \"CompiledModel\" constructor");
-
-        // If no device has been defined, the executor shall keep the default value of "nullptr". In this scenario,
-        // only export operations will be allowed
-        if (_device != nullptr) {
-            _executorPtr = _device->createExecutor(_networkPtr, _config);
-        }
-    } else {
-        _logger.info("Executor will not be created inside the \"CompiledModel\" constructor");
-    }
+    create_executor();
 
     OV_ITT_TASK_SKIP(COMPILED_MODEL);
 }
@@ -314,6 +331,25 @@ void CompiledModel::initialize_properties() {
         if (std::get<0>(property.second)) {
             _supportedProperties.emplace_back(property.first, std::get<1>(property.second));
         }
+    }
+}
+
+void CompiledModel::create_executor() {
+    const bool configCreateExecutor = _config.get<CREATE_EXECUTOR>();
+    static const auto envVar = std::getenv("IE_NPU_CREATE_EXECUTOR");
+    const bool IE_NPU_CREATE_EXECUTOR =
+        envVar ? envVarStrToBool("IE_NPU_CREATE_EXECUTOR", envVar) : configCreateExecutor;
+
+    if (IE_NPU_CREATE_EXECUTOR) {
+        _logger.info("Creating the executor inside the \"CompiledModel\" constructor");
+
+        // If no device has been defined, the executor shall keep the default value of "nullptr". In this scenario,
+        // only export operations will be allowed
+        if (_device != nullptr) {
+            _executorPtr = _device->createExecutor(_networkPtr, _config);
+        }
+    } else {
+        _logger.info("Executor will not be created inside the \"CompiledModel\" constructor");
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -508,28 +508,16 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
 
     OV_ITT_TASK_NEXT(PLUGIN_COMPILE_MODEL, "compile");
 
-    std::shared_ptr<const NetworkDescription> networkDescription;
     std::shared_ptr<ov::ICompiledModel> compiledModel;
-
-    ov::SoPtr<ICompiler> compiler;
-    try {
-        compiler = getCompiler(localConfig);
-        networkDescription = std::make_shared<const NetworkDescription>(compiler->compile(model, localConfig));
-    } catch (const std::exception& ex) {
-        OPENVINO_THROW(ex.what());
-    } catch (...) {
-        _logger.error("Unexpected exception");
-        OPENVINO_THROW("NPU ExecutableNetwork got unexpected exception from compiler");
-    }
 
     try {
         bool profiling = localConfig.get<PERF_COUNT>();
 
         compiledModel = std::make_shared<CompiledModel>(model,
                                                         shared_from_this(),
-                                                        networkDescription,
                                                         device,
-                                                        profiling ? std::optional(compiler) : std::nullopt,
+                                                        getCompiler(localConfig),
+                                                        profiling,
                                                         localConfig);
     } catch (const std::exception& ex) {
         OPENVINO_THROW(ex.what());


### PR DESCRIPTION
### Details:
 - The first requirement from the attached ticket: "Move call of transformations to CompiledModel constructor. Since the CompiledModel constructor requires input and output ports, such ports should be passed before transformations are called, otherwise we can have issues when transformation mistakenly changed names of tensors and we have issues like https://jira.devtools.intel.com/browse/CVS-122932"
 - Moving the compilation step inside the `intel_npu::CompiledModel` constructor led to the divergence of the function signature required by the two methods calling the constructor: [`intel_npu::Plugin::compile_model`](https://github.com/razvanapetroaie/openvino/blob/60dec94dc466ca41002cf5a996b005c00264af91/src/plugins/intel_npu/src/plugin/src/plugin.cpp#L510-L516) and [`intel_npu::Plugin::import_model`](https://github.com/razvanapetroaie/openvino/blob/60dec94dc466ca41002cf5a996b005c00264af91/src/plugins/intel_npu/src/plugin/src/plugin.cpp#L582-L588). Thus, the current PR introduces an additional constructor.

### Tickets:
 - *CVS-132132*

### Extra Validation:
 - PR-10217, NPU plugin repository