### PR TITLE
[EISW-112824] Register missing compiler option

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -329,7 +329,7 @@ Plugin::Plugin()
          {true,
           ov::PropertyMutability::RO,
           [&](const Config& config) {
-              return _metrics->GetDriverVersion(get_specified_device_name(config));
+              return _metrics->GetDriverVersion();
           }}},
         // NPU Private
         // =========

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -329,7 +329,7 @@ Plugin::Plugin()
          {true,
           ov::PropertyMutability::RO,
           [&](const Config& config) {
-              return _metrics->GetDriverVersion();
+              return _metrics->GetDriverVersion(get_specified_device_name(config));
           }}},
         // NPU Private
         // =========
@@ -416,6 +416,12 @@ Plugin::Plugin()
           ov::PropertyMutability::RW,
           [](const Config& config) {
               return config.get<PROFILING_TYPE>();
+          }}},
+        {ov::intel_npu::backend_compilation_params.name(),
+         {false,
+          ov::PropertyMutability::RW,
+          [](const Config& config) {
+              return config.getString<BACKEND_COMPILATION_PARAMS>();
           }}},
     };
 


### PR DESCRIPTION
### Details:
 - Register BACKEND_COMPILATION_PARAMS in properties

### Tickets:
 - *[EISW-112824](https://jira.devtools.intel.com/browse/EISW-112824)* The option was added to compiler as part of this ticket. But we also need this option registered to properties in order to start using it with single image test
