### PR TITLE
[Snippets] Test infrastructure for lowered passes

### DIFF
--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -26,7 +26,6 @@ class Expression : public std::enable_shared_from_this<Expression> {
 
 public:
     Expression() = default;
-    virtual ~Expression() = default;
 
     std::shared_ptr<Node> get_node() const;
     std::shared_ptr<Emitter> get_emitter() const;
@@ -57,19 +56,18 @@ public:
     std::vector<ExpressionPort> get_output_ports();
 
     void updateShapes();
-    virtual bool needShapeInfer() const {return true; }
-
+    bool needShapeInfer() const { return m_need_shape_infer; }
     const std::vector<size_t>& get_loop_ids() const;
     void set_loop_ids(const std::vector<size_t>& loops);
-    virtual ExpressionPtr clone_with_new_inputs(const std::vector<PortConnectorPtr>& new_inputs,
-                                                const std::shared_ptr<Node>& new_node) const;
+    ExpressionPtr clone_with_new_inputs(const std::vector<PortConnectorPtr>& new_inputs,
+                                        const std::shared_ptr<Node>& new_node) const;
     ExpressionPtr clone_with_new_inputs(const ExpressionMap& expr_map, const std::shared_ptr<Node>& new_node) const;
 
 protected:
     Expression(const Expression& other);
     // Note: The constructor initialization is private since an expression can be created only by Linear IR.
     //       The method must be used only by Linear IR builder of expressions!
-    Expression(const std::shared_ptr<Node>& n, const std::shared_ptr<IShapeInferSnippetsFactory>& factory);
+    Expression(const std::shared_ptr<Node>& n, const std::shared_ptr<IShapeInferSnippetsFactory>& factory, bool need_shape_infer = true);
     void update_node_and_connectors(const std::vector<PortConnectorPtr>& new_inputs, const std::shared_ptr<Node>& new_node);
 
     std::shared_ptr<Node> m_source_node{nullptr};
@@ -82,26 +80,7 @@ protected:
     // Note: The loops with the same dimension index (splitted dimension) should be successively nested
     std::vector<size_t> m_loop_ids{};
     std::shared_ptr<IShapeInferSnippets> m_shapeInference{nullptr};
-};
-
-class IOExpression : public Expression {
-    friend class LinearIR;
-
-public:
-    enum class io_type {INPUT, OUTPUT, UNDEFINED};
-    ExpressionPtr clone_with_new_inputs(const std::vector<PortConnectorPtr>& new_inputs,
-                                        const std::shared_ptr<Node>& new_node) const override;
-    int64_t get_index() const  { return m_index; }
-    io_type get_type() const { return m_type; }
-    // Result needs shapeInfer to copy shape from Parent's output to this expr input
-    bool needShapeInfer() const override {return m_type == io_type::OUTPUT; }
-private:
-    IOExpression(const IOExpression& other) = default;
-    explicit IOExpression(const std::shared_ptr<ov::opset1::Parameter>& n, int64_t index, const std::shared_ptr<IShapeInferSnippetsFactory>& factory);
-    explicit IOExpression(const std::shared_ptr<ov::opset1::Result>& n, int64_t index, const std::shared_ptr<IShapeInferSnippetsFactory>& factory);
-
-    int64_t m_index = -1;
-    io_type m_type = io_type::UNDEFINED;
+    const bool m_need_shape_infer = true;
 };
 
 } // namespace lowered

--- a/src/common/snippets/include/snippets/lowered/expression_factory.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_factory.hpp
@@ -33,22 +33,12 @@ public:
         }
         return create(n, params...);
     }
-    template<class ExprType, typename std::enable_if<std::is_base_of<Expression, ExprType>::value, bool>::type = true>
-    static ExpressionPtr shallow_copy(const std::shared_ptr<ExprType>& expr) {
-        if (const auto& io_expr = std::dynamic_pointer_cast<IOExpression>(expr))
-            return std::make_shared<IOExpression>(*io_expr);
-        else
-            return std::make_shared<ExprType>(*expr);
-    }
 
 private:
     /* -- Default Builders - initialize input port connectors from parents and create new output port connectors themselves */
-    static ExpressionPtr create(const std::shared_ptr<ov::op::v0::Parameter>& par, const LinearIR& linear_ir,
-                                const std::shared_ptr<ov::Model>& model);
-    static ExpressionPtr create(const std::shared_ptr<ov::op::v0::Result>& res, const LinearIR& linear_ir,
-                                const std::shared_ptr<ov::Model>& model);
-    static ExpressionPtr create(const std::shared_ptr<ov::Node>& n, const LinearIR& linear_ir,
-                                const std::shared_ptr<ov::Model>& model);
+    static ExpressionPtr create(const std::shared_ptr<ov::op::v0::Parameter>& par, const LinearIR& linear_ir);
+    static ExpressionPtr create(const std::shared_ptr<ov::op::v0::Result>& res, const LinearIR& linear_ir);
+    static ExpressionPtr create(const std::shared_ptr<ov::Node>& n, const LinearIR& linear_ir);
 
     /* -- Input Builders - get input port connectors from method parameters and create new output port connectors themselves */
     static ExpressionPtr create(const std::shared_ptr<op::LoopBegin>& n, const std::vector<PortConnectorPtr>& inputs, const LinearIR& linear_ir);

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -70,7 +70,7 @@ public:
     using exprReverseIt = container::reverse_iterator;
     using constExprReverseIt = container::const_reverse_iterator;
 
-    LinearIR(Config config = {});
+    LinearIR(Config config = {}, const std::shared_ptr<IShapeInferSnippetsFactory>& factory = {});
     LinearIR(const std::shared_ptr<ov::Model>& m, const std::shared_ptr<IShapeInferSnippetsFactory>& factory, Config config = {});
 
     ExpressionPtr create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& inputs) const;
@@ -254,17 +254,15 @@ public:
     }
 
 private:
-    std::shared_ptr<ShapeInferSnippetsNode> m_shape_infer = nullptr;
-
     class LIRShapeInfer : public ShapeInferSnippetsNode {
     public:
-        explicit LIRShapeInfer(container& body_exprs, container& param_exprs, container& result_exprs);
+        explicit LIRShapeInfer(const container& body_exprs, const container& param_exprs, const container& result_exprs);
         Result infer(const std::vector<VectorDimsRef>& input_shapes) override;
 
     private:
-        const std::shared_ptr<container> m_exprs = nullptr;
-        const std::shared_ptr<container> m_input_exprs {};
-        const std::shared_ptr<container> m_output_exprs {};
+        const container& m_exprs;
+        const container& m_input_exprs;
+        const container& m_output_exprs;
     };
 
     static ov::NodeVector get_ordered_ops(const std::shared_ptr<ov::Model>& model);
@@ -283,6 +281,7 @@ private:
     Config m_config{};
     LoopManagerPtr m_loop_manager;
     std::shared_ptr<IShapeInferSnippetsFactory> m_shape_infer_factory;
+    std::shared_ptr<ShapeInferSnippetsNode> m_shape_infer = nullptr;
     bool m_is_dynamic = false;
 
     size_t m_buffer_scratchpad_size = 0;

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -47,6 +47,10 @@ public:
     // True if the Buffer scratchpad size of LinearIR will be optimized (all possible optimizations will be activated)
     // False if all Buffers will have uniqie ID and offsets in the Linear IR
     bool m_are_buffers_optimized = true;
+    // Ticket 139785: cover this flag in LinearIR builder logic
+    // True if LIR can be fully manually built: all (including I/O) expressions can be added to LIR
+    // False if LIR can be built from ov::Model only. Prevents adding I/O expressions
+    bool m_manual_build_support = false;
 };
 
 class LinearIRBuilder;
@@ -61,19 +65,19 @@ class LinearIR {
     class ExpressionFactory;
 public:
     using container = std::list<ExpressionPtr>;
-    using io_container = std::list<std::shared_ptr<IOExpression>>;
     using exprIt = container::iterator;
     using constExprIt = container::const_iterator;
     using exprReverseIt = container::reverse_iterator;
     using constExprReverseIt = container::const_reverse_iterator;
 
-    LinearIR() = default;
+    LinearIR(Config config = {});
     LinearIR(const std::shared_ptr<ov::Model>& m, const std::shared_ptr<IShapeInferSnippetsFactory>& factory, Config config = {});
 
     ExpressionPtr create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& inputs) const;
 
     const container& get_ops() const { return m_expressions; }
-    const io_container& get_IO_ops() const { return m_io_expressions; }
+    const container& get_parameters() const { return m_parameter_expressions; }
+    const container& get_results() const { return m_result_expressions; }
     const Config& get_config() const { return m_config; }
     size_t get_buffer_scratchpad_size() const { return m_buffer_scratchpad_size; }
 
@@ -174,6 +178,22 @@ public:
         const auto consumers_py_port = consumers.empty() ? std::vector<std::set<ExpressionPort>>{} : std::vector<std::set<ExpressionPort>>{ consumers };
         return insert_node(new_node, inputs, loop_ids, update_loop_ports, place, consumers_py_port);
     }
+
+    /**
+     * @brief Constructs ov::Node from args, and inserts the node to LinearIR
+     * @param pos insertion position
+     * @param args ov::Node constructor arguments
+     * @return Pair of iterator on the inserted expr and the constructed node.
+     */
+    template <typename T, typename... Args, typename std::enable_if<std::is_base_of<ov::Node, T>::value, bool>::type = true>
+    std::pair<constExprIt, std::shared_ptr<T>> insert_node(constExprIt pos, Args&&... args) {
+        const auto node = std::make_shared<T>(std::forward<Args>(args)...);
+        const auto expr_it = insert(pos, node);
+        if (node->is_dynamic())
+            expr_it->get()->updateShapes();
+        return std::make_pair(expr_it, node);
+    }
+
     /**
      * @brief Replace the several existing expressions with the one new expression that contains `new_node`.
      *        Calls the helper `insert_node` and performs substitution: removes `old_exprs`.
@@ -223,40 +243,51 @@ public:
      */
     exprIt replace_with_expr(const std::vector<ExpressionPtr>& old_exprs, const ExpressionPtr& new_expr);
 
+    /**
+     * @brief Constructs ov::Node from args, and pushes the node to LinearIR
+     * @param args ov::Node constructor arguments
+     * @return Pair of iterator on the inserted expr and the constructed node.
+     */
+    template <typename T, typename... Args, typename std::enable_if<std::is_base_of<ov::Node, T>::value, bool>::type = true>
+    std::pair<constExprIt, std::shared_ptr<T>> push_node(Args&&... args) {
+        return insert_node<T>(end(), std::forward<Args>(args)...);
+    }
+
 private:
     std::shared_ptr<ShapeInferSnippetsNode> m_shape_infer = nullptr;
 
     class LIRShapeInfer : public ShapeInferSnippetsNode {
     public:
-        using IOExpression = lowered::IOExpression;
-        explicit LIRShapeInfer(container& body_exprs, io_container& io_exprs);
+        explicit LIRShapeInfer(container& body_exprs, container& param_exprs, container& result_exprs);
         Result infer(const std::vector<VectorDimsRef>& input_shapes) override;
 
     private:
         const std::shared_ptr<container> m_exprs = nullptr;
-        std::vector<std::shared_ptr<IOExpression>> m_input_exprs {};
-        std::vector<std::shared_ptr<IOExpression>> m_output_exprs {};
+        const std::shared_ptr<container> m_input_exprs {};
+        const std::shared_ptr<container> m_output_exprs {};
     };
 
     static ov::NodeVector get_ordered_ops(const std::shared_ptr<ov::Model>& model);
-    // Default ctor - can be called only from Linear IR initialization as default way
-    ExpressionPtr create_expression(const std::shared_ptr<Node>& n, const std::shared_ptr<ov::Model>& model = nullptr);
+    // Default way: expr port connectors are constructed basing on ov::Node connection
+    ExpressionPtr create_expression(const std::shared_ptr<Node>& n);
     ExpressionPtr create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& new_inputs,
                                     const std::vector<size_t>& loop_ids, bool update_loop_ports, const std::vector<std::set<ExpressionPort>>& consumers = {});
 
-    void register_expression(const ExpressionPtr& expr, bool io_allowed = false);
+    void register_expression(const ExpressionPtr& expr, bool io_allowed);
     void unregister_expression(const ExpressionPtr& expr);
 
     container m_expressions{};
     std::unordered_map<std::shared_ptr<Node>, std::shared_ptr<Expression>> m_node2expression_map;
-    io_container m_io_expressions;
+    container m_parameter_expressions{};
+    container m_result_expressions{};
     Config m_config{};
-    LoopManagerPtr m_loop_manager = nullptr;
+    LoopManagerPtr m_loop_manager;
     std::shared_ptr<IShapeInferSnippetsFactory> m_shape_infer_factory;
     bool m_is_dynamic = false;
 
     size_t m_buffer_scratchpad_size = 0;
 };
+using LinearIRPtr = std::shared_ptr<LinearIR>;
 
 template<typename iterator>
 iterator LinearIR::find(iterator begin, iterator end, const ExpressionPtr& target) const {
@@ -264,6 +295,7 @@ iterator LinearIR::find(iterator begin, iterator end, const ExpressionPtr& targe
     OPENVINO_ASSERT(found != end, "Expression has not been found");
     return found;
 }
+
 } // namespace lowered
 } // namespace snippets
 } // namespace ov

--- a/src/common/snippets/include/snippets/lowered/specific_loop_iter_types.hpp
+++ b/src/common/snippets/include/snippets/lowered/specific_loop_iter_types.hpp
@@ -12,6 +12,23 @@ enum class SpecificLoopIterType {
     FIRST_ITER, MAIN_BODY, LAST_ITER
 };
 
+inline std::ostream& operator<<(std::ostream& out, const SpecificLoopIterType& type) {
+    switch (type) {
+    case SpecificLoopIterType::FIRST_ITER:
+        out << "FIRST_ITER";
+        break;
+    case SpecificLoopIterType::MAIN_BODY:
+        out << "MAIN_BODY";
+        break;
+    case SpecificLoopIterType::LAST_ITER:
+        out << "LAST_ITER";
+        break;
+    default:
+        OPENVINO_THROW("Unknown SpecificLoopIterType");
+    }
+    return out;
+}
+
 } // namespace lowered
 } // namespace snippets
 } // namespace ov

--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -141,10 +141,6 @@ public:
                                       const std::shared_ptr<lowered::pass::PassConfig>& lowered_pass_config = std::make_shared<lowered::pass::PassConfig>(),
                                       const std::vector<snippets::lowered::pass::PassPipeline::PositionedPassLowered>& lowered_backend_passes = {});
 
-    std::shared_ptr<lowered::LinearIR>
-    convert_body_to_linear_ir(size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,
-                              const std::shared_ptr<IShapeInferSnippetsFactory>& shape_infer_factory = std::make_shared<IShapeInferSnippetsFactory>());
-
     Schedule generate(const void* compile_params = nullptr) const;
     Schedule generate(const BlockedShapeVector& blocked_input_shapes = {},
                       const std::vector<ov::element::Type>& input_precisions = {},
@@ -157,6 +153,10 @@ public:
                       const void* compile_params = nullptr);
 
 private:
+    std::shared_ptr<lowered::LinearIR>
+    convert_body_to_linear_ir(size_t min_parallel_work_amount = 8, size_t min_kernel_work_amount = 256,
+                              const std::shared_ptr<IShapeInferSnippetsFactory>& shape_infer_factory = std::make_shared<IShapeInferSnippetsFactory>());
+
     void init_config();
     // Count of Subgraph virtual ports:
     //  - Potential non-scalar Constants that will be created after some transformations (At the moment it's relevant only for FakeQuantize decomposition)

--- a/src/common/snippets/include/snippets/shape_inference/shape_infer_instances.hpp
+++ b/src/common/snippets/include/snippets/shape_inference/shape_infer_instances.hpp
@@ -82,6 +82,5 @@ public:
     explicit ReshapeShapeInfer(const std::shared_ptr<Node>& n);
     Result infer(const std::vector<VectorDimsRef>& input_shapes) override;
 };
-
 } // namespace snippets
 } // namespace ov

--- a/src/common/snippets/src/lowered/expression.cpp
+++ b/src/common/snippets/src/lowered/expression.cpp
@@ -14,9 +14,9 @@ namespace ov {
 namespace snippets {
 namespace lowered {
 
-Expression::Expression(const std::shared_ptr<Node>& n, const std::shared_ptr<IShapeInferSnippetsFactory>& factory)
-        : m_source_node{n}, m_emitter{nullptr},
-        m_input_port_connectors{}, m_output_port_connectors{}, m_shapeInference(make_shape_inference(n, factory)) {
+Expression::Expression(const std::shared_ptr<Node>& n, const std::shared_ptr<IShapeInferSnippetsFactory>& factory, bool need_shape_infer)
+        : m_source_node{n}, m_emitter{nullptr}, m_input_port_connectors{}, m_output_port_connectors{},
+          m_shapeInference(make_shape_inference(n, factory)), m_need_shape_infer(need_shape_infer) {
     m_input_port_descriptors.reserve(n->get_input_size());
     m_output_port_descriptors.reserve(n->get_output_size());
     for (const auto& input : n->inputs()) {
@@ -28,8 +28,8 @@ Expression::Expression(const std::shared_ptr<Node>& n, const std::shared_ptr<ISh
 }
 
 Expression::Expression(const Expression& other) :
-    std::enable_shared_from_this<Expression>(other), m_source_node(other.m_source_node),
-    m_emitter(other.m_emitter), m_loop_ids(other.m_loop_ids), m_shapeInference(other.m_shapeInference) {
+    std::enable_shared_from_this<Expression>(other), m_source_node(other.m_source_node), m_emitter(other.m_emitter),
+    m_loop_ids(other.m_loop_ids), m_shapeInference(other.m_shapeInference), m_need_shape_infer(other.m_need_shape_infer) {
     auto clone_ports_descriptors = [](const std::vector<PortDescriptorPtr>& src, std::vector<PortDescriptorPtr>& dst) {
         dst.resize(src.size());
         for (size_t i = 0; i < src.size(); i++)
@@ -204,41 +204,24 @@ void Expression::updateShapes() {
     IShapeInferSnippets::Result result;
     try {
         std::vector<VectorDimsRef> input_shapes;
-
-        const auto& in_connectors = get_input_port_connectors();
-        const auto& in_descriptors = get_input_port_descriptors();
-
-        input_shapes.reserve(in_connectors.size());
-        for (size_t i = 0; i < in_connectors.size(); i++) {
-            const auto& src_port_desc = in_connectors[i]->get_source().get_descriptor_ptr();
-            in_descriptors[i]->set_shape(src_port_desc->get_shape());
+        input_shapes.reserve(m_input_port_connectors.size());
+        for (size_t i = 0; i < m_input_port_connectors.size(); i++) {
+            const auto& src_port_desc = m_input_port_connectors[i]->get_source().get_descriptor_ptr();
+            m_input_port_descriptors[i]->set_shape(src_port_desc->get_shape());
             // Note that input_shape is a reference, so we should always bind it to an object with a longer lifetime
-            input_shapes.emplace_back(in_descriptors[i]->get_shape());
+            input_shapes.emplace_back(m_input_port_descriptors[i]->get_shape());
         }
 
         result = m_shapeInference->infer(input_shapes);
     }
     catch (const std::exception& exp) {
-        OPENVINO_THROW("Shape inference of " + (get_node()->get_friendly_name()) + " failed: " + exp.what());
+        OPENVINO_THROW("Shape inference of " + (m_source_node->get_friendly_name()) + " failed: " + exp.what());
     }
     OPENVINO_ASSERT(result.status == ShapeInferStatus::success,
-                    "Shape inference of " + (get_node()->get_friendly_name()) + " didn't return success status");
-    const auto& out_descriptors = get_output_port_descriptors();
-    OPENVINO_ASSERT(result.dims.size() == out_descriptors.size(), "shapeInference call returned invalid number of output shapes");
-    for (size_t i = 0; i < out_descriptors.size(); i++)
-        out_descriptors[i]->set_shape(result.dims[i]);
-}
-
-IOExpression::IOExpression(const std::shared_ptr<ov::opset1::Parameter>& par, int64_t index, const std::shared_ptr<IShapeInferSnippetsFactory>& factory)
-        : Expression(par, factory), m_index(index), m_type{io_type::INPUT} {}
-IOExpression::IOExpression(const std::shared_ptr<ov::opset1::Result>& res, int64_t index, const std::shared_ptr<IShapeInferSnippetsFactory>& factory)
-        : Expression(res, factory), m_index(index), m_type{io_type::OUTPUT} {}
-
-ExpressionPtr IOExpression::clone_with_new_inputs(const std::vector<PortConnectorPtr>& new_inputs,
-                                                  const std::shared_ptr<Node>& new_node) const {
-    const auto& expr = std::shared_ptr<IOExpression>(new IOExpression(*this));
-    expr->update_node_and_connectors(new_inputs, new_node);
-    return expr;
+                    "Shape inference of " + (m_source_node->get_friendly_name()) + " didn't return success status");
+    OPENVINO_ASSERT(result.dims.size() == m_output_port_descriptors.size(), "shapeInference call returned invalid number of output shapes");
+    for (size_t i = 0; i < m_output_port_descriptors.size(); i++)
+        m_output_port_descriptors[i]->set_shape(result.dims[i]);
 }
 
 } // namespace lowered

--- a/src/common/snippets/src/lowered/expression_factory.cpp
+++ b/src/common/snippets/src/lowered/expression_factory.cpp
@@ -53,21 +53,17 @@ void LinearIR::ExpressionFactory::init_expression_inputs(const ExpressionPtr& ex
     expr->m_input_port_connectors = inputs;
 }
 
-ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::op::v0::Parameter>& par,
-                                                  const LinearIR& linear_ir, const std::shared_ptr<ov::Model>& model) {
+ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::op::v0::Parameter>& par, const LinearIR& linear_ir) {
     // Note: ctor of shared_ptr isn't friend class for Expression -> we cannot use directly make_shared<Expression>(args)
-    OPENVINO_ASSERT(model != nullptr, "To create IOExpression from Parameter there must be inited model!");
-    auto expr = std::shared_ptr<IOExpression>(new IOExpression(par, model->get_parameter_index(par), linear_ir.m_shape_infer_factory));
+    auto expr = std::shared_ptr<Expression>(new Expression(par, linear_ir.m_shape_infer_factory, false));
     create_expression_outputs(expr);
     expr->validate();
     return expr;
 }
 
-ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::op::v0::Result>& res,
-                                                  const LinearIR& linear_ir, const std::shared_ptr<ov::Model>& model) {
+ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::op::v0::Result>& res, const LinearIR& linear_ir) {
     // Note: ctor of shared_ptr isn't friend class for Expression -> we cannot use directly make_shared<Expression>(args)
-    OPENVINO_ASSERT(model != nullptr, "To create IOExpression from Result there must be inited model!");
-    auto expr = std::shared_ptr<IOExpression>(new IOExpression(res, model->get_result_index(res), linear_ir.m_shape_infer_factory));
+    auto expr = std::shared_ptr<Expression>(new Expression(res, linear_ir.m_shape_infer_factory));
     create_expression_inputs(linear_ir, expr);
     // The Result node don't need output port (because of sense of the node). But each node in openvino must have one output at least.
     // The port descriptors are automatically created in constructor. We manually clean output ports.
@@ -76,8 +72,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::op::
     return expr;
 }
 
-ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::Node>& n, const LinearIR& linear_ir,
-                                                  const std::shared_ptr<ov::Model>& model) {
+ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<ov::Node>& n, const LinearIR& linear_ir) {
     OPENVINO_ASSERT(!ov::is_type<op::LoopBase>(n), "Default expression builder doesn't support LoopBegin and LoopEnd");
     // Note: ctor of shared_ptr isn't friend class for Expression
     auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory));
@@ -91,7 +86,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::Loop
                                                   const std::vector<PortConnectorPtr>& inputs,
                                                   const LinearIR& linear_ir) {
     OPENVINO_ASSERT(inputs.empty(), "LoopBegin cannot have inputs");
-    auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory));
+    auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory, false));
     init_expression_inputs(expr, inputs);
     create_expression_outputs(expr);
     expr->validate();
@@ -101,7 +96,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::Loop
 ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::LoopEnd>& n,
                                                   const std::vector<PortConnectorPtr>& inputs,
                                                   const LinearIR& linear_ir) {
-    auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory));
+    auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory, false));
     expr->m_input_port_descriptors.resize(inputs.size(), nullptr);
     for (size_t i = 0; i < inputs.size() - 1; ++i) {
         expr->m_input_port_descriptors[i] = std::make_shared<PortDescriptor>();
@@ -134,7 +129,7 @@ ExpressionPtr LinearIR::ExpressionFactory::create(const std::shared_ptr<op::Perf
 
 ExpressionPtr LinearIR::ExpressionFactory::create_without_connections(const std::shared_ptr<ov::Node>& n,
                                                                       const LinearIR& linear_ir) {
-    auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory));
+    auto expr = std::shared_ptr<Expression>(new Expression(n, linear_ir.m_shape_infer_factory, false));
     expr->m_input_port_descriptors.clear();
     expr->m_output_port_descriptors.clear();
     expr->validate();

--- a/src/common/snippets/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/src/lowered/linear_ir.cpp
@@ -18,12 +18,26 @@ namespace ov {
 namespace snippets {
 namespace lowered {
 
-LinearIR::LinearIR(const std::shared_ptr<ov::Model>& model, const std::shared_ptr<IShapeInferSnippetsFactory>& factory, Config config)
-        : m_io_expressions{}, m_config{config}, m_loop_manager(std::make_shared<LoopManager>()), m_shape_infer_factory(factory) {
+LinearIR::LinearIR(Config config)
+    : m_shape_infer{},
+      m_parameter_expressions{},
+      m_result_expressions{},
+      m_config(std::move(config)),
+      m_loop_manager(std::make_shared<LoopManager>()),
+      m_shape_infer_factory{} {}
+
+LinearIR::LinearIR(const std::shared_ptr<ov::Model>& model,
+                   const std::shared_ptr<IShapeInferSnippetsFactory>& factory,
+                   Config config)
+    : m_parameter_expressions{},
+      m_result_expressions{},
+      m_config{std::move(config)},
+      m_loop_manager(std::make_shared<LoopManager>()),
+      m_shape_infer_factory(factory) {
     constExprIt last_param = m_expressions.end();
     for (const auto& n : get_ordered_ops(model)) {
         constExprIt insertion_pos = m_expressions.end();
-        const auto expr = create_expression(n, model);
+        const auto expr = create_expression(n);
 
         // Scalar should be on the Linear IR beginning after Parameters to have valid expression order after Loop passes.
         // After these passes we must call pass MoveScalarToConsumer() to have a correct accuracy.
@@ -34,28 +48,18 @@ LinearIR::LinearIR(const std::shared_ptr<ov::Model>& model, const std::shared_pt
 
         register_expression(expr, true);
         const auto& it = m_expressions.insert(insertion_pos, expr);
-
-        if (const auto io_expr = std::dynamic_pointer_cast<IOExpression>(expr)) {
-            m_io_expressions.push_back(io_expr);
-            if (ov::is_type<ov::op::v0::Parameter>(n))
-                last_param = it;
-            switch (io_expr->get_type()) {
-                case IOExpression::io_type::INPUT:
-                    m_is_dynamic = m_is_dynamic || utils::is_dynamic_vdims(io_expr->get_output_port_descriptor(0)->get_shape());
-                    break;
-                case IOExpression::io_type::OUTPUT:
-                    m_is_dynamic = m_is_dynamic || utils::is_dynamic_vdims(io_expr->get_input_port_descriptor(0)->get_shape());
-                    break;
-                default:
-                    OPENVINO_THROW("Incorrect IO Expression type");
-            }
-        }
+        if (ov::is_type<ov::op::v0::Parameter>(n))
+            last_param = it;
     }
-    m_shape_infer = std::make_shared<LIRShapeInfer>(m_expressions, m_io_expressions);
+    for (const auto& param_expr : m_parameter_expressions)
+        m_is_dynamic = m_is_dynamic || utils::is_dynamic_vdims(param_expr->get_output_port_descriptor(0)->get_shape());
+    for (const auto& result_expr : m_result_expressions)
+        m_is_dynamic = m_is_dynamic || utils::is_dynamic_vdims(result_expr->get_input_port_descriptor(0)->get_shape());
+    m_shape_infer = std::make_shared<LIRShapeInfer>(m_expressions, m_parameter_expressions, m_result_expressions);
 }
 
-ExpressionPtr LinearIR::create_expression(const std::shared_ptr<Node>& n, const std::shared_ptr<ov::Model>& model) {
-    return ExpressionFactory::build(n, *this, model);
+ExpressionPtr LinearIR::create_expression(const std::shared_ptr<Node>& n) {
+    return ExpressionFactory::build(n, *this);
 }
 
 ExpressionPtr LinearIR::create_expression(const std::shared_ptr<Node>& n, const std::vector<PortConnectorPtr>& inputs) const {
@@ -171,13 +175,14 @@ const ExpressionPtr& LinearIR::get_expr_by_node(const std::shared_ptr<Node>& n) 
 
 void LinearIR::register_expression(const ExpressionPtr& expr, bool io_allowed) {
     const auto& node = expr->get_node();
-    if (!io_allowed && (is_type<ov::op::v0::Result>(node) || is_type<ov::op::v0::Parameter>(node)))
-        OPENVINO_THROW("LinearIR::insert can't be used to add Parameters or Results to IR");
-    {
-        const auto& res = m_node2expression_map.insert({node, expr});
-        if (!res.second)
-            OPENVINO_THROW("Duplicate node is detected in linear IR: " + std::string(node->get_friendly_name()));
-    }
+    OPENVINO_ASSERT(io_allowed || (!is_type<ov::op::v0::Result>(node) && !is_type<ov::op::v0::Parameter>(node)),
+                    "LinearIR::insert can't be used to add Parameters or Results to IR");
+    const auto& res = m_node2expression_map.insert({node, expr});
+    OPENVINO_ASSERT(res.second, "Duplicate node is detected in linear IR: ", node);
+    if (ov::is_type<ov::op::v0::Parameter>(node))
+        m_parameter_expressions.push_back(expr);
+    if (ov::is_type<ov::op::v0::Result>(node))
+        m_result_expressions.push_back(expr);
 }
 
 void LinearIR::unregister_expression(const ExpressionPtr& expr) {
@@ -186,16 +191,19 @@ void LinearIR::unregister_expression(const ExpressionPtr& expr) {
         input->remove_consumer(expr->get_input_port(i));
     }
 
-    m_node2expression_map.erase(expr->get_node());
+    const auto& node = expr->get_node();
+    m_node2expression_map.erase(node);
+    OPENVINO_ASSERT(!ov::is_type<ov::op::v0::Parameter>(node) && !ov::is_type<ov::op::v0::Result>(node),
+                    "unregister_expression mustn't be called for parameter or result expressions");
 }
 
 LinearIR::exprIt LinearIR::insert(constExprIt pos, container::value_type&& value) {
-    register_expression(value);
+    register_expression(value, m_config.m_manual_build_support);
     return m_expressions.insert(pos, value);
 }
 
 LinearIR::exprIt LinearIR::insert(constExprIt pos, const container::value_type& value) {
-    register_expression(value);
+    register_expression(value, m_config.m_manual_build_support);
     return m_expressions.insert(pos, value);
 }
 
@@ -207,7 +215,7 @@ LinearIR::exprIt LinearIR::insert(constExprIt pos, exprIt begin, exprIt end) {
 
 LinearIR::exprIt LinearIR::insert(constExprIt pos, constExprIt begin, constExprIt end) {
     for (auto b = begin; b != end; b++)
-        register_expression(*b);
+        register_expression(*b, m_config.m_manual_build_support);
     return m_expressions.insert(pos, begin, end);
 }
 
@@ -215,7 +223,7 @@ LinearIR::exprIt LinearIR::insert(LinearIR::constExprIt pos, const NodeVector& n
     auto ret = m_expressions.end();
     for (const auto& n : nodes) {
         const auto& expr = create_expression(n);
-        register_expression(expr);
+        register_expression(expr, m_config.m_manual_build_support);
         ret = m_expressions.insert(pos, expr);
     }
     // Need to return iterator to the first of the inserted values
@@ -224,7 +232,7 @@ LinearIR::exprIt LinearIR::insert(LinearIR::constExprIt pos, const NodeVector& n
 
 LinearIR::exprIt LinearIR::insert(LinearIR::constExprIt pos, const std::shared_ptr<Node>& n) {
     const auto& expr = create_expression(n);
-    register_expression(expr);
+    register_expression(expr, m_config.m_manual_build_support);
     return m_expressions.insert(pos, expr);
 }
 
@@ -271,24 +279,20 @@ IShapeInferSnippets::Result LinearIR::shape_infer(const std::vector<VectorDimsRe
 VectorDims LinearIR::get_master_shape() const {
     VectorDims master_shape{};
     // Note: inputs and outputs must be broadcastable, so it's enough to broadcast-merge only outputs
-    std::vector<std::shared_ptr<IOExpression>> out_exprs;
-    for (const auto& ioe : m_io_expressions) {
-        if (ioe->get_type() == IOExpression::io_type::OUTPUT)
-            out_exprs.push_back(ioe);
-    }
     // Note: Snippets would benefit from a more generic master_shape calculation approach.
     //  It will be implemented in the scope of ROI propagation activity (ticket 120505)
-    if (out_exprs.size() == 1) {
-        const auto& source = out_exprs[0]->get_input_port_connector(0)->get_source();
+    if (m_result_expressions.size() == 1) {
+        const auto& out_expr = *m_result_expressions.begin();
+        const auto& source = out_expr->get_input_port_connector(0)->get_source();
         if (!m_config.m_enable_domain_optimization && ov::is_type<snippets::op::Brgemm>(source.get_expr()->get_node())) {
             master_shape = utils::get_preordered_vdims(source);
         } else {
-            const auto& shape_infer_seq = utils::get_first_parent_shape_infer_expr_seq(out_exprs[0]);
-            const auto& expr = shape_infer_seq.empty() ? out_exprs[0] : shape_infer_seq.back();
+            const auto& shape_infer_seq = utils::get_first_parent_shape_infer_expr_seq(out_expr);
+            const auto& expr = shape_infer_seq.empty() ? out_expr : shape_infer_seq.back();
             master_shape = utils::get_preordered_vdims(expr->get_input_port_connector(0)->get_source());
         }
     } else {
-        for (const auto& oe : out_exprs) {
+        for (const auto& oe : m_result_expressions) {
             const auto& port_desc = oe->get_input_port_descriptor(0);
             OPENVINO_ASSERT(ov::snippets::broadcast_merge_into(master_shape, port_desc->get_shape()),
                             "Failed to merge input shapes in infer_master_shape");
@@ -406,24 +410,16 @@ LinearIR::exprIt LinearIR::replace_with_expr(const std::vector<ExpressionPtr>& o
     return replace_with_expr(old_exprs, new_expr, insertion_place);
 }
 
-LinearIR::LIRShapeInfer::LIRShapeInfer(container& body_exprs, io_container& io_exprs)
+LinearIR::LIRShapeInfer::LIRShapeInfer(container& body_exprs, container& param_exprs, container& result_exprs)
                                        : ShapeInferSnippetsNode(),
-                                         m_exprs{std::make_shared<container>(body_exprs)} {
-    // Note that here we rely on the assumption that io_expressions can't be changed after the LIR was created
-    for (const auto& expr : io_exprs) {
-        if (expr->get_type() == IOExpression::io_type::INPUT) {
-            m_input_exprs.push_back(expr);
-        } else if (expr->get_type() == IOExpression::io_type::OUTPUT) {
-            m_output_exprs.emplace_back(expr);
-        } else {
-            OPENVINO_THROW("Invalid io expression type detected");
-        }
-    }
+                                         m_exprs{std::make_shared<container>(body_exprs)},
+                                         m_input_exprs{std::make_shared<container>(param_exprs)},
+                                         m_output_exprs{std::make_shared<container>(result_exprs)} {
     // Note that if all output shapes are static, as in the case when the first shape infer was performed on nGraph,
     // we can treat them as the last result
     std::vector<VectorDims> outputDims;
-    outputDims.reserve(m_output_exprs.size());
-    for (const auto& expr : m_output_exprs) {
+    outputDims.reserve(m_output_exprs->size());
+    for (const auto& expr : *m_output_exprs) {
         const auto &shape = expr->get_input_port_descriptor(0)->get_shape();
         if (utils::is_dynamic_vdims(shape)) {
             outputDims.clear();
@@ -435,9 +431,10 @@ LinearIR::LIRShapeInfer::LIRShapeInfer(container& body_exprs, io_container& io_e
 }
 
 IShapeInferSnippets::Result LinearIR::LIRShapeInfer::infer(const std::vector<VectorDimsRef>& input_shapes) {
-    OPENVINO_ASSERT(m_input_exprs.size() == input_shapes.size(), "Got invalid number of input shapes in LIR ShapeInfer");
-    for (size_t i = 0; i < m_input_exprs.size(); i++)
-        m_input_exprs[i]->get_output_port_descriptor(0)->set_shape(input_shapes[i]);
+    OPENVINO_ASSERT(m_input_exprs->size() == input_shapes.size(), "Got invalid number of input shapes in LIR ShapeInfer");
+    size_t input_count = 0;
+    for (const auto& expr : *m_input_exprs)
+        expr->get_output_port_descriptor(0)->set_shape(input_shapes[input_count++]);
 
     for (const auto& expr : *m_exprs) {
         if (expr->needShapeInfer())
@@ -445,8 +442,8 @@ IShapeInferSnippets::Result LinearIR::LIRShapeInfer::infer(const std::vector<Vec
     }
 
     std::vector<VectorDims> outputDims;
-    outputDims.reserve(m_output_exprs.size());
-    for (const auto& expr : m_output_exprs) {
+    outputDims.reserve(m_output_exprs->size());
+    for (const auto& expr : *m_output_exprs) {
         outputDims.push_back(expr->get_input_port_descriptor(0)->get_shape());
     }
     m_last_result = {outputDims, ShapeInferStatus::success};

--- a/src/common/snippets/src/lowered/linear_ir_builder.cpp
+++ b/src/common/snippets/src/lowered/linear_ir_builder.cpp
@@ -72,15 +72,13 @@ std::shared_ptr<LinearIR> LinearIRBuilder::clone(const std::shared_ptr<LinearIR>
     ExpressionMap expression_map;
     cloned->m_expressions = clone_range(linear_ir->m_expressions.cbegin(), linear_ir->m_expressions.cend(), expression_map);
     for (const auto& expr : cloned->m_expressions) {
-        cloned->m_node2expression_map[expr->get_node()] = expr;
-        if (const auto& io = std::dynamic_pointer_cast<IOExpression>(expr))
-            cloned->m_io_expressions.push_back(io);
+        cloned->register_expression(expr, true);
     }
 
     cloned->m_loop_manager = linear_ir->m_loop_manager->clone_with_new_expr(expression_map);
     // It's Ok to share shapeInfer factory ptr, since the factory doesn't depend on LIR in any way
     cloned->m_shape_infer_factory = linear_ir->m_shape_infer_factory;
-    cloned->m_shape_infer = std::make_shared<LinearIR::LIRShapeInfer>(cloned->m_expressions, cloned->m_io_expressions);
+    cloned->m_shape_infer = std::make_shared<LinearIR::LIRShapeInfer>(cloned->m_expressions, cloned->m_parameter_expressions, cloned->m_result_expressions);
     cloned->m_is_dynamic = linear_ir->m_is_dynamic;
     return cloned;
 }

--- a/src/common/snippets/src/lowered/pass/optimize_domain.cpp
+++ b/src/common/snippets/src/lowered/pass/optimize_domain.cpp
@@ -101,27 +101,25 @@ bool OptimizeDomain::run(snippets::lowered::LinearIR& linear_ir) {
     OPENVINO_ASSERT(config.m_min_parallel_work_amount != 0, "OptimizeDomain: Min parallel work amount can't equal to zero");
     std::vector<VectorDims> input_shapes;
     bool blocked_input_shapes = false;
-    for (const auto& io_expr : linear_ir.get_IO_ops()) {
-        if (io_expr->get_type() == snippets::lowered::IOExpression::io_type::INPUT) {
-            auto consumer_inputs = io_expr->get_output_port_connector(0)->get_consumers();
-            const auto& first_consumer = consumer_inputs.begin()->get_expr();
-            if (auto rank_norm = as_type_ptr<op::RankNormalization>(first_consumer->get_node())) {
-                // If RankNormalization appends dims, then the appended dims will be broadcasted
-                // so collapsing is not allowed. We may increment tile rank though.
-                if (rank_norm->get_num_append() != 0)
-                    blocked_input_shapes = true;
-                // If RankNormalization prepends dims, then the dims should be ignored during domain optimization
-                // to avoid passing already incremented shapes to linear_ir.shape_infer()
-            }
-            const ExpressionPtr& shape_producing_expr = blocked_input_shapes ?
-                                                        first_consumer :
-                                                        io_expr;
-            const auto& shape = utils::get_preordered_vdims(shape_producing_expr->get_output_port(0));
-            OPENVINO_ASSERT(std::none_of(shape.begin(), shape.end(),
-                                        [](size_t d) { return utils::is_dynamic_value(d); }),
-                            "OptimizeDomain pass does not support dynamic shapes");
-            input_shapes.emplace_back(shape);
+    for (const auto& param : linear_ir.get_parameters()) {
+        auto consumer_inputs = param->get_output_port_connector(0)->get_consumers();
+        const auto& first_consumer = consumer_inputs.begin()->get_expr();
+        if (auto rank_norm = as_type_ptr<op::RankNormalization>(first_consumer->get_node())) {
+            // If RankNormalization appends dims, then the appended dims will be broadcasted
+            // so collapsing is not allowed. We may increment tile rank though.
+            if (rank_norm->get_num_append() != 0)
+                blocked_input_shapes = true;
+            // If RankNormalization prepends dims, then the dims should be ignored during domain optimization
+            // to avoid passing already incremented shapes to linear_ir.shape_infer()
         }
+        const ExpressionPtr& shape_producing_expr = blocked_input_shapes ?
+                                                    first_consumer :
+                                                    param;
+        const auto& shape = utils::get_preordered_vdims(shape_producing_expr->get_output_port(0));
+        OPENVINO_ASSERT(std::none_of(shape.begin(), shape.end(),
+                                    [](size_t d) { return utils::is_dynamic_value(d); }),
+                        "OptimizeDomain pass does not support dynamic shapes");
+        input_shapes.emplace_back(shape);
     }
     const auto total_work_amount = std::accumulate(master_shape.begin(),
                                                    master_shape.end(),

--- a/src/common/snippets/src/lowered/pass/reduce_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/reduce_decomposition.cpp
@@ -18,45 +18,47 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 
-namespace {
-uint32_t get_initial_value(const ov::DiscreteTypeInfo& type_info) {
-    static const std::map<ov::DiscreteTypeInfo, uint32_t> reduce_initial_values {
-        {op::ReduceMax::get_type_info_static(), uint32_t(0xff7fffff)},
-        {op::ReduceSum::get_type_info_static(), uint32_t(0x00000000)},
-    };
-    OPENVINO_ASSERT(reduce_initial_values.count(type_info), "Unexpected ReduceType");
-    return reduce_initial_values.at(type_info);
-}
-
-std::shared_ptr<ov::Node> get_accumulation_node(const ov::Output<ov::Node>& input0,
-                                                const ov::Output<ov::Node>& input1,
-                                                const ov::DiscreteTypeInfo& type_info) {
-    if (type_info == op::ReduceMax::get_type_info_static()) {
-        return std::make_shared<ov::op::v1::Maximum>(input0, input1);
-    } else if (type_info == op::ReduceSum::get_type_info_static()) {
-        return std::make_shared<ov::op::v1::Add>(input0, input1);
-    } else {
-        OPENVINO_THROW("Unsupported reduce type: ", type_info);
-    }
-}
-
-std::shared_ptr<ov::Node> get_horizon_node(const ov::Output<ov::Node>& input, const ov::DiscreteTypeInfo& type_info) {
-    if (type_info == op::ReduceMax::get_type_info_static()) {
-        return std::make_shared<op::HorizonMax>(input);
-    } else if (type_info == op::ReduceSum::get_type_info_static()) {
-        return std::make_shared<op::HorizonSum>(input);
-    } else {
-        OPENVINO_THROW("Unsupported reduce type: ", type_info);
-    }
-}
-}  // namespace
-
 ReduceDecomposition::ReduceDecomposition(size_t vector_size) : RangedPass(), m_vector_size{vector_size} {}
 
 bool ReduceDecomposition::run(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ReduceMaxDecompositionLowered")
-    const auto& loop_manager = linear_ir.get_loop_manager();
+
+    auto get_initial_value = [](const ov::DiscreteTypeInfo& type_info) {
+        static const std::map<ov::DiscreteTypeInfo, uint32_t> reduce_initial_values{
+            {op::ReduceMax::get_type_info_static(), uint32_t(0xff7fffff)},
+            {op::ReduceSum::get_type_info_static(), uint32_t(0x00000000)},
+        };
+        OPENVINO_ASSERT(reduce_initial_values.count(type_info), "Unexpected ReduceType");
+        return reduce_initial_values.at(type_info);
+    };
+
+    auto insert_accumulation_node = [&linear_ir](const LinearIR::constExprIt& expr_it,
+                                                 const ov::Output<ov::Node>& input0,
+                                                 const ov::Output<ov::Node>& input1,
+                                                 const ov::DiscreteTypeInfo& type_info) -> std::pair<LinearIR::constExprIt, std::shared_ptr<ov::Node>> {
+        if (type_info == op::ReduceMax::get_type_info_static()) {
+            return linear_ir.insert_node<ov::op::v1::Maximum>(expr_it, input0, input1);
+        } else if (type_info == op::ReduceSum::get_type_info_static()) {
+            return linear_ir.insert_node<ov::op::v1::Add>(expr_it, input0, input1);
+        } else {
+            OPENVINO_THROW("Unsupported reduce type: ", type_info);
+        }
+    };
+
+    auto insert_horizon_node = [&linear_ir](const LinearIR::constExprIt& expr_it,
+                                            const ov::Output<ov::Node>& input,
+                                            const ov::DiscreteTypeInfo& type_info) -> std::pair<LinearIR::constExprIt, std::shared_ptr<ov::Node>> {
+        if (type_info == op::ReduceMax::get_type_info_static()) {
+            return linear_ir.insert_node<op::HorizonMax>(expr_it, input);
+        } else if (type_info == op::ReduceSum::get_type_info_static()) {
+            return linear_ir.insert_node<op::HorizonSum>(expr_it, input);
+        } else {
+            OPENVINO_THROW("Unsupported reduce type: ", type_info);
+        }
+    };
+
     bool modified = false;
+    const auto& loop_manager = linear_ir.get_loop_manager();
     for (auto expr_it = begin; expr_it != end; expr_it++) {
         const auto& reduce_expr = *expr_it;
         const auto& reduce = ov::as_type_ptr<ov::snippets::op::ReduceBase>(reduce_expr->get_node());
@@ -67,26 +69,18 @@ bool ReduceDecomposition::run(LinearIR& linear_ir, LinearIR::constExprIt begin, 
         const auto& input_shape = reduce_expr->get_input_port_descriptor(0)->get_shape();
         const auto work_amount = *(input_shape.rbegin());
         const auto increment = utils::is_dynamic_value(work_amount) || m_vector_size <= work_amount ? m_vector_size : work_amount;
-        const bool is_dynamic = reduce->is_dynamic();
         OPENVINO_ASSERT(reduce->get_axis() == input_shape.size() - 1, "ReduceDecomposition supports only Reduce by last dimension.");
 
-        // We need an iterator to the inserted element
-        auto push_node = [&](const std::shared_ptr<Node>& n) {
-            const auto expr = linear_ir.insert(expr_it, n);
-            if (is_dynamic)
-                expr->get()->updateShapes();
-            return std::make_pair(expr, n);
-        };
         // Float constant values in byte representation
         const auto fill_value = get_initial_value(reduce_type_info);
         // Note: VectorBuffer is a special case, since it should go before the initial Load.
         // The buffer must be initialized with fill_value before reduction
-        const auto vector_buffer = push_node(std::make_shared<op::VectorBuffer>());
-        const auto initial_fill = push_node(std::make_shared<op::Fill>(vector_buffer.second, 0, fill_value));
+        const auto vector_buffer = linear_ir.insert_node<op::VectorBuffer>(expr_it);
+        const auto initial_fill = linear_ir.insert_node<op::Fill>(expr_it, vector_buffer.second, 0, fill_value);
 
         // Reduce loop
-        const auto fill = push_node(std::make_shared<op::Fill>(reduce->get_input_source_output(0), increment, fill_value));
-        const auto accumulation = push_node(get_accumulation_node(fill.second, initial_fill.second, reduce_type_info));
+        const auto fill = linear_ir.insert_node<op::Fill>(expr_it, reduce->get_input_source_output(0), increment, fill_value);
+        const auto accumulation = insert_accumulation_node(expr_it, fill.second, initial_fill.second, reduce_type_info);
 
         const auto reduce_loop_id = loop_manager->mark_loop(
             fill.first,
@@ -101,7 +95,7 @@ bool ReduceDecomposition::run(LinearIR& linear_ir, LinearIR::constExprIt begin, 
             const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(reduce_loop_id);
             loop_info->register_pass_to_handler<SpecificLoopIterType::LAST_ITER, SetFillOffset>(tail_size);
         }
-        const auto horizon = push_node(get_horizon_node(accumulation.second, reduce_type_info));
+        const auto horizon = insert_horizon_node(expr_it, accumulation.second, reduce_type_info);
 
         // Transfer original ExpressionPorts
         replace_input_port_connectors({fill.first->get()->get_input_port(0)}, reduce_expr->get_input_port_connector(0));

--- a/src/common/snippets/src/lowered/pass/serialize_data_flow.cpp
+++ b/src/common/snippets/src/lowered/pass/serialize_data_flow.cpp
@@ -32,16 +32,14 @@ bool SerializeDataFlow::run(LinearIR& linear_ir) {
             OPENVINO_ASSERT(ops_map.count(input_expr), "input node wasn't found during serialization");
             inputs[i] = ops_map[input_expr]->output(expr->get_input_port_connector(i)->get_source().get_index());
         }
-        if (auto ioexpr = std::dynamic_pointer_cast<IOExpression>(expr)) {
-            if (ioexpr->get_type() == IOExpression::io_type::INPUT) {
-                const auto parameter = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{});
-                ops_map[ioexpr] = parameter;
-                parameters.push_back(parameter);
-            } else {
-                const auto result = std::make_shared<ov::op::v0::Result>(inputs[0]);
-                ops_map[ioexpr] = result;
-                results.push_back(result);
-            }
+        if (ov::is_type<ov::op::v0::Parameter>(node)) {
+            const auto parameter = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{});
+            ops_map[expr] = parameter;
+            parameters.push_back(parameter);
+        } else if (ov::is_type<ov::op::v0::Result>(node)) {
+            const auto result = std::make_shared<ov::op::v0::Result>(inputs[0]);
+            ops_map[expr] = result;
+            results.push_back(result);
         } else {
             const auto serialization_node = std::make_shared<op::SerializationNode>(inputs, expr, serialization_mode);
             ops_map[expr] = serialization_node;

--- a/src/common/snippets/src/op/brgemm.cpp
+++ b/src/common/snippets/src/op/brgemm.cpp
@@ -180,7 +180,7 @@ ov::PartialShape Brgemm::get_output_partial_shape(const std::vector<ov::PartialS
     auto arg0_col_dim = arg0_shape_tmp[arg0_rank - 1];
     auto arg1_row_dim = arg1_shape_tmp[arg1_rank - 2];
     OPENVINO_ASSERT(DimType::merge(merged_dimension, arg0_col_dim, arg1_row_dim) || arg0_col_dim.is_dynamic() || arg1_row_dim.is_dynamic(),
-                    "Incompatible Brgemm matrix dimension");
+                    "Incompatible Brgemm matrix dimension. arg0_col_dim = ", arg0_col_dim, ", arg1_row_dim = ", arg1_row_dim);
 
     // add 1 to begin to align shape ranks if needed
     if (arg0_rank < arg1_rank)

--- a/src/common/snippets/tests/CMakeLists.txt
+++ b/src/common/snippets/tests/CMakeLists.txt
@@ -28,6 +28,10 @@ ov_build_target_faster(${TARGET_NAME}
 )
 
 add_library(snippets_test_utils STATIC ${CMAKE_CURRENT_SOURCE_DIR}/include/lowering_utils.hpp
-                                       ${CMAKE_CURRENT_SOURCE_DIR}/src/lowering_utils.cpp)
+                                       ${CMAKE_CURRENT_SOURCE_DIR}/include/lir_test_utils.hpp
+                                       ${CMAKE_CURRENT_SOURCE_DIR}/include/lir_comparator.hpp
+                                       ${CMAKE_CURRENT_SOURCE_DIR}/src/lowering_utils.cpp
+                                       ${CMAKE_CURRENT_SOURCE_DIR}/src/lir_test_utils.cpp
+                                       ${CMAKE_CURRENT_SOURCE_DIR}/src/lir_comparator.cpp)
 target_include_directories(snippets_test_utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(snippets_test_utils PRIVATE common_test_utils ov_snippets_models)

--- a/src/common/snippets/tests/include/lir_comparator.hpp
+++ b/src/common/snippets/tests/include/lir_comparator.hpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "common_test_utils/graph_comparator.hpp"
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/loop_info.hpp"
+#include "snippets/lowered/loop_manager.hpp"
+#include "snippets/lowered/loop_port.hpp"
+#include "snippets/lowered/specific_loop_iter_handlers.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+class LIRComparator {
+public:
+    using NodesCmpValues = FunctionsComparator::CmpValues;
+    using Result = FunctionsComparator::Result;
+
+    enum LIRCmpValues {
+        NONE = 0,
+        PORT_DESCRIPTORS = 1 << 0,
+        PORT_CONNECTORS = 1 << 1,
+        LOOP_INDICES = 1 << 2,
+        LOOP_MANAGER = 1 << 3,
+    };
+
+    // Creates LIRComparator with all CmpValues disabled
+    static LIRComparator no_default() noexcept {
+        return LIRComparator(NodesCmpValues::NONE, LIRCmpValues::NONE);
+    }
+
+    // Enables comparison of nodes owned by expressions. Considers the fields specified by the NodesCmpValues argument
+    LIRComparator& enable(NodesCmpValues f) noexcept {
+        m_nodes_cmp_values = static_cast<NodesCmpValues>(m_nodes_cmp_values | f);
+        return *this;
+    }
+
+    // Enables comparison of expressions. Considers the fields specified by the LIRCmpValues argument
+    LIRComparator& enable(LIRCmpValues f) noexcept {
+        m_lir_cmp_values = static_cast<LIRCmpValues>(m_lir_cmp_values | f);
+        return *this;
+    }
+
+    // Disables comparison of nodes owned by expressions. Considers the fields specified by the NodesCmpValues argument
+    LIRComparator& disable(NodesCmpValues f) noexcept {
+        m_nodes_cmp_values = static_cast<NodesCmpValues>(m_nodes_cmp_values & ~f);
+        return *this;
+    }
+
+    // Disables comparison of expressions. Considers the fields specified by the LIRCmpValues argument
+    LIRComparator& disable(LIRCmpValues f) noexcept {
+        m_lir_cmp_values = static_cast<LIRCmpValues>(m_lir_cmp_values & ~f);
+        return *this;
+    }
+
+    // Compares 2 Linear IRs based on enabled LIRCmpValues and NodesCmpValues
+    Result compare(const std::shared_ptr<ov::snippets::lowered::LinearIR>& linear_ir,
+                   const std::shared_ptr<ov::snippets::lowered::LinearIR>& linear_ir_ref);
+
+private:
+    explicit LIRComparator(NodesCmpValues nodes_vals, LIRCmpValues lir_vals) noexcept
+        : m_nodes_cmp_values(nodes_vals),
+          m_lir_cmp_values(lir_vals) {}
+
+    bool should_compare(LIRCmpValues f) const noexcept {
+        return m_lir_cmp_values & f;
+    }
+
+    static Result compare_descs(const std::vector<ov::snippets::lowered::PortDescriptorPtr>& descs,
+                                const std::vector<ov::snippets::lowered::PortDescriptorPtr>& descs_ref);
+
+    static Result compare_loop_managers(const ov::snippets::lowered::LoopManagerPtr& loop_manager,
+                                        const ov::snippets::lowered::LoopManagerPtr& loop_manager_ref);
+
+    static Result compare_loop_info(const ov::snippets::lowered::LoopInfoPtr& loop_info,
+                                    const ov::snippets::lowered::LoopInfoPtr& loop_info_ref);
+
+    static Result compare_unified_loop_info(const ov::snippets::lowered::UnifiedLoopInfoPtr& loop_info,
+                                            const ov::snippets::lowered::UnifiedLoopInfoPtr& loop_info_ref);
+
+    static Result compare_expaned_loop_info(const ov::snippets::lowered::ExpandedLoopInfoPtr& loop_info,
+                                            const ov::snippets::lowered::ExpandedLoopInfoPtr& loop_info_ref);
+
+    static Result compare_loop_ports(const std::vector<ov::snippets::lowered::LoopPort>& loop_ports,
+                                     const std::vector<ov::snippets::lowered::LoopPort>& loop_ports_ref);
+
+    static Result compare_expression_ports(const ov::snippets::lowered::ExpressionPort& expr_port,
+                                           const ov::snippets::lowered::ExpressionPort& expr_port_ref);
+
+    static Result compare_port_connectors(const std::vector<ov::snippets::lowered::PortConnectorPtr>& connectors,
+                                          const std::vector<ov::snippets::lowered::PortConnectorPtr>& connectors_ref);
+
+    static Result compare_handlers(const ov::snippets::lowered::SpecificIterationHandlers& handlers,
+                                   const ov::snippets::lowered::SpecificIterationHandlers& handlers_ref);
+
+    NodesCmpValues m_nodes_cmp_values;
+    LIRCmpValues m_lir_cmp_values;
+};
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/common/snippets/tests/include/lir_test_utils.hpp
+++ b/src/common/snippets/tests/include/lir_test_utils.hpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "common_test_utils/test_common.hpp"
+#include "lir_comparator.hpp"
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/pass/pass.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+class LoweredPassTestsF : public ov::test::TestsCommon {
+public:
+    LoweredPassTestsF();
+
+    void SetUp() override {}
+
+    void TearDown() override;
+
+    std::shared_ptr<ov::snippets::lowered::LinearIR> linear_ir, linear_ir_ref;
+    ov::snippets::lowered::pass::PassPipeline pipeline;
+    LIRComparator comparator;
+};
+
+/**
+ * @brief Returns default 2D subtensor filled with FULL_DIM values.
+ * @return default subtensor
+ */
+ov::snippets::VectorDims get_default_subtensor();
+
+/**
+ * @brief Inits input and output descriptors, and sets them to expression and its ov::Node.
+ * @attention Descriptor shapes are initialized using ov::Node input/output shapes
+ * @attention If optional vector of parameters (subtensors or layouts) is set, its size must be equal to n_inputs + n_outputs
+ * @attention If subtensors are not set, default 2D subtensor (filled with FULL_DIM values) is created
+ * @param expr expression whose descriptors should be initialized
+ * @param subtensors vector of subtensors to set
+ * @param layouts vector of layouts to set
+ */
+void init_expr_descriptors(const ov::snippets::lowered::ExpressionPtr& expr,
+                           const std::vector<ov::snippets::VectorDims>& subtensors = {},
+                           const std::vector<ov::snippets::VectorDims>& layouts = {});
+
+/**
+ * @brief Creates unified loop info based on provided entry and exit points, and adds it to the linear_ir's loops map
+ * @attention This helper wraps LoopManager::mark_loop method, but only for LoopInfo creation (whereas original
+ * mark_loop method also marks expressions with the corresponding loop info).
+ * @param linear_ir linear_ir in which loop info should be added
+ * @param entries entry points of loop
+ * @param exits exit points of loop
+ */
+void create_and_add_unified_loop_info(const std::shared_ptr<ov::snippets::lowered::LinearIR>& linear_ir,
+                                      size_t work_amount,
+                                      size_t increment,
+                                      const std::vector<ov::snippets::lowered::LoopPort>& entries,
+                                      const std::vector<ov::snippets::lowered::LoopPort>& exits,
+                                      bool add_default_handlers = true);
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/common/snippets/tests/include/lowered/pass/optimize_domain.hpp
+++ b/src/common/snippets/tests/include/lowered/pass/optimize_domain.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <common_test_utils/ov_test_utils.hpp>
+
+#include "snippets/lowered/linear_ir.hpp"
 #include "snippets/shape_types.hpp"
 
 namespace ov {
@@ -27,7 +29,7 @@ public:
     static std::string getTestCaseName(testing::TestParamInfo<OptimizeDomainParams> obj);
 protected:
     void SetUp() override;
-    std::shared_ptr<ov::Model> m_model;
+    ov::snippets::lowered::LinearIRPtr m_linear_ir;
     OptimizeDomainParams m_domain_opt_params;
 };
 

--- a/src/common/snippets/tests/src/lir_comparator.cpp
+++ b/src/common/snippets/tests/src/lir_comparator.cpp
@@ -1,0 +1,250 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "lir_comparator.hpp"
+
+#include "common_test_utils/graph_comparator.hpp"
+#include "snippets/lowered/pass/pass.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+using namespace ov::snippets::lowered;
+
+namespace std {
+template <typename T>
+inline string to_string(const vector<T>& vec) {
+    return ov::test::utils::vec2str<T>(vec);
+}
+
+inline string to_string(const ov::snippets::Reg& reg) {
+    return string("Reg(type = " + ov::snippets::regTypeToStr(reg.type) + ", idx = " + to_string(reg.idx) + ")");
+}
+
+inline string to_string(const ov::Node::type_info_t& info) {
+    stringstream ss;
+    ss << info;
+    return ss.str();
+}
+
+inline string to_string(const SpecificLoopIterType& type) {
+    stringstream ss;
+    ss << type;
+    return ss.str();
+}
+} // namespace std
+
+namespace ov {
+namespace test {
+namespace snippets {
+#define COMPARE(error_msg, lhs, rhs) \
+    if (lhs != rhs)                  \
+        return Result::error(std::string(error_msg) + " are different: " + std::to_string(lhs) + " and " + std::to_string(rhs))
+
+#define PROPAGATE_ERROR(prefix, result) \
+    if (!result.valid)                  \
+        return Result::error(std::string(prefix) + ": " + result.message)
+
+LIRComparator::Result LIRComparator::compare(const LinearIRPtr& linear_ir,
+                                             const LinearIRPtr& linear_ir_ref) {
+    OPENVINO_ASSERT(m_nodes_cmp_values != NodesCmpValues::NONE || m_lir_cmp_values != LIRCmpValues::NONE,
+                    "Comparator mustn't be called with NONE cmp values");
+    const auto& ops = linear_ir->get_ops();
+    const auto& ops_ref = linear_ir_ref->get_ops();
+    COMPARE("Number of ops", ops.size(), ops_ref.size());
+    const auto& parameters = linear_ir->get_parameters();
+    const auto& parameters_ref = linear_ir_ref->get_parameters();
+    COMPARE("Number of parameters", parameters.size(), parameters_ref.size());
+    const auto& results = linear_ir->get_results();
+    const auto& results_ref = linear_ir_ref->get_results();
+    COMPARE("Number of results", results.size(), results_ref.size());
+
+    auto run_comparison = [&](const LinearIR::constExprIt& expr_it, const LinearIR::constExprIt& expr_it_ref) {
+        const auto& expr = expr_it->get();
+        const auto& expr_ref = expr_it_ref->get();
+
+        const auto node = expr->get_node();
+        const auto node_ref = expr_ref->get_node();
+        if (m_nodes_cmp_values != NodesCmpValues::NONE)
+            PROPAGATE_ERROR("", Comparator(m_nodes_cmp_values).compare(node.get(), node_ref.get()));
+
+        const std::string err_prefix = "Comparison failed for nodes " + node->get_friendly_name() + ", " + node_ref->get_friendly_name() + ". ";
+        if (should_compare(LIRCmpValues::LOOP_INDICES))
+            COMPARE(err_prefix + "Loop indices", expr->get_loop_ids(), expr_ref->get_loop_ids());
+
+        if (should_compare(LIRCmpValues::PORT_DESCRIPTORS)) {
+            PROPAGATE_ERROR(err_prefix + "Input descsriptors", compare_descs(expr->get_input_port_descriptors(), expr_ref->get_input_port_descriptors()));
+            PROPAGATE_ERROR(err_prefix + "Output descsriptors", compare_descs(expr->get_output_port_descriptors(), expr_ref->get_output_port_descriptors()));
+        }
+        if (should_compare(LIRCmpValues::PORT_CONNECTORS)) {
+            const auto& in_connectors = expr->get_input_port_connectors();
+            const auto& in_connectors_ref = expr_ref->get_input_port_connectors();
+            PROPAGATE_ERROR(err_prefix + "Input connectors", compare_port_connectors(in_connectors, in_connectors_ref));
+            const auto& out_connectors = expr->get_output_port_connectors();
+            const auto& out_connectors_ref = expr_ref->get_output_port_connectors();
+            PROPAGATE_ERROR(err_prefix + "Output connectors", compare_port_connectors(out_connectors, out_connectors_ref));
+        }
+        return Result::ok();
+    };
+
+    for (auto param_it = parameters.begin(), param_it_ref = parameters_ref.begin(); param_it != parameters.end(); ++param_it, ++param_it_ref)
+        PROPAGATE_ERROR("", run_comparison(param_it, param_it_ref));
+    for (auto expr_it = ops.begin(), expr_it_ref = ops_ref.begin(); expr_it != ops.end(); ++expr_it, ++expr_it_ref)
+        PROPAGATE_ERROR("", run_comparison(expr_it, expr_it_ref));
+    for (auto result_it = results.begin(), result_it_ref = results_ref.begin(); result_it != results.end(); ++result_it, ++result_it_ref)
+        PROPAGATE_ERROR("", run_comparison(result_it, result_it_ref));
+
+    if (should_compare(LIRCmpValues::LOOP_MANAGER))
+        PROPAGATE_ERROR("Loop managers", compare_loop_managers(linear_ir->get_loop_manager(), linear_ir_ref->get_loop_manager()));
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_descs(const std::vector<PortDescriptorPtr>& descs, const std::vector<PortDescriptorPtr>& descs_ref) {
+    COMPARE("Descriptors number", descs.size(), descs_ref.size());
+    for (size_t i = 0; i < descs.size(); ++i) {
+        COMPARE("Shapes", descs[i]->get_shape(), descs_ref[i]->get_shape());
+        COMPARE("Layouts", descs[i]->get_layout(), descs_ref[i]->get_layout());
+        COMPARE("Subtensors", descs[i]->get_subtensor(), descs_ref[i]->get_subtensor());
+        COMPARE("Registers", descs[i]->get_reg(), descs_ref[i]->get_reg());
+    }
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_loop_managers(const LoopManagerPtr& loop_manager,
+                                                           const LoopManagerPtr& loop_manager_ref) {
+    const auto& map = loop_manager->get_map();
+    const auto& map_ref = loop_manager_ref->get_map();
+    COMPARE("Loops map size", map.size(), map_ref.size());
+
+    for (const auto& map_elem : map) {
+        const auto& id = map_elem.first;
+        auto iter = map_ref.find(id);
+        if (iter == map_ref.end())
+            return Result::error("Loop with id " + std::to_string(id) + " is not found in reference map");
+        const auto& loop_info = map_elem.second;
+        const auto& loop_info_ref = iter->second;
+        PROPAGATE_ERROR("Loop with id " + std::to_string(id), compare_loop_info(loop_info, loop_info_ref));
+    }
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_loop_info(const LoopInfoPtr& loop_info, const LoopInfoPtr& loop_info_ref) {
+    COMPARE("Loop info type", loop_info->get_type_info(), loop_info_ref->get_type_info());
+    COMPARE("Work amounts", loop_info->get_work_amount(), loop_info_ref->get_work_amount());
+    COMPARE("Increments", loop_info->get_increment(), loop_info_ref->get_increment());
+
+    PROPAGATE_ERROR("Input ports", compare_loop_ports(loop_info->get_input_ports(), loop_info_ref->get_input_ports()));
+    PROPAGATE_ERROR("Output ports", compare_loop_ports(loop_info->get_output_ports(), loop_info_ref->get_output_ports()));
+    if (ov::is_type<UnifiedLoopInfo>(loop_info)) {
+        const auto unified_loop_info = ov::as_type_ptr<UnifiedLoopInfo>(loop_info);
+        const auto unified_loop_info_ref = ov::as_type_ptr<UnifiedLoopInfo>(loop_info_ref);
+        PROPAGATE_ERROR("Unified loop info", compare_unified_loop_info(unified_loop_info, unified_loop_info_ref));
+    } else {
+        const auto expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_info);
+        const auto expanded_loop_info_ref = ov::as_type_ptr<ExpandedLoopInfo>(loop_info_ref);
+        PROPAGATE_ERROR("Expanded loop info", compare_expaned_loop_info(expanded_loop_info, expanded_loop_info_ref));
+    }
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_unified_loop_info(const UnifiedLoopInfoPtr& loop_info,
+                                                               const UnifiedLoopInfoPtr& loop_info_ref) {
+    OPENVINO_ASSERT(loop_info && loop_info_ref, "compare_unified_loop_info got incorrect loop info");
+    PROPAGATE_ERROR("Handlers", compare_handlers(loop_info->get_handlers(), loop_info_ref->get_handlers()));
+    COMPARE("ptr increments", loop_info->get_ptr_increments(), loop_info_ref->get_ptr_increments());
+    COMPARE("finalization offsets", loop_info->get_finalization_offsets(), loop_info_ref->get_finalization_offsets());
+    COMPARE("data sizes", loop_info->get_data_sizes(), loop_info_ref->get_data_sizes());
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_expaned_loop_info(const ExpandedLoopInfoPtr& loop_info,
+                                                               const ExpandedLoopInfoPtr& loop_info_ref) {
+    OPENVINO_ASSERT(loop_info && loop_info_ref, "compare_expaned_loop_info got incorrect loop info");
+    COMPARE("ptr increments", loop_info->get_ptr_increments(), loop_info_ref->get_ptr_increments());
+    COMPARE("finalization offsets", loop_info->get_finalization_offsets(), loop_info_ref->get_finalization_offsets());
+    COMPARE("data sizes", loop_info->get_data_sizes(), loop_info_ref->get_data_sizes());
+    COMPARE("Loop iter type", loop_info->get_type(), loop_info_ref->get_type());
+    const auto& unified_loop_info = loop_info->get_unified_loop_info();
+    const auto& unified_loop_info_ref = loop_info_ref->get_unified_loop_info();
+    PROPAGATE_ERROR("Unified loop info", compare_loop_info(unified_loop_info, unified_loop_info_ref));
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_loop_ports(const std::vector<LoopPort>& loop_ports,
+                                                        const std::vector<LoopPort>& loop_ports_ref) {
+    COMPARE("Loop ports size", loop_ports.size(), loop_ports_ref.size());
+    for (size_t i = 0; i < loop_ports.size(); ++i) {
+        const std::string prefix = "Loop port " + std::to_string(i) + ": ";
+        COMPARE(prefix + "is_incremented", loop_ports[i].is_incremented, loop_ports_ref[i].is_incremented);
+        COMPARE(prefix + "dim_idx", loop_ports[i].dim_idx, loop_ports_ref[i].dim_idx);
+        PROPAGATE_ERROR(prefix + "expr_port", compare_expression_ports(*loop_ports[i].expr_port, *loop_ports_ref[i].expr_port));
+    }
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_expression_ports(const ExpressionPort& expr_port,
+                                                              const ExpressionPort& expr_port_ref) {
+    const auto& port_node = expr_port.get_expr()->get_node();
+    const auto& port_node_ref = expr_port_ref.get_expr()->get_node();
+    COMPARE("port types", expr_port.get_type(), expr_port_ref.get_type());
+    COMPARE("port index", expr_port.get_index(), expr_port_ref.get_index());
+    COMPARE("port expression type", port_node->get_type_info(), port_node_ref->get_type_info());
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_port_connectors(const std::vector<PortConnectorPtr>& connectors,
+                                                             const std::vector<PortConnectorPtr>& connectors_ref) {
+    COMPARE("Port connectors size", connectors.size(), connectors_ref.size());
+    for (size_t i = 0; i < connectors.size(); ++i) {
+        const auto& connector = connectors[i];
+        const auto& connector_ref = connectors_ref[i];
+        PROPAGATE_ERROR("source port", compare_expression_ports(connector->get_source(), connector_ref->get_source()));
+
+        const auto& consumers = connector->get_consumers();
+        auto consumers_ref = connector_ref->get_consumers();
+        COMPARE("consumers number", consumers.size(), consumers_ref.size());
+        // Note: consumers are stored in std::set, and their order is not predefined
+        for (const auto& consumer : consumers) {
+            auto it = std::find_if(consumers_ref.begin(), consumers_ref.end(), [&consumer](const ExpressionPort& ref_port) {
+                return compare_expression_ports(consumer, ref_port).valid;
+            });
+            if (it == consumers_ref.end())
+                return Result::error("consumer was not found in consumers_ref");
+            consumers_ref.erase(it);
+        }
+    }
+    return Result::ok();
+}
+
+LIRComparator::Result LIRComparator::compare_handlers(const SpecificIterationHandlers& handlers,
+                                                      const SpecificIterationHandlers& handlers_ref) {
+    auto compare_pipelines = [](const ov::snippets::lowered::pass::PassPipeline& pipeline,
+                                const ov::snippets::lowered::pass::PassPipeline& pipeline_ref) {
+        const auto& passes = pipeline.get_passes();
+        const auto& passes_ref = pipeline_ref.get_passes();
+        COMPARE("Passes count", passes.size(), passes_ref.size());
+        for (size_t i = 0; i < passes.size(); ++i) {
+            const auto& pass = passes[i];
+            const auto& pass_ref = passes_ref[i];
+            if (pass->get_type_info() != pass_ref->get_type_info() || pass->merge(pass_ref) == nullptr) {
+                return Result::error("Passes are not equal: " + std::string(pass->get_type_name()) + " and " +
+                                     std::string(pass_ref->get_type_name()) +
+                                     ". Pass names or parameters are not matched, or merge method is not overrided.");
+            }
+        }
+        return Result::ok();
+    };
+    constexpr auto FIRST_ITER = SpecificLoopIterType::FIRST_ITER;
+    constexpr auto MAIN_BODY = SpecificLoopIterType::MAIN_BODY;
+    constexpr auto LAST_ITER = SpecificLoopIterType::LAST_ITER;
+    PROPAGATE_ERROR("First iter passes", compare_pipelines(handlers.get_passes<FIRST_ITER>(), handlers_ref.get_passes<FIRST_ITER>()));
+    PROPAGATE_ERROR("First iter passes", compare_pipelines(handlers.get_passes<MAIN_BODY>(), handlers_ref.get_passes<MAIN_BODY>()));
+    PROPAGATE_ERROR("First iter passes", compare_pipelines(handlers.get_passes<LAST_ITER>(), handlers_ref.get_passes<LAST_ITER>()));
+    return Result::ok();
+}
+
+#undef COMPARE
+#undef PROPAGATE_ERROR
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/common/snippets/tests/src/lir_test_utils.cpp
+++ b/src/common/snippets/tests/src/lir_test_utils.cpp
@@ -1,0 +1,101 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "lir_test_utils.hpp"
+
+#include "snippets/lowered/linear_ir_builder.hpp"
+#include "snippets/utils.hpp"
+
+using namespace ov::snippets::lowered;
+using namespace ov::snippets::utils;
+using namespace ov::snippets;
+
+namespace ov {
+namespace test {
+namespace snippets {
+LoweredPassTestsF::LoweredPassTestsF() : comparator(LIRComparator::no_default()) {
+    Config lir_config;
+    lir_config.m_manual_build_support = true;
+    linear_ir = std::make_shared<LinearIR>(lir_config);
+    linear_ir_ref = std::make_shared<LinearIR>(lir_config);
+
+    comparator.enable(LIRComparator::NodesCmpValues::NODES);
+    comparator.enable(LIRComparator::NodesCmpValues::CONST_VALUES);
+    comparator.enable(LIRComparator::NodesCmpValues::RUNTIME_KEYS);
+    comparator.enable(LIRComparator::NodesCmpValues::PRECISIONS);
+    comparator.enable(LIRComparator::NodesCmpValues::ATTRIBUTES);
+}
+
+void LoweredPassTestsF::TearDown() {
+    OPENVINO_ASSERT(linear_ir, "Test LIR is not initialized.");
+    OPENVINO_ASSERT(linear_ir_ref, "Reference LIR is not initialized.");
+    if (linear_ir_ref->get_ops().empty()) {
+        linear_ir_ref = lowered::LinearIRBuilder().clone(linear_ir);
+    }
+    pipeline.run(*linear_ir);
+    auto res = comparator.compare(linear_ir, linear_ir_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
+ov::snippets::VectorDims get_default_subtensor() {
+    static const VectorDims default_subtensor{PortDescriptor::ServiceDimensions::FULL_DIM,
+                                              PortDescriptor::ServiceDimensions::FULL_DIM};
+    return default_subtensor;
+}
+
+void init_expr_descriptors(const ov::snippets::lowered::ExpressionPtr& expr,
+                           const std::vector<ov::snippets::VectorDims>& subtensors,
+                           const std::vector<ov::snippets::VectorDims>& layouts) {
+    const auto n_inputs = expr->get_input_count();
+    const auto n_outputs = expr->get_output_count();
+    OPENVINO_ASSERT(subtensors.empty() || subtensors.size() == n_inputs + n_outputs,
+                    "subtensors vec size (",
+                    subtensors.size(),
+                    ") is not equal to n_inputs + n_outputs (",
+                    n_inputs + n_outputs,
+                    ")");
+    OPENVINO_ASSERT(layouts.empty() || layouts.size() == n_inputs + n_outputs,
+                    "layouts vec size (",
+                    layouts.size(),
+                    ") is not equal to n_inputs + n_outputs (",
+                    n_inputs + n_outputs,
+                    ")");
+
+    auto update_expr_desc = [](const PortDescriptorPtr& expr_desc, const PortDescriptorPtr& new_desc) {
+        expr_desc->set_shape(new_desc->get_shape());
+        expr_desc->set_layout(new_desc->get_layout());
+        expr_desc->set_subtensor(new_desc->get_subtensor());
+    };
+
+    const auto node = expr->get_node();
+    for (size_t i = 0; i < n_inputs; ++i) {
+        const auto& subtensor = subtensors.empty() ? get_default_subtensor() : subtensors[i];
+        const auto& layout = layouts.empty() ? VectorDims{} : layouts[i];
+        const auto desc = std::make_shared<PortDescriptor>(pshape_to_vdims(node->get_input_partial_shape(i)), subtensor, layout);
+        PortDescriptorUtils::set_port_descriptor_ptr(node->input(i), desc);
+        update_expr_desc(expr->get_input_port_descriptor(i), desc);
+    }
+    for (size_t i = 0; i < n_outputs; ++i) {
+        const auto& subtensor = subtensors.empty() ? get_default_subtensor() : subtensors[i + n_inputs];
+        const auto& layout = layouts.empty() ? VectorDims{} : layouts[i + n_inputs];
+        const auto desc = std::make_shared<PortDescriptor>(pshape_to_vdims(node->get_output_partial_shape(i)), subtensor, layout);
+        PortDescriptorUtils::set_port_descriptor_ptr(node->output(i), desc);
+        update_expr_desc(expr->get_output_port_descriptor(i), desc);
+    }
+}
+
+void create_and_add_unified_loop_info(const LinearIRPtr& linear_ir,
+                                      size_t work_amount,
+                                      size_t increment,
+                                      const std::vector<LoopPort>& entries,
+                                      const std::vector<LoopPort>& exits,
+                                      bool set_default_handlers) {
+    const auto& loop_manager = linear_ir->get_loop_manager();
+    // Equal begin and end iterators are set to avoid expressions marking with new loop id
+    loop_manager->mark_loop(linear_ir->begin(), linear_ir->begin(), work_amount, increment, entries, exits, set_default_handlers);
+}
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/common/snippets/tests/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/insert_load_store.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "lir_test_utils.hpp"
+
+#include "openvino/opsets/opset10.hpp"
+#include "snippets/lowered/pass/insert_load_store.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+using namespace ov::snippets::lowered;
+using namespace ov::snippets::lowered::pass;
+
+TEST_F(LoweredPassTestsF, InsertLoadStore) {
+    const auto vector_size = 16ul;
+    const auto input_precision = ov::element::i8;
+    const auto convert_precision = ov::element::f32;
+    const ov::PartialShape input_shape{1, 3, 16, 16};
+    {
+        auto param = linear_ir->push_node<ov::opset10::Parameter>(input_precision, input_shape);
+        auto convert = linear_ir->push_node<ov::opset10::Convert>(param.second, convert_precision);
+        auto result = linear_ir->push_node<ov::opset10::Result>(convert.second);
+    }
+    pipeline.register_pass<InsertLoadStore>(vector_size);
+    {
+        auto param = linear_ir_ref->push_node<ov::opset10::Parameter>(input_precision, input_shape);
+        auto load = linear_ir_ref->push_node<ov::snippets::op::Load>(param.second, vector_size);
+        auto convert = linear_ir_ref->push_node<ov::opset10::Convert>(load.second, convert_precision);
+        auto store = linear_ir_ref->push_node<ov::snippets::op::Store>(convert.second, vector_size);
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(store.second);
+    }
+}
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/common/snippets/tests/src/lowered/pass/optimize_domain.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/optimize_domain.cpp
@@ -39,15 +39,26 @@ std::string OptimizeDomainTest::getTestCaseName(testing::TestParamInfo<OptimizeD
 
 void OptimizeDomainTest::SetUp() {
     m_domain_opt_params = this->GetParam();
-    m_model = std::make_shared<EltwiseFunction>(m_domain_opt_params.input_shapes)->getOriginal();
+
+    ov::snippets::lowered::Config lir_config;
+    lir_config.m_manual_build_support = true;
+    lir_config.m_enable_domain_optimization = true;
+    lir_config.m_min_parallel_work_amount = m_domain_opt_params.min_parallel_work_amount;
+    lir_config.m_min_kernel_work_amount = m_domain_opt_params.min_jit_work_amount;
+    m_linear_ir = std::make_shared<ov::snippets::lowered::LinearIR>(lir_config, std::make_shared<ov::snippets::IShapeInferSnippetsFactory>());
+
+    const auto precision = ov::element::f32;
+    OPENVINO_ASSERT(m_domain_opt_params.input_shapes.size() == 2);
+    auto param1 = m_linear_ir->push_node<ov::op::v0::Parameter>(precision, m_domain_opt_params.input_shapes[0]);
+    auto param2 = m_linear_ir->push_node<ov::op::v0::Parameter>(precision, m_domain_opt_params.input_shapes[1]);
+    auto add = m_linear_ir->push_node<ov::op::v1::Add>(param1.second, param2.second);
+    auto result = m_linear_ir->push_node<ov::op::v0::Result>(add.second);
 }
 
 TEST_P(OptimizeDomainTest, DomainOptimization) {
-    auto subgraph = LoweringTests::getTokenizedSubgraph(m_model);
-    auto linear_ir = subgraph->convert_body_to_linear_ir(m_domain_opt_params.min_parallel_work_amount, m_domain_opt_params.min_jit_work_amount);
     size_t loop_depth = 1;
-    ov::snippets::lowered::pass::OptimizeDomain(loop_depth).run(*linear_ir);
-    const auto& master_shape = linear_ir->get_master_shape();
+    ov::snippets::lowered::pass::OptimizeDomain(loop_depth).run(*m_linear_ir);
+    const auto& master_shape = m_linear_ir->get_master_shape();
     EXPECT_EQ(loop_depth, m_domain_opt_params.exp_loop_depth) << "Inconsistent loop depth detected";
     EXPECT_THAT(master_shape, testing::ContainerEq(m_domain_opt_params.exp_master_shape)) << "Inconsistent master_shape detected";
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "jit_kernel_emitter.hpp"
+
 #include "emitters/utils.hpp"
+#include "snippets/utils.hpp"
 
 using namespace Xbyak_aarch64;
 
@@ -34,24 +36,15 @@ jit_kernel_emitter::jit_kernel_emitter(jit_generator* h, cpu_isa_t isa, const ov
     OV_CPU_JIT_EMITTER_ASSERT(!kernel->region->empty(), "Invoked with empty body");
     body = kernel->region;
     jcp = *reinterpret_cast<const jit_snippets_compile_args*>(kernel->compile_params);
-    num_inputs = 0;
-    num_outputs = 0;
-    const auto& io_exprs = body->get_IO_ops();
-    for (const auto& expr : io_exprs) {
-        switch (expr->get_type()) {
-            case snippets::lowered::IOExpression::io_type::INPUT: {
-                num_inputs++;
-                break;
-            }
-            case snippets::lowered::IOExpression::io_type::OUTPUT: {
-                num_outputs++;
-                break;
-            } default : {
-                OV_CPU_JIT_EMITTER_THROW("Detected unsupported io_type");
-            }
-        }
-        mem_access_exprs.push_back(expr);
-    }
+    const auto& parameters = body->get_parameters();
+    const auto& results = body->get_results();
+    num_inputs = parameters.size();
+    num_outputs = results.size();
+    for (const auto& param : parameters)
+        mem_access_exprs.push_back(param);
+    for (const auto& result : results)
+        mem_access_exprs.push_back(result);
+
     std::set<size_t> unique_buffers;
     for (const auto& expr : *body) {
         if (const auto buffer = ov::as_type_ptr<snippets::op::Buffer>(expr->get_node())) {
@@ -61,7 +54,8 @@ jit_kernel_emitter::jit_kernel_emitter(jit_generator* h, cpu_isa_t isa, const ov
                 unique_buffers.insert(buffer_id);
             }
         } else {
-            if (std::find(io_exprs.cbegin(), io_exprs.cend(), expr) == io_exprs.cend())
+            if (std::find(parameters.cbegin(), parameters.cend(), expr) == parameters.cend() &&
+                std::find(results.cbegin(), results.cend(), expr) == results.cend())
                 general_exprs.emplace_back(expr);
         }
     }

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
@@ -3,8 +3,8 @@
 //
 
 #include "jit_kernel_emitter.hpp"
-#include "snippets/utils.hpp"
 
+#include "snippets/utils.hpp"
 
 using namespace Xbyak;
 using namespace dnnl::impl;
@@ -32,24 +32,15 @@ jit_kernel_emitter::jit_kernel_emitter(jit_generator* h, cpu_isa_t isa, const ov
     OV_CPU_JIT_EMITTER_ASSERT(!kernel->region->empty(), "invoked with empty body");
     body = kernel->region;
     jcp = *reinterpret_cast<const jit_snippets_compile_args*>(kernel->compile_params);
-    num_inputs = 0;
-    num_outputs = 0;
-    const auto& io_exprs = body->get_IO_ops();
-    for (const auto& expr : io_exprs) {
-        switch (expr->get_type()) {
-            case snippets::lowered::IOExpression::io_type::INPUT: {
-                num_inputs++;
-                break;
-            }
-            case snippets::lowered::IOExpression::io_type::OUTPUT: {
-                num_outputs++;
-                break;
-            } default : {
-                OV_CPU_JIT_EMITTER_THROW("detected unsupported io_type");
-            }
-        }
-        mem_access_exprs.push_back(expr);
-    }
+    const auto& parameters = body->get_parameters();
+    const auto& results = body->get_results();
+    num_inputs = parameters.size();
+    num_outputs = results.size();
+    for (const auto& param : parameters)
+        mem_access_exprs.push_back(param);
+    for (const auto& result : results)
+        mem_access_exprs.push_back(result);
+
     std::set<size_t> unique_buffers;
     for (const auto& expr : *body) {
         if (const auto buffer = ov::as_type_ptr<snippets::op::Buffer>(expr->get_node())) {
@@ -59,7 +50,8 @@ jit_kernel_emitter::jit_kernel_emitter(jit_generator* h, cpu_isa_t isa, const ov
                 unique_buffers.insert(buffer_id);
             }
         } else {
-            if (std::find(io_exprs.cbegin(), io_exprs.cend(), expr) == io_exprs.cend())
+            if (std::find(parameters.cbegin(), parameters.cend(), expr) == parameters.cend() &&
+                std::find(results.cbegin(), results.cend(), expr) == results.cend())
                 general_exprs.emplace_back(expr);
         }
     }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.cpp
@@ -5,7 +5,6 @@
 #include "snippets/itt.hpp"
 #include "snippets/utils.hpp"
 #include "snippets/op/buffer.hpp"
-
 #include "brgemm_copy_b.hpp"
 
 #include "utils/general_utils.h"
@@ -51,6 +50,11 @@ bool BrgemmCopyB::visit_attributes(AttributeVisitor& visitor) {
     INTERNAL_OP_SCOPE(BrgemmRepack_visit_attributes);
     MemoryAccess::visit_attributes(visitor);
     visitor.on_attribute("src_type", m_src_type);
+    visitor.on_attribute("type", m_type);
+    visitor.on_attribute("K_blk", m_K_blk);
+    visitor.on_attribute("N_blk", m_N_blk);
+    visitor.on_attribute("inner_n_block", m_inner_n_block);
+    visitor.on_attribute("brgemmVNNIFactor", m_brgemmVNNIFactor);
     return true;
 }
 
@@ -138,6 +142,14 @@ ov::snippets::IShapeInferSnippets::Result BrgemmCopyB::ShapeInfer::infer(const s
     std::vector<ov::snippets::VectorDims> new_shapes(m_num_outs, planar_shape);
     return {new_shapes, ov::snippets::ShapeInferStatus::success};
 }
-
 } // namespace intel_cpu
+
+template <>
+EnumNames<intel_cpu::BrgemmCopyB::Type>& EnumNames<intel_cpu::BrgemmCopyB::Type>::get() {
+    static auto enum_names = EnumNames<intel_cpu::BrgemmCopyB::Type>(
+        "ov::intel_cpu::BrgemmCopyB::Type",
+        {{"only_repacking", intel_cpu::BrgemmCopyB::Type::OnlyRepacking},
+         {"with_compensations", intel_cpu::BrgemmCopyB::Type::WithCompensations}});
+    return enum_names;
+}
 } // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
@@ -4,9 +4,10 @@
 
 #pragma once
 
+#include "openvino/core/attribute_visitor.hpp"
 #include "snippets/op/memory_access.hpp"
+#include "snippets/shape_inference/shape_inference.hpp"
 #include "snippets/shape_types.hpp"
-#include <snippets/shape_inference/shape_inference.hpp>
 
 namespace ov {
 namespace intel_cpu {
@@ -22,7 +23,7 @@ class BrgemmCopyB : public snippets::modifier::MemoryAccess, public ov::op::Op {
 public:
     OPENVINO_OP("BrgemmCopyB", "SnippetsOpset");
 
-    enum Type {
+    enum class Type {
         OnlyRepacking,     // Just data repacking - one output
         WithCompensations, // Repack data and caclulate compensations - 2 outputs (is needed for BrgemmCPU with compensations)
     };
@@ -30,8 +31,8 @@ public:
     BrgemmCopyB(const Output<Node>& x, const element::Type src_type, const Type type = Type::OnlyRepacking,
                 const size_t offset_in = 0lu, const size_t offset_out0 = 0lu, const size_t offset_out1 = 0lu,
                 std::vector<size_t> layout_input = {}, const size_t blk_size_k = 0, const size_t blk_size_n = 0);
-    BrgemmCopyB(const Output<Node>& x, const element::Type src_type, const Type type = Type::OnlyRepacking,
-                const PortDescriptor& desc_in0 = {}, const PortDescriptor& desc_out0 = {}, const PortDescriptor& desc_out1 = {},
+    BrgemmCopyB(const Output<Node>& x, const element::Type src_type, const Type type,
+                const PortDescriptor& desc_in0, const PortDescriptor& desc_out0, const PortDescriptor& desc_out1,
                 std::vector<size_t> layout_input = {}, const size_t blk_size_k = 0, const size_t blk_size_n = 0);
     BrgemmCopyB() = default;
 
@@ -81,6 +82,12 @@ private:
     size_t m_inner_n_block = 0;
     size_t m_brgemmVNNIFactor = 1;
 };
-
 } // namespace intel_cpu
+
+template <>
+class AttributeAdapter<intel_cpu::BrgemmCopyB::Type> : public EnumAttributeAdapterBase<intel_cpu::BrgemmCopyB::Type> {
+public:
+    AttributeAdapter(intel_cpu::BrgemmCopyB::Type& value) : EnumAttributeAdapterBase<intel_cpu::BrgemmCopyB::Type>(value) {}
+    OPENVINO_RTTI("AttributeAdapter<ov::intel_cpu::BrgemmCopyB::Type>");
+};
 } // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.cpp
@@ -90,7 +90,7 @@ void BrgemmCPU::custom_constructor_validate_and_infer_types(std::vector<size_t> 
     set_output_type(0, get_output_type(), snippets::utils::get_planar_pshape(output_shape, layout_c));
 
     // Additional check for 3rd input
-    validate_with_scratchpad(planar_input_shapes[1].get_shape());
+    validate_with_scratchpad();
 }
 
 void BrgemmCPU::validate_and_infer_types() {
@@ -103,10 +103,10 @@ void BrgemmCPU::validate_and_infer_types() {
     set_output_type(0, get_output_type(), get_planar_output_shape(output_shape));
 
     // Additional check for 3rd input
-    validate_with_scratchpad(planar_input_shapes[1].get_shape());
+    validate_with_scratchpad();
 }
 
-void BrgemmCPU::validate_with_scratchpad(const ov::Shape& shape_b) const {
+void BrgemmCPU::validate_with_scratchpad() const {
     // Additional check for 3rd input
     if (one_of(m_type, Type::WithCompensations, Type::AMX)) {
         const auto& pshape = get_input_partial_shape(2);
@@ -169,8 +169,19 @@ size_t BrgemmCPU::get_offset_scratch() const {
 
 bool BrgemmCPU::visit_attributes(AttributeVisitor& visitor) {
     Brgemm::visit_attributes(visitor);
+    visitor.on_attribute("type", m_type);
     return true;
 }
-
 } // namespace intel_cpu
+
+template <>
+EnumNames<intel_cpu::BrgemmCPU::Type>& EnumNames<intel_cpu::BrgemmCPU::Type>::get() {
+    static auto enum_names =
+        EnumNames<intel_cpu::BrgemmCPU::Type>("ov::intel_cpu::BrgemmCPU::Type",
+                                              {{"floating", intel_cpu::BrgemmCPU::Type::Floating},
+                                               {"with_data_repacking", intel_cpu::BrgemmCPU::Type::WithDataRepacking},
+                                               {"with_compensations", intel_cpu::BrgemmCPU::Type::WithCompensations},
+                                               {"amx", intel_cpu::BrgemmCPU::Type::AMX}});
+    return enum_names;
+}
 } // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
@@ -22,7 +22,7 @@ class BrgemmCPU : public snippets::op::Brgemm {
 public:
     OPENVINO_OP("BrgemmCPU", "SnippetsOpset", snippets::op::Brgemm);
 
-    enum Type {
+    enum class Type {
         Floating,          // f32|f32
         WithDataRepacking, // u8|i8 or bf16|bf16 (non-AMX system) - needs BrgemmCopyB on second input for data repacking
         WithCompensations, // i8|i8 (non-AMX system) - needs BrgemmCopyB for data repacking and compensations
@@ -66,11 +66,17 @@ public:
 
 private:
     void custom_constructor_validate_and_infer_types(std::vector<size_t> layout_a, std::vector<size_t> layout_b, std::vector<size_t> layout_c);
-    void validate_with_scratchpad(const ov::Shape& shape_b) const;
+    void validate_with_scratchpad() const;
     void validate_inputs() const;
 
     Type m_type = Type::Floating;
 };
-
 } // namespace intel_cpu
+
+template <>
+class AttributeAdapter<intel_cpu::BrgemmCPU::Type> : public EnumAttributeAdapterBase<intel_cpu::BrgemmCPU::Type> {
+public:
+    AttributeAdapter(intel_cpu::BrgemmCPU::Type& value) : EnumAttributeAdapterBase<intel_cpu::BrgemmCPU::Type>(value) {}
+    OPENVINO_RTTI("AttributeAdapter<ov::intel_cpu::BrgemmCPU::Type>");
+};
 } // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.cpp
@@ -88,7 +88,7 @@ pass::BrgemmToBrgemmCPU::BrgemmToBrgemmCPU() {
                                                      offset_a, offset_b, offset_c,
                                                      brgemm_in0_desc->get_layout(), brgemm_in1_desc->get_layout(), brgemm_out_desc->get_layout());
         } else {
-            const auto copy_b_type = with_comp ? BrgemmCopyB::WithCompensations : BrgemmCopyB::OnlyRepacking;
+            const auto copy_b_type = with_comp ? BrgemmCopyB::Type::WithCompensations : BrgemmCopyB::Type::OnlyRepacking;
             brgemm_repacking = std::make_shared<BrgemmCopyB>(brgemm->input_value(1), element_type_a, copy_b_type, offset_b, 0, 0,
                                                              brgemm_in1_desc->get_layout());
             set_port_desc(brgemm_repacking->input(0), brgemm_in1_desc->get_shape(), brgemm_in1_desc->get_subtensor(), brgemm_in1_desc->get_layout());

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_blocking.cpp
@@ -134,6 +134,9 @@ bool BrgemmBlocking::run(LinearIR& linear_ir, LinearIR::constExprIt begin, Linea
                 // Compensations are computed by N dimension
                 *compensations_subtensor.rbegin() = block_size_n;
                 *++compensations_subtensor.rbegin() = 1;
+
+                OPENVINO_ASSERT(brgemm_expr->get_input_count() == 3, "Brgemm must have 3 inputs in case of compensations.");
+                brgemm_expr->get_input_port_descriptor(2)->set_subtensor(compensations_subtensor);
                 copy_b_expr->get_output_port_descriptor(1)->set_subtensor(compensations_subtensor);
             }
         }

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
@@ -1,0 +1,350 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/snippets/x64/pass/lowered/brgemm_blocking.hpp"
+
+#include "lir_test_utils.hpp"
+#include "openvino/opsets/opset10.hpp"
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/snippets_isa.hpp"
+#include "transformations/snippets/x64/op/brgemm_copy_b.hpp"
+#include "transformations/snippets/x64/op/brgemm_cpu.hpp"
+#include "transformations/snippets/x64/pass/lowered/cpu_iter_handlers.hpp"
+#include "transformations/tpp/x64/op/brgemm.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+using namespace ov::intel_cpu;
+using namespace ov::snippets::lowered;
+using namespace ov::snippets;
+
+namespace {
+void create_brgemm_loop_infos(const LinearIRPtr& linear_ir,
+                              const ExpressionPtr& brgemm_expr,
+                              size_t m = 0, size_t m_blk = 0,
+                              size_t k = 0, size_t k_blk = 0,
+                              size_t n = 0, size_t n_blk = 0) {
+    const bool k_block = k != 0 && k_blk != 0;
+    const bool n_block = k != 0 && k_blk != 0;
+    const bool m_block = m != 0 && m_blk != 0;
+    if (k_block) {
+        create_and_add_unified_loop_info(linear_ir, k, k_blk,
+                                        {LoopPort(brgemm_expr->get_input_port(0)), LoopPort(brgemm_expr->get_input_port(1), true, 1)},
+                                        {LoopPort(brgemm_expr->get_output_port(0), false)});
+        const auto& loop_info = linear_ir->get_loop_manager()->get_loop_info<UnifiedLoopInfo>(0);
+        loop_info->register_pass_to_handler<SpecificLoopIterType::FIRST_ITER, ov::intel_cpu::pass::SetBrgemmBeta>(0.f);
+    }
+    if (n_block) {
+        create_and_add_unified_loop_info(linear_ir, n, n_blk,
+                                        {LoopPort(brgemm_expr->get_input_port(0), false), LoopPort(brgemm_expr->get_input_port(1))},
+                                        {LoopPort(brgemm_expr->get_output_port(0))});
+    }
+    if (m_block) {
+        create_and_add_unified_loop_info(linear_ir, m, m_blk,
+                                        {LoopPort(brgemm_expr->get_input_port(0), true, 1), LoopPort(brgemm_expr->get_input_port(1), false, 1)},
+                                        {LoopPort(brgemm_expr->get_output_port(0), true, 1)});
+    }
+}
+
+void create_brgemm_with_copy_b_loop_infos(const LinearIRPtr& linear_ir,
+                                          const ExpressionPtr& brgemm_expr,
+                                          const ExpressionPtr& copy_b_expr,
+                                          size_t m = 0, size_t m_blk = 0,
+                                          size_t k = 0, size_t k_blk = 0,
+                                          size_t n = 0, size_t n_blk = 0) {
+    const bool k_block = k != 0 && k_blk != 0;
+    const bool n_block = k != 0 && k_blk != 0;
+    const bool m_block = m != 0 && m_blk != 0;
+    if (k_block) {
+        create_and_add_unified_loop_info(linear_ir, k, k_blk,
+                                        {LoopPort(brgemm_expr->get_input_port(0)), LoopPort(copy_b_expr->get_input_port(0), true, 1)},
+                                        {LoopPort(brgemm_expr->get_output_port(0), false)});
+        const auto& loop_info = linear_ir->get_loop_manager()->get_loop_info<UnifiedLoopInfo>(0);
+        loop_info->register_pass_to_handler<SpecificLoopIterType::FIRST_ITER, ov::intel_cpu::pass::SetBrgemmBeta>(0.f);
+    }
+    if (n_block) {
+        create_and_add_unified_loop_info(linear_ir, n, n_blk,
+                                        {LoopPort(brgemm_expr->get_input_port(0), false), LoopPort(copy_b_expr->get_input_port(0))},
+                                        {LoopPort(brgemm_expr->get_output_port(0))});
+    }
+    if (m_block) {
+        const auto& second_input_port = k_block || n_block ? copy_b_expr->get_input_port(0) : brgemm_expr->get_input_port(1);
+        create_and_add_unified_loop_info(linear_ir, m, m_blk,
+                                        {LoopPort(brgemm_expr->get_input_port(0), true, 1), LoopPort(second_input_port, false, 1)},
+                                        {LoopPort(brgemm_expr->get_output_port(0), true, 1)});
+    }
+}
+} // namespace
+
+class BrgemmBlockingTest : public LoweredPassTestsF {
+public:
+    BrgemmBlockingTest() : LoweredPassTestsF() {
+        comparator.enable(LIRComparator::LIRCmpValues::LOOP_INDICES);
+        comparator.enable(LIRComparator::LIRCmpValues::PORT_DESCRIPTORS);
+        comparator.enable(LIRComparator::LIRCmpValues::PORT_CONNECTORS);
+        comparator.enable(LIRComparator::LIRCmpValues::LOOP_MANAGER);
+    }
+
+    void SetUp() override {
+        pipeline.register_pass<ov::intel_cpu::pass::BrgemmBlocking>();
+    }
+};
+
+TEST_F(BrgemmBlockingTest, Floating) {
+    const size_t m_blk = 32;
+    const size_t k_blk = 16;
+    const size_t n_blk = 64;
+    const ov::PartialShape input_shape_a{1, 384, 16, 64};
+    const ov::PartialShape input_shape_b{1, 384, 16, 64};
+    const auto precision = ov::element::f32;
+    const VectorDims layout_a{0, 2, 1, 3};
+    const VectorDims layout_b{0, 2, 3, 1};
+    const VectorDims layout_c{0, 2, 1, 3};
+
+    {
+        auto data_a = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto brgemm = linear_ir->push_node<BrgemmCPU>(data_a.second, data_b.second, BrgemmCPU::Type::Floating,
+                                                      0, 0, 0, layout_a, layout_b, layout_c, m_blk, k_blk, n_blk);
+        init_expr_descriptors(*brgemm.first, {}, {layout_a, layout_b, layout_c});
+        auto result = linear_ir->push_node<ov::opset10::Result>(brgemm.second);
+    }
+    {
+        auto data_a = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto brgemm = linear_ir_ref->push_node<BrgemmCPU>(data_a.second, data_b.second, BrgemmCPU::Type::Floating,
+                                                          0, 0, 0, layout_a, layout_b, layout_c, m_blk, k_blk, n_blk);
+        const auto& brgemm_expr = *brgemm.first;
+        init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, {m_blk, n_blk}}, {layout_a, layout_b, layout_c});
+        create_brgemm_loop_infos(linear_ir_ref, brgemm_expr, 384, m_blk, 64, k_blk, 384, n_blk);
+        brgemm_expr->set_loop_ids({2, 1, 0});
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
+    }
+}
+
+TEST_F(BrgemmBlockingTest, BlockingIsNotNeeded) {
+    const size_t m = 32;
+    const size_t k = 16;
+    const size_t n = 64;
+    const ov::PartialShape input_shape_a{1, 16, m, k};
+    const ov::PartialShape input_shape_b{1, 16, k, n};
+    const auto precision = ov::element::f32;
+
+    {
+        auto data_a = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto brgemm = linear_ir->push_node<BrgemmCPU>(data_a.second, data_b.second, BrgemmCPU::Type::Floating);
+        init_expr_descriptors(*brgemm.first);
+        auto result = linear_ir->push_node<ov::opset10::Result>(brgemm.second);
+    }
+    {
+        auto data_a = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto brgemm = linear_ir_ref->push_node<BrgemmCPU>(data_a.second, data_b.second, BrgemmCPU::Type::Floating);
+        brgemm.second->set_beta(0.f);
+        init_expr_descriptors(*brgemm.first, {{m, k}, {k, n}, {m, n}});
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
+    }
+}
+
+TEST_F(BrgemmBlockingTest, WithDataRepacking) {
+    const size_t m_blk = 32;
+    const size_t k_blk = 16;
+    const size_t n_blk = 64;
+    const ov::PartialShape input_shape_a{1, 16, 384, 64};
+    const ov::PartialShape input_shape_b{1, 16, 64, 384};
+    const auto precision_a = ov::element::u8;
+    const auto precision_b = ov::element::i8;
+
+    {
+        auto data_a = linear_ir->push_node<ov::opset10::Parameter>(precision_a, input_shape_a);
+        auto data_b = linear_ir->push_node<ov::opset10::Parameter>(precision_b, input_shape_b);
+        auto copy_b = linear_ir->push_node<BrgemmCopyB>(data_b.second, precision_a, BrgemmCopyB::Type::OnlyRepacking,
+                                                        0, 0, 0, VectorDims{}, k_blk, n_blk);
+        init_expr_descriptors(*copy_b.first);
+
+        auto brgemm = linear_ir->push_node<BrgemmCPU>(data_a.second, copy_b.second, BrgemmCPU::Type::WithDataRepacking,
+                                                      0, 0, 0, VectorDims{}, VectorDims{}, VectorDims{}, m_blk, k_blk, n_blk);
+        init_expr_descriptors(*brgemm.first);
+        auto result = linear_ir->push_node<ov::opset10::Result>(brgemm.second);
+    }
+    {
+        auto data_a = linear_ir_ref->push_node<ov::opset10::Parameter>(precision_a, input_shape_a);
+        auto data_b = linear_ir_ref->push_node<ov::opset10::Parameter>(precision_b, input_shape_b);
+        auto copy_b = linear_ir_ref->push_node<BrgemmCopyB>(data_b.second, precision_a, BrgemmCopyB::Type::OnlyRepacking,
+                                                            0, 0, 0, VectorDims{}, k_blk, n_blk);
+        const auto copy_b_expr = *copy_b.first;
+        init_expr_descriptors(copy_b_expr, {{k_blk, n_blk}, {k_blk, n_blk}});
+        copy_b_expr->set_loop_ids({2, 1, 0});
+
+        auto brgemm = linear_ir_ref->push_node<BrgemmCPU>(data_a.second, copy_b.second, BrgemmCPU::Type::WithDataRepacking,
+                                                          0, 0, 0, VectorDims{}, VectorDims{}, VectorDims{}, m_blk, k_blk, n_blk);
+        const auto& brgemm_expr = *brgemm.first;
+        init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, {m_blk, n_blk}});
+        create_brgemm_with_copy_b_loop_infos(linear_ir_ref, brgemm_expr, copy_b_expr, 384, m_blk, 64, k_blk, 384, n_blk);
+        brgemm_expr->set_loop_ids({2, 1, 0});
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
+    }
+}
+
+TEST_F(BrgemmBlockingTest, WithDataRepackingOnlyByM) {
+    const size_t m_blk = 32;
+    const size_t k = 64;
+    const size_t n = 384;
+    const ov::PartialShape input_shape_a{1, 16, 384, 64};
+    const ov::PartialShape input_shape_b{1, 16, 64, 384};
+    const auto precision_a = ov::element::u8;
+    const auto precision_b = ov::element::i8;
+
+    {
+        auto data_a = linear_ir->push_node<ov::opset10::Parameter>(precision_a, input_shape_a);
+        auto data_b = linear_ir->push_node<ov::opset10::Parameter>(precision_b, input_shape_b);
+        auto copy_b = linear_ir->push_node<BrgemmCopyB>(data_b.second, precision_a, BrgemmCopyB::Type::OnlyRepacking,
+                                                        0, 0, 0, VectorDims{}, k, n);
+        init_expr_descriptors(*copy_b.first);
+
+        auto brgemm = linear_ir->push_node<BrgemmCPU>(data_a.second, copy_b.second, BrgemmCPU::Type::WithDataRepacking,
+                                                      0, 0, 0, VectorDims{}, VectorDims{}, VectorDims{}, m_blk, k, n);
+        init_expr_descriptors(*brgemm.first);
+        auto result = linear_ir->push_node<ov::opset10::Result>(brgemm.second);
+    }
+    {
+        auto data_a = linear_ir_ref->push_node<ov::opset10::Parameter>(precision_a, input_shape_a);
+        auto data_b = linear_ir_ref->push_node<ov::opset10::Parameter>(precision_b, input_shape_b);
+        auto copy_b = linear_ir_ref->push_node<BrgemmCopyB>(data_b.second, precision_a, BrgemmCopyB::Type::OnlyRepacking,
+                                                            0, 0, 0, VectorDims{}, k, n);
+        const auto copy_b_expr = *copy_b.first;
+        init_expr_descriptors(copy_b_expr, {{k, n}, {k, n}});
+        copy_b_expr->set_loop_ids({});
+
+        auto brgemm = linear_ir_ref->push_node<BrgemmCPU>(data_a.second, copy_b.second, BrgemmCPU::Type::WithDataRepacking,
+                                                          0, 0, 0, VectorDims{}, VectorDims{}, VectorDims{}, m_blk, k, n, 0.f);
+        const auto& brgemm_expr = *brgemm.first;
+        init_expr_descriptors(brgemm_expr, {{m_blk, k}, {k, n}, {m_blk, n}});
+        create_brgemm_with_copy_b_loop_infos(linear_ir_ref, brgemm_expr, copy_b_expr, 384, m_blk);
+        brgemm_expr->set_loop_ids({0});
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
+    }
+}
+
+TEST_F(BrgemmBlockingTest, WithCompensations) {
+    const size_t m_blk = 32;
+    const size_t k_blk = 16;
+    const size_t n_blk = 64;
+    const ov::PartialShape input_shape_a{1, 16, 384, 64};
+    const ov::PartialShape input_shape_b{1, 16, 64, 384};
+    const auto precision = ov::element::i8;
+
+    {
+        auto data_a = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto copy_b = linear_ir->push_node<BrgemmCopyB>(data_b.second, precision, BrgemmCopyB::Type::WithCompensations,
+                                                        0, 0, 0, VectorDims{}, k_blk, n_blk);
+        init_expr_descriptors(*copy_b.first);
+        const auto& copy_b_n = copy_b.second;
+        auto brgemm = linear_ir->push_node<BrgemmCPU>(data_a.second, copy_b_n->output(0), copy_b_n->output(1), BrgemmCPU::Type::WithCompensations,
+                                                      0, 0, 0, 0, VectorDims{}, VectorDims{}, VectorDims{}, m_blk, k_blk, n_blk);
+        init_expr_descriptors(*brgemm.first);
+        auto result = linear_ir->push_node<ov::opset10::Result>(brgemm.second);
+    }
+    {
+        auto data_a = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto copy_b = linear_ir_ref->push_node<BrgemmCopyB>(data_b.second, precision, BrgemmCopyB::Type::WithCompensations,
+                                                            0, 0, 0, VectorDims{}, k_blk, n_blk);
+        const auto copy_b_expr = *copy_b.first;
+        init_expr_descriptors(copy_b_expr, {{k_blk, n_blk}, {k_blk, n_blk}, {1, n_blk}});
+        copy_b_expr->set_loop_ids({2, 1, 0});
+
+        const auto& copy_b_n = copy_b.second;
+        auto brgemm = linear_ir_ref->push_node<BrgemmCPU>(data_a.second, copy_b_n->output(0), copy_b_n->output(1), BrgemmCPU::Type::WithCompensations,
+                                                          0, 0, 0, 0, VectorDims{}, VectorDims{}, VectorDims{}, m_blk, k_blk, n_blk);
+        const auto& brgemm_expr = *brgemm.first;
+        init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, {1, n_blk}, {m_blk, n_blk}});
+        create_brgemm_with_copy_b_loop_infos(linear_ir_ref, brgemm_expr, copy_b_expr, 384, m_blk, 64, k_blk, 384, n_blk);
+        brgemm_expr->set_loop_ids({2, 1, 0});
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
+    }
+}
+
+TEST_F(BrgemmBlockingTest, AMX) {
+    const size_t m_blk = 32;
+    const size_t k_blk = 16;
+    const size_t n_blk = 64;
+    const ov::PartialShape input_shape_a{1, 16, 384, 64};
+    const ov::PartialShape input_shape_b{1, 16, 64, 384};
+    const auto precision = ov::element::bf16;
+
+    {
+        auto data_a = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto scratch = linear_ir->push_node<snippets::op::NewMemoryBuffer>(ov::Shape{BrgemmCPU::SCRATCH_BYTE_SIZE});
+        auto copy_b = linear_ir->push_node<BrgemmCopyB>(data_b.second, precision, BrgemmCopyB::Type::OnlyRepacking,
+                                                        0, 0, 0, VectorDims{}, k_blk, n_blk);
+        init_expr_descriptors(*copy_b.first);
+        auto brgemm = linear_ir->push_node<BrgemmCPU>(data_a.second, copy_b.second, scratch.second, BrgemmCPU::Type::AMX,
+                                                      0, 0, 0, 0, VectorDims{}, VectorDims{}, VectorDims{}, m_blk, k_blk, n_blk);
+        init_expr_descriptors(*brgemm.first);
+        auto result = linear_ir->push_node<ov::opset10::Result>(brgemm.second);
+    }
+    {
+        auto data_a = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto copy_b = linear_ir_ref->push_node<BrgemmCopyB>(data_b.second, precision, BrgemmCopyB::Type::OnlyRepacking,
+                                                            0, 0, 0, VectorDims{}, k_blk, n_blk);
+        const auto copy_b_expr = *copy_b.first;
+        init_expr_descriptors(copy_b_expr, {{k_blk, n_blk}, {k_blk, n_blk}});
+        copy_b_expr->set_loop_ids({2, 1, 0});
+
+        auto scratch = linear_ir_ref->push_node<snippets::op::NewMemoryBuffer>(ov::Shape{BrgemmCPU::SCRATCH_BYTE_SIZE});
+        scratch.first->get()->set_loop_ids({2, 1, 0});
+
+        auto brgemm = linear_ir_ref->push_node<BrgemmCPU>(data_a.second, copy_b.second, scratch.second, BrgemmCPU::Type::AMX,
+                                                          0, 0, 0, 0, VectorDims{}, VectorDims{}, VectorDims{}, m_blk, k_blk, n_blk);
+        const auto& brgemm_expr = *brgemm.first;
+        init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, get_default_subtensor(), {m_blk, n_blk}});
+        create_brgemm_with_copy_b_loop_infos(linear_ir_ref, brgemm_expr, copy_b_expr, 384, m_blk, 64, k_blk, 384, n_blk);
+        brgemm_expr->set_loop_ids({2, 1, 0});
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
+    }
+}
+
+#ifdef SNIPPETS_LIBXSMM_TPP
+TEST_F(BrgemmBlockingTest, TPPFloating) {
+    const size_t m_blk = 32;
+    const size_t k_blk = 16;
+    const size_t n_blk = 64;
+    const ov::PartialShape input_shape_a{1, 384, 16, 64};
+    const ov::PartialShape input_shape_b{1, 384, 16, 64};
+    const auto precision = ov::element::f32;
+    const VectorDims layout_a{0, 2, 1, 3};
+    const VectorDims layout_b{0, 2, 3, 1};
+    const VectorDims layout_c{0, 2, 1, 3};
+
+    {
+        auto data_a = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto brgemm = linear_ir->push_node<tpp::op::BrgemmTPP>(data_a.second, data_b.second, 0, 0, 0,
+                                                               layout_a, layout_b, layout_c, m_blk, k_blk, n_blk);
+        init_expr_descriptors(*brgemm.first, {}, {layout_a, layout_b, layout_c});
+        auto result = linear_ir->push_node<ov::opset10::Result>(brgemm.second);
+    }
+    {
+        auto data_a = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_a);
+        auto data_b = linear_ir_ref->push_node<ov::opset10::Parameter>(precision, input_shape_b);
+        auto brgemm = linear_ir_ref->push_node<tpp::op::BrgemmTPP>(data_a.second, data_b.second, 0, 0, 0,
+                                                                   layout_a, layout_b, layout_c, m_blk, k_blk, n_blk);
+        const auto& brgemm_expr = *brgemm.first;
+        init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, {m_blk, n_blk}}, {layout_a, layout_b, layout_c});
+        create_brgemm_loop_infos(linear_ir_ref, brgemm_expr, 384, m_blk, 64, k_blk, 384, n_blk);
+        brgemm_expr->set_loop_ids({2, 1, 0});
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
+    }
+}
+#endif // SNIPPETS_LIBXSMM_TPP
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/buffer_allocation.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/buffer_allocation.cpp
@@ -146,7 +146,7 @@ protected:
         const auto convert1 = std::make_shared<ov::snippets::op::ConvertSaturation>(relu0, ov::element::bf16);
 
         const auto brgemm_copyb0 = std::make_shared<ov::intel_cpu::BrgemmCopyB>(
-            convert1, ov::element::bf16, ov::intel_cpu::BrgemmCopyB::OnlyRepacking, 0, 0, 0);
+            convert1, ov::element::bf16, ov::intel_cpu::BrgemmCopyB::Type::OnlyRepacking, 0, 0, 0);
         const auto scratch0 = std::make_shared<ov::snippets::op::NewMemoryBuffer>(ov::Shape{ov::intel_cpu::BrgemmCPU::SCRATCH_BYTE_SIZE});
         const auto brgemm_cpu0 = std::make_shared<ov::intel_cpu::BrgemmCPU>(
             parameter0, brgemm_copyb0->output(0), scratch0, ov::intel_cpu::BrgemmCPU::Type::AMX);
@@ -172,7 +172,7 @@ protected:
         const auto convert2 = std::make_shared<ov::snippets::op::ConvertSaturation>(multiply, ov::element::bf16);
 
         const auto brgemm_copyb1 = std::make_shared<ov::intel_cpu::BrgemmCopyB>(
-            parameter2, ov::element::bf16, ov::intel_cpu::BrgemmCopyB::OnlyRepacking, 0, 0, 0);
+            parameter2, ov::element::bf16, ov::intel_cpu::BrgemmCopyB::Type::OnlyRepacking, 0, 0, 0);
         const auto scratch1 = std::make_shared<ov::snippets::op::NewMemoryBuffer>(ov::Shape{ov::intel_cpu::BrgemmCPU::SCRATCH_BYTE_SIZE});
         const auto brgemm_cpu1 = std::make_shared<ov::intel_cpu::BrgemmCPU>(
             convert2, brgemm_copyb1->output(0), scratch1, ov::intel_cpu::BrgemmCPU::Type::AMX);


### PR DESCRIPTION
### Details:
 - *Extended LIR interface to make LIR creation from scratch possible*
 - *Introduced `LoweredPassTestsF` base class for LIR comparison*
 - *Added some helpers for easier LIR creation from scratch (not from `ov::Model`)*
 - *Introduced `LIRComparator` class. For LIR related things comparison, a custom comparators were written. For `ov::Node` comparison, the existing comparator from `GraphComparator` class is used.*
 - *Added a test case for `InsertLoadStore` pass: as an example of a simple LIR comparison (only expressions + `ov::Node` comparison is necessary to fully cover the pass code)*. The pass was not fully covered.
 - *Added test cases for `BrgemmBlocking` cpu lowered pass: as an example of complicated LIR comparison, where `LoopManager` and descriptors comparison are also necessary. This pass was fully covered.*

### Tickets:
 - *CVS-139926*
