### PR TITLE
[intel-npu] Adding f32 to supported values of INFERENCE_PRECISION_HINT

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/common.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/common.hpp
@@ -98,12 +98,14 @@ struct INFERENCE_PRECISION_HINT final : OptionBase<INFERENCE_PRECISION_HINT, ov:
             return ov::element::f16;
         } else if (val == "i8") {
             return ov::element::i8;
+        } else if (val == "f32") {
+            return ov::element::f32;
         } else {
             OPENVINO_THROW("Wrong value ",
                            val.data(),
                            " for property key ",
                            ov::hint::inference_precision.name(),
-                           ". Supported values: f16, i8");
+                           ". Supported values: f32, f16, i8");
         }
     };
 };


### PR DESCRIPTION
### Details:
 - Adding f32 to supported values of INFERENCE_PRECISION_HINT

### Tickets:
[ - *ticket-id*](https://jira.devtools.intel.com/browse/CVS-138219)
