### PR TITLE
Added torchdynamo backend entry point in package setup

### DIFF
--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -621,6 +621,7 @@ def find_entry_points(install_cfg):
     """Creates a list of entry points for OpenVINO runtime package."""
     entry_points = {
         "console_scripts": [],
+        "torch_dynamo_backends": ["openvino=openvino.frontend.pytorch.torchdynamo.backend:openvino"],
     }
     for comp_info in install_cfg.values():
         empty_point = comp_info.get("entry_point")


### PR DESCRIPTION
With this change, users don't have to add "import openvino.torch" in their applications. Providing torch.compile(model, backend="openvino") automatically imports the necessary modules. This simplifies the user experience and enables PT2 based benchmarking OOB without any changes. .

More information can be found here: https://github.com/pytorch/pytorch/pull/124536

JIRA: https://jira.devtools.intel.com/browse/CVS-139370