### PR TITLE
[GHA] Switch Conformance tests to self-hosted runners

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -319,11 +319,15 @@ jobs:
 
   Conformance:
     needs: [ Build, Smart_CI ]
-    timeout-minutes: ${{ matrix.TEST_TYPE == 'API' && 5 || 20 }}
+    timeout-minutes: ${{ matrix.TEST_TYPE == 'API' && 5 || 30 }}
     defaults:
       run:
         shell: bash
-    runs-on: ubuntu-20.04-8-cores
+    runs-on: aks-linux-8-cores-64gb
+    container:
+      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04
+      volumes:
+        - /mount:/mount
     strategy:
       max-parallel: 2
       fail-fast: false
@@ -382,13 +386,12 @@ jobs:
         uses: ./openvino/.github/actions/setup_python
         with:
           version: ${{ env.PYTHON_VERSION }}
-          should-setup-pip-paths: 'false'
-          self-hosted-runner: 'false'
+          should-setup-pip-paths: 'true'
+          self-hosted-runner: 'true'
 
       - name: Install Dependencies
         run: |
-          sudo -E ${INSTALL_DIR}/install_dependencies/install_openvino_dependencies.sh -c=core -y
-
+          ${INSTALL_DIR}/install_dependencies/install_openvino_dependencies.sh -c=core -y
           python3 -m pip install -r ${CONFORMANCE_TOOLS_DIR}/requirements.txt
 
       #

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -345,6 +345,19 @@ jobs:
     if: fromJSON(needs.smart_ci.outputs.affected_components).CPU.test
 
     steps:
+
+      #
+      # Print system info
+      #
+      - name: Fetch system_info action
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/system_info
+
+      - name: System info
+        uses: ./.github/actions/system_info
+
       - name: Create Directories
         run: |
           mkdir -p ${CONFORMANCE_ARTIFACTS_DIR}


### PR DESCRIPTION
### Details:
 - Use Azure self-hosted runners instead of GHA owned

### Tickets:
 - *ticket-id*
