### PR TITLE
[OV JS] Port of Update nodejs version in gha workflows (#24158)

### DIFF
--- a/.github/workflows/job_openvino_js.yml
+++ b/.github/workflows/job_openvino_js.yml
@@ -26,7 +26,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive # to prevent apt-get from waiting user input
       OPENVINO_JS_DIR: ${{ github.workspace }}/openvino/src/bindings/js
       OPENVINO_JS_LIBS_DIR: ${{ github.workspace }}/openvino/src/bindings/js/node/bin
-      NODE_VERSION: 18
+      NODE_VERSION: 20
     steps:
       - name: Fetch OpenVINO JS sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Port of #24158

### Details:
 - To fix issues like that: https://github.com/openvinotoolkit/openvino/actions/runs/8756801704/job/24034484068?pr=24066#step:8:10
