### PR TITLE
Revert "Workaround apt issues on ubuntu 22"

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: Install ShellCheck
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt update
           sudo apt --assume-yes install shellcheck
 
@@ -78,7 +77,6 @@ jobs:
 
       - name: Install Clang dependency
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt update
           sudo apt --assume-yes remove clang-7 clang-8 clang-9 clang-10 clang-11 clang-12 clang-13 clang-15
           sudo apt --assume-yes install clang-14 libclang-14-dev


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#24214

The original issue should be fixed now: https://github.com/microsoft/linux-package-repositories/issues/130#issuecomment-2074910628