### PR TITLE
Migration to clang-format-15

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   clang-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     steps:
@@ -15,10 +15,10 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Install clang-format-9
+      - name: Install clang-format-15
         run: |
           sudo apt update
-          sudo apt --assume-yes install clang-format-9
+          sudo apt --assume-yes install clang-format-15
 
       # Run cmake with -DENABLE_PROFILING_ITT=ON -DSELECTIVE_BUILD=COLLECT in order to enable codestyle check for ITT collector
       - name: CMake configure

--- a/cmake/developer_package/clang_format/clang_format.cmake
+++ b/cmake/developer_package/clang_format/clang_format.cmake
@@ -3,7 +3,7 @@
 #
 
 if(ENABLE_CLANG_FORMAT)
-    set(CLANG_FORMAT_REQUIRED_VERSION 9 CACHE STRING "Clang-format version to use")
+    set(CLANG_FORMAT_REQUIRED_VERSION 15 CACHE STRING "Clang-format version to use")
     set(CLANG_FORMAT_FILENAME clang-format-${CLANG_FORMAT_REQUIRED_VERSION} clang-format)
     find_host_program(CLANG_FORMAT NAMES ${CLANG_FORMAT_FILENAME} PATHS ENV PATH)
     if(CLANG_FORMAT)

--- a/src/bindings/c/include/openvino/c/deprecated.h
+++ b/src/bindings/c/include/openvino/c/deprecated.h
@@ -62,7 +62,7 @@
 
 // Suppress warning "-Wdeprecated-declarations" / C4996
 #if defined(__GNUC__)
-#    define OPENVINO_DO_PRAGMA(x) _Pragma(#    x)
+#    define OPENVINO_DO_PRAGMA(x) _Pragma(#x)
 #elif defined(_MSC_VER)
 #    define OPENVINO_DO_PRAGMA(x) __pragma(x)
 #else

--- a/src/bindings/js/node/src/compiled_model.cpp
+++ b/src/bindings/js/node/src/compiled_model.cpp
@@ -49,7 +49,7 @@ Napi::Value CompiledModelWrap::get_output(const Napi::CallbackInfo& info) {
         return get_node(
             info,
             static_cast<const ov::Output<const ov::Node>& (ov::CompiledModel::*)() const>(&ov::CompiledModel::output),
-            static_cast<const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&)const>(
+            static_cast<const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&) const>(
                 &ov::CompiledModel::output),
             static_cast<const ov::Output<const ov::Node>& (ov::CompiledModel::*)(size_t) const>(
                 &ov::CompiledModel::output));
@@ -75,7 +75,7 @@ Napi::Value CompiledModelWrap::get_input(const Napi::CallbackInfo& info) {
         return get_node(
             info,
             static_cast<const ov::Output<const ov::Node>& (ov::CompiledModel::*)() const>(&ov::CompiledModel::input),
-            static_cast<const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&)const>(
+            static_cast<const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&) const>(
                 &ov::CompiledModel::input),
             static_cast<const ov::Output<const ov::Node>& (ov::CompiledModel::*)(size_t) const>(
                 &ov::CompiledModel::input));
@@ -99,7 +99,7 @@ Napi::Value CompiledModelWrap::get_inputs(const Napi::CallbackInfo& info) {
 Napi::Value CompiledModelWrap::get_node(
     const Napi::CallbackInfo& info,
     const ov::Output<const ov::Node>& (ov::CompiledModel::*func)() const,
-    const ov::Output<const ov::Node>& (ov::CompiledModel::*func_tname)(const std::string&)const,
+    const ov::Output<const ov::Node>& (ov::CompiledModel::*func_tname)(const std::string&) const,
     const ov::Output<const ov::Node>& (ov::CompiledModel::*func_idx)(size_t) const) {
     if (info.Length() == 0) {
         return Output<const ov::Node>::wrap(info.Env(), (_compiled_model.*func)());

--- a/src/bindings/python/src/pyopenvino/core/compiled_model.cpp
+++ b/src/bindings/python/src/pyopenvino/core/compiled_model.cpp
@@ -209,7 +209,7 @@ void regclass_CompiledModel(py::module m) {
 
     cls.def(
         "input",
-        (const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&)const) & ov::CompiledModel::input,
+        (const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&) const) & ov::CompiledModel::input,
         py::arg("tensor_name"),
         R"(
                 Gets input of a compiled model identified by a tensor_name.
@@ -253,11 +253,11 @@ void regclass_CompiledModel(py::module m) {
                 :rtype: openvino.runtime.ConstOutput
             )");
 
-    cls.def(
-        "output",
-        (const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&)const) & ov::CompiledModel::output,
-        py::arg("tensor_name"),
-        R"(
+    cls.def("output",
+            (const ov::Output<const ov::Node>& (ov::CompiledModel::*)(const std::string&) const) &
+                ov::CompiledModel::output,
+            py::arg("tensor_name"),
+            R"(
                 Gets output of a compiled model identified by a tensor_name.
                 If the output with given tensor name is not found, this method throws an exception.
 

--- a/src/common/itt/include/openvino/itt.hpp
+++ b/src/common/itt/include/openvino/itt.hpp
@@ -27,7 +27,7 @@ namespace itt {
  * @brief A domain type which enables tagging trace data for different modules or libraries in a program.
  */
 typedef struct domain_ {
-} * domain_t;
+}* domain_t;
 
 /**
  * @typedef handle_t
@@ -35,7 +35,7 @@ typedef struct domain_ {
  * @brief Annotation handle for section of code which would be named at runtime.
  */
 typedef struct handle_ {
-} * handle_t;
+}* handle_t;
 
 /**
  * @cond

--- a/src/core/include/openvino/core/deprecated.hpp
+++ b/src/core/include/openvino/core/deprecated.hpp
@@ -38,7 +38,7 @@
 
 // Suppress warning "-Wdeprecated-declarations" / C4996
 #if defined(__GNUC__)
-#    define OPENVINO_DO_PRAGMA(x) _Pragma(#    x)
+#    define OPENVINO_DO_PRAGMA(x) _Pragma(#x)
 #elif defined(_MSC_VER)
 #    define OPENVINO_DO_PRAGMA(x) __pragma(x)
 #else

--- a/src/core/include/openvino/core/extension.hpp
+++ b/src/core/include/openvino/core/extension.hpp
@@ -47,8 +47,6 @@ void OV_CREATE_EXTENSION(std::vector<ov::Extension::Ptr>&);
  *
  * @param vector of extensions
  */
-#define OPENVINO_CREATE_EXTENSIONS(extensions)                                                \
-    OPENVINO_EXTENSION_C_API void OV_CREATE_EXTENSION(std::vector<ov::Extension::Ptr>& ext);  \
-    OPENVINO_EXTENSION_C_API void OV_CREATE_EXTENSION(std::vector<ov::Extension::Ptr>& ext) { \
-        ext = extensions;                                                                     \
-    }
+#define OPENVINO_CREATE_EXTENSIONS(extensions)                                               \
+    OPENVINO_EXTENSION_C_API void OV_CREATE_EXTENSION(std::vector<ov::Extension::Ptr>& ext); \
+    OPENVINO_EXTENSION_C_API void OV_CREATE_EXTENSION(std::vector<ov::Extension::Ptr>& ext) { ext = extensions; }

--- a/src/core/include/openvino/core/rtti.hpp
+++ b/src/core/include/openvino/core/rtti.hpp
@@ -18,9 +18,7 @@
         type_info_static.hash();                                                          \
         return type_info_static;                                                          \
     }                                                                                     \
-    const ::ov::DiscreteTypeInfo& get_type_info() const override {                        \
-        return get_type_info_static();                                                    \
-    }
+    const ::ov::DiscreteTypeInfo& get_type_info() const override { return get_type_info_static(); }
 
 #define _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT(TYPE_NAME, VERSION_NAME, PARENT_CLASS) \
     _OPENVINO_RTTI_WITH_TYPE_VERSIONS_PARENT(TYPE_NAME, VERSION_NAME, PARENT_CLASS)
@@ -33,9 +31,7 @@
         type_info_static.hash();                                                               \
         return type_info_static;                                                               \
     }                                                                                          \
-    const ::ov::DiscreteTypeInfo& get_type_info() const override {                             \
-        return get_type_info_static();                                                         \
-    }
+    const ::ov::DiscreteTypeInfo& get_type_info() const override { return get_type_info_static(); }
 
 /// Helper macro that puts necessary declarations of RTTI block inside a class definition.
 /// Should be used in the scope of class that requires type identification besides one provided by

--- a/src/core/src/itt.hpp
+++ b/src/core/src/itt.hpp
@@ -50,11 +50,9 @@ OV_CC_DOMAINS(ov_opset);
 #    define INSERT_OP(opset_name, op_name, op_namespace) opset.insert<op_namespace::op_name>()
 #endif
 
-#define OPENVINO_TYPE_CASE(region, a, ...)                      \
-    case ov::element::Type_t::a: {                              \
-        OV_SCOPE(ov_op, OV_PP_CAT3(region, _, a)) {             \
-            rc = evaluate<ov::element::Type_t::a>(__VA_ARGS__); \
-        }                                                       \
+#define OPENVINO_TYPE_CASE(region, a, ...)                                                                \
+    case ov::element::Type_t::a: {                                                                        \
+        OV_SCOPE(ov_op, OV_PP_CAT3(region, _, a)) { rc = evaluate<ov::element::Type_t::a>(__VA_ARGS__); } \
     } break
 
 #define OPENVINO_2_TYPES_CASE(region, a, b, ...)                                \
@@ -64,9 +62,7 @@ OV_CC_DOMAINS(ov_opset);
         }                                                                       \
     } break
 
-#define OPENVINO_COPY_TENSOR(region, a, ...)                       \
-    case ov::element::Type_t::a: {                                 \
-        OV_SCOPE(ov_op, OV_PP_CAT3(region, _, a)) {                \
-            rc = copy_tensor<ov::element::Type_t::a>(__VA_ARGS__); \
-        }                                                          \
+#define OPENVINO_COPY_TENSOR(region, a, ...)                                                                 \
+    case ov::element::Type_t::a: {                                                                           \
+        OV_SCOPE(ov_op, OV_PP_CAT3(region, _, a)) { rc = copy_tensor<ov::element::Type_t::a>(__VA_ARGS__); } \
     } break

--- a/src/core/src/opsets/opset.cpp
+++ b/src/core/src/opsets/opset.cpp
@@ -96,7 +96,9 @@ std::string ov::OpSet::to_upper_name(const std::string& name) {
 
 const std::map<std::string, std::function<const ov::OpSet&()>>& ov::get_available_opsets() {
 #define _OPENVINO_REG_OPSET(OPSET) \
-    { #OPSET, ov::get_##OPSET }
+    {                              \
+#        OPSET, ov::get_##OPSET    \
+    }
     const static std::map<std::string, std::function<const ov::OpSet&()>> opset_map = {_OPENVINO_REG_OPSET(opset1),
                                                                                        _OPENVINO_REG_OPSET(opset2),
                                                                                        _OPENVINO_REG_OPSET(opset3),

--- a/src/core/tests/type_prop/generate_proposals.cpp
+++ b/src/core/tests/type_prop/generate_proposals.cpp
@@ -282,12 +282,10 @@ TEST(type_prop, generate_proposals_dynamic) {
         if (s.scores_shape.rank().is_static())
             set_shape_symbols(s.scores_shape);
 
-        auto expected_batch_label =
-            s.scores_shape.rank().is_static()
-                ? s.scores_shape[0].get_symbol()
-                : s.deltas_shape.rank().is_static()
-                      ? s.deltas_shape[0].get_symbol()
-                      : s.im_info_shape.rank().is_static() ? s.im_info_shape[0].get_symbol() : nullptr;
+        auto expected_batch_label = s.scores_shape.rank().is_static()    ? s.scores_shape[0].get_symbol()
+                                    : s.deltas_shape.rank().is_static()  ? s.deltas_shape[0].get_symbol()
+                                    : s.im_info_shape.rank().is_static() ? s.im_info_shape[0].get_symbol()
+                                                                         : nullptr;
 
         auto im_info = std::make_shared<ov::op::v0::Parameter>(element::f32, s.im_info_shape);
         auto anchors = std::make_shared<ov::op::v0::Parameter>(element::f32, s.anchors_shape);

--- a/src/frontends/ir/src/ir_deserializer.cpp
+++ b/src/frontends/ir/src/ir_deserializer.cpp
@@ -757,11 +757,15 @@ ov::GenericLayerParams ov::XmlDeserializer::parse_generic_params(const pugi::xml
 
     auto outNode = node.child("output");
     if (!outNode.empty()) {
-        FOREACH_CHILD (_cn, outNode, "port") { params.outputPorts.emplace_back(parsePort(_cn, params, false)); }
+        FOREACH_CHILD (_cn, outNode, "port") {
+            params.outputPorts.emplace_back(parsePort(_cn, params, false));
+        }
     }
     auto inpNode = node.child("input");
     if (!inpNode.empty()) {
-        FOREACH_CHILD (_cn, inpNode, "port") { params.inputPorts.emplace_back(parsePort(_cn, params, true)); }
+        FOREACH_CHILD (_cn, inpNode, "port") {
+            params.inputPorts.emplace_back(parsePort(_cn, params, true));
+        }
     }
     return params;
 }

--- a/src/inference/src/cpp/core.cpp
+++ b/src/inference/src/cpp/core.cpp
@@ -78,9 +78,7 @@ Core::Core(const std::string& xml_config_file) {
 }
 
 std::map<std::string, Version> Core::get_versions(const std::string& device_name) const {
-    OV_CORE_CALL_STATEMENT({ return _impl->get_versions(device_name); })
-}
-
+    OV_CORE_CALL_STATEMENT({ return _impl->get_versions(device_name); })}
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 std::shared_ptr<ov::Model> Core::read_model(const std::wstring& model_path, const std::wstring& bin_path) const {
     OV_CORE_CALL_STATEMENT(

--- a/src/inference/src/dev/threading/parallel_custom_arena.cpp
+++ b/src/inference/src/dev/threading/parallel_custom_arena.cpp
@@ -246,19 +246,17 @@ task_arena::task_arena(int max_concurrency_, unsigned reserved_for_masters)
 
 task_arena::task_arena(const constraints& constraints_, unsigned reserved_for_masters)
 #    if USE_TBBBIND_2_5
-    : my_task_arena {
-    info::default_concurrency(constraints_), reserved_for_masters
-}
+    : my_task_arena{info::default_concurrency(constraints_), reserved_for_masters}
 #    elif TBB_NUMA_SUPPORT_PRESENT || TBB_HYBRID_CPUS_SUPPORT_PRESENT
-    : my_task_arena {
-    convert_constraints(constraints_), reserved_for_masters
-}
+    : my_task_arena{convert_constraints(constraints_), reserved_for_masters}
 #    else
-    : my_task_arena {
-    constraints_.max_concurrency, reserved_for_masters
-}
+    : my_task_arena{constraints_.max_concurrency, reserved_for_masters}
 #    endif
-, my_initialization_state{}, my_constraints{constraints_}, my_binding_observer{} {}
+      ,
+      my_initialization_state{},
+      my_constraints{constraints_},
+      my_binding_observer{} {
+}
 
 task_arena::task_arena(const task_arena& s)
     : my_task_arena{s.my_task_arena},

--- a/src/inference/tests/unit/cpu_map_parser/parser_windows.cpp
+++ b/src/inference/tests/unit/cpu_map_parser/parser_windows.cpp
@@ -16,9 +16,10 @@ namespace {
 #if defined(_WIN32)
 
 int Hex2Int(char c) {
-    return (c >= '0' && c <= '9')
-               ? (c) - '0'
-               : (c >= 'A' && c <= 'F') ? (c) - 'A' + 10 : (c >= 'a' && c <= 'f') ? (c) - 'a' + 10 : 0;
+    return (c >= '0' && c <= '9')   ? (c) - '0'
+           : (c >= 'A' && c <= 'F') ? (c) - 'A' + 10
+           : (c >= 'a' && c <= 'f') ? (c) - 'a' + 10
+                                    : 0;
 }
 
 void Hex2Bin(const char* hex, std::size_t sz, char* out) {

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/config.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/config.hpp
@@ -33,15 +33,11 @@ struct TypePrinter {
     static constexpr const char* name();
 };
 
-#define TYPE_PRINTER(type)                    \
-    template <>                               \
-    struct TypePrinter<type> {                \
-        static constexpr bool hasName() {     \
-            return true;                      \
-        }                                     \
-        static constexpr const char* name() { \
-            return #type;                     \
-        }                                     \
+#define TYPE_PRINTER(type)                                    \
+    template <>                                               \
+    struct TypePrinter<type> {                                \
+        static constexpr bool hasName() { return true; }      \
+        static constexpr const char* name() { return #type; } \
     };
 
 TYPE_PRINTER(bool)

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/graph_comparator.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/graph_comparator.hpp
@@ -517,10 +517,8 @@ class ReadAndStoreAttributes : public ov::AttributeVisitor, protected storage::S
 public:
     void on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) override;
 
-#define ON_ADAPTER(TYPE)                                                                  \
-    void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { \
-        insert(name, adapter.get());                                                      \
-    }
+#define ON_ADAPTER(TYPE) \
+    void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { insert(name, adapter.get()); }
 
     ON_ADAPTER(bool)
     ON_ADAPTER(std::string)
@@ -913,10 +911,8 @@ public:
         verify_others(name, adapter);
     }
 
-#define ON_ADAPTER(TYPE)                                                                  \
-    void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { \
-        verify(name, adapter.get());                                                      \
-    }
+#define ON_ADAPTER(TYPE) \
+    void on_adapter(const std::string& name, ov::ValueAccessor<TYPE>& adapter) override { verify(name, adapter.get()); }
 
     ON_ADAPTER(bool)
     ON_ADAPTER(std::string)


### PR DESCRIPTION
### Details:
 - Migration to clang-format-15 which is available in Ubuntu 22.04
