### PR TITLE
[GPU] Fix unintentional allow_new_shape_infer true in static model.

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/program_builder.cpp
+++ b/src/plugins/intel_gpu/src/plugin/program_builder.cpp
@@ -340,9 +340,6 @@ bool ProgramBuilder::requires_new_shape_infer(const std::shared_ptr<ov::Node>& o
             return true;
     }
 
-    if (ov::is_type<op::FullyConnectedCompressed>(op))
-        return true;
-
     for (size_t i = 0; i < op->get_output_size(); i++) {
         if (op->get_output_partial_shape(i).size() > 6)
             return true;


### PR DESCRIPTION
SD1.5 weight compressed model's Perf issue in a770.
Even though static model, set formats likes dynamic mode. It cause huge performance issues.


### Tickets:
 - *138632*
