### PR TITLE
[intel-npu] Fix build when using specific Werror

### DIFF
--- a/src/plugins/intel_npu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_npu/thirdparty/CMakeLists.txt
@@ -22,8 +22,7 @@ if(ENABLE_ZEROAPI_BACKEND)
         # Close spectre for ze loader
         add_compile_options("/Qspectre-")
     elseif(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)
-        string(REPLACE "-Werror" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-        string(REPLACE "-Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+        ov_add_compiler_flags(-Wno-error)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
             -Wno-undef \
             -Wno-unused-but-set-variable \


### PR DESCRIPTION
The commit eb025fad1e800280746eb2d543818bece701c9c6 breaks the build when `CXXFLAGS` or `CFLAGS` have a specific `-Werror` flag.

For example, when `CXXFLAGS` have `-Werror=format-security`, the build fails with this message:

```
c++: warning: =format-security: linker input file unused because linking not done
c++: error: =format-security: linker input file not found: No such file or directory
```

That's because every occurrence of the `-Werror` string is being replaced in the original `CXXFLAGS` and `CFLAGS` variables. So, if they contain `-Werror=<something>`, it will become just `=<something>`, which will be an unrecognized option.

The current commit fixes this by appending `-Wno-error` to `CXXFLAGS` and `CFLAGS` to properly disable errors on warnings.
