### PR TITLE
Fixed case when users explicitly pass different gcc ABI via cxx flags

### DIFF
--- a/cmake/developer_package/target_flags.cmake
+++ b/cmake/developer_package/target_flags.cmake
@@ -119,7 +119,7 @@ function(ov_get_compiler_definition definition var)
     endif()
 
     execute_process(COMMAND echo "#include <string>"
-                    COMMAND "${CMAKE_CXX_COMPILER}" -x c++ - -E -dM
+                    COMMAND "${CMAKE_CXX_COMPILER}" -x c++ - -E -dM ${CMAKE_CXX_FLAGS}
                     COMMAND grep -E "^#define ${definition} "
                     OUTPUT_VARIABLE output_value
                     ERROR_VARIABLE error_message


### PR DESCRIPTION
### Details:
 - Should help with https://github.com/conan-io/conan-center-index/pull/23754
 - Taken from https://github.com/openvinotoolkit/openvino/pull/23534
