### PR TITLE
[GPU] Disabling use OneDNN for FC with zero_point_scalar and group size that is not a power of two

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -982,7 +982,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             auto fused_node = parents[fused_idx].first;
             auto peer_node = parents[peer_idx].first;
 
-            if (_lo.get_optimization_attributes().use_onednn_impls) {
+            if (_lo.get_optimization_attributes().use_onednn_impls && _lo.is_node_suitable_for_onednn(*fused_node)) {
                 auto eltw_in_size = peer_node->get_output_layout();
                 if (eltw_in_size.is_dynamic())
                     return;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -334,7 +334,12 @@ public:
             dzp_data_type = convert_data_type(broadcasted_layout_zp.data_type);
             zp_mem = engine.allocate_memory(broadcasted_layout_zp, false);
             mem_fill(stream, zp_mem, static_cast<uint8_t>(std::round(prim->decompression_zero_point_scalar.value())));
-            attr->set_zero_points(DNNL_ARG_WEIGHTS, (1 << 1) + (1 << 0), {group_size, 1}, dzp_data_type);
+
+            if (!is_four_bit_weight) {
+                attr->set_zero_points(DNNL_ARG_WEIGHTS, 1 << 1, dnnl::memory::dims{}, dzp_data_type);
+            } else {
+                attr->set_zero_points(DNNL_ARG_WEIGHTS, (1 << 1) + (1 << 0), {group_size, 1}, dzp_data_type);
+            }
         } else if (!prim->decompression_zero_point.empty()) {
             auto decompression_zp_idx = !arg.bias_term() ? 3 : 4;
             auto &zp_node = arg.get_dependency(decompression_zp_idx).as<data>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -385,14 +385,14 @@ public:
             if (!prim->decompression_scale.empty()) {
                 auto decompression_scale_idx = !arg.bias_term() ? 2 : 3;
                 ds_data_type = convert_data_type(arg.get_dependency(decompression_scale_idx).get_output_layout().data_type);
+                auto ifm = arg.get_dependency(1).get_output_layout().get_dim(1);
+                auto ngroups = arg.get_dependency(decompression_scale_idx).get_output_layout().get_dim(1);
+                group_size = ifm / ngroups;
                 if (!is_four_bit_weight) {
                     // 8-bit quantized weight
                     attr->set_scales(DNNL_ARG_WEIGHTS, 1 << 1, dnnl::memory::dims{}, ds_data_type);
                 } else {
                     // OneDNN does not support scalar zero-point for s4 and u8 type. Need to broadcast it.
-                    auto ifm = arg.get_dependency(1).get_output_layout().get_dim(1);
-                    auto ngroups = arg.get_dependency(decompression_scale_idx).get_output_layout().get_dim(1);
-                    group_size = ifm / ngroups;
                     attr->set_scales(DNNL_ARG_WEIGHTS, (1 << 1) + (1 << 0), {group_size, 1}, ds_data_type);
                 }
             }

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -951,27 +951,6 @@ static bool is_node_for_onednn(fully_connected_node const& node) {
         }
     }
 
-    if (fc_prim->decompression_zero_point_scalar.has_value() && !fc_prim->decompression_scale.empty()) {
-        size_t decompression_scale_idx = !node.bias_term() ? 2ul : 3ul;
-        const auto& weights_pshape = node.get_dependency(1).get_output_pshape();
-        const auto& decompression_scale_pshape = node.get_dependency(decompression_scale_idx).get_output_pshape();
-
-        const auto& ifm = weights_pshape[1];
-        const auto& ngroups = decompression_scale_pshape[1];
-
-        if (ifm.is_static() && ngroups.is_static()) {
-            auto is_power_of_two = [](int64_t x) {
-                return (x & (x - 1)) == 0;
-            };
-
-            int64_t group_size = ifm.get_length() / ngroups.get_length();
-
-            if (!is_power_of_two(group_size)) {
-                return false;
-            }
-        }
-    }
-
     return true;
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -3083,6 +3083,7 @@ TEST_F(fully_connected_gpu_tests, compressed_scale_fp16_cached) {
 }
 
 TEST_F(fully_connected_gpu_tests, compressed_int8_scale_zp_scalar) {
+    // Testing support for decompression zero points with group size that is not a power of two
     this->test_compressed_int8_scale_zp_scalar(false);
 }
 


### PR DESCRIPTION
### Tickets:
 - *[138780](https://jira.devtools.intel.com/browse/CVS-138780)*
