### PR TITLE
[AUTO] Fix memory leak in ov_auto_unit_tests  

### DIFF
--- a/src/inference/dev_api/openvino/runtime/isync_infer_request.hpp
+++ b/src/inference/dev_api/openvino/runtime/isync_infer_request.hpp
@@ -158,7 +158,7 @@ protected:
 
     std::unordered_map<std::shared_ptr<ov::descriptor::Tensor>, std::vector<ov::SoPtr<ov::ITensor>>> m_batched_tensors;
     ov::SoPtr<ov::ITensor>& get_tensor_ptr(const ov::Output<const ov::Node>& port) const;
-
+    void Reset_m_compiled_model();
 private:
     std::shared_ptr<const ov::ICompiledModel> m_compiled_model;
     // Mutable to return reference to ov::Tensor

--- a/src/inference/src/dev/isync_infer_request.cpp
+++ b/src/inference/src/dev/isync_infer_request.cpp
@@ -306,3 +306,8 @@ void ov::ISyncInferRequest::check_tensors() const {
         check_tensor(outputs[i], m_tensors.at(outputs[i].get_tensor_ptr()));
     }
 }
+
+void ov::ISyncInferRequest::Reset_m_compiled_model()
+{
+    m_compiled_model.reset();
+}

--- a/src/plugins/auto/tests/unit/auto_unit_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_unit_test.cpp
@@ -134,6 +134,8 @@ ov::mock_auto_plugin::tests::BaseTest::~BaseTest() {
     mockExeNetworkActual = {};
     config.clear();
     metaDevices.clear();
+    inferReqInternal->Reset_m_compiled_model();
+    inferReqInternalActual->Reset_m_compiled_model();
     inferReqInternal.reset();
     inferReqInternalActual.reset();
     mock_plugin_cpu.reset();


### PR DESCRIPTION
### Details:
 - Fix SharePtr mutual reference in auto_unit_test.cpp which causes memory leaks

### Tickets:
 - [*CVS-134423*](https://jira.devtools.intel.com/browse/CVS-134423)
