### PR TITLE
[NPU] Return false in case backend is not available

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/backends.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/backends.cpp
@@ -160,7 +160,7 @@ bool NPUBackends::isBatchingSupported() const {
         return _backend->isBatchingSupported();
     }
 
-    OPENVINO_THROW("No available backend");
+    return false;
 }
 
 std::shared_ptr<IDevice> NPUBackends::getDevice(const std::string& specificName) const {


### PR DESCRIPTION
### Details:
 - *Return false in case the backend is not available when using offline compilation without having a backend*

### Tickets:
 - *ticket-id*
