### PR TITLE
Fix compilation without a backend

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/backends.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/backends.cpp
@@ -158,9 +158,9 @@ uint32_t NPUBackends::getDriverExtVersion() const {
 bool NPUBackends::isBatchingSupported() const {
     if (_backend != nullptr) {
         return _backend->isBatchingSupported();
+    } else {
+        return false;
     }
-
-    OPENVINO_THROW("No available backend");
 }
 
 std::shared_ptr<IDevice> NPUBackends::getDevice(const std::string& specificName) const {


### PR DESCRIPTION
After batching introduction plugin will throw an error when no backend was found. This breaks compilation on platforms without backend. As a temporary fix return false from isBatchingSupported when no backend is found instead of throwing an exception.
 
### Tickets:
 - [E#122682]
