### PR TITLE
[GPU] Optimize update dispatch data for few primitives

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -288,6 +288,8 @@ public:
     void load(cldnn::BinaryInputBuffer& ib);
     bool is_loaded_from_cache() const { return _loaded_from_cache; }
 
+    bool is_new_shape_infer() const { return new_shape_infer; }
+
 private:
     uint32_t prog_id = 0;
     engine& _engine;
@@ -309,6 +311,8 @@ private:
     const size_t _impls_cache_capacity = 300;
     std::shared_ptr<ICompilationContext> _compilation_context;
     bool _loaded_from_cache = false;
+
+    bool new_shape_infer = false;
 
     std::map<primitive_id, std::shared_ptr<program_node>> nodes_map;
     std::list<primitive_id> optimized_out;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
@@ -407,7 +407,7 @@ struct layout {
     bool identical(const layout& other) const;
 
     static size_t max_rank() { return 8; }
-    static ov::PartialShape transform(const ov::PartialShape& pshape, cldnn::format old_fmt, cldnn::format new_fmt);
+    static ov::PartialShape transform(const ov::PartialShape& pshape, const cldnn::format& old_fmt, const cldnn::format& new_fmt);
 
     size_t hash() const {
         size_t seed = 0;

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -157,7 +157,7 @@ std::vector<layout> fully_connected_inst::calc_output_layouts(fully_connected_no
     std::vector<ShapeType> output_shapes = ov::op::v0::shape_infer(&op, input_shapes);
 
     bool is_static = input_layout.is_static() && weights_layout.is_static();
-    bool allow_new_shape_infer = impl_param.get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+    bool allow_new_shape_infer = impl_param.get_program().is_new_shape_infer();
     format::type output_format = is_static && !allow_new_shape_infer ? get_preferred_format(node, impl_param) :
                                               input_layout.format.value;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
@@ -72,7 +72,7 @@ void handle_reshape::run(program& p) {
             // In case of new shape infer we should not shrink reshapes chain if first reshape changes input rank, e.g.
             // [a, b] -> reshape1 -> [a1, b1, c1] -> reshape2 -> [a2, b2, 0] and any of the reshapes has special_zero=true
             // Configuration above will fail if we remove reshape1 node as attempt to handle special zero will fail due to small rank of input
-            if (p.get_config().get_property(ov::intel_gpu::allow_new_shape_infer) &&
+            if (p.is_new_shape_infer() &&
                 out_node->get_output_pshape().size() != node.get_input_pshape().size() &&
                 (out_reshape.get_primitive()->special_zero || node.get_primitive()->special_zero))
                 return;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_shape_of_subgraphs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_shape_of_subgraphs.cpp
@@ -112,7 +112,7 @@ void mark_shape_of_subgraphs::mark_node(program_node& node) {
 }
 
 void mark_shape_of_subgraphs::run(program& p) {
-    if (p.get_config().get_property(ov::intel_gpu::allow_new_shape_infer)) {
+    if (p.is_new_shape_infer()) {
         for (auto& node : p.get_processing_order()) {
             look_for_shape_of_subgraph(*node);
         }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -649,7 +649,7 @@ void remove_redundant_reorders::run(program& p) {
         // In case of new shape infer we should not shrink reshapes chain if first reshape changes input rank, e.g.
         // [a, b] -> reshape1 -> [a1, b1, c1] -> reshape2 -> [a2, b2, 0] and any of the reshapes has special_zero=true
         // Configuration above will fail if we remove reshape1 node as attempt to handle special zero will fail due to small rank of input
-        if (p.get_config().get_property(ov::intel_gpu::allow_new_shape_infer) &&
+        if (p.is_new_shape_infer() &&
             reshape_node.get_output_pshape().size() != dep_node.get_input_pshape().size() &&
             (reshape_node.get_primitive()->special_zero || reshape_input_node.get_primitive()->special_zero))
             continue;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -43,7 +43,7 @@ public:
                 }
                 default: OPENVINO_ASSERT(false, "[GPU] Not supported index element type");
             }
-            bool allow_new_shape_infer = impl_param.get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+            bool allow_new_shape_infer = impl_param.get_program().is_new_shape_infer();
             if (allow_new_shape_infer) {
                 params.outputs_num = 2;
                 params.outputs.push_back(convert_data_tensor(impl_param.get_output_layout(1)));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -129,8 +129,8 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
-        auto kernel_params = get_kernel_params(impl_param, true);
-        (_kernel_data.update_dispatch_data_func)(kernel_params, _kernel_data);
+        update_shapes(*_kernel_data.params, impl_param);
+        (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -70,7 +70,7 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
         auto output_rank = output_pshape.size();
 
         if (primitive->axes_mapping.empty()) {
-            bool use_new_shape_infer = impl_params.prog->get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+            bool use_new_shape_infer = impl_params.prog->is_new_shape_infer();
             if (!broadcastable(input_pshape, output_pshape, use_new_shape_infer)) {
                 input_pshape = extend_shape_to_rank_from_begin(input_pshape, output_pshape.size());
             } else {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -129,6 +129,11 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
+        // If model loaded from cache, params are not initialized, so we create a new object and reuse it in the future
+        if (_kernel_data.params == nullptr) {
+            _kernel_data.params = std::make_shared<kernel_params_t>(get_kernel_params(impl_param, true));
+        }
+
         update_shapes(*_kernel_data.params, impl_param);
         (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
@@ -31,7 +31,7 @@ struct ctc_greedy_decoder_impl : typed_primitive_impl_ocl<ctc_greedy_decoder> {
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
         params.merge_repeated = primitive->ctc_merge_repeated;
 
-        bool allow_new_shape_infer = impl_param.get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+        bool allow_new_shape_infer = impl_param.get_program().is_new_shape_infer();
         if (allow_new_shape_infer && primitive->num_outputs == 2) {
             if (primitive->blank_index == UINT32_MAX) {
                 params.blank_index = impl_param.get_input_layout(0).spatial(1) - 1;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -27,7 +27,7 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
         auto params = get_default_params<kernel_selector::dft_params>(impl_param);
         auto& memory_deps = impl_param.memory_deps;
 
-        bool allow_new_shape_infer = impl_param.get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+        bool allow_new_shape_infer = impl_param.get_program().is_new_shape_infer();
         if (allow_new_shape_infer && primitive->axes.empty() && primitive->signal_size.empty()) {
             if (memory_deps.count(1)) {
                 auto axes_mem = memory_deps.at(1);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -152,8 +152,8 @@ public:
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
-        auto kernel_params = get_kernel_params(impl_param, true);
-        (_kernel_data.update_dispatch_data_func)(kernel_params, _kernel_data);
+        update_shapes(*_kernel_data.params, impl_param);
+        (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -129,7 +129,7 @@ public:
 
     static kernel_impl_params static_canonicalize_shapes(const kernel_impl_params& impl_params) {
         auto updated_impl_params = canonicalize_fused_shapes(impl_params);
-        bool use_new_shape_infer = impl_params.prog->get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+        bool use_new_shape_infer = impl_params.prog->is_new_shape_infer();
 
         auto& output_layout = updated_impl_params.output_layouts[0];
         auto out_pshape = output_layout.get_partial_shape();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -152,6 +152,11 @@ public:
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
+        // If model loaded from cache, params are not initialized, so we create a new object and reuse it in the future
+        if (_kernel_data.params == nullptr) {
+            _kernel_data.params = std::make_shared<kernel_params_t>(get_kernel_params(impl_param, true));
+        }
+
         update_shapes(*_kernel_data.params, impl_param);
         (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -147,7 +147,7 @@ public:
             return updated_out_layout;
         };
 
-        bool allow_new_shape_infer = impl_param.get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+        bool allow_new_shape_infer = impl_param.get_program().is_new_shape_infer();
         auto updated_impl_param = impl_param;
 
         const auto input_layouts = get_fc_input_layouts(impl_param.input_layouts, allow_new_shape_infer);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
@@ -275,4 +275,23 @@ inline std::shared_ptr<WeightsReorderParams> create_weights_reorder_params(const
     return std::make_shared<WeightsReorderParams>(from_weights_tensor(params.src), from_weights_tensor(params.dest), params.rotate);
 }
 
+inline void update_shapes(kernel_selector::Params& p, const kernel_impl_params& impl_param) {
+    auto& bp = static_cast<kernel_selector::base_params&>(p);
+    for (size_t i = 0; i < bp.inputs.size(); i++) {
+        bp.inputs[i] = convert_data_tensor(impl_param.input_layouts[i]);
+    }
+    for (size_t i = 0; i < bp.outputs.size(); i++) {
+        bp.outputs[i] = convert_data_tensor(impl_param.output_layouts[i]);
+    }
+
+    for (size_t i = 0; i < bp.fused_ops.size(); i++) {
+        const auto& fused_prim = impl_param.fused_desc[i];
+        auto& fd = bp.fused_ops[i];
+        fd.output_tensor = convert_data_tensor(fused_prim.output_layout);
+        for (size_t i = fd.dep_idx_start; i < fd.dep_idx_start + fd.dep_size; i++) {
+            fd.tensors.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
+        }
+    }
+}
+
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
@@ -248,7 +248,7 @@ inline bool broadcastable(const ov::PartialShape& first_pshape, const ov::Partia
 
 inline kernel_impl_params canonicalize_fused_shapes(const kernel_impl_params& impl_params) {
     auto updated_impl_params = impl_params;
-    bool use_new_shape_infer = impl_params.prog->get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+    bool use_new_shape_infer = impl_params.prog->is_new_shape_infer();
 
     for (auto& fd : updated_impl_params.fused_desc) {
         if (fd.is_type<eltwise>() && fd.total_num_deps == 2 && fd.has_outer_dep()) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -291,8 +291,14 @@ struct kv_cache_impl : multi_stage_primitive<kv_cache> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
-        auto kv_cache_kernel_params = get_concat_kernel_params(impl_param, impl_param.is_dynamic());
-        (_kernels_data[concat_stage].update_dispatch_data_func)(kv_cache_kernel_params, _kernels_data[concat_stage]);
+        auto& params = static_cast<kernel_params_t&>(*_kernels_data[concat_stage].params);
+        const auto inputs_count = 2;
+        for (size_t i = 0; i < inputs_count; ++i) {
+            params.inputs[i] = convert_data_tensor(impl_param.input_layouts[i]);
+        }
+        params.outputs[0] = convert_data_tensor(impl_param.output_layouts[0]);
+
+        (_kernels_data[concat_stage].update_dispatch_data_func)(params, _kernels_data[concat_stage]);
         _kernels_data[concat_stage].kernels[0].skip_execution = impl_param._can_be_optimized || impl_param.get_input_layout(0).count() == 0;
     }
 };

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -291,6 +291,10 @@ struct kv_cache_impl : multi_stage_primitive<kv_cache> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
+        // If model loaded from cache, params are not initialized, so we create a new object and reuse it in the future
+        if (_kernels_data[concat_stage].params == nullptr) {
+            _kernels_data[concat_stage].params = std::make_shared<kernel_params_t>(get_concat_kernel_params(impl_param, true));
+        }
         auto& params = static_cast<kernel_params_t&>(*_kernels_data[concat_stage].params);
         const auto inputs_count = 2;
         for (size_t i = 0; i < inputs_count; ++i) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -41,8 +41,8 @@ struct range_impl : typed_primitive_impl_ocl<range> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
-       auto kernel_params = get_kernel_params(impl_param, true);
-       (_kernel_data.update_dispatch_data_func)(kernel_params, _kernel_data);
+        update_shapes(*_kernel_data.params, impl_param);
+        (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -41,6 +41,11 @@ struct range_impl : typed_primitive_impl_ocl<range> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
+        // If model loaded from cache, params are not initialized, so we create a new object and reuse it in the future
+        if (_kernel_data.params == nullptr) {
+            _kernel_data.params = std::make_shared<kernel_params_t>(get_kernel_params(impl_param, true));
+        }
+
         update_shapes(*_kernel_data.params, impl_param);
         (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -65,8 +65,8 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
-        auto kernel_params = get_kernel_params(impl_param, true);
-        (_kernel_data.update_dispatch_data_func)(kernel_params, _kernel_data);
+        update_shapes(*_kernel_data.params, impl_param);
+        (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -65,6 +65,10 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
+        // If model loaded from cache, params are not initialized, so we create a new object and reuse it in the future
+        if (_kernel_data.params == nullptr) {
+            _kernel_data.params = std::make_shared<kernel_params_t>(get_kernel_params(impl_param, true));
+        }
         update_shapes(*_kernel_data.params, impl_param);
         (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -230,8 +230,8 @@ public:
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
-        auto kernel_params = get_kernel_params(impl_param, true);
-        (_kernel_data.update_dispatch_data_func)(kernel_params, _kernel_data);
+        update_shapes(*_kernel_data.params, impl_param);
+        (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -230,6 +230,11 @@ public:
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
+        // If model loaded from cache, params are not initialized, so we create a new object and reuse it in the future
+        if (_kernel_data.params == nullptr) {
+            _kernel_data.params = std::make_shared<kernel_params_t>(get_kernel_params(impl_param, true));
+        }
+
         update_shapes(*_kernel_data.params, impl_param);
         (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -82,7 +82,7 @@ public:
     }
 
     bool is_shape_infer_dep(void) const {
-        if (!myprog.get_config().get_property(ov::intel_gpu::allow_new_shape_infer))
+        if (!myprog.is_new_shape_infer())
             return false;
         for (auto u : users) {
             for (auto dep_idx : u->get_shape_infer_dependencies()) {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -425,7 +425,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
 }
 
 bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, reorder_node& node, format fmt_prev, format fmt_next) {
-    bool allow_new_shape_infer = node.get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+    bool allow_new_shape_infer = node.get_program().is_new_shape_infer();
     // Because mvn and concatenation kernel can work cross-layout, if reorder only performs type conversion,
     // fusing reorder to the previous node can be done even if it is a dynamic shape case
     if ((prev.is_type<mvn>() || prev.is_type<concatenation>()) &&
@@ -1774,7 +1774,7 @@ format layout_optimizer::get_preferred_format(program_node& node) {
     auto output_layout = node.get_output_layout();
     bool use_onednn_impls = _optimization_attributes.use_onednn_impls;
 
-    bool allow_new_shape_infer = node.get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+    bool allow_new_shape_infer = node.get_program().is_new_shape_infer();
 
     if (allow_new_shape_infer) {
         // Let reorder_input pass to check input format instead of output_format in forward investigation, vice versa

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -752,23 +752,24 @@ void primitive_inst::fill_shape_info_data(const layout& runtime_layout, const la
         GPU_DEBUG_TRACE_DETAIL << "tensor is static. Skipping" << std::endl;
         return;
     }
-    auto pshape = runtime_layout.get_partial_shape();
+    const auto& pshape = runtime_layout.get_partial_shape();
+    auto shape_info_fmt = format::get_default_format(layout::max_rank());
     auto shape_with_max_rank = layout::transform(pshape,
                                                  format::get_default_format(pshape.size()),
-                                                 format::get_default_format(layout::max_rank())).to_shape();
+                                                 shape_info_fmt).to_shape();
     for (size_t j = 0; j < shape_with_max_rank.size(); ++j) {
         GPU_DEBUG_TRACE_DETAIL << " shape_info[" << offset << "] = " << shape_with_max_rank[j] << std::endl;
         shape_info_ptr[offset++] = static_cast<int32_t>(shape_with_max_rank[j]);
     }
-    auto dynamic_pad = node_layout.data_padding.get_dynamic_pad_dims().sizes(format::get_default_format(layout::max_rank()));
-    auto data_padding = runtime_layout.data_padding;
+    auto dynamic_pad = node_layout.data_padding.get_dynamic_pad_dims().sizes(shape_info_fmt);
+    const auto& data_padding = runtime_layout.data_padding;
+    auto lower_pads = data_padding.lower_size().sizes(shape_info_fmt);
+    auto upper_pads = data_padding.upper_size().sizes(shape_info_fmt);
     for (size_t j = 0; j < shape_with_max_rank.size(); ++j) {
         if (dynamic_pad[j] == 1) {
-            auto lower_pads = data_padding.lower_size().sizes(format::get_default_format(layout::max_rank()));
             GPU_DEBUG_TRACE_DETAIL << " shape_info[" << offset << "] = " << lower_pads[j]
                                    << "(pad_before for " << j << "-th dim)" << std::endl;
             shape_info_ptr[offset++] = lower_pads[j];  // pad_before
-            auto upper_pads = data_padding.upper_size().sizes(format::get_default_format(layout::max_rank()));
             GPU_DEBUG_TRACE_DETAIL << " shape_info[" << offset << "] = " << upper_pads[j]
                                    << "(pad_after for " << j << "-th dim)" << std::endl;
             shape_info_ptr[offset++] = upper_pads[j];  // pad_after

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -207,6 +207,7 @@ program::program(engine& engine,
       processing_order() {
     init_primitives();
     _config.apply_user_properties(_engine.get_device_info());
+    new_shape_infer = _config.get_property(ov::intel_gpu::allow_new_shape_infer);
 }
 
 program::~program() {

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -217,6 +217,7 @@ void program::init_program() {
     set_options();
 
     pm = std::unique_ptr<pass_manager>(new pass_manager(*this));
+    new_shape_infer = _config.get_property(ov::intel_gpu::allow_new_shape_infer);
 
     if (_task_executor == nullptr)
         _task_executor = program::make_task_executor(_config);

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -368,7 +368,7 @@ bool program_node::is_detached(bool whole_branch) {
 }
 
 layout program_node::calc_output_layout() const {
-    bool allow_new_shape_infer = get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+    bool allow_new_shape_infer = get_program().is_new_shape_infer();
     if (allow_new_shape_infer) {
         auto out_layouts = type()->calc_output_layouts(*this, *get_kernel_impl_params());
         if (!out_layouts.empty()) {
@@ -384,7 +384,7 @@ layout program_node::calc_output_layout() const {
 }
 
 std::vector<layout> program_node::calc_output_layouts() const {
-    bool allow_new_shape_infer = get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+    bool allow_new_shape_infer = get_program().is_new_shape_infer();
     if (allow_new_shape_infer) {
         auto out_layouts = type()->calc_output_layouts(*this, *get_kernel_impl_params());
         if (!out_layouts.empty())
@@ -1449,7 +1449,7 @@ void program_node::init_onednn_primitive_attributes() {
         auto& desc = cldnn_post_ops[idx];
         if (desc.is_type<activation>()) {
             auto fused_desc = desc.typed_desc<activation>();
-            bool allow_new_shape_infer = get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer);
+            bool allow_new_shape_infer = get_program().is_new_shape_infer();
             if (fused_desc->activation_function == cldnn::activation_func::relu_negative_slope
                 && !fused_desc->additional_params_input.empty()) {
                 auto dep_idx = cldnn_post_ops[idx].outer_dep_start_idx;

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -299,8 +299,7 @@ void reshape_inst::update_output_memory() {
         return;
 
     build_deps();  // reshape need deps
-    if (node->get_program().get_config().get_property(ov::intel_gpu::allow_new_shape_infer) &&
-        input_memory_ptr() == nullptr)
+    if (node->get_program().is_new_shape_infer() && input_memory_ptr() == nullptr)
         return;
     OPENVINO_ASSERT(input_memory_ptr() != nullptr, "[GPU] Failed to reuse input in ", id(), " primitive: input memory was not allocated");
     _outputs = {_network.get_engine().reinterpret_buffer(input_memory(), _impl_params->get_output_layout())};

--- a/src/plugins/intel_gpu/src/runtime/format.cpp
+++ b/src/plugins/intel_gpu/src/runtime/format.cpp
@@ -165,8 +165,9 @@ static const std::map<format::type, format_traits> format_traits_map {
 };
 
 const format_traits& format::traits(type fmt) {
-    OPENVINO_ASSERT(format_traits_map.find(fmt) != format_traits_map.end(), "[GPU] Format description is missing in fmt traits");
-    return format_traits_map.at(fmt);
+    auto it = format_traits_map.find(fmt);
+    OPENVINO_ASSERT(it != format_traits_map.end(), "[GPU] Format description is missing in fmt traits");
+    return it->second;
 }
 
 const format_traits& format::traits() const {

--- a/src/plugins/intel_gpu/src/runtime/layout.cpp
+++ b/src/plugins/intel_gpu/src/runtime/layout.cpp
@@ -7,12 +7,14 @@
 #include <list>
 #include <vector>
 #include <algorithm>
+#include "openvino/core/dimension.hpp"
+#include "openvino/core/partial_shape.hpp"
 
 namespace cldnn {
 static inline bool check_redundant_1d_along_feature(layout const& l1, layout const& l2);
 namespace {
 
-std::vector<int32_t> convert_dimensions(const std::vector<int32_t>& sizes, std::string in_order, std::string out_order) {
+std::vector<int32_t> convert_dimensions(const std::vector<int32_t>& sizes, const std::string& in_order, const std::string& out_order) {
     std::vector<int32_t> new_sizes(out_order.size(), {-1});
     for (size_t out_idx = 0; out_idx < out_order.size(); ++out_idx) {
         auto channel = out_order[out_idx];
@@ -501,23 +503,33 @@ bool layout::identical(const layout& other) const {
     return ret;
 }
 
-ov::PartialShape layout::transform(const ov::PartialShape& pshape, cldnn::format old_fmt, cldnn::format new_fmt) {
+ov::PartialShape layout::transform(const ov::PartialShape& pshape, const cldnn::format& old_fmt, const cldnn::format& new_fmt) {
     if (old_fmt == new_fmt) {
         return pshape;
     }
 
+    // shortcut for transform to max rank default fmt which is used in fill_shape_info_data to improve perf
+    if (format::is_default_format(old_fmt) && new_fmt == format::bfvuwzyx) {
+        ov::PartialShape res = pshape;
+        size_t num_to_insert = layout::max_rank() - pshape.size();
+        size_t pos_to_insert = pshape.size() > 1 ? 2 : 1;
+        res.insert(res.begin() + pos_to_insert, num_to_insert, 1);
+
+        return res;
+    }
+
     int32_t default_size = -1;
-    auto shape = pshape.to_shape();
     std::vector<int32_t> dims;
-    for (auto dim : shape) {
-        dims.push_back(static_cast<int32_t>(dim));
+    dims.reserve(pshape.size());
+    for (auto dim : pshape) {
+        dims.push_back(static_cast<int32_t>(dim.get_length()));
     }
 
     const cldnn::format default_fmt = cldnn::format::bfvuwzyx;
     auto old_sizes = convert_dimensions(dims, old_fmt.order(), default_fmt.internal_order()); // convert to internal order (bfxyzwuv)
 
-    auto val_order = default_fmt.internal_order();
-    auto new_order = new_fmt.internal_order();
+    const auto& val_order = default_fmt.internal_order();
+    const auto& new_order = new_fmt.internal_order();
     const auto& new_traits = new_fmt.traits();
 
     std::vector<int32_t> new_sizes(old_sizes.size(), {default_size});
@@ -566,8 +578,12 @@ ov::PartialShape layout::transform(const ov::PartialShape& pshape, cldnn::format
             new_dims[idx] *= -1;
     }
 
-    ov::Shape new_shape(new_dims.begin(), new_dims.end());
-    return ov::PartialShape(new_shape);
+    ov::PartialShape res;
+    res.reserve(new_dims.size());
+    for (size_t i = 0; i < new_dims.size(); i++) {
+        res.push_back(ov::Dimension(new_dims[i]));
+    }
+    return res;
 }
 
 // Check a reorder is 1d along feature axis. Or feature size fits to inner block size of feature axis

--- a/src/plugins/intel_gpu/src/runtime/layout.cpp
+++ b/src/plugins/intel_gpu/src/runtime/layout.cpp
@@ -512,7 +512,7 @@ ov::PartialShape layout::transform(const ov::PartialShape& pshape, const cldnn::
     if (format::is_default_format(old_fmt) && new_fmt == format::bfvuwzyx) {
         ov::PartialShape res = pshape;
         size_t num_to_insert = layout::max_rank() - pshape.size();
-        size_t pos_to_insert = pshape.size() > 1 ? 2 : 1;
+        size_t pos_to_insert = std::min<size_t>(pshape.size(), 2);
         res.insert(res.begin() + pos_to_insert, num_to_insert, 1);
 
         return res;


### PR DESCRIPTION
### Details:
 - Reuse kernel selector params object created on impl init in update_dispatch_data() function for some primitives and just update shapes of in/out/fused tensors.
 - Small improvements for `fill_shape_info_data`
 - Slightly improves host code execution time (~2-3ms)
 - Save new_shape_infer flag once in program to avoid config access overhead in runtime

### Tickets:
 - CVS-140264, CVS-140267