### PR TITLE
Manually define CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION

### DIFF
--- a/cmake/developer_package/api_validator/api_validator.cmake
+++ b/cmake/developer_package/api_validator/api_validator.cmake
@@ -3,6 +3,20 @@
 #
 
 if(WIN32)
+    # CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION is only set when
+    # Visual Studio generators are used, but we need it
+    # when we use Ninja as well
+    if(NOT DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
+        if(DEFINED ENV{WindowsSDKVersion})
+            string(REPLACE "\\" "" WINDOWS_SDK_VERSION $ENV{WindowsSDKVersion})
+            set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION ${WINDOWS_SDK_VERSION})
+            message(STATUS "Use ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} Windows SDK version")
+        else()
+          message(FATAL_ERROR "WindowsSDKVersion environment variable is not set,\
+can't find Windows SDK version. Try to use vcvarsall.bat script")
+        endif()
+    endif()
+
     set(PROGRAMFILES_ENV "ProgramFiles\(X86\)")
 
     # check that PROGRAMFILES_ENV is defined, because in case of cross-compilation for Windows


### PR DESCRIPTION
### Details:
`CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION` is supposed to be set by CMake when Windows SDK is installed in the system, but it works only for Visual Studio generators. As we use Ninja, we set this variable manually, trying to mimic the default behavior. 
