### PR TITLE
[TFL FE]: gelu: fix issue when approximate is not specified

### DIFF
--- a/src/frontends/tensorflow_common/src/op/gelu.cpp
+++ b/src/frontends/tensorflow_common/src/op/gelu.cpp
@@ -18,7 +18,7 @@ namespace op {
 OutputVector translate_gelu_op(const NodeContext& node) {
     default_op_checks(node, 1, {"GELU"});
     auto input = node.get_input(0);
-    auto approximate = node.get_attribute<bool>("approximate");
+    bool approximate = node.get_attribute<bool>("approximate", false);
     const auto mode = (approximate == true) ? ov::op::GeluApproximationMode::TANH : ov::op::GeluApproximationMode::ERF;
     auto res = make_shared<ov::op::v7::Gelu>(input, mode);
     set_node_name(node.get_name(), res);

--- a/src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp
+++ b/src/frontends/tensorflow_lite/src/decoder_flatbuffer.cpp
@@ -324,7 +324,12 @@ ov::Any DecoderFlatBuffer::get_attribute(const std::string& name) const {
                 m_type == "REDUCE_MIN" || m_type == "REDUCE_PROD" || m_type == "SUM")) {
         return this->get_attribute(&tflite::ReducerOptions::keep_dims);
     } else if (name == "approximate" && m_type == "GELU") {
-        return this->get_attribute(&tflite::GeluOptions::approximate);
+        bool has_attribute = this->has_attribute(&tflite::GeluOptions::approximate);
+        if (has_attribute) {
+            return this->get_attribute(&tflite::GeluOptions::approximate);
+        } else {
+            return {};
+        }
     }
 
     const auto opts = m_node_def->custom_options();


### PR DESCRIPTION
Sometimes the approximate attribute is not specified in the .tflite file, we need to check its availability before retriving it, otherwise we might hit the 'Check 'opts != nullptr' failed' failure with calling get_attribute() directly.

