### PR TITLE
[GPU] Unit test fixes

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_ref.cl
@@ -7,7 +7,7 @@ typedef __global INPUT1_TYPE grid_t;
 typedef __global OUTPUT_TYPE output_t;
 
 typedef INPUT0_TYPE data_et;
-typedef INPUT1_TYPE grid_et;
+typedef float grid_et;
 typedef OUTPUT_TYPE output_et;
 
 inline const data_et FUNC(

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -3581,9 +3581,17 @@ public:
         quant_data.output_low  = std::numeric_limits<WeightsT>::lowest();
         quant_data.output_high = std::numeric_limits<WeightsT>::max();
 
+        int min = -10;
+        int max = 10;
+
+        if (!std::numeric_limits<WeightsT>::is_signed) {
+            min = 0;
+            max = 20;
+        }
+
         VVVVF<InputT> input_data = rg.template generate_random_4d<InputT>(b, in_f, in_y, in_x, 0, 127);
-        VVVVF<WeightsT> weights_data = rg.template generate_random_4d<WeightsT>(out_f, in_f, in_y, in_x, quant_data.output_low , quant_data.output_high);
-        VF<WeightsT> bias_data = rg.template generate_random_1d<WeightsT>(out_f, quant_data.output_low , quant_data.output_high);
+        VVVVF<WeightsT> weights_data = rg.template generate_random_4d<WeightsT>(out_f, in_f, in_y, in_x, min, max);
+        VF<WeightsT> bias_data = rg.template generate_random_1d<WeightsT>(out_f, min, max);
 
         this->set_input(input_data);
         this->set_weights(weights_data);
@@ -3718,4 +3726,3 @@ TEST_F(fully_connected_gpu_tests, weights_reorder_shapes_update) {
 TEST_F(fully_connected_gpu_tests, weights_reorder_shapes_update_cached) {
     this->test_weights_reorder_shapes_update(true);
 }
-


### PR DESCRIPTION
### Details:
 - Use float for intermediate calculation of grid sample op
 - Adjust data ranges for fc unit test to avoid huge numbers

### Tickets:
 - *CVS-134015*
