### PR TITLE
[CPU] Avoid shared weights double repacking in latency mode

### DIFF
--- a/src/inference/dev_api/openvino/runtime/threading/cpu_streams_executor.hpp
+++ b/src/inference/dev_api/openvino/runtime/threading/cpu_streams_executor.hpp
@@ -49,6 +49,8 @@ public:
 
     int get_stream_id() override;
 
+    int get_streams_num();
+
     int get_numa_node_id() override;
 
     int get_socket_id() override;

--- a/src/inference/src/dev/threading/cpu_streams_executor.cpp
+++ b/src/inference/src/dev/threading/cpu_streams_executor.cpp
@@ -498,6 +498,10 @@ int CPUStreamsExecutor::get_stream_id() {
     return stream->_streamId;
 }
 
+int CPUStreamsExecutor::get_streams_num() {
+    return _impl->_config.get_streams();
+}
+
 int CPUStreamsExecutor::get_numa_node_id() {
     auto stream = _impl->_streams.local();
     return stream->_numaNodeId;

--- a/src/plugins/intel_cpu/src/compiled_model.cpp
+++ b/src/plugins/intel_cpu/src/compiled_model.cpp
@@ -130,13 +130,11 @@ CompiledModel::GraphGuard::Lock CompiledModel::get_graph() const {
                 GraphContext::Ptr ctx;
                 {
                     std::lock_guard<std::mutex> lock{*m_mutex.get()};
-                    // disable weights caching if graph was created only once
-                    auto weightsCache = m_cfg.streamExecutorConfig.get_streams() != 1 ? m_socketWeights[socketId] : nullptr;
                     auto isQuantizedFlag =
                         (m_cfg.lpTransformsMode == Config::On) &&
                         ov::pass::low_precision::LowPrecision::isFunctionQuantized(m_model);
 
-                    ctx = std::make_shared<GraphContext>(m_cfg, weightsCache, isQuantizedFlag, streamsExecutor);
+                    ctx = std::make_shared<GraphContext>(m_cfg, m_socketWeights[socketId], isQuantizedFlag, streamsExecutor);
                 }
                 const std::shared_ptr<const ov::Model> model = m_model;
                 graphLock._graph.CreateGraph(model, ctx);

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -895,7 +895,7 @@ MemoryPtr Node::prepareWeightMemory(DnnlMemoryDescPtr dstWeightDesc, DnnlMemoryD
     MemoryPtr ptr;
     const auto& format = dstWeightDesc->serializeFormat();
 
-    assert(privateWeightCache);
+    OPENVINO_ASSERT(privateWeightCache, "privateWeightCache is nullptr");
 
     auto itr = privateWeightCache->find(format);
     if (privateWeightCache->end() != itr) {

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.cpp
@@ -32,6 +32,7 @@ MemoryPtr prepareWeightsMemory(const DnnlMemoryDescPtr srcWeightDesc,
     const auto& format = dstWeightDesc->serializeFormat();
 
     const auto privateWeightCache = context->getPrivateWeighCache();
+    OPENVINO_ASSERT(privateWeightCache, "privateWeightCache is nullptr");
     if (privateWeightCache) {
         auto itr = privateWeightCache->find(format);
         if (privateWeightCache->end() != itr) {
@@ -86,7 +87,7 @@ MemoryPtr prepareWeightsMemory(const DnnlMemoryDescPtr srcWeightDesc,
     if (globalWeightCache &&
         dnnl::memory::format_kind::blocked == dstWeightDesc->getDnnlDesc().get_format_kind()) {
         const std::string string_hash = format + "_" + std::to_string(weightsMem->getSize()) + "_" +
-                                        std::to_string(*weightsMem->getDataAs<uint64_t>());
+                                        std::to_string(reinterpret_cast<uint64_t>(weightsMem->getData()));
         ptr = *globalWeightCache->findOrCreate(string_hash, create);
     } else {
         ptr = create();

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -51,7 +51,7 @@ static MemoryPtr prepareWeightMemory(const MemoryPtr weightsMemory,
     if (weightCache != nullptr) {
         std::string format = "gemm_mlas_" + std::to_string(N) + "_" + std::to_string(K);
         const std::string string_hash = format + "_" + std::to_string(weightsMemory->getSize()) + "_" +
-            std::to_string(*weightsMemory->getDataAs<uint64_t>());
+                                        std::to_string(reinterpret_cast<uint64_t>(weightsMemory->getData()));
         DEBUG_LOG("MlasGemmExecutor: findOrCreate, string_hash: ", string_hash);
         return *weightCache->findOrCreate(string_hash, create);
     }

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -373,18 +373,20 @@ void Input::cloneBlobIfRequired() {
                 + "_" + ptr;
     };
 
-    auto weightCache = context->getWeightsCache();
+    const auto weightCache = context->getWeightsCache();
+    const bool clone_is_not_needed =
+        prec != element::string && !isWA() &&
+        // IRs already have all subnormals flushed to zero, but in
+        // read_model scenario with directly loaded original model still can have subnormals
+        isBlobAligned() && (!needFlushDenormalsToZero || !hasSubnormals()) &&
+        // Blob should be cloned in cache only if original weights are stored on other numa node.
+        // This is possible only in multistream case on multisocket machine.
+        // TODO: don't clone blob for multisocket + multistream case if current stream is run on the numa node where original weights are stored.
+        (!weightCache || context->getNumNumaNodes() == 1 || context->getCPUStreamExecutor()->get_streams_num() == 1);
 
-    if (weightCache) {
-        MemoryPtr ptr = *weightCache->findOrCreate(blobKey(), cloneBlob);
-        memoryPtr = std::const_pointer_cast<const IMemory>(ptr);
-    // IRs already have all subnormals flushed to zero, but in
-    // read_model scenario with directly loaded original model still can have subnormals
-    } else if (prec != element::string && isBlobAligned() && (!needFlushDenormalsToZero || !hasSubnormals()) && !isWA()) {
-        memoryPtr = std::make_shared<Memory>(getEngine(), memDesc, constOp->get_data_ptr());
-    } else {
-        memoryPtr = std::const_pointer_cast<const IMemory>(cloneBlob());
-    }
+    memoryPtr = clone_is_not_needed ? std::make_shared<Memory>(getEngine(), memDesc, constOp->get_data_ptr())
+                                    : std::const_pointer_cast<const IMemory>(
+                                          weightCache ? *weightCache->findOrCreate(blobKey(), cloneBlob) : cloneBlob());
 }
 
 static std::vector<Shape> createInputShapes(const Shape& shape,


### PR DESCRIPTION
### Details:
 - *Weights caching enabled in single stream mode*
 - *Avoid unnecessary weights repacking on single socket machines*

### Tickets:
 - *CVS-139671*
