### PR TITLE
[DOCS] Enabling GPU for inference on systems with conda-forge - port to 24.1

### DIFF
--- a/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
@@ -95,6 +95,14 @@ To reactivate your Conda environment, execute the following command:
 Once you have reactivated your Conda environment, make sure that all the necessary environment
 variables are properly set and proceed with linking the OpenVINO libraries.
 
+Enabling GPU device for inference
++++++++++++++++++++++++++++++++++
+
+To use a GPU device for OpenVINO inference, you must install OpenCL ICD:
+
+.. code-block:: sh
+
+   conda install ocl-icd-system
 
 Uninstalling OpenVINO™ Runtime
 ###########################################################
@@ -105,8 +113,6 @@ with the proper OpenVINO version number:
 .. code-block:: sh
 
    conda remove openvino=2024.1.0
-
-
 
 What's Next?
 ############################################################
@@ -124,7 +130,4 @@ Visit the :doc:`Samples <../../../learn-openvino/openvino-samples>` page for oth
 
 * :doc:`Basic object detection with the Hello Reshape SSD C++ sample <../../../learn-openvino/openvino-samples/hello-reshape-ssd>`
 * :doc:`Object classification sample <../../../learn-openvino/openvino-samples/hello-classification>`
-
-
-
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-conda.rst
@@ -98,11 +98,15 @@ variables are properly set and proceed with linking the OpenVINO libraries.
 Enabling GPU device for inference
 +++++++++++++++++++++++++++++++++
 
-To use a GPU device for OpenVINO inference, you must install OpenCL ICD:
+To use a GPU device for OpenVINO inference on Linux, you must install OpenCL ICD:
 
 .. code-block:: sh
 
    conda install ocl-icd-system
+
+This step is not required on Windows, as Intel® Graphics Compute Runtime for
+OpenCL™ Driver is included with the Intel® Graphics Driver package.
+
 
 Uninstalling OpenVINO™ Runtime
 ###########################################################


### PR DESCRIPTION
Adding instructions for installation of `opencl-icd-system` package which enables users to select a GPU device for OpenVINO inference.

Porting: https://github.com/openvinotoolkit/openvino/pull/24390
