### PR TITLE
Adding a check for plugin/driver compiler compatibility

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -170,15 +170,14 @@ const ov::SoPtr<ICompiler>& CompiledModel::get_compiler() const {
 
 void CompiledModel::configure_stream_executors() {
     std::shared_ptr<ov::threading::ITaskExecutor> task_executor;
-    if (get_plugin()->get_property(ov::internal::exclusive_async_requests.name(), {}).as<bool>()) {
+    if (_config.get<EXCLUSIVE_ASYNC_REQUESTS>()) {
         task_executor = ov::threading::executor_manager()->get_executor("NPU");
     } else if (get_property(ov::hint::enable_cpu_pinning.name()).as<bool>()) {
-        auto executor_config = ov::threading::IStreamsExecutor::Config{
-            "Intel NPU plugin executor",
-            get_plugin()->get_property(ov::num_streams.name(), {}).as<ov::streams::Num>(),
-            1,
-            ov::hint::SchedulingCoreType::PCORE_ONLY,
-            true};
+        auto executor_config = ov::threading::IStreamsExecutor::Config{"Intel NPU plugin executor",
+                                                                       _config.get<NUM_STREAMS>(),
+                                                                       1,
+                                                                       ov::hint::SchedulingCoreType::PCORE_ONLY,
+                                                                       true};
         task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(executor_config);
     } else {
         task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -101,7 +101,6 @@ std::shared_ptr<ov::Model> create_dummy_model(const IONodeDescriptorMap& paramet
     return std::make_shared<ov::Model>(results, parameters);
 }
 
-<<<<<<< Updated upstream
 /**
  * @brief Setting batching mode
  * @details  In the case of older drivers or discrete platforms, we force batching to compiler mode since it is not
@@ -127,7 +126,8 @@ void set_batch_config(bool isBatchingSupported, Config& config) {
         strStream << ov::intel_npu::BatchMode::AUTO;
         config.update({{ov::intel_npu::batch_mode.name(), strStream.str()}});
     }
-=======
+}
+
 inline std::shared_ptr<ov::Model> get_validation_model(ov::element::Type type) {
     ov::ResultVector results;
     ov::ParameterVector params;
@@ -139,7 +139,6 @@ inline std::shared_ptr<ov::Model> get_validation_model(ov::element::Type type) {
     res->get_output_tensor(0).set_names({"tensor_output"});
     results.push_back(res);
     return std::make_shared<ov::Model>(results, params);
->>>>>>> Stashed changes
 }
 
 std::map<std::string, std::string> any_copy(const ov::AnyMap& params) {
@@ -518,15 +517,15 @@ Plugin::Plugin()
         _globalConfig.update(options);
 
     } catch (const std::exception& ex) {
-        _logger.warning("Current MLIR compiler version is incompatible with the current driver version due to: ",
-                        ex.what(),
-                        " Driver compiler will be used as default compiler type.");
+        _logger.warning(ex.what());
+        _logger.warning("Current MLIR compiler version is incompatible with the current driver version. "
+                        "Driver compiler will be used as default compiler type.");
         Config::ConfigMap options;
         options[ov::intel_npu::compiler_type.name()] = stringifyEnum(ov::intel_npu::CompilerType::DRIVER);
         _globalConfig.update(options);
     } catch (...) {
         _logger.warning("Current MLIR compiler version is incompatible with the current driver version. "
-                        " Driver compiler will be used as default compiler type.");
+                        "Driver compiler will be used as default compiler type.");
         Config::ConfigMap options;
         options[ov::intel_npu::compiler_type.name()] = stringifyEnum(ov::intel_npu::CompilerType::DRIVER);
         _globalConfig.update(options);

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -4,17 +4,23 @@
 
 #include "plugin.hpp"
 
-#include <fstream>
-
 #include "compiled_model.hpp"
 #include "compiler.hpp"
 #include "device_helpers.hpp"
 #include "intel_npu/al/config/common.hpp"
 #include "intel_npu/al/config/compiler.hpp"
+#include "intel_npu/al/config/config.hpp"
 #include "intel_npu/al/config/runtime.hpp"
 #include "intel_npu/al/itt.hpp"
+#include "npu_private_properties.hpp"
+#include "openvino/core/any.hpp"
+#include "openvino/core/model.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/parameter.hpp"
+#include "openvino/opsets/opset8.hpp"
+#include "openvino/runtime/iasync_infer_request.hpp"
+#include "openvino/runtime/iinfer_request.hpp"
+#include "openvino/runtime/infer_request.hpp"
 #include "openvino/runtime/intel_npu/properties.hpp"
 
 using namespace intel_npu;
@@ -95,6 +101,7 @@ std::shared_ptr<ov::Model> create_dummy_model(const IONodeDescriptorMap& paramet
     return std::make_shared<ov::Model>(results, parameters);
 }
 
+<<<<<<< Updated upstream
 /**
  * @brief Setting batching mode
  * @details  In the case of older drivers or discrete platforms, we force batching to compiler mode since it is not
@@ -120,6 +127,19 @@ void set_batch_config(bool isBatchingSupported, Config& config) {
         strStream << ov::intel_npu::BatchMode::AUTO;
         config.update({{ov::intel_npu::batch_mode.name(), strStream.str()}});
     }
+=======
+inline std::shared_ptr<ov::Model> get_validation_model(ov::element::Type type) {
+    ov::ResultVector results;
+    ov::ParameterVector params;
+    auto op = std::make_shared<ov::op::v1::Add>(ov::opset8::Constant::create(type, {1}, {1}),
+                                                ov::opset8::Constant::create(type, {1}, {1}));
+    op->set_friendly_name("Add");
+    auto res = std::make_shared<ov::op::v0::Result>(op);
+    res->set_friendly_name("Result");
+    res->get_output_tensor(0).set_names({"tensor_output"});
+    results.push_back(res);
+    return std::make_shared<ov::Model>(results, params);
+>>>>>>> Stashed changes
 }
 
 std::map<std::string, std::string> any_copy(const ov::AnyMap& params) {
@@ -484,6 +504,32 @@ Plugin::Plugin()
         if (std::get<0>(property.second)) {
             _supportedProperties.emplace_back(ov::PropertyName(property.first, std::get<1>(property.second)));
         }
+    }
+
+    // Compile and infer a test model to check MLIR compiler compatibility with the driver
+    try {
+        const auto model = get_validation_model(ov::element::f32);
+        ov::AnyMap config{{ov::intel_npu::compiler_type.name(), ov::intel_npu::CompilerType::MLIR}};
+        const auto compiledModel = compile_model(model, config);
+        const auto inferRequest = compiledModel->create_infer_request();
+        inferRequest->infer();
+        Config::ConfigMap options;
+        options[ov::intel_npu::compiler_type.name()] = stringifyEnum(ov::intel_npu::CompilerType::MLIR);
+        _globalConfig.update(options);
+
+    } catch (const std::exception& ex) {
+        _logger.warning("Current MLIR compiler version is incompatible with the current driver version due to: ",
+                        ex.what(),
+                        " Driver compiler will be used as default compiler type.");
+        Config::ConfigMap options;
+        options[ov::intel_npu::compiler_type.name()] = stringifyEnum(ov::intel_npu::CompilerType::DRIVER);
+        _globalConfig.update(options);
+    } catch (...) {
+        _logger.warning("Current MLIR compiler version is incompatible with the current driver version. "
+                        " Driver compiler will be used as default compiler type.");
+        Config::ConfigMap options;
+        options[ov::intel_npu::compiler_type.name()] = stringifyEnum(ov::intel_npu::CompilerType::DRIVER);
+        _globalConfig.update(options);
     }
 }
 


### PR DESCRIPTION
### Details:
 - Adding a check for plugin/driver compiler compatibility when NPU the plugin is constructed. If the MLIR compiler is not compatible with the current driver, the driver compiler will be set as the default compiler, otherwise the MLIR compiler will be the default.

### Tickets:
 - EISW-103348
 - EISW-119835
