### PR TITLE
[GPU] Update of the shortcut in layout::transfrom for 3D layouts

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/layout.cpp
+++ b/src/plugins/intel_gpu/src/runtime/layout.cpp
@@ -511,8 +511,11 @@ ov::PartialShape layout::transform(const ov::PartialShape& pshape, const cldnn::
     // shortcut for transform to max rank default fmt which is used in fill_shape_info_data to improve perf
     if (format::is_default_format(old_fmt) && new_fmt == format::bfvuwzyx) {
         ov::PartialShape res = pshape;
-        size_t num_to_insert = layout::max_rank() - pshape.size();
-        size_t pos_to_insert = std::min<size_t>(pshape.size(), 2);
+        // This part is necessary because we treat 3D layouts as "bfy", not as "bfx".
+        if (res.size() == 3)
+            res.push_back(1);
+        size_t num_to_insert = layout::max_rank() - res.size();
+        size_t pos_to_insert = std::min<size_t>(res.size(), 2);
         res.insert(res.begin() + pos_to_insert, num_to_insert, 1);
 
         return res;

--- a/src/plugins/intel_gpu/tests/unit/module_tests/layout_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/layout_test.cpp
@@ -266,6 +266,7 @@ INSTANTIATE_TEST_SUITE_P(smoke, layout_transform_test,
         {format::bfyx, format::bfwzyx, ov::PartialShape{1, 2, 3, 4}, ov::PartialShape{1, 2, 1, 1, 3, 4}},
         {format::bfyx, format::bfuwzyx, ov::PartialShape{1, 2, 3, 4}, ov::PartialShape{1, 2, 1, 1, 1, 3, 4}},
         {format::bfyx, format::bfvuwzyx, ov::PartialShape{1, 2, 3, 4}, ov::PartialShape{1, 2, 1, 1, 1, 1, 3, 4}},
+        {format::bfyx, format::bfvuwzyx, ov::PartialShape{1, 2, 3}, ov::PartialShape{1, 2, 1, 1, 1, 1, 3, 1}},
 
         {format::b_fs_yx_fsv16, format::bfyx, ov::PartialShape{1, 2, 3, 4}, ov::PartialShape{1, 2, 3, 4}},
         {format::b_fs_yx_fsv16, format::bfzyx, ov::PartialShape{1, 2, 3, 4}, ov::PartialShape{1, 2, 1, 3, 4}},


### PR DESCRIPTION
### Details:
 - This PR updates the shortcut logic in `layout::transform` for 3D layouts.
   - 3D layouts are handled as `bfy`, not as `bfx` in the GPU plugin.