### PR TITLE
[`EISW-109425`] [`NPU plugin`] [`ov::execution_devices`] Fix bad execution devices value for NPU plugin

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -230,12 +230,7 @@ void CompiledModel::initialize_properties() {
          {true,
           ov::PropertyMutability::RO,
           [&](const Config& config) {
-              // This mainly concerns the device name displayed to the user
-              // e.g. "NPU.3720" or "NPU" if the platform is set to "AUTO_DETECT"
-              if (config.get<PLATFORM>() == ov::intel_npu::Platform::AUTO_DETECT) {
-                  return std::string("NPU");
-              }
-              return std::string("NPU.") + ov::intel_npu::Platform::standardize(config.get<PLATFORM>());
+              return std::string("NPU");
           }}},
         {ov::loaded_from_cache.name(),
          {true,

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -235,8 +235,7 @@ void CompiledModel::initialize_properties() {
               if (config.get<PLATFORM>() == ov::intel_npu::Platform::AUTO_DETECT) {
                   return std::string("NPU");
               }
-              OPENVINO_ASSERT(_device != nullptr, "GetMetric: the device is not initialized");
-              return std::string("NPU.") + _device->getName();
+              return std::string("NPU.") + config.get<PLATFORM>();
           }}},
         {ov::loaded_from_cache.name(),
          {true,

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -235,7 +235,7 @@ void CompiledModel::initialize_properties() {
               if (config.get<PLATFORM>() == ov::intel_npu::Platform::AUTO_DETECT) {
                   return std::string("NPU");
               }
-              return std::string("NPU.") + config.get<PLATFORM>();
+              return std::string("NPU.") + ov::intel_npu::Platform::standardize(config.get<PLATFORM>());
           }}},
         {ov::loaded_from_cache.name(),
          {true,

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -229,7 +229,7 @@ void CompiledModel::initialize_properties() {
         {ov::execution_devices.name(),
          {true,
           ov::PropertyMutability::RO,
-          [&](const Config& config) {
+          [&](const Config&) {
               return std::string("NPU");
           }}},
         {ov::loaded_from_cache.name(),

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -556,7 +556,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
 
     // Update stepping w/ information from driver, unless provided by user or we are off-device
     // Ignore, if compilation was requested for platform, different from current
-    if (!localConfig.has<STEPPING>() && device != nullptr && device->getName() == platform) {
+    if (!localConfig.has<STEPPING>() && device != nullptr && device->getName() == ov::intel_npu::Platform::standardize(platform)) {
         try {
             localConfig.update({{ov::intel_npu::stepping.name(), std::to_string(device->getSubDevId())}});
         } catch (...) {
@@ -566,7 +566,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
     }
     // Update max_tiles w/ information from driver, unless provided by user or we are off-device
     // Ignore, if compilation was requested for platform, different from current
-    if (!localConfig.has<MAX_TILES>() && device != nullptr && device->getName() == platform) {
+    if (!localConfig.has<MAX_TILES>() && device != nullptr && device->getName() == ov::intel_npu::Platform::standardize(platform)) {
         try {
             localConfig.update({{ov::intel_npu::max_tiles.name(), std::to_string(device->getMaxNumSlices())}});
         } catch (...) {


### PR DESCRIPTION
### Details:
 - Certain `execution devices` tests for `compiled_model` would fail like:
 ```
 src\tests\functional\plugin\shared\src\behavior\compiled_model\properties.cpp(329): error: Expected equality of these values:
  expectedTargets
    Which is: { "NPU.XXXX" }
  exeTargets
    Which is: { "NPU.AUTO_DETECT" }
 ```
To overcome this problem, tests' `expectedTargets` were updated to `NPU` only, but the value got from `ov::execution_devices` config had to be updated to `NPU` as well.

- Other problem occurred for `NPU_TILES` config where prefixed values for `NPU_PLATFORM` config e.g. `NPUXXXX` were not standardized to digits only, causing `NPU_STEPPING` and `NPU_MAX_TILES` to be missing from local config.

### Tickets:
 - Instantiation of shared compiled model tests is being tracked in *EISW-109425*
