### PR TITLE
Extend network precision with `u4`, `i4` for L0 backend

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -382,6 +382,10 @@ void ZeroInferRequest::check_network_precision(const ov::element::Type_t precisi
         break;
     case ov::element::Type_t::f16:
         break;
+    case ov::element::Type_t::u4:
+        break;
+    case ov::element::Type_t::i4:
+        break;
     case ov::element::Type_t::u8:
         break;
     case ov::element::Type_t::i8:
@@ -400,7 +404,7 @@ void ZeroInferRequest::check_network_precision(const ov::element::Type_t precisi
         break;
     default:
         OPENVINO_THROW("Unsupported tensor precision: " + ov::element::Type(precision).get_type_name() +
-                       "! Supported precisions: FP32, FP16, U8, I8, U16, I16, U32, I32, U64, I64");
+                       "! Supported precisions: FP32, FP16, U4, I4, U8, I8, U16, I16, U32, I32, U64, I64");
     }
 }
 


### PR DESCRIPTION
### Details:
 - *Update `zero_infer_request.cpp` with `u4` and `i4`* for intel_npu.
 - *...*

### Tickets:
 - *E#121561*
