### PR TITLE
[NPU] Set default value for batch mode property

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/common.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/common.hpp
@@ -252,6 +252,10 @@ struct BATCH_MODE final : OptionBase<BATCH_MODE, ov::intel_npu::BatchMode> {
         return "ov::intel_npu::BatchMode";
     }
 
+    static ov::intel_npu::BatchMode defaultValue() {
+        return ov::intel_npu::BatchMode::AUTO;
+    }
+
     static ov::intel_npu::BatchMode parse(std::string_view val);
 
     static std::string toString(const ov::intel_npu::BatchMode& val);


### PR DESCRIPTION
### Details:
 - *A default value should be provided when the property is used by the caching mechanism if the property was not provided by the user*

### Tickets:
 - *ticket-id*
