### PR TITLE
[OV JS] Join conversion functions for ov::Any

### DIFF
--- a/src/bindings/js/node/include/helper.hpp
+++ b/src/bindings/js/node/include/helper.hpp
@@ -38,6 +38,9 @@ TargetType js_to_cpp(const Napi::CallbackInfo& info, const size_t idx, const std
 template <typename TargetType>
 TargetType js_to_cpp(const Napi::Value&, const std::vector<napi_types>& acceptable_types);
 
+template <typename TargetType>
+TargetType js_to_cpp(const Napi::Env& env, const Napi::Value& value);
+
 template <>
 int32_t js_to_cpp<int32_t>(const Napi::CallbackInfo& info,
                            const size_t idx,
@@ -98,7 +101,7 @@ ov::preprocess::ResizeAlgorithm js_to_cpp<ov::preprocess::ResizeAlgorithm>(
 
 /** @brief  A template specialization for TargetType ov::Any */
 template <>
-ov::Any js_to_cpp<ov::Any>(const Napi::Value&, const std::vector<napi_types>& acceptable_types);
+ov::Any js_to_cpp<ov::Any>(const Napi::Env& env, const Napi::Value& value);
 
 /** @brief  A template specialization for TargetType std::map<std::string, ov::Any */
 template <>
@@ -177,8 +180,6 @@ napi_types napiType(const Napi::Value& val);
 bool acceptableType(const Napi::Value& val, const std::vector<napi_types>& acceptable);
 
 Napi::Value any_to_js(const Napi::CallbackInfo& info, ov::Any value);
-
-ov::Any js_to_any(const Napi::Env& env, const Napi::Value& value);
 
 bool is_napi_value_int(const Napi::Env& env, const Napi::Value& num);
 

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -189,16 +189,31 @@ ov::preprocess::ResizeAlgorithm js_to_cpp<ov::preprocess::ResizeAlgorithm>(
 }
 
 template <>
-ov::Any js_to_cpp<ov::Any>(const Napi::Value& value, const std::vector<napi_types>& acceptable_types) {
-    if (!acceptableType(value, acceptable_types)) {
-        OPENVINO_THROW(std::string("Cannot convert Napi::Value to ov::Any"));
-    }
+ov::Any js_to_cpp<ov::Any>(const Napi::Env& env, const Napi::Value& value) {
     if (value.IsString()) {
-        return value.ToString().Utf8Value();
+        return ov::Any(value.ToString().Utf8Value());
+    } else if (value.IsBigInt()) {
+        Napi::BigInt big_value = value.As<Napi::BigInt>();
+        bool is_lossless;
+        int64_t big_num = big_value.Int64Value(&is_lossless);
+
+        if (!is_lossless) {
+            OPENVINO_THROW("Result of BigInt conversion to int64_t results in a loss of precision");
+        }
+
+        return ov::Any(big_num);
     } else if (value.IsNumber()) {
-        return value.ToNumber().Int32Value();
+        Napi::Number num = value.ToNumber();
+
+        if (is_napi_value_int(env, value)) {
+            return ov::Any(num.Int32Value());
+        } else {
+            return ov::Any(num.DoubleValue());
+        }
+    } else if (value.IsBoolean()) {
+        return ov::Any(value.ToBoolean());
     } else {
-        OPENVINO_THROW(std::string("The conversion is not supported yet."));
+        OPENVINO_THROW("Cannot convert to ov::Any");
     }
 }
 
@@ -217,7 +232,7 @@ std::map<std::string, ov::Any> js_to_cpp<std::map<std::string, ov::Any>>(
 
     for (uint32_t i = 0; i < keys.Length(); ++i) {
         const std::string& option = static_cast<Napi::Value>(keys[i]).ToString();
-        properties_to_cpp[option] = js_to_cpp<ov::Any>(config.Get(option), {napi_string});
+        properties_to_cpp[option] = js_to_cpp<ov::Any>(info.Env(), config.Get(option));
     }
 
     return properties_to_cpp;
@@ -525,34 +540,6 @@ Napi::Value any_to_js(const Napi::CallbackInfo& info, ov::Any value) {
     return info.Env().Undefined();
 }
 
-ov::Any js_to_any(const Napi::Env& env, const Napi::Value& value) {
-    if (value.IsString()) {
-        return ov::Any(value.ToString().Utf8Value());
-    } else if (value.IsBigInt()) {
-        Napi::BigInt big_value = value.As<Napi::BigInt>();
-        bool is_lossless;
-        int64_t big_num = big_value.Int64Value(&is_lossless);
-
-        if (!is_lossless) {
-            OPENVINO_THROW("Result of BigInt conversion to int64_t results in a loss of precision");
-        }
-
-        return ov::Any(big_num);
-    } else if (value.IsNumber()) {
-        Napi::Number num = value.ToNumber();
-
-        if (is_napi_value_int(env, value)) {
-            return ov::Any(num.Int32Value());
-        } else {
-            return ov::Any(num.DoubleValue());
-        }
-    } else if (value.IsBoolean()) {
-        return ov::Any(value.ToBoolean());
-    } else {
-        OPENVINO_THROW("Cannot convert to ov::Any");
-    }
-}
-
 bool is_napi_value_int(const Napi::Env& env, const Napi::Value& num) {
     return env.Global().Get("Number").ToObject().Get("isInteger").As<Napi::Function>().Call({num}).ToBoolean().Value();
 }
@@ -568,7 +555,7 @@ ov::AnyMap to_anyMap(const Napi::Env& env, const Napi::Value& val) {
     for (uint32_t i = 0; i < keys.Length(); ++i) {
         const auto& property_name = static_cast<Napi::Value>(keys[i]).ToString().Utf8Value();
 
-        ov::Any any_value = js_to_any(env, parameters.Get(property_name));
+        const auto& any_value = js_to_cpp<ov::Any>(env, parameters.Get(property_name));
 
         properties.insert(std::make_pair(property_name, any_value));
     }

--- a/src/bindings/js/node/tests/basic.test.js
+++ b/src/bindings/js/node/tests/basic.test.js
@@ -84,7 +84,7 @@ describe('Core.compileModelSync()', () => {
   it('compileModelSync(model, device, config) throws when config value is not a string', () => {
     assert.throws(
       () => core.compileModelSync(model, 'CPU', { 'PERFORMANCE_HINT': tput }),
-      /Cannot convert Napi::Value to ov::Any/
+      /Cannot convert to ov::Any/
     );
   });
 
@@ -131,7 +131,7 @@ describe('Core.compileModel()', () => {
   it('compileModel(model, device, config) throws when config value is not a string', () => {
     assert.throws(
       () => core.compileModel(model, 'CPU', { 'PERFORMANCE_HINT': tput }).then(),
-      /Cannot convert Napi::Value to ov::Any/
+      /Cannot convert to ov::Any/
     );
   });
 


### PR DESCRIPTION
### Details:
 - Join two existing functions  for converting Napi::Value to ov::Any:
ov::Any js_to_cpp<ov::Any>(const Napi::Value&, const std::vector<napi_types>& acceptable_types) 
and
ov::Any js_to_any(const Napi::Env& env, const Napi::Value& value)

 - `template <typename TargetType>
TargetType js_to_cpp(const Napi::Value&, const std::vector<napi_types>& acceptable_types);` is set to be removed (_140428_)

### Tickets:
 - *140426*
