### PR TITLE
[GPU] Enable Xe2 in oneDNN build

### DIFF
--- a/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
@@ -13,7 +13,7 @@ if(ENABLE_ONEDNN_FOR_GPU)
         set(ONEDNN_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/onednn_gpu_install" CACHE PATH "Installation path for oneDNN GPU library")
         set(ONEDNN_PREFIX_DIR "${CMAKE_CURRENT_BINARY_DIR}/onednn_gpu_root")
         set(ONEDNN_ENABLED_PRIMITIVES "CONCAT;CONVOLUTION;DECONVOLUTION;INNER_PRODUCT;MATMUL;REORDER;POOLING;REDUCTION")
-        set(ONEDNN_ENABLED_ISA "XEHP;XEHPG;XEHPC")
+        set(ONEDNN_ENABLED_ISA "XEHP;XEHPG;XEHPC;XE2")
         set(DNNL_GPU_LIBRARY_NAME "openvino_onednn_gpu" CACHE STRING "Name of oneDNN library for Intel GPU Plugin")
 
         if(X86_64)


### PR DESCRIPTION
OpenVINO selectively enables GPU ISAs when building oneDNN; this PR adds Xe2 to the list.