### PR TITLE
[GPU] updates to build some selected kernels in separate batches

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -160,9 +160,8 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
                     return true;
 
                 // check if the current_batch has one of special_kernels
-                auto& entry_points = current_bucket.back().entry_point_to_id;
-                for (auto ep_iter = entry_points.begin(); ep_iter != entry_points.end(); ep_iter++) {
-                    target_base_kernel_name = get_base_kernel_name(ep_iter->first);
+                if (current_bucket.back().kernels_counter == 1) {
+                    target_base_kernel_name = get_base_kernel_name(current_bucket.back().entry_point_to_id.begin()->first);
                     if (std::count(special_kernels.begin(), special_kernels.end(), target_base_kernel_name) > 0)
                         return true;
                 }

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -142,7 +142,7 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
                     if (unique_kernel_name.at(pos) == '_') {
                         matched += 1;
                     }
-                    if (matched == 3) {
+                    if (matched == 2) {
                         break;
                     }
                 }
@@ -165,7 +165,7 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
                     }
                     bool found_target = false;
                     auto target_base_kernel_name = get_base_kernel_name(entry_point);
-                    std::cout << entry_point << " --> " << target_base_kernel_name << std::endl;
+
                     while (iter != current_bucket.rbegin()) {
                         iter--;
                         bool found_same_base_kernel = false;

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -131,7 +131,7 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
                 current_bucket.push_back(batch_program(bucket_id, batch_id, options, batch_header_str));
             }
 
-            auto get_base_kernel_name = [](std::string unique_kernel_name) -> std::string {
+            auto get_base_kernel_name = [](const std::string& unique_kernel_name) -> std::string {
                 int matched = 0;
                 size_t pos = unique_kernel_name.length();
                 if (unique_kernel_name.substr(pos-4, 4).compare("__sa") == 0) {
@@ -142,57 +142,43 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
                     if (unique_kernel_name.at(pos) == '_') {
                         matched += 1;
                     }
-                    if (matched == 2) {
+                    if (matched == 3) {
                         break;
                     }
                 }
                 return unique_kernel_name.substr(0, pos);
             };
 
-            auto get_target_batch = [&]() -> batch_program& {
-                if (current_bucket.back().kernels_counter >= get_max_kernels_per_batch()) {
-                    const auto& batch_id = static_cast<int32_t>(current_bucket.size());
-                    current_bucket.push_back(batch_program(bucket_id, batch_id, options, batch_header_str));
-                    return current_bucket.back();
-                } else {
-                    auto iter = current_bucket.rbegin();
-                    while (iter != current_bucket.rend()) {
-                        if (iter->kernels_counter < get_max_kernels_per_batch()) {
-                            iter++;
-                        } else {
-                            break;
-                        }
-                    }
-                    bool found_target = false;
-                    auto target_base_kernel_name = get_base_kernel_name(entry_point);
+            // This is a temporary walk-around to avoid severe performance drop.
+            // It will be removed after OpenCL compiler is updated.
+            auto need_separate_batch = [&](std::string& unique_kernel_name) -> bool {
+                const std::vector<std::string> special_kernels = {"gemm_tiled_opt"};
 
-                    while (iter != current_bucket.rbegin()) {
-                        iter--;
-                        bool found_same_base_kernel = false;
-                        for (auto& item : iter->entry_point_to_id) {
-                            if (get_base_kernel_name(item.first).compare(target_base_kernel_name) == 0) {
-                                found_same_base_kernel = true;
-                                break;
-                            }
-                        }
-                        if (found_same_base_kernel) {
-                            continue;
-                        } else {
-                            found_target = true;
-                            break; 
-                        }
-                    }
-                    if (found_target) {
-                        return *iter;
-                    } else {
-                        const auto& batch_id = static_cast<int32_t>(current_bucket.size());
-                        current_bucket.push_back(batch_program(bucket_id, batch_id, options, batch_header_str));
-                        return current_bucket.back();
-                    }
+                // check if the current kernel name is in special_kernels
+                auto target_base_kernel_name = get_base_kernel_name(entry_point);
+                if (std::count(special_kernels.begin(), special_kernels.end(), target_base_kernel_name) > 0)
+                    return true;
+
+                // check if the current_batch has one of special_kernels
+                auto& entry_points = current_bucket.back().entry_point_to_id;
+                for (auto ep_iter = entry_points.begin(); ep_iter != entry_points.end(); ep_iter++) {
+                    target_base_kernel_name = get_base_kernel_name(ep_iter->first);
+                    if (std::count(special_kernels.begin(), special_kernels.end(), target_base_kernel_name) > 0)
+                        return true;
                 }
+                return false;
             };
 
-            auto& current_batch = get_target_batch();
+            // Create new kernels batch when the limit is reached
+            // and current kernel's entry_point is duplicated in this kernels batch
+            if (current_bucket.back().kernels_counter >= get_max_kernels_per_batch()
+                || current_bucket.back().entry_point_to_id.find(entry_point) != current_bucket.back().entry_point_to_id.end()
+                || need_separate_batch(entry_point)) {
+                const auto& batch_id = static_cast<int32_t>(current_bucket.size());
+                current_bucket.push_back(batch_program(bucket_id, batch_id, options, batch_header_str));
+            }
+
+            auto& current_batch = current_bucket.back();
             current_batch.dump_custom_program = dump_custom_program;
             current_batch.entry_point_to_id.emplace(entry_point, std::make_pair(code.params, kernel_part_idx));
 


### PR DESCRIPTION
### Details:
 - This PR updates the `kernels_cache` to build the selected kernels in separate batches.
   - This is a temporary WA to resolve performance degradation when some kernels are built with other kernels in the same batch
   - Currently, the selected kernel includes `gemm_tiled_opt`.
   - The impacted scenario : Qwen INT4 first token latency for > 1K input  in MTL 

### Tickets:
 - GSD-8910