### PR TITLE
enable fc split under allreduce

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -223,6 +223,13 @@ cross_compiled_file(${TARGET_NAME}
         NAME        attn_quantkv paged_attn_quantkv attn_quant_u8 attn_dequant_u8
         NAMESPACE   ov::Extensions::Cpu::XARCH
 )
+cross_compiled_file(${TARGET_NAME}
+        ARCH AVX512F AVX2 ANY
+                    src/nodes/kernels/ccl/allreduce.cpp
+        API         src/nodes/kernels/ccl/allreduce.hpp
+        NAME        allreduce_float32
+        NAMESPACE   ov::Extensions::Cpu::XARCH
+)
 # system dependencies must go last
 target_link_libraries(${TARGET_NAME} PRIVATE openvino::pugixml)
 ov_set_threading_interface_for(${TARGET_NAME})

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -135,9 +135,11 @@ void GraphOptimizer::ApplyCommonGraphOptimizations(Graph &graph) {
     FuseConvolutionAndSimpleOperation(graph);
     graph.RemoveDroppedNodes();
 
-    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseFullyConnectedAndSimpleOperation");
-    FuseFullyConnectedAndSimpleOperation(graph);
-    graph.RemoveDroppedNodes();
+    if (!getenv("ENABLE_TP")) {
+        OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseFullyConnectedAndSimpleOperation");
+        FuseFullyConnectedAndSimpleOperation(graph);
+        graph.RemoveDroppedNodes();
+    }
 
     OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseMatMulAndSimpleOperation");
     FuseMatMulAndSimpleOperation(graph);

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -9,6 +9,7 @@
 #include <openvino/op/constant.hpp>
 
 #include "common/cpu_convert.h"
+#include "common/cpu_memcpy.h"
 #include "dnnl_extension_utils.h"
 #include "executors/memory_arguments.hpp"
 #include "graph_context.h"
@@ -19,11 +20,13 @@
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/threading/cpu_message.hpp"
 #include "post_ops.hpp"
 #include "shape_inference/custom/fullyconnected.hpp"
 #include "transformations/cpu_opset/common/op/fully_connected.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
+#include "kernels/ccl/allreduce.hpp"
 
 using namespace dnnl;
 using namespace ov::element;
@@ -59,9 +62,41 @@ bool FullyConnected::isSupportedOperation(const std::shared_ptr<const ov::Node>&
 FullyConnected::FullyConnected(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
     : Node(op, context, FCShapeInferFactory(op)),
       errorPrefix("FullyConnected node with name '" + getName() + "'") {
+    // init w_rank and w_size
+    if (!context->getCPUStreamExecutor()->get_rank().empty()) {
+        w_rank = context->getCPUStreamExecutor()->get_rank()[0];
+        // TODO@Xiaoxia: get correct stream num
+        // context->getConfig().streamExecutorConfig.get_streams();
+        w_size = 2;
+        flag_tp = true;
+        // std::cout << "[dbg] w_rank: " << w_rank << ", w_size: " << w_size << "\n";
+        message = ov::threading::message_manager();
+    }
     std::string errorMessage;
     if (!isSupportedOperation(op, errorMessage))
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
+}
+
+void FullyConnected::allreduce(void *send_buf, void *recv_buf, size_t count, ov::element::Type dtype) {
+    ov::threading::MessageInfo send_message;
+    send_message.msg_type = ov::threading::MsgType::TP;
+    send_message.rank = {w_rank};
+    send_message.buf = send_buf;
+    message->send_message(send_message);
+    auto vec_message = message->wait_message(/*cur_rank*/w_rank, /*streams_num*/w_size);
+    float* recv_ptr = static_cast<float*>(recv_buf);
+    for (int idx=0; idx < w_size; ++idx) {
+        // if (idx == w_rank) {
+        //     continue;
+        // }
+        float* send_ptr = static_cast<float*>(vec_message[idx].buf);
+        ov::Extensions::Cpu::XARCH::allreduce_float32(send_ptr, recv_ptr, count);
+    }
+    // sync before return
+    ov::threading::MessageInfo msg_info;
+    msg_info.msg_type = ov::threading::MsgType::REDUCE;
+    message->send_message(msg_info);
+    message->reduce_wait(w_rank, w_size);
 }
 
 bool FullyConnected::canBeExecutedInInt8() const {
@@ -72,6 +107,14 @@ bool FullyConnected::canBeExecutedInInt8() const {
 }
 
 ExecutorPtr FullyConnected::createExecutor() {
+    if (auto env = getenv("ENABLE_TP") && flag_tp) {
+        auto srcMemoryBuffer = getSrcMemoryAtPort(DATA_ID);
+        auto select_src = split_v(srcMemoryBuffer, -1, w_rank, w_size);
+        memory[ARG_SRC] = select_src;
+
+        // TODO: update dst shape once output shape is changed.
+        memory[ARG_DST] = getDstMemoryAtPort(0);
+    }
     const auto& executor = factory->make(memory);
     getSelectedPrimitiveDescriptor()->setImplementationType(executor->implType());
 
@@ -83,7 +126,40 @@ void FullyConnected::prepareParams() {
 }
 
 void FullyConnected::execute(dnnl::stream strm) {
-    executor->execute(memory);
+    if (auto env = getenv("ENABLE_TP") && flag_tp) {
+        auto srcMemoryBuffer = getSrcMemoryAtPort(DATA_ID);
+        auto select_src = split_v(srcMemoryBuffer, -1, w_rank, w_size);
+        memory[ARG_SRC] = select_src;
+    }
+
+    {
+        executor->execute(memory);
+    }
+
+    if (auto env = getenv("ENABLE_TP") && flag_tp) {
+        // post process output
+        auto send_mem = memory[ARG_DST];
+        auto send_ptr = send_mem->getData();
+        auto prec = send_mem->getPrecision();
+        auto ele_num = send_mem->getSize() / prec.size();
+        // MemoryPtr recv_mem = std::make_shared<Memory>(context->getEngine(), send_mem->getDescPtr(), send_ptr);
+        MemoryPtr recv_mem = std::make_shared<Memory>(context->getEngine(), send_mem->getDescPtr(), nullptr);
+        auto recv_ptr = recv_mem->getData();
+        memset(recv_ptr, 0, recv_mem->getSize());
+        // TODO
+        if (prec == ov::element::bf16) {
+            printf("Unsupported bf16 for now!!!.\n");
+            exit(-1);
+        } else if (prec == ov::element::f32) {
+            allreduce(send_ptr, recv_ptr, ele_num, prec);
+        } else {
+            printf("Unsupported data type for reduceAdd.\n");
+            exit(-1);
+        }
+
+        cpu_parallel_memcpy(send_ptr, recv_ptr, send_mem->getSize());
+        memory[ARG_DST] = send_mem;
+    }
 }
 
 void FullyConnected::executeDynamicImpl(dnnl::stream strm) {
@@ -247,10 +323,90 @@ void FullyConnected::initSupportedPrimitiveDescriptors() {
     supportedPrimitiveDescriptors.emplace_back(nodeConfig, impl_desc_type::undef);
 }
 
+MemoryPtr FullyConnected::split_h(const MemoryPtr src, int dim, int w_rank, int w_size) {
+    auto desc = src->getDescPtr();
+    auto shape = src->getShape();
+    auto dims = shape.getDims();
+    auto prec = src->getPrecision();
+    if (dim < 0) {
+        dim += dims.size();
+    }
+    auto element_size = prec.size();
+    VectorDims new_dims = dims;
+    new_dims[dim] = dims[dim] / w_size;
+    // const int stride = dims[dim] / w_size;
+    auto new_desc = desc->cloneWithNewDims(new_dims, true);
+    auto srcPtr = src->getData();
+    const size_t stride = src->getSize() / w_size;
+
+    MemoryPtr ptr = std::make_shared<Memory>(context->getEngine(), new_desc, srcPtr + w_rank * stride);
+    return ptr;
+}
+
+
+MemoryPtr FullyConnected::split_v(const MemoryPtr src, int dim, int w_rank, int w_size) {
+    auto desc = src->getDescPtr();
+    auto shape = src->getShape();
+    auto dims = shape.getDims();
+    auto prec = src->getPrecision();
+    if (dim < 0) {
+        dim += dims.size();
+    }
+    if (shape.isDynamic()) {
+        const auto& pshape = shape.toPartialShape();
+        if (pshape[dim].is_dynamic()) {
+            OPENVINO_THROW("Can't split data with dynamic shapes");
+        }
+        auto new_pshape = pshape;
+        new_pshape[dim] = pshape[dim] / w_size;
+        auto new_desc = std::make_shared<CpuBlockedMemoryDesc>(prec, Shape{new_pshape});
+        MemoryPtr ptr = std::make_shared<Memory>(context->getEngine(), new_desc);
+        return ptr;
+    }
+    auto element_size = prec.size();
+    VectorDims new_dims = dims;
+    new_dims[dim] = dims[dim] / w_size;
+    auto new_desc = desc->cloneWithNewDims(new_dims, true);
+    MemoryPtr ptr = std::make_shared<Memory>(context->getEngine(), new_desc);
+    // copy
+    auto srcPtr = static_cast<uint8_t*>(src->getData());
+    auto dstPtr = static_cast<uint8_t*>(ptr->getData());
+    auto mem_size = src->getSize(); // total bytes
+    auto channel_size = dims[dim] * element_size; // selected dim bytes
+    const int step = (mem_size / channel_size); // the steps need to copy.
+    const int stride = dims[dim] / w_size; // elements of half selected dim.
+    const auto copySize = stride * element_size; // bytes of half selected dim.
+    parallel_for(step, [&](int i){
+        int dst_offset = i * copySize;
+        int src_offset = i * copySize* 2 + w_rank * copySize;
+        cpu_parallel_memcpy(dstPtr + dst_offset, srcPtr + src_offset, copySize);
+    });
+    return ptr;
+}
+
 void FullyConnected::createPrimitive() {
-    memory[ARG_SRC] = getSrcMemoryAtPort(DATA_ID);
-    memory[ARG_WEI] = getSrcMemoryAtPort(WEIGHTS_ID);
-    memory[ARG_BIAS] = attrs.withBias ? getSrcMemoryAtPort(BIAS_ID) : MemoryDescUtils::makeEmptyMemory(context);
+    auto src = getSrcMemoryAtPort(DATA_ID);
+    auto wgt = getSrcMemoryAtPort(WEIGHTS_ID);
+    auto dst = getDstMemoryAtPort(0);
+    if (auto env = getenv("ENABLE_TP") && flag_tp) {
+        auto select_src= split_v(src, -1, w_rank, w_size);
+        auto select_wgt = attrs.weightsNonTransposed ? split_h(wgt, -1, w_rank, w_size)
+                          : split_v(wgt, -1, w_rank, w_size);
+        // TODO: by default, we consider the weight is constant.
+        // cache for later reuse.
+        memory[ARG_SRC] = select_src;
+        memory[ARG_WEI] = select_wgt;
+        if (attrs.withBias && w_rank == 0) {
+            auto bias = getSrcMemoryAtPort(BIAS_ID);
+            memory[ARG_BIAS] = getSrcMemoryAtPort(BIAS_ID);
+        } else {
+            memory[ARG_BIAS] = MemoryDescUtils::makeEmptyMemory(context);
+        }
+    } else {
+        memory[ARG_SRC] = getSrcMemoryAtPort(DATA_ID);
+        memory[ARG_WEI] = getSrcMemoryAtPort(WEIGHTS_ID);
+        memory[ARG_BIAS] = attrs.withBias ? getSrcMemoryAtPort(BIAS_ID) : MemoryDescUtils::makeEmptyMemory(context);
+    }
     memory[ARG_DST] = getDstMemoryAtPort(0);
     // @todo should we preconfigure only for dynamic shapes?
     // Since for static shapes primitive is created in scope of compile_model() anyway

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -16,6 +16,7 @@
 #include "nodes/executors/memory_arguments.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
 #include "post_ops.hpp"
+#include "openvino/runtime/threading/cpu_message.hpp"
 
 namespace ov {
 namespace intel_cpu {
@@ -62,6 +63,10 @@ public:
     void fuseDecompressionMultiply(const MemoryCPtr& memory);
     void fuseDecompressionSubtract(const MemoryCPtr& memory);
 
+    MemoryPtr split_h(const MemoryPtr src, int dim, int w_rank, int w_size);
+    MemoryPtr split_v(const MemoryPtr src, int dim, int w_rank, int w_size);
+    void allreduce(void *send_buf, void *recv_buf, size_t count, ov::element::Type dtype);
+
 protected:
     void toNumaNodeImpl(int numaID) override;
 
@@ -79,6 +84,10 @@ private:
     ExecutorFactoryPtr<FCAttrs, node::FullyConnected> factory;
     ExecutorPtr executor = nullptr;
     std::string errorPrefix;
+    int w_rank = -1;
+    int w_size = -1;
+    bool flag_tp = false;
+    std::shared_ptr<ov::threading::MessageManage> message = nullptr;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/kernels/ccl/allreduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/ccl/allreduce.cpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <float.h>
+
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <type_traits>
+
+#if defined(HAVE_AVX2) || defined(HAVE_AVX512F)
+#    include <immintrin.h>
+#endif
+
+#include "openvino/core/type/bfloat16.hpp"
+#include "openvino/core/parallel.hpp"
+#include "allreduce.hpp"
+
+namespace ov {
+namespace Extensions {
+namespace Cpu {
+namespace XARCH {
+
+void allreduce_float32(const float* send_buf, float* recv_buf, size_t count) {
+#if defined(HAVE_AVX512F)
+    const size_t stride = 16;
+    size_t step = count / stride;
+    parallel_for(step, [&](size_t j){
+      __m512 vecA, vecB, vecC;
+      size_t i = j * stride;
+      // iter 0
+      vecA = _mm512_loadu_ps(send_buf + i);
+      vecB = _mm512_loadu_ps(recv_buf + i);
+      vecC = _mm512_add_ps(vecA, vecB);
+      _mm512_storeu_ps(recv_buf + i, vecC);
+      // // iter 1
+      // __m512 vecX, vecY, vecZ;
+      // size_t i1 = j * stride + stride;
+      // vecX = _mm512_loadu_ps(send_buf + i1);
+      // vecY = _mm512_loadu_ps(recv_buf + i1);
+      // vecZ = _mm512_add_ps(vecX, vecY);
+      // _mm512_storeu_ps(recv_buf + i1, vecZ);
+    });
+    size_t tail = count & ~(stride - 1);
+    for (size_t i = tail; i < count; ++i) {
+      recv_buf[i] += send_buf[i];
+    }
+#elif defined(HAVE_AVX2)
+    const size_t stride = 8;
+    size_t step = count / stride;
+    parallel_for(step, [&](size_t j){
+      __m256 vecA, vecB, vecC;
+      size_t i = j * stride;
+      vecA = _mm256_loadu_ps(send_buf + i);
+      vecB = _mm256_loadu_ps(recv_buf + i);
+      vecC = _mm256_add_ps(vecA, vecB);
+      _mm256_storeu_ps(recv_buf + i, vecC);
+    });
+    size_t tail = count & ~(stride - 1);
+    for (size_t i = tail; i < count; ++i) {
+        recv_buf[i] += send_buf[i];
+    }
+#else
+    const size_t stride = 8;
+    const size_t unloop = 8;
+    size_t step = count / unloop;
+    parallel_for(step, [&](size_t i) {
+      recv_buf[i * unloop]     += send_buf[i * unloop];
+      recv_buf[i * unloop + 1] += send_buf[i * unloop + 1];
+      recv_buf[i * unloop + 2] += send_buf[i * unloop + 2];
+      recv_buf[i * unloop + 3] += send_buf[i * unloop + 3];
+      recv_buf[i * unloop + 4] += send_buf[i * unloop + 4];
+      recv_buf[i * unloop + 5] += send_buf[i * unloop + 5];
+      recv_buf[i * unloop + 6] += send_buf[i * unloop + 6];
+      recv_buf[i * unloop + 7] += send_buf[i * unloop + 7];
+    });
+    size_t tail = count & ~(stride - 1);
+    for (size_t i = tail; i < count; ++i) {
+      recv_buf[i] += send_buf[i];
+    }
+#endif
+}
+
+}  // namespace XARCH
+}  // namespace Cpu
+}  // namespace Extensions
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/kernels/ccl/allreduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/ccl/allreduce.hpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov {
+namespace Extensions {
+namespace Cpu {
+namespace XARCH {
+
+void allreduce_float32(const float* send_buf,
+                       float* recv_buf,
+                       size_t count);
+
+}  // namespace XARCH
+}  // namespace Cpu
+}  // namespace Extensions
+}  // namespace ov


### PR DESCRIPTION
- add allreduce fp32 avx512/avx2/common kernel
- integrate allreduce in fc node
- integrate stream message in fc node
- support fc weight split
- `ENABLE_TP` is an env to control tensor parallel on or off.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
