### PR TITLE
[CPU] Created BrgemmCompiledKernel to cache palette with kernel

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
@@ -40,6 +40,8 @@ private:
 
 struct BrgemmCompiledKernel {
     std::unique_ptr<dnnl::impl::cpu::x64::brgemm_kernel_t> compiled_kernel = nullptr;
+    // Note: Palette is treated as a part of a kernel because it is initialized during the kernel compilation stage.
+    //       Each kernel need to store the pallet it was compiled with.
     char palette[64] = {};
 };
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
@@ -31,7 +31,6 @@ public:
 #endif
 private:
     dnnl_data_type_t dt_in0 {dnnl_f32}, dt_in1 {dnnl_f32};
-    char palette[64] = {};
     bool is_with_amx {false};
     bool is_with_comp {false};
     float beta {0};
@@ -39,8 +38,12 @@ private:
     dnnl_dim_t M {0}, N {0}, K {0}, LDA {0}, LDB {0}, LDC {0};
 };
 
+struct BrgemmCompiledKernel {
+    std::unique_ptr<dnnl::impl::cpu::x64::brgemm_kernel_t> compiled_kernel = nullptr;
+    char palette[64] = {};
+};
 
-class BrgemmKernelExecutor : public CPUKernelExecutor<BrgemmKernelConfig, dnnl::impl::cpu::x64::brgemm_kernel_t> {
+class BrgemmKernelExecutor : public CPUKernelExecutor<BrgemmKernelConfig, BrgemmCompiledKernel> {
 public:
     struct call_args {
         const void* A = nullptr;
@@ -62,7 +65,7 @@ public:
     std::string config_to_string() const;
 #endif
 protected:
-    std::shared_ptr<dnnl::impl::cpu::x64::brgemm_kernel_t> compile_kernel(const std::shared_ptr<BrgemmKernelConfig>& c) const override;
+    std::shared_ptr<BrgemmCompiledKernel> compile_kernel(const std::shared_ptr<BrgemmKernelConfig>& c) const override;
 };
 }   // namespace intel_cpu
 }   // namespace ov


### PR DESCRIPTION
### Details:
 - *If there are several MHA-patterns with the same Brgemms inside (the same configs), first Brgemm calls `compile_kernel` using executor: initializes `palette` and compile `kernel`. The brgemm from the second MHA finds in the cache this `kernel` by the config that is equal to first Brgemm has. Hovewer, previously `palette` was stored in `config` - this `config` is not cached and not shared between emitters. Thus, second Brgemm had cached `kernel` and config with empty `palette` since it's inited `compile_kernel` that is not called for this `Brgemm`. The PR introduces new structure that contains `compiled_kernel` and `palette` - these values are cached together and can be shared between nodes and emitters*

### Tickets:
 - *140771*
