### PR TITLE
[SAMPLES] Get the correct batch size when running with pre-compiled models

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -792,6 +792,11 @@ int main(int argc, char* argv[]) {
                                               FLAGS_scale_values,
                                               FLAGS_mean_values,
                                               compiledModel.inputs());
+
+            batchSize = get_batch_size(app_inputs_info.at(0));
+            warn_if_no_batch(app_inputs_info.at(0));
+            slog::info << "Model batch size: " << batchSize << slog::endl;
+
             if (batchSize == 0) {
                 batchSize = 1;
             }


### PR DESCRIPTION
### Details:
 - *get the correct batch size when running with pre-compiled models*

### Tickets:
 - *CVS-140703*
