### PR TITLE
[Snippets] United Static and Dynamic Loops into one node

### DIFF
--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -35,6 +35,12 @@ public:
     virtual std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const = 0;
 
     /**
+     * @brief Check if some parameters of Loop are dynamic (undefined)
+     * @return True if some parameters of Loop are unknown, False if all parameters are static
+     */
+    virtual bool is_dynamic() const;
+
+    /**
      * @brief Returns count of input ports
      * @return count
      */
@@ -184,6 +190,8 @@ public:
         int64_t ptr_increment = 0;
         int64_t finalization_offset = 0;
         int64_t data_size = 0;
+
+        bool is_dynamic() const;
     };
     // The structure describes full information about port
     // - TODO [140365] : UnifiedLoopInfo should have the map of LoopPorts and LoopDesc as class field
@@ -211,6 +219,12 @@ public:
      * @return the copy
      */
     std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const override;
+
+    /**
+     * @brief Check if some parameters of Loop are dynamic (undefined)
+     * @return True if some parameters of Loop are unknown, False if all parameters are static
+     */
+    bool is_dynamic() const override;
 
     /**
      * @brief Returns handlers of loop specific iterations
@@ -372,6 +386,12 @@ public:
      * @return the copy
      */
     std::shared_ptr<LoopInfo> clone_with_new_expr(const ExpressionMap& expr_map) const override;
+
+    /**
+     * @brief Check if some parameters of Loop are dynamic (undefined)
+     * @return True if some parameters of Loop are unknown, False if all parameters are static
+     */
+    bool is_dynamic() const override;
 
     /**
      * @brief Returns original unified LoopInfo from which this LoopInfo was created

--- a/src/common/snippets/include/snippets/lowered/pass/identify_buffers.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/identify_buffers.hpp
@@ -6,6 +6,8 @@
 
 #include "pass.hpp"
 
+#include "snippets/utils.hpp"
+
 namespace ov {
 namespace snippets {
 namespace lowered {
@@ -45,6 +47,10 @@ public:
         int64_t data_size = 0;
         int64_t ptr_increment = 0;
         int64_t finalization_offset = 0;
+
+        inline bool is_static() const {
+            return !utils::is_dynamic_value(ptr_increment) && !utils::is_dynamic_value(finalization_offset);
+        }
 
         friend bool operator==(const ShiftPtrParams& lhs, const ShiftPtrParams& rhs);
         friend bool operator!=(const ShiftPtrParams& lhs, const ShiftPtrParams& rhs);

--- a/src/common/snippets/include/snippets/lowered/pass/insert_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_loops.hpp
@@ -26,7 +26,6 @@ public:
     bool run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, lowered::LinearIR::constExprIt end) override;
 private:
     static void insertion(LinearIR& linear_ir, const LoopManagerPtr& loop_manager, size_t loop_id);
-    static bool is_loop_dynamic(const UnifiedLoopInfoPtr& loop_info);
 };
 
 } // namespace pass

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -82,22 +82,16 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
     // TODO [133463]: We have to update LoopEnd and LoopInfo since the both entities must be valid.
     //                To avoid the both changes, we have to insert Loop ops to LinearIR in the end of pipeline.
     auto new_is_incremented = loop_end->get_is_incremented();
-    if (const auto loop_end_dynamic = ov::as_type_ptr<op::LoopEndDynamic>(loop_end_expr->get_node())) {
-        for (auto idx_to_drop : resetting_data_indexes) {
-            new_is_incremented[idx_to_drop] = false;
-        }
-    } else if (const auto loop_end_static = ov::as_type_ptr<op::LoopEndStatic>(loop_end_expr->get_node())) {
-        auto new_ptr_increments = loop_end_static->get_ptr_increments();
-        auto new_finalization_offsets = loop_end_static->get_finalization_offsets();
-        for (auto idx_to_drop : resetting_data_indexes) {
-            new_ptr_increments[idx_to_drop] = 0;
-            new_finalization_offsets[idx_to_drop] = 0;
-            new_is_incremented[idx_to_drop] = false;
-        }
-        loop_end_static->set_ptr_increments(new_ptr_increments);
-        loop_end_static->set_finalization_offsets(new_finalization_offsets);
+    auto new_ptr_increments = loop_end->get_ptr_increments();
+    auto new_finalization_offsets = loop_end->get_finalization_offsets();
+    for (auto idx_to_drop : resetting_data_indexes) {
+        new_is_incremented[idx_to_drop] = false;
+        new_ptr_increments[idx_to_drop] = 0;
+        new_finalization_offsets[idx_to_drop] = 0;
     }
     loop_end->set_is_incremented(new_is_incremented);
+    loop_end->set_ptr_increments(new_ptr_increments);
+    loop_end->set_finalization_offsets(new_finalization_offsets);
 
     const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     size_t loop_port_idx = 0;

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -72,23 +72,26 @@ inline void init_is_incremented(LoopPort& port, size_t loop_id) {
     }
 }
 
-inline int64_t get_ptr_increment(const LoopPort& loop_port, size_t work_amount) {
+inline int64_t get_ptr_increment(const LoopPort& loop_port, size_t work_amount, size_t input_port_count, size_t output_port_count) {
     if (!loop_port.is_incremented)
         return 0;
 
     const auto& expr_port = loop_port.expr_port;
     const auto& layout = expr_port->get_descriptor_ptr()->get_layout();
     const auto& shape = expr_port->get_descriptor_ptr()->get_shape();
+    size_t port_count = 0;
     size_t dim = 0;
     if (expr_port->get_type() == ExpressionPort::Input) {
         dim = utils::get_input_dim_idx(layout, loop_port.dim_idx);
+        port_count = input_port_count;
     } else if (expr_port->get_type() == ExpressionPort::Output) {
         dim = utils::get_output_dim_idx(layout, loop_port.dim_idx);
+        port_count = output_port_count;
     } else {
         OPENVINO_THROW("Unsupported expression port type!");
     }
-    // When we cannot say about broadcasting by last dim
-    if (dim == shape.size() - 1 && utils::is_dynamic_value(shape.back())) {
+    // When we cannot say about broadcasting
+    if (utils::is_dynamic_value(shape[dim]) && port_count > 1) {
         return utils::get_dynamic_value<int64_t>();
     } else if (!(shape[dim] == 1 && work_amount != 1)) {
         return get_stride(dim, shape);
@@ -134,9 +137,11 @@ void InitLoops::init_loop_info(const UnifiedLoopInfoPtr& loop_info, const size_t
         init_work_amount(loop_info);
 
     const auto work_amount = loop_info->get_work_amount();
+    const auto input_count = loop_info->get_input_count();
+    const auto output_count = loop_info->get_output_count();
 
-    auto init_runtime_parameters = [&work_amount](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
-        ptr_shifts_params.ptr_increment = get_ptr_increment(loop_port, work_amount);
+    auto init_runtime_parameters = [&work_amount, &input_count, &output_count](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
+        ptr_shifts_params.ptr_increment = get_ptr_increment(loop_port, work_amount, input_count, output_count);
         ptr_shifts_params.finalization_offset = get_finalization_offset(work_amount, ptr_shifts_params.ptr_increment);
     };
 

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -72,21 +72,18 @@ inline void init_is_incremented(LoopPort& port, size_t loop_id) {
     }
 }
 
-inline int64_t get_ptr_increment(const LoopPort& loop_port, size_t work_amount, size_t input_port_count, size_t output_port_count) {
+inline int64_t get_ptr_increment(const LoopPort& loop_port, size_t work_amount, size_t port_count) {
     if (!loop_port.is_incremented)
         return 0;
 
     const auto& expr_port = loop_port.expr_port;
     const auto& layout = expr_port->get_descriptor_ptr()->get_layout();
     const auto& shape = expr_port->get_descriptor_ptr()->get_shape();
-    size_t port_count = 0;
     size_t dim = 0;
     if (expr_port->get_type() == ExpressionPort::Input) {
         dim = utils::get_input_dim_idx(layout, loop_port.dim_idx);
-        port_count = input_port_count;
     } else if (expr_port->get_type() == ExpressionPort::Output) {
         dim = utils::get_output_dim_idx(layout, loop_port.dim_idx);
-        port_count = output_port_count;
     } else {
         OPENVINO_THROW("Unsupported expression port type!");
     }
@@ -141,7 +138,8 @@ void InitLoops::init_loop_info(const UnifiedLoopInfoPtr& loop_info, const size_t
     const auto output_count = loop_info->get_output_count();
 
     auto init_runtime_parameters = [&work_amount, &input_count, &output_count](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
-        ptr_shifts_params.ptr_increment = get_ptr_increment(loop_port, work_amount, input_count, output_count);
+        ptr_shifts_params.ptr_increment = get_ptr_increment(loop_port, work_amount,
+                                                            loop_port.expr_port->get_type() == ExpressionPort::Input ? input_count : output_count);
         ptr_shifts_params.finalization_offset = get_finalization_offset(work_amount, ptr_shifts_params.ptr_increment);
     };
 

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -101,12 +101,10 @@ void InsertSpecificIterations::init_decomposed_loop(LinearIR& linear_ir, LinearI
     const auto& loop_manager = linear_ir.get_loop_manager();
     const auto new_id = loop_manager->replace_with_new_loop(linear_ir, begin, std::next(end), decomposed_loop_info, unified_loop_id);
     decomposed_loop_end->set_id(new_id);
+    decomposed_loop_end->set_work_amount(decomposed_loop_info->get_work_amount());
     decomposed_loop_end->set_increment(decomposed_loop_info->get_increment());
-    if (const auto static_loop_end = ov::as_type_ptr<op::LoopEndStatic>(decomposed_loop_end)) {
-        static_loop_end->set_work_amount(decomposed_loop_info->get_work_amount());
-        static_loop_end->set_ptr_increments(decomposed_loop_info->get_ptr_increments());
-        static_loop_end->set_finalization_offsets(decomposed_loop_info->get_finalization_offsets());
-    }
+    decomposed_loop_end->set_ptr_increments(decomposed_loop_info->get_ptr_increments());
+    decomposed_loop_end->set_finalization_offsets(decomposed_loop_info->get_finalization_offsets());
     // Note: handlers must be run on the range started with the first operation in the loop body.
     const auto handlers = decomposed_loop_info->get_handler_passes();
     handlers.run(linear_ir, std::next(begin), end);

--- a/src/common/snippets/src/lowered/pass/iter_handler.cpp
+++ b/src/common/snippets/src/lowered/pass/iter_handler.cpp
@@ -105,17 +105,13 @@ bool TransformInnerSplitLoop::run(LinearIR& linear_ir, LinearIR::constExprIt beg
         const auto inner_dim_idx = inner_loop_info->get_dim_idx();
         if (inner_dim_idx != current_dim_idx)
             continue;
+        // TODO [141735] : At the moment Splitted loops are not supported in dynamic case
+        OPENVINO_ASSERT(!inner_loop_end->has_dynamic_params(), "inner loop must be static in TransformInnerSplitLoop");
         const auto inner_loop_begin = inner_loop_end->get_loop_begin();
         const auto inner_loop_work_amount = static_cast<int64_t>(inner_loop_end->get_work_amount());
-        // TODO [141735] : At the moment Splitted loops are not supported in dynamic case
-        OPENVINO_ASSERT(!utils::is_dynamic_value(inner_loop_work_amount),
-                        "work_amount of inner loop must be static in TransformInnerSplitLoop");
         const auto inner_loop_increment = inner_loop_end->get_increment();
         auto inner_finalization_offsets = inner_loop_end->get_finalization_offsets();
         for (auto& offset : inner_finalization_offsets) {
-            // TODO [141735] : At the moment Splitted loops are not supported in dynamic case
-            OPENVINO_ASSERT(!utils::is_dynamic_value(offset),
-                            "finalizatiion_offset must be static in TransformInnerSplitLoop");
             offset = offset / inner_loop_work_amount * static_cast<int64_t>(m_tail_size);
         }
         inner_loop_end->set_work_amount(m_tail_size);

--- a/src/common/snippets/src/lowered/pass/iter_handler.cpp
+++ b/src/common/snippets/src/lowered/pass/iter_handler.cpp
@@ -85,7 +85,7 @@ TransformInnerSplitLoop::TransformInnerSplitLoop(size_t tail_size) : RangedPass(
 bool TransformInnerSplitLoop::run(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end) {
     const auto& expr = *end;
     const auto node = expr->get_node();
-    const auto loop_end = ov::as_type_ptr<op::LoopEndStatic>(node);
+    const auto loop_end = ov::as_type_ptr<op::LoopEnd>(node);
     OPENVINO_ASSERT(loop_end, "the last operation in range must be LoopEnd");
 
     const auto& loop_manager = linear_ir.get_loop_manager();
@@ -97,7 +97,7 @@ bool TransformInnerSplitLoop::run(LinearIR& linear_ir, LinearIR::constExprIt beg
     bool modified = false;
     for (auto it = begin; it != end; ++it) {
         const auto& expr = *it;
-        const auto inner_loop_end = ov::as_type_ptr<op::LoopEndStatic>(expr->get_node());
+        const auto inner_loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node());
         if (!inner_loop_end)
             continue;
         // There is already ExpandedLoopInfo
@@ -107,9 +107,15 @@ bool TransformInnerSplitLoop::run(LinearIR& linear_ir, LinearIR::constExprIt beg
             continue;
         const auto inner_loop_begin = inner_loop_end->get_loop_begin();
         const auto inner_loop_work_amount = static_cast<int64_t>(inner_loop_end->get_work_amount());
+        // TODO [141735] : At the moment Splitted loops are not supported in dynamic case
+        OPENVINO_ASSERT(!utils::is_dynamic_value(inner_loop_work_amount),
+                        "work_amount of inner loop must be static in TransformInnerSplitLoop");
         const auto inner_loop_increment = inner_loop_end->get_increment();
         auto inner_finalization_offsets = inner_loop_end->get_finalization_offsets();
         for (auto& offset : inner_finalization_offsets) {
+            // TODO [141735] : At the moment Splitted loops are not supported in dynamic case
+            OPENVINO_ASSERT(!utils::is_dynamic_value(offset),
+                            "finalizatiion_offset must be static in TransformInnerSplitLoop");
             offset = offset / inner_loop_work_amount * static_cast<int64_t>(m_tail_size);
         }
         inner_loop_end->set_work_amount(m_tail_size);

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -26,7 +26,9 @@ bool SplitLoops::can_be_split(const UnifiedLoopInfoPtr& loop_to_split, const Uni
     const bool equal_dim_idxes = current_dim_idx != LoopInfo::UNDEFINED_DIM_IDX && current_dim_idx == parent_dim_idx;
     const bool only_main_body = handlers.get_passes<SpecificLoopIterType::FIRST_ITER>().empty() &&
                                 handlers.get_passes<SpecificLoopIterType::LAST_ITER>().empty();
-    return loop_to_split->get_work_amount() == loop_to_fuse->get_work_amount() &&
+    // TODO [141735] : At the moment Splitted loops are not supported in dynamic case
+    const auto are_static = !loop_to_split->is_dynamic() && !loop_to_fuse->is_dynamic();
+    return are_static && loop_to_split->get_work_amount() == loop_to_fuse->get_work_amount() &&
            loop_to_split->get_increment() != loop_to_fuse->get_increment() && equal_dim_idxes && only_main_body;
 }
 

--- a/src/common/snippets/src/lowered/pass/validate.cpp
+++ b/src/common/snippets/src/lowered/pass/validate.cpp
@@ -83,23 +83,23 @@ void validate_buffer(const ExpressionPtr& expr, const LinearIR& linear_ir) {
     }
 }
 
-void validate_loop_end_static(const ExpressionPtr& expr, const LinearIR& linear_ir) {
-    const auto loop_end = ov::as_type_ptr<op::LoopEndStatic>(expr->get_node());
-    OPENVINO_ASSERT(loop_end, "LoopEndStatic validation expects LoopEndStatic op");
-    OPENVINO_ASSERT(ov::is_type<op::LoopBeginStatic>(loop_end->get_loop_begin()),
-                    "LoopEndStatic must be connected to the LoopBeginStatic");
+void validate_loop_end(const ExpressionPtr& expr, const LinearIR& linear_ir) {
+    const auto loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node());
+    OPENVINO_ASSERT(loop_end, "LoopEnd validation expects LoopEnd op");
+    OPENVINO_ASSERT(loop_end->get_loop_begin() != nullptr,
+                    "LoopEnd must be connected to the LoopBegin");
 
     const auto& loop_manager = linear_ir.get_loop_manager();
     const auto& loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     OPENVINO_ASSERT(loop_info->get_work_amount() == loop_end->get_work_amount() &&
                     loop_info->get_increment() == loop_end->get_increment(),
-                    "Incompatible LoopEndStatic and the corresponding LoopInfo");
+                    "Incompatible LoopEnd and the corresponding LoopInfo");
 
     const auto input_port_infos = loop_info->get_input_ports_info();
     const auto output_port_infos = loop_info->get_output_ports_info();
     OPENVINO_ASSERT(input_port_infos.size() == loop_end->get_input_num() &&
                     output_port_infos.size() == loop_end->get_output_num(),
-                    "Incompatible LoopEndStatic and the corresponding LoopInfo");
+                    "Incompatible LoopEnd and the corresponding LoopInfo");
 
     const auto& is_incremented = loop_end->get_is_incremented();
     const auto& ptr_increments = loop_end->get_ptr_increments();
@@ -109,38 +109,11 @@ void validate_loop_end_static(const ExpressionPtr& expr, const LinearIR& linear_
             OPENVINO_ASSERT(is_incremented[i + shift] == loop_port_infos[i].port.is_incremented &&
                             ptr_increments[i + shift] == loop_port_infos[i].desc.ptr_increment &&
                             final_offsets[i + shift] == loop_port_infos[i].desc.finalization_offset,
-                            "Incompatible data ptr shifts in LoopEndStatic and the corresponding LoopInfo");
+                            "Incompatible data ptr shifts in LoopEnd and the corresponding LoopInfo");
         }
     };
     validate_loop_ports(input_port_infos);
     validate_loop_ports(output_port_infos, loop_end->get_input_num());
-}
-
-void validate_loop_end_dynamic(const ExpressionPtr& expr, const LinearIR& linear_ir) {
-    const auto loop_end = ov::as_type_ptr<op::LoopEndDynamic>(expr->get_node());
-    OPENVINO_ASSERT(loop_end, "LoopEndDynamic validation expects LoopEndStatic op");
-    OPENVINO_ASSERT(ov::is_type<op::LoopBeginDynamic>(loop_end->get_loop_begin()),
-                    "LoopEndDynamic must be connected to the LoopBeginDynamic");
-
-    const auto& loop_manager = linear_ir.get_loop_manager();
-    const auto& loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
-    OPENVINO_ASSERT(loop_info->get_increment() == loop_end->get_increment(),
-                    "Incompatible LoopEndDynamic and the corresponding LoopInfo");
-
-    OPENVINO_ASSERT(loop_info->get_input_count() == loop_end->get_input_num() &&
-                    loop_info->get_output_count() == loop_end->get_output_num(),
-                    "Incompatible LoopEndStatic and the corresponding LoopInfo");
-
-    const auto& is_incremented = loop_end->get_is_incremented();
-
-    auto validate_loop_ports = [&](const std::vector<LoopPort>& loop_ports, size_t shift = 0) {
-        for (size_t i = 0; i < loop_ports.size(); ++i) {
-        OPENVINO_ASSERT(is_incremented[i + shift] == loop_ports[i].is_incremented,
-                        "Incompatible data ptr shifts in LoopEndStatic and the corresponding LoopInfo");
-        }
-    };
-    validate_loop_ports(loop_info->get_input_ports());
-    validate_loop_ports(loop_info->get_output_ports(), loop_end->get_input_num());
 }
 } // namespace
 
@@ -149,8 +122,7 @@ Validate::Validate() {
         {ov::op::v0::Parameter::get_type_info_static(), validate_parameter},
         {ov::op::v0::Result::get_type_info_static(), validate_result},
         {ov::snippets::op::Buffer::get_type_info_static(), validate_buffer},
-        {ov::snippets::op::LoopEndStatic::get_type_info_static(), validate_loop_end_static},
-        {ov::snippets::op::LoopEndDynamic::get_type_info_static(), validate_loop_end_dynamic}
+        {ov::snippets::op::LoopEnd::get_type_info_static(), validate_loop_end},
     };
 }
 

--- a/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_expanded_loops.cpp
@@ -110,18 +110,16 @@ void ValidateExpandedLoops::validate_loop_expressions(const LinearIR& linear_ir)
             const auto expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_manager->get_loop_info(loop_id));
             INFORMATIVE_ASSERT(expanded_loop_info, "expects only ExpandedLoopInfo in LoopManager");
 
+            INFORMATIVE_ASSERT(loop_end->get_work_amount() == expanded_loop_info->get_work_amount(),
+                               "incompatible work amount of LoopEnd and ExpandedLoopInfo");
             INFORMATIVE_ASSERT(loop_end->get_increment() == expanded_loop_info->get_increment(),
                                "incompatible increment of LoopEnd and ExpandedLoopInfo");
             INFORMATIVE_ASSERT(loop_end->get_element_type_sizes() == expanded_loop_info->get_data_sizes(),
                                "incompatible element sizes of LoopEnd and ExpandedLoopInfo");
-            if (const auto static_loop_end = ov::as_type_ptr<op::LoopEndStatic>(expr->get_node())) {
-                INFORMATIVE_ASSERT(static_loop_end->get_work_amount() == expanded_loop_info->get_work_amount(),
-                                   "incompatible work amount of LoopEnd and ExpandedLoopInfo");
-                INFORMATIVE_ASSERT(static_loop_end->get_ptr_increments() == expanded_loop_info->get_ptr_increments(),
-                                   "incompatible pointer increments of LoopEnd and ExpandedLoopInfo");
-                INFORMATIVE_ASSERT(static_loop_end->get_finalization_offsets() == expanded_loop_info->get_finalization_offsets(),
-                                   "incompatible finalization offsets of LoopEnd and ExpandedLoopInfo");
-            }
+            INFORMATIVE_ASSERT(loop_end->get_ptr_increments() == expanded_loop_info->get_ptr_increments(),
+                               "incompatible pointer increments of LoopEnd and ExpandedLoopInfo");
+            INFORMATIVE_ASSERT(loop_end->get_finalization_offsets() == expanded_loop_info->get_finalization_offsets(),
+                               "incompatible finalization offsets of LoopEnd and ExpandedLoopInfo");
         }
     }
     INFORMATIVE_ASSERT(unique_loop_ids.size() == loop_manager->get_map().size(),

--- a/src/common/snippets/src/op/loop.cpp
+++ b/src/common/snippets/src/op/loop.cpp
@@ -3,7 +3,8 @@
 //
 
 #include "snippets/op/loop.hpp"
-#include "snippets/generator.hpp"
+
+#include "snippets/utils.hpp"
 
 namespace ov {
 namespace snippets {
@@ -29,6 +30,10 @@ void LoopBegin::validate_and_infer_types() {
                     "LoopBegin must have LoopEnd connected to its last output");
 }
 
+std::shared_ptr<Node> LoopBegin::clone_with_new_inputs(const OutputVector& inputs) const {
+    return std::make_shared<LoopBegin>();
+}
+
 std::shared_ptr<LoopEnd> LoopBegin::get_loop_end() const {
     const auto& last_output_inputs = get_output_target_inputs(0);
     OPENVINO_ASSERT(last_output_inputs.size() == 1, "LoopBegin has more than one inputs attached to the last output");
@@ -37,35 +42,84 @@ std::shared_ptr<LoopEnd> LoopBegin::get_loop_end() const {
     return loop_end;
 }
 
-std::shared_ptr<Node> LoopBeginStatic::clone_with_new_inputs(const OutputVector& inputs) const {
-    return std::make_shared<LoopBeginStatic>();
-}
-
-std::shared_ptr<Node> LoopBeginDynamic::clone_with_new_inputs(const OutputVector& inputs) const {
-    return std::make_shared<LoopBeginDynamic>();
-}
-
-LoopEnd::LoopEnd(const Output<Node>& loop_begin, size_t work_amount_increment, std::vector<bool> is_incremented,
+LoopEnd::LoopEnd(const Output<Node>& loop_begin, size_t work_amount, size_t work_amount_increment,
+                 std::vector<bool> is_incremented, std::vector<int64_t> ptr_increments, std::vector<int64_t> finalization_offsets,
                  std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num, size_t id)
         : LoopBase({loop_begin}),
         m_is_incremented(std::move(is_incremented)),
+        m_ptr_increments(std::move(ptr_increments)),
+        m_finalization_offsets(std::move(finalization_offsets)),
         m_element_type_sizes(std::move(element_type_sizes)),
+        m_work_amount(work_amount),
         m_work_amount_increment(work_amount_increment),
         m_input_num(input_num),
         m_output_num(output_num),
-        m_id(id) {
+        m_id(id),
+        m_evaluate_once(false) {
     constructor_validate_and_infer_types();
+}
+
+void LoopEnd::validate_and_infer_types() {
+    NODE_VALIDATION_CHECK(this, get_input_size() == 1, "LoopEnd must have one input");
+    const auto loop_begin = ov::as_type_ptr<LoopBegin>(get_input_node_shared_ptr(0));
+    const auto io_size = m_input_num + m_output_num;
+    NODE_VALIDATION_CHECK(this, loop_begin != nullptr, "LoopEnd must have LoopBegin as the last argument");
+
+#define VALIDATE_VALUES(values, name, default_value)                                                                         \
+    NODE_VALIDATION_CHECK(this, values.empty() || values.size() == io_size,                                                  \
+                          name, " must be either empty or defined per every input & output of joined Loop. Expected size: ", \
+                          io_size, " got ", values.size());                                                                  \
+    if (values.empty())                                                                                                      \
+        values.resize(io_size, default_value);
+
+    VALIDATE_VALUES(m_is_incremented, "is_incremented", true)
+    VALIDATE_VALUES(m_ptr_increments, "ptr_increments", 0)
+    VALIDATE_VALUES(m_finalization_offsets, "finalization_offsets", 0)
+    VALIDATE_VALUES(m_element_type_sizes, "element_type_sizes", 0)
+#undef VALIDATE_VALUES
+
+    set_output_type(0, element::f32, ov::PartialShape{});
+}
+
+bool LoopEnd::visit_attributes(AttributeVisitor &visitor) {
+    std::vector<int> int_incremented(m_is_incremented.cbegin(), m_is_incremented.cend());
+    visitor.on_attribute("is_incremented", int_incremented);
+    visitor.on_attribute("ptr_incr", m_ptr_increments);
+    visitor.on_attribute("fin_offset", m_finalization_offsets);
+    visitor.on_attribute("data_sizes", m_element_type_sizes);
+    visitor.on_attribute("work_amount", m_work_amount);
+    visitor.on_attribute("increment", m_work_amount_increment);
+    visitor.on_attribute("input_num", m_input_num);
+    visitor.on_attribute("output_num", m_output_num);
+    visitor.on_attribute("id", m_id);
+    visitor.on_attribute("evaluate_once", m_evaluate_once);
+    return true;
+}
+
+std::shared_ptr<Node> LoopEnd::clone_with_new_inputs(const OutputVector& inputs) const {
+    check_new_args_count(this, inputs);
+    const auto loop_end = std::make_shared<LoopEnd>(inputs.at(0), m_work_amount, m_work_amount_increment, m_is_incremented, m_ptr_increments,
+                                                    m_finalization_offsets, m_element_type_sizes, m_input_num, m_output_num, m_id);
+    loop_end->m_evaluate_once = m_evaluate_once;
+    return loop_end;
 }
 
 std::shared_ptr<LoopBegin> LoopEnd::get_loop_begin() {
     const auto& loop_begin = ov::as_type_ptr<LoopBegin>(get_input_source_output(get_input_size() - 1).get_node_shared_ptr());
-    if (!loop_begin)
-        throw std::invalid_argument("LoopEnd last input is not connected to LoopBegin");
+    OPENVINO_ASSERT(loop_begin != nullptr, "LoopEnd last input is not connected to LoopBegin");
     return loop_begin;
 }
 
 const std::vector<bool>& LoopEnd::get_is_incremented() const {
     return m_is_incremented;
+}
+
+const std::vector<int64_t>& LoopEnd::get_finalization_offsets() const {
+    return m_finalization_offsets;
+}
+
+const std::vector<int64_t>& LoopEnd::get_ptr_increments() const {
+    return m_ptr_increments;
 }
 
 const std::vector<int64_t>& LoopEnd::get_element_type_sizes() const {
@@ -80,6 +134,10 @@ size_t LoopEnd::get_output_num() const {
     return m_output_num;
 }
 
+size_t LoopEnd::get_work_amount() const {
+    return m_work_amount;
+}
+
 size_t LoopEnd::get_increment() const {
     return m_work_amount_increment;
 }
@@ -88,129 +146,49 @@ size_t LoopEnd::get_id() const {
     return m_id;
 }
 
+bool LoopEnd::get_evaluate_once() const {
+    return m_evaluate_once;
+}
+
+bool LoopEnd::has_dynamic_params() const {
+    auto is_vector_dynamic = [](const std::vector<int64_t>& values) {
+        return std::any_of(values.cbegin(), values.cend(), utils::is_dynamic_value<int64_t>);
+    };
+    return utils::is_dynamic_value(m_work_amount) || is_vector_dynamic(m_ptr_increments) || is_vector_dynamic(m_finalization_offsets);
+}
+
 void LoopEnd::set_is_incremented(std::vector<bool> is_incremented) {
     OPENVINO_ASSERT(is_incremented.size() == m_input_num + m_output_num,
                     "LoopEnd set_is_incremented is called with inconsistent is_incremented.size()");
     m_is_incremented = std::move(is_incremented);
 }
 
-void LoopEnd::set_increment(size_t new_increment) {
-    m_work_amount_increment = new_increment;
-}
-
-void LoopEnd::set_id(size_t id) {
-    m_id = id;
-}
-
-void LoopEnd::validate_and_infer_types() {
-    NODE_VALIDATION_CHECK(this, get_input_size() == 1, "LoopEnd must have one input");
-    const auto loop_begin = ov::as_type_ptr<LoopBegin>(get_input_node_shared_ptr(0));
-    const auto io_size = m_input_num + m_output_num;
-    NODE_VALIDATION_CHECK(this, loop_begin != nullptr, "LoopEnd must have LoopBegin as the last argument");
-    NODE_VALIDATION_CHECK(this, m_is_incremented.empty() || m_is_incremented.size() == io_size,
-                          "is_incremented must be either empty or defined per every input & output of joined Loop. Expected size: ",
-                          io_size, " got ", m_is_incremented.size());
-    set_output_type(0, element::f32, ov::PartialShape{});
-}
-
-bool LoopEnd::visit_attributes(AttributeVisitor &visitor) {
-    std::vector<int> int_incremented(m_is_incremented.cbegin(), m_is_incremented.cend());
-    visitor.on_attribute("is_incremented", int_incremented);
-    visitor.on_attribute("data_sizes", m_element_type_sizes);
-    visitor.on_attribute("increment", m_work_amount_increment);
-    visitor.on_attribute("input_num", m_input_num);
-    visitor.on_attribute("output_num", m_output_num);
-    visitor.on_attribute("id", m_id);
-    return true;
-}
-
-LoopEndStatic::LoopEndStatic(const Output<Node>& loop_begin, size_t work_amount, size_t work_amount_increment,
-                             std::vector<bool> is_incremented, std::vector<int64_t> ptr_increments, std::vector<int64_t> finalization_offsets,
-                             std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num, size_t id)
-    : LoopEnd(loop_begin, work_amount_increment, std::move(is_incremented), std::move(element_type_sizes), input_num, output_num, id),
-      m_ptr_increments(std::move(ptr_increments)), m_finalization_offsets(std::move(finalization_offsets)), m_work_amount(work_amount),
-      m_evaluate_once(false) {}
-
-std::shared_ptr<Node> LoopEndStatic::clone_with_new_inputs(const OutputVector& inputs) const {
-    check_new_args_count(this, inputs);
-    const auto loop_end = std::make_shared<LoopEndStatic>(inputs.at(0), m_work_amount, m_work_amount_increment, m_is_incremented, m_ptr_increments,
-                                                          m_finalization_offsets, m_element_type_sizes, m_input_num, m_output_num, m_id);
-    loop_end->m_evaluate_once = m_evaluate_once;
-    return loop_end;
-}
-
-void LoopEndStatic::validate_and_infer_types() {
-    LoopEnd::validate_and_infer_types();
-    const auto io_size = m_input_num + m_output_num;
-    NODE_VALIDATION_CHECK(this, m_ptr_increments.empty() || m_ptr_increments.size() == io_size,
-                          "ptr_increments must be either empty or defined per every input & output of joined Loop. Expected size: ",
-                          io_size, " got ", m_ptr_increments.size());
-    NODE_VALIDATION_CHECK(this, m_finalization_offsets.empty() || m_finalization_offsets.size() == io_size,
-                          "finalization_offsets must be either empty or defined per every input & output of joined Loop. Expected size: ",
-                          io_size, " got ", m_finalization_offsets.size());
-    if (m_ptr_increments.empty())
-        m_ptr_increments.resize(io_size, 0);
-    if (m_finalization_offsets.empty())
-        m_finalization_offsets.resize(io_size, 0);
-}
-
-bool LoopEndStatic::visit_attributes(AttributeVisitor &visitor) {
-    visitor.on_attribute("work_amount", m_work_amount);
-    visitor.on_attribute("ptr_incr", m_ptr_increments);
-    visitor.on_attribute("fin_offset", m_finalization_offsets);
-    visitor.on_attribute("evaluate_once", m_evaluate_once);
-    return LoopEnd::visit_attributes(visitor);
-}
-
-const std::vector<int64_t>& LoopEndStatic::get_finalization_offsets() const {
-    return m_finalization_offsets;
-}
-
-const std::vector<int64_t>& LoopEndStatic::get_ptr_increments() const {
-    return m_ptr_increments;
-}
-
-size_t LoopEndStatic::get_work_amount() const {
-    return m_work_amount;
-}
-
-bool LoopEndStatic::get_evaluate_once() const {
-    return m_evaluate_once;
-}
-
-void LoopEndStatic::set_finalization_offsets(std::vector<int64_t> offsets) {
+void LoopEnd::set_finalization_offsets(std::vector<int64_t> offsets) {
     OPENVINO_ASSERT(offsets.size() == m_input_num + m_output_num,
                     "LoopEnd set_finalization_offsets is called with inconsistent offsets.size()");
     m_finalization_offsets = std::move(offsets);
 }
 
-void LoopEndStatic::set_ptr_increments(std::vector<int64_t> new_ptr_increments) {
+void LoopEnd::set_ptr_increments(std::vector<int64_t> new_ptr_increments) {
     OPENVINO_ASSERT(new_ptr_increments.size() == m_input_num + m_output_num,
                     "LoopEnd set_ptr_increments is called with inconsistent new_ptr_increments.size()");
     m_ptr_increments = std::move(new_ptr_increments);
 }
-void LoopEndStatic::update_ptr_increments(int64_t new_increment) {
-    std::transform(m_ptr_increments.begin(), m_ptr_increments.end(), m_ptr_increments.begin(),
-                   [new_increment](int64_t old_increment){
-                        return old_increment != 0 ? new_increment : 0;
-                   });
-}
 
-void LoopEndStatic::set_work_amount(size_t new_work_amount) {
+void LoopEnd::set_work_amount(size_t new_work_amount) {
     m_work_amount = new_work_amount;
 }
 
-void LoopEndStatic::set_evaluate_once(bool once) {
+void LoopEnd::set_increment(size_t new_increment) {
+    m_work_amount_increment = new_increment;
+}
+
+void LoopEnd::set_evaluate_once(bool once) {
     m_evaluate_once = once;
 }
 
-LoopEndDynamic::LoopEndDynamic(const Output<Node>& loop_begin, size_t work_amount_increment, std::vector<bool> is_incremented,
-                               std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num, size_t id)
-    : LoopEnd(loop_begin, work_amount_increment, std::move(is_incremented), std::move(element_type_sizes), input_num, output_num, id) {}
-
-std::shared_ptr<Node> LoopEndDynamic::clone_with_new_inputs(const OutputVector& inputs) const {
-    check_new_args_count(this, inputs);
-    return std::make_shared<LoopEndDynamic>(inputs.at(0), m_work_amount_increment, m_is_incremented, m_element_type_sizes, m_input_num, m_output_num, m_id);
+void LoopEnd::set_id(size_t id) {
+    m_id = id;
 }
 
 } // namespace op

--- a/src/common/snippets/src/op/loop.cpp
+++ b/src/common/snippets/src/op/loop.cpp
@@ -31,6 +31,7 @@ void LoopBegin::validate_and_infer_types() {
 }
 
 std::shared_ptr<Node> LoopBegin::clone_with_new_inputs(const OutputVector& inputs) const {
+    OPENVINO_ASSERT(inputs.empty(), "LoopBegin should not contain inputs");
     return std::make_shared<LoopBegin>();
 }
 

--- a/src/common/snippets/src/shape_inference/shape_inference.cpp
+++ b/src/common/snippets/src/shape_inference/shape_inference.cpp
@@ -47,12 +47,10 @@ const IShapeInferSnippetsFactory::TRegistry IShapeInferSnippetsFactory::registry
         SHAPE_INFER_PREDEFINED(op::HorizonMax, HorizonOpShapeInfer),
         SHAPE_INFER_PREDEFINED(op::HorizonSum, HorizonOpShapeInfer),
         //
-        SHAPE_INFER_PREDEFINED(op::LoopBeginStatic, SingleElementShapeInfer),
-        SHAPE_INFER_PREDEFINED(op::LoopBeginDynamic, SingleElementShapeInfer),
+        SHAPE_INFER_PREDEFINED(op::LoopBegin, SingleElementShapeInfer),
         SHAPE_INFER_PREDEFINED(op::Scalar, SingleElementShapeInfer),
         SHAPE_INFER_PREDEFINED(op::VectorBuffer, SingleElementShapeInfer),
-        SHAPE_INFER_PREDEFINED(op::LoopEndStatic, EmptyShapeInfer),
-        SHAPE_INFER_PREDEFINED(op::LoopEndDynamic, EmptyShapeInfer),
+        SHAPE_INFER_PREDEFINED(op::LoopEnd, EmptyShapeInfer),
 #ifdef SNIPPETS_DEBUG_CAPS
         SHAPE_INFER_PREDEFINED(op::PerfCountBegin, EmptyShapeInfer),
         SHAPE_INFER_PREDEFINED(op::PerfCountEnd, EmptyShapeInfer),

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -79,8 +79,7 @@ static void validate(const LinearIR& linear_ir, const ref_map& reference) {
     size_t loop_num = 0;
     for (const auto& expr : linear_ir) {
         const auto& node = expr->get_node();
-        ASSERT_TRUE(!ov::is_type<ov::snippets::op::LoopBeginDynamic>(node) && !ov::is_type<ov::snippets::op::LoopEndDynamic>(node));
-        const auto loop_end = ov::as_type_ptr<ov::snippets::op::LoopEndStatic>(node);
+        const auto loop_end = ov::as_type_ptr<ov::snippets::op::LoopEnd>(node);
         if (!loop_end)
             continue;
         ASSERT_GT(reference.count(loop_num), 0);

--- a/src/common/snippets/tests/src/lowering_utils.cpp
+++ b/src/common/snippets/tests/src/lowering_utils.cpp
@@ -42,10 +42,8 @@ DummyTargetMachine::DummyTargetMachine(const std::vector<ov::Node::type_info_t>&
     jitters[ov::snippets::op::BroadcastMove::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::KernelDynamic::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::KernelStatic::get_type_info_static()] = dummy_functor;
-    jitters[ov::snippets::op::LoopBeginDynamic::get_type_info_static()] = dummy_functor;
-    jitters[ov::snippets::op::LoopBeginStatic::get_type_info_static()] = dummy_functor;
-    jitters[ov::snippets::op::LoopEndDynamic::get_type_info_static()] = dummy_functor;
-    jitters[ov::snippets::op::LoopEndStatic::get_type_info_static()] = dummy_functor;
+    jitters[ov::snippets::op::LoopBegin::get_type_info_static()] = dummy_functor;
+    jitters[ov::snippets::op::LoopEnd::get_type_info_static()] = dummy_functor;
 #ifdef SNIPPETS_DEBUG_CAPS
     jitters[ov::snippets::op::PerfCountBegin::get_type_info_static()] = dummy_functor;
     jitters[ov::snippets::op::PerfCountEnd::get_type_info_static()] = dummy_functor;

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -97,10 +97,8 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     // control flow
     jitters[snippets::op::KernelStatic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_kernel_static_emitter);
     jitters[snippets::op::KernelDynamic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_kernel_dynamic_emitter);
-    jitters[snippets::op::LoopBeginStatic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_loop_begin_static_emitter);
-    jitters[snippets::op::LoopBeginDynamic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_loop_begin_dynamic_emitter);
-    jitters[snippets::op::LoopEndStatic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_loop_end_static_emitter);
-    jitters[snippets::op::LoopEndDynamic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_loop_end_dynamic_emitter);
+    jitters[snippets::op::LoopBegin::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_loop_begin_emitter);
+    jitters[snippets::op::LoopEnd::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_loop_end_emitter);
 
     // others
     jitters[snippets::op::Scalar::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(jit_scalar_emitter);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.hpp
@@ -21,49 +21,19 @@ public:
 
     size_t get_inputs_count() const override { return 0; }
 
+    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
+                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
+
     std::shared_ptr<const Xbyak_aarch64::Label> get_begin_label() { return loop_begin_label; }
 
 protected:
-    static std::shared_ptr<ov::snippets::op::LoopEnd> get_loop_end(const ov::snippets::lowered::ExpressionPtr& expr);
+    void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
+    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
 
     std::shared_ptr<Xbyak_aarch64::Label> loop_begin_label;
-    int64_t wa_increment = 0;
-};
-
-class jit_loop_begin_static_emitter: public jit_loop_begin_emitter {
-public:
-    jit_loop_begin_static_emitter(dnnl::impl::cpu::aarch64::jit_generator* h, dnnl::impl::cpu::aarch64::cpu_isa_t isa,
-                                  const ov::snippets::lowered::ExpressionPtr& expr);
-
-    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
-protected:
-    void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
-    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
-
-    bool evaluate_once = false;
     size_t work_amount = 0;
-};
-
-class jit_loop_begin_dynamic_emitter: public jit_loop_begin_emitter {
-public:
-    jit_loop_begin_dynamic_emitter(dnnl::impl::cpu::aarch64::jit_generator* h, dnnl::impl::cpu::aarch64::cpu_isa_t isa,
-                                   const ov::snippets::lowered::ExpressionPtr& expr);
-
-    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
-
-    void set_loop_end_label(const std::shared_ptr<const Xbyak_aarch64::Label>& label) { loop_end_label = label; }
-
-protected:
-    void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
-    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
-
-    // For Loop arguments
-    size_t get_aux_gprs_count() const override { return 1; }
-
-    std::shared_ptr<const Xbyak_aarch64::Label> loop_end_label;
-    size_t loop_id;
+    int64_t wa_increment = 0;
+    bool evaluate_once = false;
 };
 
 /* ============================================================== */
@@ -77,53 +47,25 @@ public:
 
     size_t get_inputs_count() const override { return 0; }
 
+    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
+                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
+
 protected:
+    void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
+    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
+
     static ov::snippets::lowered::ExpressionPtr get_loop_begin_expr(const ov::snippets::lowered::ExpressionPtr& expr);
 
     std::shared_ptr<const Xbyak_aarch64::Label> loop_begin_label;
     size_t num_inputs = 0;
     size_t num_outputs = 0;
-    int64_t wa_increment = 0;
-    std::vector<bool> is_incremented = {};
-};
-
-class jit_loop_end_static_emitter: public jit_loop_end_emitter {
-public:
-    jit_loop_end_static_emitter(dnnl::impl::cpu::aarch64::jit_generator* h, dnnl::impl::cpu::aarch64::cpu_isa_t isa,
-                                const ov::snippets::lowered::ExpressionPtr& expr);
-
-    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
-
-protected:
-    void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
-    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
-
     size_t work_amount = 0;
+    int64_t wa_increment = 0;
     std::vector<bool> is_incremented = {};
     std::vector<int64_t> ptr_increments = {};
     std::vector<int64_t> finalization_offsets = {};
     std::vector<int64_t> data_sizes = {};
     bool evaluate_once = false;
-};
-
-class jit_loop_end_dynamic_emitter: public jit_loop_end_emitter {
-public:
-    jit_loop_end_dynamic_emitter(dnnl::impl::cpu::aarch64::jit_generator* h, dnnl::impl::cpu::aarch64::cpu_isa_t isa,
-                                 const ov::snippets::lowered::ExpressionPtr& expr);
-
-    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
-
-protected:
-    void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
-    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
-
-    // For Loop arguments
-    size_t get_aux_gprs_count() const override { return 2; }
-
-    std::shared_ptr<Xbyak_aarch64::Label> loop_end_label;
-    size_t loop_id;
 };
 
 /* ============================================================== */

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
@@ -239,10 +239,8 @@ intel_cpu::CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t ho
 
     jitters[snippets::op::KernelStatic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_kernel_static_emitter);
     jitters[snippets::op::KernelDynamic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_kernel_dynamic_emitter);
-    jitters[snippets::op::LoopBeginStatic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_loop_begin_static_emitter);
-    jitters[snippets::op::LoopBeginDynamic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_loop_begin_dynamic_emitter);
-    jitters[snippets::op::LoopEndStatic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_loop_end_static_emitter);
-    jitters[snippets::op::LoopEndDynamic::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_loop_end_dynamic_emitter);
+    jitters[snippets::op::LoopBegin::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_loop_begin_emitter);
+    jitters[snippets::op::LoopEnd::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_loop_end_emitter);
     // Note: jit_brgemm_emitter supports runtime recompilation, so its constructor takes additional arguments
     jitters[intel_cpu::BrgemmCPU::get_type_info_static()] = CREATE_SNIPPETS_EMITTER(intel_cpu::jit_brgemm_emitter,
                                                                                     kernel_executor_table,

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
@@ -5,6 +5,7 @@
 #include "jit_loop_emitters.hpp"
 
 #include "emitters/snippets/jit_snippets_call_args.hpp"
+#include "snippets/utils.hpp"
 
 using namespace Xbyak;
 using namespace dnnl::impl;
@@ -13,93 +14,58 @@ using namespace dnnl::impl::cpu::x64;
 namespace ov {
 namespace intel_cpu {
 
-inline static void transform_idxs_to_regs(const std::vector<size_t>& idxs, std::vector<Xbyak::Reg64>& regs) {
-    regs.resize(idxs.size());
-    std::transform(idxs.begin(), idxs.end(), regs.begin(), [](size_t idx){ return Xbyak::Reg64(static_cast<int>(idx)); });
-}
-
 /* ================== jit_loop_begin_emitter ====================== */
 
 jit_loop_begin_emitter::jit_loop_begin_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
                                                const ov::snippets::lowered::ExpressionPtr& expr)
-    : jit_emitter(h, isa), loop_begin_label{new Xbyak::Label()} {
-    in_out_type_ = emitter_in_out_map::gpr_to_gpr;
-}
-
-std::shared_ptr<ov::snippets::op::LoopEnd> jit_loop_begin_emitter::get_loop_end(const ov::snippets::lowered::ExpressionPtr& expr) {
-    OV_CPU_JIT_EMITTER_ASSERT(expr->get_output_port_connectors().size() == 1, "has invalid LoopBegin expression configuration");
-    const auto& consumers = expr->get_output_port_connector(0)->get_consumers();
-    OV_CPU_JIT_EMITTER_ASSERT(consumers.size() == 1, "has invalid LoopBegin expression configuration");
-    const auto loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(consumers.cbegin()->get_expr()->get_node());
-    OV_CPU_JIT_EMITTER_ASSERT(loop_end != nullptr, "has invalid LoopBegin expression configuration");
-    return loop_end;
-}
-
-jit_loop_begin_static_emitter::jit_loop_begin_static_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
-                                                             const ov::snippets::lowered::ExpressionPtr& expr)
-    : jit_loop_begin_emitter(h, isa, expr) {
-    OV_CPU_JIT_EMITTER_ASSERT(ov::is_type<snippets::op::LoopBeginStatic>(expr->get_node()),
-                              "expects LoopBeginStatic expression");
-    const auto loop_end = ov::as_type_ptr<snippets::op::LoopEndStatic>(get_loop_end(expr));
+    : jit_emitter(h, isa), loop_begin_label{new Xbyak::Label()}, loop_end_label(nullptr) {
+    const auto loop_begin = ov::as_type_ptr<snippets::op::LoopBegin>(expr->get_node());
+    OV_CPU_JIT_EMITTER_ASSERT(loop_begin, "expects LoopBegin expression");
+    const auto loop_end = loop_begin->get_loop_end();
     work_amount = loop_end->get_work_amount();
     wa_increment = loop_end->get_increment();
     evaluate_once = loop_end->get_evaluate_once();
+    loop_id = loop_end->get_id();
+    need_runtime_args = ov::snippets::utils::is_dynamic_value(work_amount);
+    in_out_type_ = emitter_in_out_map::gpr_to_gpr;
 }
 
-void jit_loop_begin_static_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+size_t jit_loop_begin_emitter::aux_gprs_count() const {
+    // for runtime arguments
+    return need_runtime_args ? 1 : 0;
+}
+
+void jit_loop_begin_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
     OV_CPU_JIT_EMITTER_ASSERT(in.empty(), "Invalid inputs size: expected 0 got " + std::to_string(in.size()));
     // Note: the only expected output is work amount register (communicated to jit_loop_end_emitter)
     OV_CPU_JIT_EMITTER_ASSERT(out.size() == 1, "Invalid outputs size: expected 1 got " + std::to_string(out.size()));
+    OV_CPU_JIT_EMITTER_ASSERT(loop_begin_label != nullptr && loop_end_label != nullptr, "has not inited labels!");
+    OV_CPU_JIT_EMITTER_ASSERT(implication(need_runtime_args, !evaluate_once), "with dynamic work_amount cannot evaluate once!");
 }
 
-void jit_loop_begin_static_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
-    Xbyak::Reg64 reg_work_amount = Xbyak::Reg64(static_cast<int>(out.back()));
-    if (!evaluate_once) {
+void jit_loop_begin_emitter::emit_code(const std::vector<size_t> &in, const std::vector<size_t> &out,
+                                       const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const {
+    validate_arguments(in, out);
+    jit_emitter::emit_code(in, out, pool_vec_idxs, pool_gpr_idxs);
+}
+
+void jit_loop_begin_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
+    Reg64 reg_work_amount = Reg64(static_cast<int>(out.back()));
+    if (need_runtime_args) {
+        Reg64 reg_runtime_params = abi_param1;  // defined by jit_kernel_emitter
+        Reg64 reg_loop_args_ptr = Reg64(static_cast<int>(aux_gpr_idxs[0]));
+        const auto id_offset = loop_id * sizeof(jit_snippets_call_args::loop_args_t);
+        h->mov(reg_loop_args_ptr, h->ptr[reg_runtime_params + GET_OFF(loop_args)]);
+        h->mov(reg_work_amount, h->ptr[reg_loop_args_ptr + id_offset + GET_OFF_LOOP_ARGS(m_work_amount)]);
+    } else if (!evaluate_once) {
         h->mov(reg_work_amount, work_amount);
     }
-    h->L(*loop_begin_label);
-}
 
-void jit_loop_begin_static_emitter::emit_code(const std::vector<size_t> &in, const std::vector<size_t> &out,
-                                              const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const {
-    validate_arguments(in, out);
-    emit_impl(in, out);
-}
-
-jit_loop_begin_dynamic_emitter::jit_loop_begin_dynamic_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
-                                                               const ov::snippets::lowered::ExpressionPtr& expr)
-    : jit_loop_begin_emitter(h, isa, expr), loop_end_label(nullptr) {
-    OV_CPU_JIT_EMITTER_ASSERT(ov::is_type<snippets::op::LoopBeginDynamic>(expr->get_node()), "expects LoopBeginDynamic expression");
-    const auto loop_end = get_loop_end(expr);
-    wa_increment = loop_end->get_increment();
-    loop_id = loop_end->get_id();
-}
-
-void jit_loop_begin_dynamic_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
-    // Note: the only expected input is the reg_runtime_params_idx
-    OV_CPU_JIT_EMITTER_ASSERT(in.empty(), "Invalid inputs size: expected 0 got " + std::to_string(in.size()));
-    // Note: the only expected output is work amount register (communicated to jit_loop_end_emitter)
-    OV_CPU_JIT_EMITTER_ASSERT(out.size() == 1, "Invalid outputs size: expected 1 got " + std::to_string(out.size()));
-    OV_CPU_JIT_EMITTER_ASSERT(loop_end_label != nullptr && loop_begin_label != nullptr, "has not inited labels!");
-}
-
-void jit_loop_begin_dynamic_emitter::emit_code(const std::vector<size_t> &in, const std::vector<size_t> &out,
-                                               const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const {
-    validate_arguments(in, out);
-    jit_emitter::emit_code(in, out);
-}
-
-void jit_loop_begin_dynamic_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
-    Xbyak::Reg64 reg_runtime_params = abi_param1;  // defined by jit_kernel_emitter
-    Xbyak::Reg64 reg_work_amount = Xbyak::Reg64(static_cast<int>(out.back()));
-    Xbyak::Reg64 reg_loop_args_ptr = Xbyak::Reg64(static_cast<int>(aux_gpr_idxs[0]));
-    const auto id_offset = loop_id * sizeof(jit_snippets_call_args::loop_args_t);
-    h->mov(reg_loop_args_ptr, h->ptr[reg_runtime_params + GET_OFF(loop_args)]);
-    h->mov(reg_work_amount, h->ptr[reg_loop_args_ptr + id_offset + GET_OFF_LOOP_ARGS(m_work_amount)]);
-
-    // if wa < increment, skip the loop
-    h->cmp(reg_work_amount, wa_increment);
-    h->jl(*loop_end_label, Xbyak::CodeGenerator::T_NEAR);
+    if (!evaluate_once) {
+        // if wa < increment, skip the loop
+        h->cmp(reg_work_amount, wa_increment);
+        h->jl(*loop_end_label, Xbyak::CodeGenerator::T_NEAR);
+    }
 
     h->L(*loop_begin_label);
 }
@@ -110,19 +76,31 @@ void jit_loop_begin_dynamic_emitter::emit_impl(const std::vector<size_t>& in, co
 
 jit_loop_end_emitter::jit_loop_end_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
                                            const ov::snippets::lowered::ExpressionPtr& expr)
-    : jit_emitter(h, isa), loop_begin_label{nullptr} {
+    : jit_emitter(h, isa), loop_begin_label{nullptr}, loop_end_label{new Xbyak::Label()} {
     in_out_type_ = emitter_in_out_map::gpr_to_gpr;
     const auto loop_end = ov::as_type_ptr<snippets::op::LoopEnd>(expr->get_node());
     OV_CPU_JIT_EMITTER_ASSERT(loop_end != nullptr, "expected LoopEnd expr");
-    // Note that 1 edge connects LoopBegin and LoopEnd
     num_inputs = loop_end->get_input_num();
     num_outputs = loop_end->get_output_num();
+    work_amount = loop_end->get_work_amount();
     wa_increment = loop_end->get_increment();
     is_incremented = loop_end->get_is_incremented();
+    ptr_increments = loop_end->get_ptr_increments();
+    finalization_offsets = loop_end->get_finalization_offsets();
+    data_sizes = loop_end->get_element_type_sizes();
+    evaluate_once = loop_end->get_evaluate_once();
+    loop_id = loop_end->get_id();
+
+    need_runtime_args_for_ptr_inc =
+        std::any_of(ptr_increments.cbegin(), ptr_increments.cend(), ov::snippets::utils::is_dynamic_value<int64_t>);
+    need_runtime_args_for_final_offs =
+        std::any_of(finalization_offsets.cbegin(), finalization_offsets.cend(), ov::snippets::utils::is_dynamic_value<int64_t>);
+    need_runtime_args = need_runtime_args_for_ptr_inc || need_runtime_args_for_final_offs;
 
     const auto begin_expr = get_loop_begin_expr(expr);
     const auto& loop_begin_emitter = std::dynamic_pointer_cast<jit_loop_begin_emitter>(begin_expr->get_emitter());
     OV_CPU_JIT_EMITTER_ASSERT(loop_begin_emitter, "LoopBegin expected jit_loop_begin_emitter");
+    loop_begin_emitter->set_loop_end_label(loop_end_label);
     loop_begin_label = loop_begin_emitter->get_begin_label();
 }
 
@@ -133,118 +111,72 @@ ov::snippets::lowered::ExpressionPtr jit_loop_end_emitter::get_loop_begin_expr(c
     return begin_expr;
 }
 
-jit_loop_end_static_emitter::jit_loop_end_static_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
-                                                         const ov::snippets::lowered::ExpressionPtr& expr)
-    : jit_loop_end_emitter(h, isa, expr) {
-    const auto loop_end = ov::as_type_ptr<snippets::op::LoopEndStatic>(expr->get_node());
-    OV_CPU_JIT_EMITTER_ASSERT(loop_end != nullptr, "expected LoopEndStatic expr");
-    work_amount = static_cast<int64_t>(loop_end->get_work_amount());
-    is_incremented = loop_end->get_is_incremented();
-    ptr_increments = loop_end->get_ptr_increments();
-    finalization_offsets = loop_end->get_finalization_offsets();
-    data_sizes = loop_end->get_element_type_sizes();
-    evaluate_once = loop_end->get_evaluate_once();
-}
-
-void jit_loop_end_static_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
+void jit_loop_end_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
     const auto io_size = num_inputs + num_outputs;
     OV_CPU_JIT_EMITTER_ASSERT(out.size() == 0, "Invalid number of out arguments: expected ", 0, " got ", out.size());
     OV_CPU_JIT_EMITTER_ASSERT(in.size() == io_size + 1, "Invalid number of in arguments: expected ", io_size + 1, " got ", in.size());
+    OV_CPU_JIT_EMITTER_ASSERT(is_incremented.size() == io_size, "Invalid is_incremented size: expected ", io_size, " got ", is_incremented.size());
     OV_CPU_JIT_EMITTER_ASSERT(ptr_increments.size() == io_size, "Invalid ptr_increments size: expected ", io_size, " got ", ptr_increments.size());
     OV_CPU_JIT_EMITTER_ASSERT(finalization_offsets.size() == io_size,
                               "Invalid finalization_offsets size: expected: ", io_size, " got ", finalization_offsets.size());
     OV_CPU_JIT_EMITTER_ASSERT(data_sizes.size() == io_size, "Invalid data_sizes size: expected: ", io_size, " got ", data_sizes.size());
+    OV_CPU_JIT_EMITTER_ASSERT(loop_end_label != nullptr && loop_begin_label != nullptr, "has not inited labels!");
+    OV_CPU_JIT_EMITTER_ASSERT(implication(need_runtime_args, !evaluate_once), "with dynamic work_amount cannot evaluate once!");
 }
 
-void jit_loop_end_static_emitter::emit_code(const std::vector<size_t> &in, const std::vector<size_t> &out,
-                                            const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const {
+void jit_loop_end_emitter::emit_code(const std::vector<size_t> &in, const std::vector<size_t> &out,
+                                     const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const {
     validate_arguments(in, out);
-    emit_impl(in, out);
+    jit_emitter::emit_code(in, out, pool_vec_idxs, pool_gpr_idxs);
 }
 
-void jit_loop_end_static_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
+size_t jit_loop_end_emitter::aux_gprs_count() const {
+    return need_runtime_args ? 1 : 0;
+}
+
+void jit_loop_end_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     std::vector<size_t> data_ptr_reg_idxs;
     // the last input is actually a work_amount reg
-    data_ptr_reg_idxs.reserve(num_inputs - 1);
+    data_ptr_reg_idxs.reserve(num_inputs + num_outputs);
     std::copy(in.begin(), in.end() - 1, std::back_inserter(data_ptr_reg_idxs));
 
+    const auto id_offset = loop_id * sizeof(jit_snippets_call_args::loop_args_t);
+    Reg64 reg_increments = need_runtime_args ? Reg64(static_cast<int>(aux_gpr_idxs[0])) : Reg64();
     Reg64 reg_work_amount = Reg64(in.back());
-    if (!evaluate_once) {
-        for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {
-            if (!is_incremented[idx] || ptr_increments[idx] == 0)
-                continue;
-            Reg64 data_reg = Reg64(static_cast<int>(data_ptr_reg_idxs[idx]));
-            h->add(data_reg, ptr_increments[idx] * wa_increment * data_sizes[idx]);
+
+    auto apply_increment = [&](size_t idx, int64_t increment, int64_t scale = 1) {
+        if (is_incremented[idx] && increment != 0) {
+            if (ov::snippets::utils::is_dynamic_value(increment)) {
+                h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), h->ptr[reg_increments + idx * sizeof(int64_t)]);
+            } else {
+                h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), increment * scale * data_sizes[idx]);
+            }
         }
+    };
+
+#define APPLY_INCREMENTS(COND, TYPE, INCREMENTS, SCALE)                                         \
+    if (COND) {                                                                                 \
+        Reg64 reg_runtime_params = abi_param1; /* defined by jit_kernel_emitter */              \
+        h->mov(reg_increments, h->ptr[reg_runtime_params + GET_OFF(loop_args)]);                \
+        h->mov(reg_increments, h->ptr[reg_increments + id_offset + GET_OFF_LOOP_ARGS(TYPE)]);   \
+    }                                                                                           \
+    for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {                               \
+        apply_increment(idx, INCREMENTS[idx], SCALE);                                           \
+    }
+
+    if (!evaluate_once) {
+        APPLY_INCREMENTS(need_runtime_args_for_ptr_inc, m_ptr_increments, ptr_increments, wa_increment);
+
         h->sub(reg_work_amount, wa_increment);
         h->cmp(reg_work_amount, wa_increment);
-        h->jge(*loop_begin_label);
+        h->jge(*loop_begin_label, Xbyak::CodeGenerator::T_NEAR);
     }
 
-    for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {
-        if (!is_incremented[idx] || finalization_offsets[idx] == 0)
-            continue;
-        Reg64 data_reg = Reg64(static_cast<int>(data_ptr_reg_idxs[idx]));
-        h->add(data_reg, finalization_offsets[idx] * data_sizes[idx]);
-    }
-}
-
-jit_loop_end_dynamic_emitter::jit_loop_end_dynamic_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
-                                                           const ov::snippets::lowered::ExpressionPtr& expr)
-    : jit_loop_end_emitter(h, isa, expr), loop_end_label{new Xbyak::Label()} {
-    const auto loop_end = ov::as_type_ptr<snippets::op::LoopEndDynamic>(expr->get_node());
-    OV_CPU_JIT_EMITTER_ASSERT(loop_end != nullptr, "expected LoopEndDynamic expr");
-    loop_id = loop_end->get_id();
-
-    const auto begin_expr = get_loop_begin_expr(expr);
-    const auto& loop_begin_emitter = std::dynamic_pointer_cast<jit_loop_begin_dynamic_emitter>(begin_expr->get_emitter());
-    OV_CPU_JIT_EMITTER_ASSERT(loop_begin_emitter, "LoopBeginDynamic expected jit_loop_begin_dynamic_emitter");
-    loop_begin_emitter->set_loop_end_label(loop_end_label);
-}
-
-void jit_loop_end_dynamic_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
-    OV_CPU_JIT_EMITTER_ASSERT(loop_end_label != nullptr && loop_begin_label != nullptr, "has not inited labels!");
-    // Note: there must be additional input argument for runtime parameters
-    const auto io_size = num_inputs + num_outputs;
-    OV_CPU_JIT_EMITTER_ASSERT(in.size() == io_size + 1, "Invalid number of in arguments: expected ", io_size + 1, " got ", in.size());
-    OV_CPU_JIT_EMITTER_ASSERT(out.size() == 0, "Invalid number of out arguments: expected ", 0, " got ", out.size());
-}
-
-void jit_loop_end_dynamic_emitter::emit_code(const std::vector<size_t> &in, const std::vector<size_t> &out,
-                                             const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const {
-    validate_arguments(in, out);
-    jit_emitter::emit_code(in, out);
-}
-
-void jit_loop_end_dynamic_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
-    Xbyak::Reg64 reg_runtime_params = abi_param1;  // defined by jit_kernel_emitter
-    Xbyak::Reg64 reg_work_amount = Xbyak::Reg64(static_cast<int>(in[in.size() - 1]));
-    Xbyak::Reg64 reg_increments = Xbyak::Reg64(static_cast<int>(aux_gpr_idxs[0]));
-    const auto id_offset = loop_id * sizeof(jit_snippets_call_args::loop_args_t);
-
-    std::vector<Xbyak::Reg64> data_ptr_regs;
-    transform_idxs_to_regs(std::vector<size_t>(in.begin(), in.end() - 1), data_ptr_regs);
-
-    // todo: Note that we can pre-save reg_loop_args_ptr in jit_loop_begin_dynamic_emitter and pass it here like work_amount_reg
-    //        this would save us one dereferencing here and in finalization offsets
-    h->mov(reg_increments, h->ptr[reg_runtime_params + GET_OFF(loop_args)]);
-    h->mov(reg_increments, h->ptr[reg_increments + id_offset + GET_OFF_LOOP_ARGS(m_ptr_increments)]);
-    for (size_t idx = 0; idx < data_ptr_regs.size(); idx++) {
-        if (is_incremented[idx])
-            h->add(data_ptr_regs[idx], h->ptr[reg_increments + idx * sizeof(int64_t)]);
-    }
-    h->sub(reg_work_amount, wa_increment);
-    h->cmp(reg_work_amount, wa_increment);
-    h->jge(*loop_begin_label, Xbyak::CodeGenerator::T_NEAR);
-
-    h->mov(reg_increments, h->ptr[reg_runtime_params + GET_OFF(loop_args)]);
-    h->mov(reg_increments, h->ptr[reg_increments + id_offset + GET_OFF_LOOP_ARGS(m_finalization_offsets)]);
-    for (size_t idx = 0; idx < data_ptr_regs.size(); idx++) {
-        if (is_incremented[idx])
-            h->add(data_ptr_regs[idx], h->ptr[reg_increments + idx * sizeof(int64_t)]);
-    }
+    APPLY_INCREMENTS(need_runtime_args_for_final_offs, m_finalization_offsets, finalization_offsets, 1);
 
     h->L(*loop_end_label);
+
+#undef APPLY_INCREMENTS
 }
 
 /* ============================================================== */

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
@@ -148,26 +148,30 @@ void jit_loop_end_emitter::emit_impl(const std::vector<size_t>& in, const std::v
     const auto id_offset = loop_id * sizeof(jit_snippets_call_args::loop_args_t);
     Reg64 reg_increments = are_ptr_shifts_dynamic ? Reg64(static_cast<int>(aux_gpr_idxs[0])) : Reg64();
 
-#define APPLY_INCREMENTS(USE_RUNTIME_ARGS, TYPE, INCREMENTS, SCALE)                                                         \
+    auto apply_increments = [&](const std::vector<int64_t>& increments, size_t scale, bool use_runtime_args) {
+        for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {
+            const auto& increment = increments[idx];
+            if (is_incremented[idx] && increment != 0) {
+                if (ov::snippets::utils::is_dynamic_value(increment)) {
+                    OV_CPU_JIT_EMITTER_ASSERT(use_runtime_args, "Loop argument structure cannot be pushed to aux GPR");
+                    h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), h->ptr[reg_increments + idx * sizeof(int64_t)]);
+                } else {
+                    h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), increment * scale * data_sizes[idx]);
+                }
+            }
+        }
+    };
+
+#define INIT_RUNTIME_REG(USE_RUNTIME_ARGS, TYPE)                                                                            \
     if (USE_RUNTIME_ARGS) {                                                                                                 \
         Reg64 reg_runtime_params = abi_param1; /* defined by jit_kernel_emitter */                                          \
         h->mov(reg_increments, h->ptr[reg_runtime_params + GET_OFF(loop_args)]);                                            \
         h->mov(reg_increments, h->ptr[reg_increments + id_offset + GET_OFF_LOOP_ARGS(TYPE)]);                               \
-    }                                                                                                                       \
-    for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {                                                           \
-        const auto& increment = INCREMENTS[idx];                                                                            \
-        if (is_incremented[idx] && increment != 0) {                                                                        \
-            if (ov::snippets::utils::is_dynamic_value(increment)) {                                                         \
-                OV_CPU_JIT_EMITTER_ASSERT(USE_RUNTIME_ARGS, "Loop argument structure cannot be pushed to aux GPR");         \
-                h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), h->ptr[reg_increments + idx * sizeof(int64_t)]);    \
-            } else {                                                                                                        \
-                h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), increment * SCALE * data_sizes[idx]);               \
-            }                                                                                                               \
-        }                                                                                                                   \
     }
 
     if (!evaluate_once) {
-        APPLY_INCREMENTS(are_ptr_increments_dynamic, m_ptr_increments, ptr_increments, wa_increment);
+        INIT_RUNTIME_REG(are_ptr_increments_dynamic, m_ptr_increments);
+        apply_increments(ptr_increments, wa_increment, are_ptr_increments_dynamic);
 
         Reg64 reg_work_amount = Reg64(in.back());
         h->sub(reg_work_amount, wa_increment);
@@ -175,11 +179,12 @@ void jit_loop_end_emitter::emit_impl(const std::vector<size_t>& in, const std::v
         h->jge(*loop_begin_label, Xbyak::CodeGenerator::T_NEAR);
     }
 
-    APPLY_INCREMENTS(are_final_offsets_dynamic, m_finalization_offsets, finalization_offsets, 1);
+    INIT_RUNTIME_REG(are_final_offsets_dynamic, m_finalization_offsets);
+    apply_increments(finalization_offsets, 1, are_final_offsets_dynamic);
 
     h->L(*loop_end_label);
 
-#undef APPLY_INCREMENTS
+#undef INIT_RUNTIME_REG
 }
 
 /* ============================================================== */

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
@@ -21,8 +21,8 @@ public:
 
     size_t get_inputs_num() const override { return 0; }
 
-     void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
+    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
+                  const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
 
     void set_loop_end_label(const std::shared_ptr<const Xbyak::Label>& label) { loop_end_label = label; }
     std::shared_ptr<const Xbyak::Label> get_begin_label() { return loop_begin_label; }

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
@@ -39,7 +39,7 @@ protected:
     size_t wa_increment = 0;
     size_t loop_id = 0;
     bool evaluate_once = false;
-    bool need_runtime_args = false;
+    bool is_work_amount_dynamic = false;
 };
 
 
@@ -77,9 +77,9 @@ protected:
     std::vector<int64_t> data_sizes = {};
     size_t loop_id = 0;
     bool evaluate_once = false;
-    bool need_runtime_args_for_ptr_inc = false;
-    bool need_runtime_args_for_final_offs = false;
-    bool need_runtime_args = false;
+    bool are_ptr_increments_dynamic = false;
+    bool are_final_offsets_dynamic = false;
+    bool are_ptr_shifts_dynamic = false;
 };
 
 /* ============================================================== */

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
@@ -7,6 +7,7 @@
 #include "emitters/plugin/x64/jit_emitter.hpp"
 
 #include "snippets/op/loop.hpp"
+#include "snippets/utils.hpp"
 
 namespace ov {
 namespace intel_cpu {
@@ -20,50 +21,27 @@ public:
 
     size_t get_inputs_num() const override { return 0; }
 
-    std::shared_ptr<const Xbyak::Label> get_begin_label() { return loop_begin_label; }
-
-protected:
-    static std::shared_ptr<ov::snippets::op::LoopEnd> get_loop_end(const ov::snippets::lowered::ExpressionPtr& expr);
-
-    std::shared_ptr<Xbyak::Label> loop_begin_label;
-    int64_t wa_increment = 0;
-};
-
-class jit_loop_begin_static_emitter: public jit_loop_begin_emitter {
-public:
-    jit_loop_begin_static_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
-                                  const ov::snippets::lowered::ExpressionPtr& expr);
-
-    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
-protected:
-    void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
-    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
-
-    bool evaluate_once = false;
-    size_t work_amount = 0;
-};
-
-class jit_loop_begin_dynamic_emitter: public jit_loop_begin_emitter {
-public:
-    jit_loop_begin_dynamic_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
-                                   const ov::snippets::lowered::ExpressionPtr& expr);
-
-    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
+     void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
                    const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
 
     void set_loop_end_label(const std::shared_ptr<const Xbyak::Label>& label) { loop_end_label = label; }
+    std::shared_ptr<const Xbyak::Label> get_begin_label() { return loop_begin_label; }
 
 protected:
     void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
 
-    // For Loop arguments
-    size_t aux_gprs_count() const override { return 1; }
+    size_t aux_gprs_count() const override;
 
-    std::shared_ptr<const Xbyak::Label> loop_end_label;
-    size_t loop_id;
+    std::shared_ptr<Xbyak::Label> loop_begin_label = nullptr;
+    std::shared_ptr<const Xbyak::Label> loop_end_label = nullptr;
+    size_t work_amount = 0;
+    size_t wa_increment = 0;
+    size_t loop_id = 0;
+    bool evaluate_once = false;
+    bool need_runtime_args = false;
 };
+
 
 /* ============================================================== */
 
@@ -76,21 +54,6 @@ public:
 
     size_t get_inputs_num() const override { return 0; }
 
-protected:
-    static ov::snippets::lowered::ExpressionPtr get_loop_begin_expr(const ov::snippets::lowered::ExpressionPtr& expr);
-
-    std::shared_ptr<const Xbyak::Label> loop_begin_label;
-    size_t num_inputs = 0;
-    size_t num_outputs = 0;
-    int64_t wa_increment = 0;
-    std::vector<bool> is_incremented = {};
-};
-
-class jit_loop_end_static_emitter: public jit_loop_end_emitter {
-public:
-    jit_loop_end_static_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
-                                const ov::snippets::lowered::ExpressionPtr& expr);
-
     void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
                    const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
 
@@ -98,31 +61,25 @@ protected:
     void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
 
+    size_t aux_gprs_count() const override;
+
+    static ov::snippets::lowered::ExpressionPtr get_loop_begin_expr(const ov::snippets::lowered::ExpressionPtr& expr);
+
+    std::shared_ptr<const Xbyak::Label> loop_begin_label = nullptr;
+    std::shared_ptr<Xbyak::Label> loop_end_label = nullptr;
+    size_t num_inputs = 0;
+    size_t num_outputs = 0;
     size_t work_amount = 0;
+    size_t wa_increment = 0;
     std::vector<bool> is_incremented = {};
     std::vector<int64_t> ptr_increments = {};
     std::vector<int64_t> finalization_offsets = {};
     std::vector<int64_t> data_sizes = {};
+    size_t loop_id = 0;
     bool evaluate_once = false;
-};
-
-class jit_loop_end_dynamic_emitter: public jit_loop_end_emitter {
-public:
-    jit_loop_end_dynamic_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
-                                 const ov::snippets::lowered::ExpressionPtr& expr);
-
-    void emit_code(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                   const std::vector<size_t> &pool_vec_idxs = {}, const std::vector<size_t> &pool_gpr_idxs = {}) const override;
-
-protected:
-    void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
-    void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
-
-    // For Loop arguments
-    size_t aux_gprs_count() const override { return 1; }
-
-    std::shared_ptr<Xbyak::Label> loop_end_label;
-    size_t loop_id;
+    bool need_runtime_args_for_ptr_inc = false;
+    bool need_runtime_args_for_final_offs = false;
+    bool need_runtime_args = false;
 };
 
 /* ============================================================== */

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -159,10 +159,8 @@ private:
     OP_EXTENSION(ov::snippets::op::IntermediateMemoryBuffer) \
     OP_EXTENSION(ov::snippets::op::Load)                     \
     OP_EXTENSION(ov::snippets::op::LoadReshape)              \
-    OP_EXTENSION(ov::snippets::op::LoopBeginStatic)          \
-    OP_EXTENSION(ov::snippets::op::LoopBeginDynamic)         \
-    OP_EXTENSION(ov::snippets::op::LoopEndStatic)            \
-    OP_EXTENSION(ov::snippets::op::LoopEndDynamic)           \
+    OP_EXTENSION(ov::snippets::op::LoopBegin)                \
+    OP_EXTENSION(ov::snippets::op::LoopEnd)                  \
     OP_EXTENSION(ov::snippets::op::NewMemoryBuffer)          \
     OP_EXTENSION(ov::snippets::op::Nop)                      \
     OP_EXTENSION(ov::snippets::op::PowerStatic)              \


### PR DESCRIPTION
### Details:
 - *United `LoopEndStatic` and `LoopEndDynamic`  into one node `LoopEnd` to avoid extra conditions in the code and improve performance since some pointer data shifts might be known and compiled in JIT code*
 - *Removed dynamic aarch64 loop emitters since they don't work anyway CVS-141550*
 - *Added support dynamism to `IdentifyBuffers` and `DefineBufferClusters`. It's not efficient algorithm since we don't know exact values of data pointer shifts and cannot be sure that they will be proportionally in runtime. It should be implemented as the separate feature based on some judgments, for example*

### Tickets:
 - *141268*


### Prerequisites:
- *https://github.com/openvinotoolkit/openvino/pull/21922*
