### PR TITLE
Abs value inference and optimization

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/simplify_shape_of_sub_graph.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/simplify_shape_of_sub_graph.hpp
@@ -18,6 +18,7 @@ class TRANSFORMATIONS_API GroupedGatherElimination;
 class TRANSFORMATIONS_API GatherNopElimination;
 class TRANSFORMATIONS_API SimplifyGatherShapeOf;
 class TRANSFORMATIONS_API SimplifySecondInputOfReshape;
+class TRANSFORMATIONS_API AbsSinking;
 
 }  // namespace pass
 }  // namespace ov
@@ -79,4 +80,16 @@ class ov::pass::SimplifySecondInputOfReshape : public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("SimplifySecondInputOfReshape", "0");
     SimplifySecondInputOfReshape();
+};
+
+/**
+ * @ingroup ov_transformation_common_api
+ * @brief AbsSinking optimizes out the Abs which input is non negative. Has a special case for Concat -> Abs graph, it
+ * moves Abs up through Concat to its inputs, tries to constant fold new Abs ops. In case folding fails applies
+ * optimization to the leftover Abs ops
+ */
+class ov::pass::AbsSinking : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("AbsSinking", "0");
+    AbsSinking();
 };

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -9,8 +9,11 @@
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/core/bound_evaluation_util.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/tensor_util.hpp"
 #include "openvino/core/validation_util.hpp"
+#include "openvino/op/abs.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/fake_quantize.hpp"
@@ -136,6 +139,40 @@ pass::GatherNopElimination::GatherNopElimination() {
         return replace_output_update_name(gather->output(0), gather->input_value(0));
     };
     auto m = std::make_shared<Matcher>(gather_label, matcher_name);
+    this->register_matcher(m, callback);
+}
+
+pass::AbsSinking::AbsSinking() {
+    MATCHER_SCOPE(AbsSinking);
+    const auto abs_label = wrap_type<op::v0::Abs>(pattern::rank_equals(1));
+
+    matcher_pass_callback callback = [](Matcher& m) {
+        NodeVector abs_ops = {m.get_match_root()};
+
+        bool graph_got_changed = false;
+
+        if (auto concat = as_type_ptr<v0::Concat>(abs_ops[0]->get_input_node_shared_ptr(0))) {
+            for (const auto& input : concat->inputs()) {
+                auto new_abs = ov::op::util::make_try_fold<v0::Abs>(input.get_source_output());
+                if (!as_type_ptr<v0::Constant>(new_abs))
+                    abs_ops.push_back(new_abs);
+                input.replace_source_output(new_abs);
+                ov::copy_runtime_info(abs_ops[0], new_abs);
+            }
+            replace_output_update_name(abs_ops[0]->output(0), abs_ops[0]->input_value(0));
+            abs_ops.erase(abs_ops.begin());
+            graph_got_changed = true;
+        }
+        for (const auto& abs : abs_ops) {
+            auto bounds = ov::evaluate_both_bounds(abs->input_value(0));
+            if (ov::util::all(ov::util::ge(bounds.first, 0))) {
+                replace_output_update_name(abs->output(0), abs->input_value(0));
+                graph_got_changed = true;
+            }
+        }
+        return graph_got_changed;
+    };
+    auto m = std::make_shared<Matcher>(abs_label, matcher_name);
     this->register_matcher(m, callback);
 }
 
@@ -320,6 +357,7 @@ bool pass::SimplifyShapeOfSubGraph::run_on_model(const std::shared_ptr<Model>& f
     manager.set_per_pass_validation(false);
 
     REGISTER_PASS(manager, PrepareShapeOpsForEliminationAroundBE)
+    REGISTER_PASS(manager, AbsSinking)
     REGISTER_PASS(manager, SharedOpOptimization)
     REGISTER_PASS(manager, EliminateGatherUnsqueeze)  // should run after SharedOpOptimization
     REGISTER_PASS(manager, NopElimination, m_use_shapes)

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -165,7 +165,7 @@ pass::AbsSinking::AbsSinking() {
         }
         for (const auto& abs : abs_ops) {
             auto bounds = ov::evaluate_both_bounds(abs->input_value(0));
-            if (ov::util::all(ov::util::ge(bounds.first, 0))) {
+            if (ov::util::reduce_and(ov::util::greater_equal(bounds.first, 0))) {
                 replace_output_update_name(abs->output(0), abs->input_value(0));
                 graph_got_changed = true;
             }

--- a/src/common/transformations/tests/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/tests/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -407,8 +407,7 @@ TEST_F(TransformationTestsF, SingleAbsOnShape) {
     {
         auto data = std::make_shared<opset7::Parameter>(element::f32, shape);
         auto shape_op = std::make_shared<opset7::ShapeOf>(data);
-        auto gather = gatherv8(shape_op, {0});
-        auto abs = std::make_shared<opset7::Abs>(gather);
+        auto abs = std::make_shared<opset7::Abs>(shape_op);
 
         model = std::make_shared<Model>(NodeVector{abs}, ParameterVector{data});
         manager.register_pass<pass::AbsSinking>();
@@ -416,9 +415,8 @@ TEST_F(TransformationTestsF, SingleAbsOnShape) {
     {
         auto data = std::make_shared<opset7::Parameter>(element::f32, shape);
         auto shape_op = std::make_shared<opset7::ShapeOf>(data);
-        auto gather = gatherv8(shape_op, {0});
 
-        model_ref = std::make_shared<Model>(OutputVector{gather}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{shape_op}, ParameterVector{data});
     }
 }
 

--- a/src/common/transformations/tests/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/tests/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -372,3 +372,63 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNotCompatibleIndiciesCannot
         manager.register_pass<pass::GroupedGatherElimination>();
     }
 }
+
+TEST_F(TransformationTestsF, ConcatAbsCombo) {
+    PartialShape shape = PartialShape::dynamic(4);
+    {
+        auto data = std::make_shared<opset7::Parameter>(element::f32, shape);
+        auto shape_op = std::make_shared<opset7::ShapeOf>(data);
+        auto gather = gatherv8(shape_op, {0});
+
+        auto one = opset7::Constant::create(element::i64, {1}, {1});
+        auto minus_one = opset7::Constant::create(element::i64, {1}, {-1});
+        auto concat = std::make_shared<opset7::Concat>(OutputVector{gather, minus_one, one, minus_one}, 0);
+        auto abs = std::make_shared<opset7::Abs>(concat);
+
+        model = std::make_shared<Model>(NodeVector{abs}, ParameterVector{data});
+        manager.register_pass<pass::AbsSinking>();
+    }
+    {
+        auto data = std::make_shared<opset7::Parameter>(element::f32, shape);
+        auto shape_op = std::make_shared<opset7::ShapeOf>(data);
+        auto gather = gatherv8(shape_op, {0});
+
+        auto one0 = opset7::Constant::create(element::i64, {1}, {1});
+        auto one1 = opset7::Constant::create(element::i64, {1}, {1});
+        auto one2 = opset7::Constant::create(element::i64, {1}, {1});
+        auto concat = std::make_shared<opset7::Concat>(OutputVector{gather, one0, one1, one2}, 0);
+
+        model_ref = std::make_shared<Model>(NodeVector{concat}, ParameterVector{data});
+    }
+}
+
+TEST_F(TransformationTestsF, SingleAbsOnShape) {
+    PartialShape shape = PartialShape::dynamic(4);
+    {
+        auto data = std::make_shared<opset7::Parameter>(element::f32, shape);
+        auto shape_op = std::make_shared<opset7::ShapeOf>(data);
+        auto gather = gatherv8(shape_op, {0});
+        auto abs = std::make_shared<opset7::Abs>(gather);
+
+        model = std::make_shared<Model>(NodeVector{abs}, ParameterVector{data});
+        manager.register_pass<pass::AbsSinking>();
+    }
+    {
+        auto data = std::make_shared<opset7::Parameter>(element::f32, shape);
+        auto shape_op = std::make_shared<opset7::ShapeOf>(data);
+        auto gather = gatherv8(shape_op, {0});
+
+        model_ref = std::make_shared<Model>(OutputVector{gather}, ParameterVector{data});
+    }
+}
+
+TEST_F(TransformationTestsF, AbsInTheUnknown) {
+    PartialShape data_shape{2, 128};
+    {
+        auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
+        auto abs = std::make_shared<opset7::Abs>(data);
+
+        model = std::make_shared<Model>(NodeVector{abs}, ParameterVector{data});
+        manager.register_pass<pass::AbsSinking>();
+    }
+}

--- a/src/core/dev_api/openvino/core/tensor_util.hpp
+++ b/src/core/dev_api/openvino/core/tensor_util.hpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/constant.hpp"
+
+namespace ov {
+namespace util {
+
+OPENVINO_API Tensor ge(const ov::Tensor& lhs, const ov::Tensor& rhs);
+template <typename T>
+OPENVINO_API Tensor ge(const ov::Tensor& lhs, const T& element);
+OPENVINO_API bool all(const ov::Tensor& t);
+template <typename T>
+OPENVINO_API std::vector<T> to_vector(const ov::Tensor& t);
+
+template <typename T>
+Tensor make_tensor_of_value(const element::Type_t& et, const T& value) {
+    auto c = op::v0::Constant(et, Shape{}, value);
+    auto t = Tensor(et, Shape{});
+    std::memcpy(t.data(), c.get_data_ptr(), t.get_byte_size());
+    return t;
+}
+
+template <typename T>
+Tensor make_tensor_of_value(const element::Type_t& et, const Shape& shape, const std::vector<T>& value) {
+    auto c = op::v0::Constant(et, shape, value);
+    auto t = Tensor(et, Shape{});
+    std::memcpy(t.data(), c.get_data_ptr(), t.get_byte_size());
+    return t;
+}
+
+template <typename T>
+Tensor ge(const ov::Tensor& lhs, const T& element) {
+    const auto& other = make_tensor_of_value(lhs.get_element_type(), element);
+    return ge(lhs, other);
+}
+
+template <typename T>
+std::vector<T> to_vector(const ov::Tensor& t) {
+    return t ? ov::op::v0::Constant(t).cast_vector<T>() : std::vector<T>{};
+}
+}  // namespace util
+}  // namespace ov

--- a/src/core/include/openvino/op/abs.hpp
+++ b/src/core/include/openvino/op/abs.hpp
@@ -31,6 +31,9 @@ public:
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
     bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
+    bool evaluate_lower(ov::TensorVector& output_values) const override;
+    bool evaluate_upper(ov::TensorVector& output_values) const override;
+    bool evaluate_symbol(ov::TensorSymbolVector& output_symbols) const override;
     bool has_evaluate() const override;
 };
 }  // namespace v0

--- a/src/core/src/bound_evaluate.hpp
+++ b/src/core/src/bound_evaluate.hpp
@@ -9,9 +9,6 @@
 namespace ov {
 // bool could_propagate(const Output<Node>& output, std::vector<Node*>& order);
 
-/// \brief Checks if all the elements of the bound Tensor are non-negative
-bool tensor_is_non_negative(const Tensor& bound);
-
 /// \brief Checks if any element of the bound Tensor has max possible value
 bool tensor_has_max_value(const Tensor& bound);
 

--- a/src/core/src/op/abs.cpp
+++ b/src/core/src/op/abs.cpp
@@ -4,8 +4,14 @@
 
 #include "openvino/op/abs.hpp"
 
+#include "bound_evaluate.hpp"
+#include "compare.hpp"
 #include "element_visitor.hpp"
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/greater_eq.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
 #include "openvino/reference/abs.hpp"
 
 namespace ov {
@@ -21,6 +27,38 @@ struct Evaluate : ov::element::NoAction<bool> {
         return true;
     }
 };
+
+static bool evaluate_bound(const ov::op::v0::Abs* op,
+                    const ov::descriptor::Tensor& tensor,
+                    TensorVector& output_values,
+                    bool is_lower) {
+    const auto &lv = tensor.get_lower_value(), &uv = tensor.get_upper_value();
+    if (!lv || !uv || !op->has_evaluate())
+        return false;
+    TensorVector lower_output{ov::Tensor(lv.get_element_type(), lv.get_shape())},
+        upper_output{ov::Tensor(uv.get_element_type(), uv.get_shape())};
+    if (!op->evaluate(lower_output, {lv}) || !op->evaluate(upper_output, {uv}))
+        return false;
+    if (is_lower)
+        return v1::Minimum().evaluate(output_values, {lower_output[0], upper_output[0]});
+    else
+        return v1::Maximum().evaluate(output_values, {lower_output[0], upper_output[0]});
+}
+
+static std::vector<bool> tensor_non_negative(const ov::descriptor::Tensor& tensor) {
+    const auto& lv = tensor.get_lower_value();
+    if (!lv)
+        return {};
+    auto l_const = std::make_shared<v0::Constant>(lv);
+    auto zero_const = std::make_shared<v0::Constant>(lv.get_element_type(), lv.get_shape(), 0);
+    OutputVector outputs(1);
+    if (!std::make_shared<v1::GreaterEqual>(l_const, zero_const)->constant_fold(outputs, {l_const, zero_const}))
+        return {};
+    if (auto constant = ov::as_type_ptr<ov::op::v0::Constant>(outputs[0].get_node_shared_ptr()))
+        return constant->cast_vector<bool>();
+    return {};
+}
+
 }  // namespace abs
 
 namespace v0 {
@@ -68,6 +106,27 @@ bool Abs::has_evaluate() const {
     default:
         return false;
     }
+}
+
+bool Abs::evaluate_lower(TensorVector& output_values) const {
+    return ov::op::abs::evaluate_bound(this, get_input_tensor(0), output_values, true);
+}
+
+bool Abs::evaluate_upper(TensorVector& output_values) const {
+    return ov::op::abs::evaluate_bound(this, get_input_tensor(0), output_values, false);
+}
+
+bool Abs::evaluate_symbol(TensorSymbolVector& output_symbols) const {
+    const auto& non_negative = ov::op::abs::tensor_non_negative(get_input_tensor(0));
+    const auto& input_symbols = get_input_tensor(0).get_value_symbol();
+    if (non_negative.empty() || input_symbols.size() != non_negative.size())
+        return false;
+    output_symbols.resize(1);
+    output_symbols[0].resize(non_negative.size(), nullptr);
+    for (size_t i = 0; i < non_negative.size(); ++i)
+        if (non_negative[i])
+            output_symbols[0][i] = input_symbols[i];
+    return true;
 }
 }  // namespace v0
 }  // namespace op

--- a/src/core/src/op/abs.cpp
+++ b/src/core/src/op/abs.cpp
@@ -4,8 +4,6 @@
 
 #include "openvino/op/abs.hpp"
 
-#include "bound_evaluate.hpp"
-#include "compare.hpp"
 #include "element_visitor.hpp"
 #include "itt.hpp"
 #include "openvino/core/tensor_util.hpp"
@@ -27,11 +25,8 @@ struct Evaluate : ov::element::NoAction<bool> {
     }
 };
 
-static bool evaluate_bound(const ov::op::v0::Abs* op,
-                           const ov::descriptor::Tensor& tensor,
-                           TensorVector& output_values,
-                           bool is_lower) {
-    const auto &lv = tensor.get_lower_value(), &uv = tensor.get_upper_value();
+static bool evaluate_bound(const ov::op::v0::Abs* op, TensorVector& output_values, bool is_lower) {
+    const auto &lv = op->get_input_tensor(0).get_lower_value(), &uv = op->get_input_tensor(0).get_upper_value();
     if (!lv || !uv || !op->has_evaluate())
         return false;
     TensorVector lower_output{ov::Tensor(lv.get_element_type(), lv.get_shape())},
@@ -93,22 +88,23 @@ bool Abs::has_evaluate() const {
 }
 
 bool Abs::evaluate_lower(TensorVector& output_values) const {
-    return ov::op::abs::evaluate_bound(this, get_input_tensor(0), output_values, true);
+    return ov::op::abs::evaluate_bound(this, output_values, true);
 }
 
 bool Abs::evaluate_upper(TensorVector& output_values) const {
-    return ov::op::abs::evaluate_bound(this, get_input_tensor(0), output_values, false);
+    return ov::op::abs::evaluate_bound(this, output_values, false);
 }
 
 bool Abs::evaluate_symbol(TensorSymbolVector& output_symbols) const {
-    const auto& non_negative = ov::util::to_vector<bool>(ov::util::ge(get_input_tensor(0).get_lower_value(), 0));
+    const auto& non_negative = ov::util::greater_equal(get_input_tensor(0).get_lower_value(), 0);
     const auto& input_symbols = get_input_tensor(0).get_value_symbol();
-    if (non_negative.empty() || input_symbols.size() != non_negative.size())
+    if (!non_negative || input_symbols.size() != ov::shape_size(non_negative.get_shape()))
         return false;
+    auto non_negative_ptr = non_negative.data<char>();
     output_symbols.resize(1);
-    output_symbols[0].resize(non_negative.size(), nullptr);
-    for (size_t i = 0; i < non_negative.size(); ++i)
-        if (non_negative[i])
+    output_symbols[0].resize(input_symbols.size(), nullptr);
+    for (size_t i = 0; i < input_symbols.size(); ++i)
+        if (non_negative_ptr[i])
             output_symbols[0][i] = input_symbols[i];
     return true;
 }

--- a/src/core/src/op/mod.cpp
+++ b/src/core/src/op/mod.cpp
@@ -7,6 +7,7 @@
 #include "bound_evaluate.hpp"
 #include "element_visitor.hpp"
 #include "itt.hpp"
+#include "openvino/core/tensor_util.hpp"
 #include "openvino/core/validation_util.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/equal.hpp"
@@ -16,17 +17,6 @@
 #include "utils.hpp"
 
 namespace ov {
-namespace util {
-namespace {
-Tensor make_tensor_of_value(const element::Type_t et, const int64_t value) {
-    auto c = op::v0::Constant(et, Shape{}, value);
-    auto t = Tensor(et, Shape{});
-    std::memcpy(t.data(), c.get_data_ptr(), t.get_byte_size());
-    return t;
-}
-}  // namespace
-}  // namespace util
-
 namespace op {
 namespace mod {
 struct Evaluate : ov::element::NoAction<bool> {

--- a/src/core/src/op/reduce_prod.cpp
+++ b/src/core/src/op/reduce_prod.cpp
@@ -8,6 +8,7 @@
 #include "element_visitor.hpp"
 #include "itt.hpp"
 #include "openvino/core/shape_util.hpp"
+#include "openvino/core/tensor_util.hpp"
 #include "openvino/core/validation_util.hpp"
 #include "openvino/op/util/axes_util.hpp"
 #include "openvino/reference/reduce_prod.hpp"
@@ -20,7 +21,7 @@ bool has_non_negative_bounds_on_data(const Node* const op) {
     const auto& lb = op->get_input_tensor(0).get_lower_value();
     const auto& ub = op->get_input_tensor(0).get_upper_value();
 
-    return lb && ub && tensor_is_non_negative(lb) && tensor_is_non_negative(ub);
+    return lb && ub && ov::util::all(ov::util::ge(lb, 0)) && ov::util::all(ov::util::ge(ub, 0));
 }
 }  // namespace
 

--- a/src/core/src/op/reduce_prod.cpp
+++ b/src/core/src/op/reduce_prod.cpp
@@ -21,7 +21,8 @@ bool has_non_negative_bounds_on_data(const Node* const op) {
     const auto& lb = op->get_input_tensor(0).get_lower_value();
     const auto& ub = op->get_input_tensor(0).get_upper_value();
 
-    return lb && ub && ov::util::all(ov::util::ge(lb, 0)) && ov::util::all(ov::util::ge(ub, 0));
+    return lb && ub && ov::util::reduce_and(ov::util::greater_equal(lb, 0)) &&
+           ov::util::reduce_and(ov::util::greater_equal(ub, 0));
 }
 }  // namespace
 

--- a/src/core/src/tensor_util.cpp
+++ b/src/core/src/tensor_util.cpp
@@ -7,7 +7,7 @@
 #include "openvino/op/greater_eq.hpp"
 #include "openvino/op/reduce_logical_and.hpp"
 
-ov::Tensor ov::util::ge(const ov::Tensor& lhs, const ov::Tensor& rhs) {
+ov::Tensor ov::util::greater_equal(const ov::Tensor& lhs, const ov::Tensor& rhs) {
     if (!lhs || !rhs)
         return {};
     Tensor result(element::boolean, {});
@@ -18,21 +18,14 @@ ov::Tensor ov::util::ge(const ov::Tensor& lhs, const ov::Tensor& rhs) {
         return {};
 }
 
-bool ov::util::all(const ov::Tensor& t) {
+bool ov::util::reduce_and(const ov::Tensor& t) {
     if (!t)
         return false;
 
-    Tensor result(element::boolean, {});
-    TensorVector outputs = {result};
-
-    auto axes_vector = std::vector<int64_t>(t.get_shape().size());
-    std::iota(axes_vector.begin(), axes_vector.end(), 0);
-    auto axes = make_tensor_of_value(element::i64, Shape(axes_vector.size()), axes_vector);
-
+    auto outputs = TensorVector{{element::boolean, Shape{}}};
+    auto axes = Tensor(element::i64, Shape{t.get_shape().size()});
+    std::iota(axes.data<int64_t>(), axes.data<int64_t>() + t.get_shape().size(), 0);
     if (!ov::op::v1::ReduceLogicalAnd().evaluate(outputs, {t, axes}))
         return false;
-    auto result_as_vector = to_vector<bool>(result);
-    if (result_as_vector.size() != 1)
-        return false;
-    return result_as_vector[0];
+    return outputs[0].data<char>();
 }

--- a/src/core/src/tensor_util.cpp
+++ b/src/core/src/tensor_util.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/tensor_util.hpp"
+
+#include "openvino/op/greater_eq.hpp"
+#include "openvino/op/reduce_logical_and.hpp"
+
+ov::Tensor ov::util::ge(const ov::Tensor& lhs, const ov::Tensor& rhs) {
+    if (!lhs || !rhs)
+        return {};
+    Tensor result(element::boolean, {});
+    TensorVector outputs = {result};
+    if (ov::op::v1::GreaterEqual().evaluate(outputs, {lhs, rhs}))
+        return outputs[0];
+    else
+        return {};
+}
+
+bool ov::util::all(const ov::Tensor& t) {
+    if (!t)
+        return false;
+
+    Tensor result(element::boolean, {});
+    TensorVector outputs = {result};
+
+    auto axes_vector = std::vector<int64_t>(t.get_shape().size());
+    std::iota(axes_vector.begin(), axes_vector.end(), 0);
+    auto axes = make_tensor_of_value(element::i64, Shape(axes_vector.size()), axes_vector);
+
+    if (!ov::op::v1::ReduceLogicalAnd().evaluate(outputs, {t, axes}))
+        return false;
+    auto result_as_vector = to_vector<bool>(result);
+    if (result_as_vector.size() != 1)
+        return false;
+    return result_as_vector[0];
+}

--- a/src/core/tests/type_prop/abs.cpp
+++ b/src/core/tests/type_prop/abs.cpp
@@ -4,8 +4,94 @@
 
 #include "openvino/op/abs.hpp"
 
+#include <gtest/gtest.h>
+
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/shape_of.hpp"
 #include "unary_ops.hpp"
 
 using Type = ::testing::Types<ov::op::v0::Abs>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(type_prop_abs, UnaryOperator, Type);
+
+struct bound {
+    int64_t lower, upper, expected_lower, expected_upper;
+    std::shared_ptr<ov::Symbol> in_symbol;
+};
+
+using AbsTestParams = std::vector<bound>;
+
+class AbsTest : public testing::TestWithParam<AbsTestParams> {};
+
+std::shared_ptr<ov::Node> construct_graph_with_partial_value(const AbsTestParams& params) {
+    auto shape = std::vector<ov::Dimension>();
+    auto subtrahend = std::vector<int64_t>();
+
+    for (const auto& i_bound : params) {
+        if (i_bound.lower >= 0) {
+            shape.emplace_back(i_bound.lower, i_bound.upper);
+            subtrahend.push_back(0);
+        } else {
+            shape.emplace_back(0, (i_bound.upper - i_bound.lower));
+            subtrahend.push_back(i_bound.lower);
+        }
+    }
+
+    auto parameter = std::make_shared<ov::op::v0::Parameter>(ov::element::dynamic, shape);
+    auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(parameter);
+    auto subtract = std::make_shared<ov::op::v1::Add>(
+        shape_of,
+        ov::op::v0::Constant::create(element::i64, ov::Shape{subtrahend.size()}, subtrahend));
+    return subtract;
+}
+
+TEST_P(AbsTest, type_prop_abs) {
+    std::vector<bound> data = GetParam();
+
+    auto abs = std::make_shared<ov::op::v0::Abs>(construct_graph_with_partial_value(data));
+    ov::TensorSymbol symbols;
+    for (auto& item : data)
+        symbols.push_back(item.in_symbol);
+    abs->get_input_tensor(0).set_value_symbol(symbols);
+
+    ov::PartialShape output_value;
+    ASSERT_TRUE(ov::util::evaluate_as_partial_shape(abs->output(0), output_value));
+    ASSERT_TRUE(output_value.rank().is_static());
+    ASSERT_EQ(output_value.size(), data.size());
+
+    for (size_t i = 0; i < output_value.size(); ++i) {
+        ASSERT_EQ(output_value[i].get_min_length(), data[i].expected_lower);
+        ASSERT_EQ(output_value[i].get_max_length(), data[i].expected_upper);
+        if (data[i].lower == data[i].expected_lower && data[i].upper == data[i].expected_upper)
+            ASSERT_TRUE(ov::symbol::are_equal(symbols[i], output_value[i].get_symbol()));
+        else
+            ASSERT_TRUE(output_value[i].get_symbol() == nullptr);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(type_prop_abs,
+                         AbsTest,
+                         testing::ValuesIn(std::vector<AbsTestParams>{{
+                             //    lower, upper
+                             // negative, negative (equal)
+                             {-6, -6, 6, 6, std::make_shared<ov::Symbol>()},
+                             // negative, negative (not equal)
+                             {-5, -4, 4, 5, std::make_shared<ov::Symbol>()},
+                             // negative, zero
+                             {-4, 0, 0, 4, std::make_shared<ov::Symbol>()},
+                             // negative, positive (abs makes them equal)
+                             {-4, 4, 4, 4, std::make_shared<ov::Symbol>()},
+                             // negative, positive (abs makes lower bigger than upper)
+                             {-4, 3, 3, 4, std::make_shared<ov::Symbol>()},
+                             // negative, positive (abs keeps upper bigger than lower)
+                             {-3, 4, 3, 4, std::make_shared<ov::Symbol>()},
+                             //     zero, zero
+                             {0, 0, 0, 0, std::make_shared<ov::Symbol>()},
+                             //     zero, positive
+                             {0, 2, 0, 2, std::make_shared<ov::Symbol>()},
+                             // positive, positive (equal)
+                             {1, 1, 1, 1, std::make_shared<ov::Symbol>()},
+                             // positive, positive (not equal)
+                             {1, 42, 1, 42, std::make_shared<ov::Symbol>()},
+                         }}));

--- a/src/core/tests/type_prop/abs.cpp
+++ b/src/core/tests/type_prop/abs.cpp
@@ -15,15 +15,16 @@ using Type = ::testing::Types<ov::op::v0::Abs>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(type_prop_abs, UnaryOperator, Type);
 
-struct bound {
+struct Bound {
     int64_t lower, upper, expected_lower, expected_upper;
     std::shared_ptr<ov::Symbol> in_symbol;
 };
 
-using AbsTestParams = std::vector<bound>;
+using AbsTestParams = std::vector<Bound>;
 
-class AbsTest : public testing::TestWithParam<AbsTestParams> {};
+class TypePropAbsV0Test : public testing::TestWithParam<AbsTestParams> {};
 
+namespace {
 std::shared_ptr<ov::Node> construct_graph_with_partial_value(const AbsTestParams& params) {
     auto shape = std::vector<ov::Dimension>();
     auto subtrahend = std::vector<int64_t>();
@@ -45,9 +46,10 @@ std::shared_ptr<ov::Node> construct_graph_with_partial_value(const AbsTestParams
         ov::op::v0::Constant::create(element::i64, ov::Shape{subtrahend.size()}, subtrahend));
     return subtract;
 }
+}  // namespace
 
-TEST_P(AbsTest, type_prop_abs) {
-    std::vector<bound> data = GetParam();
+TEST_P(TypePropAbsV0Test, type_prop_abs) {
+    const auto& data = GetParam();
 
     auto abs = std::make_shared<ov::op::v0::Abs>(construct_graph_with_partial_value(data));
     ov::TensorSymbol symbols;
@@ -71,7 +73,7 @@ TEST_P(AbsTest, type_prop_abs) {
 }
 
 INSTANTIATE_TEST_SUITE_P(type_prop_abs,
-                         AbsTest,
+                         TypePropAbsV0Test,
                          testing::ValuesIn(std::vector<AbsTestParams>{{
                              //    lower, upper
                              // negative, negative (equal)


### PR DESCRIPTION
### Details:
PyTorch semantic of Expand operation requires Abs operation for translation which is usually a no-op.

1. partial value and symbol propagation for Abs operation
2. optimize out the Abs with nonnegative input
3. for this case Abs(Concat([Gather(ShapeOf), -1, 1, -1])) pulls Abs and tries to const-fold it. Resulting in Concat([Abs(Gather(ShapeOf)), 1, 1, 1]). Applies (2) to the graph and gets Concat([Gather(ShapeOf), 1, 1, 1]) because ShapeOf's lower bound is 0.

### Tickets:
 - *CVS-141274*
