### PR TITLE
[intel-npu] Adding EXECUTION_DEVICES read-only property

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -368,7 +368,11 @@ Plugin::Plugin()
          {true,
           ov::PropertyMutability::RO,
           [&](const Config& config) {
-              return std::string("NPU" + config.get<DEVICE_ID>());
+              if (_metrics->GetAvailableDevicesNames().size() > 1) {
+                  return std::string("NPU." + config.get<DEVICE_ID>());
+              } else {
+                  return std::string("NPU");
+              }
           }}},
         // OV Internals
         // =========

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -364,6 +364,12 @@ Plugin::Plugin()
           [&](const Config& config) {
               return _metrics->GetDeviceType(get_specified_device_name(config));
           }}},
+        {ov::execution_devices.name(),
+         {true,
+          ov::PropertyMutability::RO,
+          [&](const Config& config) {
+              return std::string("NPU" + config.get<DEVICE_ID>());
+          }}},
         // OV Internals
         // =========
         {ov::internal::caching_properties.name(),


### PR DESCRIPTION
### Details:
 - Adding EXECUTION_DEVICES read-only property for intel-npu plugin.

### Tickets:
 - EISW-112990
