### PR TITLE
[intel-npu] removing cpu_pinning string from CID command string

### DIFF
--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -382,17 +382,6 @@ std::string LevelZeroCompilerInDriver<TableExtension>::serializeConfig(
     const Config& config,
     ze_graph_compiler_version_info_t& compilerVersion) const {
     std::string content = config.toString();
-    // From 5.0.0, driver compiler start to use NPU_ prefix, the old version uses VPU_ prefix
-    if (compilerVersion.major < 5) {
-        std::regex reg("NPU_");
-        content = std::regex_replace(content, reg, "VPU_");
-        // From 4.0.0, driver compiler start to use VPU_ prefix, the old version uses VPUX_ prefix
-        if (compilerVersion.major < 4) {
-            // Replace VPU_ with VPUX_ for old driver compiler
-            std::regex reg("VPU_");
-            content = std::regex_replace(content, reg, "VPUX_");
-        }
-    }
 
     // As a consequence of complying to the conventions established in the 2.0 OV API, the set of values corresponding
     // to the "model priority" key has been modified
@@ -480,6 +469,19 @@ std::string LevelZeroCompilerInDriver<TableExtension>::serializeConfig(
         _logger.warning(
             "EXECUTION_MODE_HINT property is not suppored by this compiler version. Removing from parameters");
         content = std::regex_replace(content, std::regex(batchstr.str()), "");
+    }
+
+    // FINAL step to convert prefixes of remaining params, to ensure backwards compatibility
+    // From 5.0.0, driver compiler start to use NPU_ prefix, the old version uses VPU_ prefix
+    if (compilerVersion.major < 5) {
+        std::regex reg("NPU_");
+        content = std::regex_replace(content, reg, "VPU_");
+        // From 4.0.0, driver compiler start to use VPU_ prefix, the old version uses VPUX_ prefix
+        if (compilerVersion.major < 4) {
+            // Replace VPU_ with VPUX_ for old driver compiler
+            std::regex reg("VPU_");
+            content = std::regex_replace(content, reg, "VPUX_");
+        }
     }
 
     return "--config " + content;

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -453,13 +453,19 @@ std::string LevelZeroCompilerInDriver<TableExtension>::serializeConfig(
         content = std::regex_replace(content, std::regex(ov::intel_npu::tiles.name()), "NPU_DPU_GROUPS");
     }
 
-    // Batch mode property is not supported in versions < 5.5 - need to remove it
+    // Batch mode and cpu pinning properties is not supported in versions < 5.5 - need to remove them
     if ((compilerVersion.major < 5) || (compilerVersion.major == 5 && compilerVersion.minor < 5)) {
         std::ostringstream batchstr;
         batchstr << ov::intel_npu::batch_mode.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+"
                  << VALUE_DELIMITER;
+        std::ostringstream pinningstr;
+        pinningstr << ov::hint::enable_cpu_pinning.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+"
+                   << VALUE_DELIMITER;
         _logger.warning("NPU_BATCH_MODE property is not suppored by this compiler version. Removing from parameters");
         content = std::regex_replace(content, std::regex(batchstr.str()), "");
+        _logger.warning(
+            "ENABLE_CPU_PINNING property is not suppored by this compiler version. Removing from parameters");
+        content = std::regex_replace(content, std::regex(pinningstr.str()), "");
     }
 
     // EXECUTION_MODE_HINT is not supported in versions < 5.6 - need to remove it


### PR DESCRIPTION
### Details:
 - removing ENABLE_CPU_PINNING from command string passed to CiD, for older compiler versions to enable backwards compatibility

### Tickets:
 - EISW-124233
