### PR TITLE
[PyOV] Reenable test_cancel

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_async_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_async_infer_request.py
@@ -296,7 +296,6 @@ def test_array_like_input_async_infer_queue(device, share_inputs):
             infer_queue_list[i].get_output_tensor().data, np.abs(input_data))
 
 
-@pytest.mark.skip(reason="Sporadically failed. Need further investigation. Ticket - 95967")
 def test_cancel(device):
     core = Core()
     model = get_relu_model()
@@ -308,13 +307,13 @@ def test_cancel(device):
     request.cancel()
     with pytest.raises(RuntimeError) as e:
         request.wait()
-    assert "[ INFER_CANCELLED ]" in str(e.value)
+    assert "Infer Request was canceled" in str(e.value)
 
     request.start_async({"data": img})
     request.cancel()
     with pytest.raises(RuntimeError) as e:
         request.wait_for(1)
-    assert "[ INFER_CANCELLED ]" in str(e.value)
+    assert "Infer Request was canceled" in str(e.value)
 
 
 @pytest.mark.parametrize("share_inputs", [True, False])


### PR DESCRIPTION
### Details:
 - Do not skip the test of `InferReuqest.cancel()`

### Tickets:
 - *CVS-95967*