### PR TITLE
[Windows][Unicode] wstring to string in windows failed

### DIFF
--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "openvino/util/file_util.hpp"
-#    define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+
 #include <sys/stat.h>
 
 #include <algorithm>
@@ -339,11 +339,13 @@ void ov::util::convert_path_win_style(std::string& path) {
 #    endif
 
 std::string ov::util::wstring_to_string(const std::wstring& wstr) {
+#    define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
     std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_decoder;
     return wstring_decoder.to_bytes(wstr);
 }
 
 std::wstring ov::util::string_to_wstring(const std::string& string) {
+#    define _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
     const char* str = string.c_str();
     std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_encoder;
     std::wstring result = wstring_encoder.from_bytes(str);

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -7,13 +7,14 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <codecvt>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <locale>
 #include <sstream>
 
 #include "openvino/util/common_util.hpp"
-
 #ifdef _WIN32
 #    ifndef NOMINMAX
 #        define NOMINMAX
@@ -44,11 +45,6 @@
 #    include <sys/file.h>
 #    include <sys/time.h>
 #    include <unistd.h>
-
-#    ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-#        include <codecvt>
-#        include <locale>
-#    endif
 
 /// @brief Max length of absolute file path
 #    define MAX_ABS_PATH                    PATH_MAX
@@ -340,30 +336,15 @@ void ov::util::convert_path_win_style(std::string& path) {
 #    endif
 
 std::string ov::util::wstring_to_string(const std::wstring& wstr) {
-#    ifdef _WIN32
-    int size_needed = WideCharToMultiByte(CP_ACP, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
-    std::string strTo(size_needed, 0);
-    WideCharToMultiByte(CP_ACP, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
-    return strTo;
-#    else
     std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_decoder;
     return wstring_decoder.to_bytes(wstr);
-#    endif
 }
 
 std::wstring ov::util::string_to_wstring(const std::string& string) {
     const char* str = string.c_str();
-#    ifdef _WIN32
-    int strSize = static_cast<int>(std::strlen(str));
-    int size_needed = MultiByteToWideChar(CP_ACP, 0, str, strSize, NULL, 0);
-    std::wstring wstrTo(size_needed, 0);
-    MultiByteToWideChar(CP_ACP, 0, str, strSize, &wstrTo[0], size_needed);
-    return wstrTo;
-#    else
     std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_encoder;
     std::wstring result = wstring_encoder.from_bytes(str);
     return result;
-#    endif
 }
 
 #    ifdef __APPLE__

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "openvino/util/file_util.hpp"
-
+#    define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include <sys/stat.h>
 
 #include <algorithm>
@@ -339,13 +339,11 @@ void ov::util::convert_path_win_style(std::string& path) {
 #    endif
 
 std::string ov::util::wstring_to_string(const std::wstring& wstr) {
-#    define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
     std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_decoder;
     return wstring_decoder.to_bytes(wstr);
 }
 
 std::wstring ov::util::string_to_wstring(const std::string& string) {
-#    define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
     const char* str = string.c_str();
     std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_encoder;
     std::wstring result = wstring_encoder.from_bytes(str);

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -339,11 +339,13 @@ void ov::util::convert_path_win_style(std::string& path) {
 #    endif
 
 std::string ov::util::wstring_to_string(const std::wstring& wstr) {
+#    define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
     std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_decoder;
     return wstring_decoder.to_bytes(wstr);
 }
 
 std::wstring ov::util::string_to_wstring(const std::string& string) {
+#    define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
     const char* str = string.c_str();
     std::wstring_convert<std::codecvt_utf8<wchar_t>> wstring_encoder;
     std::wstring result = wstring_encoder.from_bytes(str);

--- a/src/inference/src/cache_manager.hpp
+++ b/src/inference/src/cache_manager.hpp
@@ -120,15 +120,22 @@ private:
     void write_cache_entry(const std::string& id, StreamWriter writer) override {
         // Fix the bug caused by pugixml, which may return unexpected results if the locale is different from "C".
         ScopedLocale plocal_C(LC_ALL, "C");
-
+#if defined(_WIN32) && defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT)
+        std::ofstream stream(ov::util::string_to_wstring(getBlobFile(id)), std::ios_base::binary | std::ofstream::out);
+#else
         std::ofstream stream(getBlobFile(id), std::ios_base::binary | std::ofstream::out);
+#endif
         writer(stream);
     }
 
     void read_cache_entry(const std::string& id, StreamReader reader) override {
         // Fix the bug caused by pugixml, which may return unexpected results if the locale is different from "C".
         ScopedLocale plocal_C(LC_ALL, "C");
+#if defined(_WIN32) && defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT)
+        auto blobFileName = ov::util::string_to_wstring(getBlobFile(id));
+#else
         auto blobFileName = getBlobFile(id);
+#endif
         if (ov::util::file_exists(blobFileName)) {
             std::ifstream stream(blobFileName, std::ios_base::binary);
             reader(stream);

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/file_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/file_utils.hpp
@@ -18,6 +18,7 @@
 #include "openvino/runtime/iplugin.hpp"
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/shared_object.hpp"
+#include "openvino/util/util.hpp"
 
 #ifdef _WIN32
 #    include <direct.h>
@@ -138,7 +139,11 @@ inline int removeDir(const std::string& path) {
 
 inline int createDirectory(const std::string& dirPath) {
 #ifdef _WIN32
+#    ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
+    return _wmkdir(ov::util::string_to_wstring(dirPath).c_str());
+#    else
     return _mkdir(dirPath.c_str());
+#    endif
 #else
     return mkdir(dirPath.c_str(), mode_t(0777));
 #endif


### PR DESCRIPTION
### Details:
 - Windows std::wstring convert to std::string some unicode will be ???, such as L"unicode_Яㅎあ" -> "unicode_???"
 - Solution using the same way as Linux

### Tickets:
 - CVS-141444
 - CVS-141729
