### PR TITLE
[AUTO] Load cached model to target device W/O CPU accelerating

### DIFF
--- a/src/plugins/auto/src/auto_schedule.cpp
+++ b/src/plugins/auto/src/auto_schedule.cpp
@@ -170,7 +170,7 @@ void AutoSchedule::init() {
                                                 ? device_config[ov::cache_dir.name()].as<std::string>()
                                                 : m_context->m_ov_core->get_property("", ov::cache_dir);
 
-                    if (!m_context->m_is_set_startup_fallback && !cache_dir.empty()) {
+                    if (m_context->m_startup_fallback && !cache_dir.empty()) {
                         const auto properties =
                             m_context->m_ov_core->create_compile_config(ov::DeviceIDParser(device).get_device_name(),
                                                                         device_config);

--- a/src/plugins/auto/src/auto_schedule.cpp
+++ b/src/plugins/auto/src/auto_schedule.cpp
@@ -133,7 +133,6 @@ void AutoSchedule::init() {
     if (m_compile_context[ACTUALDEVICE].m_is_enabled) {
         LOG_INFO_TAG("select device:%s", m_compile_context[ACTUALDEVICE].m_device_info.device_name.c_str());
         bool is_actual_cpu = m_compile_context[ACTUALDEVICE].m_device_info.device_name.find("CPU") != std::string::npos;
-        bool is_actual_gpu = m_compile_context[ACTUALDEVICE].m_device_info.device_name.find("GPU") != std::string::npos;
         // if Actual device is CPU or perf_hint is cumulative, disabled m_compile_context[CPU], only use
         // m_compile_context[ACTUALDEVICE]
         if (is_actual_cpu || !m_context->m_startup_fallback) {
@@ -148,24 +147,6 @@ void AutoSchedule::init() {
                     // limit the threads num for compiling
                     auto device = m_compile_context[ACTUALDEVICE].m_device_info.device_name;
                     auto& device_config = m_compile_context[ACTUALDEVICE].m_device_info.config;
-                    if (is_actual_gpu) {
-                        int max_threads = 0;
-                        try {
-                            max_threads = m_context->m_ov_core->get_property(device, ov::compilation_num_threads);
-                        } catch (const ov::Exception&) {
-                            LOG_DEBUG_TAG("cannot get MAX_NUM_THREADS from GPU");
-                        }
-                        if (max_threads == static_cast<int>(std::thread::hardware_concurrency())) {
-                            int thread_num = max_threads / 2;
-                            m_compile_context[ACTUALDEVICE].m_device_info.config.insert(
-                                ov::compilation_num_threads(thread_num));
-                            LOG_DEBUG_TAG("gpu streams number for compiling: %d", thread_num);
-                        } else {
-                            // user set the compiling threads num
-                            // use the user's val anyway
-                            LOG_DEBUG_TAG("user defined compiling threads: %d", max_threads);
-                        }
-                    }
                     std::string cache_dir = device_config.count(ov::cache_dir.name())
                                                 ? device_config[ov::cache_dir.name()].as<std::string>()
                                                 : m_context->m_ov_core->get_property("", ov::cache_dir);
@@ -323,15 +304,21 @@ void AutoSchedule::try_to_compile_model(AutoCompileContext& context, const std::
              device_config.find(ov::compilation_num_threads.name()) != device_config.end());
         if (cur_dev_is_gpu && m_compile_context[CPU].m_is_enabled && !is_already_set_gpu) {
             device_config.insert(ov::intel_gpu::hint::host_task_priority(ov::hint::Priority::HIGH));
-            auto proc_type_table = get_org_proc_type_table();
-            int compilation_num_threads = proc_type_table[0][MAIN_CORE_PROC] != 0
-                                              ? proc_type_table[0][MAIN_CORE_PROC]
-                                              : proc_type_table[0][EFFICIENT_CORE_PROC];
-            if (device_config.insert(ov::compilation_num_threads(compilation_num_threads)).second)
-                LOG_DEBUG_TAG("gpu streams number for compiling: %d", compilation_num_threads);
-            else
-                LOG_DEBUG_TAG("user defined compiling threads: %d",
-                              device_config[ov::compilation_num_threads.name()].as<int32_t>());
+            int max_threads = 0;
+            try {
+                max_threads = m_context->m_ov_core->get_property(device, ov::compilation_num_threads);
+            } catch (const ov::Exception&) {
+                LOG_DEBUG_TAG("cannot get MAX_NUM_THREADS from GPU");
+            }
+            if (max_threads == static_cast<int>(std::thread::hardware_concurrency())) {
+                int thread_num = max_threads / 2;
+                m_compile_context[ACTUALDEVICE].m_device_info.config.insert(ov::compilation_num_threads(thread_num));
+                LOG_DEBUG_TAG("gpu streams number for compiling: %d", thread_num);
+            } else {
+                // user set the compiling threads num
+                // use the user's val anyway
+                LOG_DEBUG_TAG("user defined compiling threads: %d", max_threads);
+            }
         }
     }
     try {

--- a/src/plugins/auto/src/auto_schedule.cpp
+++ b/src/plugins/auto/src/auto_schedule.cpp
@@ -306,7 +306,7 @@ void AutoSchedule::try_to_compile_model(AutoCompileContext& context, const std::
             device_config.insert(ov::intel_gpu::hint::host_task_priority(ov::hint::Priority::HIGH));
             int max_threads = 0;
             try {
-                max_threads = m_context->m_ov_core->get_property(device, ov::compilation_num_threads);
+                m_context->m_ov_core->get_property(device, ov::compilation_num_threads);
                 auto proc_type_table = get_org_proc_type_table();
                 max_threads = proc_type_table[0][MAIN_CORE_PROC] != 0 ? proc_type_table[0][MAIN_CORE_PROC]
                                                                       : proc_type_table[0][EFFICIENT_CORE_PROC];

--- a/src/plugins/auto/src/common.hpp
+++ b/src/plugins/auto/src/common.hpp
@@ -207,7 +207,6 @@ public:
     bool                                           m_need_perf_counters;
     bool                                           m_batching_disabled = false;
     bool                                           m_startup_fallback = true;
-    bool                                           m_is_set_startup_fallback = false;
     bool                                           m_runtime_fallback = true;
     bool                                           m_bind_buffer = false;
     std::shared_ptr<ov::Model>                     m_model;

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -436,7 +436,6 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model_impl(const std::string
     OPENVINO_ASSERT(auto_s_context->m_ov_core);
     auto_s_context->m_log_tag = get_device_name();
     auto_s_context->m_model_precision = model_precision;
-    auto_s_context->m_is_set_startup_fallback = load_config.is_set_by_user(ov::intel_auto::enable_startup_fallback);
     auto_s_context->m_startup_fallback = load_config.get_property(ov::intel_auto::enable_startup_fallback);
     auto_s_context->m_runtime_fallback = load_config.get_property(ov::intel_auto::enable_runtime_fallback);
     auto_s_context->m_bind_buffer = load_config.get_property(ov::intel_auto::device_bind_buffer);


### PR DESCRIPTION
### Details:
 - update logic of only loading cached model to GPU with AUTO if GPU cached blob exists and `ov::intel_auto::enable_startup_fallback` is enable

### Tickets:
 - CVS-138574
