### PR TITLE
Set _GLIBCXX_USE_CXX11_ABI globally in OV cmake

### DIFF
--- a/cmake/templates/OpenVINOConfig.cmake.in
+++ b/cmake/templates/OpenVINOConfig.cmake.in
@@ -92,8 +92,15 @@
 #   `OpenVINO_VERSION_PATCH`
 #   Patch version component
 #
+#  OpenVINO build configuration variables:
+#
+#   `OpenVINO_GLIBCXX_USE_CXX11_ABI`
+#   Linux only: defines _GLIBCXX_USE_CXX11_ABI used to compiled OpenVINO
+#
 
 @PACKAGE_INIT@
+
+set(OpenVINO_GLIBCXX_USE_CXX11_ABI "@OV_GLIBCXX_USE_CXX11_ABI@")
 
 #
 # Common functions
@@ -473,6 +480,11 @@ set(_OV_ENABLE_OPENVINO_BUILD_SHARED "@BUILD_SHARED_LIBS@")
 if(NOT TARGET openvino)
     set(_ov_as_external_package ON)
     include("${CMAKE_CURRENT_LIST_DIR}/OpenVINOTargets.cmake")
+
+    # since OpenVINO is compiled with _GLIBCXX_USE_CXX11_ABI=0
+    if(NOT OpenVINO_GLIBCXX_USE_CXX11_ABI STREQUAL "")
+        add_definitions(-D_GLIBCXX_USE_CXX11_ABI=${OpenVINO_GLIBCXX_USE_CXX11_ABI})
+    endif()
 endif()
 
 if(NOT _OV_ENABLE_OPENVINO_BUILD_SHARED)


### PR DESCRIPTION
### Details:
 - It can be useful when other targets within user project need to be linked with _GLIBCXX_USE_CXX11_ABI=0