### PR TITLE
[GPU] do async-compilation of gemm when sdpa optimization is enabled

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -766,9 +766,11 @@ bool primitive_inst::use_async_compilation() {
     bool compile_gemm_impls = _node->is_type<gemm>();
     if (compile_gemm_impls) {
         // Do not async-compile if opt_gemm is chosen for iGPU
-        // Do async-compile if it is to be executed from onednn
+        // Do async-compile if it is to be executed from onednn or SDPA is enabled.
+        // When SDPA is enabled, less gemm layers are executed. So, we can build static gemm kernels without large memory consumption.
         compile_gemm_impls = _node->get_selected_impl() && _node->get_selected_impl()->get_kernel_name().find("gemm_ref") != std::string::npos;
         compile_gemm_impls |= (_node->get_preferred_impl_type() == impl_types::onednn);
+        compile_gemm_impls |= get_network().get_config().get_property(ov::intel_gpu::hint::enable_sdpa_optimization);
     }
 
     return (_node->is_type<convolution>() || compile_fc_impls || compile_gemm_impls ||

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -797,7 +797,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>();
-        if (device_info.supports_immad) {
+        if (device_info.supports_immad || config.get_property(ov::intel_gpu::hint::enable_sdpa_optimization)) {
             manager.get_pass_config()->disable<ov::intel_gpu::TransposeMatMulMatcher>();
             manager.get_pass_config()->disable<ov::intel_gpu::TransposeMatMulTransposeMatcher>();
         }


### PR DESCRIPTION
### Details:
 - If SDPA optimization is enabled, less `gemm` layers are executed. So, we can build static `gemm` kernels without large memory consumption.
   - In addition to this, `transpose` + `gemm` fusion can be disabled in this case.
 - Performance gain is expected especially for dynamic stable diffusion models.