### PR TITLE
[GPU][LNL] Fix subgroup size issue of fc_imad_sa kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_imad.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_imad.cpp
@@ -155,7 +155,7 @@ FullyConnectedKernelIMAD::FullyConnectedTuningData FullyConnectedKernelIMAD::Get
     }
 
     // In most cases SIMD8 works faster than SIMD16
-    tuning_data.sub_group_size = 8;
+    tuning_data.sub_group_size = IsSIMDSizeSupported(params.engineInfo, 8) ? 8 : 16;
 
     if (!params.is_shape_agnostic) {
         auto mk_size = if_num * ib_num;


### PR DESCRIPTION
LNL does not support 8 as subgroup size. It need to check before compiling fc_imad shape agnostic kernel.

### Details:
 - *Set subgroup size to 16 if simd8 is not supported in the target device.*


