### PR TITLE
optimize ReduceMax pattern

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_reducemax_scalar_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_reducemax_scalar_output.cpp
@@ -1,0 +1,92 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "convert_reducemax_scalar_output.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "openvino/op/reduce_max.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/core/rt_info.hpp"
+
+ov::intel_gpu::ConvertReduceMaxScalarOutput::ConvertReduceMaxScalarOutput() {
+    // Check all Reduce nodes
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(ov::pass::pattern::wrap_type<ov::op::v1::ReduceMax>(),
+                                                          "ConvertReduceMaxScalarOutput");
+    register_matcher(m, [&](ov::pass::pattern::Matcher& m) {
+        auto reduce_max = std::dynamic_pointer_cast<ov::op::v1::ReduceMax>(m.get_match_root());
+        if (!reduce_max || transformation_callback(reduce_max)) {
+            return false;
+        }
+
+        const auto input_shape = reduce_max->input_value(0).get_partial_shape();
+        auto reduce_shape = reduce_max->input_value(1).get_partial_shape();
+        if (reduce_shape.is_dynamic() || reduce_shape.size() != 1 || reduce_shape.to_shape()[0] != input_shape.size() ||
+            reduce_shape.to_shape()[0] <= 1) {
+            return false;
+        }
+
+        auto dynamic_shape = false;
+        const auto output_shape = reduce_max->get_output_partial_shape(0);
+        if (input_shape.is_dynamic() || output_shape.is_dynamic()) {
+            dynamic_shape = true;
+        }
+
+        std::shared_ptr<ov::op::v1::ReduceMax> reduce_ = nullptr, reduce = nullptr;
+        if (dynamic_shape == false) {
+            // Output size decides at most how many EUs can be used for this node execution,
+            // less than 4 EUs to execute a primitive will lead to poor performance.
+            if (ov::shape_size(output_shape.to_shape()) > 4) {
+                return false;
+            }
+            // Input shape is too small, 1 EU should be enough.
+            const auto input_static_shape = input_shape.to_shape();
+            if (ov::shape_size(input_static_shape) < 64) {
+                return false;
+            }
+
+            // Find out the the most length dimension
+            size_t max_dim = std::distance(input_static_shape.begin(),
+                                           std::max_element(input_static_shape.begin(), input_static_shape.end()));
+            if (input_static_shape[max_dim] == ov::shape_size(input_static_shape)) {
+                return false;
+            }
+
+            reduce_ = std::make_shared<ov::op::v1::ReduceMax>(
+                reduce_max->input_value(0),
+                ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {max_dim}),
+                true);
+        } else if (input_shape.rank().is_static()) {
+            // Dynamic shape and output shape is [0], which will lead to 1 EU to do all work
+            for (size_t i = 0; i < input_shape.size() - 1; i++) {
+                // Reduce one dimension by one dimension to avoid 1 EU do all work.
+                if (input_shape[i].is_dynamic() || (input_shape[i].is_static() && input_shape[i].get_length() >= 4)) {
+                    if (!reduce_)
+                        reduce_ = std::make_shared<ov::op::v1::ReduceMax>(
+                            reduce_max->input_value(0),
+                            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {i}),
+                            true);
+                    else
+                        reduce_ = std::make_shared<ov::op::v1::ReduceMax>(
+                            reduce_->get_default_output(),
+                            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {i}),
+                            true);
+                }
+            }
+        }
+
+        if (!reduce_)
+            return false;
+        reduce = std::make_shared<ov::op::v1::ReduceMax>(reduce_->get_default_output(),
+                                                         reduce_max->input_value(1),
+                                                         reduce_max->get_keep_dims());
+        reduce->set_friendly_name(reduce_max->get_friendly_name());
+        copy_runtime_info(reduce_max, reduce);
+        replace_node(reduce_max, reduce);
+        return true;
+    });
+}

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_reducemax_scalar_output.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_reducemax_scalar_output.hpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/core/visibility.hpp"
+
+namespace ov {
+namespace intel_gpu {
+
+class ConvertReduceMaxScalarOutput : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("ConvertReduceMaxScalarOutput", "0");
+    ConvertReduceMaxScalarOutput();
+};
+
+}  // namespace intel_gpu
+}  // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -56,6 +56,7 @@
 #include "plugin/transformations/clamp_fp16_output.hpp"
 #include "plugin/transformations/convert_fc_to_compressed.hpp"
 #include "plugin/transformations/convert_matmul_to_fc.hpp"
+#include "plugin/transformations/convert_reducemax_scalar_output.hpp"
 #include "plugin/transformations/fc_convert_fusion.hpp"
 #include "plugin/transformations/kv_cache_fusion.hpp"
 #include "plugin/transformations/move_fc_reshape_to_weights.hpp"
@@ -388,6 +389,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::pass::ConvertMulticlassNmsToMulticlassNmsIE>();
         manager.register_pass<ov::pass::TransposeMatMul>();
         manager.register_pass<ov::pass::ConvertPad12ToPad1, false>();
+        manager.register_pass<ConvertReduceMaxScalarOutput>();
 
         precisions_map int_convert_precision_map {
                 {ov::element::i64, ov::element::i32},

--- a/src/plugins/intel_gpu/tests/unit/transformations/split_reduce_max_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/split_reduce_max_test.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <openvino/core/model.hpp>
+#include <openvino/opsets/opset9.hpp>
+#include <openvino/pass/manager.hpp>
+#include <string>
+
+#include "plugin/transformations/convert_reducemax_scalar_output.hpp"
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+static std::shared_ptr<ov::Model> BuildFunction(const ov::PartialShape& input_shape,
+                                                const ov::element::Type& input_type,
+                                                const std::vector<size_t>& reduction_axes,
+                                                const bool keep_dim) {
+    const auto in = std::make_shared<ov::op::v0::Parameter>(input_type, input_shape);
+    const auto reduce = std::make_shared<ov::op::v1::ReduceMax>(
+        in->get_default_output(),
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{reduction_axes.size()}, reduction_axes),
+        keep_dim);
+
+    return std::make_shared<ov::Model>(ov::NodeVector{reduce}, ov::ParameterVector{in});
+}
+
+TEST(TransformationTests, SplitReduceMaxTest1) {
+    ov::pass::Manager manager;
+    manager.set_per_pass_validation(false);
+    manager.register_pass<ov::intel_gpu::ConvertReduceMaxScalarOutput>();
+
+    const std::vector<size_t> reduction_axes = {0, 1, 2, 3};
+    auto func = BuildFunction({1, 256, 1024, 10}, ov::element::Type_t::f16, reduction_axes, false);
+    manager.run_passes(func);
+
+    size_t reduce_count = 0;
+    for (auto& ops : func->get_ops()) {
+        std::string type_name(ops->get_type_name());
+        if (type_name.find("ReduceMax") != std::string::npos) {
+            reduce_count++;
+        }
+    }
+    ASSERT_TRUE(reduce_count == 2);
+}
+
+TEST(TransformationTests, SplitReduceMaxTest2) {
+    ov::pass::Manager manager;
+    manager.set_per_pass_validation(false);
+    manager.register_pass<ov::intel_gpu::ConvertReduceMaxScalarOutput>();
+
+    const std::vector<size_t> reduction_axes = {0, 1, 2};
+    auto func = BuildFunction({256, 1024, 10}, ov::element::Type_t::f16, reduction_axes, true);
+    manager.run_passes(func);
+
+    size_t reduce_count = 0;
+    for (auto& ops : func->get_ops()) {
+        std::string type_name(ops->get_type_name());
+        if (type_name.find("ReduceMax") != std::string::npos) {
+            reduce_count++;
+        }
+    }
+    ASSERT_TRUE(reduce_count == 2);
+}
+
+TEST(TransformationTests, SplitReduceMaxTest3) {
+    ov::pass::Manager manager;
+    manager.set_per_pass_validation(false);
+    manager.register_pass<ov::intel_gpu::ConvertReduceMaxScalarOutput>();
+
+    const std::vector<size_t> reduction_axes = {1};
+    auto func = BuildFunction({256, 1024, 10}, ov::element::Type_t::f16, reduction_axes, true);
+    manager.run_passes(func);
+
+    size_t reduce_count = 0;
+    for (auto& ops : func->get_ops()) {
+        std::string type_name(ops->get_type_name());
+        if (type_name.find("ReduceMax") != std::string::npos) {
+            reduce_count++;
+        }
+    }
+    ASSERT_TRUE(reduce_count == reduction_axes.size());
+}
+
+TEST(TransformationTests, SplitReduceMaxTest4) {
+    ov::pass::Manager manager;
+    manager.set_per_pass_validation(false);
+    manager.register_pass<ov::intel_gpu::ConvertReduceMaxScalarOutput>();
+
+    const std::vector<size_t> reduction_axes = {0, 1, 2, 3};
+    auto func = BuildFunction({4, -1, -1, 10}, ov::element::Type_t::f16, reduction_axes, false);
+    manager.run_passes(func);
+
+    size_t reduce_count = 0;
+    for (auto& ops : func->get_ops()) {
+        std::string type_name(ops->get_type_name());
+        if (type_name.find("ReduceMax") != std::string::npos) {
+            reduce_count++;
+        }
+    }
+    ASSERT_TRUE(reduce_count == reduction_axes.size());
+}
+
+TEST(TransformationTests, SplitReduceMaxTest5) {
+    ov::pass::Manager manager;
+    manager.set_per_pass_validation(false);
+    manager.register_pass<ov::intel_gpu::ConvertReduceMaxScalarOutput>();
+
+    const std::vector<size_t> reduction_axes = {1};
+    auto func = BuildFunction({256, -1, 10}, ov::element::Type_t::f16, reduction_axes, true);
+    manager.run_passes(func);
+
+    size_t reduce_count = 0;
+    for (auto& ops : func->get_ops()) {
+        std::string type_name(ops->get_type_name());
+        if (type_name.find("ReduceMax") != std::string::npos) {
+            reduce_count++;
+        }
+    }
+    ASSERT_TRUE(reduce_count == reduction_axes.size());
+}


### PR DESCRIPTION
https://github.com/openvinotoolkit/openvino/pull/24073 There are many ReduceMax layers are used to  convert 3D/4D shape data to scalar output, which leads to all computation is executed in single EUs while other 511 EUs are idle. It causes very poor performance for ReduceMax primitive execution.
For example: Grounding DINO models
     ReduceMax cost 59.24 ms and cosumed 49% execution times out of whole models.

To break this bottleneck, this PR applys more EUs execute this primitive by doing reduceMax one dimension by one dimension. Test result show:
     ReduceMax will be improved from 59.24 ms to 2.25 ms, fps from 8.24 to 15.55 (+88% improvement)
Update to set same keep_dim with origin reReduceMax op Update condition

### Details:
 - *For validation only*
 - *...*

### Tickets:
 - *ticket-id*
