### PR TITLE
[GPU] Do not use shape-agnostic kernel for OneDNN FC fp16

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
@@ -54,7 +54,6 @@ void compile_graph::run(program& p) {
 
         if (change_initial_impl) {
             if (node->is_type<fully_connected>()) {
-                const auto fc_prim = node->as<fully_connected>().get_primitive();
                 // Do not change impl (i.e. do not use ocl shape-agnostic kernels)
                 // since oneDNN primitives/kernels caching mechanism will be used instead.
                 change_initial_impl = false;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
@@ -55,10 +55,9 @@ void compile_graph::run(program& p) {
         if (change_initial_impl) {
             if (node->is_type<fully_connected>()) {
                 const auto fc_prim = node->as<fully_connected>().get_primitive();
-                // Do not change impl (i.e. do not use ocl shape-agnostic kernels) in case of compressed weights,
+                // Do not change impl (i.e. do not use ocl shape-agnostic kernels)
                 // since oneDNN primitives/kernels caching mechanism will be used instead.
-                if (fc_prim->compressed_weights)
-                    change_initial_impl = false;
+                change_initial_impl = false;
             } else if (node->is_type<gemm>() && !disable_permute_fuse_onednn_gemm) {
                 // permute is fused to onednn gemm. The updated memory formats are not supported by ocl this keep onednn impl
                 for (const auto& dep : node->get_dependencies()) {

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -661,7 +661,8 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
     bool is_remote = remote_ptr != nullptr;
     bool is_usm_host_tensor = usm_host_ptr != nullptr;
 
-    GPU_DEBUG_TRACE_DETAIL << "Prepare input for " << internal_name << " ( is_remote ? " << is_remote << ", is_usm_host_tensor ? " << is_usm_host_tensor << ")" << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << "Prepare input for " << internal_name
+            << " ( is_remote ? " << is_remote << ", is_usm_host_tensor ? " << is_usm_host_tensor << ")" << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "    port shape       : " << pshape.to_string() << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "    user_tensor shape: " << user_tensor->get_shape().to_string() << std::endl;
 

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -164,7 +164,7 @@ void SyncInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
         user_tensors[port_index] = { tensor._ptr, new_tensor_owner };
 
         // We need to properly handle PLUGIN -> USER ownership change to prevent invalid PLUGIN's ush_host buffer sharing,
-        // so remove plugin's tensor to reallocate it in prepare_input() mehtod
+        // so remove plugin's tensor to reallocate it in prepare_input() method
         if (current_tensor_owner == TensorOwner::PLUGIN && new_tensor_owner == TensorOwner::USER) {
             if (plugin_tensors.count(port_index) && std::dynamic_pointer_cast<RemoteTensorImpl>(plugin_tensors[port_index].ptr)->is_shared())
                 plugin_tensors.erase(plugin_tensors.find(port_index));
@@ -661,7 +661,7 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
     bool is_remote = remote_ptr != nullptr;
     bool is_usm_host_tensor = usm_host_ptr != nullptr;
 
-    GPU_DEBUG_TRACE_DETAIL << "Prepare input for " << internal_name << " ( is_remote ? " << is_remote << ")" << std::endl;
+    GPU_DEBUG_TRACE_DETAIL << "Prepare input for " << internal_name << " ( is_remote ? " << is_remote << ", is_usm_host_tensor ? " << is_usm_host_tensor << ")" << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "    port shape       : " << pshape.to_string() << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "    user_tensor shape: " << user_tensor->get_shape().to_string() << std::endl;
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -2145,6 +2145,10 @@ public:
     void test_weights_reorder_shapes_update(bool is_caching_test) {
         auto& engine = get_test_engine();
 
+        // This test is skipped for immad case because shape-agnostic kernel is not used.
+        if (engine.get_device_info().supports_immad)
+            return;
+
         const int32_t input_f = 3, input_b = 1, weight_b = 4;
 
         auto input_dyn_layout = layout{ ov::PartialShape{ ov::Dimension(1, 10), input_f }, data_types::f32, format::bfyx };
@@ -2890,74 +2894,6 @@ INSTANTIATE_TEST_SUITE_P(
 );
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-TEST(fully_connected_onednn, impl_replacement_with_cldnn) {
-    auto& engine = get_test_engine();
-
-    if (!engine.get_device_info().supports_immad)
-        return;
-
-    const int32_t input_f = 3, input_b = 1, weight_b = 4;
-
-    auto fake_alignment_size = engine.get_device_info().supports_immad ? 8 : 16;
-    auto input_dyn_layout = layout{ ov::PartialShape{ ov::Dimension(1, 10), input_f }, data_types::f32,format::bfyx };
-    auto input_data = engine.allocate_memory(layout{ ov::PartialShape{ input_b, input_f }, data_types::f32,format::bfyx });
-    auto weights_data = engine.allocate_memory({ ov::PartialShape{ weight_b, input_f }, data_types::f32,format::bfyx });
-
-    set_values(input_data, { -0.5f, 2.0f, 0.5f });
-    set_values(weights_data, { 1.5f, 1.0f, 0.5f, -1.0f, 0.0f, 0.5f, 0.5f, -0.5f, -2.0f, -0.5f, 1.0f, 1.5f });
-
-    cldnn::topology topology{
-        input_layout("input", input_dyn_layout),
-        data("weights", weights_data),
-        fully_connected("fc", input_info("input"), "weights")
-    };
-
-    ov::intel_gpu::ImplementationDesc fc_impl = { format::bfyx, "", impl_types::onednn };
-    ExecutionConfig cfg{ ov::intel_gpu::queue_type(QueueTypes::in_order),
-                         ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"fc_prim", fc_impl} }),
-                         ov::intel_gpu::optimize_data(true),
-                         ov::intel_gpu::allow_new_shape_infer(true) };
-
-    network network(engine, topology, cfg);
-    network.set_input_data("input", input_data);
-
-    // Check if shape agnostic kernel is used as default impl or not
-    auto inst = network.get_primitive("fc");
-    auto impl = inst->get_impl();
-    ASSERT_TRUE(impl != nullptr);
-    ASSERT_TRUE(impl->is_dynamic());
-
-    auto outputs = network.execute();
-    ASSERT_EQ(outputs.size(), size_t(1));
-    ASSERT_EQ(outputs.begin()->first, "fc");
-
-    auto output_prim_mem = outputs.begin()->second.get_memory();
-
-    auto out_l = network.get_output_layout(outputs.begin()->first);
-    ASSERT_EQ(output_prim_mem->get_layout().batch(), align_to(input_b, fake_alignment_size)); // fake_alignment
-    ASSERT_EQ(out_l.batch(), input_b);
-    ASSERT_EQ(out_l.feature(), weight_b);
-    ASSERT_EQ(out_l.spatial(0), 1);
-    ASSERT_EQ(out_l.spatial(1), 1);
-
-    cldnn::mem_lock<float> output_ptr (output_prim_mem, get_test_stream());
-
-    ASSERT_EQ(1.5f, output_ptr[0]);
-    ASSERT_EQ(0.75f, output_ptr[1]);
-    ASSERT_EQ(-2.25f, output_ptr[2]);
-    ASSERT_EQ(3.0f, output_ptr[3]);
-
-    // WA: Call wait_all() to wait for all queued kernels compilation finish
-    network.get_program()->get_compilation_context().wait_all();
-
-    // Check if OneDNN's impl is used for the next execute() call
-    network.execute();
-    inst = network.get_primitive("fc");
-    impl = inst->get_impl();
-    ASSERT_TRUE(impl != nullptr);
-    ASSERT_FALSE(impl->is_dynamic());
-}
-
 TEST(fully_connected_onednn_gpu, no_biases_int8) {
     //  Input  : 3x1
     //  Output : 4x1


### PR DESCRIPTION
### Details:
 - WA of out-of-bound access for fc kernel.
 - Use OneDNN FC kernel for fp16 FC when possible. It hides the issue because the target platform can use OneDNN.
 - For shape-agnostic kernel, TILE_B=8 is chosen. It causes out-of-bound memory access for LLM 2nd token.

### Tickets:
 - 142277
