### PR TITLE
[CPU] Reduce post ops as subgraph when output is not f32 precision

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
@@ -402,7 +402,7 @@ bool isSuitableChildForFusingSumActivation(const std::shared_ptr<const Node> &no
     return SupportsFusingWithConvolution_SumActivation(node);
 }
 bool isSuitableReduceChild(const std::shared_ptr<const Node> &node, const int channelAxis = DEFAULT_AXIS) {
-    return isSuitableChildForFusingSimple(node, channelAxis);
+    return node->get_output_element_type(0) == ov::element::f32 && isSuitableChildForFusingSimple(node, channelAxis);
 }
 bool isSuitableMatMulWithConstantPath(const std::shared_ptr<Node>& node) {
     return ov::is_type<ov::opset1::MatMul>(node) &&


### PR DESCRIPTION
### Details:
 - *reduce post ops only support f32 precision*

### Tickets:
 - *CVS-142322*
 
### PR for Release:
 - *https://github.com/openvinotoolkit/openvino/pull/24724*
