### PR TITLE
Update `CompiledModel` tests after `ov::model_name` prop was fixed

### DIFF
--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
@@ -49,6 +49,10 @@ const std::vector<std::pair<std::string, ov::Any>> compiledModelProperties = {
         {ov::intel_npu::use_elf_compiler_backend.name(), ov::Any(ov::intel_npu::ElfCompilerBackend::NO)},
         {ov::intel_npu::create_executor.name(), ov::Any(2)}};
 
+const std::string& expectedModelName = []() -> std::string {
+    return ov::test::behavior::getDefaultNGraphFunctionForTheDevice()->get_friendly_name();
+}();
+
 const std::vector<ov::AnyMap> publicCompiledModelConfigs = {
         {{ov::device::id.name(), ov::Any("")}},
         {{ov::hint::enable_cpu_pinning.name(), ov::Any(false)}},
@@ -57,21 +61,11 @@ const std::vector<ov::AnyMap> publicCompiledModelConfigs = {
         {{ov::hint::execution_mode.name(), ov::Any(ov::hint::ExecutionMode::PERFORMANCE)}},
         {{ov::hint::inference_precision.name(), ov::Any(ov::element::f16)}},
         {{ov::loaded_from_cache.name(), ov::Any(false)}},
-        {{ov::model_name.name(), ov::Any("")}},
+        {{ov::model_name.name(), ov::Any(expectedModelName)}},
         {{ov::optimal_number_of_infer_requests.name(), ov::Any(1u)}},
         {{ov::hint::performance_mode.name(), ov::Any(ov::hint::PerformanceMode::LATENCY)}},
         {{ov::hint::num_requests.name(), ov::Any(1u)}},
-        {{ov::enable_profiling.name(), ov::Any(false)}},
-        {{ov::supported_properties.name(),  // needed for HETERO
-          ov::Any(std::vector<ov::PropertyName>{
-                  ov::PropertyName(ov::device::id.name()), ov::PropertyName(ov::hint::enable_cpu_pinning.name()),
-                  ov::PropertyName(ov::execution_devices.name()), ov::PropertyName(ov::hint::execution_mode.name()),
-                  ov::PropertyName(ov::hint::inference_precision.name()),
-                  ov::PropertyName(ov::loaded_from_cache.name()), ov::PropertyName(ov::hint::model_priority.name()),
-                  ov::PropertyName(ov::model_name.name()),
-                  ov::PropertyName(ov::optimal_number_of_infer_requests.name()),
-                  ov::PropertyName(ov::hint::performance_mode.name()), ov::PropertyName(ov::hint::num_requests.name()),
-                  ov::PropertyName(ov::enable_profiling.name()), ov::PropertyName(ov::supported_properties.name())})}}};
+        {{ov::enable_profiling.name(), ov::Any(false)}}};
 
 const std::vector<ov::AnyMap> compiledModelIncorrectConfigs = {
         {{"NPU_INEXISTENT_PROPERTY", "NPU_INEXISTENT_PROPERTY_VALUE"}}};
@@ -80,8 +74,8 @@ const std::vector<std::pair<std::string, ov::Any>> allModelPriorities = {
         ov::hint::model_priority(ov::hint::Priority::LOW), ov::hint::model_priority(ov::hint::Priority::MEDIUM),
         ov::hint::model_priority(ov::hint::Priority::HIGH)};
 
-std::vector<std::pair<std::string, std::string>> compiledModelPropertiesAnyToString =
-        []() -> const std::vector<std::pair<std::string, std::string>> {
+const std::vector<std::pair<std::string, std::string>>& compiledModelPropertiesAnyToString =
+        []() -> std::vector<std::pair<std::string, std::string>> {
     std::vector<std::pair<std::string, std::string>> compiledModelProps(compiledModelProperties.size());
     for (auto it = compiledModelProperties.cbegin(); it != compiledModelProperties.cend(); ++it) {
         auto&& distance = it - compiledModelProperties.cbegin();
@@ -90,7 +84,7 @@ std::vector<std::pair<std::string, std::string>> compiledModelPropertiesAnyToStr
     return compiledModelProps;
 }();
 
-std::vector<ov::AnyMap> compiledModelConfigs = []() -> std::vector<ov::AnyMap> {
+const std::vector<ov::AnyMap>& compiledModelConfigs = []() -> std::vector<ov::AnyMap> {
     std::vector<ov::AnyMap> compiledModelConfigsMap(compiledModelProperties.size());
     for (auto it = compiledModelProperties.cbegin(); it != compiledModelProperties.cend(); ++it) {
         auto&& distance = it - compiledModelProperties.cbegin();
@@ -99,7 +93,7 @@ std::vector<ov::AnyMap> compiledModelConfigs = []() -> std::vector<ov::AnyMap> {
     return compiledModelConfigsMap;
 }();
 
-auto heteroCompiledModelConfigs = []() -> std::vector<ov::AnyMap> {
+const auto& heteroCompiledModelConfigs = []() -> std::vector<ov::AnyMap> {
     std::vector<ov::AnyMap> heteroConfigs(compiledModelConfigs.size());
     for (auto it = compiledModelConfigs.cbegin(); it != compiledModelConfigs.cend(); ++it) {
         auto&& distance = it - compiledModelConfigs.cbegin();
@@ -110,21 +104,7 @@ auto heteroCompiledModelConfigs = []() -> std::vector<ov::AnyMap> {
     return heteroConfigs;
 }();
 
-auto heteroCompiledModelPublicConfigs = []() -> ov::AnyMap {
-    ov::AnyMap heteroPublicConfigs = {
-            ov::device::priorities(ov::test::utils::DEVICE_NPU),
-            {ov::device::properties.name(), ov::Any(ov::AnyMap{{ov::test::utils::DEVICE_NPU, ov::Any(ov::AnyMap{})}})}};
-    auto& devicePropertiesAnyMap = heteroPublicConfigs.find(ov::device::properties.name())
-                                           ->second.as<ov::AnyMap>()
-                                           .begin()
-                                           ->second.as<ov::AnyMap>();
-    for (auto&& publicCompiledModelProp : publicCompiledModelConfigs) {
-        devicePropertiesAnyMap.emplace(*publicCompiledModelProp.begin());
-    }
-    return heteroPublicConfigs;
-}();
-
-auto combineParamsExecDevices = []() -> std::vector<std::pair<ov::AnyMap, std::string>> {
+const auto& combineParamsExecDevices = []() -> std::vector<std::pair<ov::AnyMap, std::string>> {
     std::vector<std::pair<ov::AnyMap, std::string>> execParams(compiledModelConfigs.size());
     for (auto it = compiledModelConfigs.cbegin(); it != compiledModelConfigs.cend(); ++it) {
         auto&& distance = it - compiledModelConfigs.cbegin();
@@ -133,7 +113,7 @@ auto combineParamsExecDevices = []() -> std::vector<std::pair<ov::AnyMap, std::s
     return execParams;
 }();
 
-auto combineHeteroParamsExecDevices = []() -> std::vector<std::pair<ov::AnyMap, std::string>> {
+const auto& combineHeteroParamsExecDevices = []() -> std::vector<std::pair<ov::AnyMap, std::string>> {
     std::vector<std::pair<ov::AnyMap, std::string>> execHeteroParams(heteroCompiledModelConfigs.size());
     for (auto it = heteroCompiledModelConfigs.cbegin(); it != heteroCompiledModelConfigs.cend(); ++it) {
         auto&& distance = it - heteroCompiledModelConfigs.cbegin();
@@ -202,12 +182,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVCompiledModelPropertiesDefaultSu
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelPropertiesDefaultTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(publicCompiledModelConfigs)),
-                         ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelPropertiesDefaultTests>);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompiledModelPropertiesDefaultTests,
-                         ::testing::Combine(::testing::Values(std::string(ov::test::utils::DEVICE_HETERO) + ":" +
-                                                              ov::test::utils::DEVICE_NPU),
-                                            ::testing::Values(heteroCompiledModelPublicConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelPropertiesDefaultTests>);
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelSetCorrectConfigTest,


### PR DESCRIPTION
### Details:
 - *To align newly added behavior tests with other plugins, `OVClassCompiledModelPropertiesDefaultTests` should not be tested with `HETERO` device, as it is in `intel_cpu` plugin: https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp#L63-L67*

### Tickets:
 - *E-120273*
