### PR TITLE
Bigger runner for Windows Conditional Compilation build

### DIFF
--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -50,7 +50,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
-    runs-on: aks-win-8-cores-64gb
+    runs-on: aks-win-32-cores-128gb
     env:
       CMAKE_BUILD_TYPE: 'Release'
       CMAKE_GENERATOR: 'Ninja Multi-Config'
@@ -262,7 +262,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
-    runs-on: aks-win-8-cores-64gb
+    runs-on: aks-win-32-cores-128gb
     env:
       CMAKE_BUILD_TYPE: 'Release'
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"


### PR DESCRIPTION
### Details:
This PR moves Windows Conditional Compilation build to a self-hosted runner in Azure with 32 cores and 128 GB of RAM