### PR TITLE
[NPU] Change NPUbackends log

### DIFF
--- a/src/plugins/intel_npu/src/plugin/include/backends.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/backends.hpp
@@ -36,6 +36,9 @@ public:
     std::string getCompilationPlatform(const std::string_view platform, const std::string& deviceId) const;
 
     void setup(const Config& config);
+    bool is_empty() const {
+        return _backend == nullptr ? true : false;
+    }
 
 private:
     Logger _logger;

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -10,6 +10,7 @@
 #include "intel_npu/utils/logger/logger.hpp"
 #include "npu.hpp"
 #include "openvino/runtime/so_ptr.hpp"
+#include "plugin.hpp"
 
 namespace intel_npu {
 

--- a/src/plugins/intel_npu/src/plugin/include/plugin.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/plugin.hpp
@@ -53,6 +53,10 @@ public:
     ov::SupportedOpsMap query_model(const std::shared_ptr<const ov::Model>& model,
                                     const ov::AnyMap& properties) const override;
 
+    bool is_backend_empty() const {
+        return _backends->is_empty() ? true : false;
+    }
+
 private:
     ov::SoPtr<ICompiler> getCompiler(const Config& config) const;
 

--- a/src/plugins/intel_npu/src/plugin/src/backends.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/backends.cpp
@@ -109,9 +109,9 @@ NPUBackends::NPUBackends(const std::vector<AvailableBackends>& backendRegistry, 
             }
 #endif
         } catch (const std::exception& ex) {
-            _logger.error("Got an error during backend '%s' loading : %s", backendName.c_str(), ex.what());
+            _logger.warning("Got an issue during backend '%s' loading : %s", backendName.c_str(), ex.what());
         } catch (...) {
-            _logger.error("Got an unknown error during backend '%s' loading", backendName.c_str());
+            _logger.warning("Got an issue warning during backend '%s' loading", backendName.c_str());
         }
     }
 
@@ -127,7 +127,8 @@ NPUBackends::NPUBackends(const std::vector<AvailableBackends>& backendRegistry, 
     if (_backend != nullptr) {
         _logger.info("Use '%s' backend for inference", _backend->getName().c_str());
     } else {
-        _logger.error("Cannot find backend for inference. Make sure the device is available.");
+        _logger.warning("Cannot find backend. Make sure the device is available. It is ok to compilation, but will "
+                        "result in failure of inference!");
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -104,6 +104,14 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
 std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() const {
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "CompiledModel::create_infer_request");
 
+    // Check if backend in plugin is available
+    if (std::dynamic_pointer_cast<const Plugin>(get_plugin())->is_backend_empty()) {
+        _logger.error("Cannot find backend in inference. Make sure the device is available!");
+        throw "ERROR Cannot find backend before inference";
+    } else {
+        _logger.info("backend is ready for inference.");
+    }
+
     if (_executorPtr == nullptr && _device != nullptr) {
         _executorPtr = _device->createExecutor(_networkPtr, _config);
     }

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -104,12 +104,11 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
 std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() const {
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "CompiledModel::create_infer_request");
 
-    // Check if backend in plugin is available
+    // Check if backend in plugin is available for inference
     if (std::dynamic_pointer_cast<const Plugin>(get_plugin())->is_backend_empty()) {
-        _logger.error("Cannot find backend in inference. Make sure the device is available!");
-        throw "ERROR Cannot find backend before inference";
+        _logger.error("Cannot find backend in inference, will lead to failure. Make sure the device is available!");
     } else {
-        _logger.info("backend is ready for inference.");
+        _logger.info("Backend is ready for inference.");
     }
 
     if (_executorPtr == nullptr && _device != nullptr) {


### PR DESCRIPTION
### Details:
 - *Update the confusing log in `NPUbackends`. OpenVINO compilation steps need to use NPU `Plugin`, `NPUbackends` and other components. Hope to remove `NPUbackends` initialization to get a dry execution, but `NPUbackends` can not be removed or moved. `NPUbackends` must be used to handle property.*
     - *Change `_logger.error`  to `_logger.warning` in `NPUBackends` constructor*
     - *Add judgment  about available  backends in `CompiledModel.create_infer_requesrt()`*

### Tickets:
 - *E-83001*
