### PR TITLE
[PyOV] Added symbolic propoagation to model visualization to enhance OV developer experience

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/offline_transformations.cpp
+++ b/src/bindings/python/src/pyopenvino/core/offline_transformations.cpp
@@ -10,6 +10,7 @@
 #include <openvino/pass/make_stateful.hpp>
 #include <openvino/pass/sdpa_to_paged_attention.hpp>
 #include <openvino/pass/serialize.hpp>
+#include <openvino/pass/visualize_tree.hpp>
 #include <pruning.hpp>
 #include <transformations/common_optimizations/compress_float_constants.hpp>
 #include <transformations/common_optimizations/fused_names_cleanup.hpp>
@@ -137,4 +138,16 @@ void regmodule_offline_transformations(py::module m) {
             manager.run_passes(model);
         },
         py::arg("model"));
+
+    // developer utilities which are only available in the package:
+    // ov._pyopenvino._offline_transformations
+    m_offline_transformations.def(
+        "_visualize",
+        [](std::shared_ptr<ov::Model> model, const std::string& output_file_name) {
+            ov::pass::Manager manager;
+            manager.register_pass<ov::pass::VisualizeTree>(output_file_name);
+            manager.run_passes(model);
+        },
+        py::arg("model"),
+        py::arg("output_file_name"));
 }

--- a/src/bindings/python/src/pyopenvino/core/offline_transformations.cpp
+++ b/src/bindings/python/src/pyopenvino/core/offline_transformations.cpp
@@ -10,7 +10,6 @@
 #include <openvino/pass/make_stateful.hpp>
 #include <openvino/pass/sdpa_to_paged_attention.hpp>
 #include <openvino/pass/serialize.hpp>
-#include <openvino/pass/visualize_tree.hpp>
 #include <pruning.hpp>
 #include <transformations/common_optimizations/compress_float_constants.hpp>
 #include <transformations/common_optimizations/fused_names_cleanup.hpp>
@@ -138,16 +137,4 @@ void regmodule_offline_transformations(py::module m) {
             manager.run_passes(model);
         },
         py::arg("model"));
-
-    // developer utilities which are only available in the package:
-    // ov._pyopenvino._offline_transformations
-    m_offline_transformations.def(
-        "_visualize",
-        [](std::shared_ptr<ov::Model> model, const std::string& output_file_name) {
-            ov::pass::Manager manager;
-            manager.register_pass<ov::pass::VisualizeTree>(output_file_name);
-            manager.run_passes(model);
-        },
-        py::arg("model"),
-        py::arg("output_file_name"));
 }

--- a/src/core/src/pass/visualize_tree.cpp
+++ b/src/core/src/pass/visualize_tree.cpp
@@ -13,9 +13,11 @@
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/op/util/op_types.hpp"
+#include "openvino/op/util/symbolic_info.hpp"
 #include "openvino/util/common_util.hpp"
 #include "openvino/util/env_util.hpp"
 #include "openvino/util/file_util.hpp"
+#include "transformations/symbolic_transformations/symbolic_optimizations.hpp"
 
 /*
  * As we are visualizing the graph, we will make some tweaks to the generated dot file to make
@@ -213,6 +215,16 @@ static void collect_symbol_print_values(const std::shared_ptr<ov::Model>& m,
 
 bool ov::pass::VisualizeTree::run_on_model(const std::shared_ptr<ov::Model>& f) {
     RUN_ON_MODEL_SCOPE(VisualizeTree);
+
+    static const bool ovasp = ov::util::getenv_bool("OV_VISUALIZE_APPLY_SYMBOLIC_PROPAGATION");
+    if (ovasp) {
+        std::cerr << "Warning: OV_VISUALIZE_APPLY_SYMBOLIC_PROPAGATION enabled. ov::pass::SymbolicPropagation will be "
+                     "triggered"
+                  << std::endl;
+        ov::pass::SymbolicPropagation().run_on_model(f);
+        std::cerr << "ov::pass::SymbolicPropagation finished successfully" << std::endl;
+    }
+
     std::unordered_map<Node*, HeightMap> height_maps;
 
     for (auto& node : f->get_ops()) {
@@ -257,7 +269,13 @@ bool ov::pass::VisualizeTree::run_on_model(const std::shared_ptr<ov::Model>& f) 
 
     // Clean up local variable not to hold node pointers
     m_nodes_with_attributes.clear();
-
+    if (ovasp) {
+        std::cerr << "Warning: Due to previously triggered SymbolicPropagation we need to clean-up the model from "
+                     "symbols. It includes model revalidation"
+                  << std::endl;
+        ov::remove_skip_invalidation_rti(f);
+        std::cerr << "Model revalidation finished successfully" << std::endl;
+    }
     return false;
 }
 


### PR DESCRIPTION
### Details:

As a result, you can use this code for most of your needs:

- in a Jupiter notebook
- as a cmd tool
- with model weights being far away

```
def configure_visualizer(enable=True, max_const_elements=7):
    # parameter max_const_elements manipulates the number of first elements of a constant that will be serialized
    # to svg. Put 0 if the model is on a share
    import os
    envs_to_set = [
        'OV_VISUALIZE_TREE_IO',
        'OV_VISUALIZE_TREE_OUTPUT_SHAPES',
        'OV_VISUALIZE_TREE_OUTPUT_TYPES',
        'OV_VISUALIZE_TREE_EDGE_LABELS',
        # symbolic information and partial values
        'OV_VISUALIZE_APPLY_SYMBOLIC_PROPAGATION',
        'OV_VISUALIZE_PARTIAL_VALUES_AND_LABELS'
    ]
    for e in envs_to_set:
        os.environ[e] = '1' if enable else '0'
    os.environ["OV_VISUALIZE_TREE_CONST_MAX_ELEMENTS"] = str(max_const_elements) if enable else "7"


def serialize_model_to_svg(model, output_name='serialized_model.svg'):
    from openvino.runtime.passes import VisualizeTree
    configure_visualizer(True)
    VisualizeTree(output_name).run_on_model(model)
    configure_visualizer(False)


def convert_model_to_svg(input_name, output_name=None):
    import openvino as ov
    core = ov.Core()
    model = core.read_model(input_name)
    if output_name is None:
        output_name = os.path.splitext(os.path.basename(input_name))[0] + '.svg'
    serialize_model_to_svg(model, output_name)


if __name__ == "__main__":
    import sys, os

    arguments = sys.argv[1:]
    if len(arguments) not in [1, 2]:
        print(f"Usage {sys.executable} {__file__} /path/to/model [output_file_name.svg]")
        sys.exit(1)
    output_file = os.path.splitext(os.path.basename(arguments[0]))[0] + '.svg' if len(arguments) == 1 else arguments[1]
    convert_model_to_svg(arguments[0], output_file)
```