### PR TITLE
Do not convert Squeeze/Unsqueeze to Reshape in Symbolic transformations

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/nop_elimination.hpp
@@ -19,6 +19,7 @@ class TRANSFORMATIONS_API EliminatePad;
 class TRANSFORMATIONS_API EliminateSplit;
 class TRANSFORMATIONS_API EliminateSplitConcat;
 class TRANSFORMATIONS_API EliminateSqueeze;
+class TRANSFORMATIONS_API EliminateUnsqueeze;
 class TRANSFORMATIONS_API EliminateTranspose;
 class TRANSFORMATIONS_API EliminateNopBroadcast;
 class TRANSFORMATIONS_API NopSliceBeforeGatherElements;
@@ -88,6 +89,16 @@ class ov::pass::EliminateSqueeze : public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("EliminateSqueeze", "0");
     EliminateSqueeze();
+};
+
+/**
+ * @ingroup ov_transformation_common_api
+ * @brief EliminateUnsqueeze eliminates squeeze that does nothing
+ */
+class ov::pass::EliminateUnsqueeze : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("EliminateUnsqueeze", "0");
+    EliminateUnsqueeze();
 };
 
 /**

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -280,7 +280,7 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     REGISTER_PASS(manager, SharedOpOptimization)
     REGISTER_PASS(manager, ConstantFolding)
     REGISTER_PASS(manager, SymbolicOptimizations)
-    manager.register_pass<ResolveNameCollisions>(true);
+    REGISTER_PASS(manager, ResolveNameCollisions, true);
     manager.run_passes(f);
 
     if (!m_use_shapes) {

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -455,7 +455,7 @@ pass::EliminateUnsqueeze::EliminateUnsqueeze() {
     auto unsqueeze_pattern = pattern::wrap_type<ov::op::v0::Unsqueeze>();
 
     ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
-                return eliminate_unsqueeze(m.get_match_root());
+        return eliminate_unsqueeze(m.get_match_root());
     };
     auto m = make_shared<pattern::Matcher>(unsqueeze_pattern, matcher_name);
     this->register_matcher(m, callback);

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -338,7 +338,6 @@ static bool eliminate_unsqueeze(const shared_ptr<Node>& node) {
     };
 
 SIMPLE_MATCHER_PASS_DEFINITION(EliminateReshape, eliminate_reshape_v1, ov::op::v1::Reshape);
-SIMPLE_MATCHER_PASS_DEFINITION(EliminateUnsqueeze, eliminate_unsqueeze, ov::op::v0::Unsqueeze);
 SIMPLE_MATCHER_PASS_DEFINITION(EliminateBroadcast, eliminate_nop, op::v1::Broadcast, op::v3::Broadcast);
 SIMPLE_MATCHER_PASS_DEFINITION(EliminateGather,
                                simplify_gather,
@@ -448,6 +447,17 @@ pass::EliminateSplit::EliminateSplit() {
     };
 
     auto m = make_shared<pattern::Matcher>(convert_pattern, matcher_name);
+    this->register_matcher(m, callback);
+}
+
+pass::EliminateUnsqueeze::EliminateUnsqueeze() {
+    MATCHER_SCOPE(EliminateUnsqueeze);
+    auto unsqueeze_pattern = pattern::wrap_type<ov::op::v0::Unsqueeze>();
+
+    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+                return eliminate_unsqueeze(m.get_match_root());
+    };
+    auto m = make_shared<pattern::Matcher>(unsqueeze_pattern, matcher_name);
     this->register_matcher(m, callback);
 }
 

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -353,7 +353,7 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
 
 bool pass::SimplifyShapeOfSubGraph::run_on_model(const std::shared_ptr<Model>& f) {
     RUN_ON_FUNCTION_SCOPE(SimplifyShapeOfSubGraph);
-    Manager manager;
+    Manager manager(get_pass_config());
     manager.set_per_pass_validation(false);
 
     REGISTER_PASS(manager, PrepareShapeOpsForEliminationAroundBE)

--- a/src/common/transformations/src/transformations/symbolic_transformations/symbolic_optimizations.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/symbolic_optimizations.cpp
@@ -200,6 +200,14 @@ ov::pass::SymbolicOptimizations::SymbolicOptimizations(bool full_run) {
 
 bool ov::pass::SymbolicOptimizations::run_on_model(const std::shared_ptr<ov::Model>& m) {
     RUN_ON_FUNCTION_SCOPE(SymbolicOptimizations);
+
+    // Eliminate Squeeze/Unsqueeze might convert Squeeze/Unsqueeze ops to Reshape
+    // it may break NNCF patterns and lead to unexpected FakeQuantize ops in the model.
+    // So we decided to disable these passes in SymbolicOptimizations.
+    const auto& pass_config = m_manager->get_pass_config();
+    pass_config->disable<EliminateSqueeze>();
+    pass_config->disable<EliminateUnsqueeze>();
+
     m_manager->run_passes(m);
     ov::remove_skip_invalidation_rti(m);
     return true;

--- a/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
@@ -11,6 +11,7 @@
 #include "openvino/core/model.hpp"
 #include "openvino/opsets/opset12.hpp"
 #include "openvino/pass/manager.hpp"
+#include "common_test_utils/ov_test_utils.hpp"
 
 using namespace testing;
 using namespace ov;
@@ -59,3 +60,22 @@ TEST(TransformationTests, TestModelTensorsConsistencyUseShapesFalse) {
     model->validate_nodes_and_infer_types();
     EXPECT_TRUE(model->outputs()[0].get_names() == new_tensors);
 }
+
+TEST_F(TransformationTestsF, SqueezeRemainsSqueezeAfterMOC) {
+    {
+        using namespace ov::op;
+        auto input = std::make_shared<v0::Parameter>(element::f32, Shape{30});
+        auto shape  = v0::Constant::create(element::i64, Shape{5}, {2, 3, 1, 5, 1});
+        auto reshape = std::make_shared<v1::Reshape>(input, shape, false);
+        auto unsqueeze_axes = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto unsqueeze = std::make_shared<v0::Unsqueeze>(reshape, unsqueeze_axes);
+
+        auto squeeze_axes = v0::Constant::create(element::i64, Shape{2}, {3, 5});
+        auto squeeze = std::make_shared<v0::Squeeze>(unsqueeze, squeeze_axes);
+
+        auto res = std::make_shared<v0::Result>(squeeze);
+        model = std::make_shared<ov::Model>(ov::ResultVector{res}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MOCTransformations>(false);
+    }
+}
+

--- a/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
@@ -8,10 +8,10 @@
 
 #include <string>
 
+#include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/opsets/opset12.hpp"
 #include "openvino/pass/manager.hpp"
-#include "common_test_utils/ov_test_utils.hpp"
 
 using namespace testing;
 using namespace ov;
@@ -65,7 +65,7 @@ TEST_F(TransformationTestsF, SqueezeRemainsSqueezeAfterMOC) {
     {
         using namespace ov::op;
         auto input = std::make_shared<v0::Parameter>(element::f32, Shape{30});
-        auto shape  = v0::Constant::create(element::i64, Shape{5}, {2, 3, 1, 5, 1});
+        auto shape = v0::Constant::create(element::i64, Shape{5}, {2, 3, 1, 5, 1});
         auto reshape = std::make_shared<v1::Reshape>(input, shape, false);
         auto unsqueeze_axes = v0::Constant::create(element::i64, Shape{1}, {0});
         auto unsqueeze = std::make_shared<v0::Unsqueeze>(reshape, unsqueeze_axes);
@@ -78,4 +78,3 @@ TEST_F(TransformationTestsF, SqueezeRemainsSqueezeAfterMOC) {
         manager.register_pass<ov::pass::MOCTransformations>(false);
     }
 }
-


### PR DESCRIPTION
### Details:
Disable EliminateSqueeze/EliminateUnsqueeze passes in SymbolicOptimizations

### Tickets:
 - *CVS-141814*
