### PR TITLE
[Tests] Fixed debug info about ranges

### DIFF
--- a/src/tests/functional/shared_test_classes/src/base/utils/ranges.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/ranges.cpp
@@ -85,12 +85,12 @@ void ModelRange::find_mode_ranges(const std::shared_ptr<ov::Model>& model) {
             std::cout << ex.what() << std::endl;
 #endif
         }
-// #ifndef NDEBUG
+#ifndef NDEBUG
         std::cout << "RANGE FOR PARAMETER: " << param->get_friendly_name()
                   << "  start from: " << std::to_string(data->start_from) << "  range: " << std::to_string(data->range)
                   << "  resolution: " << std::to_string(data->resolution) << "  seed: " << std::to_string(data->seed)
                   << std::endl;
-// #endif
+#endif
 
         std::string range_id = get_range_id(param);
         node_ranges[range_id] = data;


### PR DESCRIPTION
### Details:
 - *Removed Debug info printing by default from https://github.com/openvinotoolkit/openvino/pull/23428*
 ```
 [ RUN      ] smoke_Snippets_Softmax/Softmax.CompareWithRefImpl/IS=[?.?]_TS=((1.16))_((1.32))_((1.1))_((1.9))_((1.17))_((1.19))_((1.49))_((1.50))_((5.16))_((1.16))_((1.9))_Axis=-1_#N=1_#S=1_targetDevice=CPU

MEM_USAGE=3007144KB
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Parameter_1590025  start from: 0.000000  range: 8  resolution: 32  seed: 1
[       OK ] smoke_Snippets_Softmax/Softmax.CompareWithRefImpl/IS=[?.?]_TS=((1.16))_((1.32))_((1.1))_((1.9))_((1.17))_((1.19))_((1.49))_((1.50))_((5.16))_((1.16))_((1.9))_Axis=-1_#N=1_#S=1_targetDevice=CPU (132 ms)
 ```

### Tickets:
 - *N/A*
