### PR TITLE
[NPU] Add the "create_executor" property inside the Plugin's list as well

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -482,6 +482,12 @@ Plugin::Plugin()
           [](const Config& config) {
               return config.getString<USE_ELF_COMPILER_BACKEND>();
           }}},
+        {ov::intel_npu::create_executor.name(),
+         {false,
+          ov::PropertyMutability::RW,
+          [](const Config& config) {
+              return config.get<CREATE_EXECUTOR>();
+          }}},
         {ov::intel_npu::dynamic_shape_to_static.name(),
          {false,
           ov::PropertyMutability::RW,

--- a/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
@@ -144,6 +144,7 @@ std::vector<std::pair<std::string, ov::Any>> plugin_internal_mutable_properties 
         {ov::intel_npu::stepping.name(), ov::Any(4)},
         {ov::intel_npu::dpu_groups.name(), ov::Any(2)},
         {ov::intel_npu::use_elf_compiler_backend.name(), ov::Any(ov::intel_npu::ElfCompilerBackend::YES)},
+        {ov::intel_npu::create_executor.name(), ov::Any(0)},
 };
 
 std::vector<std::pair<std::string, ov::Any>> plugin_public_immutable_properties = {


### PR DESCRIPTION
### Details:
 - `ov::intel_npu::create_executor` is declared a supported property only for the `intel_npu::CompiledModel` class. The current PR adds an entry inside `intel_npu::Plugin` as well.

### Tickets:
 - *CVS-143060*
