### PR TITLE
[CPU] [Snippets] Fix performance regression in calling parallel_nt

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -879,7 +879,7 @@ void Subgraph::SubgraphExecutor::parallel_for6d(const std::function<void(jit_sni
     segfault_detector();
 #endif
 
-    parallel_nt(m_nthreads, [&](const int ithr, const int nthr) {
+    parallel_nt_static(m_nthreads, [&](const int ithr, const int nthr) {
         jit_snippets_call_args call_args;
         initializer(call_args);
 

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -903,7 +903,7 @@ void Subgraph::SubgraphExecutor::parallel_forNd(const std::function<void(jit_sni
     segfault_detector();
 #endif
 
-    parallel_nt(m_nthreads, [&](const int ithr, const int nthr) {
+    parallel_nt_static(m_nthreads, [&](const int ithr, const int nthr) {
         jit_snippets_call_args call_args;
         initializer(call_args);
 


### PR DESCRIPTION
### Details:
 - *This PR fixes geomean level performance issue caused by https://github.com/openvinotoolkit/openvino/pull/23180 on platforms with sufficient cores.*
 - *In the PR mensioned above, `parallel_nt` is used for executing subgraph instead of `parallel_for5d`, becuase the former has performance advantage for the case where #tasks is more than #threads*. That is becuase using `parallel_nt`, we can initilize parameters for each thread, while parameters are initilized for each task in using `parallel_for5d`. So `parallel_nt` has less overheads.
 - *However, for the case where #tasks is less than #threads, `parallel_nt` brings performance regression. Because compared with `parallel_for5d`, `parallel_nt` doesn't apply the argument `tbb::static_partitioner{}` when calling `tbb::parallel_for`. Here we use `parallel_nt_static` instead to fix the performance regression.*

