### PR TITLE
[CPU] Bring back mem allocation using the upper bound

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -107,10 +107,12 @@ void Memory::create(MemoryDescPtr desc, const void* data, bool pads_zeroing) {
     m_padsZeroing = pads_zeroing;
     dnnlMemHandle.resetDnnlPrim();
 
-    if (!m_pMemDesc->isDefined()) {
+    const size_t memSize = m_pMemDesc->getMaxMemSize();
+
+    if (MemoryDesc::UNDEFINED_SIZE == memSize) {
         return;
     }
-    auto memSize = m_pMemDesc->getCurrentMemSize();
+
     if (nullptr != data) {
         m_mgrHandle->setExtBuff(const_cast<void*>(data), memSize);
     } else {
@@ -128,7 +130,7 @@ void Memory::load(const IMemory& src, bool ftz) const {
 void Memory::nullify() {
     void* dataPtr = getData();
     if (dataPtr != nullptr)
-        memset(dataPtr, 0, getDesc().getCurrentMemSize());
+        memset(dataPtr, 0, getDesc().getMaxMemSize());
 }
 
 void Memory::redefineDesc(MemoryDescPtr desc) {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -773,8 +773,8 @@ void Graph::AllocateWithReuse(const std::vector<size_t>& syncNodesInds) {
             int e_start = edge->getParent()->execIndex;
             int e_finish = edge->getChild()->execIndex;
 
-            if (boxSize != -1 && edge->getDesc().isDefined()) {
-                int64_t e_size = edge->getDesc().getCurrentMemSize();  // size in bytes (from the beginning of data to the last element)
+            if (boxSize != -1 && edge->getDesc().hasDefinedMaxSize()) {
+                int64_t e_size = edge->getDesc().getMaxMemSize();  // size in bytes (from the beginning of data to the last element)
                 boxSize = std::max(e_size, boxSize);
             } else {
                 boxSize = -1;


### PR DESCRIPTION
### Details:
Use memory solver to preallocate memory using the upper bound of partially defined shapes.

### Tickets:
 - CVS-141182
