### PR TITLE
[GPU] Don't add crop for unused out ports of Split op

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/split.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/split.cpp
@@ -65,6 +65,11 @@ static void CreateCommonSplitOp(ProgramBuilder& p, const std::shared_ptr<ov::Nod
         }
 
         for (size_t i = 0; i < op->get_output_size(); i++) {
+            const auto& users = op->get_output_target_inputs(i);
+            // don't add crop primitive if port is not used by anyone
+            if (users.size() == 0)
+                continue;
+
             auto cropPrim = cldnn::crop(get_layer_name(i),
                                         inputs,
                                         cldnn::tensor(1),


### PR DESCRIPTION
### Details:
 - Currently we insert crop primitive for each out port of (Variadic)Split ops, and if some of them are not used we just waste some execution time. This patch modifies converter for Split to process ports with real users only.
