### PR TITLE
[GPU] Model stat print, host time measurement debug knob

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -282,6 +282,7 @@ private:
     void set_variables_state_info(const std::string& variable_id, const layout& variable_layout, ov::element::Type user_specified_type, const primitive* p);
     void dump_memory_pool(std::string dump_path, int64_t curr_iter);
 
+    std::vector<uint64_t> host_exec_times;
 #ifdef GPU_DEBUG_CONFIG
     int64_t iteration = 0;
 #endif

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
@@ -109,6 +109,7 @@ public:
     int disable_onednn_opt_post_ops;                            // Disable onednn optimize post operators
     std::string dump_profiling_data;                            // Enables dump of extended performance profiling to specified dir
     int dump_profiling_data_per_iter;                           // Enables dump of extended performance profiling to specified dir for each iteration
+    int host_time_profiling;                                    // Enables measurement of scheduling time spend on the host
     std::string dump_graphs;                                    // Dump optimized graph
     std::string dump_sources;                                   // Dump opencl sources
     std::string dump_layers_path;                               // Enable dumping intermediate buffers and set the dest path

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -433,6 +433,22 @@ network::network(program::ptr program, stream::ptr stream, uint16_t stream_id)
     : network(program, program->get_config(), stream, false, stream_id == 0) {}
 
 network::~network() {
+    GPU_DEBUG_IF(debug_configuration::get_instance()->host_time_profiling) {
+        if (host_exec_times.size() >= 2) {
+            double first = static_cast<double>(host_exec_times[0]);
+            double avg = static_cast<double>(std::accumulate(host_exec_times.begin() + 1, host_exec_times.end(), (size_t)0, std::plus<size_t>()));
+            avg /= (host_exec_times.size() - 1);
+            std::string resolution = " us";
+            if (avg > 1000.0) {
+                resolution = " ms";
+                avg /= 1000.0;
+                first /= 1000.0;
+            }
+            GPU_DEBUG_COUT << "Network[" << net_id << "] First infer host time: " << first << resolution << std::endl;
+            GPU_DEBUG_COUT << "Network[" << net_id << "] Infer avg host time: " << avg << resolution << std::endl;
+        }
+    }
+
     if (_program != nullptr)
         _program->cancel_compilation_context();
     _memory_pool->clear_pool_for_network(net_id);
@@ -915,7 +931,12 @@ void network::add_to_exec_order(const primitive_id& id) {
 }
 
 std::map<primitive_id, network_output> network::execute(const std::vector<event::ptr>& dependencies) {
+    auto start = std::chrono::high_resolution_clock::now();
     execute_impl(dependencies);
+    auto end = std::chrono::high_resolution_clock::now();
+
+    GPU_DEBUG_IF(debug_configuration::get_instance()->host_time_profiling)
+        host_exec_times.push_back(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
 
     auto output_ids = get_output_ids();
     std::map<primitive_id, network_output> result;

--- a/src/plugins/intel_gpu/src/plugin/transformations/print_model_statistics.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/print_model_statistics.cpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "print_model_statistics.hpp"
+#include "intel_gpu/runtime/debug_configuration.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/op/util/multi_subgraph_base.hpp"
+#include <memory>
+
+namespace ov {
+namespace intel_gpu {
+namespace {
+size_t collect_stats(const std::shared_ptr<ov::Model>& m, std::map<DiscreteTypeInfo, size_t>& ops_stat) {
+    const std::vector<std::shared_ptr<ov::Node>> ops = m->get_ops();
+    size_t total = ops.size();
+    for (auto& op : ops) {
+        const auto& tinfo = op->get_type_info();
+        if (ops_stat.find(tinfo) == ops_stat.end()) {
+            ops_stat[tinfo] = 0;
+        }
+
+        ops_stat[tinfo]++;
+
+        if (auto subgraph_op = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(op)) {
+            for (const auto& subgraph : subgraph_op->get_functions()) {
+                total += collect_stats(subgraph, ops_stat);
+            }
+        }
+    }
+
+    return total;
+}
+
+}  // namespace
+
+bool PrintModelStatistics::run_on_model(const std::shared_ptr<ov::Model>& m) {
+    std::map<DiscreteTypeInfo, size_t> ops_stat;
+    size_t total = collect_stats(m, ops_stat);
+
+    std::stringstream ss;
+    ss << "Operations statistics:\n";
+    for (auto& kv : ops_stat) {
+        ss << "\t" << kv.first.version_id << "::" << kv.first.name << " " << kv.second << std::endl;
+    }
+
+    ss << "\tTotal: " << total;
+
+    GPU_DEBUG_INFO << ss.str() << std::endl;;
+    return false;
+}
+
+}  // namespace intel_gpu
+}  // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations/print_model_statistics.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/print_model_statistics.hpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/pass.hpp"
+
+namespace ov {
+namespace intel_gpu {
+
+class PrintModelStatistics : public ov::pass::ModelPass {
+public:
+    OPENVINO_RTTI("PrintModelStatistics", "0");
+    PrintModelStatistics() = default;
+
+    bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
+};
+
+}  // namespace intel_gpu
+}  // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -61,6 +61,7 @@
 #include "plugin/transformations/kv_cache_fusion.hpp"
 #include "plugin/transformations/move_fc_reshape_to_weights.hpp"
 #include "plugin/transformations/bcast_and_pad_zp_buffers.hpp"
+#include "plugin/transformations/print_model_statistics.hpp"
 #include "plugin/transformations/swiglu_fusion.hpp"
 #include "plugin/transformations/transpose_fusion.hpp"
 #include "plugin/transformations/indirect_kv_cache.hpp"
@@ -823,6 +824,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         // This is supposed to be the last pass to ensure that we don't have name collisions until
         // GPU plugin stops using friendly names for program creation
         manager.register_pass<ov::pass::ResolveNameCollisions>(true);
+        GPU_DEBUG_IF(cldnn::debug_configuration::get_instance()->verbose >= 1) {
+            manager.register_pass<ov::intel_gpu::PrintModelStatistics>();
+        }
 
         manager.run_passes(func);
     }

--- a/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
+++ b/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
@@ -144,6 +144,7 @@ static void print_help_messages() {
                               "from one specific iteration by giving the same values for the start and end, and the open "
                               "ended range is also available by range from given start to the last iteration as -1. e.g. "
                               "OV_GPU_DumpProfilingDataIteration='10..-1'");
+    message_list.emplace_back("OV_GPU_HostTimeProfiling", "Enable collecting of model enqueue time spent on the host");
     message_list.emplace_back("OV_GPU_DumpGraphs", "1) dump ngraph before and after transformation. 2) dump graph in model compiling."
                               "3) dump graph in execution.");
     message_list.emplace_back("OV_GPU_DumpSources", "Dump opencl sources");
@@ -218,6 +219,7 @@ debug_configuration::debug_configuration()
         , disable_onednn_opt_post_ops(0)
         , dump_profiling_data(std::string(""))
         , dump_profiling_data_per_iter(0)
+        , host_time_profiling(0)
         , dump_graphs(std::string())
         , dump_sources(std::string())
         , dump_layers_path(std::string())
@@ -266,6 +268,7 @@ debug_configuration::debug_configuration()
     get_gpu_debug_env_var("DisableOnednnOptPostOps", disable_onednn_opt_post_ops);
     get_gpu_debug_env_var("DumpProfilingData", dump_profiling_data);
     get_gpu_debug_env_var("DumpProfilingDataPerIter", dump_profiling_data_per_iter);
+    get_gpu_debug_env_var("HostTimeProfiling", host_time_profiling);
     std::string dump_prof_data_iter_str;
     get_gpu_debug_env_var("DumpProfilingDataIteration", dump_prof_data_iter_str);
     get_gpu_debug_env_var("DryRunPath", dry_run_path);

--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -430,10 +430,6 @@ public:
         mvn_results /= tensor_size ? tensor_size : 1;
         if (!incorrect_values_abs.empty() && equal(1.f, topk_threshold) ||
             incorrect_values_abs.size() > static_cast<int>(std::floor(topk_threshold * tensor_size))) {
-#ifdef NDEBUG
-            std::string msg = "[ COMPARATION ] COMPARATION IS FAILED!";
-            msg += "  Use DEBUG mode to print `incorrect_values_abs` and get detailed information!";
-#else
             std::string msg = "[ COMPARATION ] COMPARATION IS FAILED! incorrect elem counter: ";
             msg += std::to_string(incorrect_values_abs.size());
             msg += " among ";
@@ -441,11 +437,14 @@ public:
             msg += " shapes.";
             for (auto val : incorrect_values_abs) {
                 std::cout << "\nExpected: " << val.expected_value << " Actual: " << val.actual_value
+                          << " Coordinate: " << val.coordinate
                           << " Diff: " << std::fabs(val.expected_value - val.actual_value)
                           << " calculated_abs_threshold: " << val.threshold << " abs_threshold: " << abs_threshold
                           << " rel_threshold: " << rel_threshold << "\n";
-            }
+#ifdef NDEBUG
+                break;
 #endif
+            }
             throw std::runtime_error(msg);
         } else if (!less_or_equal(mvn_results, mvn_threshold)) {
             std::string msg = "[ COMPARATION ] COMPARATION IS FAILED due to MVN THRESHOLD: ";


### PR DESCRIPTION
### Details:
 - Added dev pass to log operations statistics when VERBOSE=1
 - Added debug knob to collect network::execute() time to measure time required to schedule all primitives
 - Updated common results comparison routine to print coordinate and to show first mismatched element info in release build
