### PR TITLE
[GPU] Enable shape agnostic Gemm in dpas platform.

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/format.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/format.hpp
@@ -75,6 +75,7 @@ struct format {
     enum type : int32_t {
         // Data formats
         bfyx,                                   ///< the most common format for activations in clDNN.
+        bfxy,
         bfzyx,                                  ///< format for 5d data tensors
         bfwzyx,                                 ///< batch, feature, 4D spatial
         bfuwzyx,                                ///< 7d tensor
@@ -291,7 +292,7 @@ struct format {
     /// @brief Checks if @p format is simple data format
     static bool is_simple_data_format(const format& fmt) {
         return (fmt == yxfb || fmt == byxf || fmt == byfx || fmt == bxfy || fmt == bfyx || fmt == fyxb || fmt == fybx ||
-                fmt == xbfy || fmt == ybfx || fmt == fbyx || fmt == bfzyx || fmt == bfwzyx || fmt == bfuwzyx ||
+                fmt == bfxy ||fmt == xbfy || fmt == ybfx || fmt == fbyx || fmt == bfzyx || fmt == bfwzyx || fmt == bfuwzyx ||
                 fmt == bfvuwzyx);
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -170,7 +170,6 @@ protected:
                 }
 
                 if (ret) {
-                    auto original_tag = tag;
                     tag = convert_data_format(transposed_format);
                     dnnl::memory::dims original_dims = dims;
                     for (size_t i = 0; i < original_dims.size(); ++i) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -81,14 +81,8 @@ protected:
         if (gemm_with_bias) {
             in_layouts.emplace_back(impl_params.get_input_layout(2));
         }
-        if (prim->id.find("__module.text_model.encoder.layers.0.self_attn/aten::bmm/MatMul") != std::string::npos) {
-            GPU_DEBUG_INFO << "__module.text_model.encoder.layers.0.self_attn/aten::bmm/MatMul" << std::endl;
-        }
-        GPU_DEBUG_INFO << prim->id << ": trans_in0/in1: " << prim->transpose_input0 << ", " << prim->transpose_input1 << std::endl;
-        GPU_DEBUG_INFO << in_layouts[0].to_short_string() << ", " << in_layouts[1].to_short_string() << std::endl;
         in_layouts = gemm_inst::transform_input_layouts(prim, in_layouts);
         out_l = gemm_inst::transform_output_layout(prim, in_layouts, out_l);
-        GPU_DEBUG_INFO << in_layouts[0].to_short_string() << ", " << in_layouts[1].to_short_string() << std::endl;
 
         const auto& in0_l = in_layouts[0];
         const auto& in1_l = in_layouts[1];
@@ -124,7 +118,6 @@ protected:
                 std::swap(in0_padded_dims[in0_padded_dims.size() - 1], in0_padded_dims[in0_padded_dims.size() - 2]);
             }
             in0_strides = onednn::get_strides(in0_padded_dims);
-            GPU_DEBUG_INFO << prim->id <<  ": in0 has padding" << std::endl;
         }
 
         if (in1_l.data_padding) {
@@ -133,159 +126,7 @@ protected:
                 std::swap(in1_padded_dims[in1_padded_dims.size() - 1], in1_padded_dims[in1_padded_dims.size() - 2]);
             }
             in1_strides = onednn::get_strides(in1_padded_dims);
-            GPU_DEBUG_INFO << prim->id <<  ": in1 has padding" << std::endl;
         }
-#if 0
-        if (prim->transpose_input0 || prim->transpose_input1) {
-            GPU_DEBUG_INFO << "in0 dim" << std::endl;
-            for (auto i : in0_dims) {
-                std::cout << i << " ";
-            }
-            std::cout << std::endl;
-            GPU_DEBUG_INFO << "in1 dim" << std::endl;
-            for (auto i : in1_dims) {
-                std::cout << i << " ";
-            }
-            std::cout << std::endl;
-
-            GPU_DEBUG_INFO << "in0 input0_transpose_order" << std::endl;
-            for (auto i : prim->input0_transpose_order) {
-                std::cout << i << " ";
-            }
-            std::cout << std::endl;
-            GPU_DEBUG_INFO << "in0 input1_transpose_order" << std::endl;
-            for (auto i : prim->input1_transpose_order) {
-                std::cout << i << " ";
-            }
-            std::cout << std::endl;
-        }
-
-#if 1
-        if (prim->transpose_input0 && batched_dims_can_be_removed) {
-            // GPU_DEBUG_COUT << prim->id <<  ": need transpose_in0: " << static_cast<int>(in0_fmt) << ", " << std::endl;
-            // for (auto i : prim->input0_transpose_order) {
-            //     std::cout << i << " ";
-            // }
-            // std::cout << std::endl;
-            in0_fmt = transpose_format(in0_fmt);
-            std::swap(in0_dims[in0_dims.size() - 1], in0_dims[in0_dims.size() - 2]);
-        }
-
-        if (prim->transpose_input1 && batched_dims_can_be_removed) {
-            // GPU_DEBUG_COUT << prim->id <<  ": need transpose_in1: " << static_cast<int>(in1_fmt) << std::endl;
-            // for (auto i : prim->input1_transpose_order) {
-            //     std::cout << i << " ";
-            // }
-            // std::cout << std::endl;
-            // std::vector<size_t> order(std::begin(prim->input1_transpose_order), std::end(prim->input1_transpose_order));
-            // format target = format::bfyx;
-            // gemm_inst::is_fusable_permute_input_order_onednn(order, target);
-            // auto temp = in1_fmt;
-            // in1_fmt = convert_data_format(target);  // dnnl_adbc
-            // std::cout << "tag change : " << static_cast<int>(temp) << " TO " << static_cast<int>(in1_fmt) << std::endl;
-
-            // dnnl::memory::dims temp_dims = in1_dims;
-            // for (size_t i = 0; i < in1_dims.size(); ++i) {
-            //     in1_dims[i] = temp_dims[order[i]];
-            // }
-            in1_fmt = transpose_format(in1_fmt);
-            std::swap(in1_dims[in1_dims.size() - 1], in1_dims[in1_dims.size() - 2]);
-        }
-#endif
-        // Check whether transpose_order increase sequential or not.
-        // Return true when transpose_order is not 0, 1, 2, 3.
-        auto has_transpose_order = [](std::vector<int64_t> transpose_order) {
-            for (size_t i = 0; i < transpose_order.size(); i++) {
-                if (i != static_cast<size_t>(transpose_order[i])) {
-                    return true;
-                }
-            }
-            return false;
-        };
-        auto transpose_dims_and_format_tag = [](std::vector<int64_t> transpose_order, dnnl::memory::dims& dims, dnnl::memory::format_tag& tag) {
-            std::vector<size_t> order(std::begin(transpose_order), std::end(transpose_order));
-            if (dims.size() > order.size()) {
-                size_t orders_to_add = dims.size() - order.size();
-                for (size_t i = orders_to_add - 1; i == 0; --i)
-                     order.insert(order.begin(), i);
-                for (size_t i = orders_to_add; i < order.size(); ++i)
-                    order[i] = order[i] + orders_to_add;
-            } else if (dims.size() < order.size()) {
-                size_t orders_to_remove = order.size() - dims.size();
-                for (size_t i = 0; i < orders_to_remove; ++i) {
-                    order.erase(order.begin());
-                }
-                for (size_t i = 0; i< order.size(); ++i) {
-                    order[i] = order[i] - orders_to_remove;
-                }
-            }
-            GPU_DEBUG_COUT << "my order: " << std::endl;
-            for (auto i : order)
-                std::cout << i << ", ";
-            std::cout << std::endl;
-
-            format transposed_format = format::bfyx;
-            if (gemm_inst::is_fusable_permute_input_order_onednn(order, transposed_format)) {
-                auto original_tag = tag;
-                tag = convert_data_format(transposed_format);
-                GPU_DEBUG_COUT << "Transpose tag: " << static_cast<int>(original_tag) << " to " << static_cast<int>(tag) << std::endl;
-                dnnl::memory::dims original_dims = dims;
-                for (size_t i = 0; i < original_dims.size(); ++i) {
-                    dims[i] = original_dims[order[i]];
-                }
-            } else {
-                GPU_DEBUG_COUT << "order is not included in white list!!!!" << std::endl;
-            }
-        };
-
-        GPU_DEBUG_COUT << "in0" << std::endl;
-        if (has_transpose_order(prim->input0_transpose_order)) transpose_dims_and_format_tag(prim->input0_transpose_order, in0_dims, in0_fmt);
-        GPU_DEBUG_COUT << "in1" << std::endl;
-        if (has_transpose_order(prim->input1_transpose_order)) transpose_dims_and_format_tag(prim->input1_transpose_order, in1_dims, in1_fmt);
-        GPU_DEBUG_COUT << "out" << std::endl;
-        if (has_transpose_order(prim->output_transpose_order)) transpose_dims_and_format_tag(prim->output_transpose_order, out_dims, out_fmt);
-#if 0
-        if (has_transpose_order(prim->input0_transpose_order)) {
-            std::vector<size_t> order(std::begin(prim->input0_transpose_order), std::end(prim->input0_transpose_order));
-            format target = format::bfyx;
-            gemm_inst::is_fusable_permute_input_order_onednn(order, target);
-            auto temp = in0_fmt;
-            in0_fmt = convert_data_format(target);
-            std::cout << "tag change : " << static_cast<int>(temp) << " TO " << static_cast<int>(in0_fmt) << std::endl;
-
-            dnnl::memory::dims temp_dims = in0_dims;
-            for (size_t i = 0; i < in0_dims.size(); ++i) {
-                in0_dims[i] = temp_dims[order[i]];
-            }
-        }
-        if (has_transpose_order(prim->input1_transpose_order)) {
-            std::vector<size_t> order(std::begin(prim->input1_transpose_order), std::end(prim->input1_transpose_order));
-            format target = format::bfyx;
-            gemm_inst::is_fusable_permute_input_order_onednn(order, target);
-            auto temp = in1_fmt;
-            in1_fmt = convert_data_format(target);
-            std::cout << "tag change : " << static_cast<int>(temp) << " TO " << static_cast<int>(in1_fmt) << std::endl;
-
-            dnnl::memory::dims temp_dims = in1_dims;
-            for (size_t i = 0; i < in1_dims.size(); ++i) {
-                in1_dims[i] = temp_dims[order[i]];
-            }
-        }
-        if (!has_transpose_order(prim->output_transpose_order)) {
-            std::vector<size_t> order(std::begin(prim->output_transpose_order), std::end(prim->output_transpose_order));
-            format target = format::bfyx;
-            gemm_inst::is_fusable_permute_input_order_onednn(order, target);
-            auto temp = out_fmt;
-            out_fmt = convert_data_format(target);
-            std::cout << "tag change : " << static_cast<int>(temp) << " TO " << static_cast<int>(out_fmt) << std::endl;
-
-            dnnl::memory::dims temp_dims = out_dims;
-            for (size_t i = 0; i < out_dims.size(); ++i) {
-                out_dims[i] = temp_dims[order[i]];
-            }
-        }
-#endif
-#endif
 
         if (batched_dims_can_be_removed) {
             if (prim->transpose_input0) {
@@ -312,28 +153,13 @@ protected:
                                                     dnnl::memory::format_tag& tag,
                                                     bool is_input = true) {
                 std::vector<size_t> order(std::begin(transpose_order), std::end(transpose_order));
-                // GPU_DEBUG_INFO << "dims -> " << std::endl;
-                // for (auto i : dims) {
-                //     std::cout << i << ", ";
-                // }
-                // std::cout << std::endl;
-                // GPU_DEBUG_INFO << "order before -> " << std::endl;
-                // for (auto i : order) {
-                //     std::cout << i << ", ";
-                // }
-                // std::cout << std::endl;
                 if (dims.size() > order.size()) {
-                    GPU_DEBUG_INFO << "dims.size() > order.size() case" << std::endl;
                     size_t orders_to_add = dims.size() - order.size();
                     for (size_t i = 0; i < orders_to_add; ++i)
                         order.insert(order.begin(), i);
                     for (size_t i = orders_to_add; i < order.size(); ++i)
                         order[i] = order[i] + orders_to_add;
                 }
-                // GPU_DEBUG_INFO << "order after : " << std::endl;
-                // for (auto i : order)
-                //     std::cout << i << ", ";
-                // std::cout << std::endl;
 
                 bool ret = false;
                 format transposed_format = format::bfyx;
@@ -346,7 +172,6 @@ protected:
                 if (ret) {
                     auto original_tag = tag;
                     tag = convert_data_format(transposed_format);
-                    GPU_DEBUG_INFO << "Transpose tag: " << static_cast<int>(original_tag) << " to " << static_cast<int>(tag) << std::endl;
                     dnnl::memory::dims original_dims = dims;
                     for (size_t i = 0; i < original_dims.size(); ++i) {
                         dims[i] = original_dims[order[i]];
@@ -355,11 +180,8 @@ protected:
                     OPENVINO_ASSERT(false, "[GPU] Can't find fusable transpoed format: ", transposed_format.to_string());
                 }
             };
-            GPU_DEBUG_INFO << "in0" << std::endl;
             if (has_transpose_order(prim->input0_transpose_order)) transpose_dims_and_format_tag(prim->input0_transpose_order, in0_dims, in0_fmt);
-            GPU_DEBUG_INFO << "in1" << std::endl;
             if (has_transpose_order(prim->input1_transpose_order)) transpose_dims_and_format_tag(prim->input1_transpose_order, in1_dims, in1_fmt);
-            GPU_DEBUG_INFO << "out" << std::endl;
             if (has_transpose_order(prim->output_transpose_order)) transpose_dims_and_format_tag(prim->output_transpose_order, out_dims, out_fmt, false);
         }
 
@@ -370,20 +192,6 @@ protected:
             bias_dims = onednn::convert_gemm_tensor(bias_l.get_tensor(), bias_rank, batched_dims_can_be_removed);
             bias_fmt = onednn::convert_gemm_data_format(bias_dims, bias_l.format);
         }
-
-        // GPU_DEBUG_INFO<< "fmt: " << static_cast<int>(in0_fmt) << ", " << static_cast<int>(in1_fmt)  << ", " << static_cast<int>(out_fmt) << std::endl;
-        // for (auto i : in0_dims) {
-        //     std::cout << i << ", ";
-        // }
-        // std::cout << std::endl;
-        // for (auto i : in1_dims) {
-        //     std::cout << i << ", ";
-        // }
-        // std::cout << std::endl;
-        // for (auto i : out_dims) {
-        //     std::cout << i << ", ";
-        // }
-        // std::cout << std::endl;
     }
 
     static dnnl::memory::desc get_input_memory_desc(const dnnl::memory::dims& dims,

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -144,6 +144,7 @@ std::vector<std::pair<cldnn::format, dnnl::memory::format_tag>> format_map = {
         { cldnn::format::g_os_is_zyx_isv16_osv16,  dnnl::memory::format_tag::gIOdhw16i16o },
 
         { cldnn::format::bfyx,  dnnl::memory::format_tag::nchw },
+        { cldnn::format::bfxy,  dnnl::memory::format_tag::abdc },
         { cldnn::format::byxf,  dnnl::memory::format_tag::nhwc },
         { cldnn::format::byfx,  dnnl::memory::format_tag::acbd },
         { cldnn::format::bxfy,  dnnl::memory::format_tag::adbc },

--- a/src/plugins/intel_gpu/src/graph/include/gemm_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/gemm_inst.h
@@ -39,6 +39,7 @@ public:
 
     static bool is_fusable_permute_input_order_onednn(const std::vector<size_t>& permute_order, format& fmt) {
         const std::vector<format> gemm_in_format_white_list = {format::bfyx,
+                                                               format::bfxy,
                                                                format::fyxb,
                                                                format::byfx,
                                                                format::bxfy,
@@ -62,10 +63,11 @@ public:
 
     static bool is_fusable_permute_output_order_onednn(const std::vector<size_t>& target_order, format& fmt) {
         const std::vector<format> gemm_out_format_white_list = {format::bfyx,
-                                                               format::fyxb,
-                                                               format::fybx,
-                                                               format::byfx,
-                                                               format::ybfx};
+                                                                format::bfxy,
+                                                                format::fyxb,
+                                                                format::fybx,
+                                                                format::byfx,
+                                                                format::ybfx};
 
         for (const auto& cand_format : gemm_out_format_white_list) {
             const auto cand_format_order = format::traits(static_cast<format::type>(cand_format))._order;

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -949,7 +949,7 @@ static bool is_node_for_onednn(fully_connected_node const& node) {
 static bool is_node_for_onednn(gemm_node const& node) {
     if (!layout_optimizer::are_data_types_suitable_for_onednn((program_node&)node))
         return false;
-
+#if 0
     auto gemm_prim = node.get_primitive();
 
     for (size_t idx = 0; idx < gemm_prim->output_transpose_order.size(); idx++) {
@@ -969,7 +969,7 @@ static bool is_node_for_onednn(gemm_node const& node) {
         if (idx != static_cast<size_t>(gemm_prim->input1_transpose_order[idx]))
             return false;
     }
-
+#endif
     return true;
 }
 

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -949,27 +949,7 @@ static bool is_node_for_onednn(fully_connected_node const& node) {
 static bool is_node_for_onednn(gemm_node const& node) {
     if (!layout_optimizer::are_data_types_suitable_for_onednn((program_node&)node))
         return false;
-#if 0
-    auto gemm_prim = node.get_primitive();
 
-    for (size_t idx = 0; idx < gemm_prim->output_transpose_order.size(); idx++) {
-        if (idx != static_cast<size_t>(gemm_prim->output_transpose_order[idx]))
-            return false;
-    }
-
-    if (gemm_prim->transpose_input0 > 1 || gemm_prim->transpose_input0 > 1)
-        return false;
-
-    for (size_t idx = 0; idx < (gemm_prim->input0_transpose_order.size() - 2); idx++) {
-        if (idx != static_cast<size_t>(gemm_prim->input0_transpose_order[idx]))
-            return false;
-    }
-
-    for (size_t idx = 0; idx < (gemm_prim->input1_transpose_order.size() - 2); idx++) {
-        if (idx != static_cast<size_t>(gemm_prim->input1_transpose_order[idx]))
-            return false;
-    }
-#endif
     return true;
 }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -798,10 +798,12 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>();
+#if 0
         if (device_info.supports_immad) {
             manager.get_pass_config()->disable<ov::intel_gpu::TransposeMatMulMatcher>();
             manager.get_pass_config()->disable<ov::intel_gpu::TransposeMatMulTransposeMatcher>();
         }
+#endif
 
         if (!device_info.supports_immad) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -798,12 +798,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>();
-#if 0
-        if (device_info.supports_immad) {
-            manager.get_pass_config()->disable<ov::intel_gpu::TransposeMatMulMatcher>();
-            manager.get_pass_config()->disable<ov::intel_gpu::TransposeMatMulTransposeMatcher>();
-        }
-#endif
 
         if (!device_info.supports_immad) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();

--- a/src/plugins/intel_gpu/src/runtime/format.cpp
+++ b/src/plugins/intel_gpu/src/runtime/format.cpp
@@ -25,6 +25,7 @@ static const std::map<format::type, format_traits> format_traits_map {
         FMT_TRAITS(yxfb,                  1, 1, 2, 0, {2, 3, 1, 0},             "yxfb",     "bfxy",     {}),
         FMT_TRAITS(byxf,                  1, 1, 2, 0, {0, 2, 3, 1},             "byxf",     "bfxy",     {}),
         FMT_TRAITS(bfyx,                  1, 1, 2, 0, {0, 1, 2, 3},             "bfyx",     "bfxy",     {}),
+        FMT_TRAITS(bfxy,                  1, 1, 2, 0, {0, 1, 3, 2},             "bfxy",     "bfxy",     {}),
         FMT_TRAITS(fbyx,                  1, 1, 2, 0, {1, 0, 2, 3},             "fbyx",     "bfxy",     {}),
         FMT_TRAITS(fyxb,                  1, 1, 2, 0, {1, 2, 3, 0},             "fyxb",     "bfxy",     {}),
         FMT_TRAITS(fybx,                  1, 1, 2, 0, {1, 2, 0, 3},             "fybx",     "bfxy",     {}),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -1563,6 +1563,8 @@ TEST_F(gemm_gpu_tests, transpose_matmul_transpose_static_3d) {
     this->test_transpose_matmul_transpose(3, false, false);
 }
 
+#ifndef ENABLE_ONEDNN_FOR_GPU
+// Disable onednn test because onednn does not support format_tag::cbda, format_tag::badc.
 TEST_F(gemm_gpu_tests, transpose_matmul_transpose_dynamic_4d) {
     this->test_transpose_matmul_transpose(4, true, false);
 }
@@ -1570,6 +1572,7 @@ TEST_F(gemm_gpu_tests, transpose_matmul_transpose_dynamic_4d) {
 TEST_F(gemm_gpu_tests, transpose_matmul_transpose_static_4d) {
     this->test_transpose_matmul_transpose(4, false, false);
 }
+#endif
 
 INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_t1t2,
@@ -3224,7 +3227,10 @@ TEST_F(gemm_gpu_tests, transpose_matmul_dynamic_4d_cached) {
     this->test_transpose_matmul_f16(4, true, true, /*BMKN*/{19, 37, 23, 29}, /*input0_order*/{0, 2, 3, 1}, /*input1_order*/{1, 2, 3, 0});
 }
 
+#ifndef ENABLE_ONEDNN_FOR_GPU
+// Disable onednn test because onednn does not support format_tag::cbda, format_tag::badc.
 TEST_F(gemm_gpu_tests, transpose_matmul_transpose_dynamic_4d_cached) {
     this->test_transpose_matmul_transpose(4, true, true);
 }
+#endif
 } // namespace

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -105,7 +105,7 @@ public:
         const auto params_hash = prim_inst->get_impl_params()->hash();
 
         ASSERT_EQ(primitive_hash, 8439414674502129643UL);
-        ASSERT_EQ(params_hash, 9235751886952244871UL);
+        ASSERT_EQ(params_hash, 18030913546439900045UL);
     }
 
     void test_gemm_basic(bool is_caching_test) {
@@ -176,7 +176,7 @@ public:
         const auto params_hash = prim_inst->get_impl_params()->hash();
 
         ASSERT_EQ(primitive_hash, 16293979194373117693UL);
-        ASSERT_EQ(params_hash, 4712165546063627148UL);
+        ASSERT_EQ(params_hash, 3339057685641907457UL);
     }
 
     void test_reshape_basic(bool is_caching_test) {
@@ -225,7 +225,7 @@ public:
         const auto params_hash = prim_inst->get_impl_params()->hash();
 
         ASSERT_EQ(primitive_hash, 13549661972131371304UL);
-        ASSERT_EQ(params_hash, 7127098854451559675UL);
+        ASSERT_EQ(params_hash, 17196242702975187963UL);
     }
 
     void test_quantize_basic(bool is_caching_test) {


### PR DESCRIPTION
Current Gemm in dpas always compile and use onednn kernel in 1st inference.
Shape agnostic Gemm kernel is not used. So PR enable SA Gemm in dpas for reducing 1st inference latency.

### Tickets:
 - *143315*
