### PR TITLE
[CI] [GHA] Add `Timeout was reached` to the list of errors in rerunner

### DIFF
--- a/.github/scripts/workflow_rerun/errors_to_look_for.json
+++ b/.github/scripts/workflow_rerun/errors_to_look_for.json
@@ -54,5 +54,9 @@
     {
         "error_text": "Unable to fetch some archives",
         "ticket": 130965
+    },
+    {
+        "error_text": "status_string: \"Timeout was reached\"",
+        "ticket": 142653
     }
 ]


### PR DESCRIPTION
### Tickets:
 - *142653*
