### PR TITLE
[core] Integrate f4e2m1 with std::numeric_limits

### DIFF
--- a/src/core/include/openvino/core/type/float4_e2m1.hpp
+++ b/src/core/include/openvino/core/type/float4_e2m1.hpp
@@ -149,3 +149,66 @@ float4_e2m1 float4_e2m1::operator/=(const T& other) {
 #    pragma warning(pop)
 #endif
 }  // namespace ov
+
+namespace std {
+template <>
+class numeric_limits<ov::float4_e2m1> {
+public:
+    static constexpr bool is_specialized = true;
+    static constexpr ov::float4_e2m1 min() noexcept {
+        return ov::float4_e2m1::from_bits(0b0010);  // minimum positive normalized value
+    }
+    static constexpr ov::float4_e2m1 max() noexcept {
+        return ov::float4_e2m1::from_bits(0b0111);
+    }
+    static constexpr ov::float4_e2m1 lowest() noexcept {
+        return ov::float4_e2m1::from_bits(0b1111);
+    }
+    static constexpr int digits = 2;
+    static constexpr int digits10 = 0;
+
+    static constexpr bool is_signed = true;
+    static constexpr bool is_integer = false;
+    static constexpr bool is_exact = false;
+
+    static constexpr int radix = 2;
+
+    static constexpr ov::float4_e2m1 epsilon() noexcept {
+        return ov::float4_e2m1::from_bits(0b0001);
+    }
+    static constexpr ov::float4_e2m1 round_error() noexcept {
+        return ov::float4_e2m1::from_bits(0b001);
+    }
+
+    static constexpr int min_exponent = 1;
+    static constexpr int min_exponent10 = 0;
+    static constexpr int max_exponent = 3;
+    static constexpr int max_exponent10 = 0;
+
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+
+    static constexpr float_denorm_style has_denorm = denorm_present;
+    static constexpr bool has_denorm_loss = false;
+
+    static constexpr ov::float4_e2m1 infinity() noexcept {
+        return ov::float4_e2m1::from_bits(0);  // no infinity
+    }
+    static constexpr ov::float4_e2m1 quiet_NaN() noexcept {
+        return ov::float4_e2m1::from_bits(0);  // no quiet NaN
+    }
+    static constexpr ov::float4_e2m1 signaling_NaN() noexcept {
+        return ov::float4_e2m1::from_bits(0);  // no signaling NaN
+    }
+    static constexpr ov::float4_e2m1 denorm_min() noexcept {
+        return ov::float4_e2m1::from_bits(0b0001);  // minimum positive denormalized value
+    }
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = false;
+    static constexpr bool is_modulo = false;
+    static constexpr bool traps = false;
+    static constexpr bool tinyness_before = false;
+    static constexpr float_round_style round_style = round_to_nearest;
+};
+}  // namespace std

--- a/src/core/tests/float4_e2m1.cpp
+++ b/src/core/tests/float4_e2m1.cpp
@@ -134,5 +134,125 @@ TEST_P(F4E2M1PTest, f32_to_f4_bits) {
 
     EXPECT_EQ(f4.to_bits(), exp_value);
 }
+
+TEST(F4E2M1Test, f48e2m1_num_limits_exp) {
+    const auto min_exp = std::numeric_limits<ov::float4_e2m1>::min_exponent;
+    const auto min_exp10 = std::numeric_limits<ov::float4_e2m1>::min_exponent10;
+    const auto max_exp = std::numeric_limits<ov::float4_e2m1>::max_exponent;
+    const auto max_exp10 = std::numeric_limits<ov::float4_e2m1>::max_exponent10;
+
+    EXPECT_EQ(min_exp, 1);
+    EXPECT_EQ(min_exp10, 0);
+    EXPECT_EQ(max_exp, 3);
+    EXPECT_EQ(max_exp10, 0);
+}
+
+TEST(F4E2M1Test, min_normalized) {
+    const auto f4 = ov::float4_e2m1(0.8f);
+
+    EXPECT_EQ(f4.to_bits(), 0b0010);
+    EXPECT_EQ(f4.to_bits(), std::numeric_limits<ov::float4_e2m1>::min().to_bits());
+}
+
+TEST(F4E2M1Test, max_normalized) {
+    const auto f4 = ov::float4_e2m1(6.0f);
+
+    EXPECT_EQ(f4.to_bits(), 0b0111);
+    EXPECT_EQ(f4.to_bits(), std::numeric_limits<ov::float4_e2m1>::max().to_bits());
+}
+
+TEST(F4E2M1Test, lowest_normalized) {
+    const auto f4 = ov::float4_e2m1(-6.0f);
+
+    EXPECT_EQ(f4.to_bits(), 0b1111);
+    EXPECT_EQ(f4.to_bits(), std::numeric_limits<ov::float4_e2m1>::lowest().to_bits());
+}
+
+TEST(F4E2M1Test, denorm_min) {
+    const auto f4 = ov::float4_e2m1(0.5f);
+
+    EXPECT_EQ(f4.to_bits(), 0b0001);
+    EXPECT_EQ(f4.to_bits(), std::numeric_limits<ov::float4_e2m1>::denorm_min().to_bits());
+}
+
+TEST(F4E2M1Test, num_limits_is_specialized) {
+    const auto val = std::numeric_limits<ov::float4_e2m1>::is_specialized;
+    EXPECT_TRUE(val);
+}
+
+TEST(F4E2M1Test, num_limits_is_signed) {
+    const auto val = std::numeric_limits<ov::float4_e2m1>::is_signed;
+    EXPECT_TRUE(val);
+}
+
+TEST(F4E2M1Test, num_limits_is_integer) {
+    const auto val = std::numeric_limits<ov::float4_e2m1>::is_integer;
+    EXPECT_FALSE(val);
+}
+
+TEST(F4E2M1Test, num_limits_is_exact) {
+    const auto val = std::numeric_limits<ov::float4_e2m1>::is_exact;
+    EXPECT_FALSE(val);
+}
+
+TEST(F4E2M1Test, num_limits_radix) {
+    const auto val = std::numeric_limits<ov::float4_e2m1>::radix;
+    EXPECT_EQ(val, 2);
+}
+
+TEST(F4E2M1Test, num_limits_digits) {
+    const auto val = std::numeric_limits<ov::float4_e2m1>::digits;
+    EXPECT_EQ(val, 2);
+}
+
+TEST(F4E2M1Test, num_limits_digits10) {
+    const auto f4_dig = std::numeric_limits<ov::float4_e2m1>::digits;
+    const auto f4_dig10 = std::numeric_limits<ov::float4_e2m1>::digits10;
+
+    EXPECT_EQ(f4_dig10, static_cast<int>((f4_dig - 1) * std::log10(2)));
+    EXPECT_EQ(f4_dig10, 0);
+}
+
+TEST(F4E2M1Test, num_limits_epsilon) {
+    const auto f4_1 = ov::float4_e2m1(1.f);
+    const auto f4_1_bits = f4_1.to_bits();
+    const auto f4_1_next_bits = f4_1_bits + 1u;
+
+    const auto f4_eps = ov::float4_e2m1::from_bits(f4_1_next_bits - f4_1_bits);
+
+    EXPECT_EQ(f4_eps, std::numeric_limits<ov::float4_e2m1>::epsilon());
+    EXPECT_EQ(f4_eps.to_bits(), std::numeric_limits<ov::float4_e2m1>::epsilon().to_bits());
+}
+
+TEST(F4E2M1Test, num_limits_round_error) {
+    const auto f4 = ov::float4_e2m1(0.5f);
+
+    EXPECT_EQ(f4, std::numeric_limits<ov::float4_e2m1>::round_error());
+    EXPECT_EQ(f4.to_bits(), std::numeric_limits<ov::float4_e2m1>::round_error().to_bits());
+}
+
+TEST(F4E2M1Test, quiet_nan) {
+    const auto has_quiet_nan = std::numeric_limits<ov::float4_e2m1>::has_quiet_NaN;
+    EXPECT_FALSE(has_quiet_nan);
+    EXPECT_EQ(std::numeric_limits<ov::float4_e2m1>::quiet_NaN().to_bits(), 0);
+}
+
+TEST(F4E2M1Test, f32_quiet_nan) {
+    const auto f4 = ov::float4_e2m1(std::numeric_limits<float>::quiet_NaN());
+
+    EXPECT_FALSE(std::isnan(f4));
+    EXPECT_EQ(f4.to_bits(), 0b0111);
+    EXPECT_EQ(0, std::numeric_limits<ov::float4_e2m1>::quiet_NaN().to_bits());
+}
+
+TEST(F4E2M1Test, f32_sig_nan) {
+    const auto f4 = ov::float4_e2m1(std::numeric_limits<float>::signaling_NaN());
+
+    const auto has_sig_nan = std::numeric_limits<ov::float4_e2m1>::has_signaling_NaN;
+    EXPECT_FALSE(has_sig_nan);
+    EXPECT_FALSE(std::isnan(f4));
+    EXPECT_EQ(f4.to_bits(), 0b0111);
+    EXPECT_EQ(0, std::numeric_limits<ov::float4_e2m1>::signaling_NaN().to_bits());
+}
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Add custom std::numeric limits for `ov::float4_e2m1`

### Tickets:
 - [CVS-141576](https://jira.devtools.intel.com/browse/CVS-141576)
