### PR TITLE
[TF FE Tests] Change HSVToRGB Unit Test To Test Grayscale Image

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_HSVToRGB.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_HSVToRGB.py
@@ -17,8 +17,9 @@ class TestHSVToRGB(CommonTFLayerTest):
             inputs_data['images:0'] = np.zeros(images_shape).astype(self.input_type) 
         elif self.special_case == "Grayscale Image":
             images_shape = inputs_info['images:0']
+            images_shape[-1] = 1
             inputs_data = {}
-            inputs_data['images:0'] = np.ones(images_shape).astype(self.input_type) * np.random.rand()
+            inputs_data['images:0'] = np.tile([0,0,.5], images_shape).astype(self.input_type)
         else:
             images_shape = inputs_info['images:0']
             inputs_data = {} 

--- a/tests/layer_tests/tensorflow_tests/test_tf_HSVToRGB.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_HSVToRGB.py
@@ -17,7 +17,6 @@ class TestHSVToRGB(CommonTFLayerTest):
             inputs_data['images:0'] = np.zeros(images_shape).astype(self.input_type) 
         elif self.special_case == "Grayscale Image":
             images_shape = inputs_info['images:0']
-            images_shape[-1] = 1
             inputs_data = {}
             inputs_data['images:0'] = np.tile([0, 0, 0.5], images_shape).astype(self.input_type)
         else:

--- a/tests/layer_tests/tensorflow_tests/test_tf_HSVToRGB.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_HSVToRGB.py
@@ -18,7 +18,7 @@ class TestHSVToRGB(CommonTFLayerTest):
         elif self.special_case == "Grayscale Image":
             images_shape = inputs_info['images:0']
             inputs_data = {}
-            inputs_data['images:0'] = np.tile([0, 0, 0.5], images_shape).astype(self.input_type)
+            inputs_data['images:0'] = np.broadcast_to([0, 0, 0.5], images_shape).astype(self.input_type)
         else:
             images_shape = inputs_info['images:0']
             inputs_data = {} 

--- a/tests/layer_tests/tensorflow_tests/test_tf_HSVToRGB.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_HSVToRGB.py
@@ -19,7 +19,7 @@ class TestHSVToRGB(CommonTFLayerTest):
             images_shape = inputs_info['images:0']
             images_shape[-1] = 1
             inputs_data = {}
-            inputs_data['images:0'] = np.tile([0,0,.5], images_shape).astype(self.input_type)
+            inputs_data['images:0'] = np.tile([0, 0, 0.5], images_shape).astype(self.input_type)
         else:
             images_shape = inputs_info['images:0']
             inputs_data = {} 


### PR DESCRIPTION

### Details:
 - Currently, the unit test for HSVToRGB is creating a tensor of all ones in the Grayscale special case as mentioned in [#24875](https://github.com/openvinotoolkit/openvino/pull/24875). Since the images are expected to be in HSV and not RGB format, this will create images that are green, and not gray. Grayscale in HSV can be achieved by creating a tensor with HSV entries of [0, 0, .5].

### Tickets:
 - N/A
