### PR TITLE
Let ocl FC to use tile size 1 only when the # of threads is less than the w/ minimal # of threads

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -247,10 +247,11 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
     if (params.weights.GetDType() == WeightsType::UINT4 || params.weights.GetDType() == WeightsType::INT4) {
         if (!params.is_shape_agnostic && batch == 1) {
             // Tuning for Meteor Lake
-            size_t ideal_num_threads = params.engineInfo.maxThreadsPerDevice * simd;
-            if (output_f / 2 < ideal_num_threads * 0.8 && params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
+            size_t min_num_threads = params.engineInfo.computeUnitsCount * simd;
+            if (output_f / 2 < min_num_threads && params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
                 GPU_DEBUG_TRACE_DETAIL << "FC bf tiled: Set ofm_tile 1. (output_f : " << output_f
-                                       << ", ideal threads : " << ideal_num_threads << ")" << std::endl;
+                    << ", computeUnitsCount : " << params.engineInfo.computeUnitsCount
+                    << " min_num_threads : " << min_num_threads << ")" << std::endl;
                 return selector.Default(tune_params(1, 1, 4, 2, 1, 1, EXE_MODE_DEFAULT));
             } else {
                 return selector.Default(tune_params(1, 2, 4, 2, 1, 1, EXE_MODE_DEFAULT));


### PR DESCRIPTION
### Details:
 - Fix to resolve perf issue in the platforms with small # of EUs than 128. 
### Tickets:
 - *ticket-id*
