### PR TITLE
[CPU] Align cpu execution order before/after ResolveComplexInplaceConflicts()

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1516,8 +1516,11 @@ void Graph::SortTopologically() {
 
     // Insert nodes in outputNodesMap in front of graphNodes to make sure it always
     // start tranverse from outputs
-    graphNodes.erase(std::remove_if(graphNodes.begin(), graphNodes.end(), [](const NodePtr node){
-        return node->getTypeStr().compare("Result") == 0;
+    graphNodes.erase(std::remove_if(graphNodes.begin(), graphNodes.end(), [&](const NodePtr node){
+        auto it = std::find_if(outputNodesMap.begin(), outputNodesMap.end(), [&](const std::pair<std::size_t, NodePtr>& kvp) {
+            return kvp.second == node;
+        });
+        return it != outputNodesMap.end();
     }), graphNodes.end());
 
     for (auto&& kvp : outputNodesMap) {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1469,17 +1469,12 @@ void Graph::SortTopologically() {
     for (auto &node : graphNodes) {
         // Sort in / out Parent edges by port index
         // Make first N (N == port_num) edge indexes match with port index
-        int port_num = node->inputShapes.size();
-        std::vector<EdgePtr> res(port_num);
-        for (size_t i = 0; i < node->parentEdges.size(); i++) {
-            auto edge = node->getParentEdgeAt(i);
-            int port = edge->getOutputNum();
-            if (port < port_num && !res[port])
-                res[port] = edge;
-            else
-                res.push_back(edge);
-        }
-        node->parentEdges = {res.begin(), res.end()};
+       std::sort(node->parentEdges.begin(), node->parentEdges.end(), [](const EdgeWeakPtr& lhs, const EdgeWeakPtr& rhs) {
+           auto lhs_ptr = lhs.lock();
+           auto rhs_ptr = rhs.lock();
+           OPENVINO_ASSERT(lhs_ptr && rhs_ptr);
+           return lhs_ptr->getOutputNum() < rhs_ptr->getOutputNum();
+        });
 
         // Set execIndex of all nodes to default invaild value
         node->execIndex = -1;

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1466,37 +1466,58 @@ void Graph::Infer(SyncInferRequest* request) {
 void Graph::SortTopologically() {
     OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "Graph::SortTopologically");
 
+    for (auto &node : graphNodes) {
+        // Sort in / out Parent edges by port index
+        // Make first N (N == port_num) edge indexes match with port index
+        int port_num = node->inputShapes.size();
+        std::vector<EdgePtr> res(port_num);
+        for (size_t i = 0; i < node->parentEdges.size(); i++) {
+            auto edge = node->getParentEdgeAt(i);
+            int port = edge->getOutputNum();
+            if (port < port_num && !res[port])
+                res[port] = edge;
+            else
+                res.push_back(edge);
+        }
+        node->parentEdges = {res.begin(), res.end()};
+
+        // Set execIndex of all nodes to default invaild value
+        node->execIndex = -1;
+    }
+
     auto sort = [](const std::vector<NodePtr>& nodes) {
-        std::unordered_set<NodePtr> visited;
-        visited.reserve(nodes.size());
         std::vector<NodePtr> sorted;
         sorted.reserve(nodes.size());
 
+        int execIndexCnt = -1;
+
         std::function<void(const NodePtr)> visit;
-        visit = [&visited, &sorted, &visit](const NodePtr node) {
-            const bool inserted = visited.insert(node).second;
-            if (!inserted)
+        visit = [&execIndexCnt, &sorted, &visit](const NodePtr node) {
+            if (node->execIndex >= 0)
                 return; // already visited
 
             if (!node->parallelWith.empty()) {
                 for (auto& n : node->parallelWith) {
-                    for (size_t i = 0; i < n->getChildEdges().size(); i++) {
-                        visit(n->getChildEdgeAt(i)->getChild());
+                    for (size_t i = 0; i < n->getParentEdges().size(); i++) {
+                        visit(n->getParentEdgeAt(i)->getParent());
                     }
                 }
 
-                // make sure parallel nodes are always enqueue together
+                // parallel nodes has same execIndex
+                // so they can provide correct start/end time point for
+                // their input and output memory object
+                ++execIndexCnt;
                 for (auto& n : node->parallelWith) {
-                    if (std::find(sorted.begin(), sorted.end(), n) == sorted.end()) {
-                        sorted.push_back(n);
-                    }
+                    sorted.push_back(n);
+                    n->execIndex = execIndexCnt;
                 }
             } else {
-                for (size_t i = 0; i < node->getChildEdges().size(); i++) {
-                    visit(node->getChildEdgeAt(i)->getChild());
+                for (size_t i = 0; i < node->getParentEdges().size(); i++) {
+                    visit(node->getParentEdgeAt(i)->getParent());
                 }
 
                 sorted.push_back(node);
+                node->execIndex = ++execIndexCnt;
             }
         };
 
@@ -1507,42 +1528,7 @@ void Graph::SortTopologically() {
         return sorted;
     };
 
-    // as a first step sort in reversed topological order to avoid an insertion into the front of the vector
     graphNodes = sort(graphNodes);
-    // reverse to the actual topological order
-    std::reverse(graphNodes.begin(), graphNodes.end());
-    // number the nodes based on topological order
-    for (size_t i = 0; i < graphNodes.size(); i++) {
-        // parallel nodes has same execIndex
-        // so they can provide correct start/end time point for
-        // their input and output memory object
-        if (graphNodes[i]->parallelWith.size()) {
-            if (graphNodes[i]->parallelWith[0] == graphNodes[i]) {
-                for (auto& n : graphNodes[i]->parallelWith) {
-                    n->execIndex = static_cast<int>(i);
-                }
-            }
-            continue;
-        }
-        graphNodes[i]->execIndex = static_cast<int>(i);
-    }
-
-    // Sort in / out child edges by port index
-    // Make first N (N == port_num) edge indexes match with port index
-    for (auto &node : graphNodes) {
-        int port_num = node->outputShapes.size();
-        std::vector<EdgePtr> res(port_num);
-
-        for (size_t i = 0; i < node->childEdges.size(); i++) {
-            auto edge = node->getChildEdgeAt(i);
-            int port = edge->getInputNum();
-            if (port < port_num && !res[port])
-                res[port] = edge;
-            else
-                res.push_back(edge);
-        }
-        node->childEdges = {res.begin(), res.end()};
-    }
 }
 
 void Graph::GetPerfData(std::vector<ov::ProfilingInfo>& perfMap) const {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1471,7 +1471,7 @@ void Graph::SortTopologically() {
         node->execIndex = -1;
     }
 
-    auto sort = [](const std::vector<NodePtr>& nodes) {
+    auto sort = [this](const std::vector<NodePtr>& nodes) {
         std::vector<NodePtr> sorted;
         sorted.reserve(nodes.size());
 
@@ -1507,25 +1507,17 @@ void Graph::SortTopologically() {
             }
         };
 
+        // Always start from output nodes
+        for (auto&& kvp : outputNodesMap) {
+            visit(kvp.second);
+        }
+
         for (const auto& node : nodes) {
             visit(node);
         }
 
         return sorted;
     };
-
-    // Insert nodes in outputNodesMap in front of graphNodes to make sure it always
-    // start tranverse from outputs
-    graphNodes.erase(std::remove_if(graphNodes.begin(), graphNodes.end(), [&](const NodePtr node){
-        auto it = std::find_if(outputNodesMap.begin(), outputNodesMap.end(), [&](const std::pair<std::size_t, NodePtr>& kvp) {
-            return kvp.second == node;
-        });
-        return it != outputNodesMap.end();
-    }), graphNodes.end());
-
-    for (auto&& kvp : outputNodesMap) {
-        graphNodes.insert(graphNodes.begin(), kvp.second);
-    }
 
     graphNodes = sort(graphNodes);
 

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1529,6 +1529,23 @@ void Graph::SortTopologically() {
     };
 
     graphNodes = sort(graphNodes);
+
+    // Sort in / out child edges by port index
+    // Make first N (N == port_num) edge indexes match with port index
+    for (auto &node : graphNodes) {
+        int port_num = node->outputShapes.size();
+        std::vector<EdgePtr> res(port_num);
+
+        for (size_t i = 0; i < node->childEdges.size(); i++) {
+            auto edge = node->getChildEdgeAt(i);
+            int port = edge->getInputNum();
+            if (port < port_num && !res[port])
+                res[port] = edge;
+            else
+                res.push_back(edge);
+        }
+        node->childEdges = {res.begin(), res.end()};
+    }
 }
 
 void Graph::GetPerfData(std::vector<ov::ProfilingInfo>& perfMap) const {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1466,17 +1466,8 @@ void Graph::Infer(SyncInferRequest* request) {
 void Graph::SortTopologically() {
     OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "Graph::SortTopologically");
 
+    // Set execIndex of all nodes to default invaild value
     for (auto &node : graphNodes) {
-        // Sort in / out Parent edges by port index
-        // Make first N (N == port_num) edge indexes match with port index
-       std::sort(node->parentEdges.begin(), node->parentEdges.end(), [](const EdgeWeakPtr& lhs, const EdgeWeakPtr& rhs) {
-           auto lhs_ptr = lhs.lock();
-           auto rhs_ptr = rhs.lock();
-           OPENVINO_ASSERT(lhs_ptr && rhs_ptr);
-           return lhs_ptr->getOutputNum() < rhs_ptr->getOutputNum();
-        });
-
-        // Set execIndex of all nodes to default invaild value
         node->execIndex = -1;
     }
 

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -345,6 +345,8 @@ void Graph::InitGraph(bool optimize) {
     optimizer.ShareReorders(*this);
     RemoveDroppedNodes();
 
+    SortTopologically();
+
     ResolveComplexInplaceConflicts();
 
     optimizer.ApplyImplSpecificGraphOptimizations(*this);

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1514,6 +1514,16 @@ void Graph::SortTopologically() {
         return sorted;
     };
 
+    // Insert nodes in outputNodesMap in front of graphNodes to make sure it always
+    // start tranverse from outputs
+    graphNodes.erase(std::remove_if(graphNodes.begin(), graphNodes.end(), [](const NodePtr node){
+        return node->getTypeStr().compare("Result") == 0;
+    }), graphNodes.end());
+
+    for (auto&& kvp : outputNodesMap) {
+        graphNodes.insert(graphNodes.begin(), kvp.second);
+    }
+
     graphNodes = sort(graphNodes);
 
     // Sort in / out child edges by port index

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1507,6 +1507,14 @@ void Graph::SortTopologically() {
             }
         };
 
+        // First execute MemoryInput because it will change the memory pointer of
+        // its sibling MemoryOutput. So execute first to avoid potential issue.
+        for (const auto& node : nodes) {
+            if (node->getType() == Type::MemoryInput) {
+                visit(node);
+            }
+        }
+
         // Always start from output nodes
         for (auto&& kvp : outputNodesMap) {
             visit(kvp.second);

--- a/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
@@ -120,8 +120,8 @@ TEST(ResolveEdgeConflictsCPUTest2, smoke_Run_ResolveEdgeConflicts2) {
     auto org_Constant_1 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1}, std::vector<int64_t>{1});
     auto org_ScatterNDUpdate_411 = std::make_shared<ov::op::v3::ScatterNDUpdate>(org_ShapeOf_386, org_Constant_387, org_Constant_1);
 
-    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(org_ReduceProd_423),
-                             std::make_shared<ov::op::v0::Result>(org_ScatterNDUpdate_411)};
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(org_ScatterNDUpdate_411),
+                             std::make_shared<ov::op::v0::Result>(org_ReduceProd_423)};
 
     const auto model = std::make_shared<const ov::Model>(results, params, "test_graph");
     graph->CreateGraph(model, context);

--- a/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
@@ -8,8 +8,13 @@
 #include "nodes/input.h"
 #include "nodes/concat.h"
 #include "openvino/op/concat.hpp"
+#include "openvino/opsets/opset.hpp"
+#include "openvino/op/shape_of.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/result.hpp"
+#include "openvino/op/reduce_prod.hpp"
+#include "openvino/op/scatter_nd_update.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov::intel_cpu;
 
@@ -85,4 +90,46 @@ TEST(ResolveEdgeConflictsCPUTest, smoke_Run_ResolveEdgeConflicts) {
     // Check whether reorder is inserted
     NodePtr expected_reorder = dummyNode2->getParentEdgeAt(0)->getParent();
     ASSERT_EQ(expected_reorder->getType(), Type::Reorder);
+}
+
+TEST(ResolveEdgeConflictsCPUTest2, smoke_Run_ResolveEdgeConflicts2) {
+    /*  create graph:
+                                                    Parameter
+                                                       |
+                                                    ShapeOf      Parameter
+        <*NOTE: Should insert reorder here>         /      \        /
+        <*NOTE: inplaced>               ScatterNDUpdate     ReduceProd
+                                           |                   |
+                                         Result              Result
+    */
+    Config conf;
+    conf.rtCacheCapacity = 100;
+    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+
+    std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
+
+    const ov::element::Type_t testPrec = ov::element::Type_t::f32;
+    const ov::Shape testShape{1, 384};
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(testPrec, testShape),
+                               std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::i32, ov::Shape{})};
+    auto org_ShapeOf_386 = std::make_shared<ov::op::v3::ShapeOf>(params[0], ov::element::Type_t::i32);
+
+    auto org_ReduceProd_423 = std::make_shared<ov::op::v1::ReduceProd>(org_ShapeOf_386, params[1]);
+
+    auto org_Constant_387 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1, 1}, std::vector<int64_t>{1});
+    auto org_Constant_1 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1}, std::vector<int64_t>{1});
+    auto org_ScatterNDUpdate_411 = std::make_shared<ov::op::v3::ScatterNDUpdate>(org_ShapeOf_386, org_Constant_387, org_Constant_1);
+
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(org_ReduceProd_423),
+                             std::make_shared<ov::op::v0::Result>(org_ScatterNDUpdate_411)};
+
+    const auto model = std::make_shared<const ov::Model>(results, params, "test_graph");
+    graph->CreateGraph(model, context);
+    for (auto node : graph->GetNodes()) {
+        if (node->getType() == Type::ScatterNDUpdate) {
+            NodePtr expected_reorder = node->getParentEdgeAt(0)->getParent();
+            ASSERT_EQ(expected_reorder->getType(), Type::Reorder);
+            break;
+        }
+    }
 }


### PR DESCRIPTION
### Details:
 - *Align cpu execution order before/after ResolveComplexInplaceConflicts()*
 - *Keep order information of Results and Parameters when dump CPU graph to ov::Model*
 - *Let MemoryInput always execute first to avoid potential issue because it will update its sibling MemoryOutput memory after execution*

### Tickets:
 - *CVS-134638*
 - *CVS-148497*

### Description:
 - CPU execution order of some nodes may changes after https://github.com/openvinotoolkit/openvino/blob/2024.2.0.dev20240513/src/plugins/intel_cpu/src/graph.cpp#L285. Sometimes that may give ResolveComplexInplaceConflicts() incorrect execution order information. That may lead to  ResolveComplexInplaceConflicts() get the wrong conclusion which edge memory should be shared. So this PR add SortTopologically() right before ResolveComplexInplaceConflicts() to let execution order not change much before/after ResolveComplexInplaceConflicts()*
 - *The node order of CPU graph topology is not stable. For example in below graph*
![image](https://github.com/openvinotoolkit/openvino/assets/37289649/ca14e697-6986-4c30-9c2a-86603cc4a106)
*If Parameter0 is before than Parameter1 in graphNodes, in original SortTopologically(), it will first recurse node down from Parameter0. So in final sorted graphNodes, Parameter0 will be sorted after Parameter1. Then in second round of SortTopologically(), it will first recurse from Parameter1 and in final sorted graphNodes, Parameter0 will be sorted before Parameter0 again. This will make sometimes ReduceProd is executed before ScatterNDUpdate while sometimes ReduceProd is after ScatterNDUpdate. It will mislead ResolveComplexInplaceConflicts()*
- *MemoryInput will update its sibling MemoryOutput memory after execution. To avoid memory changes during the execution of other nodes, always let MemoryInput execute first*
