### PR TITLE
[Snippets] [ARM] Add subgraph tokenization for more Eltwise operations

### DIFF
--- a/src/common/snippets/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/src/pass/collapse_subgraph.cpp
@@ -124,6 +124,7 @@ auto is_supported_op(const std::shared_ptr<const Node> &n) -> bool {
             || ov::is_type<ov::op::v0::Erf>(n)
             || ov::is_type<ov::op::v0::Exp>(n)
             || ov::is_type<ov::op::v1::LogicalNot>(n)
+            || ov::is_type<ov::op::v4::Mish>(n)
             || ov::is_type<ov::op::v0::Negative>(n)
             || ov::is_type<ov::op::v0::Relu>(n)
             || ov::is_type<ov::op::v5::Round>(n)

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
@@ -741,6 +741,70 @@ std::set<std::vector<element::Type>> jit_gelu_tanh_emitter::get_supported_precis
     return {{element::f32}};
 }
 
+/// GELU_V7 ///
+jit_gelu_v7_emitter::jit_gelu_v7_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
+                                         dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
+                                         const std::shared_ptr<ov::Node>& node)
+        : jit_emitter(host, host_isa, node, get_arithmetic_binary_exec_precision(node)) {
+    const auto gelu = std::dynamic_pointer_cast<ov::op::v7::Gelu>(node);
+    if (gelu == nullptr) {
+        OV_CPU_JIT_EMITTER_THROW("Can't cast to ov::op::v7::Gelu");
+    }
+    approximationMode = gelu->get_approximation_mode();
+    if (approximationMode == ov::op::GeluApproximationMode::ERF) {
+        gelu_erf_emitter = std::make_unique<jit_gelu_erf_emitter>(h, host_isa, node);
+    } else if (approximationMode == ov::op::GeluApproximationMode::TANH) {
+        gelu_tanh_emitter = std::make_unique<jit_gelu_tanh_emitter>(h, host_isa, node);
+    } else {
+        OV_CPU_JIT_EMITTER_THROW("Unsupported Gelu approximation mode");
+    }
+}
+
+size_t jit_gelu_v7_emitter::get_inputs_count() const { return 1; }
+
+size_t jit_gelu_v7_emitter::get_aux_vecs_count() const {
+    return approximationMode == ov::op::GeluApproximationMode::ERF ?
+           gelu_erf_emitter->get_aux_vecs_count() :
+           gelu_tanh_emitter->get_aux_vecs_count();
+}
+
+size_t jit_gelu_v7_emitter::get_aux_gprs_count() const {
+    return approximationMode == ov::op::GeluApproximationMode::ERF ?
+           gelu_erf_emitter->get_aux_gprs_count() :
+           gelu_tanh_emitter->get_aux_gprs_count();
+}
+
+void jit_gelu_v7_emitter::emit_impl(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const {
+    if (host_isa_ == dnnl::impl::cpu::aarch64::asimd) {
+        emit_isa<dnnl::impl::cpu::aarch64::asimd>(in_vec_idxs, out_vec_idxs);
+    } else {
+        OV_CPU_JIT_EMITTER_THROW("Can't create jit eltwise kernel");
+    }
+}
+
+template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+void jit_gelu_v7_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const {
+    approximationMode == ov::op::GeluApproximationMode::ERF ?
+    gelu_erf_emitter->emit_code(in_vec_idxs, out_vec_idxs, aux_vec_idxs, aux_gpr_idxs) :
+    gelu_tanh_emitter->emit_code(in_vec_idxs, out_vec_idxs, aux_vec_idxs, aux_gpr_idxs);
+}
+
+void jit_gelu_v7_emitter::register_table_entries() {
+    approximationMode == ov::op::GeluApproximationMode::ERF ?
+    gelu_erf_emitter->register_table_entries() :
+    gelu_tanh_emitter->register_table_entries();
+}
+
+void jit_gelu_v7_emitter::emit_data() const {
+    approximationMode == ov::op::GeluApproximationMode::ERF ?
+    gelu_erf_emitter->emit_data() :
+    gelu_tanh_emitter->emit_data();
+}
+
+std::set<std::vector<element::Type>> jit_gelu_v7_emitter::get_supported_precisions(const std::shared_ptr<ov::Node>& node) {
+    return {{element::f32}};
+}
+
 /// HARD_SWISH ///
 jit_hswish_emitter::jit_hswish_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
                                                  dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "jit_eltwise_emitters.hpp"
+#include "transformations/cpu_opset/common/op/swish_cpu.hpp"
 
 #include <memory>
 #include "common/utils.hpp"
@@ -1618,6 +1619,12 @@ jit_swish_emitter::jit_swish_emitter(dnnl::impl::cpu::aarch64::jit_generator* ho
                                      dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
                                      const std::shared_ptr<ov::Node>& node)
         : jit_emitter(host, host_isa, node, get_arithmetic_binary_exec_precision(node)) {
+    const auto swish = std::dynamic_pointer_cast<SwishNode>(node);
+    if (swish == nullptr) {
+        OV_CPU_JIT_EMITTER_THROW("Can't cast to SwishNode");
+    }
+    beta = static_cast<float>(swish->get_alpha());
+
     prepare_table();
     sigmoid_emitter = std::make_unique<jit_sigmoid_emitter>(h, host_isa, node);
 }

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
@@ -936,7 +936,7 @@ void jit_maximum_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const
 }
 
 std::set<std::vector<element::Type>> jit_maximum_emitter::get_supported_precisions(const std::shared_ptr<ov::Node>& node) {
-    return {{element::f32}, {element::f32}};
+    return {{element::f32, element::f32}};
 }
 
 /// MIN ///
@@ -974,7 +974,7 @@ void jit_minimum_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const
 }
 
 std::set<std::vector<element::Type>> jit_minimum_emitter::get_supported_precisions(const std::shared_ptr<ov::Node>& node) {
-    return {{element::f32}, {element::f32}};
+    return {{element::f32, element::f32}};
 }
 
 /// MISH ///

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.hpp
@@ -214,18 +214,7 @@ private:
     void emit_isa(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const;
 };
 
-class jit_gelu_base_emitter : public jit_emitter {
-public:
-    jit_gelu_base_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
-                          dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
-                          const ov::element::Type exec_prc = ov::element::f32);
-
-    jit_gelu_base_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
-                          dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
-                          const std::shared_ptr<ov::Node>& node);
-};
-
-class jit_gelu_erf_emitter : public jit_gelu_base_emitter {
+class jit_gelu_erf_emitter : public jit_emitter {
 public:
     jit_gelu_erf_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
                          dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
@@ -258,7 +247,7 @@ private:
 
 class jit_tanh_emitter;
 
-class jit_gelu_tanh_emitter : public jit_gelu_base_emitter {
+class jit_gelu_tanh_emitter : public jit_emitter {
 public:
     jit_gelu_tanh_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
                           dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
@@ -282,31 +271,6 @@ public:
 
 private:
     std::unique_ptr<jit_tanh_emitter> tanh_emitter;
-
-    void emit_impl(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const override;
-
-    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
-    void emit_isa(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const;
-};
-
-class jit_gelu_v7_emitter : public jit_emitter {
-public:
-    jit_gelu_v7_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
-                        dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
-                        const std::shared_ptr<ov::Node>& node);
-
-    size_t get_inputs_count() const override;
-
-    size_t get_aux_vecs_count() const override;
-
-    size_t get_aux_gprs_count() const override;
-
-    void emit_data() const override;
-
-    static std::set<std::vector<element::Type>> get_supported_precisions(const std::shared_ptr<ov::Node>& node = nullptr);
-
-private:
-    std::shared_ptr<jit_gelu_base_emitter> gelu_emitter;
 
     void emit_impl(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const override;
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.hpp
@@ -278,6 +278,35 @@ private:
     void emit_isa(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const;
 };
 
+class jit_gelu_v7_emitter : public jit_emitter {
+public:
+    jit_gelu_v7_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
+                        dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
+                        const std::shared_ptr<ov::Node>& node);
+
+    size_t get_inputs_count() const override;
+
+    size_t get_aux_vecs_count() const override;
+
+    size_t get_aux_gprs_count() const override;
+
+    void register_table_entries() override;
+
+    void emit_data() const override;
+
+    static std::set<std::vector<element::Type>> get_supported_precisions(const std::shared_ptr<ov::Node>& node = nullptr);
+
+private:
+    ov::op::GeluApproximationMode approximationMode;
+    std::unique_ptr<jit_gelu_erf_emitter> gelu_erf_emitter;
+    std::unique_ptr<jit_gelu_tanh_emitter> gelu_tanh_emitter;
+
+    void emit_impl(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const override;
+
+    template <dnnl::impl::cpu::aarch64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const;
+};
+
 class jit_hswish_emitter : public jit_emitter {
 public:
     jit_hswish_emitter(dnnl::impl::cpu::aarch64::jit_generator *host,

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.hpp
@@ -214,7 +214,18 @@ private:
     void emit_isa(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const;
 };
 
-class jit_gelu_erf_emitter : public jit_emitter {
+class jit_gelu_base_emitter : public jit_emitter {
+public:
+    jit_gelu_base_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
+                          dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
+                          const ov::element::Type exec_prc = ov::element::f32);
+
+    jit_gelu_base_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
+                          dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
+                          const std::shared_ptr<ov::Node>& node);
+};
+
+class jit_gelu_erf_emitter : public jit_gelu_base_emitter {
 public:
     jit_gelu_erf_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
                          dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
@@ -247,7 +258,7 @@ private:
 
 class jit_tanh_emitter;
 
-class jit_gelu_tanh_emitter : public jit_emitter {
+class jit_gelu_tanh_emitter : public jit_gelu_base_emitter {
 public:
     jit_gelu_tanh_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
                           dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
@@ -290,16 +301,12 @@ public:
 
     size_t get_aux_gprs_count() const override;
 
-    void register_table_entries() override;
-
     void emit_data() const override;
 
     static std::set<std::vector<element::Type>> get_supported_precisions(const std::shared_ptr<ov::Node>& node = nullptr);
 
 private:
-    ov::op::GeluApproximationMode approximationMode;
-    std::unique_ptr<jit_gelu_erf_emitter> gelu_erf_emitter;
-    std::unique_ptr<jit_gelu_tanh_emitter> gelu_tanh_emitter;
+    std::shared_ptr<jit_gelu_base_emitter> gelu_emitter;
 
     void emit_impl(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const override;
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -92,6 +92,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     // unary
     jitters[ov::op::v0::Abs::get_type_info_static()] = CREATE_CPU_EMITTER(jit_abs_emitter);
     jitters[ov::op::v0::Clamp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_clamp_emitter);
+    jitters[ov::op::v0::Elu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_elu_emitter);
     jitters[ov::op::v0::Exp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_exp_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
     jitters[ov::op::v0::Tanh::get_type_info_static()] = CREATE_CPU_EMITTER(jit_tanh_emitter);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -90,6 +90,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     jitters[op::v1::Multiply::get_type_info_static()] = CREATE_CPU_EMITTER(jit_multiply_emitter);
 
     // unary
+    jitters[ov::op::v0::Abs::get_type_info_static()] = CREATE_CPU_EMITTER(jit_abs_emitter);
     jitters[ov::op::v0::Exp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_exp_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
     jitters[ov::op::v0::Tanh::get_type_info_static()] = CREATE_CPU_EMITTER(jit_tanh_emitter);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -91,6 +91,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
 
     // unary
     jitters[ov::op::v0::Abs::get_type_info_static()] = CREATE_CPU_EMITTER(jit_abs_emitter);
+    jitters[ov::op::v0::Clamp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_clamp_emitter);
     jitters[ov::op::v0::Exp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_exp_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
     jitters[ov::op::v0::Tanh::get_type_info_static()] = CREATE_CPU_EMITTER(jit_tanh_emitter);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -96,6 +96,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     jitters[ov::op::v0::Exp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_exp_emitter);
     jitters[ov::op::v4::HSwish::get_type_info_static()] = CREATE_CPU_EMITTER(jit_hswish_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
+    jitters[ov::op::v0::Sigmoid::get_type_info_static()] = CREATE_CPU_EMITTER(jit_sigmoid_emitter);
     jitters[ov::op::v0::Tanh::get_type_info_static()] = CREATE_CPU_EMITTER(jit_tanh_emitter);
 
     // control flow

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -14,6 +14,7 @@
 #include "emitters/snippets/aarch64/jit_fill_emitter.hpp"
 
 #include "transformations/snippets/common/op/fused_mul_add.hpp"
+#include "transformations/cpu_opset/common/op/swish_cpu.hpp"
 
 #include "openvino/opsets/opset13.hpp"
 
@@ -97,6 +98,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     jitters[ov::op::v4::HSwish::get_type_info_static()] = CREATE_CPU_EMITTER(jit_hswish_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
     jitters[ov::op::v0::Sigmoid::get_type_info_static()] = CREATE_CPU_EMITTER(jit_sigmoid_emitter);
+    jitters[ov::intel_cpu::SwishNode::get_type_info_static()] = CREATE_CPU_EMITTER(jit_swish_emitter);
     jitters[ov::op::v0::Tanh::get_type_info_static()] = CREATE_CPU_EMITTER(jit_tanh_emitter);
 
     // control flow
@@ -155,7 +157,8 @@ std::shared_ptr<snippets::Generator> CPUGenerator::clone() const {
 
 ov::snippets::RegType CPUGenerator::get_specific_op_out_reg_type(const ov::Output<ov::Node>& out) const {
     const auto op = out.get_node_shared_ptr();
-    if (std::dynamic_pointer_cast<intel_cpu::FusedMulAdd>(op))
+    if (std::dynamic_pointer_cast<intel_cpu::FusedMulAdd>(op) ||
+        std::dynamic_pointer_cast<intel_cpu::SwishNode>(op))
         return ov::snippets::RegType::vec;
     else
         return ov::snippets::RegType::undefined;

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -88,6 +88,8 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     // binary
     jitters[op::v1::Add::get_type_info_static()] = CREATE_CPU_EMITTER(jit_add_emitter);
     jitters[op::v1::Divide::get_type_info_static()] = CREATE_CPU_EMITTER(jit_divide_emitter);
+    jitters[op::v1::Maximum::get_type_info_static()] = CREATE_CPU_EMITTER(jit_maximum_emitter);
+    jitters[op::v1::Minimum::get_type_info_static()] = CREATE_CPU_EMITTER(jit_minimum_emitter);
     jitters[op::v1::Mod::get_type_info_static()] = CREATE_CPU_EMITTER(jit_mod_emitter);
     jitters[op::v1::Multiply::get_type_info_static()] = CREATE_CPU_EMITTER(jit_multiply_emitter);
     jitters[op::v1::Subtract::get_type_info_static()] = CREATE_CPU_EMITTER(jit_subtract_emitter);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -94,6 +94,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     jitters[ov::op::v0::Clamp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_clamp_emitter);
     jitters[ov::op::v0::Elu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_elu_emitter);
     jitters[ov::op::v0::Exp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_exp_emitter);
+    jitters[ov::op::v4::HSwish::get_type_info_static()] = CREATE_CPU_EMITTER(jit_hswish_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
     jitters[ov::op::v0::Tanh::get_type_info_static()] = CREATE_CPU_EMITTER(jit_tanh_emitter);
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -101,6 +101,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     jitters[ov::op::v0::Exp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_exp_emitter);
     jitters[ov::op::v0::Floor::get_type_info_static()] = CREATE_CPU_EMITTER(jit_floor_emitter);
     jitters[ov::op::v4::HSwish::get_type_info_static()] = CREATE_CPU_EMITTER(jit_hswish_emitter);
+    jitters[ov::op::v4::Mish::get_type_info_static()] = CREATE_CPU_EMITTER(jit_mish_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
     jitters[ov::op::v0::Sigmoid::get_type_info_static()] = CREATE_CPU_EMITTER(jit_sigmoid_emitter);
     jitters[ov::intel_cpu::SwishNode::get_type_info_static()] = CREATE_CPU_EMITTER(jit_swish_emitter);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -96,6 +96,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     jitters[ov::op::v0::Clamp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_clamp_emitter);
     jitters[ov::op::v0::Elu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_elu_emitter);
     jitters[ov::op::v0::Exp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_exp_emitter);
+    jitters[ov::op::v0::Floor::get_type_info_static()] = CREATE_CPU_EMITTER(jit_floor_emitter);
     jitters[ov::op::v4::HSwish::get_type_info_static()] = CREATE_CPU_EMITTER(jit_hswish_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);
     jitters[ov::op::v0::Sigmoid::get_type_info_static()] = CREATE_CPU_EMITTER(jit_sigmoid_emitter);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -90,6 +90,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     jitters[op::v1::Divide::get_type_info_static()] = CREATE_CPU_EMITTER(jit_divide_emitter);
     jitters[op::v1::Mod::get_type_info_static()] = CREATE_CPU_EMITTER(jit_mod_emitter);
     jitters[op::v1::Multiply::get_type_info_static()] = CREATE_CPU_EMITTER(jit_multiply_emitter);
+    jitters[op::v1::Subtract::get_type_info_static()] = CREATE_CPU_EMITTER(jit_subtract_emitter);
 
     // unary
     jitters[ov::op::v0::Abs::get_type_info_static()] = CREATE_CPU_EMITTER(jit_abs_emitter);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -88,6 +88,7 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     // binary
     jitters[op::v1::Add::get_type_info_static()] = CREATE_CPU_EMITTER(jit_add_emitter);
     jitters[op::v1::Divide::get_type_info_static()] = CREATE_CPU_EMITTER(jit_divide_emitter);
+    jitters[op::v1::Mod::get_type_info_static()] = CREATE_CPU_EMITTER(jit_mod_emitter);
     jitters[op::v1::Multiply::get_type_info_static()] = CREATE_CPU_EMITTER(jit_multiply_emitter);
 
     // unary

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -100,6 +100,8 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa)
     jitters[ov::op::v0::Elu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_elu_emitter);
     jitters[ov::op::v0::Exp::get_type_info_static()] = CREATE_CPU_EMITTER(jit_exp_emitter);
     jitters[ov::op::v0::Floor::get_type_info_static()] = CREATE_CPU_EMITTER(jit_floor_emitter);
+    jitters[ov::op::v0::Gelu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_gelu_erf_emitter);
+    jitters[ov::op::v7::Gelu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_gelu_v7_emitter);
     jitters[ov::op::v4::HSwish::get_type_info_static()] = CREATE_CPU_EMITTER(jit_hswish_emitter);
     jitters[ov::op::v4::Mish::get_type_info_static()] = CREATE_CPU_EMITTER(jit_mish_emitter);
     jitters[ov::op::v0::Relu::get_type_info_static()] = CREATE_CPU_EMITTER(jit_relu_emitter);

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -631,7 +631,7 @@ Subgraph::DataFlowPasses Subgraph::getDataFlowPasses() const {
 #    define SNIPPETS_REGISTER_PASS_RELATIVE_X86_64(PASS_PLACE, TARGET_PASS, PASS, ...)
 #endif  // OPENVINO_ARCH_X86_64
 
-    SNIPPETS_REGISTER_PASS_ABSOLUTE_X86_64(Place::PipelineStart, ConvertToSwishCPU);
+    SNIPPETS_REGISTER_PASS_ABSOLUTE_COMMON(Place::PipelineStart, ConvertToSwishCPU);
     if (context->getConfig().inferencePrecision == ov::element::bf16 && subgraph_attrs->snippet->has_domain_sensitive_ops()) {
         // enforce BF16 precisions to supported operations
         // MatMul has to be decomposed to Brgemm operations before enforcement

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -77,6 +77,7 @@ bool SupportsFusingWithConvolution_Simple(const std::shared_ptr<const Node> &nod
     // Skip them here, when they are supported by Snippets ARM. Ticket: 141170.
     return ov::is_type<ov::op::v0::Abs>(node) ||
            ov::is_type<ov::op::v0::Clamp>(node) ||
+           ov::is_type<ov::op::v0::Elu>(node) ||
            ov::is_type<ov::op::v0::Relu>(node) ||
            ov::is_type<ov::op::v0::Tanh>(node);
 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -75,8 +75,9 @@ bool isFullyConnected(const std::shared_ptr<const ov::Node>& node) {
 bool SupportsFusingWithConvolution_Simple(const std::shared_ptr<const Node> &node) {
     // Note: some other operations support this fusing (Abs, Clamp, Elu, Sigmoid, SoftPlus, Sqrt).
     // Skip them here, when they are supported by Snippets ARM. Ticket: 141170.
-    return ov::is_type<ov::op::v0::Tanh>(node) ||
-           ov::is_type<ov::op::v0::Relu>(node);
+    return ov::is_type<ov::op::v0::Abs>(node) ||
+           ov::is_type<ov::op::v0::Relu>(node) ||
+           ov::is_type<ov::op::v0::Tanh>(node);
 }
 // Convolution is a special case, since it supports peculiar fusings
 bool isSuitableConvolutionParent(const std::shared_ptr<const Node> &node) {

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -79,6 +79,7 @@ bool SupportsFusingWithConvolution_Simple(const std::shared_ptr<const Node> &nod
            ov::is_type<ov::op::v0::Clamp>(node) ||
            ov::is_type<ov::op::v0::Elu>(node) ||
            ov::is_type<ov::op::v0::Relu>(node) ||
+           ov::is_type<ov::op::v0::Sigmoid>(node) ||
            ov::is_type<ov::op::v0::Tanh>(node);
 }
 // Convolution is a special case, since it supports peculiar fusings

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -73,7 +73,7 @@ bool isFullyConnected(const std::shared_ptr<const ov::Node>& node) {
 }
 
 bool SupportsFusingWithConvolution_Simple(const std::shared_ptr<const Node> &node) {
-    // Note: some other operations support this fusing (Abs, Clamp, Elu, Sigmoid, SoftPlus, Sqrt).
+    // Note: some other operations support this fusing (SoftPlus, Sqrt).
     // Skip them here, when they are supported by Snippets ARM. Ticket: 141170.
     return ov::is_type<ov::op::v0::Abs>(node) ||
            ov::is_type<ov::op::v0::Clamp>(node) ||

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -76,6 +76,7 @@ bool SupportsFusingWithConvolution_Simple(const std::shared_ptr<const Node> &nod
     // Note: some other operations support this fusing (Abs, Clamp, Elu, Sigmoid, SoftPlus, Sqrt).
     // Skip them here, when they are supported by Snippets ARM. Ticket: 141170.
     return ov::is_type<ov::op::v0::Abs>(node) ||
+           ov::is_type<ov::op::v0::Clamp>(node) ||
            ov::is_type<ov::op::v0::Relu>(node) ||
            ov::is_type<ov::op::v0::Tanh>(node);
 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/shape_inference.cpp
@@ -5,6 +5,7 @@
 #include "shape_inference.hpp"
 #include "snippets/shape_inference/shape_infer_instances.hpp"
 #include "transformations/snippets/common/op/fused_mul_add.hpp"
+#include "transformations/cpu_opset/common/op/swish_cpu.hpp"
 
 namespace ov {
 namespace snippets {
@@ -26,7 +27,8 @@ ShapeInferPtr CPUShapeInferSnippetsFactory::get_specific_op_shape_infer(const ov
     { OP::get_type_info_static(), [](const std::shared_ptr<ov::Node>& n) { return std::make_shared<InferType>(n);} }
 
 const CPUShapeInferSnippetsFactory::TRegistry CPUShapeInferSnippetsFactory::specific_ops_registry {
-    SHAPE_INFER_PREDEFINED(ov::intel_cpu::FusedMulAdd, NumpyBroadcastShapeInfer)
+    SHAPE_INFER_PREDEFINED(ov::intel_cpu::FusedMulAdd, NumpyBroadcastShapeInfer),
+    SHAPE_INFER_PREDEFINED(ov::intel_cpu::SwishNode, PassThroughShapeInfer),
 };
 #undef SHAPE_INFER_OP_SPECIFIC
 #undef SHAPE_INFER_PREDEFINED

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -952,6 +952,8 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v0::Elu>(n) ||
                 ov::is_type<ov::op::v0::Exp>(n) ||
                 ov::is_type<ov::op::v0::Floor>(n) ||
+                ov::is_type<ov::op::v0::Gelu>(n) ||
+                ov::is_type<ov::op::v7::Gelu>(n) ||
                 ov::is_type<ov::op::v4::HSwish>(n) ||
                 ov::is_type<ov::op::v1::Maximum>(n) ||
                 ov::is_type<ov::op::v1::Minimum>(n) ||

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -951,6 +951,7 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v1::Divide>(n) ||
                 ov::is_type<ov::op::v0::Elu>(n) ||
                 ov::is_type<ov::op::v0::Exp>(n) ||
+                ov::is_type<ov::op::v0::Floor>(n) ||
                 ov::is_type<ov::op::v4::HSwish>(n) ||
                 ov::is_type<ov::op::v1::Mod>(n) ||
                 ov::is_type<ov::op::v1::Multiply>(n) ||

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -955,6 +955,7 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v4::HSwish>(n) ||
                 ov::is_type<ov::op::v1::Maximum>(n) ||
                 ov::is_type<ov::op::v1::Minimum>(n) ||
+                ov::is_type<ov::op::v4::Mish>(n) ||
                 ov::is_type<ov::op::v1::Mod>(n) ||
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Relu>(n) ||
@@ -968,6 +969,10 @@ void Transformations::MainSnippets(void) {
             return ov::is_type<const ov::op::v4::Swish>(n) && n->inputs().size() > 1 &&
                    !ov::is_type<const ov::op::v0::Constant>(n->get_input_node_shared_ptr(1));
         };
+        // CPU Plugin does not support the following ops for x64
+        auto is_unsupported_by_x64 = [](const std::shared_ptr<const ov::Node> &n) {
+            return ov::is_type<const ov::op::v4::Mish>(n);
+        };
         // todo: general tokenization flow is not currently supported for these operations.
         // they can be tokenized only as a part of complex patterns
         auto is_unsupported_by_common_tokenization = [](const std::shared_ptr<const ov::Node> &n) {
@@ -980,7 +985,7 @@ void Transformations::MainSnippets(void) {
                     ov::is_type<const ov::op::v1::ReduceMax>(n) ||
                     ov::is_type<const ov::op::v1::ReduceSum>(n));
         };
-        return !is_unsupported_swish(n) && !is_unsupported_by_common_tokenization(n);
+        return !is_unsupported_swish(n) && !is_unsupported_by_x64(n) && !is_unsupported_by_common_tokenization(n);
 #endif
     };
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -951,6 +951,7 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v1::Divide>(n) ||
                 ov::is_type<ov::op::v0::Elu>(n) ||
                 ov::is_type<ov::op::v0::Exp>(n) ||
+                ov::is_type<ov::op::v4::HSwish>(n) ||
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Relu>(n) ||
                 ov::is_type<ov::op::v0::Tanh>(n));

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -954,6 +954,7 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v4::HSwish>(n) ||
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Relu>(n) ||
+                ov::is_type<ov::op::v0::Sigmoid>(n) ||
                 ov::is_type<ov::op::v0::Tanh>(n));
 #else
         // CPU Plugin support Swish in Subgraph via conversion to SwichCPU which assumes second input to be constant

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -957,6 +957,7 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Relu>(n) ||
                 ov::is_type<ov::op::v0::Sigmoid>(n) ||
+                ov::is_type<ov::op::v1::Subtract>(n) ||
                 ov::is_type<ov::op::v4::Swish>(n) ||
                 ov::is_type<ov::op::v0::Tanh>(n));
 #else

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -945,7 +945,8 @@ void Transformations::MainSnippets(void) {
 
     auto is_supported_op = [](const std::shared_ptr<const ov::Node> &n) -> bool {
 #if defined(OPENVINO_ARCH_ARM64)
-        return (ov::is_type<ov::op::v1::Add>(n) ||
+        return (ov::is_type<ov::op::v0::Abs>(n) ||
+                ov::is_type<ov::op::v1::Add>(n) ||
                 ov::is_type<ov::op::v1::Divide>(n) ||
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Exp>(n) ||

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -955,6 +955,7 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Relu>(n) ||
                 ov::is_type<ov::op::v0::Sigmoid>(n) ||
+                ov::is_type<ov::op::v4::Swish>(n) ||
                 ov::is_type<ov::op::v0::Tanh>(n));
 #else
         // CPU Plugin support Swish in Subgraph via conversion to SwichCPU which assumes second input to be constant

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -952,6 +952,7 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v0::Elu>(n) ||
                 ov::is_type<ov::op::v0::Exp>(n) ||
                 ov::is_type<ov::op::v4::HSwish>(n) ||
+                ov::is_type<ov::op::v1::Mod>(n) ||
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Relu>(n) ||
                 ov::is_type<ov::op::v0::Sigmoid>(n) ||

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -947,6 +947,7 @@ void Transformations::MainSnippets(void) {
 #if defined(OPENVINO_ARCH_ARM64)
         return (ov::is_type<ov::op::v0::Abs>(n) ||
                 ov::is_type<ov::op::v1::Add>(n) ||
+                ov::is_type<ov::op::v0::Clamp>(n) ||
                 ov::is_type<ov::op::v1::Divide>(n) ||
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Exp>(n) ||

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -953,6 +953,8 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v0::Exp>(n) ||
                 ov::is_type<ov::op::v0::Floor>(n) ||
                 ov::is_type<ov::op::v4::HSwish>(n) ||
+                ov::is_type<ov::op::v1::Maximum>(n) ||
+                ov::is_type<ov::op::v1::Minimum>(n) ||
                 ov::is_type<ov::op::v1::Mod>(n) ||
                 ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Relu>(n) ||

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -949,8 +949,9 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v1::Add>(n) ||
                 ov::is_type<ov::op::v0::Clamp>(n) ||
                 ov::is_type<ov::op::v1::Divide>(n) ||
-                ov::is_type<ov::op::v1::Multiply>(n) ||
+                ov::is_type<ov::op::v0::Elu>(n) ||
                 ov::is_type<ov::op::v0::Exp>(n) ||
+                ov::is_type<ov::op::v1::Multiply>(n) ||
                 ov::is_type<ov::op::v0::Relu>(n) ||
                 ov::is_type<ov::op::v0::Tanh>(n));
 #else

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -238,6 +238,7 @@ const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activat
         {Exp,         {{}}},
         {Clamp,       {{-2.0f, 2.0f}}},
         {Elu,         {{0.1f}}},
+        {Floor,       {{}}},
         {Relu,        {{}}},
         {HSwish,      {{}}},
         {Sigmoid,     {{}}},

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -241,6 +241,7 @@ const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activat
         {Relu,        {{}}},
         {HSwish,      {{}}},
         {Sigmoid,     {{}}},
+        {Swish,       {{0.1f}}},
         {Tanh,        {{}}},
     };
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -240,6 +240,7 @@ const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activat
         {Elu,         {{0.1f}}},
         {Relu,        {{}}},
         {HSwish,      {{}}},
+        {Sigmoid,     {{}}},
         {Tanh,        {{}}},
     };
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -236,6 +236,7 @@ const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activat
     static const std::map<utils::ActivationTypes, std::vector<std::vector<float>>> activationTypes {
         {Abs,         {{}}},
         {Exp,         {{}}},
+        {Clamp,       {{-2.0f, 2.0f}}},
         {Relu,        {{}}},
         {Tanh,        {{}}},
     };

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -237,6 +237,7 @@ const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activat
         {Abs,         {{}}},
         {Exp,         {{}}},
         {Clamp,       {{-2.0f, 2.0f}}},
+        {Elu,         {{0.1f}}},
         {Relu,        {{}}},
         {Tanh,        {{}}},
     };

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -239,6 +239,8 @@ const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activat
         {Clamp,       {{-2.0f, 2.0f}}},
         {Elu,         {{0.1f}}},
         {Floor,       {{}}},
+        {GeluErf,     {{}}},
+        {GeluTanh,    {{}}},
         {Relu,        {{}}},
         {HSwish,      {{}}},
 #if defined(OPENVINO_ARCH_ARM64)

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -241,6 +241,9 @@ const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activat
         {Floor,       {{}}},
         {Relu,        {{}}},
         {HSwish,      {{}}},
+#if defined(OPENVINO_ARCH_ARM64)
+        {Mish,        {{}}},
+#endif
         {Sigmoid,     {{}}},
         {Swish,       {{0.1f}}},
         {Tanh,        {{}}},

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -239,6 +239,7 @@ const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activat
         {Clamp,       {{-2.0f, 2.0f}}},
         {Elu,         {{0.1f}}},
         {Relu,        {{}}},
+        {HSwish,      {{}}},
         {Tanh,        {{}}},
     };
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.hpp
@@ -22,7 +22,8 @@ using ActivationLayerCPUTestParamSet =
                ov::element::Type,                                      // Net precision
                ov::element::Type,                                      // Input precision
                ov::element::Type,                                      // Output precision
-               CPUTestUtils::CPUSpecificParams>;
+               CPUTestUtils::CPUSpecificParams,
+               bool>;
 
 class ActivationLayerCPUTest : public testing::WithParamInterface<ActivationLayerCPUTestParamSet>,
                                virtual public ov::test::SubgraphBaseTest,
@@ -49,6 +50,7 @@ namespace Activation {
 const std::vector<size_t> activationShapes();
 
 const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activationTypes();
+const std::map<utils::ActivationTypes, std::vector<std::vector<float>>>& activationTypesSnippets();
 
 const std::vector<ov::element::Type>& netPrc();
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.cpp
@@ -314,6 +314,15 @@ const std::vector<utils::EltwiseTypes>& eltwiseOpTypesBinInp() {
     return eltwiseOpTypesBinInp;
 }
 
+const std::vector<utils::EltwiseTypes>& eltwiseOpTypesBinInpSnippets() {
+    static const std::vector<utils::EltwiseTypes> eltwiseOpTypesBinInp = {
+        utils::EltwiseTypes::ADD,
+        utils::EltwiseTypes::MULTIPLY,
+        utils::EltwiseTypes::MOD,
+    };
+    return eltwiseOpTypesBinInp;
+}
+
 const std::vector<utils::EltwiseTypes>& eltwiseOpTypesDiffInp() {
     static const std::vector<utils::EltwiseTypes> eltwiseOpTypesDiffInp = { // Different number of input nodes depending on optimizations
         utils::EltwiseTypes::POWER,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.hpp
@@ -51,6 +51,7 @@ const std::vector<utils::EltwiseTypes>& eltwiseOpTypesBinInp();
 const std::vector<utils::InputLayerType>& secondaryInputTypes();
 
 const std::vector<utils::EltwiseTypes>& eltwiseOpTypesBinInp();
+const std::vector<utils::EltwiseTypes>& eltwiseOpTypesBinInpSnippets();
 const std::vector<utils::EltwiseTypes>& eltwiseOpTypesDiffInp();
 const std::vector<utils::EltwiseTypes>& eltwiseOpTypesBinDyn();
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.cpp
@@ -77,7 +77,14 @@ void ExtremumLayerCPUTest::SetUp() {
 }
 
 std::string ExtremumLayerCPUTest::getPrimitiveType() {
+#if defined(OV_CPU_WITH_ACL)
+#if defined(OPENVINO_ARCH_ARM64)
     return "jit";
+#endif
+    return "acl";
+#else
+    return CPUTestsBase::getPrimitiveType();
+#endif
 }
 
 TEST_P(ExtremumLayerCPUTest, CompareWithRefs) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.cpp
@@ -1,0 +1,127 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "extremum.hpp"
+#include "internal_properties.hpp"
+#include "common_test_utils/node_builders/extremum.hpp"
+#include "shared_test_classes/single_op/minimum_maximum.hpp"
+
+namespace ov {
+namespace test {
+
+using namespace CPUTestUtils;
+using namespace ov::test::utils;
+
+std::string ExtremumLayerCPUTest::getTestCaseName(const testing::TestParamInfo<ExtremumLayerCPUTestParamSet> &obj) {
+    std::vector<ov::test::InputShape> inputShapes;
+    utils::MinMaxOpType extremumType;
+    ov::element::Type netPrecision, inPrecision, outPrecision;
+    CPUTestUtils::CPUSpecificParams cpuParams;
+    bool enforceSnippets;
+    std::tie(inputShapes, extremumType, netPrecision, inPrecision, outPrecision, cpuParams, enforceSnippets) = obj.param;
+    std::ostringstream result;
+    result << extremumNames[extremumType] << "_";
+    if (inputShapes.front().first.size() != 0) {
+        result << "IS=(";
+        for (const auto &shape : inputShapes) {
+            result << ov::test::utils::partialShape2str({shape.first}) << "_";
+        }
+        result.seekp(-1, result.cur);
+        result << ")_";
+    }
+    result << "TS=";
+    for (const auto& shape : inputShapes) {
+        for (const auto& item : shape.second) {
+            result << ov::test::utils::vec2str(item) << "_";
+        }
+    }
+    result << "netPRC=" << netPrecision.to_string() << "_";
+    result << "inPRC=" << inPrecision.to_string() << "_";
+    result << "outPRC=" << outPrecision.to_string() << "_";
+    result << CPUTestUtils::CPUTestsBase::getTestCaseName(cpuParams);
+    result << "_enforceSnippets=" << enforceSnippets;
+
+    return result.str();
+}
+
+void ExtremumLayerCPUTest::SetUp() {
+    targetDevice = ov::test::utils::DEVICE_CPU;
+
+    std::vector<ov::test::InputShape> inputShapes;
+    utils::MinMaxOpType extremumType;
+    ov::element::Type netPrecision, inPrecision, outPrecision;
+    CPUTestUtils::CPUSpecificParams cpuParams;
+    bool enforceSnippets;
+    std::tie(inputShapes, extremumType, netPrecision, inPrecision, outPrecision, cpuParams, enforceSnippets) = this->GetParam();
+    std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+
+    inType  = inPrecision;
+    outType = outPrecision;
+    const auto primitiveType = getPrimitiveType();
+    selectedType = primitiveType.empty() ? "" : primitiveType + "_" + netPrecision.to_string();
+
+    init_input_shapes(inputShapes);
+
+    if (enforceSnippets) {
+        configuration.insert(ov::intel_cpu::snippets_mode(ov::intel_cpu::SnippetsMode::IGNORE_CALLBACK));
+    } else {
+        configuration.insert(ov::intel_cpu::snippets_mode(ov::intel_cpu::SnippetsMode::DISABLE));
+    }
+
+    auto param1 = std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes[0]);
+    auto param2 = std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes[1]);
+    auto extremum = utils::make_extremum(param1, param2, extremumType);
+    extremum->get_rt_info() = getCPUInfo();
+    function = std::make_shared<ov::Model>(ov::NodeVector{extremum}, ov::ParameterVector{param1, param2}, "Extremum");
+}
+
+std::string ExtremumLayerCPUTest::getPrimitiveType() {
+    return "jit";
+}
+
+TEST_P(ExtremumLayerCPUTest, CompareWithRefs) {
+    run();
+    CheckPluginRelatedResults(compiledModel, "Eltwise");
+}
+
+namespace extremum {
+
+const std::vector<std::vector<ov::Shape>>& inputShape() {
+    static const std::vector<std::vector<ov::Shape>> shape {
+        {{2, 4, 4, 1}, {2, 4, 4, 1}},
+        {{2, 17, 5, 4}, {2, 17, 5, 4}},
+    };
+
+    return shape;
+}
+
+const std::vector<utils::MinMaxOpType>& extremumTypes() {
+    static std::vector<utils::MinMaxOpType> types {
+        MINIMUM,
+        MAXIMUM,
+    };
+
+    return types;
+}
+
+const std::vector<ov::element::Type>& netPrecisions() {
+    static const std::vector<ov::element::Type> netPrecisions {
+        ov::element::f32
+    };
+
+    return netPrecisions;
+}
+
+const std::vector<CPUSpecificParams>& cpuParams4D() {
+    static const std::vector<CPUSpecificParams> cpuParams4D {
+        CPUSpecificParams({nhwc}, {nhwc}, {}, {}),
+        CPUSpecificParams({nchw}, {nchw}, {}, {})
+    };
+
+    return cpuParams4D;
+}
+
+}  // namespace extremum
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.hpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "utils/cpu_test_utils.hpp"
+#include "gtest/gtest.h"
+#include "common_test_utils/test_enums.hpp"
+
+namespace ov {
+namespace test {
+
+using ExtremumLayerCPUTestParamSet =
+    std::tuple<std::vector<InputShape>,           // Input shapes
+               utils::MinMaxOpType,               // Extremum type
+               ov::element::Type,                 // Net precision
+               ov::element::Type,                 // Input precision
+               ov::element::Type,                 // Output precision
+               CPUTestUtils::CPUSpecificParams,
+               bool>;
+
+class ExtremumLayerCPUTest : public testing::WithParamInterface<ExtremumLayerCPUTestParamSet>,
+                             virtual public ov::test::SubgraphBaseTest,
+                             public CPUTestUtils::CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<ExtremumLayerCPUTestParamSet> &obj);
+
+protected:
+    void SetUp() override;
+
+private:
+    std::string getPrimitiveType();
+};
+
+namespace extremum {
+
+const std::vector<std::vector<ov::Shape>>& inputShape();
+
+const std::vector<utils::MinMaxOpType>& extremumTypes();
+
+const std::vector<ov::element::Type>& netPrecisions();
+
+const std::vector<CPUTestUtils::CPUSpecificParams>& cpuParams4D();
+
+}  // namespace extremum
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/activation.cpp
@@ -19,10 +19,24 @@ const auto basicCases3D = ::testing::Combine(
     ::testing::ValuesIn(netPrc()),
     ::testing::Values(ov::element::f32),
     ::testing::Values(ov::element::f32),
-    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams3D()))
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams3D())),
+    ::testing::Values(false)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_Activation3D_Eltwise_CPU, ActivationLayerCPUTest, basicCases3D, ActivationLayerCPUTest::getTestCaseName);
+
+const auto basicCasesSnippets3D = ::testing::Combine(
+    ::testing::ValuesIn(static_shapes_to_test_representation(basic3D())),
+    ::testing::Values(activationShapes()),
+    ::testing::ValuesIn(ov::test::utils::combineParams(activationTypesSnippets())),
+    ::testing::ValuesIn(netPrc()),
+    ::testing::Values(ov::element::f32),
+    ::testing::Values(ov::element::f32),
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams3D())),
+    ::testing::Values(true)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Activation3D_Snippets_CPU, ActivationLayerCPUTest, basicCasesSnippets3D, ActivationLayerCPUTest::getTestCaseName);
 
 /* ============= Activation (2D) ============= */
 const auto basicCases4D = ::testing::Combine(
@@ -32,10 +46,24 @@ const auto basicCases4D = ::testing::Combine(
     ::testing::ValuesIn(netPrc()),
     ::testing::Values(ov::element::f32),
     ::testing::Values(ov::element::f32),
-    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams4D()))
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams4D())),
+    ::testing::Values(false)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_Activation4D_Eltwise_CPU, ActivationLayerCPUTest, basicCases4D, ActivationLayerCPUTest::getTestCaseName);
+
+const auto basicCasesSnippets4D = ::testing::Combine(
+    ::testing::ValuesIn(static_shapes_to_test_representation(basic4D())),
+    ::testing::Values(activationShapes()),
+    ::testing::ValuesIn(ov::test::utils::combineParams(activationTypesSnippets())),
+    ::testing::ValuesIn(netPrc()),
+    ::testing::Values(ov::element::f32),
+    ::testing::Values(ov::element::f32),
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams4D())),
+    ::testing::Values(true)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Activation4D_Snippets_CPU, ActivationLayerCPUTest, basicCasesSnippets4D, ActivationLayerCPUTest::getTestCaseName);
 
 /* ============= Activation (5D) ============= */
 const auto basicCases5D = ::testing::Combine(
@@ -45,10 +73,24 @@ const auto basicCases5D = ::testing::Combine(
     ::testing::ValuesIn(netPrc()),
     ::testing::Values(ov::element::f32),
     ::testing::Values(ov::element::f32),
-    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams5D()))
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams5D())),
+    ::testing::Values(false)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_Activation5D_Eltwise_CPU, ActivationLayerCPUTest, basicCases5D, ActivationLayerCPUTest::getTestCaseName);
+
+const auto basicCasesSnippets5D = ::testing::Combine(
+    ::testing::ValuesIn(static_shapes_to_test_representation(basic5D())),
+    ::testing::Values(activationShapes()),
+    ::testing::ValuesIn(ov::test::utils::combineParams(activationTypesSnippets())),
+    ::testing::ValuesIn(netPrc()),
+    ::testing::Values(ov::element::f32),
+    ::testing::Values(ov::element::f32),
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams5D())),
+    ::testing::Values(true)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Activation5D_Snippets_CPU, ActivationLayerCPUTest, basicCasesSnippets5D, ActivationLayerCPUTest::getTestCaseName);
 
 const auto dynamicMathBasicCases = ::testing::Combine(
     ::testing::ValuesIn(dynamicMathBasic()),
@@ -57,7 +99,8 @@ const auto dynamicMathBasicCases = ::testing::Combine(
     ::testing::ValuesIn(netPrecisions()),
     ::testing::Values(ov::element::f32),
     ::testing::Values(ov::element::f32),
-    ::testing::ValuesIn(cpuParamsDynamicMath())
+    ::testing::ValuesIn(cpuParamsDynamicMath()),
+    ::testing::Values(false)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_Activation5D_dynamicMath_CPU, ActivationLayerCPUTest, dynamicMathBasicCases, ActivationLayerCPUTest::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/eltwise.cpp
@@ -29,6 +29,23 @@ const auto params_4D = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_4D_MemOrder, EltwiseLayerCPUTest, params_4D, EltwiseLayerCPUTest::getTestCaseName);
 
+const auto params_4D_Snippets = ::testing::Combine(
+        ::testing::Combine(
+                ::testing::ValuesIn(static_shapes_to_test_representation(inShapes_4D())),
+                ::testing::ValuesIn(eltwiseOpTypesBinInpSnippets()),
+                ::testing::ValuesIn(secondaryInputTypes()),
+                ::testing::ValuesIn(opTypes()),
+                ::testing::ValuesIn(netType()),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(ov::test::utils::DEVICE_CPU),
+                ::testing::Values(additional_config()[0])),
+        ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D())),
+        ::testing::Values(emptyFusingSpec),
+        ::testing::Values(true));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_4D_MemOrder_Snippets, EltwiseLayerCPUTest, params_4D_Snippets, EltwiseLayerCPUTest::getTestCaseName);
+
 const auto params_4D_emptyCPUSpec = ::testing::Combine(
         ::testing::Combine(
                 ::testing::ValuesIn(static_shapes_to_test_representation(inShapes_4D())),

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/extremum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/extremum.cpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "custom/single_layer_tests/classes/extremum.hpp"
+#include "utils/cpu_test_utils.hpp"
+
+using namespace CPUTestUtils;
+
+namespace ov {
+namespace test {
+namespace extremum {
+
+const auto basicCasesSnippets = ::testing::Combine(
+    ::testing::ValuesIn(static_shapes_to_test_representation(inputShape())),
+    ::testing::ValuesIn(extremumTypes()),
+    ::testing::ValuesIn(netPrecisions()),
+    ::testing::Values(ov::element::f32),
+    ::testing::Values(ov::element::f32),
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams4D())),
+    ::testing::Values(true)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Extremum_Snippets_CPU, ExtremumLayerCPUTest, basicCasesSnippets, ExtremumLayerCPUTest::getTestCaseName);
+
+}  // namespace extremum
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/activation.cpp
@@ -47,7 +47,8 @@ const auto blockedCases3D = ::testing::Combine(
     ::testing::ValuesIn(netPrc()),
     ::testing::Values(ov::element::f32),
     ::testing::Values(ov::element::f32),
-    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams3Dblocked()))
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams3Dblocked())),
+    ::testing::Values(false)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_Activation3D_Eltwise_CPU_Blocked, ActivationLayerCPUTest, blockedCases3D, ActivationLayerCPUTest::getTestCaseName);
@@ -68,7 +69,8 @@ const auto basicCases4D = ::testing::Combine(
     ::testing::ValuesIn(netPrc()),
     ::testing::Values(ov::element::f32),
     ::testing::Values(ov::element::f32),
-    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams4Dblocked()))
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams4Dblocked())),
+    ::testing::Values(false)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_Activation4D_Eltwise_CPU_Blocked, ActivationLayerCPUTest, basicCases4D, ActivationLayerCPUTest::getTestCaseName);
@@ -89,7 +91,8 @@ const auto basicCases5D = ::testing::Combine(
     ::testing::ValuesIn(netPrc()),
     ::testing::Values(ov::element::f32),
     ::testing::Values(ov::element::f32),
-    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams5Dblocked()))
+    ::testing::ValuesIn(filterCPUSpecificParams(cpuParams5Dblocked())),
+    ::testing::Values(false)
 );
 
 INSTANTIATE_TEST_SUITE_P(smoke_Activation5D_Eltwise_CPU_Blocked, ActivationLayerCPUTest, basicCases5D, ActivationLayerCPUTest::getTestCaseName);

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/minimum_maximum.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_op/minimum_maximum.hpp
@@ -13,6 +13,13 @@
 
 namespace ov {
 namespace test {
+using ov::test::utils::MinMaxOpType;
+
+static std::map<MinMaxOpType, std::string> extremumNames = {
+        {MinMaxOpType::MINIMUM, "MINIMUM"},
+        {MinMaxOpType::MAXIMUM, "MAXIMUM"}
+};
+
 using MaxMinParamsTuple = typename std::tuple<
         std::vector<InputShape>,          // Input shapes
         ov::test::utils::MinMaxOpType,    // Operation type

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/extremum.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/node_builders/extremum.hpp
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "common_test_utils/test_enums.hpp"
+#include "openvino/core/node.hpp"
+
+namespace ov {
+namespace test {
+namespace utils {
+std::shared_ptr<ov::Node> make_extremum(const ov::Output<Node>& in0,
+                                        const ov::Output<Node>& in1,
+                                        ov::test::utils::MinMaxOpType extremum_type);
+}  // namespace utils
+}  // namespace test
+}  // namespace ov

--- a/src/tests/test_utils/common_test_utils/src/node_builders/extremum.cpp
+++ b/src/tests/test_utils/common_test_utils/src/node_builders/extremum.cpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/node_builders/extremum.hpp"
+
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
+
+namespace ov {
+namespace test {
+namespace utils {
+std::shared_ptr<ov::Node> make_extremum(const ov::Output<Node>& in0,
+                                        const ov::Output<Node>& in1,
+                                        ov::test::utils::MinMaxOpType extremum_type) {
+    switch (extremum_type) {
+    case ov::test::utils::MinMaxOpType::MINIMUM:
+        return std::make_shared<ov::op::v1::Minimum>(in0, in1);
+    case ov::test::utils::MinMaxOpType::MAXIMUM:
+        return std::make_shared<ov::op::v1::Maximum>(in0, in1);
+    default:
+        throw std::runtime_error("Incorrect type of Extremum operation");
+    }
+}
+}  // namespace utils
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - *Add subgraph tokenization for more Eltwise operations, such as Abs, Clamp, Elu, Floor, GeluErf, etc.*
 - *Add corresponding test cases.*

### Tickets:
 - *CVS-142847*
