### PR TITLE
[GPU] Adding GeGLU

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/op/swiglu.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/swiglu.hpp
@@ -28,9 +28,9 @@ public:
     /// \param data Input tensor with data
     /// \param axis The index of an axis in "data" along which to perform the split
     /// \param split_lenghts A list containing the sizes of each output tensor along the split "axis"
-    /// \param output_type Output element type
-    /// \param glu_type GLU type, one of Swish, Gelu
+    /// \param glu_type GLU type, one of Swish, Gelu and Gelu_Tanh
     /// \param split_to_glu_idx Output index of variadic split, which is connected to GLU
+    /// \param output_type Output element type
     SwiGLU(const Output<Node>& data,
            int64_t axis,
            int64_t split_lengths,

--- a/src/plugins/intel_gpu/include/intel_gpu/op/swiglu.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/swiglu.hpp
@@ -16,6 +16,11 @@ class SwiGLU : public ov::op::Op {
 public:
     OPENVINO_OP("SwiGLU", "gpu_opset");
 
+    enum GluType {
+        Swish = 0,
+        Gelu
+    };
+
     SwiGLU() = default;
     /// \brief Constructs an SwiGLU operation.
     ///
@@ -23,9 +28,13 @@ public:
     /// \param axis The index of an axis in "data" along which to perform the split
     /// \param split_lenghts A list containing the sizes of each output tensor along the split "axis"
     /// \param output_type Output element type
+    /// \param glu_type GLU type, one of Swish, Gelu
+    /// \param split_to_glu_idx Output index of variadic split, which is connected to GLU
     SwiGLU(const Output<Node>& data,
            int64_t axis,
            int64_t split_lengths,
+           const GluType glu_type,
+           const size_t split_to_glu_idx,
            const ov::element::Type output_type = ov::element::undefined);
 
     bool visit_attributes(ov::AttributeVisitor& visitor) override;
@@ -36,13 +45,19 @@ public:
 
     int64_t get_axis() const { return m_axis; }
     int64_t get_split_lengths() const { return m_split_lengths; }
+    GluType get_glu_type() const { return m_glu_type; }
+    size_t get_split_to_glu_idx() const { return m_split_to_glu_idx; }
 
     void set_axis(int64_t axis) { m_axis = axis; }
     void set_split_lengths(int64_t split_lengths) { m_split_lengths = split_lengths; }
+    void set_glu_type(GluType glu_type) { m_glu_type = glu_type; }
+    void set_split_to_glu_idx(size_t split_to_glu_idx) { m_split_to_glu_idx = split_to_glu_idx; }
 
 private:
     int64_t m_axis = 0;
     int64_t m_split_lengths = 0;
+    GluType m_glu_type = GluType::Swish;
+    size_t m_split_to_glu_idx = 0;
     ov::element::Type m_output_type;
 };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/op/swiglu.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/swiglu.hpp
@@ -18,7 +18,8 @@ public:
 
     enum GluType {
         Swish = 0,
-        Gelu
+        Gelu,
+        Gelu_Tanh
     };
 
     SwiGLU() = default;

--- a/src/plugins/intel_gpu/include/intel_gpu/op/swiglu.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/swiglu.hpp
@@ -11,7 +11,7 @@ namespace intel_gpu {
 namespace op {
 
 /// \brief Operator performing Swish Gated Linear Unit Activation
-/// This operation performs gated linear unit activation that combines swish activation function
+/// This operation performs gated linear unit activation that combines swish or gelu activation function
 class SwiGLU : public ov::op::Op {
 public:
     OPENVINO_OP("SwiGLU", "gpu_opset");

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/swiglu.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/swiglu.hpp
@@ -9,7 +9,7 @@
 namespace cldnn {
 
 /// @brief Swish Gated Linear Unit Activation primitive
-/// @details Performs gated linear unit activation that combines swish activation function
+/// @details Performs gated linear unit activation that combines swish or gelu activation function
 struct swiglu : public primitive_base<swiglu> {
     CLDNN_DECLARE_PRIMITIVE(swiglu);
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/swiglu.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/swiglu.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "primitive.hpp"
+#include "intel_gpu/op/swiglu.hpp"
 
 namespace cldnn {
 
@@ -24,21 +25,29 @@ struct swiglu : public primitive_base<swiglu> {
            const input_info& input,
            const int64_t& axis,
            const int64_t& split_lengths,
+           const ov::intel_gpu::op::SwiGLU::GluType glu_type,
+           const size_t split_to_glu_idx,
            const tensor output_size,
            const padding& output_padding = padding())
            : primitive_base(id, {input}, {output_padding}),
              axis(axis),
              split_lengths(split_lengths),
+             glu_type(glu_type),
+             split_to_glu_idx(split_to_glu_idx),
              output_size(output_size) {}
 
     int64_t axis = 0;
     int64_t split_lengths = 0;
+    ov::intel_gpu::op::SwiGLU::GluType glu_type = ov::intel_gpu::op::SwiGLU::GluType::Swish;
+    size_t split_to_glu_idx = 0;
     tensor output_size;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, axis);
         seed = hash_combine(seed, split_lengths);
+        seed = hash_combine(seed, glu_type);
+        seed = hash_combine(seed, split_to_glu_idx);
         return seed;
     }
 
@@ -47,7 +56,8 @@ struct swiglu : public primitive_base<swiglu> {
             return false;
 
         auto rhs_casted = downcast<const swiglu>(rhs);
-        return axis == rhs_casted.axis && split_lengths == rhs_casted.split_lengths;
+        return axis == rhs_casted.axis && split_lengths == rhs_casted.split_lengths &&
+               glu_type == rhs_casted.glu_type && split_to_glu_idx == rhs_casted.split_to_glu_idx;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
@@ -55,6 +65,8 @@ struct swiglu : public primitive_base<swiglu> {
         ob << axis;
         ob << split_lengths;
         ob << output_size;
+        ob << make_data(&glu_type, sizeof(glu_type));
+        ob << split_to_glu_idx;
     }
 
     void load(BinaryInputBuffer& ib) override {
@@ -62,6 +74,8 @@ struct swiglu : public primitive_base<swiglu> {
         ib >> axis;
         ib >> split_lengths;
         ib >> output_size;
+        ib >> make_data(&glu_type, sizeof(glu_type));
+        ib >> split_to_glu_idx;
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
@@ -39,6 +39,8 @@ struct swiglu_impl : typed_primitive_impl_ocl<swiglu> {
         auto rank = impl_param.get_input_layout(0).get_partial_shape().rank();
         params.axis = ov::util::normalize(primitive->axis, rank.get_length());
         params.split_length = primitive->split_lengths;
+        params.glu_type = primitive->glu_type;
+        params.split_to_glu_idx = primitive->split_to_glu_idx;
 
         return params;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
@@ -40,7 +40,7 @@ struct swiglu_impl : typed_primitive_impl_ocl<swiglu> {
         params.axis = ov::util::normalize(primitive->axis, rank.get_length());
         params.split_length = primitive->split_lengths;
         params.glu_type = primitive->glu_type;
-        params.split_to_glu_idx = primitive->split_to_glu_idx;
+        params.split_to_glu_idx = static_cast<int32_t>(primitive->split_to_glu_idx);
 
         return params;
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/swiglu_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/swiglu_gpu_ref.cl
@@ -46,10 +46,12 @@ KERNEL(swiglu_gpu_ref)(
     ACCUMULATOR_TYPE res = ACCUMULATOR_VAL_ZERO;
 
     res = (ACCUMULATOR_TYPE)input[gate_idx];
-    #if GLU_TYPE == 0
+    #if GLU_TYPE == 0   // Swish
         res /= ACCUMULATOR_VAL_ONE + exp(-(ACCUMULATOR_VAL_ONE * res));
-    #elif GLU_TYPE == 1
-        res = ((0.5h * res) * (1.0h + (erf((res * 0.7071067811865475h)))));
+    #elif GLU_TYPE == 1 // Gelu
+        res = (GEGLU_HALF * res * (ACCUMULATOR_VAL_ONE + (erf(res * GEGLU_MULT))));
+    #elif GLU_TYPE == 2 // Gelu_Tanh
+        res = (GEGLU_HALF * res * (ACCUMULATOR_VAL_ONE + (tanh(GEGLU_SQUARE_2_OVER_PI * res * (ACCUMULATOR_VAL_ONE + GEGLU_MULT * res * res)))));
     #endif
     res *= (ACCUMULATOR_TYPE)input[input_idx];
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.cpp
@@ -30,6 +30,8 @@ JitConstants SwiGLUKernelRef::GetJitConstants(const swiglu_params& params) const
 
     jit.AddConstants({MakeJitConstant("AXIS", params.axis)});
     jit.AddConstants({MakeJitConstant("SPLIT_LENGTH", params.split_length)});
+    jit.AddConstants({MakeJitConstant("GLU_TYPE", params.glu_type)});
+    jit.AddConstants({MakeJitConstant("SPLIT_TO_GLU_IDX", params.split_to_glu_idx)});
     jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
     jit.Merge(GetTensorFriendlyWorkGroupsJit(params.outputs[0]));
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.cpp
@@ -31,6 +31,15 @@ JitConstants SwiGLUKernelRef::GetJitConstants(const swiglu_params& params) const
     jit.AddConstants({MakeJitConstant("AXIS", params.axis)});
     jit.AddConstants({MakeJitConstant("SPLIT_LENGTH", params.split_length)});
     jit.AddConstants({MakeJitConstant("GLU_TYPE", params.glu_type)});
+    const std::string type_suffix = (GetAccumulatorType(params) == Datatype::F32) ? "f" : "h";
+    if (params.glu_type == ov::intel_gpu::op::SwiGLU::GluType::Gelu) {
+        jit.AddConstants({MakeJitConstant("GEGLU_HALF", "0.5" + type_suffix)});
+        jit.AddConstants({MakeJitConstant("GEGLU_MULT", "0.7071067811865475" + type_suffix)});
+    } else if (params.glu_type == ov::intel_gpu::op::SwiGLU::GluType::Gelu_Tanh) {
+        jit.AddConstants({MakeJitConstant("GEGLU_HALF", "0.5" + type_suffix)});
+        jit.AddConstants({MakeJitConstant("GEGLU_MULT", "0.044715" + type_suffix)});
+        jit.AddConstants({MakeJitConstant("GEGLU_SQUARE_2_OVER_PI", "0.79788458347320556640625" + type_suffix)});
+    }
     jit.AddConstants({MakeJitConstant("SPLIT_TO_GLU_IDX", params.split_to_glu_idx)});
     jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
     jit.Merge(GetTensorFriendlyWorkGroupsJit(params.outputs[0]));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.h
@@ -14,6 +14,8 @@ struct swiglu_params : public base_params {
     swiglu_params() : base_params(KernelType::SWIGLU), axis(0), split_length(0) {}
     int32_t axis;
     int32_t split_length;
+    int32_t glu_type;
+    int32_t split_to_glu_idx;
 };
 
 class SwiGLUKernelRef : public KernelBaseOpenCL {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.h
@@ -5,16 +5,18 @@
 #pragma once
 
 #include "kernel_base_opencl.h"
+#include "intel_gpu/op/swiglu.hpp"
 
 namespace kernel_selector {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // swiglu_params
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct swiglu_params : public base_params {
-    swiglu_params() : base_params(KernelType::SWIGLU), axis(0), split_length(0) {}
+    swiglu_params() : base_params(KernelType::SWIGLU), axis(0), split_length(0),
+    glu_type(ov::intel_gpu::op::SwiGLU::GluType::Swish), split_to_glu_idx(0) {}
     int32_t axis;
     int32_t split_length;
-    int32_t glu_type;
+    ov::intel_gpu::op::SwiGLU::GluType glu_type;
     int32_t split_to_glu_idx;
 };
 

--- a/src/plugins/intel_gpu/src/plugin/ops/swiglu.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/swiglu.cpp
@@ -28,6 +28,8 @@ static void CreateSwiGLUOp(ProgramBuilder& p, const std::shared_ptr<op::SwiGLU>&
                                   inputs[0],
                                   op->get_axis(),
                                   op->get_split_lengths(),
+                                  op->get_glu_type(),
+                                  op->get_split_to_glu_idx(),
                                   cldnn::tensor());
         prim.output_data_types = get_output_data_types(op);
         p.add_primitive(*op, prim);
@@ -36,6 +38,8 @@ static void CreateSwiGLUOp(ProgramBuilder& p, const std::shared_ptr<op::SwiGLU>&
                                   inputs[0],
                                   op->get_axis(),
                                   op->get_split_lengths(),
+                                  op->get_glu_type(),
+                                  op->get_split_to_glu_idx(),
                                   tensor_from_dims(op->get_output_shape(0)));
         prim.output_data_types = get_output_data_types(op);
         p.add_primitive(*op, prim);

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/swiglu.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/swiglu.cpp
@@ -15,8 +15,11 @@ namespace op {
 SwiGLU::SwiGLU(const Output<Node>& data,
                int64_t axis,
                int64_t split_lengths,
+               const GluType glu_type,
+               const size_t split_to_glu_idx,
                const ov::element::Type output_type)
-    : Op({data}), m_axis(axis), m_split_lengths(split_lengths), m_output_type(output_type) {
+    : Op({data}), m_axis(axis), m_split_lengths(split_lengths),
+      m_glu_type(glu_type), m_split_to_glu_idx(split_to_glu_idx), m_output_type(output_type) {
     validate_and_infer_types();
 }
 
@@ -44,6 +47,8 @@ std::shared_ptr<Node> SwiGLU::clone_with_new_inputs(const ov::OutputVector& new_
     return std::make_shared<SwiGLU>(new_args.at(0),
                                     m_axis,
                                     m_split_lengths,
+                                    m_glu_type,
+                                    m_split_to_glu_idx,
                                     m_output_type);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/swiglu_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/swiglu_fusion.cpp
@@ -10,7 +10,9 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/swish.hpp"
+#include "openvino/op/gelu.hpp"
 #include "openvino/op/variadic_split.hpp"
+#include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/utils/utils.hpp"
 
@@ -19,6 +21,7 @@ namespace intel_gpu {
 
 SwiGLUFusion::SwiGLUFusion() {
     using namespace ov::pass::pattern;
+    using ov::pass::pattern::op::Or;
 
     auto last_dim_static = [](const ov::Output<ov::Node>& output) {
         auto out_ps = output.get_node()->get_output_partial_shape(0);
@@ -37,14 +40,16 @@ SwiGLUFusion::SwiGLUFusion() {
 
     // Swish(Xw) = Xw * (1.0 + exp(-beta * Xw))
     auto swish_m = wrap_type<ov::op::v4::Swish>({variadic_split_m->output(0)});
+    auto gelu_m = wrap_type<ov::op::v7::Gelu>({variadic_split_m->output(0)});
 
     // Mul(Xw, Xv) = Swish(Xw) * Xv
-    auto mul_m = wrap_type<ov::op::v1::Multiply>({swish_m, variadic_split_m->output(1)});
+    auto glu_m = std::make_shared<Or>(OutputVector{swish_m, gelu_m});
+    auto mul_m = wrap_type<ov::op::v1::Multiply>({glu_m, variadic_split_m->output(1)});
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
         OPENVINO_ASSERT(pattern_map.count(mul_m));
-        OPENVINO_ASSERT(pattern_map.count(swish_m));
+        OPENVINO_ASSERT(pattern_map.count(swish_m) || pattern_map.count(gelu_m));
         OPENVINO_ASSERT(pattern_map.count(variadic_split_m));
         OPENVINO_ASSERT(pattern_map.count(split_lengths_const_m));
         OPENVINO_ASSERT(pattern_map.count(axis_const_m));
@@ -52,9 +57,25 @@ SwiGLUFusion::SwiGLUFusion() {
         if (!mul || transformation_callback(mul))
             return false;
 
-        size_t split_in_idx = ov::is_type<ov::op::v4::Swish>(mul->get_input_node_shared_ptr(0)) ? 1 : 0;
-        if (mul->input_value(split_in_idx).get_index() != 1)
-            return false;
+        auto isSwiGLU = pattern_map.count(swish_m);
+        auto isGeGLU = pattern_map.count(gelu_m);
+        size_t split_to_glu_idx = 0;
+
+        if (isSwiGLU) {
+            auto swish = std::dynamic_pointer_cast<ov::op::v4::Swish>(pattern_map.at(swish_m).get_node_shared_ptr());
+            split_to_glu_idx = swish->input_value(0).get_index();
+
+            size_t split_in_idx = ov::is_type<ov::op::v4::Swish>(mul->get_input_node_shared_ptr(0)) ? 1 : 0;
+            if (mul->input_value(split_in_idx).get_index() == split_to_glu_idx)
+                return false;
+        } else if (isGeGLU) {
+            auto gelu = std::dynamic_pointer_cast<ov::op::v7::Gelu>(pattern_map.at(gelu_m).get_node_shared_ptr());
+            split_to_glu_idx = gelu->input_value(0).get_index();
+
+            size_t split_in_idx = ov::is_type<ov::op::v7::Gelu>(mul->get_input_node_shared_ptr(0)) ? 1 : 0;
+            if (mul->input_value(split_in_idx).get_index() == split_to_glu_idx)
+                return false;
+        }
 
         auto variadic_split = std::dynamic_pointer_cast<ov::op::v1::VariadicSplit>(pattern_map.at(variadic_split_m).get_node_shared_ptr());
         auto variadic_split_in_ps = variadic_split->get_input_partial_shape(0);
@@ -80,6 +101,8 @@ SwiGLUFusion::SwiGLUFusion() {
         auto swiglu = std::make_shared<op::SwiGLU>(data,
                                                    axis_value,
                                                    split_lengths_value,
+                                                   (isSwiGLU ? ov::intel_gpu::op::SwiGLU::GluType::Swish : ov::intel_gpu::op::SwiGLU::GluType::Gelu),
+                                                   split_to_glu_idx,
                                                    output_type);
         swiglu->set_friendly_name(m.get_match_root()->get_friendly_name());
         ov::copy_runtime_info(m.get_matched_nodes(), swiglu);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/swiglu_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/swiglu_gpu_test.cpp
@@ -63,7 +63,7 @@ TEST(swiglu_gpu_test, swiglu_test_bfyx_dyn) {
 
     topology topology;
     topology.add(input_layout("input", input_layout_dynamic));
-    topology.add(swiglu("swiglu", input_info("input"), -1, 3, tensor()));
+    topology.add(swiglu("swiglu", input_info("input"), -1, 3, ov::intel_gpu::op::SwiGLU::GluType::Swish, 0, tensor()));
 
     ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));

--- a/src/plugins/intel_gpu/tests/unit/transformations/swiglu_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/swiglu_fusion_test.cpp
@@ -18,6 +18,7 @@
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/swish.hpp"
+#include "openvino/op/gelu.hpp"
 #include "openvino/op/variadic_split.hpp"
 #include "intel_gpu/op/swiglu.hpp"
 
@@ -39,8 +40,8 @@ TEST_F(TransformationTestsF, SwiGLUFusionTest1) {
     {
         int64_t axis = -1;
         int64_t split_lenghts = 3;
-        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ 2, 1, 6 });;
-        auto swiglu = std::make_shared<op::SwiGLU>(input, axis, split_lenghts, ov::element::f16);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ 2, 1, 6 });
+        auto swiglu = std::make_shared<op::SwiGLU>(input, axis, split_lenghts, op::SwiGLU::GluType::Swish, 0, ov::element::f16);
 
         model_ref = std::make_shared<ov::Model>(ov::NodeVector{swiglu}, ov::ParameterVector{input});
     }
@@ -76,7 +77,7 @@ TEST_F(TransformationTestsF, SwiGLUFusionTest3) {
         int64_t axis = -1;
         int64_t split_lenghts = 3;
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, -1, 6 });
-        auto swiglu = std::make_shared<op::SwiGLU>(input, axis, split_lenghts, ov::element::f16);
+        auto swiglu = std::make_shared<op::SwiGLU>(input, axis, split_lenghts, op::SwiGLU::GluType::Swish, 0, ov::element::f16);
 
         model_ref = std::make_shared<ov::Model>(ov::NodeVector{swiglu}, ov::ParameterVector{input});
     }
@@ -98,7 +99,7 @@ TEST_F(TransformationTestsF, SwiGLUFusionTest3ReverseOrder) {
         int64_t axis = -1;
         int64_t split_lenghts = 3;
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, -1, 6 });
-        auto swiglu = std::make_shared<op::SwiGLU>(input, axis, split_lenghts, ov::element::f16);
+        auto swiglu = std::make_shared<op::SwiGLU>(input, axis, split_lenghts, op::SwiGLU::GluType::Swish, 0, ov::element::f16);
 
         model_ref = std::make_shared<ov::Model>(ov::NodeVector{swiglu}, ov::ParameterVector{input});
     }
@@ -115,5 +116,27 @@ TEST_F(TransformationTestsF, SwiGLUFusionTest4) {
 
         model = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
         manager.register_pass<SwiGLUFusion>();
+    }
+}
+
+TEST_F(TransformationTestsF, GeGLUFusionTest1) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ 2, 1, 6 });
+        auto axis_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {-1});
+        auto split_lengths_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {3, -1});
+        auto variadic_split = std::make_shared<ov::op::v1::VariadicSplit>(input, axis_const, split_lengths_const);
+        auto gelu = std::make_shared<ov::op::v7::Gelu>(variadic_split->output(1));
+        auto mul = std::make_shared<ov::op::v1::Multiply>(variadic_split->output(0), gelu);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        manager.register_pass<SwiGLUFusion>();
+    }
+    {
+        int64_t axis = -1;
+        int64_t split_lenghts = 3;
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ 2, 1, 6 });
+        auto swiglu = std::make_shared<op::SwiGLU>(input, axis, split_lenghts, op::SwiGLU::GluType::Gelu, 1, ov::element::f16);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{swiglu}, ov::ParameterVector{input});
     }
 }


### PR DESCRIPTION
### Details:
 - This PR extends the current `SwiGLU` primitive to support `GeGLU` that has Gelu activations instead of Swish.
 - This GeGLU patterns can be found in stable diffusion models.

### Tickets:
 - 143486
