### PR TITLE
[CPU][ARM] Remove WA in `hasFP16HardwareSupport`

### DIFF
--- a/src/plugins/intel_cpu/src/utils/precision_support.cpp
+++ b/src/plugins/intel_cpu/src/utils/precision_support.cpp
@@ -23,9 +23,7 @@ static bool hasFP16HardwareSupport(const ov::element::Type& precision) {
         dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni_2))
         return true;
     return false;
-#elif defined(OPENVINO_ARCH_ARM64) && defined(OV_CPU_WITH_ACL)
-    //has_fp16() works correctly on aarch64 only
-    //TODO: remove else branch as soon as ACL issue #1096 is fixed
+#elif defined(OV_CPU_WITH_ACL)
     return arm_compute::CPUInfo::get().has_fp16();
 #else
     return false;


### PR DESCRIPTION
WA was implemented to avoid ACL issue: https://github.com/ARM-software/ComputeLibrary/issues/1096