### PR TITLE
[CPU] Apply int32 instructions directly for ReduceProd-int32

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -653,7 +653,7 @@ private:
                 assert(!"unknown src_dt");
         }
 
-        if (!isFloatCompatible(src_dt))
+        if (!isFloatCompatible(src_dt) && jcp_.reduce_mode != Algorithm::ReduceProd)
             uni_vcvtdq2ps(vmm_val, vmm_val);
         add(rsp, vlen);
     }
@@ -818,7 +818,11 @@ private:
                 uni_vorps(vmm_dst, vmm_dst, vmm_src);
                 break;
             case Algorithm::ReduceProd:
-                uni_vmulps(vmm_dst, vmm_dst, vmm_src);
+                if (isFloatCompatible(jcp_.dst_dt)) {
+                    uni_vmulps(vmm_dst, vmm_dst, vmm_src);
+                } else {
+                    uni_vpmulld(vmm_dst, vmm_dst, vmm_src);
+                }
                 break;
             default:
                 assert(!"unsupported reduce mode");
@@ -859,7 +863,11 @@ private:
                 uni_vorps(xmm_dst, xmm_dst, xmm_src);
                 break;
             case Algorithm::ReduceProd:
-                uni_vmulps(xmm_dst, xmm_dst, xmm_src);
+                if (isFloatCompatible(jcp_.dst_dt)) {
+                    uni_vmulps(xmm_dst, xmm_dst, xmm_src);
+                } else {
+                    uni_vpmulld(vmm_dst, vmm_dst, vmm_src);
+                }
                 break;
             default:
                 assert(!"unsupported reduce mode");
@@ -910,7 +918,7 @@ private:
                 assert(!"unknown src_dt");
         }
 
-        if (!isFloatCompatible(src_dt))
+        if (!isFloatCompatible(src_dt) && jcp_.reduce_mode != Algorithm::ReduceProd)
             uni_vcvtdq2ps(vmm_src, vmm_src);
     }
 
@@ -939,7 +947,7 @@ private:
                 assert(!"unknown src_dt");
         }
 
-        if (!isFloatCompatible(src_dt)) {
+        if (!isFloatCompatible(src_dt) && jcp_.reduce_mode != Algorithm::ReduceProd) {
             uni_vcvtdq2ps(xmm_src, xmm_src);
         }
     }
@@ -948,7 +956,7 @@ private:
         Xmm xmm_dst = Xmm(vmm_dst.getIdx());
         Ymm ymm_dst = Ymm(vmm_dst.getIdx());
 
-        if (!isFloatCompatible(dst_dt)) {
+        if (!isFloatCompatible(dst_dt) && jcp_.reduce_mode != Algorithm::ReduceProd) {
             uni_vcvtps2dq(vmm_dst, vmm_dst);
         }
 
@@ -999,7 +1007,7 @@ private:
     }
 
     inline void store_scalar(const Xbyak::Address &op, Xmm xmm_dst, memory::data_type dst_dt) {
-        if (!isFloatCompatible(dst_dt)) {
+        if (!isFloatCompatible(dst_dt) && jcp_.reduce_mode != Algorithm::ReduceProd) {
             uni_vcvtps2dq(xmm_dst, xmm_dst);
         }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/reduce.cpp
@@ -279,6 +279,13 @@ const std::vector<ov::test::utils::ReductionType>& reductionTypesInt32() {
     return reductionTypesInt32;
 }
 
+const std::vector<ov::test::utils::ReductionType>& reductionTypesNativeInt32() {
+    static const std::vector<ov::test::utils::ReductionType> reductionTypesNativeInt32 = {
+            ov::test::utils::ReductionType::Prod,
+    };
+    return reductionTypesNativeInt32;
+}
+
 }  // namespace Reduce
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/reduce.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/reduce.hpp
@@ -56,6 +56,7 @@ const std::vector<ElementType>& inpOutPrc();
 const std::vector<std::map<std::string, ov::element::Type>> additionalConfig();
 const std::vector<std::map<std::string, ov::element::Type>> additionalConfigFP32();
 const std::vector<utils::ReductionType>& reductionTypesInt32();
+const std::vector<utils::ReductionType>& reductionTypesNativeInt32();
 
 }  // namespace Reduce
 }  // namespace test

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
@@ -39,6 +39,10 @@ std::vector<std::vector<ov::test::InputShape>> inputShapes_NativeInt32_dyn = {
     {{{{1, 5}, 2, {1, 5}, {1, 10}}, {{2, 2, 2, 2}, {2, 2, 2, 3}}}},
 };
 
+std::vector<std::vector<ov::test::InputShape>> inputShapes_NativeInt32Gather_dyn = {
+    {{{{1, 5}, 6, {1, 5}, {1, 10}}, {{1, 6, 4, 3}, {1, 6, 4, 4}}}},
+};
+
 std::vector<std::vector<ov::test::InputShape>> inputShapes_SmallChannel_dyn = {
     {{{{1, 5}, 3, {1, 5}, {1, 10}}, {{2, 3, 2, 2}, {2, 3, 2, 9}}}},
 };
@@ -87,6 +91,10 @@ const std::vector<std::vector<int>> axes5DFusing = {
 
 const std::vector<std::vector<int>> axesHW = {
         {2, 3}
+};
+
+const std::vector<std::vector<int>> axesGather = {
+        {3}
 };
 
 std::vector<CPUSpecificParams> cpuParams_5D = {
@@ -273,6 +281,20 @@ const auto params_NativeInt32 = testing::Combine(
         testing::Values(emptyFusingSpec),
         testing::ValuesIn(additionalConfigFP32()));
 
+const auto params_NativeInt32Gather = testing::Combine(
+        testing::Combine(
+            testing::ValuesIn(axesGather),
+            testing::Values(ov::test::utils::OpType::VECTOR),
+            testing::ValuesIn(keepDims()),
+            testing::ValuesIn(reductionTypesNativeInt32()),
+            testing::Values(ElementType::i32),
+            testing::Values(ElementType::undefined),
+            testing::Values(ElementType::undefined),
+            testing::ValuesIn(inputShapes_NativeInt32Gather_dyn)),
+        testing::Values(emptyCPUSpec),
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfigFP32()));
+
 const auto params_NHWC_SmallChannel = testing::Combine(
         testing::Combine(
                 testing::ValuesIn(axesHW),
@@ -354,6 +376,13 @@ INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_NativeInt32_CPU,
         ReduceCPULayerTest,
         params_NativeInt32,
+        ReduceCPULayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        smoke_Reduce_NativeInt32Gather_CPU,
+        ReduceCPULayerTest,
+        params_NativeInt32Gather,
         ReduceCPULayerTest::getTestCaseName
 );
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
@@ -35,7 +35,7 @@ std::vector<std::vector<ov::test::InputShape>> inputShapes_Int32_dyn = {
     {{{{1, 5}, 19, {1, 5}, {1, 10}}, {{2, 19, 2, 2}, {2, 19, 2, 3}}}},
 };
 
-std::vector<std::vector<ov::test::InputShape>> inputShapes_Int32_Prod_dyn = {
+std::vector<std::vector<ov::test::InputShape>> inputShapes_NativeInt32_dyn = {
     {{{{1, 5}, 2, {1, 5}, {1, 10}}, {{2, 2, 2, 2}, {2, 2, 2, 3}}}},
 };
 
@@ -259,16 +259,16 @@ const auto params_Int32 = testing::Combine(
         testing::Values(emptyFusingSpec),
         testing::ValuesIn(additionalConfigFP32()));
 
-const auto params_Int32_Prod = testing::Combine(
+const auto params_NativeInt32 = testing::Combine(
         testing::Combine(
             testing::ValuesIn(axes()),
             testing::Values(ov::test::utils::OpType::VECTOR),
             testing::ValuesIn(keepDims()),
-            testing::Values(ov::test::utils::ReductionType::Prod),
+            testing::ValuesIn(reductionTypesNativeInt32()),
             testing::Values(ElementType::i32),
             testing::Values(ElementType::undefined),
             testing::Values(ElementType::undefined),
-            testing::ValuesIn(inputShapes_Int32_Prod_dyn)),
+            testing::ValuesIn(inputShapes_NativeInt32_dyn)),
         testing::Values(emptyCPUSpec),
         testing::Values(emptyFusingSpec),
         testing::ValuesIn(additionalConfigFP32()));
@@ -351,9 +351,9 @@ INSTANTIATE_TEST_SUITE_P(
 );
 
 INSTANTIATE_TEST_SUITE_P(
-        smoke_Reduce_Int32_Prod_CPU,
+        smoke_Reduce_NativeInt32_CPU,
         ReduceCPULayerTest,
-        params_Int32_Prod,
+        params_NativeInt32,
         ReduceCPULayerTest::getTestCaseName
 );
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
@@ -35,6 +35,10 @@ std::vector<std::vector<ov::test::InputShape>> inputShapes_Int32_dyn = {
     {{{{1, 5}, 19, {1, 5}, {1, 10}}, {{2, 19, 2, 2}, {2, 19, 2, 3}}}},
 };
 
+std::vector<std::vector<ov::test::InputShape>> inputShapes_Int32_Prod_dyn = {
+    {{{{1, 5}, 2, {1, 5}, {1, 10}}, {{2, 2, 2, 2}, {2, 2, 2, 3}}}},
+};
+
 std::vector<std::vector<ov::test::InputShape>> inputShapes_SmallChannel_dyn = {
     {{{{1, 5}, 3, {1, 5}, {1, 10}}, {{2, 3, 2, 2}, {2, 3, 2, 9}}}},
 };
@@ -255,6 +259,20 @@ const auto params_Int32 = testing::Combine(
         testing::Values(emptyFusingSpec),
         testing::ValuesIn(additionalConfigFP32()));
 
+const auto params_Int32_Prod = testing::Combine(
+        testing::Combine(
+            testing::ValuesIn(axes()),
+            testing::Values(ov::test::utils::OpType::VECTOR),
+            testing::ValuesIn(keepDims()),
+            testing::Values(ov::test::utils::ReductionType::Prod),
+            testing::Values(ElementType::i32),
+            testing::Values(ElementType::undefined),
+            testing::Values(ElementType::undefined),
+            testing::ValuesIn(inputShapes_Int32_Prod_dyn)),
+        testing::Values(emptyCPUSpec),
+        testing::Values(emptyFusingSpec),
+        testing::ValuesIn(additionalConfigFP32()));
+
 const auto params_NHWC_SmallChannel = testing::Combine(
         testing::Combine(
                 testing::ValuesIn(axesHW),
@@ -329,6 +347,13 @@ INSTANTIATE_TEST_SUITE_P(
         smoke_Reduce_Int32_CPU,
         ReduceCPULayerTest,
         params_Int32,
+        ReduceCPULayerTest::getTestCaseName
+);
+
+INSTANTIATE_TEST_SUITE_P(
+        smoke_Reduce_Int32_Prod_CPU,
+        ReduceCPULayerTest,
+        params_Int32_Prod,
         ReduceCPULayerTest::getTestCaseName
 );
 


### PR DESCRIPTION
### Details:
 - *Apply int32 instructions directly for ReduceProd with int32 precision.*

### Tickets:
 - *CVS-141153*
