### PR TITLE
[intel-npu] Fix for pci_info throw with old drivers

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -24,27 +24,20 @@ ZeroDevice::ZeroDevice(const std::shared_ptr<ZeroInitStructsHolder>& initStructs
     // Query PCI information
     // Older drivers do not have this implementend. Linux driver returns NOT_IMPLEMENTED, while windows driver returns
     // zero values. If this is detected, we populate only device with ID from device_properties for backwards
-    // compatibility
+    // compatibility. For any other error, we just fall-back to device ID to assure backwards compatibilty with even
+    // older drivers
     pci_properties.stype = ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES;
     ze_result_t retpci = zeDevicePciGetPropertiesExt(_initStructs->getDevice(), &pci_properties);
     if (ZE_RESULT_SUCCESS == retpci) {
-        // win backwards compatibility
+        // windows driver specific backwards compatibility
         if (pci_properties.address.device == 0) {
             log.warning("PCI information not available in driver. Falling back to deviceId");
             pci_properties.address.device = device_properties.deviceId;
         }
-    } else if (ZE_RESULT_ERROR_UNSUPPORTED_FEATURE == retpci) {
-        log.warning("PCI information not available in driver. Falling back to deviceId");
-        // linux backwards compatibilty
-        pci_properties.address.device = device_properties.deviceId;
     } else {
-        OPENVINO_THROW("L0 zeDevicePciGetPropertiesExt result: ",
-                       ze_result_to_string(retpci),
-                       ", code 0x",
-                       std::hex,
-                       uint64_t(retpci),
-                       " - ",
-                       ze_result_to_description(retpci));
+        // general backwards compatibility
+        log.warning("PCI information not available in driver. Falling back to deviceId");
+        pci_properties.address.device = device_properties.deviceId;
     }
 
     /// Calculate and store device GOPS with formula: frequency * number of tiles * ops per tile


### PR DESCRIPTION
### Details:
 - zero-backend/pci information: Older drivers return errors not covered by current error managment, leading to Throw in zero_device intitialization, leading to total incompatibility with certain old drivers. Since pci information is not essential for the correct functioning of the plugin, i am removing throws completely, falling back to error message and default values.

### Tickets:
 - none
