### PR TITLE
[intel-npu] initializing stepping and max_tiles default values

### DIFF
--- a/src/plugins/intel_npu/src/plugin/include/metrics.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metrics.hpp
@@ -35,6 +35,8 @@ public:
     uint64_t GetDeviceTotalMemSize(const std::string& specifiedDeviceName) const;
     uint32_t GetDriverVersion() const;
     uint32_t GetDriverExtVersion() const;
+    uint32_t GetSteppingNumber(const std::string& specifiedDeviceName) const;
+    uint32_t GetMaxTiles(const std::string& specifiedDeviceName) const;
     ov::device::PCIInfo GetPciInfo(const std::string& specifiedDeviceName) const;
     std::map<ov::element::Type, float> GetGops(const std::string& specifiedDeviceName) const;
     ov::device::Type GetDeviceType(const std::string& specifiedDeviceName) const;

--- a/src/plugins/intel_npu/src/plugin/src/metrics.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/metrics.cpp
@@ -26,6 +26,8 @@ Metrics::Metrics(const std::shared_ptr<const NPUBackends>& backends) : _backends
                          ov::intel_npu::device_alloc_mem_size.name(),
                          ov::intel_npu::device_total_mem_size.name(),
                          ov::intel_npu::driver_version.name(),
+                         ov::intel_npu::stepping.name(),
+                         ov::intel_npu::max_tiles.name(),
                          ov::device::pci_info.name(),
                          ov::device::gops.name()};
 
@@ -119,6 +121,24 @@ uint32_t Metrics::GetDriverExtVersion() const {
     }
 
     return _backends->getDriverExtVersion();
+}
+
+uint32_t Metrics::GetSteppingNumber(const std::string& specifiedDeviceName) const {
+    const auto devName = getDeviceName(specifiedDeviceName);
+    auto device = _backends->getDevice(devName);
+    if (device) {
+        return device->getSubDevId();
+    }
+    OPENVINO_THROW("No device with name '", specifiedDeviceName, "' is available");
+}
+
+uint32_t Metrics::GetMaxTiles(const std::string& specifiedDeviceName) const {
+    const auto devName = getDeviceName(specifiedDeviceName);
+    auto device = _backends->getDevice(devName);
+    if (device) {
+        return device->getMaxNumSlices();
+    }
+    OPENVINO_THROW("No device with name '", specifiedDeviceName, "' is available");
 }
 
 uint64_t Metrics::GetDeviceAllocMemSize(const std::string& specifiedDeviceName) const {

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -207,6 +207,15 @@ Plugin::Plugin()
     // parse again env_variables after backend is initialized to get backend proprieties
     _globalConfig.parseEnvVars();
 
+    // initialize properties which have device-tied default values in global config
+    // *only if there is a driver available
+    if (_metrics->GetAvailableDevicesNames().size() > 0) {
+        _globalConfig.update({{ov::intel_npu::stepping.name(),
+                               std::to_string(_metrics->GetSteppingNumber(get_specified_device_name(_globalConfig)))}});
+        _globalConfig.update({{ov::intel_npu::max_tiles.name(),
+                               std::to_string(_metrics->GetMaxTiles(get_specified_device_name(_globalConfig)))}});
+    }
+
     // Map from name to function {Config -> ov::Any}
     // Note that some properties are RW before network is loaded, and become RO after network is loaded
     _properties = {


### PR DESCRIPTION
### Details:
Stepping and max_tiles will only get populated in compile (be it manual config or driver value). As a result, if queried before model compilation, both will return -1 default values. This change initializes globalConfig with driver values, while leaving localconfig (and compiled_model config) untouched. This way, the behaviour will be as follows:
 -  core.get will return actual stepping number and max tiles of the actual device (driver populated)
 - compiled_model.get will return stepping number and max tiles the model was compiled with (be it user-supplied or driver populated)
### Tickets:
 - none
