### PR TITLE
[GPU][MTL] choose better conv kernel for filter size 32x32 in iGPU case

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp
@@ -212,7 +212,7 @@ bool ConvolutionKernel_bfyx_os_iyx_osv16::Validate(const Params& p) const {
     const size_t acceptable_filter_size = 1024;     // This acceptable size was decided by heuristics
     const auto& params = static_cast<const convolution_params&>(p);
     auto filter_size = params.filterSize.x * params.filterSize.y;
-    if (filter_size > acceptable_filter_size) {
+    if (filter_size >= acceptable_filter_size) {
         return false;
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv32.cpp
@@ -196,7 +196,7 @@ bool ConvolutionKernel_bfyx_os_iyx_osv32::Validate(const Params& p) const {
     const size_t acceptable_filter_size = 1024;     // This acceptable size was decided by heuristics
     const auto& params = static_cast<const convolution_params&>(p);
     auto filter_size = params.filterSize.x * params.filterSize.y;
-    if (filter_size > acceptable_filter_size) {
+    if (filter_size >= acceptable_filter_size) {
         return false;
     }
 


### PR DESCRIPTION
### Details:
 - MTL iGPU running convolution_gpu_byfx_os_iyx_osv32 kernel with filter size >=32x32 will get very poor performance due to need read too much input data in each thread to sync data with other threads in the same subgroup. 
 - For ViT B/32 model with bs=1,16,32,128, we can get quit low performance comparing to IPEX
 <html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


  |   |   | Input shape | Conv kernel | OV master | IPEX
-- | -- | -- | -- | -- | -- | --
ViT B/32 | FP16 | ViT B/32 | 1 *3*384*384 | convolution_gpu_bfyx_os_iyx_osv32 | 22.03 | 65
  | FP16 | ViT B/32 | 16 *3*384*384 | convolution_gpu_bfyx_os_iyx_osv32 | 19.25 | 115.4
  | FP16 | ViT B/32 | 32 *3*384*384 | convolution_gpu_yxfb_yxio_b16 | 119.20 | 104.4
  | FP16 | ViT B/32 | 128 *3*384*384 | convolution_gpu_bfyx_os_iyx_osv32 | 19.19 | 107.4



</div>

<!--EndFragment-->
</body>

</html>

 

 - The vtune  shows that convolution runs in very low performance
 
![image](https://github.com/openvinotoolkit/openvino/assets/31196718/6ab75d74-8d27-4535-b956-c1b4e2e06013)

- When bs=16 it will set loyout to be  yxfb and other bs will keep byfx, so they choose different conv oc kernel

![image](https://github.com/openvinotoolkit/openvino/assets/31196718/c8283147-00f5-4162-86c9-d3e401b74a43)

- Solution: choose better conv kernel for bfyx laypout if conv filter size is too big

- Test result show, the performance has been improved greatly

 <html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


  |   |   | Input shape | OV master | IPEX | PR
-- | -- | -- | -- | -- | -- | --
ViT B/32 | FP16 | ViT B/32 | 1 *3*384*384 | 22.03 | 65 | 61.60
  | FP16 | ViT B/32 | 16 *3*384*384 | 19.25 | 115.4 | 129.37
  | FP16 | ViT B/32 | 32 *3*384*384 | 119.20 | 104.4 | 118.95
  | FP16 | ViT B/32 | 128 *3*384*384 | 19.19 | 107.4 | 126.63



</div>

<!--EndFragment-->
</body>

</html>


- The vtune also shows good running state
![image](https://github.com/openvinotoolkit/openvino/assets/31196718/bc188eaa-0da2-42ee-897b-da05abacd39d)



### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-144262
