### PR TITLE
[intel-npu] Add pre/post commit validation for NPU plugin with `PV driver`

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
@@ -14,7 +14,7 @@ const std::vector<ov::AnyMap> configsInferRequestRunTests = {
         {ov::log::level(ov::log::Level::INFO)}
 };
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTest, InferRequestRunTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest, InferRequestRunTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configsInferRequestRunTests)),
                          InferRequestRunTests::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
@@ -14,7 +14,7 @@ const std::vector<ov::AnyMap> configsInferRequestRunTests = {
         {ov::log::level(ov::log::Level::INFO)}
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest, InferRequestRunTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTest, InferRequestRunTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configsInferRequestRunTests)),
                          InferRequestRunTests::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/downgrade_interpolate11.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/downgrade_interpolate11.cpp
@@ -13,7 +13,7 @@ const std::vector<ov::AnyMap> configs = {
         {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}},
 };
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTest, DriverCompilerAdapterDowngradeInterpolate11TestNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest, DriverCompilerAdapterDowngradeInterpolate11TestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          DriverCompilerAdapterDowngradeInterpolate11TestNPU::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/downgrade_interpolate11.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/downgrade_interpolate11.cpp
@@ -13,7 +13,7 @@ const std::vector<ov::AnyMap> configs = {
         {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest, DriverCompilerAdapterDowngradeInterpolate11TestNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTest, DriverCompilerAdapterDowngradeInterpolate11TestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          DriverCompilerAdapterDowngradeInterpolate11TestNPU::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/inputs_outputs.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/inputs_outputs.cpp
@@ -13,7 +13,7 @@ const std::vector<ov::AnyMap> configs = {
         {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest, DriverCompilerAdapterInputsOutputsTestNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTest, DriverCompilerAdapterInputsOutputsTestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          DriverCompilerAdapterInputsOutputsTestNPU::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/inputs_outputs.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/inputs_outputs.cpp
@@ -13,7 +13,7 @@ const std::vector<ov::AnyMap> configs = {
         {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}},
 };
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTest, DriverCompilerAdapterInputsOutputsTestNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest, DriverCompilerAdapterInputsOutputsTestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          DriverCompilerAdapterInputsOutputsTestNPU::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/query_network.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/query_network.cpp
@@ -122,7 +122,7 @@ TEST_P(QueryNetworkTestSuite1NPU, TestQueryNetworkSupported) {
     EXPECT_EQ(expected, actual);	
 }	
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTest, QueryNetworkTestSuite1NPU,	
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest, QueryNetworkTestSuite1NPU,	
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),	
                                             ::testing::ValuesIn(configs)),	
                          QueryNetworkTestNPU::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/query_network.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/query_network.cpp
@@ -122,7 +122,7 @@ TEST_P(QueryNetworkTestSuite1NPU, TestQueryNetworkSupported) {
     EXPECT_EQ(expected, actual);	
 }	
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest, QueryNetworkTestSuite1NPU,	
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTest, QueryNetworkTestSuite1NPU,	
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),	
                                             ::testing::ValuesIn(configs)),	
                          QueryNetworkTestNPU::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
@@ -163,13 +163,13 @@ const std::vector<ov::AnyMap> IncorrectMutablePropertiesWrongValueTypes = {
     {{ov::intel_npu::compilation_mode_params.name(), "not-a-param=true"}},
 };
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                          OVPropertiesTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(CorrectPluginMutableProperties)),
                          (ov::test::utils::appendPlatformTypeTestName<OVPropertiesTestsNPU>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                          OVPropertiesIncorrectTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(IncorrectMutablePropertiesWrongValueTypes)),

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
@@ -163,13 +163,13 @@ const std::vector<ov::AnyMap> IncorrectMutablePropertiesWrongValueTypes = {
     {{ov::intel_npu::compilation_mode_params.name(), "not-a-param=true"}},
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
                          OVPropertiesTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(CorrectPluginMutableProperties)),
                          (ov::test::utils::appendPlatformTypeTestName<OVPropertiesTestsNPU>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
                          OVPropertiesIncorrectTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(IncorrectMutablePropertiesWrongValueTypes)),

--- a/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
@@ -202,7 +202,7 @@ TEST_P(ClassPluginPropertiesTestSuite0NPU, CanSetGetPublicMutableProperty) {
     ASSERT_EQ(retrieved_value.as<std::string>(), configValue.as<std::string>());
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_ClassPluginPropertiesTestNPU, ClassPluginPropertiesTestSuite0NPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_ClassPluginPropertiesTestNPU, ClassPluginPropertiesTestSuite0NPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::getDeviceName()),
                                             ::testing::ValuesIn(plugin_public_mutable_properties)),
                          ClassPluginPropertiesTestNPU::getTestCaseName);
@@ -218,7 +218,7 @@ TEST_P(ClassPluginPropertiesTestSuite1NPU, CanSetGetInternalMutableProperty) {
     ASSERT_EQ(retrieved_value.as<std::string>(), configValue.as<std::string>());
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_ClassPluginPropertiesTestNPU, ClassPluginPropertiesTestSuite1NPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_ClassPluginPropertiesTestNPU, ClassPluginPropertiesTestSuite1NPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::getDeviceName()),
                                             ::testing::ValuesIn(plugin_internal_mutable_properties)),
                          ClassPluginPropertiesTestNPU::getTestCaseName);
@@ -279,7 +279,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_ClassPluginPropertiesOptsTest1NPU, 
                                             ::testing::ValuesIn(plugin_public_immutable_properties)),
                          ClassPluginPropertiesTestNPU::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_ClassPluginPropertiesOptsTest2NPU, ClassPluginPropertiesTestSuite3NPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_ClassPluginPropertiesOptsTest2NPU, ClassPluginPropertiesTestSuite3NPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::getDeviceName()),
                                             ::testing::ValuesIn(plugin_public_mutable_properties)),
                          ClassPluginPropertiesTestNPU::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
@@ -202,7 +202,7 @@ TEST_P(ClassPluginPropertiesTestSuite0NPU, CanSetGetPublicMutableProperty) {
     ASSERT_EQ(retrieved_value.as<std::string>(), configValue.as<std::string>());
 }
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_ClassPluginPropertiesTestNPU, ClassPluginPropertiesTestSuite0NPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_ClassPluginPropertiesTestNPU, ClassPluginPropertiesTestSuite0NPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::getDeviceName()),
                                             ::testing::ValuesIn(plugin_public_mutable_properties)),
                          ClassPluginPropertiesTestNPU::getTestCaseName);
@@ -218,7 +218,7 @@ TEST_P(ClassPluginPropertiesTestSuite1NPU, CanSetGetInternalMutableProperty) {
     ASSERT_EQ(retrieved_value.as<std::string>(), configValue.as<std::string>());
 }
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_ClassPluginPropertiesTestNPU, ClassPluginPropertiesTestSuite1NPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_ClassPluginPropertiesTestNPU, ClassPluginPropertiesTestSuite1NPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::getDeviceName()),
                                             ::testing::ValuesIn(plugin_internal_mutable_properties)),
                          ClassPluginPropertiesTestNPU::getTestCaseName);
@@ -279,7 +279,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_ClassPluginPropertiesOptsTest1NPU, 
                                             ::testing::ValuesIn(plugin_public_immutable_properties)),
                          ClassPluginPropertiesTestNPU::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_ClassPluginPropertiesOptsTest2NPU, ClassPluginPropertiesTestSuite3NPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_ClassPluginPropertiesOptsTest2NPU, ClassPluginPropertiesTestSuite3NPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::getDeviceName()),
                                             ::testing::ValuesIn(plugin_public_mutable_properties)),
                          ClassPluginPropertiesTestNPU::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/internal/overload/ov_plugin/core_integration.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/ov_plugin/core_integration.hpp
@@ -154,7 +154,7 @@ TEST_P(OVClassLoadNetworkTestNPU, LoadNetworkHETEROWithDeviceIDNoThrow) {
     }
 }
 
-TEST(backwardDrvComp_OVClassBasicPropsTestNPU, smoke_SetConfigDevicePropertiesThrows) {
+TEST(compatibility_OVClassBasicPropsTestNPU, smoke_SetConfigDevicePropertiesThrows) {
     ov::Core core;
     ASSERT_THROW(core.set_property("", ov::device::properties(ov::test::utils::DEVICE_NPU, ov::enable_profiling(true))),
                  ov::Exception);

--- a/src/plugins/intel_npu/tests/functional/internal/overload/ov_plugin/core_integration.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/ov_plugin/core_integration.hpp
@@ -154,7 +154,7 @@ TEST_P(OVClassLoadNetworkTestNPU, LoadNetworkHETEROWithDeviceIDNoThrow) {
     }
 }
 
-TEST(OVClassBasicPropsTestNPU, smoke_SetConfigDevicePropertiesThrows) {
+TEST(backwardDrvComp_OVClassBasicPropsTestNPU, smoke_SetConfigDevicePropertiesThrows) {
     ov::Core core;
     ASSERT_THROW(core.set_property("", ov::device::properties(ov::test::utils::DEVICE_NPU, ov::enable_profiling(true))),
                  ov::Exception);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/compiled_model_base.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/compiled_model_base.cpp
@@ -48,7 +48,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVCompiledModelBaseTestOpti
                                             ::testing::ValuesIn(heteroCompiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledModelBaseTestOptional>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVAutoExecutableNetworkTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVAutoExecutableNetworkTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(compiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVAutoExecutableNetworkTest>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/compiled_model_base.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/compiled_model_base.cpp
@@ -48,7 +48,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVCompiledModelBaseTestOpti
                                             ::testing::ValuesIn(heteroCompiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledModelBaseTestOptional>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVAutoExecutableNetworkTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVAutoExecutableNetworkTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(compiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVAutoExecutableNetworkTest>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
@@ -38,7 +38,7 @@ auto heteroCompiledModelConfigs = []() -> std::vector<ov::AnyMap> {
     return heteroPluginConfigs;
 }();
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVCompiledGraphImportExportTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVCompiledGraphImportExportTest,
                          ::testing::Combine(::testing::ValuesIn(convertModelTypes),
                                             ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(compiledModelConfigs)),
@@ -51,7 +51,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVCompiledGraphImportExport
                                             ::testing::ValuesIn(heteroCompiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledGraphImportExportTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelImportExportTestP,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVClassCompiledModelImportExportTestP,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelImportExportTestP>);
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
@@ -38,7 +38,7 @@ auto heteroCompiledModelConfigs = []() -> std::vector<ov::AnyMap> {
     return heteroPluginConfigs;
 }();
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVCompiledGraphImportExportTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVCompiledGraphImportExportTest,
                          ::testing::Combine(::testing::ValuesIn(convertModelTypes),
                                             ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(compiledModelConfigs)),
@@ -51,7 +51,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVCompiledGraphImportExport
                                             ::testing::ValuesIn(heteroCompiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledGraphImportExportTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelImportExportTestP,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelImportExportTestP,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelImportExportTestP>);
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
@@ -122,7 +122,7 @@ const auto& combineHeteroParamsExecDevices = []() -> std::vector<std::pair<ov::A
     return execHeteroParams;
 }();
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelGetIncorrectPropertyTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelGetIncorrectPropertyTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetIncorrectPropertyTest>);
 
@@ -131,7 +131,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompiledModelGetInco
                                            ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetIncorrectPropertyTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelGetPropertyTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelGetPropertyTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetPropertyTest>);
 
@@ -140,7 +140,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompiledModelGetProp
                                            ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetPropertyTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelGetConfigTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelGetConfigTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetConfigTest>);
 
@@ -166,12 +166,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompileModelWithCorr
                                             ::testing::ValuesIn(heteroCompiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompileModelWithCorrectPropertiesTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelPropertiesIncorrectTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelPropertiesIncorrectTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(compiledModelIncorrectConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelPropertiesIncorrectTests>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVCompiledModelIncorrectDevice,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVCompiledModelIncorrectDevice,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledModelIncorrectDevice>);
 
@@ -179,7 +179,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVCompiledModelPropertiesDefaultSu
                          ::testing::Values(ov::test::utils::DEVICE_NPU),	
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledModelPropertiesDefaultSupportedTests>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelPropertiesDefaultTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelPropertiesDefaultTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(publicCompiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelPropertiesDefaultTests>);
@@ -195,7 +195,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompiledModelSetCorr
                                             ::testing::ValuesIn(compiledModelPropertiesAnyToString)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelSetCorrectConfigTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVClassCompiledModelSetIncorrectConfigTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelSetIncorrectConfigTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelSetIncorrectConfigTest>);
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
@@ -122,7 +122,7 @@ const auto& combineHeteroParamsExecDevices = []() -> std::vector<std::pair<ov::A
     return execHeteroParams;
 }();
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelGetIncorrectPropertyTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVClassCompiledModelGetIncorrectPropertyTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetIncorrectPropertyTest>);
 
@@ -131,7 +131,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompiledModelGetInco
                                            ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetIncorrectPropertyTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelGetPropertyTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVClassCompiledModelGetPropertyTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetPropertyTest>);
 
@@ -140,7 +140,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompiledModelGetProp
                                            ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetPropertyTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelGetConfigTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVClassCompiledModelGetConfigTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelGetConfigTest>);
 
@@ -166,12 +166,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompileModelWithCorr
                                             ::testing::ValuesIn(heteroCompiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompileModelWithCorrectPropertiesTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelPropertiesIncorrectTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVClassCompiledModelPropertiesIncorrectTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(compiledModelIncorrectConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelPropertiesIncorrectTests>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVCompiledModelIncorrectDevice,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVCompiledModelIncorrectDevice,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledModelIncorrectDevice>);
 
@@ -179,7 +179,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVCompiledModelPropertiesDefaultSu
                          ::testing::Values(ov::test::utils::DEVICE_NPU),	
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledModelPropertiesDefaultSupportedTests>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelPropertiesDefaultTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVClassCompiledModelPropertiesDefaultTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(publicCompiledModelConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelPropertiesDefaultTests>);
@@ -195,7 +195,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, OVClassCompiledModelSetCorr
                                             ::testing::ValuesIn(compiledModelPropertiesAnyToString)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelSetCorrectConfigTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVClassCompiledModelSetIncorrectConfigTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVClassCompiledModelSetIncorrectConfigTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelSetIncorrectConfigTest>);
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/batched_tensors.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/batched_tensors.cpp
@@ -11,7 +11,7 @@ using namespace ov::test::behavior;
 
 namespace {
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestBatchedTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestBatchedTests,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestBatchedTests>);
 }  // namespace

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/batched_tensors.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/batched_tensors.cpp
@@ -11,7 +11,7 @@ using namespace ov::test::behavior;
 
 namespace {
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestBatchedTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestBatchedTests,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestBatchedTests>);
 }  // namespace

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/callback.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/callback.cpp
@@ -23,32 +23,32 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
          ov::device::properties(ov::test::utils::DEVICE_NPU, ov::AnyMap{})}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestCallbackTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestCallbackTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestCallbackTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestCallbackTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestCallbackTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestCallbackTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestCallbackTestsNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestCallbackTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestCallbackTestsNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestCallbackTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestCallbackTestsNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestCallbackTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/callback.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/callback.cpp
@@ -23,32 +23,32 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
          ov::device::properties(ov::test::utils::DEVICE_NPU, ov::AnyMap{})}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestCallbackTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestCallbackTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestCallbackTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestCallbackTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestCallbackTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestCallbackTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestCallbackTestsNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestCallbackTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestCallbackTestsNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestCallbackTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestCallbackTestsNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestCallbackTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/cancellation.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/cancellation.cpp
@@ -13,12 +13,12 @@ using namespace ov::test::behavior;
 namespace {
 const std::vector<ov::AnyMap> configs = {{}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestCancellationTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestCancellationTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestCancellationTestsNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestCancellationTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/cancellation.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/cancellation.cpp
@@ -13,12 +13,12 @@ using namespace ov::test::behavior;
 namespace {
 const std::vector<ov::AnyMap> configs = {{}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestCancellationTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestCancellationTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestCancellationTestsNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestCancellationTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/compile_and_infer.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/compile_and_infer.cpp
@@ -13,7 +13,7 @@ using namespace ov::test::behavior;
 
 const std::vector<ov::AnyMap> configs = {{}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVCompileAndInferRequest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVCompileAndInferRequest,
                          ::testing::Combine(::testing::Values(getConstantGraph(ov::element::f32)),
                                             ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/compile_and_infer.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/compile_and_infer.cpp
@@ -13,7 +13,7 @@ using namespace ov::test::behavior;
 
 const std::vector<ov::AnyMap> configs = {{}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVCompileAndInferRequest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVCompileAndInferRequest,
                          ::testing::Combine(::testing::Values(getConstantGraph(ov::element::f32)),
                                             ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference.cpp
@@ -10,7 +10,7 @@ namespace {
 
 using namespace ov::test::behavior;
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestInferenceTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestInferenceTests,
                          ::testing::Combine(::testing::Values(tensor_roi::roi_nchw(), tensor_roi::roi_1d()),
                                             ::testing::Values(ov::test::utils::DEVICE_NPU)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestInferenceTests>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference.cpp
@@ -10,7 +10,7 @@ namespace {
 
 using namespace ov::test::behavior;
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestInferenceTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestInferenceTests,
                          ::testing::Combine(::testing::Values(tensor_roi::roi_nchw(), tensor_roi::roi_1d()),
                                             ::testing::Values(ov::test::utils::DEVICE_NPU)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestInferenceTests>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -23,27 +23,27 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
         ov::device::properties(ov::test::utils::DEVICE_NPU, {})}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestIOTensorTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestIOTensorTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestIOTensorTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestIOTensorTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestIOTensorTestNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestIOTensorTestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestIOTensorTestNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestIOTensorTestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestIOTensorTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestIOTensorTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
@@ -54,32 +54,32 @@ const std::vector<ov::element::Type> prcs = {
         ov::element::u8,      ov::element::u16,  ov::element::u32, ov::element::u64,
 };
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTestNPU>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Mutli_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Mutli_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTestNPU>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTestNPU>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -23,27 +23,27 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
         ov::device::properties(ov::test::utils::DEVICE_NPU, {})}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestIOTensorTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestIOTensorTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestIOTensorTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestIOTensorTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestIOTensorTestNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestIOTensorTestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestIOTensorTestNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestIOTensorTestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestIOTensorTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestIOTensorTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
@@ -54,32 +54,32 @@ const std::vector<ov::element::Type> prcs = {
         ov::element::u8,      ov::element::u16,  ov::element::u32, ov::element::u64,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTestNPU>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Mutli_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Mutli_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTestNPU>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestIOTensorSetPrecisionTestNPU,
                          ::testing::Combine(::testing::ValuesIn(prcs), ::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestIOTensorSetPrecisionTestNPU>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/multithreading.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/multithreading.cpp
@@ -23,32 +23,32 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
         ov::device::properties(ov::test::utils::DEVICE_NPU, {})}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestMultithreadingTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestMultithreadingTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestMultithreadingTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestMultithreadingTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestMultithreadingTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestMultithreadingTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/multithreading.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/multithreading.cpp
@@ -23,32 +23,32 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
         ov::device::properties(ov::test::utils::DEVICE_NPU, {})}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestMultithreadingTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestMultithreadingTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestMultithreadingTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestMultithreadingTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestMultithreadingTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestMultithreadingTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestMultithreadingTestsNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          InferRequestParamsAnyMapTestName::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/perf_counters.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/perf_counters.cpp
@@ -24,17 +24,17 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
          ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestPerfCountersTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestPerfCountersTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestPerfCountersTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestPerfCountersTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestPerfCountersTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestPerfCountersTest>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestPerfCountersTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestPerfCountersTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestPerfCountersTest>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/perf_counters.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/perf_counters.cpp
@@ -24,17 +24,17 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
          ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestPerfCountersTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestPerfCountersTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestPerfCountersTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestPerfCountersTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestPerfCountersTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestPerfCountersTest>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestPerfCountersTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestPerfCountersTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestPerfCountersTest>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/properties_tests.cpp
@@ -11,7 +11,7 @@ using namespace ov::test::behavior;
 namespace {
 
 INSTANTIATE_TEST_SUITE_P(
-        smoke_BehaviorTests, InferRequestPropertiesTest,
+        backwardDrvComp_smoke_BehaviorTests, InferRequestPropertiesTest,
         ::testing::Combine(::testing::Values(2u), ::testing::Values(ov::test::utils::DEVICE_NPU),
                            ::testing::ValuesIn(std::vector<ov::AnyMap>{
                                    {}})),

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/properties_tests.cpp
@@ -11,7 +11,7 @@ using namespace ov::test::behavior;
 namespace {
 
 INSTANTIATE_TEST_SUITE_P(
-        backwardDrvComp_smoke_BehaviorTests, InferRequestPropertiesTest,
+        compatibility_smoke_BehaviorTests, InferRequestPropertiesTest,
         ::testing::Combine(::testing::Values(2u), ::testing::Values(ov::test::utils::DEVICE_NPU),
                            ::testing::ValuesIn(std::vector<ov::AnyMap>{
                                    {}})),

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/wait.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/wait.cpp
@@ -22,17 +22,17 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
         ov::device::properties(ov::test::utils::DEVICE_NPU, {})}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestWaitTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVInferRequestWaitTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestWaitTests>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestWaitTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests, OVInferRequestWaitTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestWaitTests>);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestWaitTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Auto_BehaviorTests, OVInferRequestWaitTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestWaitTests>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/wait.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/wait.cpp
@@ -22,17 +22,17 @@ const std::vector<ov::AnyMap> autoConfigs = {
         {ov::device::priorities(ov::test::utils::DEVICE_NPU),
         ov::device::properties(ov::test::utils::DEVICE_NPU, {})}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestWaitTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVInferRequestWaitTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestWaitTests>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferRequestWaitTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests, OVInferRequestWaitTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI),
                                             ::testing::ValuesIn(multiConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestWaitTests>);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferRequestWaitTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Auto_BehaviorTests, OVInferRequestWaitTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_AUTO),
                                             ::testing::ValuesIn(autoConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVInferRequestWaitTests>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -56,16 +56,13 @@ static std::string getTestCaseName(testing::TestParamInfo<std::string> obj) {
 
 const std::vector<ov::AnyMap> configs = {{}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVBasicPropertiesTestsP, OVBasicPropertiesTestsP,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVBasicPropertiesTestsP, OVBasicPropertiesTestsP,
                          ::testing::ValuesIn(plugins), OVClassBasicTestName::getTestCaseName);
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassBasicTestP, OVClassBasicTestPNPU, ::testing::ValuesIn(plugins),
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassBasicTestP, OVClassBasicTestPNPU, ::testing::ValuesIn(plugins),
                          OVClassBasicTestName::getTestCaseName);
 #endif
-
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassModelTestP, OVClassModelTestP, ::testing::ValuesIn(devices),
-                         OVClassNetworkTestName::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassNetworkTestP, OVClassNetworkTestPNPU,
                          ::testing::Combine(::testing::ValuesIn(devices), ::testing::ValuesIn(configs)),
@@ -75,14 +72,14 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassNetworkTestP, OVClassNetwork
 // IE Class GetMetric
 //
 
-INSTANTIATE_TEST_SUITE_P(BehaviorTests_OVGetMetricPropsTest_nightly, OVGetMetricPropsTest, ::testing::ValuesIn(devices),
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetMetricPropsTest_nightly, OVGetMetricPropsTest, ::testing::ValuesIn(devices),
                          OVClassNetworkTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(BehaviorTests_OVGetMetricPropsTest_nightly, OVGetMetricPropsOptionalTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetMetricPropsTest_nightly, OVGetMetricPropsOptionalTest,
                          ::testing::ValuesIn(devices), OVClassNetworkTestName::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-        BehaviorTests_OVCheckSetSupportedRWMandatoryMetricsPropsTests, OVCheckSetSupportedRWMetricsPropsTests,
+        smoke_BehaviorTests_OVCheckSetSupportedRWMandatoryMetricsPropsTests, OVCheckSetSupportedRWMetricsPropsTests,
         ::testing::Combine(::testing::Values("MULTI", "AUTO"),
                            ::testing::ValuesIn(OVCheckSetSupportedRWMetricsPropsTests::getRWOptionalPropertiesValues(
                                    {ov::log::level.name()}))),
@@ -135,11 +132,6 @@ const std::vector<ov::AnyMap> autoConfigsWithSecondaryProperties = {
          ov::device::properties(ov::test::utils::DEVICE_NPU,
                                 ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY))}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassSetDevicePriorityConfigPropsTest,
-                         OVClassSetDevicePriorityConfigPropsTest,
-                         ::testing::Combine(::testing::Values("MULTI", "AUTO"), ::testing::ValuesIn(multiConfigs)),
-                         ov::test::utils::appendPlatformTypeTestName<OVClassSetDevicePriorityConfigPropsTest>);
-
 //
 // IE Class GetConfig
 //
@@ -149,17 +141,17 @@ INSTANTIATE_TEST_SUITE_P(BehaviorTests_OVGetConfigTest_nightly, OVGetConfigTest,
 
 // IE Class Load network
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassLoadNetworkWithCorrectSecondaryPropertiesTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassLoadNetworkWithCorrectSecondaryPropertiesTest,
                          OVClassCompileModelWithCorrectPropertiesTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU, "AUTO:NPU", "MULTI:NPU"),
                                             ::testing::ValuesIn(configsWithSecondaryProperties)));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests_OVClassCompileModelWithCorrectPropertiesTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests_OVClassCompileModelWithCorrectPropertiesTest,
                          OVClassCompileModelWithCorrectPropertiesTest,
                          ::testing::Combine(::testing::Values("MULTI"),
                                             ::testing::ValuesIn(multiConfigsWithSecondaryProperties)));
 
-INSTANTIATE_TEST_SUITE_P(smoke_AUTO_BehaviorTests_OVClassCompileModelWithCorrectPropertiesTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_AUTO_BehaviorTests_OVClassCompileModelWithCorrectPropertiesTest,
                          OVClassCompileModelWithCorrectPropertiesTest,
                          ::testing::Combine(::testing::Values("AUTO"),
                                             ::testing::ValuesIn(autoConfigsWithSecondaryProperties)));
@@ -282,18 +274,18 @@ INSTANTIATE_TEST_SUITE_P(nightly_BehaviorTests_OVClassGetMetricTest, OVClassGetM
                          ::testing::Values(ov::test::utils::DEVICE_NPU), OVClassNetworkTestName::getTestCaseName);
 
 // Several devices case
-INSTANTIATE_TEST_SUITE_P(nightly_BehaviorTests_OVClassSeveralDevicesTest, OVClassSeveralDevicesTestCompileModel,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_nightly_BehaviorTests_OVClassSeveralDevicesTest, OVClassSeveralDevicesTestCompileModel,
                          ::testing::Values(std::vector<std::string>(
                                  {std::string(ov::test::utils::DEVICE_NPU) + "." +
                                   removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3700"))})),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassSeveralDevicesTestCompileModel>));
 
-INSTANTIATE_TEST_SUITE_P(nightly_BehaviorTests_OVClassModelOptionalTestP, OVClassModelOptionalTestP,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_nightly_BehaviorTests_OVClassModelOptionalTestP, OVClassModelOptionalTestP,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassModelOptionalTestP>));
 
 INSTANTIATE_TEST_SUITE_P(
-        nightly_BehaviorTests_OVClassSeveralDevicesTest, OVClassSeveralDevicesTestQueryModel,
+        backwardDrvComp_nightly_BehaviorTests_OVClassSeveralDevicesTest, OVClassSeveralDevicesTestQueryModel,
         ::testing::Values(std::vector<std::string>(
                 {std::string(ov::test::utils::DEVICE_NPU) + "." +
                          removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3700")),

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -56,11 +56,11 @@ static std::string getTestCaseName(testing::TestParamInfo<std::string> obj) {
 
 const std::vector<ov::AnyMap> configs = {{}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVBasicPropertiesTestsP, OVBasicPropertiesTestsP,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVBasicPropertiesTestsP, OVBasicPropertiesTestsP,
                          ::testing::ValuesIn(plugins), OVClassBasicTestName::getTestCaseName);
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassBasicTestP, OVClassBasicTestPNPU, ::testing::ValuesIn(plugins),
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassBasicTestP, OVClassBasicTestPNPU, ::testing::ValuesIn(plugins),
                          OVClassBasicTestName::getTestCaseName);
 #endif
 
@@ -72,10 +72,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassNetworkTestP, OVClassNetwork
 // IE Class GetMetric
 //
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetMetricPropsTest_nightly, OVGetMetricPropsTest, ::testing::ValuesIn(devices),
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVGetMetricPropsTest_nightly, OVGetMetricPropsTest, ::testing::ValuesIn(devices),
                          OVClassNetworkTestName::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetMetricPropsTest_nightly, OVGetMetricPropsOptionalTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVGetMetricPropsTest_nightly, OVGetMetricPropsOptionalTest,
                          ::testing::ValuesIn(devices), OVClassNetworkTestName::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
@@ -141,17 +141,17 @@ INSTANTIATE_TEST_SUITE_P(BehaviorTests_OVGetConfigTest_nightly, OVGetConfigTest,
 
 // IE Class Load network
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassLoadNetworkWithCorrectSecondaryPropertiesTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassLoadNetworkWithCorrectSecondaryPropertiesTest,
                          OVClassCompileModelWithCorrectPropertiesTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU, "AUTO:NPU", "MULTI:NPU"),
                                             ::testing::ValuesIn(configsWithSecondaryProperties)));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Multi_BehaviorTests_OVClassCompileModelWithCorrectPropertiesTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Multi_BehaviorTests_OVClassCompileModelWithCorrectPropertiesTest,
                          OVClassCompileModelWithCorrectPropertiesTest,
                          ::testing::Combine(::testing::Values("MULTI"),
                                             ::testing::ValuesIn(multiConfigsWithSecondaryProperties)));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_AUTO_BehaviorTests_OVClassCompileModelWithCorrectPropertiesTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_AUTO_BehaviorTests_OVClassCompileModelWithCorrectPropertiesTest,
                          OVClassCompileModelWithCorrectPropertiesTest,
                          ::testing::Combine(::testing::Values("AUTO"),
                                             ::testing::ValuesIn(autoConfigsWithSecondaryProperties)));
@@ -274,18 +274,18 @@ INSTANTIATE_TEST_SUITE_P(nightly_BehaviorTests_OVClassGetMetricTest, OVClassGetM
                          ::testing::Values(ov::test::utils::DEVICE_NPU), OVClassNetworkTestName::getTestCaseName);
 
 // Several devices case
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_nightly_BehaviorTests_OVClassSeveralDevicesTest, OVClassSeveralDevicesTestCompileModel,
+INSTANTIATE_TEST_SUITE_P(compatibility_nightly_BehaviorTests_OVClassSeveralDevicesTest, OVClassSeveralDevicesTestCompileModel,
                          ::testing::Values(std::vector<std::string>(
                                  {std::string(ov::test::utils::DEVICE_NPU) + "." +
                                   removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3700"))})),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassSeveralDevicesTestCompileModel>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_nightly_BehaviorTests_OVClassModelOptionalTestP, OVClassModelOptionalTestP,
+INSTANTIATE_TEST_SUITE_P(compatibility_nightly_BehaviorTests_OVClassModelOptionalTestP, OVClassModelOptionalTestP,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassModelOptionalTestP>));
 
 INSTANTIATE_TEST_SUITE_P(
-        backwardDrvComp_nightly_BehaviorTests_OVClassSeveralDevicesTest, OVClassSeveralDevicesTestQueryModel,
+        compatibility_nightly_BehaviorTests_OVClassSeveralDevicesTest, OVClassSeveralDevicesTestQueryModel,
         ::testing::Values(std::vector<std::string>(
                 {std::string(ov::test::utils::DEVICE_NPU) + "." +
                          removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3700")),

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
@@ -29,7 +29,7 @@ const Params paramsStreamsDRIVER[] = {
 
 }  // namespace
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadingTest, testing::ValuesIn(params),
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadingTest, testing::ValuesIn(params),
                          (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTest>));
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadingTestsWithIter,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
@@ -29,7 +29,7 @@ const Params paramsStreamsDRIVER[] = {
 
 }  // namespace
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadingTest, testing::ValuesIn(params),
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadingTest, testing::ValuesIn(params),
                          (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTest>));
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadingTestsWithIter,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/life_time.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/life_time.cpp
@@ -26,23 +26,23 @@ const std::vector<std::string> device_names_and_priorities = {
         "AUTO:NPU",   // NPU via AUTO,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVHoldersTest, ::testing::Values(ov::test::utils::DEVICE_NPU),
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVHoldersTest, ::testing::Values(ov::test::utils::DEVICE_NPU),
                          getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVHoldersTestOnImportedNetwork,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVHoldersTestOnImportedNetwork,
                          ::testing::Values(ov::test::utils::DEVICE_NPU), getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVHoldersTestNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVHoldersTestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          OVHoldersTestNPU::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVHoldersTestOnImportedNetworkNPU,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVHoldersTestOnImportedNetworkNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          OVHoldersTestOnImportedNetworkNPU::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_VirtualPlugin_BehaviorTests, OVHoldersTestWithConfig,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_VirtualPlugin_BehaviorTests, OVHoldersTestWithConfig,
                          ::testing::ValuesIn(device_names_and_priorities),
                          (ov::test::utils::appendPlatformTypeTestName<OVHoldersTestWithConfig>));
 }  // namespace

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/life_time.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/life_time.cpp
@@ -26,23 +26,23 @@ const std::vector<std::string> device_names_and_priorities = {
         "AUTO:NPU",   // NPU via AUTO,
 };
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVHoldersTest, ::testing::Values(ov::test::utils::DEVICE_NPU),
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVHoldersTest, ::testing::Values(ov::test::utils::DEVICE_NPU),
                          getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVHoldersTestOnImportedNetwork,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVHoldersTestOnImportedNetwork,
                          ::testing::Values(ov::test::utils::DEVICE_NPU), getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVHoldersTestNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVHoldersTestNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          OVHoldersTestNPU::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, OVHoldersTestOnImportedNetworkNPU,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVHoldersTestOnImportedNetworkNPU,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(configs)),
                          OVHoldersTestOnImportedNetworkNPU::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_VirtualPlugin_BehaviorTests, OVHoldersTestWithConfig,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_VirtualPlugin_BehaviorTests, OVHoldersTestWithConfig,
                          ::testing::ValuesIn(device_names_and_priorities),
                          (ov::test::utils::appendPlatformTypeTestName<OVHoldersTestWithConfig>));
 }  // namespace

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -140,13 +140,13 @@ const std::vector<ov::AnyMap> IncorrectInexistingProperties = {
     {{ov::intel_gpu::hint::host_task_priority.name(), ov::hint::Priority::LOW}},
     {{ov::intel_gpu::hint::queue_throttle.name(), ov::intel_gpu::hint::ThrottleLevel::HIGH}}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                          OVPropertiesTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(CorrectPluginMutableProperties)),
                          (ov::test::utils::appendPlatformTypeTestName<OVPropertiesTests>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                          OVPropertiesIncorrectTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(IncorrectImmutableProperties +
@@ -159,12 +159,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVPropertiesDefaultSupportedTests>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassCommon,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassCommon,
                          OVBasicPropertiesTestsP,
                          ::testing::Values(std::make_pair("openvino_intel_npu_plugin", ov::test::utils::DEVICE_NPU)),
                          (ov::test::utils::appendPlatformTypeTestName<OVBasicPropertiesTestsP>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                          OVPropertiesDefaultTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(CorrectPluginDefaultMutableProperties)),
@@ -186,7 +186,7 @@ INSTANTIATE_TEST_SUITE_P(
     (ov::test::utils::appendPlatformTypeTestName<OVCheckGetSupportedROMetricsPropsTests>));
 
 INSTANTIATE_TEST_SUITE_P(
-    backwardDrvComp_smoke_BehaviorTests_OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
+    compatibility_smoke_BehaviorTests_OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
     OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
     ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                        ::testing::ValuesIn(CorrectCompiledModelProperties)),
@@ -205,7 +205,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVCheckMetricsPropsTests_ModelDepen
                                             ::testing::ValuesIn(CorrectCompiledModelProperties)),
                          (ov::test::utils::appendPlatformTypeTestName<OVCheckMetricsPropsTests_ModelDependceProps>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassSetDefaultDeviceIDPropTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassSetDefaultDeviceIDPropTest,
                          OVClassSetDefaultDeviceIDPropTest,
                          ::testing::Values(std::make_pair(
                              ov::test::utils::DEVICE_NPU,
@@ -226,13 +226,13 @@ INSTANTIATE_TEST_SUITE_P(
                       removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3700"))),
     (ov::test::utils::appendPlatformTypeTestName<OVSpecificDeviceGetConfigTest>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetAvailableDevicesPropsTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVGetAvailableDevicesPropsTest,
                          OVGetAvailableDevicesPropsTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVGetAvailableDevicesPropsTest>));
 
 INSTANTIATE_TEST_SUITE_P(
-    backwardDrvComp_smoke_BehaviorTests_OVClassSpecificDeviceTest,
+    compatibility_smoke_BehaviorTests_OVClassSpecificDeviceTest,
     OVSpecificDeviceTestSetConfig,
     ::testing::Values(std::string(ov::test::utils::DEVICE_NPU) + "." +
                       removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3700"))),
@@ -240,7 +240,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 const std::vector<ov::AnyMap> multiConfigs = {{ov::device::priorities(ov::test::utils::DEVICE_NPU)}};
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassSetDevicePriorityConfigPropsTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassSetDevicePriorityConfigPropsTest,
                          OVClassSetDevicePriorityConfigPropsTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI,
                                                 ov::test::utils::DEVICE_AUTO,
@@ -248,12 +248,12 @@ INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassSetDevicePri
                                             ::testing::ValuesIn(multiConfigs)),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassSetDevicePriorityConfigPropsTest>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetMetricPropsTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVGetMetricPropsTest,
                          OVGetMetricPropsTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVGetMetricPropsTest>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetMetricPropsOptionalTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVGetMetricPropsOptionalTest,
                          OVGetMetricPropsOptionalTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVGetMetricPropsOptionalTest>));

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -140,13 +140,13 @@ const std::vector<ov::AnyMap> IncorrectInexistingProperties = {
     {{ov::intel_gpu::hint::host_task_priority.name(), ov::hint::Priority::LOW}},
     {{ov::intel_gpu::hint::queue_throttle.name(), ov::intel_gpu::hint::ThrottleLevel::HIGH}}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
                          OVPropertiesTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(CorrectPluginMutableProperties)),
                          (ov::test::utils::appendPlatformTypeTestName<OVPropertiesTests>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
                          OVPropertiesIncorrectTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(IncorrectImmutableProperties +
@@ -159,12 +159,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVPropertiesDefaultSupportedTests>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassCommon,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassCommon,
                          OVBasicPropertiesTestsP,
                          ::testing::Values(std::make_pair("openvino_intel_npu_plugin", ov::test::utils::DEVICE_NPU)),
                          (ov::test::utils::appendPlatformTypeTestName<OVBasicPropertiesTestsP>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests,
                          OVPropertiesDefaultTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(CorrectPluginDefaultMutableProperties)),
@@ -186,7 +186,7 @@ INSTANTIATE_TEST_SUITE_P(
     (ov::test::utils::appendPlatformTypeTestName<OVCheckGetSupportedROMetricsPropsTests>));
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_BehaviorTests_OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
+    backwardDrvComp_smoke_BehaviorTests_OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
     OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
     ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                        ::testing::ValuesIn(CorrectCompiledModelProperties)),
@@ -205,7 +205,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVCheckMetricsPropsTests_ModelDepen
                                             ::testing::ValuesIn(CorrectCompiledModelProperties)),
                          (ov::test::utils::appendPlatformTypeTestName<OVCheckMetricsPropsTests_ModelDependceProps>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassSetDefaultDeviceIDPropTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassSetDefaultDeviceIDPropTest,
                          OVClassSetDefaultDeviceIDPropTest,
                          ::testing::Values(std::make_pair(
                              ov::test::utils::DEVICE_NPU,
@@ -226,13 +226,13 @@ INSTANTIATE_TEST_SUITE_P(
                       removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3700"))),
     (ov::test::utils::appendPlatformTypeTestName<OVSpecificDeviceGetConfigTest>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVGetAvailableDevicesPropsTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetAvailableDevicesPropsTest,
                          OVGetAvailableDevicesPropsTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVGetAvailableDevicesPropsTest>));
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_BehaviorTests_OVClassSpecificDeviceTest,
+    backwardDrvComp_smoke_BehaviorTests_OVClassSpecificDeviceTest,
     OVSpecificDeviceTestSetConfig,
     ::testing::Values(std::string(ov::test::utils::DEVICE_NPU) + "." +
                       removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3700"))),
@@ -240,18 +240,20 @@ INSTANTIATE_TEST_SUITE_P(
 
 const std::vector<ov::AnyMap> multiConfigs = {{ov::device::priorities(ov::test::utils::DEVICE_NPU)}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassSetDevicePriorityConfigPropsTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassSetDevicePriorityConfigPropsTest,
                          OVClassSetDevicePriorityConfigPropsTest,
-                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_HETERO),
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_MULTI,
+                                                ov::test::utils::DEVICE_AUTO,
+                                                ov::test::utils::DEVICE_HETERO),
                                             ::testing::ValuesIn(multiConfigs)),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassSetDevicePriorityConfigPropsTest>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVGetMetricPropsTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetMetricPropsTest,
                          OVGetMetricPropsTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVGetMetricPropsTest>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVGetMetricPropsOptionalTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVGetMetricPropsOptionalTest,
                          OVGetMetricPropsOptionalTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVGetMetricPropsOptionalTest>));

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/query_model.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/query_model.cpp
@@ -10,11 +10,11 @@ namespace ov {
 namespace test {
 namespace behavior {
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassModelTestP, OVClassModelTestP,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassModelTestP, OVClassModelTestP,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassModelTestP>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassQueryModelTestTests, OVClassQueryModelTest,
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_OVClassQueryModelTestTests, OVClassQueryModelTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassQueryModelTest>));
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/query_model.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/query_model.cpp
@@ -10,11 +10,11 @@ namespace ov {
 namespace test {
 namespace behavior {
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassModelTestP, OVClassModelTestP,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassModelTestP, OVClassModelTestP,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassModelTestP>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_OVClassQueryModelTestTests, OVClassQueryModelTest,
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests_OVClassQueryModelTestTests, OVClassQueryModelTest,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<OVClassQueryModelTest>));
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/version.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/version.cpp
@@ -10,10 +10,10 @@ namespace ov {
 namespace test {
 namespace behavior {
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, VersionTests, ::testing::Values(ov::test::utils::DEVICE_NPU),
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, VersionTests, ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<VersionTests>));
 
-INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Hetero_BehaviorTests, VersionTests, ::testing::Values(ov::test::utils::DEVICE_HETERO),
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_Hetero_BehaviorTests, VersionTests, ::testing::Values(ov::test::utils::DEVICE_HETERO),
                          (ov::test::utils::appendPlatformTypeTestName<VersionTests>));
 
 }  // namespace behavior

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/version.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/version.cpp
@@ -10,10 +10,10 @@ namespace ov {
 namespace test {
 namespace behavior {
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, VersionTests, ::testing::Values(ov::test::utils::DEVICE_NPU),
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_BehaviorTests, VersionTests, ::testing::Values(ov::test::utils::DEVICE_NPU),
                          (ov::test::utils::appendPlatformTypeTestName<VersionTests>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Hetero_BehaviorTests, VersionTests, ::testing::Values(ov::test::utils::DEVICE_HETERO),
+INSTANTIATE_TEST_SUITE_P(backwardDrvComp_smoke_Hetero_BehaviorTests, VersionTests, ::testing::Values(ov::test::utils::DEVICE_HETERO),
                          (ov::test::utils::appendPlatformTypeTestName<VersionTests>));
 
 }  // namespace behavior


### PR DESCRIPTION
### Details:
 - *We need a new validation job where `ov_npu_func_tests` will be run with older `NPU drivers`. By this we will ensure backward compatibility between ov `master` branch and older drivers.*
 - *The requirement above can be fulfilled by adding a new keyword (e.g. <s>`backwardDrvComp`</s> `compatibility`) to all the test suites that passed with older drivers and new validation will use this new keyword as for `gtest_filter`.*

### Tickets:
 - *CVS-142863*
