### PR TITLE
[GPU] Fix issue of _in_layout update from onednn weights param when reorder fusing happens during post optimize weights

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp
@@ -10,7 +10,9 @@
 #include "deconvolution_inst.h"
 #include "fully_connected_inst.h"
 #include "intel_gpu/runtime/format.hpp"
-
+#ifdef ENABLE_ONEDNN_FOR_GPU
+#include "graph/impls/onednn/utils.hpp"
+#endif // ENABLE_ONEDNN_FOR_GPU
 namespace cldnn {
 
 post_optimize_weights::post_optimize_weights(reorder_factory& rf_ref)
@@ -90,6 +92,15 @@ void post_optimize_weights::optimize_weights(T& node, program& p) {
                 updated_input_layout.format = from_weights_layout(to_weights_layout(input_fmt, false));
 
                 weights_reorder_params->set_input_layout(updated_input_layout);
+#ifdef ENABLE_ONEDNN_FOR_GPU
+                // Need to update WeightsReorderParamsOneDNN of fc onednn imple when input layout data_type/format is different
+                auto onednn_weights_params = std::dynamic_pointer_cast<onednn::WeightsReorderParamsOneDNN>(weights_reorder_params);
+                if (onednn_weights_params &&
+                (updated_input_layout.format != onednn::find_data_format(onednn_weights_params->_in_desc) ||
+                onednn::convert_data_type(updated_input_layout.data_type) != onednn_weights_params->_in_desc.get_data_type())) {
+                    onednn_weights_params->_in_desc = onednn::layout_to_memory_desc(updated_input_layout);
+                }
+#endif // ENABLE_ONEDNN_FOR_GPU
                 auto weights_reorder = _rf.get_weights_reorder(prev_node.get_primitive()->input[0].pid,
                                                                weights_reorder_params);
                 auto& weights_reorder_node = p.get_or_create(weights_reorder.first);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp
@@ -96,8 +96,8 @@ void post_optimize_weights::optimize_weights(T& node, program& p) {
                 // Need to update WeightsReorderParamsOneDNN of fc onednn imple when input layout data_type/format is different
                 auto onednn_weights_params = std::dynamic_pointer_cast<onednn::WeightsReorderParamsOneDNN>(weights_reorder_params);
                 if (onednn_weights_params &&
-                (updated_input_layout.format != onednn::find_data_format(onednn_weights_params->_in_desc) ||
-                onednn::convert_data_type(updated_input_layout.data_type) != onednn_weights_params->_in_desc.get_data_type())) {
+                   (updated_input_layout.format != onednn::find_data_format(onednn_weights_params->_in_desc) ||
+                    onednn::convert_data_type(updated_input_layout.data_type) != onednn_weights_params->_in_desc.get_data_type())) {
                     onednn_weights_params->_in_desc = onednn::layout_to_memory_desc(updated_input_layout);
                 }
 #endif // ENABLE_ONEDNN_FOR_GPU

--- a/src/plugins/intel_gpu/tests/unit/passes/post_optimize_weights.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/post_optimize_weights.cpp
@@ -5,7 +5,9 @@
 #include "test_utils.h"
 #include "program_wrapper.h"
 #include "fully_connected_inst.h"
+#ifdef ENABLE_ONEDNN_FOR_GPU
 #include "graph/impls/onednn/utils.hpp"
+#endif
 
 using namespace cldnn;
 using namespace ::tests;
@@ -235,9 +237,11 @@ TEST(post_optimize_weights, fuse_reorder_to_onednn_weights_reorder_test) {
     ASSERT_TRUE(has_node(*prog, "reorder_dt"));
     auto& fc_node = prog->get_node("fc");
     auto weights_param = fc_node.as<fully_connected>().get_selected_impl()->get_weights_reorder_params();
-    auto onednn_weights_params = std::dynamic_pointer_cast<onednn::WeightsReorderParamsOneDNN>(weights_param);
     ASSERT_TRUE(format::is_weights_format(prog->get_node("reorder_dt").get_output_layout().format));
     ASSERT_TRUE(prog->get_node("reorder_dt").get_input_layout().data_type == data_types::f32);
+#ifdef ENABLE_ONEDNN_FOR_GPU
     // Check onednn_weights_params->_in_desc data_type is properly updated
+    auto onednn_weights_params = std::dynamic_pointer_cast<onednn::WeightsReorderParamsOneDNN>(weights_param);
     ASSERT_TRUE(onednn_weights_params->_in_desc.get_data_type() == onednn::convert_data_type(data_types::f32));
+#endif
 }

--- a/src/plugins/intel_gpu/tests/unit/passes/post_optimize_weights.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/post_optimize_weights.cpp
@@ -5,6 +5,7 @@
 #include "test_utils.h"
 #include "program_wrapper.h"
 #include "fully_connected_inst.h"
+#include "graph/impls/onednn/utils.hpp"
 
 using namespace cldnn;
 using namespace ::tests;
@@ -195,4 +196,48 @@ TEST(post_optimize_weights, fuse_only_with_supported_weights_layout) {
     program_wrapper::apply_opt_pass<post_optimize_weights>(*prog, rf);
 
     ASSERT_TRUE(has_node(*prog, "reorder"));
+}
+
+TEST(post_optimize_weights, fuse_reorder_to_onednn_weights_reorder_test) {
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    ov::Shape pshape = { 4, 16 };
+    auto input = engine.allocate_memory({ pshape, data_types::f16, format::bfyx });
+    auto weights = engine.allocate_memory({ pshape, data_types::f32, format::bfyx });
+
+    std::vector<float> weights_data(pshape[0] * pshape[1]);
+    std::iota(weights_data.begin(), weights_data.end(), 0.f);
+    set_values(weights, weights_data);
+
+    topology topology(
+        input_layout("input", input->get_layout()),
+        input_layout("weights", weights->get_layout()),
+        reorder("reorder_dt", input_info("weights"), format::bfyx, data_types::f16),
+        fully_connected("fc", input_info("input"), { "reorder_dt" }, "", data_types::f16)
+    );
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    if (engine.get_device_info().supports_immad) {
+        ov::intel_gpu::ImplementationDesc fc_impl = { format::bfyx, "", impl_types::onednn };
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"fc", fc_impl} }));
+    }
+
+    layout_optimizer lo(true);
+    lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);
+
+    auto prog = program::build_program(engine, topology, config);
+
+    ASSERT_TRUE(has_node(*prog, "reorder_dt"));
+    auto& fc_node = prog->get_node("fc");
+    auto weights_param = fc_node.as<fully_connected>().get_selected_impl()->get_weights_reorder_params();
+    auto onednn_weights_params = std::dynamic_pointer_cast<onednn::WeightsReorderParamsOneDNN>(weights_param);
+    ASSERT_TRUE(format::is_weights_format(prog->get_node("reorder_dt").get_output_layout().format));
+    ASSERT_TRUE(prog->get_node("reorder_dt").get_input_layout().data_type == data_types::f32);
+    // Check onednn_weights_params->_in_desc data_type is properly updated
+    ASSERT_TRUE(onednn_weights_params->_in_desc.get_data_type() == onednn::convert_data_type(data_types::f32));
 }


### PR DESCRIPTION
### Details:
 - Fix issue of _in_layout update from onednn weights param when reorder fusing happens during post optimize weights

### Tickets:
 - 143641
