### PR TITLE
[properties] Extending PCIInfo struct with product ID field

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -176,7 +176,7 @@ void regmodule_properties(py::module m) {
     cls_pciinfo.def_readonly("bus", &ov::device::PCIInfo::bus);
     cls_pciinfo.def_readonly("device", &ov::device::PCIInfo::device);
     cls_pciinfo.def_readonly("function", &ov::device::PCIInfo::function);
-    cls_pciinfo.def_readonly("function", &ov::device::PCIInfo::product);
+    cls_pciinfo.def_readonly("product", &ov::device::PCIInfo::product);
     cls_pciinfo.def("__repr__", [](const ov::device::PCIInfo& info) {
         std::stringstream pciinfo_stream;
         pciinfo_stream << info;

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -171,11 +171,12 @@ void regmodule_properties(py::module m) {
 
     // Special case: ov::device::PCIInfo
     py::class_<ov::device::PCIInfo, std::shared_ptr<ov::device::PCIInfo>> cls_pciinfo(m_device, "PCIInfo");
-    cls_pciinfo.def(py::init<const uint32_t&, const uint32_t&, const uint32_t&, const uint32_t&>());
+    cls_pciinfo.def(py::init<const uint32_t&, const uint32_t&, const uint32_t&, const uint32_t&, const uint32_t&>());
     cls_pciinfo.def_readonly("domain", &ov::device::PCIInfo::domain);
     cls_pciinfo.def_readonly("bus", &ov::device::PCIInfo::bus);
     cls_pciinfo.def_readonly("device", &ov::device::PCIInfo::device);
     cls_pciinfo.def_readonly("function", &ov::device::PCIInfo::function);
+    cls_pciinfo.def_readonly("function", &ov::device::PCIInfo::product);
     cls_pciinfo.def("__repr__", [](const ov::device::PCIInfo& info) {
         std::stringstream pciinfo_stream;
         pciinfo_stream << info;

--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -1049,7 +1049,7 @@ static constexpr Property<Type, PropertyMutability::RO> type{"DEVICE_TYPE"};
 static constexpr Property<std::map<element::Type, float>, PropertyMutability::RO> gops{"DEVICE_GOPS"};
 
 /**
- * @brief Structure to store PCI bus information of device (Domain/Bus/Device/Function)
+ * @brief Structure to store PCI bus information of device (Domain/Bus/Device/Function/Product)
  * @ingroup ov_runtime_cpp_prop_api
  */
 struct PCIInfo {
@@ -1069,18 +1069,23 @@ struct PCIInfo {
      * @brief PCI function ID
      */
     uint32_t function;
+    /**
+     * @brief PCI device's product ID
+     */
+    uint32_t product;
 };
 
 /** @cond INTERNAL */
 inline std::ostream& operator<<(std::ostream& os, const PCIInfo& pci_info) {
     return os << "{domain: " << pci_info.domain << " bus: " << pci_info.bus << " device: 0x" << std::hex
-              << pci_info.device << " function: " << std::dec << pci_info.function << "}";
+              << pci_info.device << " function: " << std::dec << pci_info.function << " product: 0x" << std::hex
+              << pci_info.product << "}";
 }
 
 inline std::istream& operator>>(std::istream& is, PCIInfo& pci_info) {
     std::string delim;
     if (!(is >> delim >> pci_info.domain >> delim >> pci_info.bus >> delim >> std::hex >> pci_info.device >> delim >>
-          std::dec >> pci_info.function)) {
+          std::dec >> pci_info.function >> delim >> std::hex >> pci_info.product)) {
         OPENVINO_THROW("Could not deserialize PCIInfo. Invalid format!");
     }
     return is;

--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -28,16 +28,8 @@ ZeroDevice::ZeroDevice(const std::shared_ptr<ZeroInitStructsHolder>& initStructs
     // older drivers
     pci_properties.stype = ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES;
     ze_result_t retpci = zeDevicePciGetPropertiesExt(_initStructs->getDevice(), &pci_properties);
-    if (ZE_RESULT_SUCCESS == retpci) {
-        // windows driver specific backwards compatibility
-        if (pci_properties.address.device == 0) {
-            log.warning("PCI information not available in driver. Falling back to deviceId");
-            pci_properties.address.device = device_properties.deviceId;
-        }
-    } else {
-        // general backwards compatibility
-        log.warning("PCI information not available in driver. Falling back to deviceId");
-        pci_properties.address.device = device_properties.deviceId;
+    if (ZE_RESULT_SUCCESS != retpci) {
+        log.warning("PCI bus information not available in driver.");
     }
 
     /// Calculate and store device GOPS with formula: frequency * number of tiles * ops per tile
@@ -154,7 +146,8 @@ ov::device::PCIInfo ZeroDevice::getPciInfo() const {
     return ov::device::PCIInfo{pci_properties.address.domain,
                                pci_properties.address.bus,
                                pci_properties.address.device,
-                               pci_properties.address.function};
+                               pci_properties.address.function,
+                               device_properties.deviceId};
 }
 
 std::map<ov::element::Type, float> ZeroDevice::getGops() const {


### PR DESCRIPTION
### Details:
- PCIInfo structure's device ID field was previously falsely believed to refer to product ID (for identification of device model), but it actually stores pci endpoint ID of the device in the system, therefore the implemented feature does not address the feature-request (PCIInfo to contain product id) PR #24111 
- This PR extends PCIInfo structure with additional field to include product ID as well

### Tickets:
 - [*CVS-138767*](https://jira.devtools.intel.com/browse/CVS-138767)
