### PR TITLE
[GPU] Fix RoPE for non-transposed input cases

### DIFF
--- a/src/plugins/intel_gpu/src/graph/rope.cpp
+++ b/src/plugins/intel_gpu/src/graph/rope.cpp
@@ -58,6 +58,7 @@ std::string rope_inst::to_string(rope_node const& node) {
 
     json_composite rope_info;
     rope_info.add("gather_position_arg_id", desc->config.gather_position_arg_id);
+    rope_info.add("gather_rank", desc->gather_rank);
     rope_info.add("head_cnt", desc->config.head_cnt);
     rope_info.add("head_size", desc->config.head_size);
     rope_info.add("input_trans0213", desc->config.input_trans0213);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.cpp
@@ -79,19 +79,16 @@ RoPEKernelBase::DispatchData RoPEKernelBase::SetDefault(const rope_params& param
     const auto& input = params.inputs[0];
     const auto& output = params.outputs[0];
 
-    std::vector<std::vector<Tensor::DataChannelName>> dims_by_gws;
+    std::vector<std::vector<Tensor::DataChannelName>> dims_by_gws = {{ Tensor::DataChannelName::BATCH }, { Tensor::DataChannelName::FEATURE },
+                                                                     { Tensor::DataChannelName::Y, Tensor::DataChannelName::X }};
     if (params.is_chatglm || params.is_qwen) {
-        dims_by_gws = {{ Tensor::DataChannelName::BATCH }, { Tensor::DataChannelName::FEATURE },
-                       { Tensor::DataChannelName::Y, Tensor::DataChannelName::X }};
         dispatchData.gws = {input.Batch().v,
                             input.Feature().v,
                             params.head_cnt * std::max(params.rotary_ndims / 2ul, params.head_size - params.rotary_ndims)};
     } else {
-        dims_by_gws = {{ Tensor::DataChannelName::BATCH }, { Tensor::DataChannelName::Y },
-                       { Tensor::DataChannelName::FEATURE, Tensor::DataChannelName::X }};
-        dispatchData.gws = {input.Batch().v,
-                            input.Y().v,
-                            input.Feature().v * params.rotary_ndims / 2ul};
+        dispatchData.gws = {output.Batch().v,
+                            output.Feature().v,
+                            output.Y().v * params.rotary_ndims / 2ul};
     }
 
     dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo, input.GetLayout(), output.GetLayout(), dims_by_gws);

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
@@ -23,10 +23,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_RoPETestLlama2,
                          ::testing::Values(ov::test::utils::DEVICE_GPU),
                          RoPETestLlama2::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_RoPETestRotateHalfWOTranspose,
-                         RoPETestRotateHalfWOTranspose,
+INSTANTIATE_TEST_SUITE_P(smoke_RoPETestRotateHalfWithoutTranspose,
+                         RoPETestRotateHalfWithoutTranspose,
                          ::testing::Values(ov::test::utils::DEVICE_GPU),
-                         RoPETestRotateHalfWOTranspose::getTestCaseName);
+                         RoPETestRotateHalfWithoutTranspose::getTestCaseName);
 
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
@@ -23,5 +23,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_RoPETestLlama2,
                          ::testing::Values(ov::test::utils::DEVICE_GPU),
                          RoPETestLlama2::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_RoPETestRotateHalfWOTranspose,
+                         RoPETestRotateHalfWOTranspose,
+                         ::testing::Values(ov::test::utils::DEVICE_GPU),
+                         RoPETestRotateHalfWOTranspose::getTestCaseName);
+
 }  // namespace test
 }  // namespace ov

--- a/src/tests/functional/plugin/shared/include/subgraph_tests/rotary_pos_emb.hpp
+++ b/src/tests/functional/plugin/shared/include/subgraph_tests/rotary_pos_emb.hpp
@@ -52,7 +52,7 @@ TEST_P(RoPETestGPTJ, CompareWithRefs) {
     CheckNumberOfNodesWithType(function, {"RoPE"}, 1);
 };
 
-TEST_P(RoPETestRotateHalfWOTranspose, CompareWithRefs) {
+TEST_P(RoPETestRotateHalfWithoutTranspose, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();
     auto function = compiledModel.get_runtime_model();

--- a/src/tests/functional/plugin/shared/include/subgraph_tests/rotary_pos_emb.hpp
+++ b/src/tests/functional/plugin/shared/include/subgraph_tests/rotary_pos_emb.hpp
@@ -52,5 +52,12 @@ TEST_P(RoPETestGPTJ, CompareWithRefs) {
     CheckNumberOfNodesWithType(function, {"RoPE"}, 1);
 };
 
+TEST_P(RoPETestRotateHalfWOTranspose, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    run();
+    auto function = compiledModel.get_runtime_model();
+    CheckNumberOfNodesWithType(function, {"RoPE"}, 1);
+};
+
 }  // namespace test
 }  // namespace ov

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/rotary_pos_emb.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/rotary_pos_emb.hpp
@@ -63,15 +63,15 @@ public:
     static std::string getTestCaseName(const testing::TestParamInfo<std::tuple<bool, std::string>>& obj);
 };
 
-class RoPETestRotateHalfWOTranspose : public SubgraphBaseTest, public testing::WithParamInterface<std::string> {
+class RoPETestRotateHalfWithoutTranspose : public SubgraphBaseTest, public testing::WithParamInterface<std::string> {
 private:
     ov::Tensor create_i32_tensor(const ov::Shape& shape, int start, int step = 1);
     ov::OutputVector makeCosSinCache(int max_position_embeddings, int rotary_ndims);
-    std::shared_ptr<ov::Model> buildROPE_RotateHalfWOTranspose(int batch,
-                                                               int seq_length,
-                                                               int max_position_embeddings,
-                                                               int num_head,
-                                                               int ndims);
+    std::shared_ptr<ov::Model> buildROPE_RotateHalfWithoutTranspose(int batch,
+                                                                    int seq_length,
+                                                                    int max_position_embeddings,
+                                                                    int num_head,
+                                                                    int ndims);
 protected:
     void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
     void SetUp() override;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/rotary_pos_emb.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/rotary_pos_emb.hpp
@@ -63,5 +63,22 @@ public:
     static std::string getTestCaseName(const testing::TestParamInfo<std::tuple<bool, std::string>>& obj);
 };
 
+class RoPETestRotateHalfWOTranspose : public SubgraphBaseTest, public testing::WithParamInterface<std::string> {
+private:
+    ov::Tensor create_i32_tensor(const ov::Shape& shape, int start, int step = 1);
+    ov::OutputVector makeCosSinCache(int max_position_embeddings, int rotary_ndims);
+    std::shared_ptr<ov::Model> buildROPE_RotateHalfWOTranspose(int batch,
+                                                               int seq_length,
+                                                               int max_position_embeddings,
+                                                               int num_head,
+                                                               int ndims);
+protected:
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
+    void SetUp() override;
+
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<std::string>& obj);
+};
+
 }  // namespace test
 }  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/subgraph/rotary_pos_emb.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/rotary_pos_emb.cpp
@@ -586,7 +586,7 @@ void RoPETestGPTJ::SetUp() {
     function = buildROPE_GPTJ(num_head, hidden_dims, rotary_dims, hasShapeOf);
 }
 
-ov::OutputVector RoPETestRotateHalfWOTranspose::makeCosSinCache(int max_position_embeddings, int rotary_ndims) {
+ov::OutputVector RoPETestRotateHalfWithoutTranspose::makeCosSinCache(int max_position_embeddings, int rotary_ndims) {
     std::vector<float> lut_sin(max_position_embeddings * rotary_ndims, 0.0f);
     std::vector<float> lut_cos(max_position_embeddings * rotary_ndims, 0.0f);
 
@@ -611,11 +611,12 @@ ov::OutputVector RoPETestRotateHalfWOTranspose::makeCosSinCache(int max_position
     return {Cos, Sin};
 }
 
-std::shared_ptr<ov::Model> RoPETestRotateHalfWOTranspose::buildROPE_RotateHalfWOTranspose(int batch,
-                                                                                          int seq_length,
-                                                                                          int max_position_embeddings,
-                                                                                          int num_head,
-                                                                                          int ndims) {
+std::shared_ptr<ov::Model>
+    RoPETestRotateHalfWithoutTranspose::buildROPE_RotateHalfWithoutTranspose(int batch,
+                                                                             int seq_length,
+                                                                             int max_position_embeddings,
+                                                                             int num_head,
+                                                                             int ndims) {
     auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, PartialShape{batch, num_head, -1, ndims});
     auto pos_id_end = std::make_shared<ov::opset1::Parameter>(ov::element::i32, ov::Shape{});
     auto pos_ids = std::make_shared<ov::opset1::Parameter>(ov::element::i32, PartialShape{1, -1});
@@ -689,7 +690,7 @@ std::shared_ptr<ov::Model> RoPETestRotateHalfWOTranspose::buildROPE_RotateHalfWO
     return std::make_shared<ov::Model>(ov::NodeVector{add_Add}, ov::ParameterVector{input, pos_id_end, pos_ids});
 }
 
-ov::Tensor RoPETestRotateHalfWOTranspose::create_i32_tensor(const ov::Shape& shape, int start, int step) {
+ov::Tensor RoPETestRotateHalfWithoutTranspose::create_i32_tensor(const ov::Shape& shape, int start, int step) {
     auto tensor = ov::Tensor(ov::element::i32, shape);
     auto* ptr = static_cast<int32_t*>(tensor.data());
     for (size_t i = 0; i < tensor.get_size(); i++) {
@@ -699,7 +700,7 @@ ov::Tensor RoPETestRotateHalfWOTranspose::create_i32_tensor(const ov::Shape& sha
     return tensor;
 }
 
-void RoPETestRotateHalfWOTranspose::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
+void RoPETestRotateHalfWithoutTranspose::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
     const auto& funcInputs = function->inputs();
 
     const int position_id_start = 15;
@@ -720,7 +721,7 @@ void RoPETestRotateHalfWOTranspose::generate_inputs(const std::vector<ov::Shape>
     inputs.insert({funcInputs[2].get_node_shared_ptr(), t_position_ids});
 }
 
-void RoPETestRotateHalfWOTranspose::SetUp() {
+void RoPETestRotateHalfWithoutTranspose::SetUp() {
     targetDevice = this->GetParam();
 
     const int batch = 2;
@@ -731,10 +732,10 @@ void RoPETestRotateHalfWOTranspose::SetUp() {
 
     InputShape inpShape = {{batch, num_head, seq_length, ndims}, {{batch, num_head, seq_length, ndims}}};
     init_input_shapes({inpShape});
-    function = buildROPE_RotateHalfWOTranspose(batch, seq_length, max_position_embeddings, num_head, ndims);
+    function = buildROPE_RotateHalfWithoutTranspose(batch, seq_length, max_position_embeddings, num_head, ndims);
 }
 
-std::string RoPETestRotateHalfWOTranspose::getTestCaseName(const testing::TestParamInfo<std::string>& obj) {
+std::string RoPETestRotateHalfWithoutTranspose::getTestCaseName(const testing::TestParamInfo<std::string>& obj) {
     std::string targetDevice = obj.param;
     std::ostringstream result;
     result << "targetDevice=" << targetDevice;


### PR DESCRIPTION
### Details:
 - This PR addresses the issue with RoPE kernel GWS configuration. Previously, it was configured considering that input is always transposed (0213 order, so {B, Y, F * X) is used), which led to the actual order being {B, F, Y * X} for transposed case and incorrect {B, Y, F * X} order for non-transposed case. The change in this PR uses the output shape for GWS calculation instead. This allows for proper configuration regardless of whether the inputs are transposed or not. 

### Tickets:
 - [*CVS-144014*](https://jira.devtools.intel.com/browse/CVS-144014), [*CVS-143741*](https://jira.devtools.intel.com/browse/CVS-143741) 
