### PR TITLE
[AUTO] fix the crash when passing model path to AUTO with model cache enabled

### DIFF
--- a/src/plugins/auto/src/auto_schedule.cpp
+++ b/src/plugins/auto/src/auto_schedule.cpp
@@ -155,9 +155,13 @@ void AutoSchedule::init() {
                         const auto properties =
                             m_context->m_ov_core->create_compile_config(ov::DeviceIDParser(device).get_device_name(),
                                                                         device_config);
-                        auto blobId =
-                            ov::ModelCache::compute_hash(std::const_pointer_cast<const ov::Model>(m_context->m_model),
-                                                         properties);
+                        std::string blobId;
+                        if (m_context->m_model)
+                            blobId = ov::ModelCache::compute_hash(
+                                std::const_pointer_cast<const ov::Model>(m_context->m_model),
+                                properties);
+                        else
+                            blobId = ov::ModelCache::compute_hash(m_context->m_model_path, properties);
                         std::string cached_model_path = ov::util::make_path(cache_dir, blobId + ".blob");
                         m_compile_context[CPU].m_is_enabled = !ov::util::file_exists(cached_model_path);
                         LOG_DEBUG_TAG("device: %s %s cached blob: %s ",

--- a/src/plugins/auto/tests/functional/behavior/caching_test.cpp
+++ b/src/plugins/auto/tests/functional/behavior/caching_test.cpp
@@ -4,6 +4,7 @@
 
 #include "auto_func_test.hpp"
 #include "common_test_utils/include/common_test_utils/file_utils.hpp"
+#include "openvino/pass/serialize.hpp"
 
 using namespace ov::auto_plugin::tests;
 
@@ -72,6 +73,53 @@ TEST_F(AutoFuncTests, load_cached_model_to_actual_device_and_disable_CPU_acceler
     // will cache model for both actual device and CPU as accelerator
     ASSERT_EQ(ov::test::utils::listFilesWithExt(cache_path, "blob").size(), 3);
     core.set_property(ov::cache_dir(""));
+}
+
+TEST_F(AutoFuncTests, load_model_path_to_actual_device_and_disable_CPU_accelerating_default_startup_fallback) {
+    std::string filePrefix = ov::test::utils::generateTestFilePrefix();
+    auto m_xml_path = filePrefix + ".xml";
+    auto m_bin_path = filePrefix + ".bin";
+    ov::pass::Serialize(m_xml_path, m_bin_path).run_on_model(model_cannot_batch);
+    core.set_property(ov::cache_dir(cache_path));
+    core.set_property("MOCK_GPU", ov::device::id("test"));  // device id for cache property distinguish with MOCK_CPU
+    {
+        auto compiled_model = core.compile_model(m_xml_path,
+                                                 "AUTO",
+                                                 {ov::device::priorities("MOCK_GPU", "MOCK_CPU"),
+                                                  ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)});
+    }
+    // No cached model for actual device
+    // will cache model for both actual device and CPU plugin
+    ASSERT_EQ(ov::test::utils::listFilesWithExt(cache_path, "blob").size(), 2);
+    ov::test::utils::removeFilesWithExt(cache_path, "blob");
+    {
+        auto compiled_model = core.compile_model(
+            m_xml_path,
+            "AUTO",
+            {ov::device::priorities("MOCK_GPU"), ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)});
+    }
+    {
+        auto compiled_model = core.compile_model(m_xml_path,
+                                                 "AUTO",
+                                                 {ov::device::priorities("MOCK_GPU", "MOCK_CPU"),
+                                                  ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)});
+    }
+    // cached model exists for actual device
+    // will reuse cached model for actual device without CPU accelerating(No cached model for CPU)
+    ASSERT_EQ(ov::test::utils::listFilesWithExt(cache_path, "blob").size(), 1);
+
+    core.set_property("MOCK_GPU", ov::device::id("test_regenerate"));
+    {
+        auto compiled_model = core.compile_model(m_xml_path,
+                                                 "AUTO",
+                                                 {ov::device::priorities("MOCK_GPU", "MOCK_CPU"),
+                                                  ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)});
+    }
+    // model hash id changed for actual device
+    // will cache model for both actual device and CPU as accelerator
+    ASSERT_EQ(ov::test::utils::listFilesWithExt(cache_path, "blob").size(), 3);
+    core.set_property(ov::cache_dir(""));
+    ov::test::utils::removeIRFiles(m_xml_path, m_bin_path);
 }
 
 TEST_F(AutoFuncTests, load_cached_model_to_actual_device_and_disable_CPU_accelerating_set_startup_fallback) {


### PR DESCRIPTION
### Details:
 - port from https://github.com/openvinotoolkit/openvino/pull/25025 to 2024.2
 - *...*

### Tickets:
 - _N/A_
