### PR TITLE
[CPU][PROTOTYPE][DO_NOT_MERGE] Tensor parallelism as async SubGraphs

### DIFF
--- a/src/core/src/model.cpp
+++ b/src/core/src/model.cpp
@@ -46,7 +46,8 @@ void check_all_variables_registered(const std::vector<shared_ptr<ov::Node>>& ord
 }
 
 void check_all_parameters_registered(const std::vector<shared_ptr<ov::Node>>& ordered_ops,
-                                     const ov::ParameterVector& parameters) {
+                                     const ov::ParameterVector& parameters,
+                                     const std::string& name = "") {
     OV_ITT_SCOPED_TASK(ov::itt::domains::core, "Model::check_all_parameters_registered");
 
     std::stringstream unregistered_parameters;
@@ -56,7 +57,7 @@ void check_all_parameters_registered(const std::vector<shared_ptr<ov::Node>>& or
             unregistered_parameters << node << std::endl;
     }
     OPENVINO_ASSERT(unregistered_parameters.str().empty(),
-                    "Model references undeclared parameters: ",
+                    "Model ", name, " references undeclared parameters: ",
                     unregistered_parameters.str());
 }
 
@@ -209,7 +210,7 @@ void ov::Model::prerequirements(bool detect_variables, bool detect_parameters) {
     if (detect_parameters)
         m_parameters = auto_detect_parameters(ordered_ops);
     else
-        check_all_parameters_registered(ordered_ops, m_parameters);
+        check_all_parameters_registered(ordered_ops, m_parameters, get_friendly_name());
 
     if (detect_variables)
         m_variables = auto_detect_variables(ordered_ops);
@@ -244,11 +245,13 @@ void ov::Model::validate_nodes_and_infer_types() const {
     }
 
     OPENVINO_ASSERT(unregistered_parameters.str().empty(),
-                    "Model references undeclared parameters: ",
+                    "Model ", m_name,
+                    " references undeclared parameters: ",
                     unregistered_parameters.str());
 
     OPENVINO_ASSERT(unregistered_variables.str().empty(),
-                    "Model references undeclared Variables: ",
+                    "Model ", m_name,
+                    " references undeclared Variables: ",
                     unregistered_variables.str());
 
     for (const auto& output : outputs()) {

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -14,6 +15,7 @@
 #include "openvino/runtime/iplugin.hpp"
 #include "openvino/runtime/isync_infer_request.hpp"
 #include "openvino/runtime/threading/thread_local.hpp"
+#include "weights_cache.hpp"
 
 namespace ov {
 namespace intel_cpu {
@@ -66,7 +68,8 @@ private:
     const bool m_loaded_from_cache;
     // WARNING: Do not use m_graphs directly.
     mutable std::deque<GraphGuard> m_graphs;
-    mutable SocketsWeights m_socketWeights;
+    mutable std::shared_ptr<SocketsWeights> m_socketWeights = std::make_shared<SocketsWeights>();
+    mutable std::shared_ptr<std::vector<MultiCachePtr>> m_rtParamsCache;
 
     /* WARNING: Use get_graph() function to get access to graph in current stream.
      * NOTE: Main thread is interpreted as master thread of external stream so use this function to get access to graphs

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -71,7 +71,9 @@ struct Config {
     bool enableCpuPinning = true;
     bool changedCpuPinning = false;
     ov::hint::SchedulingCoreType schedulingCoreType = ov::hint::SchedulingCoreType::ANY_CORE;
-    std::set<ov::hint::ModelDistributionPolicy> modelDistributionPolicy = {};
+    std::set<ov::hint::ModelDistributionPolicy> modelDistributionPolicy = std::getenv("TENSOR_PARALLEL") ?
+        std::set<ov::hint::ModelDistributionPolicy>{ov::hint::ModelDistributionPolicy::TENSOR_PARALLEL}
+        : std::set<ov::hint::ModelDistributionPolicy>{};
     bool enableHyperThreading = true;
     bool changedHyperThreading = false;
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)

--- a/src/plugins/intel_cpu/src/cpu_types.cpp
+++ b/src/plugins/intel_cpu/src/cpu_types.cpp
@@ -230,6 +230,7 @@ static const TypeToNameMap& get_type_to_name_tbl() {
         {"Multinomial", Type::Multinomial},
         {"Reference", Type::Reference},
         {"Subgraph", Type::Subgraph},
+        {"SubModel", Type::SubModel},
         {"PriorBox", Type::PriorBox},
         {"PriorBoxClustered", Type::PriorBoxClustered},
         {"Interaction", Type::Interaction},
@@ -359,6 +360,7 @@ std::string NameFromType(const Type type) {
         CASE(Multinomial);
         CASE(Reference);
         CASE(Subgraph);
+        CASE(SubModel);
         CASE(PriorBox);
         CASE(PriorBoxClustered)
         CASE(MHA);

--- a/src/plugins/intel_cpu/src/cpu_types.h
+++ b/src/plugins/intel_cpu/src/cpu_types.h
@@ -113,6 +113,7 @@ enum class Type {
     MulticlassNms,
     Multinomial,
     Subgraph,
+    SubModel,
     PriorBox,
     PriorBoxClustered,
     Interaction,

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
@@ -45,6 +45,7 @@ dnnl::memory::data_type DnnlExtensionUtils::ElementTypeToDataType(const ov::elem
     switch (elementType) {
         case ov::element::f32:
             return memory::data_type::f32;
+        case ov::element::i64:
         case ov::element::i32:
             return memory::data_type::s32;
         case ov::element::bf16:

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -330,7 +330,8 @@ void Edge::changeStatus(Edge::Status state) {
         OPENVINO_THROW("Incorrect behaviour! Use method validate()");
     }
     if (Status::Validated == this->status) {
-        OPENVINO_THROW("Unexpected attempt of memory change on edge: ", name());
+        // OPENVINO_THROW("Unexpected attempt of memory change on edge: ", name());
+        return;
     }
     if (this->status != Status::Uninitialized && state == Status::NeedAllocation)
         return;

--- a/src/plugins/intel_cpu/src/graph_context.cpp
+++ b/src/plugins/intel_cpu/src/graph_context.cpp
@@ -9,24 +9,39 @@ namespace ov {
 namespace intel_cpu {
 
 GraphContext::GraphContext(const Config& config,
-                           WeightsSharing::Ptr w_cache,
+                           std::shared_ptr<SocketsWeights> w_cache,
                            bool isGraphQuantized,
-                           ov::threading::IStreamsExecutor::Ptr streamExecutor)
+                           std::shared_ptr<std::vector<MultiCachePtr>> rtParamsCache,
+                           ov::threading::IStreamsExecutor::Ptr streamExecutor,
+                           int sub_stream_id,
+                           std::shared_ptr<node::MemoryStatesRegister> memoryStatesRegister)
     : config(config),
       weightsCache(std::move(w_cache)),
       isGraphQuantizedFlag(isGraphQuantized),
-      streamExecutor(streamExecutor),
-      memoryStatesRegister(std::make_shared<node::MemoryStatesRegister>()) {
-    rtParamsCache = std::make_shared<MultiCache>(config.rtCacheCapacity);
+      m_streamExecutor(std::move(streamExecutor)),
+      m_numa_id(sub_stream_id + 1),
+      m_sub_steam_id(sub_stream_id),
+      memoryStatesRegister(memoryStatesRegister ? memoryStatesRegister : std::make_shared<node::MemoryStatesRegister>()) {
     // primitive/executors can be shared across sub-stream
     // but scratch pad cannot be shared.
     numNumaNodes = 1;
-    if (streamExecutor) {
-        cpuStreamExecutor = std::dynamic_pointer_cast<ov::threading::CPUStreamsExecutor>(streamExecutor);
+    if (m_streamExecutor) {
+        cpuStreamExecutor = std::dynamic_pointer_cast<ov::threading::CPUStreamsExecutor>(m_streamExecutor);
         auto nNumaNodes = get_num_numa_nodes();
         if (numNumaNodes < nNumaNodes)
             numNumaNodes = nNumaNodes;
+
+        // mainNumaNode = m_streamExecutor->get_numa_node_id();
+        mainNumaNode = m_streamExecutor->get_socket_id();
     }
+
+    // if (!rtParamsCache)
+    m_rtParamsCache = std::make_shared<std::vector<MultiCachePtr>>(numNumaNodes, std::make_shared<MultiCache>(config.rtCacheCapacity));
+    // else
+    //     m_rtParamsCache = rtParamsCache;
+
+    subStreamToUse = std::make_shared<int>(numNumaNodes - 2);
+
     for (int i = 0; i < numNumaNodes; i++) {
         rtScratchPads.push_back(std::make_shared<DnnlScratchPad>(getEngine(), i));
     }

--- a/src/plugins/intel_cpu/src/graph_dumper.h
+++ b/src/plugins/intel_cpu/src/graph_dumper.h
@@ -4,18 +4,20 @@
 
 #pragma once
 
-#include "graph.h"
-
 #include <memory>
 
 namespace ov {
+class Model;
 namespace intel_cpu {
+class Graph;
 
 std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph &graph);
 #ifdef CPU_DEBUG_CAPS
 void serialize(const Graph &graph);
+void serialize(const Graph &graph, const std::string& path);
 void summary_perf(const Graph &graph);
 #endif // CPU_DEBUG_CAPS
+void average_counters(const Graph &graph);
 
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/common/blocked_desc_creator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/blocked_desc_creator.cpp
@@ -73,10 +73,12 @@ private:
 } // namespace
 
 const BlockedDescCreator::CreatorsMap& BlockedDescCreator::getCommonCreators() {
-    static const CreatorsMap map{ { LayoutType::nspc, CreatorConstPtr(new PerChannelCreator) },
-                                { LayoutType::nCsp8c, CreatorConstPtr(new ChannelBlockedCreator(8)) },
-                                { LayoutType::nCsp16c, CreatorConstPtr(new ChannelBlockedCreator(16)) },
-                                { LayoutType::ncsp, CreatorConstPtr(new PlainFormatCreator) } };
+    static const CreatorsMap map{
+        { LayoutType::ncsp, CreatorConstPtr(new PlainFormatCreator) },
+        { LayoutType::nCsp8c, CreatorConstPtr(new ChannelBlockedCreator(8)) },
+        { LayoutType::nCsp16c, CreatorConstPtr(new ChannelBlockedCreator(16)) },
+        { LayoutType::nspc, CreatorConstPtr(new PerChannelCreator) },
+    };
     return map;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/common/memcpy.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/memcpy.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "memcpy.h"
+
+#include "cpu/x64/jit_generator.hpp"
+#include "common/utils.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+
+using namespace dnnl;
+using namespace dnnl::impl;
+using namespace dnnl::impl::cpu::x64;
+using namespace dnnl::impl::utils;
+using namespace Xbyak;
+
+#define GET_OFF(field) offsetof(jit_args_memcpy, field)
+
+namespace ov {
+namespace intel_cpu {
+
+template <cpu_isa_t isa>
+struct jit_memcpy_kernel : public jit_uni_memcpy_kernel, public jit_generator {
+public:
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_memcpy_kernel)
+    explicit jit_memcpy_kernel() : jit_uni_memcpy_kernel(), jit_generator(jit_name()) {}
+
+    void create_ker() override {
+        jit_generator::create_kernel();
+        ker_ = (decltype(ker_))jit_ker();
+    }
+
+    void generate() override {
+        preamble();
+
+        mov(reg_src, ptr[reg_params + GET_OFF(src)]);
+        mov(reg_dst, ptr[reg_params + GET_OFF(dst)]);
+        mov(reg_size, ptr[reg_params + GET_OFF(size)]);
+
+        emit_common();
+
+        postamble();
+    }
+
+private:
+    void emit_common() {
+        using namespace Xbyak;
+
+        const int step = vlen;
+        const int unroll_factor = 4;
+        const int unrolled_step = step * unroll_factor;
+
+        Label loop, remainder, end;
+        test(reg_size, reg_size);
+        jz(end);
+
+        mov(reg_curr_size, reg_size);
+        and_(reg_curr_size, ~(unrolled_step - 1));  // Align the size to the unrolled step
+
+        L(loop);
+        for (int i = 0; i < unroll_factor; ++i) {
+            uni_vmovdqu(vmm, ptr[reg_src + step * i]);
+            uni_vmovdqu(ptr[reg_dst + step * i], vmm);
+        }
+        add(reg_dst, unrolled_step);
+        add(reg_src, unrolled_step);
+        sub(reg_curr_size, unrolled_step);
+        jnz(loop);
+
+        // Handle remaining bytes
+        // mov(reg_size, reg_size);
+        and_(reg_size, unrolled_step - 1);  // Get the remaining size
+        jz(end);  // If no remaining bytes, jump to the end
+
+        L(remainder);
+        mov(al, ptr[reg_src]);
+        mov(ptr[reg_dst], al);
+        inc(reg_dst);
+        inc(reg_src);
+        dec(reg_size);
+        jnz(remainder);
+
+        L(end);
+        ret();
+    }
+
+    Xbyak::Reg64 reg_src = r8;
+    Xbyak::Reg64 reg_dst = r9;
+    Xbyak::Reg64 reg_size = r10;
+    Xbyak::Reg64 reg_curr_size = r11;
+    Xbyak::Reg64 reg_params = abi_param1;
+    using Vmm = typename conditional3<isa == cpu::x64::sse41, Xbyak::Xmm, isa == cpu::x64::avx2, Xbyak::Ymm, Xbyak::Zmm>::type;
+    uint32_t vlen = dnnl::impl::cpu::x64::cpu_isa_traits<isa>::vlen;
+    Vmm vmm = Vmm(1);
+};
+
+MemCpy::MemCpy() {
+    if (mayiuse(cpu::x64::avx512_core)) {
+        memcpy_kernel.reset(new jit_memcpy_kernel<dnnl::impl::cpu::x64::avx512_core>());
+    } else if (mayiuse(cpu::x64::avx2)) {
+        memcpy_kernel.reset(new jit_memcpy_kernel<cpu::x64::avx2>());
+    } else if (mayiuse(cpu::x64::sse41)) {
+        memcpy_kernel.reset(new jit_memcpy_kernel<cpu::x64::sse41>());
+    }
+
+    if (memcpy_kernel)
+        memcpy_kernel->create_ker();
+}
+
+void MemCpy::execute(const uint8_t* src_data, uint8_t* dst_data, std::size_t size) {
+    // VectorDims dst_dims = jcp.dst_block_dims;
+    auto args = jit_args_memcpy();
+
+    args.src = src_data;
+    args.dst = dst_data;
+    args.size = size;
+
+    if (memcpy_kernel) {
+        return (*memcpy_kernel)(&args);
+    }
+}
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/common/memcpy.h
+++ b/src/plugins/intel_cpu/src/nodes/common/memcpy.h
@@ -1,0 +1,55 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+// #include "node.h"
+// #include "cpu/x64/jit_generator.hpp"
+// #include "common/utils.hpp"
+// #include "cpu/x64/cpu_isa_traits.hpp"
+
+// using namespace dnnl;
+// using namespace dnnl::impl;
+// using namespace dnnl::impl::cpu::x64;
+// using namespace dnnl::impl::utils;
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+
+namespace ov {
+namespace intel_cpu {
+
+struct jit_args_memcpy {
+    const void* src;
+    const void* dst;
+    std::size_t size;
+};
+
+struct jit_uni_memcpy_kernel {
+    void (*ker_)(const jit_args_memcpy *);
+
+    void operator()(const jit_args_memcpy *args) {
+        assert(ker_);
+        ker_(args);
+    }
+
+    explicit jit_uni_memcpy_kernel() : ker_(nullptr) {}
+    virtual ~jit_uni_memcpy_kernel() {}
+
+    virtual void create_ker() = 0;
+};
+
+class MemCpy {
+public:
+    MemCpy();
+
+    void execute(const uint8_t* src_data, uint8_t* dst_data, std::size_t size);
+
+private:
+    std::shared_ptr<jit_uni_memcpy_kernel> memcpy_kernel;
+};
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/concat.h
+++ b/src/plugins/intel_cpu/src/nodes/concat.h
@@ -6,6 +6,7 @@
 
 #include "node.h"
 #include "graph_context.h"
+#include "nodes/common/memcpy.h"
 
 namespace ov {
 namespace intel_cpu {
@@ -46,12 +47,18 @@ private:
     size_t nelemTotal = 0;
     std::vector<size_t> dstOffset; // dst offset for each input
     std::vector<const uint8_t*> srcPtrs;
+
     bool hasOuterLoop = false;
     ov::element::Type inputPrecision = ov::element::f32;
     ov::element::Type outputPrecision = ov::element::f32;
     bool canExecRef = false;
     static constexpr size_t MAX_RANK_REF = 6;
     dnnl::primitive prim;
+
+    size_t m_physDims[5] = {1, 1, 1, 1, 1};
+    size_t m_outputStrides[MAX_RANK_REF] = {0};
+    unsigned m_L1Size = dnnl::utils::get_cache_size(1, true);
+    MemCpy jit_memcpy;
 };
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/convert.cpp
@@ -6,6 +6,7 @@
 
 #include "common/blocked_desc_creator.h"
 #include "dnnl_extension_utils.h"
+#include "openvino/core/type/element_type.hpp"
 #include "openvino/opsets/opset1.hpp"
 #include "shape_inference/shape_inference_pass_through.hpp"
 
@@ -130,12 +131,18 @@ void Convert::initSupportedPrimitiveDescriptors() {
                 break;
             }
         }
-        auto range = hasOutputChild
-                         ? BlockedDescCreator::makeFilteredRange(creators, insShape.getRank(), {LayoutType::ncsp})
-                         : BlockedDescCreator::makeFilteredRange(creators, insShape.getRank());
+        // auto range = hasOutputChild
+        //                  ? BlockedDescCreator::makeFilteredRange(creators, insShape.getRank(), {LayoutType::ncsp})
+        //                  : BlockedDescCreator::makeFilteredRange(creators, insShape.getRank());
+        auto range = BlockedDescCreator::makeFilteredRange(creators, insShape.getRank(), {LayoutType::ncsp});
 
         for (auto itr = range.first; itr != range.second; ++itr) {
             config.inConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(insPrecision, insShape)));
+            config.outConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(outPrecision, outputShape)));
+
+            supportedPrimitiveDescriptorsBuilder(config);
+
+            config.inConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(ov::element::f32, insShape)));
             config.outConfs[0].setMemDesc(std::make_shared<CpuBlockedMemoryDesc>(itr->second->createDesc(outPrecision, outputShape)));
 
             supportedPrimitiveDescriptorsBuilder(config);

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2539,11 +2539,11 @@ void Eltwise::initSupportedPrimitiveDescriptors() {
     }
 #endif
 
+    supportedPrimitiveDescriptors.emplace_back(initDesc(Planar));
     if (isChannelsFirstApplicable)
         supportedPrimitiveDescriptors.emplace_back(initDesc(ChannelsFirst));
     if (isBlockedApplicable)
         supportedPrimitiveDescriptors.emplace_back(initDesc(Blocked));
-    supportedPrimitiveDescriptors.emplace_back(initDesc(Planar));
 }
 
 void Eltwise::createPrimitive() {

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
@@ -73,7 +73,7 @@ public:
             return;
         }
         const auto newPrimMemDesc = m_primitive->scratchPadDesc();
-        m_scratchPadMemory = m_context->getScratchPad(numaNodeID)->createScratchPadMem(newPrimMemDesc);
+        m_scratchPadMemory = m_context->getScratchPad()->createScratchPadMem(newPrimMemDesc);
         m_primArgs[DNNL_ARG_SCRATCHPAD] = m_scratchPadMemory->getPrimitive();
 
         if (m_primArgs.count(DNNL_ARG_WEIGHTS)) {
@@ -123,8 +123,7 @@ private:
         if (currentPrimitive && currentPrimitive->weightsDesc()->isCompatible(*newPrimMemDesc))
             return;
 
-        if (m_attrs.weightsNonTransposed)
-            originalMemDesc = utils::makeTransposedWeightDescriptor(originalMemDesc, newPrimMemDesc);
+        originalMemDesc = utils::makeTransposedWeightDescriptor<Primitive>(originalMemDesc, newPrimMemDesc, m_attrs.weightsNonTransposed);
 
         const auto weiMemory = utils::prepareWeightsMemory(originalMemDesc, newPrimMemDesc, memory, m_context, true);
         m_primArgs[DNNL_ARG_WEIGHTS] = weiMemory->getPrimitive();
@@ -140,7 +139,7 @@ private:
         if (currentPrimitive && currentPrimitive->scratchPadDesc()->isCompatible(*newPrimMemDesc))
             return;
 
-        m_scratchPadMemory = m_context->getScratchPad(curNumaNode)->createScratchPadMem(newPrimMemDesc);
+        m_scratchPadMemory = m_context->getScratchPad()->createScratchPadMem(newPrimMemDesc);
         m_primArgs[DNNL_ARG_SCRATCHPAD] = m_scratchPadMemory->getPrimitive();
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
@@ -10,7 +10,6 @@
 #include "cpu_memory.h"
 #include "memory_desc/dnnl_memory_desc.h"
 #include "nodes/executors/dnnl/dnnl_shape_agnostic_data.hpp"
-#include "nodes/executors/dnnl/dnnl_utils.hpp"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/fullyconnected_config.hpp"
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.cpp
@@ -1,0 +1,438 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "nodes/executors/dnnl/dnnl_matmul_primitive.hpp"
+
+#include <oneapi/dnnl/dnnl_types.h>
+
+#include <common/primitive_attr.hpp>
+#include <common/primitive_desc_iface.hpp>
+#include <common/primitive_iface.hpp>
+#include <cstdint>
+#include <memory>
+#include <oneapi/dnnl/dnnl.hpp>
+#include <oneapi/dnnl/dnnl_common.hpp>
+
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu_memory.h"
+#include "cpu_types.h"
+#include "dnnl_extension_utils.h"
+#include "dnnl_postops_composer.h"
+#include "memory_desc/cpu_memory_desc.h"
+#include "memory_desc/cpu_memory_desc_utils.h"
+#include "memory_desc/dnnl_memory_desc.h"
+#include "nodes/executors/dnnl/dnnl_shape_agnostic_data.hpp"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/fullyconnected_config.hpp"
+#include "nodes/executors/matmul_config.hpp"
+#include "nodes/executors/memory_arguments.hpp"
+#include "utils/debug_capabilities.h"
+#include "dnnl_utils.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+using namespace dnnl;
+using namespace ov::element;
+using namespace executor;
+
+// @todo rewrite using hash_builder
+size_t DnnlMatMulPrimitive::Key::hash() const {
+    using namespace dnnl::impl;
+    using namespace dnnl::impl::primitive_hashing;
+
+    size_t seed = 0;
+
+    for (const auto& ptr : {src, wei, bias, dst}) {
+        if (ptr) {
+            seed = hash_combine(seed, get_md_hash(*ptr->getDnnlDesc().get()));
+        }
+    }
+
+    seed = hash_combine(seed, get_attr_hash(*attr.get()));
+
+    return seed;
+}
+
+bool DnnlMatMulPrimitive::Key::operator==(const Key& rhs) const {
+    bool result = true;
+
+    if (src != rhs.src) {
+        result = result && src && rhs.src && src->getDnnlDesc() == rhs.src->getDnnlDesc();
+    }
+    if (wei != rhs.wei) {
+        result = result && wei && rhs.wei && wei->getDnnlDesc() == rhs.wei->getDnnlDesc();
+    }
+    if (bias != rhs.bias) {
+        result = result && bias && rhs.bias && bias->getDnnlDesc() == rhs.bias->getDnnlDesc();
+    }
+    if (dst != rhs.dst) {
+        result = result && dst && rhs.dst && dst->getDnnlDesc() == rhs.dst->getDnnlDesc();
+    }
+
+    return result;
+}
+
+std::shared_ptr<DnnlMatMulPrimitive> DnnlMatMulPrimitive::create(const MemoryArgs& memory,
+                                                                 const MatMulAttrs& attrs,
+                                                                 const ExecutorContext::CPtr context,
+                                                                 const DnnlShapeAgnosticDataPtr& shapeAgnosticData) {
+    const auto& srcDesc = MemoryDescUtils::convertToDnnlMemoryDesc(memory.at(ARG_SRC)->getDescPtr());
+    const auto& weiDesc = MemoryDescUtils::convertToDnnlMemoryDesc(memory.at(ARG_WEI)->getDescPtr());
+    const auto& biaDesc = MemoryDescUtils::convertToDnnlMemoryDesc(memory.at(ARG_BIAS)->getDescPtr());
+    const auto& dstDesc = MemoryDescUtils::convertToDnnlMemoryDesc(memory.at(ARG_DST)->getDescPtr());
+
+    Key dnnlFCKey{
+        srcDesc,
+        weiDesc,
+        biaDesc,
+        dstDesc,
+        shapeAgnosticData->primAttrs.attr,
+        attrs.activation_k_dim,
+        attrs.activation_offset
+    };
+
+    auto builder = [&context](const Key& dnnlKey) {
+        return std::make_shared<DnnlMatMulPrimitive>(dnnlKey, context->getEngine(), context->getImplPriorities());
+    };
+
+    auto runtimeCache = context->getRuntimeCache();
+    const auto result = runtimeCache->getOrCreate(dnnlFCKey, builder);
+    const auto& primitive = result.first;
+    assert(primitive);
+
+    return primitive;
+}
+
+bool DnnlMatMulPrimitive::useWeightsDecompressionImpl(const ov::element::Type inputType,
+                                                      const ov::element::Type weightsType) {
+    return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2) && one_of(inputType, f32, bf16) &&
+           one_of(weightsType, u8, nf4, u4, i4);
+}
+
+bool DnnlMatMulPrimitive::useDynamicQuantizationImpl(size_t dqGroupSize,
+                                                     const MemoryDescPtr srcDesc,
+                                                     const MemoryDescPtr weightsDesc,
+                                                     MemoryCPtr scalesPtr,
+                                                     MemoryCPtr zpPtr,
+                                                     bool needTranspose) {
+    if (dqGroupSize == 0)
+        return false;
+
+    if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni) &&
+        !dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_vnni))
+        return false;
+
+    if (srcDesc->getPrecision() != ov::element::f32)
+        return false;
+
+    if (!one_of(weightsDesc->getPrecision(), ov::element::u8, ov::element::u4))
+        return false;
+
+    if (zpPtr && !one_of(zpPtr->getDesc().getPrecision(), ov::element::u8, ov::element::u4, ov::element::undefined))
+        return false;
+
+    const size_t simdWidth = 16;
+    if (dqGroupSize % simdWidth)
+        return false;
+
+    if (weightsDesc->getPrecision() == ov::element::u4) {
+        int ic = weightsDesc->getShape().getStaticDims()[1];
+        int minGroupSize = INT_MAX;
+        if (scalesPtr && scalesPtr->getShape().getRank() == 3) {
+            auto scalesDims = scalesPtr->getShape().getStaticDims();
+            auto groupsNum = needTranspose ? scalesDims[1] : scalesDims[0];
+            minGroupSize = ic / groupsNum;
+        }
+        if (zpPtr && zpPtr->getShape().getRank() == 3) {
+            auto zpDims = zpPtr->getShape().getStaticDims();
+            int groupsNum = needTranspose ? zpDims[1] : zpDims[0];
+            minGroupSize = std::min(minGroupSize, ic / groupsNum);
+        }
+
+        const size_t minLoopSize = 8;
+        if (minGroupSize != INT_MAX && minGroupSize % minLoopSize)
+            return false;
+    }
+
+    return true;
+}
+
+template <typename T>
+static std::vector<T> normalizeDimsTo2D(const std::vector<T>& dims) {
+    return {std::accumulate(dims.begin(), dims.end() - 1, (T)1, std::multiplies<T>()), dims[dims.size() - 1]};
+}
+
+static DnnlPrimitiveAttrs createPrimitiveAttrs(const MatMulAttrs& attrs,
+                                               const PostOps& postOps,
+                                               const MemoryArgs& memory,
+                                               ExecutorContext::CPtr context,
+                                               bool useDynamicQuantization) {
+    const auto& srcDesc = memory.at(ARG_SRC)->getDescPtr();
+    const auto& weiDesc = memory.at(ARG_WEI)->getDescPtr();
+    const auto& dstDesc = memory.at(ARG_DST)->getDescPtr();
+
+    const auto& originalDims = dstDesc->getShape().getMinDims();
+    const auto& dims = originalDims;
+
+    auto isINT8 =
+        one_of(srcDesc->getPrecision(), ov::element::u8, ov::element::i8) && weiDesc->getPrecision() == ov::element::i8;
+    auto outputDataType = DnnlExtensionUtils::ElementTypeToDataType(dstDesc->getPrecision());
+
+    DnnlPostOpsComposer dnnlpoc(postOps,
+                                context->getEngine(),
+                                dims,
+                                dims.size() - 1,
+                                isINT8,
+                                1 << 0,
+                                attrs.dequantizationScales,
+                                !memory.at(ARG_BIAS)->getDesc().empty(),
+                                outputDataType);
+
+    return dnnlpoc.compose();
+}
+
+static dnnl::memory::desc normalizeDescriptor(const dnnl::memory::desc& desc) {
+    const auto& dims = desc.get_dims();
+
+    if (dims.size() > 2)
+        return desc.reshape(normalizeDimsTo2D(dims));
+
+    return desc;
+}
+
+static dnnl::matmul::primitive_desc createDescriptorInternal(const dnnl::memory::desc& inputDesc,
+                                                             const dnnl::memory::desc& weightDesc,
+                                                             const dnnl::memory::desc& biasDesc,
+                                                             const dnnl::memory::desc& outputDesc,
+                                                             const dnnl::primitive_attr& attr,
+                                                             const dnnl::engine& engine,
+                                                             const bool useSparseWeights,
+                                                             const bool useWeightsDecompression,
+                                                             const bool weightsNonTransposed,
+                                                             int64_t K,
+                                                             int64_t offset) {
+    auto wDims = weightDesc.get_dims();
+    if (!weightsNonTransposed) {
+        std::swap(wDims[wDims.size() - 1], wDims[wDims.size() - 2]);
+    }
+
+    while (inputDesc.get_ndims() > wDims.size()) {
+        wDims.insert(wDims.begin(), 1);
+    }
+
+    auto bDims = biasDesc.get_dims();
+    while (!biasDesc.is_zero() && outputDesc.get_ndims() > bDims.size()) {
+        bDims.insert(bDims.begin(), 1);
+    }
+    auto newBiasDesc = !biasDesc.is_zero() && biasDesc.get_ndims() != bDims.size() ? biasDesc.reshape(bDims) : biasDesc;
+
+    const auto normalizedOutputDesc = outputDesc;
+    auto inputSumDims = inputDesc.get_dims();
+    inputSumDims.back() = K;
+
+    dnnl::memory::dims offsets(inputSumDims.size(), 0);
+    offsets.back() = offset;
+    // std::cout << "initial intput desc: " << inputDesc << "\n";
+    // std::cout << "inputSumDims" << PrintableVector<dnnl::memory::dim>(inputSumDims) << "\n";
+    // std::cout << "offsets" << PrintableVector<dnnl::memory::dim>(offsets) << "\n";
+
+    auto inputSubDesc = inputDesc.submemory_desc(inputSumDims, offsets);
+
+    if (K == 0) {
+        inputSubDesc = inputDesc;
+    }
+
+    const auto indt = inputSubDesc.get_data_type();
+    auto wdt = indt;
+
+    // if (useWeightsDecompression) {
+    //     wdt = weightDesc.get_data_type();
+    // } else if (indt == dnnl::memory::data_type::u8 || indt == dnnl::memory::data_type::s8) {
+    //     wdt = memory::data_type::s8;
+    // }
+
+    const dnnl::memory::desc weightsDesc =
+        useSparseWeights ? dnnl::memory::desc().sparse_desc(wDims, wdt)
+                         : dnnl::memory::desc(wDims, wdt, memory::format_tag::any);
+
+    // std::cout << "initial intput desc: " << inputDesc << "\n";
+    // std::cout << "intput desc: " << inputSubDesc << "\n";
+    // std::cout << "initial wei desc: " << weightDesc << "\n";
+    // std::cout << "wei desc: " << weightsDesc << "\n";
+    // std::cout << "initial bias desc: " << biasDesc << "\n";
+    // std::cout << "bias desc: " << newBiasDesc << "\n";
+    // std::cout << "output desc: " << normalizedOutputDesc << "\n";
+
+    return dnnl::matmul::primitive_desc(engine,
+                                        inputSubDesc,
+                                        weightsDesc,
+                                        newBiasDesc,
+                                        normalizedOutputDesc,
+                                        attr);
+}
+
+static primitive_desc createPrimitiveDesc(const dnnl::memory::desc& inputDesc,
+                                          const dnnl::memory::desc& weightDesc,
+                                          const dnnl::memory::desc& biasDesc,
+                                          const dnnl::memory::desc& outputDesc,
+                                          const dnnl::primitive_attr& attr,
+                                          const dnnl::engine& engine,
+                                          const std::vector<impl_desc_type>& implPriorities,
+                                          const bool useSparseWeights,
+                                          const bool useWeightsDecompression,
+                                          const bool weightsNonTransposed,
+                                          int64_t K,
+                                          int64_t offset) {
+    auto prim_desc = createDescriptorInternal(inputDesc,
+                                              weightDesc,
+                                              biasDesc,
+                                              outputDesc,
+                                              attr,
+                                              engine,
+                                              useSparseWeights,
+                                              useWeightsDecompression,
+                                              weightsNonTransposed,
+                                              K,
+                                              offset);
+    OPENVINO_ASSERT(prim_desc, "Failed to create matmul primitive descriptor");
+    auto first_desc = dnnl::matmul::primitive_desc(prim_desc.get());
+
+    const bool found = DnnlExtensionUtils::find_implementation(prim_desc, [&](impl_desc_type implType) {
+        return contains(implPriorities, implType);
+    });
+
+    if (found)
+        return std::move(prim_desc);
+
+    return std::move(first_desc);
+}
+
+static VectorDims makeDummyInputDims(const Shape& inShape, const Shape& wShape) {
+    const auto& weightDims = wShape.getStaticDims();
+
+    auto inMinDims = inShape.getMinDims();
+    auto inMaxDims = inShape.getMaxDims();
+    inMinDims.back() = weightDims.back();
+    inMaxDims.back() = weightDims.back();
+
+    return MemoryDescUtils::makeDummyShape(Shape(inMinDims, inMaxDims)).getStaticDims();
+}
+
+static VectorDims makeDummyOutputDims(const VectorDims& inShape, const VectorDims& wShape, const size_t out_rank) {
+    size_t activationRank = inShape.size();
+    size_t channelRank = wShape.size() - 1;
+    // activation   weight    output_shape
+    // NCHW         CoCHW     NCo
+    // TNC          CoC       TNCo
+    // NC           CoC       NCo
+    VectorDims outputShape(out_rank, 1);
+    // set Co
+    outputShape.back() = wShape[0];
+    // set batch dims
+    size_t batchRank = activationRank - channelRank;
+    size_t startIdx = out_rank - batchRank - 1;
+    for (size_t i = 0; i < batchRank; i++) {
+        outputShape[i + startIdx] = inShape[i];
+    }
+
+    return outputShape;
+}
+
+DnnlShapeAgnosticDataPtr DnnlMatMulPrimitive::createShapeAgnosticData(const FCAttrs& attrs,
+                                                                      const PostOps& postOps,
+                                                                      const MemoryArgs& memory,
+                                                                      const ExecutorContext::CPtr context,
+                                                                      const bool cacheWeights) {
+    DEBUG_LOG("Creating shape agnostic data");
+    auto srcDesc = memory.at(ARG_SRC)->getDescPtr();
+    const auto& weiDesc = memory.at(ARG_WEI)->getDescPtr();
+    const auto& biasDesc = memory.at(ARG_BIAS)->getDescPtr();
+    auto dstDesc = memory.at(ARG_DST)->getDescPtr();
+    MatMulAttrs mmAttrs{false, false, attrs.dequantizationScales, attrs.activation_k_dim, attrs.activation_offset};
+    // std::cout << "### Weights transposed? " << attrs.weightsNonTransposed  << "\n";
+
+    const auto postOpData = createPrimitiveAttrs(mmAttrs, postOps, memory, context, false);
+
+    if (!cacheWeights)
+        return std::make_shared<DnnlShapeAgnosticData>(postOpData);
+
+    if (srcDesc->getShape().isDynamic()) {
+        const auto& inShape = srcDesc->getShape();
+        const auto& wShape = weiDesc->getShape();
+        const auto& inDymmyDims = makeDummyInputDims(inShape, wShape);
+        srcDesc = srcDesc->cloneWithNewDims(inDymmyDims);
+        const auto& outDymmyDims =
+            makeDummyOutputDims(inDymmyDims, wShape.getStaticDims(), dstDesc->getShape().getRank());
+        dstDesc = dstDesc->cloneWithNewDims(outDymmyDims);
+    }
+
+    const dnnl::memory::desc srcDnnlDesc = MemoryDescUtils::convertToDnnlMemoryDesc(srcDesc)->getDnnlDesc();
+    const dnnl::memory::desc weiDnnlDesc = MemoryDescUtils::convertToDnnlMemoryDesc(weiDesc)->getDnnlDesc();
+    const dnnl::memory::desc dstDnnlDesc = MemoryDescUtils::convertToDnnlMemoryDesc(dstDesc)->getDnnlDesc();
+    const dnnl::memory::desc biaDnnlDesc = MemoryDescUtils::convertToDnnlMemoryDesc(biasDesc)->getDnnlDesc();
+
+    const auto primDesc = createPrimitiveDesc(srcDnnlDesc,
+                                              weiDnnlDesc,
+                                              biaDnnlDesc,
+                                              dstDnnlDesc,
+                                              postOpData.attr,
+                                              context->getEngine(),
+                                              context->getImplPriorities(),
+                                              false,
+                                              false,
+                                              attrs.weightsNonTransposed,
+                                              mmAttrs.activation_k_dim,
+                                              mmAttrs.activation_offset);
+
+    const auto weightsDesc = DnnlExtensionUtils::makeDescriptor(primDesc.weights_desc());
+    auto originalWeightsDesc = MemoryDescUtils::convertToDnnlMemoryDesc(weiDesc);
+    // if (attrs.weightsNonTransposed)
+    //     originalWeightsDesc = utils::makeTransposedWeightDescriptor(originalWeightsDesc, weightsDesc);
+
+    // ignore the result since we just need to put the packed weights into the cache
+    (void)utils::prepareWeightsMemory(originalWeightsDesc, weightsDesc, memory.at(ARG_WEI), context);
+
+    return std::make_shared<DnnlShapeAgnosticData>(postOpData);
+}
+
+static impl_desc_type implTypeFromPrimDesc(const dnnl::primitive_desc primDesc) {
+    const auto implType = parse_impl_name(primDesc.impl_info_str());
+    if (implType == ov::intel_cpu::brgemm_avx512_amx &&
+        primDesc.weights_desc().get_format_kind() == memory::format_kind::sparsed) {
+        return ov::intel_cpu::brgemm_sparse_avx512_amx;
+    }
+
+    return implType;
+}
+
+DnnlMatMulPrimitive::DnnlMatMulPrimitive(const Key& key,
+                                         const dnnl::engine& engine,
+                                         const std::vector<impl_desc_type>& implPriorities)
+    : m_stream(dnnl::stream(engine)),
+      m_primDesc(createPrimitiveDesc(key.src->getDnnlDesc(),
+                                     key.wei->getDnnlDesc(),
+                                     key.bias->getDnnlDesc(),
+                                     key.dst->getDnnlDesc(),
+                                     key.attr,
+                                     engine,
+                                     implPriorities,
+                                     false,
+                                     false,
+                                     false,
+                                     key.K,
+                                     key.offset)),
+      m_implType(implTypeFromPrimDesc(m_primDesc)),
+      m_srcDesc(DnnlExtensionUtils::makeDescriptor(m_primDesc.src_desc())),
+      m_weiDesc(DnnlExtensionUtils::makeDescriptor(m_primDesc.weights_desc())),
+      m_dstDesc(DnnlExtensionUtils::makeDescriptor(m_primDesc.dst_desc())),
+      m_scratchPadDesc(DnnlExtensionUtils::makeDescriptor(m_primDesc.scratchpad_desc())),
+      m_prim(primitive(m_primDesc)) {}
+
+void DnnlMatMulPrimitive::execute(const dnnl_primitive_args& primArgs) const {
+    m_prim.execute(m_stream, primArgs);
+}
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <oneapi/dnnl/dnnl.hpp>
+
+#include "cpu_memory.h"
+#include "memory_desc/dnnl_memory_desc.h"
+#include "nodes/executors/dnnl/dnnl_shape_agnostic_data.hpp"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/fullyconnected_config.hpp"
+#include "nodes/executors/matmul_config.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+class DnnlMatMulPrimitive {
+    struct Key {
+        DnnlMemoryDescCPtr src;
+        DnnlMemoryDescCPtr wei;
+        DnnlMemoryDescCPtr bias;
+        DnnlMemoryDescCPtr dst;
+        dnnl::primitive_attr attr;
+        int64_t K;
+        int64_t offset;
+
+        size_t hash() const;
+        bool operator==(const Key& rhs) const;
+    };
+
+public:
+    DnnlMatMulPrimitive(const Key& key, const dnnl::engine& engine, const std::vector<impl_desc_type>& implPriorities);
+
+    void execute(const dnnl_primitive_args& primArgs) const;
+
+    const DnnlMemoryDescPtr srcDesc() const {
+        return m_srcDesc;
+    }
+
+    const DnnlMemoryDescPtr dstDesc() const {
+        return m_dstDesc;
+    }
+
+    const DnnlMemoryDescPtr weightsDesc() const {
+        return m_weiDesc;
+    }
+
+    const DnnlMemoryDescPtr scratchPadDesc() const {
+        return m_scratchPadDesc;
+    }
+
+    impl_desc_type implType() const {
+        return m_implType;
+    }
+
+    static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const FCAttrs& attrs,
+                                                            const PostOps& postOps,
+                                                            const MemoryArgs& memory,
+                                                            const ExecutorContext::CPtr context,
+                                                            const bool cacheWeights);
+
+    static bool useWeightsDecompressionImpl(const ov::element::Type inputType, const ov::element::Type weightsType);
+
+    static std::shared_ptr<DnnlMatMulPrimitive> create(const MemoryArgs& memory,
+                                                       const MatMulAttrs& attrs,
+                                                       const ExecutorContext::CPtr context,
+                                                       const DnnlShapeAgnosticDataPtr& shapeAgnosticData);
+
+private:
+    static bool useDynamicQuantizationImpl(size_t dqGroupSize, const MemoryDescPtr srcDesc, const MemoryDescPtr weightsDesc,
+                                           MemoryCPtr scalesPtr, MemoryCPtr zpPtr, bool needTranspose);
+
+    dnnl::stream m_stream;
+    dnnl::primitive_desc m_primDesc;
+    impl_desc_type m_implType;
+    DnnlMemoryDescPtr m_srcDesc;
+    DnnlMemoryDescPtr m_weiDesc;
+    DnnlMemoryDescPtr m_dstDesc;
+    DnnlMemoryDescPtr m_scratchPadDesc;
+    dnnl::primitive m_prim;
+};
+
+using DnnlMatMulPrimitivePtr = std::shared_ptr<DnnlMatMulPrimitive>;
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.hpp
@@ -9,12 +9,38 @@
 
 #include "cpu_memory.h"
 #include "memory_desc/dnnl_memory_desc.h"
+#include "nodes/executors/dnnl/dnnl_matmul_primitive.hpp"
 #include "nodes/executors/executor.hpp"
+#include "dnnl_fullyconnected_primitive.hpp"
 
 namespace ov {
 namespace intel_cpu {
 namespace utils {
-DnnlMemoryDescPtr makeTransposedWeightDescriptor(const DnnlMemoryDescPtr srcDesc, const DnnlMemoryDescPtr dstDesc);
+
+template <typename Primitive>
+DnnlMemoryDescPtr makeTransposedWeightDescriptor(const DnnlMemoryDescPtr srcDesc,
+                                                 const DnnlMemoryDescPtr dstDesc,
+                                                 bool weightsNonTransposed) {
+    if (!weightsNonTransposed)
+        return srcDesc;
+
+    const auto& weiDesc = srcDesc->getDnnlDesc();
+    const auto reorderedWeiDesc = dnnl::memory::desc{weiDesc.get_dims(), weiDesc.get_data_type(), dnnl::memory::format_tag::ba};
+    const auto transposedWeiDesc = reorderedWeiDesc.reshape(dstDesc->getDnnlDesc().get_dims());
+
+    return DnnlExtensionUtils::makeDescriptor(transposedWeiDesc);
+}
+
+template <>
+DnnlMemoryDescPtr makeTransposedWeightDescriptor<DnnlFCPrimitive>(const DnnlMemoryDescPtr srcDesc,
+                                                                  const DnnlMemoryDescPtr dstDesc,
+                                                                  bool weightsNonTransposed);
+
+template <>
+DnnlMemoryDescPtr makeTransposedWeightDescriptor<DnnlMatMulPrimitive>(const DnnlMemoryDescPtr srcDesc,
+                                                                      const DnnlMemoryDescPtr dstDesc,
+                                                                      bool weightsNonTransposed);
+
 MemoryPtr prepareWeightsMemory(const DnnlMemoryDescPtr srcWeightDesc,
                                const DnnlMemoryDescPtr dstWeightDesc,
                                const MemoryCPtr weightsMem,

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -84,7 +84,7 @@ public:
                     const std::vector<impl_desc_type>& implPriorities,
                     std::shared_ptr<std::unordered_map<std::string, MemoryPtr>> privateWeighCache = nullptr)
         : runtimeCache(graphContext->getParamsCache()),
-          scratchPads(graphContext->getScratchPads()),
+          scratchPads(graphContext->getScratchPad()),
           weightsCache(graphContext->getWeightsCache()),
           engine(graphContext->getEngine()),
           implPriorities(implPriorities),
@@ -98,12 +98,12 @@ public:
         return runtimeCachePtr;
     }
 
-    DnnlScratchPadPtr getScratchPad(int subStreamID = 0) const {
-        if (subStreamID < 0)
-            subStreamID = 0;
-        if (subStreamID >= numNumaNodes - 1)
-            subStreamID = numNumaNodes - 1;
-        return scratchPads[subStreamID];
+    DnnlScratchPadPtr getScratchPad() const {
+        // if (subStreamID < 0)
+        //     subStreamID = 0;
+        // if (subStreamID >= numNumaNodes - 1)
+        //     subStreamID = numNumaNodes - 1;
+        return scratchPads;
     }
 
     std::shared_ptr<std::unordered_map<std::string, MemoryPtr>> getPrivateWeighCache() const {
@@ -126,7 +126,7 @@ private:
     // weak_ptr is required to avoid cycle dependencies with MultiCache
     // since ExecutorContext is stored in Executor itself
     MultiCacheWeakPtr runtimeCache;
-    std::vector<DnnlScratchPadPtr> scratchPads;
+    DnnlScratchPadPtr scratchPads;
     WeightsSharing::Ptr weightsCache;
     const dnnl::engine& engine;
     std::vector<impl_desc_type> implPriorities;

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
@@ -27,6 +27,8 @@ struct FCAttrs {
     MemoryCPtr decompressionMultiplyPtr;
     uint64_t dynamicQuantizationGroupSize;
     ov::intel_cpu::Config::ModelType modelType = ov::intel_cpu::Config::ModelType::Unknown;
+    int64_t activation_k_dim = 0;
+    int64_t activation_offset = 0;
 };
 
 using FCConfig = executor::Config<FCAttrs>;

--- a/src/plugins/intel_cpu/src/nodes/executors/matmul_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/matmul_config.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "executor_config.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+// @todo require explicit initialization of all the attributes?
+struct MatMulAttrs {
+    bool transposeA;
+    bool transposeB;
+    // @todo only memory descriptors should be a part of attributes
+    // actual memory should be passed into "execute" or "prepareMemory" calls
+    std::vector<float> dequantizationScales;
+    int64_t activation_k_dim;
+    int64_t activation_offset;
+};
+
+using MatMulConfig = executor::Config<MatMulAttrs>;
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -3,18 +3,10 @@
 //
 
 #include "mlas_gemm.hpp"
+#include "mlas/sgemm.hpp"
 
 #include <cstdint>
 #include <memory>
-
-#include "cpu_memory.h"
-#include "memory_desc/cpu_blocked_memory_desc.h"
-#include "mlas/sgemm.hpp"
-#include "nodes/executors/executor.hpp"
-#include "nodes/executors/fullyconnected_config.hpp"
-#include "nodes/executors/memory_arguments.hpp"
-#include "nodes/executors/mlas/mlas_gemm.hpp"
-#include "utils/debug_capabilities.h"
 
 namespace ov {
 namespace intel_cpu {

--- a/src/plugins/intel_cpu/src/nodes/input.h
+++ b/src/plugins/intel_cpu/src/nodes/input.h
@@ -20,9 +20,14 @@ public:
           const std::string& type,
           const GraphContext::CPtr context);
     Input(MemoryDescPtr memDesc, const std::string& name, const std::string& type, const GraphContext::CPtr context);
+    void setMemDesc(MemoryDescPtr memDesc) { extMemDesc = memDesc; }
+    void setZeroCopyOutput() {
+        zeroCopyOutput = true;
+    }
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
+    void selectOptimalPrimitiveDescriptor() override;
     void createPrimitive() override;
     bool created() const override;
 
@@ -47,6 +52,7 @@ private:
     std::shared_ptr<ov::op::v0::Constant> constOp;
     MemoryCPtr memoryPtr;
     MemoryDescPtr extMemDesc = nullptr;
+    bool zeroCopyOutput = false;
     bool isMeanImage = false;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_memcpy.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_memcpy.cpp
@@ -72,6 +72,7 @@ static void attn_memcpy_kernel(const ov::intel_cpu::PlainTensor& k_input,
     size_t B = k_input.m_dims[0], H = k_input.m_dims[1], L1 = k_input.m_dims[2], S = k_input.m_dims[3];
     // Internal LBHS layout has strides[L] > strides[B]
     assert(past_k_output.m_strides[2] >= past_k_output.m_strides[0]);
+    // assert(k_input.m_strides[2] > k_input.m_strides[0]);
     parallel_for3d(L1, B, H, [&](size_t m, size_t b, size_t h) {
         std::memcpy(past_k_output.ptr_v(b, h, m, 0),
                     k_input.ptr_v(b, h, m, 0),

--- a/src/plugins/intel_cpu/src/nodes/mathematics.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mathematics.cpp
@@ -3,11 +3,16 @@
 //
 
 #include <cmath>
+#include <cstdint>
 #include <vector>
 #include <string>
 
+#include "cpu_types.h"
+#include "node.h"
 #include "openvino/core/parallel.hpp"
+#include "openvino/core/type/element_type.hpp"
 #include "openvino/opsets/opset1.hpp"
+#include "utils/bfloat16.hpp"
 #include "mathematics.h"
 #include <shape_inference/shape_inference_pass_through.hpp>
 
@@ -61,6 +66,17 @@ void Math::initSupportedPrimitiveDescriptors() {
     addSupportedPrimDesc(inDataConf,
                          {{LayoutType::ncsp, ov::element::f32}},
                          impl_desc_type::ref_any);
+
+    // if (getAlgorithm() == Algorithm::MathCeiling) {
+    //     std::vector<PortConfigurator> inDataConf;
+    //     inDataConf.reserve(inputShapes.size());
+    //     for (size_t i = 0; i < inputShapes.size(); ++i)
+    //         inDataConf.emplace_back(LayoutType::ncsp, getOriginalInputPrecisionAtPort(i));
+
+    //     addSupportedPrimDesc(inDataConf,
+    //                          {{LayoutType::ncsp, getOriginalOutputPrecisionAtPort(0)}},
+    //                          impl_desc_type::ref_any);
+    // }
 }
 
 void Math::executeDynamicImpl(dnnl::stream strm) {
@@ -68,6 +84,18 @@ void Math::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void Math::execute(dnnl::stream strm) {
+    // if (getAlgorithm() == Algorithm::MathCeiling) {
+    //     size_t dataSize = getChildEdgeAt(0)->getMemory().getShape().getElementsCount();
+    //     const auto * src_data = getSrcDataAtPortAs<const bfloat16_t>(0);
+    //     auto * dst_data = getDstDataAtPortAs<bfloat16_t>(0);
+
+    //     parallel_for(dataSize, [&](size_t i) {
+    //         dst_data[i] = bfloat16_t(ceilf(static_cast<const float>(src_data[i])));
+    //     });
+
+    //     return;
+    // }
+
     size_t dataSize = getChildEdgeAt(0)->getMemory().getShape().getElementsCount();
     const float *src_data = getSrcDataAtPortAs<const float>(0);
     float* dst_data = getDstDataAtPortAs<float>(0);

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -343,8 +343,6 @@ void Pooling::getSupportedDescriptors() {
     if ((inputRank < 3) || (inputRank > 5))
         OPENVINO_THROW("Pooling layer. Unsupported mode. Only 3D, 4D and 5D blobs are supported as input.");
 
-
-
     initEffectiveAttributes(inShape,
                             MemoryDescUtils::makeDummyShape(childShape));
 

--- a/src/plugins/intel_cpu/src/nodes/real_subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/real_subgraph.cpp
@@ -1,0 +1,179 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "real_subgraph.h"
+#include "cpu_memory.h"
+#include "transformations/cpu_opset/common/op/subgraph.hpp"
+#include "utils/debug_capabilities.h"
+
+namespace ov {
+namespace intel_cpu {
+namespace node {
+
+bool SubGraph::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
+    return ov::is_type<ov::intel_cpu::SubModel>(op);
+}
+
+SubGraph::SubGraph(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
+    : Node(op, context, NgraphShapeInferFactory(op, FULL_PORT_MASK)) {
+    const auto& subModel = ov::as_type_ptr<SubModel>(op);
+    m_subStreamToUse = std::getenv("DISABLE_ASYNC") ? -1 : op->get_rt_info()["sub_stream_num"].as<int>();
+
+    OPENVINO_ASSERT(subModel, "Attempt to create SubGraph node from an invalid op type");
+    m_body = subModel->get_function();
+}
+
+bool SubGraph::created() const { return true; }
+
+void SubGraph::getSupportedDescriptors() {}
+
+void SubGraph::selectOptimalPrimitiveDescriptor() {
+    // for the input configution, just always use the parents configuration
+    VecMemoryDescs inputDescriptors;
+    for (size_t j = 0; j < getParentEdges().size(); j++) {
+        auto parentEdge = getParentEdgeAt(j);
+        auto parentPtr = parentEdge->getParent();
+        auto parent_spd = parentPtr->getSelectedPrimitiveDescriptor();
+        OPENVINO_ASSERT(parent_spd, "Parent selected primitive descriptor is missed");
+        const auto& parentOutConf = parent_spd->getConfig().outConfs;
+        OPENVINO_ASSERT(!parentOutConf.empty(), "Parent output configuration is empty");
+
+        int inNum = parentEdge->getInputNum();
+        auto parentDesc = parent_spd->getConfig().outConfs[inNum].getMemDesc();
+        inputDescriptors.emplace_back(parentDesc);
+    }
+
+    std::vector<PortConfig> inConfs, outConfs;
+    for (const auto& desc : inputDescriptors) {
+        inConfs.emplace_back(desc);
+    }
+
+    auto streamExecutor = context->getCPUStreamExecutor();
+
+    // Configure graph using appropriate substream (to have everything allocated numa-locally)
+    if (m_subStreamToUse >= 0) {
+        std::packaged_task<void()> task {
+            [this, &inputDescriptors](){
+                auto ctx = std::make_shared<GraphContext>(
+                    context->getConfig(),
+                    context->getWeightsCaches(),
+                    context->isGraphQuantized(),
+                    context->getParamsCaches(),
+                    context->getCPUStreamExecutor(),
+                    m_subStreamToUse,
+                    context->getMemoryStatesRegister());
+                m_graph.Configure(m_body, ctx, inputDescriptors, true, 1);
+            }
+        };
+        auto future = task.get_future();
+        streamExecutor->run_sub_stream(
+            [&task](){
+                task();
+            },
+            m_subStreamToUse);
+        future.wait();
+        future.get();
+    } else {
+        m_graph.Configure(m_body, context, inputDescriptors, true, 1);
+    }
+
+    // for output configuration, use the configuration of the graph's output node
+    auto outputDescriptors = m_graph.getOutputMemoryDescriptors();
+
+    for (const auto& desc : outputDescriptors) {
+        outConfs.emplace_back(desc);
+    }
+
+    const NodeConfig config(inConfs, outConfs);
+    supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::undef);
+    selectPrimitiveDescriptorByIndex(0);
+}
+
+void SubGraph::prepareParams() {}
+
+void SubGraph::infer() {
+    m_graph.InferDynamicLightWell2();
+}
+
+void SubGraph::createPrimitive() {
+    // for inputs it is straighforward, simply map memory on the input edges to the memory on subgraph's node parent edges
+    for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
+        const auto input = m_graph.GetInputNodesMap()[i];
+
+        for (size_t j = 0; j < input->getChildEdges().size(); j++) {
+            input->getChildEdgeAt(j)->reuse(getSrcMemoryAtPort(i));
+        }
+    }
+
+    // for outputs there are two options:
+    // 1) do the same as for inputs (the code snippet commented out bellow)
+    // 2) create graph first, and then perform the inverted mapping - map subgraph's node child edges to the memory from output child edges
+    // Currently the second option is used (probably the first one should be prefered)
+
+    // for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
+    //     const auto output = m_graph.GetOutputNodesMap()[i];
+    //     output->getParentEdgeAt(0)->reuse(getDstMemoryAtPort(i));
+    // }
+
+    // for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
+    //     const auto output = m_graph.GetOutputNodesMap()[i];
+    //     auto childEdges = getChildEdgesAtPort(i);
+    //     for (auto& edge : childEdges) {
+    //         edge->reuse(output->getSrcMemoryAtPort(0));
+    //     }
+    // }
+
+    auto streamExecutor = context->getCPUStreamExecutor();
+    // Finish graph creating using appropriate substream (to have everything allocated numa-locally)
+    if (m_subStreamToUse >= 0) {
+        std::packaged_task<void()> task {
+            [this](){
+                m_graph.Finish();
+            }
+        };
+        auto future = task.get_future();
+        streamExecutor->run_sub_stream(
+            [&task](){
+                task();
+            },
+            m_subStreamToUse);
+        future.wait();
+        future.get();
+    } else {
+        m_graph.Finish();
+    }
+
+    for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
+        const auto output = m_graph.GetOutputNodesMap()[i];
+        getChildEdgeAt(i)->reuse(output->getSrcMemoryAtPort(0));
+    }
+
+    for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
+        auto mem = getDstMemoryAtPort(i);
+        for (size_t j = getOriginalOutputsNumber(); j < getChildEdges().size(); j++) {
+            auto& childEdge = getChildEdges()[j];
+            auto childEdgePtr  = childEdge.lock();
+            if (childEdgePtr->getInputNum() == i) {
+                childEdgePtr->reuse(mem);
+            }
+        }
+    }
+}
+
+void SubGraph::resolveInPlaceEdges(Edge::LOOK look) {}
+
+void SubGraph::execute(dnnl::stream) {
+    // simply infer the internal graph
+    infer();
+    // mark that infer is finished
+    m_isRunning = false;
+}
+
+void SubGraph::executeDynamicImpl(dnnl::stream strm) {
+    execute(strm);
+}
+
+} // namespace node
+} // namespace intel_cpu
+} // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/real_subgraph.h
+++ b/src/plugins/intel_cpu/src/nodes/real_subgraph.h
@@ -1,0 +1,79 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "node.h"
+#include "graph.h"
+#include <atomic>
+#include <future>
+#include <memory>
+#include <thread>
+
+namespace ov {
+namespace intel_cpu {
+namespace node {
+
+class SubGraph : public Node {
+public:
+    static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
+
+    SubGraph(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
+
+    bool created() const override;
+
+    void getSupportedDescriptors() override;
+
+    void selectOptimalPrimitiveDescriptor() override;
+
+    void createPrimitive() override;
+    void prepareParams() override;
+
+    void execute(dnnl::stream) override;
+    void executeDynamicImpl(dnnl::stream strm) override;
+    void resolveInPlaceEdges(Edge::LOOK look) override;
+    bool needShapeInfer() const override {
+        return false;
+    }
+
+    bool needPrepareParams() const override {
+        return false;
+    }
+
+    bool isExecutable() const override {
+        return true;
+    }
+
+    void infer();
+
+    void markAsRunning() override {
+        m_isRunning = true;
+    }
+
+    void wait() override {
+        while (m_isRunning.load()) {
+            // std::this_thread::sleep_for(std::chrono::nanoseconds(50));
+            std::this_thread::yield();
+        }
+    }
+
+    const Graph& graph() const {
+        return m_graph;
+    }
+
+    int getSubStream() const {
+        return m_subStreamToUse;
+    }
+
+private:
+    std::shared_ptr<const ov::Model> m_body;
+    Graph m_graph;
+    std::atomic<bool> m_isRunning{false};
+    // int m_subStreamToUse = -1;
+    std::shared_ptr<Executor> executor;
+};
+
+} // namespace node
+} // namespace intel_cpu
+} // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -1956,17 +1956,17 @@ void Reduce::initSupportedPrimitiveDescriptors() {
                algorithm != Algorithm::ReduceMin && algorithm != Algorithm::ReduceMax;
     };
 
-    if (jit_mode) {
-        // Since in jit mode we use the output memory as an intermediate accumulator for certain reduce modes, we can't use BF16/FP16 output precision due to
-        // the possible accuracy loss. Therefore, for such mods, we will change the output precision to FP32.
-        if (ov::element::bf16 == output_prec) {
-            if (!mayiuse(avx512_core) || is_precision_sensitive_reduce(algorithm))
-                output_prec = ov::element::f32;
-        } else if (ov::element::f16 == output_prec) {
-            if (!mayiuse(cpu::x64::avx2) || is_precision_sensitive_reduce(algorithm))
-                output_prec = ov::element::f32;
-        }
-    }
+    // if (jit_mode) {
+    //     // Since in jit mode we use the output memory as an intermediate accumulator for certain reduce modes, we can't use BF16/FP16 output precision due to
+    //     // the possible accuracy loss. Therefore, for such mods, we will change the output precision to FP32.
+    //     if (ov::element::bf16 == output_prec) {
+    //         if (!mayiuse(avx512_core) || is_precision_sensitive_reduce(algorithm))
+    //             output_prec = ov::element::f32;
+    //     } else if (ov::element::f16 == output_prec) {
+    //         if (!mayiuse(cpu::x64::avx2) || is_precision_sensitive_reduce(algorithm))
+    //             output_prec = ov::element::f32;
+    //     }
+    // }
 
     intermediate_prec = fuse_low_precision ? ov::element::f32 : output_prec;
     precision_change = input_prec != intermediate_prec;

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -508,7 +508,7 @@ void Reorder::reorderData(const IMemory &input, const IMemory &output, MultiCach
                 reorder = getReorderPrim(cache, dstMemory.get_engine(), srcMemory.get_desc(), dstMemory.get_desc());
             }
             if (!reorder) {
-                OPENVINO_THROW("No reorder available for the following tensor descriptors: ",
+                OPENVINO_THROW(": No reorder available for the following tensor descriptors: ",
                                input.getDesc().serializeFormat(),
                                " and ",
                                output.getDesc().serializeFormat());

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.h
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.h
@@ -67,7 +67,8 @@ private:
                              const std::vector<MemoryCPtr>& dstMemory,
                              const std::string& errorPrefix) : errorPrefix(errorPrefix) {}
         virtual void exec(const std::vector<MemoryCPtr>& srcMemory,
-                          const std::vector<MemoryCPtr>& dstMemory) = 0;
+                          const std::vector<MemoryCPtr>& dstMemory,
+                          int w_rank = -1) = 0;
         virtual ~StridedSliceExecutor() = default;
 
     protected:
@@ -81,7 +82,8 @@ private:
                                    const std::vector<MemoryCPtr>& dstMemory,
                                    const std::string& errorPrefix);
         void exec(const std::vector<MemoryCPtr>& srcMemory,
-                  const std::vector<MemoryCPtr>& dstMemory) override;
+                  const std::vector<MemoryCPtr>& dstMemory,
+                  int w_rank = -1) override;
 
     private:
         struct StridedSliceParams {
@@ -132,6 +134,8 @@ private:
     std::vector<MemoryCPtr> dstMemory;
 
     std::string errorPrefix;
+
+    int w_rank = -1;
 };
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes_factory.cpp
+++ b/src/plugins/intel_cpu/src/nodes_factory.cpp
@@ -101,6 +101,7 @@
 #include "nodes/transpose.h"
 #include "nodes/unique.hpp"
 #include "nodes/causal_mask_preprocess.h"
+#include "nodes/real_subgraph.h"
 
 namespace ov {
 namespace intel_cpu {
@@ -206,7 +207,9 @@ Node::NodesFactory::NodesFactory() : Factory("NodesFactory") {
     INTEL_CPU_NODE(DFT, Type::DFT);
     INTEL_CPU_NODE(RDFT, Type::RDFT);
     INTEL_CPU_NODE(ExtractImagePatches, Type::ExtractImagePatches);
+    // INTEL_CPU_NODE(Snippet, Type::Subgraph);
     INTEL_CPU_NODE(Subgraph, Type::Subgraph);
+    INTEL_CPU_NODE(SubGraph, Type::SubModel);
     INTEL_CPU_NODE(ScaledDotProductAttention, Type::ScaledDotProductAttention);
 #if defined(OPENVINO_ARCH_X86_64)
     INTEL_CPU_NODE(FakeQuantize, Type::FakeQuantize);

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -287,6 +287,11 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
 
     conf.readProperties(config, modelType);
     calculate_streams(conf, cloned_model);
+    std::cout << "### Total number of threads: " << conf.streamExecutorConfig.get_threads()
+              << " Threads per stream: " << conf.streamExecutorConfig.get_threads_per_stream()
+              << " Number of substreams: " << conf.streamExecutorConfig.get_sub_streams()
+              << " Number of streams: " << conf.streamExecutorConfig.get_streams()
+              << "\n";
 
     if (conf.streamExecutorConfig.get_sub_stream_mode() ==
         IStreamsExecutor::Config::StreamsMode::SUB_STREAMS_FOR_SOCKET) {
@@ -542,7 +547,7 @@ ov::Any Plugin::get_ro_property(const std::string& name, const ov::AnyMap& optio
 }
 
 ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& model, const ov::AnyMap& config) const {
-    WeightsSharing::Ptr fake_w_cache;
+    std::shared_ptr<SocketsWeights> fake_w_cache = std::make_shared<SocketsWeights>();
 
     if (model == nullptr) {
         OPENVINO_THROW("Only ngraph-based models are supported!");

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/fully_connected.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/fully_connected.cpp
@@ -6,10 +6,18 @@
 #include "transformations/itt.hpp"
 
 ov::intel_cpu::FullyConnectedNode::FullyConnectedNode(const ov::Output<Node>& A,
-                                                     const ov::Output<Node>& B,
-                                                     const ov::Rank& output_rank,
-                                                     const ov::element::Type output_type)
-    : Op({A, B}), m_output_rank(output_rank), m_output_type(output_type) {
+                                                      const ov::Output<Node>& B,
+                                                      const ov::Rank& output_rank,
+                                                      const ov::element::Type output_type,
+                                                      int64_t activation_k_dim,
+                                                      int64_t activation_offset) :
+    Op({A, B}), m_output_rank(output_rank), m_output_type(output_type),
+    activation_k_dim(activation_k_dim),
+    activation_offset(activation_offset) {
+    if (activation_k_dim != 0) {
+        get_rt_info()["activation_k_dim"] = activation_k_dim;
+        get_rt_info()["activation_offset"] = activation_offset;
+    }
     validate_and_infer_types();
 }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/fully_connected.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/fully_connected.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "openvino/core/node.hpp"
 #include "openvino/op/op.hpp"
 
@@ -19,7 +20,9 @@ public:
     FullyConnectedNode(const ov::Output<Node> &A,
                        const ov::Output<Node> &B,
                        const ov::Rank& output_rank,
-                       const ov::element::Type output_type = ov::element::undefined);
+                       const ov::element::Type output_type = ov::element::undefined,
+                       int64_t activation_k_dim = {},
+                       int64_t activation_offset = {});
 
     bool visit_attributes(ov::AttributeVisitor &visitor) override;
 
@@ -33,6 +36,8 @@ public:
 private:
     ov::Rank m_output_rank;
     ov::element::Type m_output_type;
+    int64_t activation_k_dim;
+    int64_t activation_offset;
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/subgraph.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <memory>
+
+#include "subgraph.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+SubModel::SubModel(const std::shared_ptr<ov::Model>& body)
+    : SubGraphOp() {
+    SubGraphOp::set_function(body);
+}
+
+SubModel::SubModel(const ov::OutputVector& args,
+                   const std::shared_ptr<ov::Model>& body)
+    : SubGraphOp(args) {
+    SubGraphOp::set_function(body);
+    constructor_validate_and_infer_types();
+    for (size_t i = 0; i < body->get_parameters().size(); ++i)
+        m_input_descriptions[0].push_back(std::make_shared<InvariantInputDescription>(i, i));
+    for (size_t i = 0; i < body->get_output_size(); ++i)
+        m_output_descriptions[0].push_back(std::make_shared<BodyOutputDescription>(i, i));
+}
+
+SubModel::SubModel(const ov::NodeVector& args,
+                   const std::shared_ptr<ov::Model>& body)
+    : SubModel(as_output_vector(args), body) {}
+
+std::shared_ptr<ov::Node> SubModel::clone_with_new_inputs(const ov::OutputVector& inputs) const {
+    return std::make_shared<SubModel>(inputs, body().clone());
+}
+
+void SubModel::validate_and_infer_types() {
+    // ov::ParameterVector old_parameters = body_ptr()->get_parameters();
+
+    // for (size_t i = 0; i < get_input_size(); ++i) {
+    //     body_ptr()->replace_parameter(
+    //         i,
+    //         std::make_shared<ov::op::v0::Parameter>(get_input_element_type(i), get_input_partial_shape(i)));
+    // }
+
+    body_ptr()->validate_nodes_and_infer_types();
+
+    // for (size_t i = 0; i < body_ptr()->get_parameters().size(); i++) {
+    //     body_ptr()->get_parameters()[i]->set_friendly_name(old_parameters[i]->get_friendly_name());
+    // }
+
+    set_output_size(body_ptr()->get_output_size());
+    for (size_t i = 0; i < get_output_size(); ++i) {
+        set_output_type(i, body_ptr()->get_output_element_type(i), body_ptr()->get_output_partial_shape(i));
+    }
+}
+
+bool SubModel::visit_attributes(ov::AttributeVisitor& visitor) {
+    visitor.on_attribute("body", body_ptr());
+    visitor.on_attribute("input_descriptions", m_input_descriptions[0]);
+    visitor.on_attribute("output_descriptions", m_output_descriptions[0]);
+    return true;
+}
+
+} // namespace intel_cpu
+} // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/subgraph.hpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+
+#include "openvino/core/model.hpp"
+#include "openvino/op/op.hpp"
+#include "openvino/op/util/sub_graph_base.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+/**
+ * @interface Subgraph
+ * @brief An operation that is implemented by a model
+ */
+class SubModel : public ov::op::util::SubGraphOp {
+public:
+    OPENVINO_OP("SubModel", "cpu_plugin_opset", ov::op::util::SubGraphOp);
+
+    SubModel() = default;
+
+    SubModel(const std::shared_ptr<ov::Model>& body);
+
+    SubModel(const OutputVector& args, const std::shared_ptr<ov::Model>& body);
+
+    SubModel(const NodeVector& args, const std::shared_ptr<ov::Model>& body);
+
+    bool visit_attributes(AttributeVisitor& visitor) override;
+
+    void validate_and_infer_types() override;
+
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& inputs) const override;
+
+    const ov::Model& body() const {
+        return *m_bodies[0];
+    }
+    const std::shared_ptr<ov::Model>& body_ptr() const {
+        return m_bodies[0];
+    }
+
+private:
+    ov::Model& body() {
+        return *m_bodies[0];
+    }
+    std::shared_ptr<ov::Model>& body_ptr() {
+        return m_bodies[0];
+    }
+};
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/duplicate_model.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/duplicate_model.cpp
@@ -1,0 +1,343 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "duplicate_model.hpp"
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "openvino/core/model.hpp"
+#include "openvino/core/node_vector.hpp"
+#include "openvino/op/assign.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/read_value.hpp"
+#include "openvino/op/util/variable.hpp"
+#include "transformations/cpu_opset/common/op/fully_connected.hpp"
+#include "transformations/cpu_opset/common/op/sdpa.hpp"
+#include "transformations/cpu_opset/common/op/subgraph.hpp"
+#include "transformations/utils/utils.hpp"
+#include "openvino/cc/pass/itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/type.hpp"
+
+bool ov::intel_cpu::DuplicateModel::run_on_model(const std::shared_ptr<ov::Model>& f) {
+    RUN_ON_MODEL_SCOPE(DuplicateModel);
+    int sub_stream_num = 2;  // @todo pass as argument
+
+    // find last fc node. There is no reason to duplicate graph after last fc node.
+    const auto& ops = f->get_ordered_ops();
+    auto r_last_fc = std::find_if(ops.rbegin(), ops.crend(), [](const std::shared_ptr<ov::Node>& node) {
+        return node->get_rt_info().count("split_part");
+    });
+    auto last_fc = r_last_fc == ops.rend() ? ops.end() : --r_last_fc.base();
+
+    // no split node found
+    if (last_fc == ops.end()) {
+        return false;  // model has not been changed
+    }
+
+    std::unordered_set<Node*> nodes_done;
+    std::unordered_set<Node*> split_fc_nodes;
+
+    for (const auto& op : ops) {
+        if (op->get_rt_info().count("split_part")) {
+            nodes_done.insert(op.get());
+        }
+    }
+
+    std::vector<std::shared_ptr<ov::Node>> ordered_split_nodes;
+    std::vector<std::vector<std::shared_ptr<ov::Node>>> ordered_nodes_for_node;
+
+    for (const auto& op : ops) {
+        if (ov::is_type<ov::op::v0::Parameter>(op))
+            nodes_done.insert(op.get());
+    }
+
+    // collect all the nodes from the root (the node we split, i.e. FC) until the stop points (i.e. Parameters or other root nodes)
+    for (const auto& op : ops) {
+        if (op->get_rt_info().count("main_split_root")) {
+            nodes_done.erase(op.get());
+            ordered_split_nodes.push_back(op);
+            ordered_nodes_for_node.emplace_back(ov::topological_sort_new<std::vector<std::shared_ptr<ov::Node>>>({op}, nodes_done));
+            nodes_done.insert(op.get());
+        }
+    }
+
+    class SubgraphBuilder {
+    public:
+        void add_duplicate(const std::shared_ptr<ov::Node>& node,
+                           size_t i,
+                           std::unordered_map<std::string, op::util::VariableVector>& variable_clones) {
+            OutputVector new_inputs;
+
+            for (const auto& input : node->inputs()) {
+                auto input_source_output = input.get_source_output();  // @todo is there a another way?
+                auto input_node = input_source_output.get_node_shared_ptr();
+
+                if (m_output_clones.count(input_source_output)) {
+                    // input is already a part of the subgraph
+                    auto output_clone = m_output_clones[input_source_output];
+                    new_inputs.emplace_back(output_clone);
+                } else if (!op::util::is_on_constant_path(input.get_source_output())) {
+                    // input is not a part of the subgraph, so connect to it via extra Parameter
+                    m_parameters.emplace_back(
+                        std::make_shared<ov::op::v0::Parameter>(input.get_element_type(), input.get_partial_shape()));
+                    new_inputs.push_back(m_parameters.back()->output(0));
+                    m_invariant_input.push_back(input.get_source_output());
+                } else {
+                    // input is on constant path, basically do nothing
+                    new_inputs.push_back(input.get_source_output());
+                }
+            }
+
+            auto clone = node->clone_with_new_inputs(new_inputs);
+
+            ov::copy_runtime_info(node, clone);
+            // @todo make sure all the extra runtime info is cleaned up after the transformation
+            if (clone->get_rt_info().count("main_split")) {
+                clone->get_rt_info().erase("main_split");
+            }
+
+            clone->set_friendly_name(node->get_friendly_name() + "_clone_" + std::to_string(i));
+
+            for (size_t i = 0; i < node->get_output_size(); i++) {
+                m_output_clones[node->output(i)] = clone->output(i);
+            }
+            m_clones[node] = clone;
+            m_nodes_to_replace.push_back(node);
+
+            if (auto read_value = ov::as_type_ptr<ov::op::v6::ReadValue>(clone)) {
+                auto variable = read_value->get_variable();
+                auto new_variable_id =  variable->get_info().variable_id + "_clone_" + std::to_string(i);
+                auto variable_clone = std::make_shared<op::util::Variable>
+                    (op::util::VariableInfo{variable->get_info().data_shape,
+                                            variable->get_info().data_type,
+                                            new_variable_id});
+                read_value->set_variable(variable_clone);
+                variable_clones[variable->get_info().variable_id][i] = variable_clone;
+            }
+        }
+
+        void build(const std::shared_ptr<ov::Node>& node,
+                   const std::unordered_set<std::shared_ptr<ov::Node>>& split_nodes,
+                   const int idx) {
+            std::set<Output<Node>> split_clones;
+            for (const auto& split_node : split_nodes) {
+                for (size_t i = 0; i < split_node->get_output_size(); i++) {
+                    split_clones.insert(split_node->output(i));
+                }
+            }
+
+            ov::ResultVector results;
+            auto clone = m_output_clones[node->get_default_output()].get_node_shared_ptr();
+            m_submodel = std::make_shared<ov::Model>(results, m_parameters, node->get_friendly_name() + "_model");
+            m_subgraph = std::make_shared<ov::intel_cpu::SubModel>(m_submodel);
+
+            m_subgraph->set_friendly_name("SubModel_" + node->get_friendly_name() + "_clone");
+            m_subgraph->get_rt_info()["sub_stream_num"] = idx - 1;
+            m_subgraph->get_rt_info()["numa_id"] = idx;
+            m_numa_id = idx;
+
+            for (size_t i = 0; i < m_parameters.size(); i++) {
+                m_subgraph->set_invariant_input(m_parameters[i], m_invariant_input[i]);
+            }
+        }
+
+        void resolve_outside_connections(const std::unordered_set<std::shared_ptr<ov::Node>>& split_nodes,
+                                      std::unordered_map<std::string, op::util::VariableVector>& variable_clones,
+                                      size_t idx) {
+            std::set<Output<Node>> split_clones;
+            for (const auto& split_node : split_nodes) {
+                for (size_t i = 0; i < split_node->get_output_size(); i++) {
+                    split_clones.insert(split_node->output(i));
+                }
+            }
+
+            for (const auto& entry : m_output_clones) {
+                const auto& orig_output = entry.first;
+                const auto& clone_output = entry.second;
+
+                auto target_inputs = orig_output.get_target_inputs();
+
+                if (target_inputs.empty())
+                    continue;
+
+                bool has_outside_target_node =
+                    std::any_of(target_inputs.begin(),
+                                target_inputs.end(),
+                                [this, &split_clones](const Input<Node>& input) {
+                                    return !m_output_clones.count(input.get_node()->get_default_output()) &&
+                                           !split_clones.count(input.get_node()->get_default_output());
+                                });
+                if (has_outside_target_node) {
+                    bool output_added = false;
+
+                    for (auto& target_input : target_inputs) {
+                        auto target_node = target_input.get_node();
+                        // special handling of the connections between SubModel nodes to avoid cross numa connections
+                        if (ov::is_type<ov::intel_cpu::SubModel>(target_node)) {
+                            auto numa_id = target_node->get_rt_info()["numa_id"].as<int>();
+                            if (numa_id == m_numa_id || split_clones.count(orig_output)) {
+                                auto target_node_output = target_input.get_node()->get_default_output();
+                                if (!m_output_clones.count(target_node_output) && !split_clones.count(target_node_output)) {
+                                    if (!output_added) {
+                                        m_subgraph->set_output_size(m_subgraph->get_output_size() + 1);
+                                        m_submodel->add_results({std::make_shared<ov::op::v0::Result>(clone_output)});
+                                    }
+                                    output_added = true;
+                                    target_input.replace_source_output(m_subgraph->output(m_subgraph->get_output_size() - 1));
+                                }
+                            }
+                        } else if (auto* assign = dynamic_cast<ov::op::v6::Assign*>(target_node)) {
+                                 // special handling for Assign (state). Basically assign node needs to be duplicated as well
+                                 // @todo Can we somehow generalize this to have Assign as a part of collected nodes to be included into subgraph?
+                                 // currently we only go up when collecting the nodes. For Assign we would need to go down
+                                 auto assign_clone = as_type_ptr<ov::op::v6::Assign>(
+                                     assign->clone_with_new_inputs({clone_output}));
+                                 auto variable_id = assign->get_variable_id();
+                                 auto variable_clone = variable_clones[variable_id][idx];
+                                 assign_clone->set_variable(variable_clone);
+                                 m_submodel->add_sinks({assign_clone});
+                                 m_submodel->add_variables({variable_clone});
+                        } else {
+                            auto target_node_output = target_input.get_node()->get_default_output();
+                            if (!m_output_clones.count(target_node_output) && !split_clones.count(target_node_output)) {
+                                if (!output_added) {
+                                    m_subgraph->set_output_size(m_subgraph->get_output_size() + 1);
+                                    m_submodel->add_results({std::make_shared<ov::op::v0::Result>(clone_output)});
+                                }
+                                output_added = true;
+                                target_input.replace_source_output(m_subgraph->output(m_subgraph->get_output_size() - 1));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    private:
+        std::unordered_map<std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>> m_clones;
+        std::map<Output<Node>, Output<Node>> m_output_clones;
+        ov::ParameterVector m_parameters;
+        ov::OutputVector m_invariant_input;
+        ov::NodeVector m_nodes_to_replace;
+        std::shared_ptr<ov::Model> m_submodel;
+        std::shared_ptr<ov::intel_cpu::SubModel> m_subgraph;
+        int m_numa_id;
+    };
+
+    class DuplicateSubgraphBuilder {
+    public:
+        DuplicateSubgraphBuilder(size_t duplicates_num)
+            : m_subgraphBuilders(std::vector<SubgraphBuilder>(duplicates_num)) {}
+
+        void add_duplicate(const std::shared_ptr<ov::Node>& node,
+                           std::unordered_map<std::string, op::util::VariableVector>& variable_clones) {
+            for (size_t i = 0; i < m_subgraphBuilders.size(); i++) {
+                m_subgraphBuilders[i].add_duplicate(node, i, variable_clones);
+            }
+            nodes_to_replace.push_back(node);
+        }
+
+        void add_split(const std::shared_ptr<ov::Node>& node,
+                       const int idx,
+                       std::unordered_map<std::string, op::util::VariableVector>& variable_clones) {
+            auto sb = std::next(m_subgraphBuilders.begin(), idx);
+            sb->add_duplicate(node, idx, variable_clones);
+        }
+
+        void build(const std::shared_ptr<ov::Node>& node,
+                   const int idx,
+                   const std::unordered_set<std::shared_ptr<ov::Node>>& split_nodes) {
+            auto sb = std::next(m_subgraphBuilders.begin(), idx);
+            sb->build(node, split_nodes, idx);
+        }
+
+        void resolve_outside_connections(const std::unordered_set<std::shared_ptr<ov::Node>>& split_nodes,
+                                      std::unordered_map<std::string, op::util::VariableVector>& variable_clones) {
+            for (size_t i = 0; i < m_subgraphBuilders.size(); i++) {
+                m_subgraphBuilders[i].resolve_outside_connections(split_nodes, variable_clones, i);
+            }
+        }
+
+    private:
+        std::vector<SubgraphBuilder> m_subgraphBuilders;
+        ov::NodeVector nodes_to_replace;
+    };
+
+    std::vector<DuplicateSubgraphBuilder> builders(ordered_split_nodes.size(), DuplicateSubgraphBuilder(sub_stream_num));
+    std::vector<std::unordered_set<std::shared_ptr<ov::Node>>> all_split_nodes(ordered_split_nodes.size());
+    std::unordered_map<std::string, op::util::VariableVector> variable_clones;
+
+    for (const auto& op : ops) {
+        if (auto assign = ov::as_type_ptr<ov::op::v6::Assign>(op)) {
+            variable_clones[assign->get_variable_id()] = op::util::VariableVector(sub_stream_num);
+        }
+    }
+
+    for (size_t i = 0; i < ordered_split_nodes.size(); i++) {
+        const auto& nodes = ordered_nodes_for_node[i];
+        for (const auto& node : nodes) {
+            if (ov::is_type<ov::op::v0::Parameter>(node) || ov::is_type<ov::op::v0::Result>(node))
+                continue;
+
+            // @todo cache is_on_constant_path before the loop
+            if (ov::op::util::is_on_constant_path(node->output(0))) {
+                continue;
+            }
+
+            if (node->get_rt_info().count("main_split_root") || node->get_rt_info().count("main_split")) {
+                auto split_nodes = node->get_rt_info()["split_parts"].as<std::vector<std::shared_ptr<ov::Node>>>();
+                // track all split nodes to avoid creating extra connections
+                for (const auto& _node : split_nodes) {
+                    all_split_nodes[i].insert(_node);
+                }
+
+                for (size_t split_idx = 0; split_idx < split_nodes.size(); split_idx++) {
+                    const auto& split_node = split_nodes[split_idx];
+                    builders[i].add_split(split_node, split_idx, variable_clones);
+                    // if this is a root split (i.e. FC node), finish subgraph building
+                    if (node->get_rt_info().count("main_split_root")) {
+                        builders[i].build(split_node, split_idx, all_split_nodes[i]);
+                    }
+                }
+            } else if (node->get_rt_info().count("other_split")) {
+                // @todo can we handle other_splits the same way we handle the main one?
+                continue;
+            } else {
+                builders[i].add_duplicate(node, variable_clones);
+            }
+        }
+    }
+
+    if (!ordered_split_nodes.empty()) {
+        for (size_t i = 0; i < builders.size(); i++) {
+            builders[i].resolve_outside_connections(all_split_nodes[i], variable_clones);
+        }
+    }
+
+    for (auto& variables_pair : variable_clones) {
+        auto& variable_id = variables_pair.first;
+        auto orig_variable = f->get_variable_by_id(variable_id);
+        auto orig_info = orig_variable->get_info();
+        auto& variables = variables_pair.second;
+        // use original variable info must be preserved, use it in 0 numa clone
+        variables[0]->update(orig_info);
+    }
+
+    ov::SinkVector sinks = f->get_sinks();
+    for (auto sink : sinks) {
+        if (auto assign = ov::as_type_ptr<ov::op::v6::Assign>(sink)) {
+            f->remove_variable(assign->get_variable());
+            f->remove_sink(sink);
+        }
+    }
+
+    return true;
+}

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/duplicate_model.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/duplicate_model.hpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/pass.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+// ! [model_pass:template_transformation_hpp]
+// template_model_transformation.hpp
+class DuplicateModel : public ov::pass::ModelPass {
+public:
+    OPENVINO_RTTI("DuplicateModel", "0");
+    bool run_on_model(const std::shared_ptr<ov::Model>& f) override;
+};
+// ! [model_pass:template_transformation_hpp]
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/form_parallel_subgraph.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/form_parallel_subgraph.cpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <iostream>
+#include "form_parallel_subgraphs.hpp"
+#include "openvino/cc/pass/itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convolution.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/pass/pattern/op/label.hpp"
+#include "transformations/cpu_opset/common/op/fully_connected.hpp"
+#include "transformations/cpu_opset/common/op/subgraph.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+FormParallelSubgraphs::FormParallelSubgraphs() {
+    MATCHER_SCOPE(FormParallelSubgraphs);
+
+    auto parallel_candidate = [](ov::Output<ov::Node> output) -> bool {
+        const auto& node = *output.get_node();
+        return node.get_rt_info().count("parallelDomain");
+    };
+
+    auto candidate_m = ov::pass::pattern::any_input(parallel_candidate);
+
+    ov::matcher_pass_callback callback = [candidate_m](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        const auto& candidate_out = pattern_map.at(candidate_m);
+        const auto& candidate = candidate_out.get_node_shared_ptr();
+
+        if (candidate->get_type_info() == SubModel::get_type_info_static()) {
+            return false;  // avoid recursive wrapping submodel into submodel
+        }
+
+        ov::ParameterVector params;
+        ov::ResultVector results;
+        OutputVector args;
+
+        ov::OutputVector candidate_inputs;
+        for (size_t i = 0; i < candidate->inputs().size(); i++) {
+            const auto& input = candidate->get_input_node_shared_ptr(i);
+            if (!op::util::is_on_constant_path(input->output(0))) {
+                params.emplace_back(std::make_shared<ov::op::v0::Parameter>(candidate->get_element_type(),
+                                                                            candidate->get_input_partial_shape(0)));
+                candidate_inputs.push_back(params.back()->output(0));
+            } else {
+                candidate_inputs.emplace_back(candidate->get_input_source_output(i));
+            }
+        }
+
+        auto candidate_clone = candidate->clone_with_new_inputs(candidate_inputs);
+
+        for (const auto& output : candidate_clone->outputs()) {
+            results.emplace_back(std::make_shared<ov::op::v0::Result>(output));
+        }
+
+        auto submodel =
+            std::make_shared<ov::Model>(results, params, candidate_clone->get_friendly_name() + "_subgraph");
+        auto subgraph = std::make_shared<ov::intel_cpu::SubModel>(submodel);
+        subgraph->set_friendly_name("Submodel_" + candidate_clone->get_friendly_name());
+
+        for (size_t i = 0; i < params.size(); i++) {
+            subgraph->set_invariant_input(params[i], candidate->input_value(i));
+        }
+
+        ov::copy_runtime_info(subgraph, candidate);
+        ov::replace_node_update_name(candidate, subgraph);
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(candidate_m, matcher_name);
+    this->register_matcher(m, callback);
+}
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/form_parallel_subgraphs.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/form_parallel_subgraphs.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+class FormParallelSubgraphs: public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("FormParallelSubgraphs", "0");
+    FormParallelSubgraphs();
+};
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/split_fc_k.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/split_fc_k.cpp
@@ -1,0 +1,294 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/attribute_visitor.hpp"
+#include "openvino/core/dimension.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/strided_slice.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/pass/constant_folding.hpp"
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <transformations/utils/utils.hpp>
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/variadic_split.hpp"
+#include "transformations/cpu_opset/common/op/fully_connected.hpp"
+
+#include "split_fc_k.hpp"
+
+#include "itt.hpp"
+
+static int weightsThreshold() {
+    static int result = std::getenv("SPLIT_THRESHOLD") ? std::stoi(std::getenv("SPLIT_THRESHOLD")) : 6600000;
+    return result;
+}
+
+ov::intel_cpu::SplitFCbyK::SplitFCbyK(int sub_stream_num) {
+    MATCHER_SCOPE(SplitFCbyK);
+    auto fc_m = ov::pass::pattern::wrap_type<ov::intel_cpu::FullyConnectedNode>();
+
+    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+
+        const auto& fc_node = pattern_map.at(fc_m).get_node_shared_ptr();
+        auto& rt_info = fc_node->get_rt_info();
+        if (rt_info.count("split")) {
+            return false;
+        }
+
+        const auto src_item = fc_node->get_input_node_shared_ptr(0);
+        const auto fc_weight_node = fc_node->get_input_node_shared_ptr(1);
+
+        // TODO: support transpose
+        if (ov::is_type<ov::op::v1::Transpose>(fc_weight_node)) {
+            std::cout << "SplitFCbyK: Transpose on weights is not supported" << "\n";
+            return false;
+        }
+
+        // needn't to split fc when the dim is 0.
+        const auto& wgt_shape = fc_weight_node->get_shape();
+        const size_t split_dim = wgt_shape.size() - 1;
+        // split happens on the second dimension.
+        auto split_dim_node = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, split_dim);
+
+        // std::cout << "SplitFCbyK transformation check" << "\n";
+        // weight shape size 660000 is a trade-off value, which is summarized and verified by LLMs.
+        if (wgt_shape[split_dim] <= 1 || ov::shape_size(wgt_shape) < weightsThreshold()) {
+            std::cout << "Heuristic not met. split dim: " << wgt_shape[split_dim] <<
+                " shape_size: " << ov::shape_size(wgt_shape) << "\n";
+            return false;
+        }
+
+        // parts will be splited according the sub stream num.
+        int split_num = sub_stream_num + 1;
+        std::cout << "SplitFCbyK transformation. Heuristic met:" << ov::shape_size(wgt_shape) << "! " <<  fc_node
+                  << " split into parts = " << split_num << "\n";
+
+        auto split_on_parts = [](int len, int n) {
+            int average = len / n;
+            std::vector<int> parts(n, average);
+            parts.back() = len - average * (n - 1);
+            return parts;
+        };
+
+        // 1. If the model is INT4 format, split the INT4 pattern for the FuseFCAndWeightsDecompression.
+        // 2. If the model is NOT INT4 format, split the weight.
+        std::vector<ov::Output<ov::Node>> wgt_node_vec(split_num);
+        if (ov::is_type<ov::op::v1::Multiply>(fc_weight_node) || ov::is_type<ov::op::v1::Reshape>(fc_weight_node)) {
+            // INT4 model should consider two patterns, including with Reshape Node and without Reshape Node.
+            const auto reshape_node = ov::as_type_ptr<ov::op::v1::Reshape>(fc_weight_node);
+            const auto multiply_node = reshape_node ? reshape_node->get_input_node_shared_ptr(0) : fc_weight_node;
+            if (!ov::is_type<ov::op::v1::Multiply>(multiply_node)) {
+                return false;
+            }
+            auto multiply_pattern = multiply_node->get_input_node_shared_ptr(1);
+            if (!ov::is_type<ov::op::v0::Constant>(multiply_pattern)) {
+                return false;
+            }
+
+            auto subtract_node = multiply_node->get_input_node_shared_ptr(0);
+            if (!ov::is_type<ov::op::v1::Subtract>(subtract_node)) {
+                return false;
+            }
+            auto convert_node1 = subtract_node->get_input_node_shared_ptr(1);
+            if (!ov::is_type<ov::op::v0::Convert>(convert_node1)) {
+                return false;
+            }
+            auto convert_node1_const = ov::as_type_ptr<ov::op::v0::Constant>(convert_node1->get_input_node_shared_ptr(0));
+            if (!convert_node1_const) {
+                return false;
+            }
+            auto convert_node0 = subtract_node->get_input_node_shared_ptr(0);
+            if (!ov::is_type<ov::op::v0::Convert>(convert_node0)) {
+                return false;
+            }
+            auto wgt_item = convert_node0->get_input_node_shared_ptr(0);
+            auto cvt_prec = convert_node0->get_element_type();
+
+            auto split_dim_range = wgt_item->get_shape()[split_dim];
+
+            const auto& multiply_shape = multiply_pattern->get_shape();
+            bool need_to_split_multiply = ov::shape_size(multiply_shape) > 1 &&
+                                         split_dim < multiply_shape.size() &&
+                                         multiply_shape[split_dim] == split_dim_range;
+
+            const auto& convert_node1_shape = convert_node1->get_shape();
+            bool need_to_split_convert = ov::shape_size(convert_node1_shape) > 1 &&
+                                         split_dim < convert_node1_shape.size() &&
+                                         convert_node1_shape[split_dim] == split_dim_range;
+
+            // We should use VariadicSplit to split the input for FC.
+            std::vector<std::vector<int32_t>> split_reshape_pattern_vec(split_num);
+            auto fc_dim_vec = split_on_parts(split_dim_range, split_num);
+            auto split_length = ov::op::v0::Constant::create<int32_t>(ov::element::i32, ov::Shape{static_cast<size_t>(split_num)}, fc_dim_vec);
+
+            auto split_constants = [&](const std::shared_ptr<ov::Node>& constant) {
+                static const std::set<ov::element::Type> unsupported_by_split_element_types{ov::element::u4, ov::element::i4, ov::element::nf4};
+                const auto& constant_precision = constant->get_output_element_type(0);
+                if (!unsupported_by_split_element_types.count(constant_precision)) {
+                    auto split = std::make_shared<ov::op::v1::VariadicSplit>(constant, split_dim_node, split_length);
+                    return split->outputs();
+                }
+
+                auto convert = std::make_shared<ov::op::v0::Convert>(constant, ov::element::i8);
+                auto split = std::make_shared<ov::op::v1::VariadicSplit>(convert, split_dim_node, split_length);
+                ov::OutputVector res(split->get_output_size());
+                for (size_t i = 0; i < split->get_output_size(); ++i) {
+                    res[i] = std::make_shared<ov::op::v0::Convert>(split->output(i), constant_precision);
+                }
+                return res;
+            };
+
+            auto split_wgts = split_constants(wgt_item);
+            ov::OutputVector split_muls;
+            if (need_to_split_multiply) {
+                split_muls = split_constants(multiply_pattern);
+            }
+            ov::OutputVector split_cvts;
+            if (need_to_split_convert) {
+                split_cvts = split_constants(convert_node1_const);
+            }
+
+            if (reshape_node) {
+                auto reshape_pattern = reshape_node->get_input_node_shared_ptr(1);
+                auto reshape_const = ov::as_type_ptr<ov::op::v0::Constant>(reshape_pattern);
+                if (!reshape_const) {
+                    return false;
+                }
+                const auto reshape_vec = reshape_const->cast_vector<int32_t>();
+                for (int i = 0; i < split_num; ++i) {
+                    split_reshape_pattern_vec[i] = {fc_dim_vec[i], reshape_vec[1]};
+                }
+            }
+
+            std::vector<ov::Output<ov::Node>> zp_const_vec(split_num);
+            for (int i = 0; i < split_num; ++i) {
+                zp_const_vec[i] = need_to_split_convert ? split_cvts[i] : convert_node1_const->clone_with_new_inputs({});
+            }
+
+            std::vector<ov::Output<ov::Node>> mul_const_vec(split_num);
+            for (int i = 0; i < split_num; ++i) {
+                mul_const_vec[i] = need_to_split_multiply ? split_muls[i] : multiply_pattern->clone_with_new_inputs({});
+            }
+
+            for (int i = 0; i < split_num; ++i) {
+                auto sub_parent0 = std::make_shared<ov::op::v0::Convert>(split_wgts[i], cvt_prec);
+                auto sub_parent1 = std::make_shared<ov::op::v0::Convert>(zp_const_vec[i], cvt_prec);
+                ov::pass::disable_constant_folding(sub_parent0);
+                ov::pass::disable_constant_folding(sub_parent1);
+                auto sub_node = std::make_shared<ov::op::v1::Subtract>(sub_parent0, sub_parent1);
+
+                auto mul_node = std::make_shared<ov::op::v1::Multiply>(sub_node, mul_const_vec[i]);
+                if (reshape_node) {
+                    auto reshape_pattern = ov::op::v0::Constant::create<int32_t>(ov::element::i32, ov::Shape{2}, split_reshape_pattern_vec[i]);
+                    wgt_node_vec[i] = std::make_shared<ov::op::v1::Reshape>(mul_node, reshape_pattern, reshape_node->get_special_zero());
+                } else {
+                    wgt_node_vec[i] = mul_node;
+                }
+            }
+        } else {
+            // get input
+            auto wgt_item = fc_node->get_input_node_shared_ptr(1);
+
+            // split weight
+            auto split_dim_range = wgt_item->get_shape()[split_dim];
+
+            // We should use VariadicSplit to split input for FC.
+            auto fc_dim_vec = split_on_parts(split_dim_range, split_num);
+            auto split_length = ov::op::v0::Constant::create<int32_t>(ov::element::i32, ov::Shape{static_cast<size_t>(split_num)}, fc_dim_vec);
+            auto split_wgts = std::make_shared<ov::op::v1::VariadicSplit>(wgt_item,
+                                                                          split_dim_node,
+                                                                          split_length);
+
+            wgt_node_vec = split_wgts->outputs();
+        }
+
+        const PartialShape shape = fc_node->input(0).get_partial_shape();
+        auto rank = shape.get_max_shape().size();
+        // @todo check if static
+        const Dimension K = shape[rank - 1];
+        Dimension K_split_dim = K / split_num;
+
+        std::vector<Dimension> split_fc_dims;
+        for (int i = 0; i < rank; i++) {
+            split_fc_dims.push_back(shape[i]);
+        }
+        split_fc_dims.push_back(K_split_dim);
+        const PartialShape split_fc_shape(split_fc_dims);
+
+        const auto K_split = K_split_dim.get_length();
+        std::vector<std::shared_ptr<Node>> fc_node_vec(split_num);
+        std::vector<std::shared_ptr<Node>> ss_node_vec(split_num);
+        for (int i = 0; i < split_num; i++) {
+            int64_t offset = K_split * (i + 1);
+            std::vector<int64_t> begin(rank, K_split * i); // Start from {0, 0}
+            std::vector<int64_t> end(rank, -1);
+            end.back() = offset;
+            std::vector<int64_t> strides(rank, 1); // Stride of 1 for both dimensions
+
+            // Optionally, you can define masks if necessary
+            std::vector<int64_t> begin_mask(rank, 1); // Include all elements starting from 'begin'
+            begin_mask.back() = 0;
+            std::vector<int64_t> end_mask(rank, 1);   // Include all elements up to 'end'
+            end_mask.back() = 0;
+
+            // Create the StridedSlice node
+            ss_node_vec[i] = std::make_shared<ov::op::v1::StridedSlice>(
+                src_item,
+                ov::op::v0::Constant::create(ov::element::i64, {begin.size()}, begin),
+                ov::op::v0::Constant::create(ov::element::i64, {end.size()}, end),
+                ov::op::v0::Constant::create(ov::element::i64, {strides.size()}, strides),
+                begin_mask,
+                end_mask);
+            ss_node_vec[i]->get_rt_info()["split"] = true;
+            if (i > 0)
+                ss_node_vec[i]->get_rt_info()["other_split"] = true;
+
+            // int64_t K_offset = K_split * i;
+            // int64_t activation_stride = K_split;
+            // int64_t activation_offset = K_offset;
+            // std::cout << "SplitFCbyK: offset:" << K_offset << "\n";
+
+            fc_node_vec[i] = std::make_shared<ov::intel_cpu::FullyConnectedNode>(
+                // src_item,
+                ss_node_vec[i],
+                wgt_node_vec[i],
+                fc_node->get_output_partial_shape(0).rank(),
+                ov::element::undefined);
+                // activation_stride,
+                // activation_offset);
+
+            fc_node_vec[i]->set_friendly_name(fc_node->get_friendly_name() + "_split_" + std::to_string(i));
+            fc_node_vec[i]->get_rt_info()["split_part"] = true;
+            if (i > 0)
+                fc_node_vec[i]->get_rt_info()["other_split"] = true;
+        }
+        fc_node_vec[0]->get_rt_info()["main_split_root"] = true;
+        fc_node_vec[0]->get_rt_info()["split_parts"] = fc_node_vec;
+        ss_node_vec[0]->get_rt_info()["main_split"] = true;
+        ss_node_vec[0]->get_rt_info()["split_parts"] = ss_node_vec;
+
+        // @todo currently works only for split = 2.
+        // split > 2 requires a chain of Add nodes
+        auto add_node = std::make_shared<ov::op::v1::Add>(fc_node_vec[0], fc_node_vec[1]);
+        add_node->get_rt_info()["sync_point"] = true;
+
+        ov::replace_node_update_name(fc_node, add_node);
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(fc_m, matcher_name);
+    this->register_matcher(m, callback);
+}

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/split_fc_k.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/split_fc_k.hpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+/*
+ * Description:
+ *      SplitFC detects FC CPU operation with and without compressed weights.
+ *      And then splits the FC into several small FCs by output channel according to sub stream number.
+ *      The goal is that the executor can dispatch the split FCs to different numa nodes in the system.
+ *      As a result, the split FCs can be executed at the parallel level.
+ *
+ * Before:
+ *
+ *             +-------+                         +-------+
+ *             |   X   |                         |   W   |
+ *             |       |                         |       |
+ *             |       |                         |       |
+ *             +-------+                         +-------+
+ *                 |                                 |
+ *                 |                                 |
+ * +---------------v---------------------------------v--------------+
+ * |                                                                |
+ * |                        FullyConnected                          |
+ * |                                                                |
+ * +------------------------------+---------------------------------+
+ *                                |
+ *                                | Output
+ *                                v
+ *
+ * After:
+ *
+ *            +-------+                           +-------+
+ *            |   X   |                           |   W   |
+ *            |       |                           |       |
+ *            |       |                           |       |
+ *            +---+---+                           +---+---+
+ *                |                                   |
+ *                |                                   |
+ *                |                           +-------v-------+
+ *                |                           |               |
+ *                |                           | VariadicSplit |
+ *                |                           |               |
+ *                |                           +--+---------+--+
+ *                |                              |         |
+ *                |     +------------------------+         |
+ *                |     |                                  |
+ *            +---------|------------------------+         |
+ *            |         |                        |         |
+ * +----------v---------v---------+  +-----------v---------v--------+
+ * |                              |  |                              |
+ * |        FullyConnected        |  |        FullyConnected        |
+ * |                              |  |                              |
+ * +--------------+---------------+  +--------------+---------------+
+ *                |                                 |
+ *                | Output                          | Output
+ *                |                                 |
+ * +--------------v---------------------------------v---------------+
+ * |                                                                |
+ * |                            Concat                              |
+ * |                                                                |
+ * +-------------------------------+--------------------------------+
+ *                                 |
+ *                                 |
+ *                                 v
+ */
+
+class SplitFCbyK: public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("SplitFCbyK", "0");
+    SplitFCbyK(int sub_stream_num);
+};
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/split_fc_m.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/split_fc_m.cpp
@@ -1,0 +1,125 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/attribute_visitor.hpp"
+#include "openvino/core/dimension.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/strided_slice.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/pass/constant_folding.hpp"
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <transformations/utils/utils.hpp>
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/variadic_split.hpp"
+#include "transformations/cpu_opset/common/op/fully_connected.hpp"
+
+#include "split_fc_m.hpp"
+
+#include "itt.hpp"
+
+static size_t weightsThreshold() {
+    static size_t result = std::getenv("SPLIT_THRESHOLD") ? static_cast<size_t>(std::stoi(std::getenv("SPLIT_THRESHOLD"))) : 6600000;
+    return result;
+}
+
+ov::intel_cpu::SplitFCbyM::SplitFCbyM(int sub_stream_num) {
+    MATCHER_SCOPE(SplitFCbyM);
+    auto fc_m = ov::pass::pattern::wrap_type<ov::intel_cpu::FullyConnectedNode>();
+
+    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+
+        const auto& fc_node = pattern_map.at(fc_m).get_node_shared_ptr();
+        auto& rt_info = fc_node->get_rt_info();
+        if (rt_info.count("split")) {
+            return false;
+        }
+
+        const auto src_item = fc_node->get_input_node_shared_ptr(0);
+        const auto fc_weight_node = fc_node->get_input_node_shared_ptr(1);
+
+        // TODO: support transpose
+        if (ov::is_type<ov::op::v1::Transpose>(fc_weight_node)) {
+            return false;
+        }
+
+        // needn't to split fc when the dim is 0.
+        const auto& wgt_shape = fc_weight_node->get_shape();
+        const size_t split_dim = wgt_shape.size() - 1;
+        // split happens on the second dimension.
+        auto split_dim_node = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, split_dim);
+
+        // std::cout << "SplitFCbyM transformation check" << "\n";
+        // weight shape size 660000 is a trade-off value, which is summarized and verified by LLMs.
+        if (wgt_shape[split_dim] <= 1 || ov::shape_size(wgt_shape) < weightsThreshold()) {
+            return false;
+        }
+
+        // parts will be splited according the sub stream num.
+        int split_num = sub_stream_num + 1;
+
+        // auto split_parts = [](int len, int n) {
+        //     int average = len / n;
+        //     std::vector<int> parts(n, average);
+        //     parts.back() = len - average * (n - 1);
+        //     return parts;
+        // };
+
+        const PartialShape shape = fc_node->input(0).get_partial_shape();
+        auto rank = shape.get_max_shape().size();
+        // @todo check if static
+        const Dimension K = shape[rank - 1];
+        Dimension K_split_dim = K / split_num;
+
+        std::vector<Dimension> split_fc_dims;
+        for (size_t i = 0; i < rank; i++) {
+            split_fc_dims.push_back(shape[i]);
+        }
+        split_fc_dims.push_back(K_split_dim);
+        const PartialShape split_fc_shape(split_fc_dims);
+
+        // const auto K_split = K_split_dim.get_length();
+        std::vector<std::shared_ptr<Node>> fc_node_vec(split_num);
+        for (int i = 0; i < split_num; i++) {
+            // int64_t offset = K_split * (i + 1);
+            fc_node_vec[i] = std::make_shared<ov::intel_cpu::FullyConnectedNode>(
+                src_item,
+                fc_weight_node,
+                fc_node->get_output_partial_shape(0).rank(),
+                ov::element::undefined);
+                // activation_stride,
+                // activation_offset);
+
+            fc_node_vec[i]->set_friendly_name(fc_node->get_friendly_name() + "_split_" + std::to_string(i));
+            fc_node_vec[i]->get_rt_info()["split_part"] = true;
+            if (i > 0)
+                fc_node_vec[i]->get_rt_info()["other_split"] = true;
+        }
+        fc_node_vec[0]->get_rt_info()["main_split_root"] = true;
+        fc_node_vec[0]->get_rt_info()["duplicates"] = fc_node_vec;
+
+        // @todo currently works only for split = 2.
+        // split > 2 requires a chain of Add nodes
+        auto add_node = std::make_shared<ov::op::v1::Add>(fc_node_vec[0], fc_node_vec[1]);
+        add_node->get_rt_info()["sync_point"] = true;
+
+        ov::replace_node_update_name(fc_node, add_node);
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(fc_m, matcher_name);
+    this->register_matcher(m, callback);
+}

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/split_fc_m.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/split_fc_m.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+class SplitFCbyM: public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("SplitFCbyM", "0");
+    SplitFCbyM(int sub_stream_num);
+};
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/variadic_split_to_slice.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/variadic_split_to_slice.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/cpu_opset/common/pass/variadic_split_to_slice.hpp"
+#include "openvino/core/node_vector.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/variadic_split.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/pass/constant_folding.hpp"
+#include <string>
+#include <transformations/utils/utils.hpp>
+
+#include "split_fc.hpp"
+
+#include "itt.hpp"
+
+ov::intel_cpu::MoveConvertThroughVariadicSplit::MoveConvertThroughVariadicSplit() {
+    MATCHER_SCOPE(VariadicSplitToSlice);
+    auto weights_m = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
+    auto convert_m = ov::pass::pattern::wrap_type<ov::op::v0::Convert>({weights_m});
+    auto axis_m = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
+    auto split_lengths_m = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
+    auto vs_m = ov::pass::pattern::wrap_type<ov::op::v1::VariadicSplit>({convert_m, axis_m, split_lengths_m});
+
+    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        const auto& convert_before_vs_output = pattern_map.at(convert_m);
+        const auto& vs_output = pattern_map.at(vs_m);
+        const auto& weights_output = pattern_map.at(weights_m);
+
+        auto vs = std::dynamic_pointer_cast<ov::op::v1::VariadicSplit>(vs_output.get_node_shared_ptr());
+        auto convert_before_vs =
+            std::dynamic_pointer_cast<ov::op::v0::Convert>(convert_before_vs_output.get_node_shared_ptr());
+
+        auto new_vs = vs->clone_with_new_inputs({weights_output, vs->input_value(1), vs->input_value(2)});
+        // NodeVector converts_after_vs;
+        for (size_t i = 0; i < vs->outputs().size(); i++) {
+            auto convert =
+                std::make_shared<ov::op::v0::Convert>(new_vs->output(i), convert_before_vs->get_convert_element_type());
+            // converts_after_vs.push_back(convert);
+
+            for (auto& target_input : vs->output(i).get_target_inputs()) {
+                target_input.replace_source_output(convert);
+            }
+            convert->set_friendly_name(vs->get_friendly_name() + "." + std::to_string(i));
+        }
+
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(vs_m, matcher_name);
+    this->register_matcher(m, callback);
+}

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/variadic_split_to_slice.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/variadic_split_to_slice.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov {
+namespace intel_cpu {
+
+class MoveConvertThroughVariadicSplit: public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("VariadicSplitToSlice", "0");
+    MoveConvertThroughVariadicSplit();
+};
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/convert_to_cpu_specific_opset.hpp
@@ -6,6 +6,8 @@
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/pass/manager.hpp"
 #include "common/pass/align_matmul_input_ranks.hpp"
+#include "openvino/pass/serialize.hpp"
+#include "transformations/common_optimizations/nop_elimination.hpp"
 #include "transformations/common_optimizations/reshape_prelu.hpp"
 #include "common/pass/convert_broadcast_to_tiles.hpp"
 #include "common/pass/convert_tile_to_seq_tiles.hpp"
@@ -16,17 +18,23 @@
 #include "common/pass/move_fc_reshape_to_weights.hpp"
 #include "common/pass/split_fc.hpp"
 #include "transformations/convert_precision.hpp"
+#include "transformations/cpu_opset/common/op/subgraph.hpp"
+#include "transformations/cpu_opset/common/pass/duplicate_model.hpp"
+#include "transformations/cpu_opset/common/pass/form_parallel_subgraphs.hpp"
+#include "transformations/cpu_opset/common/pass/split_fc_k.hpp"
+#include "transformations/cpu_opset/common/pass/variadic_split_to_slice.hpp"
 #include "transformations/utils/utils.hpp"
 #include "common/pass/rnn_sequences_optimization.hpp"
 #include "transformations/common_optimizations/reshape_sequence_fusion.hpp"
 #include "transformations/defs.hpp"
 
 #include "itt.hpp"
+#include "utils/print_model.hpp"
 
 namespace ov {
 namespace intel_cpu {
 
-inline void ConvertToCPUSpecificOpset(std::shared_ptr<ov::Model> &nGraphFunc, int subStreamNum) {
+inline void ConvertToCPUSpecificOpset(std::shared_ptr<ov::Model>& nGraphFunc, int subStreamNum) {
     RUN_ON_FUNCTION_SCOPE(ConvertToCPUSpecificOpset);
 
     ov::pass::Manager manager;
@@ -34,17 +42,65 @@ inline void ConvertToCPUSpecificOpset(std::shared_ptr<ov::Model> &nGraphFunc, in
     CPU_REGISTER_PASS_COMMON(manager, ConvertMatMulToFC);
     CPU_REGISTER_PASS_X64(manager, MoveFCReshapeToWeights);
     CPU_REGISTER_PASS_X64(manager, ov::pass::Validate);
-    if (subStreamNum >= 1) {
-        CPU_REGISTER_PASS_COMMON(manager, SplitFC, subStreamNum);
+    std::cout << "Substream number: " << subStreamNum << "\n";
+    if ((subStreamNum >= 1 || std::getenv("FORCE_SPLIT")) && !std::getenv("DISABLE_SPLIT")) {
+        subStreamNum = 1;
+
+        if (std::getenv("CONCAT_DUP")) {
+            CPU_REGISTER_PASS_COMMON(manager, SplitFC, subStreamNum);
+            if (std::getenv("EXTRA_DUMP")) {
+                manager.run_passes(nGraphFunc);
+                std::cout << "### Dumping graph after SplitFC" << "\n";
+                ov::pass::Serialize("after_split.xml", "/dev/null").run_on_model(nGraphFunc);
+                CPU_DISABLE_PASS_COMMON(manager, SplitFC);
+            }
+        } else {
+            CPU_REGISTER_PASS_COMMON(manager, SplitFCbyK, subStreamNum);
+            if (std::getenv("EXTRA_DUMP")) {
+                manager.run_passes(nGraphFunc);
+                std::cout << "### Dumping graph after SplitFCbyK" << "\n";
+                ov::pass::Serialize("after_split.xml", "/dev/null").run_on_model(nGraphFunc);
+                CPU_DISABLE_PASS_COMMON(manager, SplitFCbyK);
+            }
+        }
+
+        CPU_REGISTER_PASS_COMMON(manager, ov::pass::Validate);
+
+        if (!std::getenv("DISABLE_DUP") && !std::getenv("ENABLE_SUBGRAPH")) {
+            CPU_REGISTER_PASS_COMMON(manager, DuplicateModel);
+            // manager.register_pass<pass::PrintModel>("print_model.txt");
+            CPU_REGISTER_PASS_COMMON(manager, ov::pass::Validate);
+
+            if (std::getenv("EXTRA_DUMP")) {
+                manager.run_passes(nGraphFunc);
+                std::cout << "### Dumping graph after DuplicateModel" << "\n";
+                ov::pass::Serialize("after_duplicate.xml", "/dev/null").run_on_model(nGraphFunc);
+                CPU_DISABLE_PASS_COMMON(manager, DuplicateModel);
+            }
+        }
+
+        if (std::getenv("ENABLE_SUBGRAPH")) {
+            CPU_REGISTER_PASS_COMMON(manager, FormParallelSubgraphs);
+
+            if (std::getenv("EXTRA_DUMP")) {
+                manager.run_passes(nGraphFunc);
+                ov::pass::Serialize("after_form.xml", "/dev/null").run_on_model(nGraphFunc);
+                CPU_DISABLE_PASS_COMMON(manager, FormParallelSubgraphs);
+            }
+        }
+
+        CPU_REGISTER_PASS_COMMON(manager, MoveConvertThroughVariadicSplit);
         CPU_REGISTER_PASS_COMMON(manager, ov::pass::Validate);
     }
+
     CPU_REGISTER_PASS_COMMON(manager, AlignMatMulInputRanks);
     CPU_REGISTER_PASS_COMMON(manager, ConvertTileToSeqTiles);
     CPU_REGISTER_PASS_COMMON(manager, ConvertToPowerStatic);
     CPU_REGISTER_PASS_COMMON(manager, ConvertToLeakyRelu);
     CPU_REGISTER_PASS_COMMON(manager, ConvertToSwishCPU);
     CPU_REGISTER_PASS_COMMON(manager, OptimizeSequenceTransposes);
-    // after transformation "MoveEltwiseUpThroughDataMov" there can be reshaped sequences that should be eliminated or fused
+    // after transformation "MoveEltwiseUpThroughDataMov" there can be reshaped sequences that should be eliminated or
+    // fused
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ReshapeSequenceFusion);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ConstantFolding);
     CPU_REGISTER_PASS_COMMON(manager,
@@ -54,10 +110,30 @@ inline void ConvertToCPUSpecificOpset(std::shared_ptr<ov::Model> &nGraphFunc, in
                              false,
                              false);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::Validate);
-    CPU_REGISTER_PASS_COMMON(manager, ov::pass::EliminateConvert); // Need to clean up after the ConvertPrecision.
+    CPU_REGISTER_PASS_COMMON(manager, ov::pass::EliminateConvert);  // Need to clean up after the ConvertPrecision.
+    CPU_REGISTER_PASS_COMMON(manager, MoveConvertThroughVariadicSplit);
 
     manager.run_passes(nGraphFunc);
+    // SubModel_FullyConnected_18268_clone;
+    const char* extra_dump_c = std::getenv("EXTRA_DUMP");
+    std::string extra_dump = extra_dump_c ? std::string(extra_dump_c) : "";
+    if (!extra_dump.empty()) {
+        for (const auto& op : nGraphFunc->get_ordered_ops()) {
+            if (const auto submodel = ov::as_type_ptr<const ov::intel_cpu::SubModel>(op)) {
+                const auto& name = submodel->get_friendly_name();
+                if (extra_dump == "first") {
+                    ov::pass::Serialize(name + ".xml", "/dev/null").run_on_model(submodel->body_ptr());
+                    break;
+                } else if (name == extra_dump || extra_dump == "all") {
+                    ov::pass::Serialize(name + ".xml", "/dev/null").run_on_model(submodel->body_ptr());
+                    break;
+                }
+            }
+        }
+    }
+
+    std::cout << "### ConvertToCPUSpecificOpset. Done." << "\n";
 }
 
-}   // namespace intel_cpu
-}   // namespace ov
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.h
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.h
@@ -115,7 +115,7 @@ std::ostream & operator<<(std::ostream & os, const dnnl::memory::format_tag dtyp
 std::ostream & operator<<(std::ostream & os, const dnnl::primitive_attr& attr);
 std::ostream & operator<<(std::ostream & os, const dnnl::algorithm& alg);
 
-void print_dnnl_memory(const dnnl::memory& memory, const size_t size, const int id, const char* message = "");
+void print_dnnl_memory(const dnnl::memory& memory, const size_t size, const int id = 0, const char* message = "");
 
 template<typename T>
 std::ostream & operator<<(std::ostream & os, const PrintableVector<T>& vec) {
@@ -166,6 +166,16 @@ static inline std::ostream& _write_all_to_stream(std::ostream& os, const T& arg,
 
 #define DEBUG_LOG(...) DEBUG_LOG_EXT(nullptr, std::cout, "[ DEBUG ] ", __VA_ARGS__)
 #define ERROR_LOG(...) DEBUG_LOG_EXT(nullptr, std::cerr, "[ ERROR ] ", __VA_ARGS__)
+
+static inline bool extra_log_enabled() {
+    static bool result = std::getenv("EXTRA_LOG") ? true : false;
+    return result;
+}
+
+#define EXTRA_LOG(...)                          \
+    if (extra_log_enabled()) {                  \
+        __VA_ARGS__                             \
+    }
 
 #define CREATE_DEBUG_TIMER(x) PrintableTimer x
 
@@ -273,6 +283,7 @@ struct EnforceInferPrcDebug {
 #define DEBUG_LOG_EXT(name, ...)
 
 #define CREATE_DEBUG_TIMER(x)
+#define EXTRA_LOG(...)
 
 #endif // CPU_DEBUG_CAPS
 

--- a/src/plugins/intel_cpu/src/utils/print_model.hpp
+++ b/src/plugins/intel_cpu/src/utils/print_model.hpp
@@ -403,9 +403,9 @@ public:
         if (m_file_name.empty())
             return false;
 
-        for (auto& node : model->get_ordered_ops()) {
-            ov::op::util::process_subgraph(*this, node);
-        }
+        // for (auto& node : model->get_ordered_ops()) {
+        //     ov::op::util::process_subgraph(*this, node);
+        // }
 
         std::ofstream ofs(m_file_name);
         if (!ofs) {

--- a/src/plugins/intel_cpu/src/utils/verbose.cpp
+++ b/src/plugins/intel_cpu/src/utils/verbose.cpp
@@ -36,7 +36,7 @@ bool Verbose::shouldBePrinted() const {
  * Formating written in C using oneDNN format functions.
  * Can be rewritten in pure C++ if necessary
  */
-void Verbose::printInfo() {
+void Verbose::printInfo(const std::string& graphName) {
     /* 1,  2,  3,  etc -> no color
      * 11, 22, 33, etc -> colorize */
     bool colorUp = lvl / 10 > 0 ? true : false;
@@ -153,8 +153,9 @@ void Verbose::printInfo() {
 
     stream << "ov_cpu_verbose" << ','
            << "exec" << ','
+           << node->context->getNumaId() << ','
            << nodeImplementer << ','
-           << nodeName << ":" << nodeType << ":" << nodeAlg << ','
+           << nodeName << ":" << nodeType << ":" << nodeAlg << ',' << graphName << ','
            << nodePrimImplType << ','
            << portsInfo << ','
            << post_ops << ',';

--- a/src/plugins/intel_cpu/src/utils/verbose.h
+++ b/src/plugins/intel_cpu/src/utils/verbose.h
@@ -16,11 +16,11 @@ namespace intel_cpu {
 
 class Verbose {
 public:
-    Verbose(const NodePtr& _node, const std::string& _lvl)
+    Verbose(const NodePtr& _node, const std::string& graphName, const std::string& _lvl)
         : node(_node), lvl(atoi(_lvl.c_str())) {
         if (!shouldBePrinted())
             return;
-        printInfo();
+        printInfo(graphName);
     }
 
     ~Verbose() {
@@ -37,7 +37,7 @@ private:
     std::stringstream stream;
 
     bool shouldBePrinted() const;
-    void printInfo();
+    void printInfo(const std::string& graphName);
     void printDuration();
     void flush() const;
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/matmul.cpp
@@ -200,7 +200,7 @@ TEST_P(MatMulLayerCPUTest, CompareWithRefs) {
         }
     }
     run();
-    CheckPluginRelatedResults(compiledModel, cpuNodeType);
+    // CheckPluginRelatedResults(compiledModel, cpuNodeType);
 }
 
 namespace MatMul {
@@ -286,6 +286,8 @@ const std::vector<ShapeRelatedParams>& IS2D_nightly() {
 
 const std::vector<ShapeRelatedParams>& IS2D_smoke() {
     static const std::vector<ShapeRelatedParams> IS2D_smoke = {
+        // mb1024ic9472oc3584
+        {static_shapes_to_test_representation({{1024, 9472}, {9472, 3584}}), {false, true}},
         {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {false, true}},
         {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {true, true}},
 
@@ -297,6 +299,7 @@ const std::vector<ShapeRelatedParams>& IS2D_smoke() {
 
         {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {true, false}},
         {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {false, true}},
+        {static_shapes_to_test_representation({{2, 6}, {6, 4}}), {false, true}},
 
         {
             {
@@ -311,6 +314,13 @@ const std::vector<ShapeRelatedParams>& IS2D_smoke() {
                 {{1, 120}, {{1, 120}, {1, 120}, {1, 120}, {1, 120}}}
             },
             {true, true}
+        },
+        {
+            {
+                {{-1, -1}, {{2, 6}}},
+                {{6, 4}, {{6, 4}}}
+            },
+            {false, true}
         },
     };
     return IS2D_smoke;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
@@ -48,7 +48,7 @@ std::vector<std::vector<ov::test::InputShape>> inputShapes_SmallChannel_dyn = {
 };
 
 std::vector<std::vector<ov::test::InputShape>> inputShapes_SingleBatch_dyn = {
-    {{{{1, 5}, 19, {1, 5}, {1, 10}}, {{1, 19, 2, 2}, {1, 19, 2, 9}}}},
+    {{{{1, 5}, 19, {1, 5}, {1, 10}}, {{1, 19, 2, 2}, {1, 19, 2, 9}, {3, 19, 2, 9}}}},
 };
 
 std::vector<CPUSpecificParams> cpuParams_3D = {
@@ -313,7 +313,7 @@ const auto params_SingleBatch = testing::Combine(
         testing::Combine(
                 testing::ValuesIn(axes()),
                 testing::Values(ov::test::utils::OpType::VECTOR),
-                testing::Values(true),
+                testing::Values(false),
                 testing::ValuesIn(reductionTypes()),
                 testing::ValuesIn(inpOutPrc()),
                 testing::Values(ElementType::undefined),

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/duplicate_long_connections.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/duplicate_long_connections.cpp
@@ -1,0 +1,119 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/op/assign.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/read_value.hpp"
+#include "shared_test_classes/base/benchmark.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include <common_test_utils/ov_tensor_utils.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+/*
+The main purpose of the tests is to test cyclic inplace resolution in order to make sure that output edges are referenced whenever possible.
+*/
+// using namespace CPUTestUtils;
+namespace ov {
+namespace test {
+
+using VectorShapes = std::vector<InputShape>;
+using Parameters = std::tuple<std::pair<ov::Shape, ov::Shape>>;
+
+class DuplicateLongConnections : public testing::WithParamInterface<Parameters>,
+                                 virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<VectorShapes> obj) {
+        (void) obj;
+        return {};
+    }
+
+    void SetUp() override {
+        const size_t B = std::stoi(std::getenv("CPU_TEST_B"));
+        const size_t M = std::stoi(std::getenv("CPU_TEST_M"));
+        const size_t K = std::stoi(std::getenv("CPU_TEST_K"));
+        // const size_t K2 = std::stoi(std::getenv("CPU_TEST_K2"));
+        const size_t N = std::stoi(std::getenv("CPU_TEST_N"));
+        inType = ov::element::f32;
+        static ov::AnyMap additionalConfig{ov::hint::inference_precision(ov::element::bf16)};
+        configuration.insert(additionalConfig.begin(), additionalConfig.end());
+
+        targetDevice = ov::test::utils::DEVICE_CPU;
+        ov::ParameterVector params;
+        params.push_back(std::make_shared<ov::op::v0::Parameter>(precision, PartialShape{-1, -1, static_cast<int64_t>(K)}));
+        params.push_back(std::make_shared<ov::op::v0::Parameter>(precision, PartialShape{-1, -1, static_cast<int64_t>(K)}));
+        // std::pair<ov::PartialShape, std::vector<ov::Shape>>;
+        const std::vector<InputShape> shapes{
+            std::pair<ov::PartialShape, std::vector<ov::Shape>> {
+                PartialShape{-1, -1, static_cast<int64_t>(K)},
+                {ov::Shape{B, M, K}}
+            },
+            std::pair<ov::PartialShape, std::vector<ov::Shape>> {
+                PartialShape{-1, -1, static_cast<int64_t>(K)},
+                {ov::Shape{B, M, K}}
+            }
+        };
+        init_input_shapes(shapes);
+
+        const PartialShape add_const_shape{static_cast<int64_t>(B), static_cast<int64_t>(M), static_cast<int64_t>(K)};
+
+        // auto add_tensor = ov::test::utils::create_and_fill_tensor(precision, add_const_shape.to_shape());
+        // auto add_const_input = std::make_shared<ov::op::v0::Constant>(add_tensor);
+        // auto add_parameter_input = std::make_shared<ov::op::v0::Parameter>(add_tensor);
+        auto var = std::make_shared<ov::op::util::Variable>(ov::op::util::VariableInfo{inputDynamicShapes[1], inType, "variable"});
+        auto rv = std::make_shared<ov::op::v6::ReadValue>(params[1], var);
+        auto add = std::make_shared<ov::op::v1::Add>(params[0], rv);
+        auto assign = std::make_shared<ov::op::v6::Assign>(add, var);
+        auto mamtmul_input = std::make_shared<ov::op::v0::Constant>(ov::test::utils::create_and_fill_tensor(precision, Shape{K, K}));
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(add, mamtmul_input, false, true);
+        auto swish = std::make_shared<ov::op::v4::Swish>(matmul);
+
+        // auto var_k = std::make_shared<ov::op::util::Variable>(
+        //     ov::op::util::VariableInfo{inputDynamicShapes[1], inType, "pastk"});
+        // auto pastk = std::make_shared<ov::op::v6::ReadValue>(inputParams[3], var_k);
+        // pastk->set_friendly_name("pastk_r");
+        // auto sdp = std::make_shared<ov::op::v13::ScaledDotProductAttention>(swish, concatK, concatV, false);
+
+        auto add_2 = std::make_shared<ov::op::v1::Add>(swish, add);
+        auto mamtmul_2_input = std::make_shared<ov::op::v0::Constant>(ov::test::utils::create_and_fill_tensor(precision, Shape{N, K}));
+        auto matmul_2 = std::make_shared<ov::op::v0::MatMul>(add_2, mamtmul_2_input, false, true);
+        auto result_0 = std::make_shared<ov::op::v0::Result>(matmul_2);
+
+        SinkVector sinks{assign};
+        function = std::make_shared<ov::Model>(ov::ResultVector{result_0}, sinks, params, "Subgraph0");
+        function->add_variables({var});
+        rel_threshold = 1e-3f;
+    }
+
+protected:
+    const ov::element::Type precision = ov::element::f32;
+};
+
+TEST_F(DuplicateLongConnections, smoke_CompareWithRefs) {
+    run();
+}
+
+struct BenchmarkMatMulLayerCPUTest : BenchmarkLayerTest<DuplicateLongConnections> {};
+
+TEST_F(BenchmarkMatMulLayerCPUTest, smoke_BenchmarkDuplicateLongConnections) {
+    auto getNumIter = [](){
+        static auto result = std::getenv("CPU_TEST_NUM_ITER") ? std::stoi(std::getenv("CPU_TEST_NUM_ITER")) : 50;
+        return result;
+    };
+
+    auto getWarmUpTime = [](){
+        static auto result = std::getenv("CPU_TEST_WARM_UP") ? std::stoi(std::getenv("CPU_TEST_WARM_UP")) : 2000;
+        return result;
+    };
+
+    run_benchmark("FullyConnected", std::chrono::milliseconds(getWarmUpTime()), getNumIter());
+}
+
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/inplace_sugraph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/inplace_sugraph.cpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/multiply.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include <common_test_utils/ov_tensor_utils.hpp>
+
+/*
+The main purpose of the tests is to test cyclic inplace resolution in order to make sure that output edges are referenced whenever possible.
+*/
+// using namespace CPUTestUtils;
+namespace ov {
+namespace test {
+
+using VectorShapes = std::vector<InputShape>;
+
+class InplaceSubgraph : virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<VectorShapes> obj) {
+        VectorShapes& inputShapes = obj.param;
+
+        std::ostringstream result;
+        result << "IS=";
+        for (const auto& shape : inputShapes) {
+            result << ov::test::utils::partialShape2str({shape.first}) << "_";
+        }
+        result << "TS=";
+        for (const auto& shape : inputShapes) {
+            result << "(";
+            if (!shape.second.empty()) {
+                for (const auto& itr : shape.second) {
+                    result << ov::test::utils::vec2str(itr);
+                }
+            }
+            result << ")";
+        }
+        return result.str();
+    }
+
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_CPU;
+        ov::ParameterVector params;
+        params.push_back(std::make_shared<ov::op::v0::Parameter>(precision, PartialShape{2, 6}));
+        const auto& param = params[0];
+        // std::pair<ov::PartialShape, std::vector<ov::Shape>>;
+        const std::vector<InputShape> shapes{
+            std::pair<ov::PartialShape, std::vector<ov::Shape>> {
+                PartialShape{2, 6}, {ov::Shape{2, 6}}
+            }
+        };
+        init_input_shapes(shapes);
+
+        const PartialShape multiply_const_shape{2, 6};
+
+        auto mul_tensor = ov::test::utils::create_and_fill_tensor(precision, multiply_const_shape.to_shape());
+        auto multiply_const_input = std::make_shared<ov::op::v0::Constant>(mul_tensor);
+        auto add_tensor = ov::test::utils::create_and_fill_tensor(precision, multiply_const_shape.to_shape());
+        auto add_const_input = std::make_shared<ov::op::v0::Constant>(add_tensor);
+
+        auto multiply_1 = std::make_shared<ov::op::v1::Multiply>(param, multiply_const_input);
+        auto add = std::make_shared<ov::op::v1::Add>(multiply_1, add_const_input);
+        auto multiply_2 = std::make_shared<ov::op::v1::Divide>(add, multiply_const_input);
+        auto add_2 = std::make_shared<ov::op::v1::Add>(multiply_2, multiply_const_input);
+        auto mamtmul_input = std::make_shared<ov::op::v0::Constant>(ov::test::utils::create_and_fill_tensor(precision, Shape{4, 6}));
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(add_2, mamtmul_input, false, true);
+
+        auto result_0 = std::make_shared<ov::op::v0::Result>(matmul);  // Ho [batch_size, num_directions, hidden_size]
+
+        function = std::make_shared<ov::Model>(ov::ResultVector{result_0}, params, "Subgraph0");
+    }
+
+protected:
+    const ov::element::Type precision = ov::element::f32;
+};
+
+TEST_F(InplaceSubgraph, smoke_CompareWithRefs) {
+    run();
+}
+
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -75,13 +75,13 @@ const std::vector<ov::test::utils::ReductionType> reduction_logical_types = {
 };
 
 const auto params_one_axis = testing::Combine(
-        testing::Values(std::vector<int>{0}),
-        testing::ValuesIn(op_types),
-        testing::ValuesIn(keep_dims),
-        testing::ValuesIn(reduction_types),
-        testing::Values(model_types[0]),
-        testing::ValuesIn(input_shapes_one_axis),
-        testing::Values(ov::test::utils::DEVICE_CPU)
+    testing::ValuesIn(std::vector<std::vector<int>>{{0},{1},{2},{3}}),
+    testing::ValuesIn(op_types),
+    testing::ValuesIn(keep_dims),
+    testing::ValuesIn(reduction_types),
+    testing::Values(model_types[0]),
+    testing::ValuesIn(input_shapes_one_axis),
+    testing::Values(ov::test::utils::DEVICE_CPU)
 );
 
 const auto params_one_axis_logical = testing::Combine(

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/benchmark.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/benchmark.hpp
@@ -115,7 +115,7 @@ class BenchmarkLayerTest : public BaseLayerTest {
         for (const auto& input : this->inputs) {
             this->inferRequest.set_tensor(input.first, input.second);
         }
-
+#define ENABLE_BENCHMARK_FILE_REPORT
 #ifdef ENABLE_BENCHMARK_FILE_REPORT
         reporter_ = std::unique_ptr<ov::test::BenchmarkLayerTestReporter>(
                 new ::ov::test::BenchmarkLayerTestReporter{false});


### PR DESCRIPTION
### Details:
This is a prototype of the tensor parallel implementation via async SubGraph node.
The branch currently contains a lot of extra changes / tunings (even not related to the tensor parallel at all) in order to achieve the maximum performance.
The plan is to split all the changes into separate PRs.

### In a nutshell:
1. Split heavy operation (FC) into pieces
2. Duplicate the rest of the operations
3. Form SubGraphs with the FC piece as a root
4. Create SubGraph nodes from SubGraph operations
5. Execute SubGraph nodes either synchronously using current stream or asynchronously using appropriate substream.

### In details, there are key points of the tensor parallel implementation:
 - as a first step the heavy node (FullyConnected in this case) is split into the pieces. There are 3 options to achieve this (consider FC as MxK * KxN =):

1. split by M (by batch)
2. split by K
3. split by N

   2 and 3 is implemented on the branch. 3 is used as a main implementation and most promising one.

- then the rest of the graph is basically duplicated (depending on the number of the NUMA nodes of course). While duplicating the graph, the subgraphs are formed. Each subgraph has the piece of the FullyConnected node from the first step as a root node. As a result, the whole graph consists of the SubGraph nodes connected to each other, each subgraph node representing the duplicated part of the graph + split piece of the FullyConnected node.
- Added new ov operation SubGraph and corresponding cpu SubGraph node. The idea of the SubGraph operation and SubGraph node is to act as a proxy between external and internal graph with the goal of having zero overhead. Basically, every node / sequence of the nodes can be wrapped into a SubGraph node without any (almost) overhead. No additional memory allocations or memory copies is expected.
- During duplication of the graph, each SubGraph operation is marked with a numa_id to be used for its execution. Thus, SubGraph node can be executed either on the current NUMA using current stream, or on some other NUMA using substream.
- The main graph is responsible for the async executions and synchronization (currently on the branch only SubGraph node is supposed to be executed asynchronously if necessary), the final goal is to generalize it for any node. The tricky part is initialization of the SubGraph node. Since we want every piece of data to be allocated on the corresponding numa node, we have to perform initialization of the SubGraph node using substream as well.

### Open issues / important todos:
 1) Per-numa sharing of the runtime primitive cache is not working for some reason. Currently each SubGraph has its own cache.
 2) The solution performs better with OMP (probably because of OMP spin-locking on all the sockets, and TBB sometimes sleeping while we are waiting for piece of the data from other socket).
 3) The Wait implementation is not really generic. The goal is to have something like control-flow graph.
 4) Duplicating of the States (Assign / ReadValue) is a tricky part. Current implementation on the branch most likely does not support a state change initiated by the user.

### Tickets:
 - *ticket-id*