### PR TITLE
[GoodFirstIssue][OP CONFORMANCE][TEMPLATE] Added u64 support for the indices of Gather

### DIFF
--- a/src/plugins/template/backend/ops/gather.cpp
+++ b/src/plugins/template/backend/ops/gather.cpp
@@ -11,7 +11,16 @@ bool evaluate(const std::shared_ptr<ov::op::v8::Gather>& op,
               ov::TensorVector& outputs,
               const ov::TensorVector& inputs) {
     using T = typename ov::element_type_traits<ET>::value_type;
-    if (op->get_input_element_type(1) == ov::element::i64) {
+    if (op->get_input_element_type(1) == ov::element::u64) {
+        ov::reference::gather<T, uint64_t>(inputs[0].data<T>(),
+                                           inputs[1].data<uint64_t>(),
+                                           outputs[0].data<T>(),
+                                           op->get_input_shape(0),
+                                           op->get_input_shape(1),
+                                           op->get_output_shape(0),
+                                           op->get_axis(),
+                                           op->get_batch_dims());
+    } else if (op->get_input_element_type(1) == ov::element::i64) {
         ov::reference::gather<T, int64_t>(inputs[0].data<T>(),
                                           inputs[1].data<int64_t>(),
                                           outputs[0].data<T>(),


### PR DESCRIPTION
### Details:
 - Added u64 support for the indices of Gather. 

### Tickets:
 - https://github.com/openvinotoolkit/openvino/issues/23545

### Test is passed:
> [==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from conformance_Gather/ReadIRTest
[ RUN      ] conformance_Gather/ReadIRTest.Inference/Op=Gather.8_Type=f32_Shape=dynamic_IR=1c727cc96123227a9fe6c3079a497fd64a04f273bff45b5ea56a3c0d577eca8e_Device=TEMPLATE_Config=()
MEM_USAGE=31860KB
[ CONFORMANCE ] Influence coefficient: 4.72987e-05
[ PLUGIN      ] `SubgraphBaseTest::compile_model()` is started
[ PLUGIN      ] `SubgraphBaseTest::compile_model()` is finished successfully. Duration is 0.143964s
RANGE FOR PARAMETER: Gather-8_0  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Gather-8_1  start from: 0.000000  range: 15  resolution: 1  seed: 1
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is started
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is finished successfully. Duration is 0.0288465s
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is started
[ REFERENCE   ] Calculate reference in runtime
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is started
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is 0.0094897s
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is 0.0109919s
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is started
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is finished successfully. Duration is 0.0071786s
RANGE FOR PARAMETER: Gather-8_0  start from: 0.000000  range: 8  resolution: 32  seed: 1
RANGE FOR PARAMETER: Gather-8_1  start from: 0.000000  range: 15  resolution: 1  seed: 1
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is started
[ PLUGIN      ] `SubgraphBaseTest::get_plugin_outputs()` is finished successfully. Duration is 0.0033599s
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is started
[ REFERENCE   ] Calculate reference in runtime
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is started
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is 0.0086416s
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is 0.0105932s
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is started
[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is 0.010214s
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is started
[ COMPARATION ] `ov_tensor_utils.hpp::compare()` is finished successfully. Duration is 0.0082425s
[       OK ] conformance_Gather/ReadIRTest.Inference/Op=Gather.8_Type=f32_Shape=dynamic_IR=1c727cc96123227a9fe6c3079a497fd64a04f273bff45b5ea56a3c0d577eca8e_Device=TEMPLATE_Config=() (381 ms)
[----------] 1 test from conformance_Gather/ReadIRTest (383 ms total)
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (435 ms total)
[  PASSED  ] 1 test.