### PR TITLE
[JAX FE] Add arithmetic operations for JAX frontend.

### DIFF
--- a/src/frontends/jax/src/op_table.cpp
+++ b/src/frontends/jax/src/op_table.cpp
@@ -22,6 +22,9 @@ OP_CONVERTER(translate_convert);
 // Supported ops for Jaxpr
 const std::map<std::string, CreatorFunction> get_supported_ops_jaxpr() {
     return {{"add", op::translate_1to1_match_2_inputs<opset14::Add>},
+            {"sub", op::translate_1to1_match_2_inputs<opset14::Subtract>},
+            {"mul", op::translate_1to1_match_2_inputs<opset14::Multiply>},
+            {"div", op::translate_1to1_match_2_inputs<opset14::Divide>},
             {"constant", op::translate_constant},
             {"convert_element_type", op::translate_convert}};
 };

--- a/tests/layer_tests/jax_tests/test_div.py
+++ b/tests/layer_tests/jax_tests/test_div.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from jax_layer_test_class import JaxLayerTest
+import jax.numpy as jnp
+
+def get_rand_jnp_array(shape, dtype):
+    if dtype in [np.float32, np.float16, np.float64]:
+        return jnp.array(np.random.uniform(-1000, 1000, shape).astype(dtype))
+    else:
+        return jnp.array(np.random.randint(-10, 10, shape).astype(dtype))
+
+class TestDiv(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+
+        def jax_div(lhs, rhs):
+            return lhs / rhs
+
+        return jax_div, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_div(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)
+
+class TestDivWithConstant(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+        self.const = jnp.ones(self.lhs_shape, dtype=self.lhs_type)
+
+        def jax_div_with_constant(lhs, rhs):
+            return lhs / rhs / self.const
+
+        return jax_div_with_constant, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_div_with_constant(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)
+        
+class TestDivWithLiteralInvar(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+
+        def jax_div_with_constant(lhs, rhs):
+            x = lhs / 5
+            return x / rhs
+
+        return jax_div_with_constant, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_div_with_literal_invar(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)

--- a/tests/layer_tests/jax_tests/test_div.py
+++ b/tests/layer_tests/jax_tests/test_div.py
@@ -9,9 +9,11 @@ import jax.numpy as jnp
 
 def get_rand_jnp_array(shape, dtype):
     if dtype in [np.float32, np.float16, np.float64]:
-        return jnp.array(np.random.uniform(-1000, 1000, shape).astype(dtype))
+        res = np.random.uniform(-1000, 1000, shape).astype(dtype)
     else:
-        return jnp.array(np.random.randint(-10, 10, shape).astype(dtype))
+        res = np.random.randint(-10, 10, shape).astype(dtype)
+    res[res == 0] = 1e-6
+    return jnp.array(res)
 
 class TestDiv(JaxLayerTest):
     def _prepare_input(self):

--- a/tests/layer_tests/jax_tests/test_mul.py
+++ b/tests/layer_tests/jax_tests/test_mul.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from jax_layer_test_class import JaxLayerTest
+import jax.numpy as jnp
+
+def get_rand_jnp_array(shape, dtype):
+    if dtype in [np.float32, np.float16, np.float64]:
+        return jnp.array(np.random.uniform(-1000, 1000, shape).astype(dtype))
+    else:
+        return jnp.array(np.random.randint(-10, 10, shape).astype(dtype))
+
+class TestMul(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+
+        def jax_mul(lhs, rhs):
+            return lhs * rhs
+
+        return jax_mul, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_mul(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)
+
+class TestMulWithConstant(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+        self.const = jnp.ones(self.lhs_shape, dtype=self.lhs_type)
+
+        def jax_mul_with_constant(lhs, rhs):
+            return lhs * rhs * self.const
+
+        return jax_mul_with_constant, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_mul_with_constant(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)
+        
+class TestMulWithLiteralInvar(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+
+        def jax_mul_with_constant(lhs, rhs):
+            x = lhs * 5
+            return x * rhs
+
+        return jax_mul_with_constant, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_mul_with_literal_invar(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)

--- a/tests/layer_tests/jax_tests/test_sub.py
+++ b/tests/layer_tests/jax_tests/test_sub.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from jax_layer_test_class import JaxLayerTest
+import jax.numpy as jnp
+
+def get_rand_jnp_array(shape, dtype):
+    if dtype in [np.float32, np.float16, np.float64]:
+        return jnp.array(np.random.uniform(-1000, 1000, shape).astype(dtype))
+    else:
+        return jnp.array(np.random.randint(-10, 10, shape).astype(dtype))
+
+class TestSub(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+
+        def jax_sub(lhs, rhs):
+            return lhs - rhs
+
+        return jax_sub, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_sub(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)
+
+class TestSubWithConstant(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+        self.const = jnp.ones(self.lhs_shape, dtype=self.lhs_type)
+
+        def jax_sub_with_constant(lhs, rhs):
+            return lhs - rhs - self.const
+
+        return jax_sub_with_constant, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_sub_with_constant(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)
+        
+class TestSubWithLiteralInvar(JaxLayerTest):
+    def _prepare_input(self):
+        lhs = get_rand_jnp_array(self.lhs_shape, self.lhs_type)
+        rhs = get_rand_jnp_array(self.rhs_shape, self.rhs_type)
+        return (lhs, rhs)
+
+    def create_model(self, lhs_shape, rhs_shape, lhs_type, rhs_type):
+        self.lhs_shape = lhs_shape
+        self.rhs_shape = rhs_shape
+        self.lhs_type = lhs_type
+        self.rhs_type = rhs_type
+
+        def jax_sub_with_constant(lhs, rhs):
+            x = lhs - 5
+            return x - rhs
+
+        return jax_sub_with_constant, None
+
+    test_data = [
+        dict(lhs_shape=[4], rhs_shape=[4]),
+        dict(lhs_shape=[2, 5], rhs_shape=[2, 5]),
+        dict(lhs_shape=[2, 3, 4, 5], rhs_shape=[2, 3, 4, 5]),
+    ]
+    
+    input_types = [
+        (np.float32, np.float32),
+        (np.int32, np.float32),
+        (np.float32, np.float16),
+        (np.int32, np.int64),
+    ]
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit_jax_fe
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.parametrize("input_type", input_types)
+    def test_sub_with_literal_invar(self, ie_device, precision, ir_version, params, input_type):
+        self._test(*self.create_model(**params, lhs_type=input_type[0], rhs_type=input_type[1]), ie_device, precision,
+                   ir_version)


### PR DESCRIPTION
### Details:
Add `sub`, `mul` and `div`, and corresponding unit tests.

### Tickets:
No ticket
