### PR TITLE
[CPU] Limit f16 in Accuracy mode by hardware support

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -531,8 +531,9 @@ void Convolution::getSupportedDescriptors() {
         auto dt = memory::data_type::f32;
 
         // supported lower precisions: bf16, f16
-        if (one_of(originalDT, memory::data_type::bf16, memory::data_type::f16))
+        if (one_of(originalDT, memory::data_type::bf16, memory::data_type::f16) && hasHardwareSupport(originalPrec)) {
             dt = originalDT;
+        }
 
         // fallback to f32 on special case for performance reasons
         if (isDepthWise() && ndims == 5)

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -356,6 +356,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
         // @todo should we always convert to f32 regardless of hardware support, as it is done for f16?
         if (!hasHardwareSupport(ov::element::bf16))
             map.insert({ov::element::bf16, ov::element::f32});
+        // TODO: Remove 'hasHardwareSupport' when all nodes are able to handle f16 properly.
         if (!one_of(inferencePrecision, element::f16, element::undefined) || !hasHardwareSupport(element::f16)) {
             map.insert({ov::element::f16, ov::element::f32});
         }

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -356,7 +356,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
         // @todo should we always convert to f32 regardless of hardware support, as it is done for f16?
         if (!hasHardwareSupport(ov::element::bf16))
             map.insert({ov::element::bf16, ov::element::f32});
-        if (!one_of(inferencePrecision, element::f16, element::undefined)) {
+        if (!one_of(inferencePrecision, element::f16, element::undefined) || !hasHardwareSupport(element::f16)) {
             map.insert({ov::element::f16, ov::element::f32});
         }
         return map;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/undefined_et.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/undefined_et.cpp
@@ -75,6 +75,12 @@ void UndefinedEtSubgraphTest::SetUp() {
     auto logical_not = std::make_shared<op::v1::LogicalNot>(cvt_f32);
 
     function = std::make_shared<ov::Model>(OutputVector{logical_not->output(0)}, ParameterVector{param_0, param_1, param_2}, "UndefinedET");
+
+    // TODO: Need to remove when the hardware checking for f16 will be eliminated in the Transformations pipeline.
+    if (m_data_et == element::f16 && !ov::intel_cpu::hasHardwareSupport(m_data_et)) {
+        abs_threshold = 1.f;
+        rel_threshold = 0.1f;
+    }
 }
 
 template<typename TD, typename TS>
@@ -136,11 +142,6 @@ fill_data(tensor->data<ov::element_type_traits<P>::value_type>(), S, L); break;
 }
 
 TEST_P(UndefinedEtSubgraphTest, CompareWithRefs) {
-    if (m_data_et == element::f16 && !ov::intel_cpu::hasHardwareSupport(m_data_et)) {
-        abs_threshold = 1.f;
-        rel_threshold = 0.1f;
-    }
-
     run();
 
     if (IsSkipped()) {


### PR DESCRIPTION
### Details:
 - *Restrict usage of f16 in transformations pipeline if it's not supported by hardware for ACCURACY MODE*

### Tickets:
 - *145051*
