### PR TITLE
[GPU] Skip fc fake alignment when fused desc has full tensor input

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -197,7 +197,7 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
                 break;
             }
             // Check fused desc's input has full tensor, then do not fake alignment
-            if (orig_output_layout.get_tensor() == fused_op_input_layout.get_tensor()) {
+            if (orig_output_layout.get_shape() == fused_op_input_layout.get_shape()) {
                 can_apply_fake_alignment = false;
                 break;
             }

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -188,17 +188,20 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         can_apply_fake_alignment &= orig_output_layout.data_padding.lower_size().sizes()[1] == 0 &&
                                     orig_output_layout.data_padding.upper_size().sizes()[1] == 0;
 
-    size_t num_of_inputs = orig_impl_param.input_layouts.size();
-    size_t num_of_fused_desc = 0;
-
     for (auto& fused_desc : orig_impl_param.fused_desc) {
-        if (!fused_desc.deps.empty())
-            num_of_fused_desc++;
-    }
-    for (size_t i = 0; i < num_of_fused_desc; i++) {
-        // Check fused desc's input has full tensor, then do not fake alignment
-        if (orig_output_layout.get_tensor() == orig_impl_param.input_layouts[num_of_inputs - i - 1].get_tensor())
-            can_apply_fake_alignment = false;
+        if (fused_desc.has_outer_dep()) {
+            auto fused_op_input_layout = orig_impl_param.input_layouts[fused_desc.outer_dep_start_idx];
+            // Check fused desc's input is still dynamic, then do not fake alignment
+            if (fused_op_input_layout.is_dynamic()) {
+                can_apply_fake_alignment = false;
+                break;
+            }
+            // Check fused desc's input has full tensor, then do not fake alignment
+            if (orig_output_layout.get_tensor() == fused_op_input_layout.get_tensor()) {
+                can_apply_fake_alignment = false;
+                break;
+            }
+        }
     }
 
     GPU_DEBUG_GET_INSTANCE(debug_config);

--- a/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
@@ -7,8 +7,11 @@
 #include <intel_gpu/primitives/input_layout.hpp>
 #include <intel_gpu/primitives/fully_connected.hpp>
 #include <intel_gpu/primitives/data.hpp>
+#include <intel_gpu/primitives/eltwise.hpp>
+#include <intel_gpu/primitives/permute.hpp>
 
 #include "fully_connected_inst.h"
+#include "eltwise_inst.h"
 
 #include "program_wrapper.h"
 
@@ -210,4 +213,67 @@ INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_fake_align_test,
         },
     }));
 
+class fully_connected_skip_fake_align_test : public testing::TestWithParam<fc_fake_align_params> {};
+
+// Skip fake alignment when fused desc has full tensor dependency
+TEST_P(fully_connected_skip_fake_align_test, skip_fake_alignment_case) {
+    auto p = GetParam();
+
+    auto& engine = get_test_engine();
+    topology topology;
+    cldnn::program prog(engine);
+
+    topology.add(input_layout("input", p.input_layout));
+    topology.add(input_layout("eltwise_data1",p.input_layout));
+    topology.add(eltwise("eltwise_add1", { input_info("input"), input_info("eltwise_data1") }, eltwise_mode::sum));
+
+    topology.add(input_layout("weights", p.weight_layout));
+    topology.add(fully_connected("fc_prim1", input_info("eltwise_add1"), "weights", "",
+                 cldnn::data_types::f32, padding(), p.input_layout.get_rank(), p.weight_layout.get_rank()));
+    
+    topology.add(input_layout("bias",
+                 layout{ov::PartialShape{1, 1, p.expected_output_layout_igpu.get_dims()[2]}, cldnn::data_types::f32, cldnn::format::bfyx}));
+    topology.add(eltwise("bias_add", { input_info("fc_prim1"), input_info("bias") }, eltwise_mode::sum));
+    
+    topology.add(input_layout("dequantize_scale",
+                 layout{ov::PartialShape{1, 1, p.expected_output_layout_igpu.get_dims()[2]}, cldnn::data_types::f32, cldnn::format::bfyx}));
+    topology.add(eltwise("eltwise_multiply", { input_info("bias_add"), input_info("dequantize_scale") }, eltwise_mode::prod));
+    
+    topology.add(input_layout("eltwise_data2", p.expected_output_layout_igpu));
+    topology.add(eltwise("eltwise_add2", { input_info("eltwise_multiply"), input_info("eltwise_data2") }, eltwise_mode::sum));
+    topology.add(permute("permute", input_info("eltwise_add2"), {2, 1, 0}));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+
+    auto impl_param = network.get_primitive("fc_prim1")->get_impl_params();
+
+    if (impl_param->get_input_layout().is_dynamic() || impl_param->get_output_layout().is_dynamic()) {
+        EXPECT_THROW(fully_connected_inst::get_fake_aligned_params(*impl_param), std::exception);
+    } else {
+        auto updated_param = fully_connected_inst::get_fake_aligned_params(*impl_param);
+        if (!engine.get_device_info().supports_immad) {
+            ASSERT_EQ(updated_param.get_input_layout(), p.expected_input_layout_igpu);
+            ASSERT_EQ(updated_param.get_output_layout(), p.expected_output_layout_igpu);
+        } else {
+            ASSERT_EQ(updated_param.get_input_layout(), p.expected_input_layout_dgpu);
+            ASSERT_EQ(updated_param.get_output_layout(), p.expected_output_layout_dgpu);
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_skip_fake_align_test,
+    testing::ValuesIn(std::vector<fc_fake_align_params>{
+        {
+            layout{ov::PartialShape{1, 1000, 2048}, data_types::u8, format::bfyx},    // input_layout
+            layout{ov::PartialShape{512, 2048}, data_types::i8, format::bfyx},        // weight layout
+            data_types::f32,
+            layout{ov::PartialShape{1, 1000, 2048}, data_types::u8, format::bfyx},    // skiped fake_aligned input layout_igpu
+            layout{ov::PartialShape{1, 1000, 512}, data_types::f32, format::bfyx},    // skipped fake_aligned output layout_igpu
+            layout{ov::PartialShape{1, 1000, 2048}, data_types::u8, format::bfyx},    // skipped fake_aligned input layout_dgpu
+            layout{ov::PartialShape{1, 1000, 512}, data_types::f32, format::bfyx}     // skipped fake_aligned output layout_dgpu
+        },
+    }));
 }  // fake_alignment_tests


### PR DESCRIPTION
### Details:
 - Skip fc fake alignment when fused desc has full tensor input

### Tickets:
 - 144293
