### PR TITLE
fix cmake path issue

### DIFF
--- a/cmake/developer_package/api_validator/api_validator.cmake
+++ b/cmake/developer_package/api_validator/api_validator.cmake
@@ -23,7 +23,7 @@ can't find Windows SDK version. Try to use vcvarsall.bat script")
         endif()
     endif()
 
-    set(PROGRAMFILES_ENV "ProgramFiles\(X86\)")
+    set(PROGRAMFILES_ENV "ProgramFiles\(X86\)" PARENT_SCOPE)
 
     # check that PROGRAMFILES_ENV is defined, because in case of cross-compilation for Windows
     # we don't have such variable


### PR DESCRIPTION
### Details:
 - build openvino will get the UniversalDDIs.xml can not find issue.
    ```
    [2024-06-26T21:58:25.848Z] CMake Error at cmake/developer_package/api_validator/api_validator.cmake:124 (message):
    [2024-06-26T21:58:25.848Z]   Internal error: apiValidator is found (C:/Program Files (x86)/Windows
    [2024-06-26T21:58:25.848Z]   Kits/10/bin/10.0.22621.0/x64/apivalidator.exe), but UniversalDDIs.xml file
    [2024-06-26T21:58:25.848Z]   has not been found for x64 platform
    ```
 - error is from the below [code](https://github.com/openvinotoolkit/openvino/blob/master/cmake/developer_package/api_validator/api_validator.cmake#L116) and it is used in `_ov_add_api_validator_post_build_step` function.  `${PROGRAMFILES}`  is empty and [defined ](https://github.com/openvinotoolkit/openvino/blob/master/cmake/developer_package/api_validator/api_validator.cmake#L26) in function `ov_search_api_validator`.
     ```
        find_file(ONECORE_API_VALIDATOR_APIS NAMES UniversalDDIs.xml
                  PATHS "${PROGRAMFILES}/Windows Kits/10/build/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/universalDDIs/${wdk_platform}"
                        "${PROGRAMFILES}/Windows Kits/10/build/universalDDIs/${wdk_platform}"
                  DOC "Path to UniversalDDIs.xml file")
    ```

### Tickets:
 - *ticket-id*
