### PR TITLE
[Snippets] Disabled tokenization of MHA pattern with dynamic  ops

### DIFF
--- a/src/common/snippets/include/snippets/pass/tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/tokenization.hpp
@@ -66,9 +66,11 @@ public:
      * @ingroup snippets
      */
     struct Config {
-        Config(size_t concurrency, size_t data_ptr_gpr_count, bool split_m_dimension, bool enable_transpose_on_output, std::set<size_t> mha_transpose_ranks)
+        Config(size_t concurrency, size_t data_ptr_gpr_count, bool split_m_dimension, bool enable_transpose_on_output,
+               bool dyn_mha_supported, std::set<size_t> mha_transpose_ranks)
             : concurrency(concurrency), data_ptr_gpr_count(data_ptr_gpr_count), split_m_dimension(split_m_dimension),
-              mha_token_enable_transpose_on_output(enable_transpose_on_output), mha_supported_transpose_ranks(std::move(mha_transpose_ranks)) {
+              mha_token_enable_transpose_on_output(enable_transpose_on_output), is_dynamic_mha_supported(dyn_mha_supported),
+              mha_supported_transpose_ranks(std::move(mha_transpose_ranks)) {
             OPENVINO_ASSERT(concurrency > 0, "Concurrency should be greater than 0");
             OPENVINO_ASSERT(data_ptr_gpr_count > 0, "data_ptr_gpr_count should be greater than 0");
         }
@@ -93,6 +95,10 @@ public:
             return mha_token_enable_transpose_on_output;
         }
 
+        bool get_dynamic_mha_support() const {
+            return is_dynamic_mha_supported;
+        }
+
         std::set<size_t> get_mha_supported_transpose_ranks() const {
             return mha_supported_transpose_ranks;
         }
@@ -108,6 +114,9 @@ public:
         // Otherwise, it may be fused into Subgraph if possible
         // TODO [111813]: Remove please when the ticket 111813 is implemented
         bool mha_token_enable_transpose_on_output = true;
+        // True if dynamic MHA is supported by backend
+        // Otherwise dynamic MHA won't be tokenized
+        bool is_dynamic_mha_supported = true;
         // Set of supported Transpose shape ranks for tokenization in MHATokenization pass.
         // Note that in general Snippets support Transpose of any ranks.
         // But at the moment Transpose is used only in MHA pattern where 3D and 4D tensors are supported.

--- a/src/common/snippets/include/snippets/pass/tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/tokenization.hpp
@@ -67,60 +67,61 @@ public:
      */
     struct Config {
         Config(size_t concurrency, size_t data_ptr_gpr_count, bool split_m_dimension, bool enable_transpose_on_output,
-               bool dyn_mha_supported, std::set<size_t> mha_transpose_ranks)
-            : concurrency(concurrency), data_ptr_gpr_count(data_ptr_gpr_count), split_m_dimension(split_m_dimension),
-              mha_token_enable_transpose_on_output(enable_transpose_on_output), is_dynamic_mha_supported(dyn_mha_supported),
-              mha_supported_transpose_ranks(std::move(mha_transpose_ranks)) {
+               bool dyn_mha_token, std::set<size_t> mha_transpose_ranks)
+            : m_concurrency(concurrency), m_data_ptr_gpr_count(data_ptr_gpr_count), m_split_m_dimension(split_m_dimension),
+              m_mha_token_enable_transpose_on_output(enable_transpose_on_output), m_is_dynamic_mha_token_enabled(dyn_mha_token),
+              m_mha_supported_transpose_ranks(std::move(mha_transpose_ranks)) {
             OPENVINO_ASSERT(concurrency > 0, "Concurrency should be greater than 0");
             OPENVINO_ASSERT(data_ptr_gpr_count > 0, "data_ptr_gpr_count should be greater than 0");
         }
 
         void set_concurrency(size_t concur) {
-            concurrency = concur;
+            m_concurrency = concur;
         }
 
         size_t get_concurrency() const {
-            return concurrency;
+            return m_concurrency;
         }
 
         size_t get_data_ptr_gpr_count() const {
-            return data_ptr_gpr_count;
+            return m_data_ptr_gpr_count;
         }
 
         bool get_split_m_dimension() const {
-            return split_m_dimension;
+            return m_split_m_dimension;
         }
 
         bool get_mha_token_enable_transpose_on_output() const {
-            return mha_token_enable_transpose_on_output;
+            return m_mha_token_enable_transpose_on_output;
         }
 
-        bool get_dynamic_mha_support() const {
-            return is_dynamic_mha_supported;
+        bool is_dynamic_mha_token_enabled() const {
+            return m_is_dynamic_mha_token_enabled;
         }
 
         std::set<size_t> get_mha_supported_transpose_ranks() const {
-            return mha_supported_transpose_ranks;
+            return m_mha_supported_transpose_ranks;
         }
 
     private:
-        size_t concurrency = 0;
+        size_t m_concurrency = 0;
         // The number of gpr that can be used as data pointers for data nodes (Parameter (and non-Scalar Constants),
         // Result, Buffers with the same ID)
-        size_t data_ptr_gpr_count = 0;
+        size_t m_data_ptr_gpr_count = 0;
         // True if "SplitDimensionM" optimization is enabled. Otherwise, it's disabled.
-        bool split_m_dimension = true;
+        bool m_split_m_dimension = true;
         // False if Transpose on output isn't tokenized in MHA Tokenization.
         // Otherwise, it may be fused into Subgraph if possible
         // TODO [111813]: Remove please when the ticket 111813 is implemented
-        bool mha_token_enable_transpose_on_output = true;
-        // True if dynamic MHA is supported by backend
+        bool m_mha_token_enable_transpose_on_output = true;
+        // If True, MHA pattern with dynamic nodes will be tokenized
         // Otherwise dynamic MHA won't be tokenized
-        bool is_dynamic_mha_supported = true;
+        // Currently, the flag can be set to `True` only for testing purposes.
+        bool m_is_dynamic_mha_token_enabled = true;
         // Set of supported Transpose shape ranks for tokenization in MHATokenization pass.
         // Note that in general Snippets support Transpose of any ranks.
         // But at the moment Transpose is used only in MHA pattern where 3D and 4D tensors are supported.
-        std::set<size_t> mha_supported_transpose_ranks = { 3, 4 };
+        std::set<size_t> m_mha_supported_transpose_ranks = { 3, 4 };
     };
 
     OPENVINO_RTTI("SnippetsTokenization", "0");

--- a/src/common/snippets/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/src/pass/mha_tokenization.cpp
@@ -476,8 +476,8 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             return false;
         }
 
-        // If backend doesn't support dynamic MHA tokenization, return false
-        if (!config.get_dynamic_mha_support()) {
+        // If backend doesn't enable dynamic MHA tokenization, return false
+        if (!config.is_dynamic_mha_token_enabled()) {
             if (std::any_of(ordered_ops.cbegin(), ordered_ops.cend(), [](const std::shared_ptr<ov::Node>& op) { return op->is_dynamic(); }))
                 return false;
         }

--- a/src/common/snippets/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/src/pass/mha_tokenization.cpp
@@ -468,13 +468,23 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
 
         /* ================================ */
 
-        /* ====== Subgraph creation ======= */
+        /* ======= Support checks ========= */
 
         // TODO [75567]: move this plugin-specific constraint to the plugin callback
         const auto last_node = ordered_ops.back();
         if (potential_body_params_count + last_node->get_output_size() + hidden_virtual_ports_count + uniqie_buffer_reg_group_count > 11) {
             return false;
         }
+
+        // If backend doesn't support dynamic MHA tokenization, return false
+        if (!config.get_dynamic_mha_support()) {
+            if (std::any_of(ordered_ops.cbegin(), ordered_ops.cend(), [](const std::shared_ptr<ov::Node>& op) { return op->is_dynamic(); }))
+                return false;
+        }
+
+        /* ================================ */
+
+        /* ====== Subgraph creation ======= */
 
         ov::OutputVector body_inputs, subgraph_inputs;
         ov::ParameterVector body_parameters;

--- a/src/common/snippets/tests/include/utils.hpp
+++ b/src/common/snippets/tests/include/utils.hpp
@@ -11,7 +11,7 @@ namespace test {
 namespace snippets {
 
 static ov::snippets::pass::SnippetsTokenization::Config get_default_tokenization_config() {
-    return { 1, std::numeric_limits<size_t>::max(), true, true, { 3, 4 } };
+    return { 1, std::numeric_limits<size_t>::max(), true, true, true, { 3, 4 } };
 }
 
 }  // namespace snippets

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -47,6 +47,22 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Dynamic) {
     run();
 }
 
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Partially_Dynamic) {
+    const auto &f = MHAFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 1, -1, 1}, {1, 128, 12, 64}},
+                                std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), true, false);
+    model = f.getOriginal();
+    model_ref = f.getReference();
+    run();
+}
+
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Partially_Dynamic_Disabled_Dynamic) {
+    const auto &f = MHAFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 1, -1, 1}, {1, 128, 12, 64}},
+                                std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), true, false);
+    model = f.getOriginal();
+    config = ov::snippets::pass::SnippetsTokenization::Config{1, std::numeric_limits<size_t>::max(), true, true, false, { 3, 4 }};
+    run();
+}
+
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Dynamic_M) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{1, -1, 12, 64}, {1, 128, 12, 64}, {1, 12, -1, 128}, {1, 128, 12, 64}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), true, false);
@@ -145,7 +161,7 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Transpose_fusion) {
     run();
 }
 
-TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Dyanmic_Transpose_fusion) {
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Dynamic_Transpose_fusion) {
     const auto& f = MHATransposedInputFunction(std::vector<PartialShape>{{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}}, false,
                                                std::vector<int64_t>{0, 2, 1, 3});
     model = f.getOriginal();

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -876,11 +876,11 @@ void Transformations::MainSnippets(void) {
     // To avoid uncontrolled behavior in tests, we disabled the optimization when there is Config::SnippetsMode::IgnoreCallback
     bool split_m_dimension = !ignoreCallback;
     // [113198] Add dynamic Subgraph with MHA pattern inside execution support
-    bool is_dynamic_mha_supported = false;
+    bool is_dynamic_mha_token_enabled = false;
     // [122706] Some 3D MHA Patterns have perf regressions when Transpose op is tokenized
     std::set<size_t> mha_supported_transpose_ranks = { 4 };
     snippets::pass::SnippetsTokenization::Config tokenization_config(concurrency, data_ptr_gpr_count, split_m_dimension,
-                                                                     mha_token_enable_transpose_on_output, is_dynamic_mha_supported,
+                                                                     mha_token_enable_transpose_on_output, is_dynamic_mha_token_enabled,
                                                                      mha_supported_transpose_ranks);
 
     ov::pass::Manager snippetsManager;

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -875,10 +875,13 @@ void Transformations::MainSnippets(void) {
     // The optimization "SplitDimensionM" depends on target machine (thread count).
     // To avoid uncontrolled behavior in tests, we disabled the optimization when there is Config::SnippetsMode::IgnoreCallback
     bool split_m_dimension = !ignoreCallback;
+    // [113198] Add dynamic Subgraph with MHA pattern inside execution support
+    bool is_dynamic_mha_supported = false;
     // [122706] Some 3D MHA Patterns have perf regressions when Transpose op is tokenized
     std::set<size_t> mha_supported_transpose_ranks = { 4 };
-    ov::snippets::pass::SnippetsTokenization::Config tokenization_config(concurrency, data_ptr_gpr_count, split_m_dimension,
-                                                     mha_token_enable_transpose_on_output, mha_supported_transpose_ranks);
+    snippets::pass::SnippetsTokenization::Config tokenization_config(concurrency, data_ptr_gpr_count, split_m_dimension,
+                                                                     mha_token_enable_transpose_on_output, is_dynamic_mha_supported,
+                                                                     mha_supported_transpose_ranks);
 
     ov::pass::Manager snippetsManager;
     snippetsManager.set_per_pass_validation(false);

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/arm/snipptes_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/arm/snipptes_mark_skipped.cpp
@@ -16,7 +16,7 @@ class SnippetsMarkSkippedTests : public TransformationTestsF {
 public:
     void run() {
         ASSERT_TRUE(model);
-        ov::snippets::pass::SnippetsTokenization::Config config = { 1, 23, true, true, { 3, 4 } };
+        ov::snippets::pass::SnippetsTokenization::Config config = { 1, 23, true, true, true, { 3, 4 } };
         manager.register_pass<ov::intel_cpu::SnippetsMarkSkipped>();
         manager.register_pass<ov::snippets::pass::EnumerateNodes>();
         manager.register_pass<ov::snippets::pass::TokenizeSnippets>(config);

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/fake_quantize_tokenization_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/fake_quantize_tokenization_test.cpp
@@ -20,7 +20,7 @@ namespace snippets {
 class FakeQuantizeTokenizationTest : public TransformationTestsF {
 public:
     void register_passes() {
-        ov::snippets::pass::SnippetsTokenization::Config config = { 1, std::numeric_limits<size_t>::max(), true, true, { 3, 4 } };
+        ov::snippets::pass::SnippetsTokenization::Config config = { 1, std::numeric_limits<size_t>::max(), true, true, true, { 3, 4 } };
         manager.register_pass<ov::intel_cpu::SnippetsMarkSkipped>();
         manager.register_pass<ov::snippets::pass::EnumerateNodes>();
         manager.register_pass<ov::snippets::pass::TokenizeSnippets>(config);

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/snipptes_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/snipptes_mark_skipped.cpp
@@ -17,7 +17,7 @@ class SnippetsMarkSkippedTests : public TransformationTestsF {
 public:
     void run() {
         ASSERT_TRUE(model);
-        ov::snippets::pass::SnippetsTokenization::Config config = { 1, 11, true, true, { 3, 4 } };
+        ov::snippets::pass::SnippetsTokenization::Config config = { 1, 11, true, true, true, { 3, 4 } };
         manager.register_pass<ov::intel_cpu::SnippetsMarkSkipped>();
         manager.register_pass<ov::snippets::pass::EnumerateNodes>();
         manager.register_pass<ov::snippets::pass::TokenizeSnippets>(config);


### PR DESCRIPTION
### Details:
- *CP Plugin disabled MHA tokenization with only dynamic MatMuls. However, there are some MHA patterns with static MatMuls but with dynamic inputs of intermediate ops. It was not covered by the current implementation - Snippets tokenized these patterns and couldn't execute.*
![image](https://github.com/openvinotoolkit/openvino/assets/43129309/a69d6bf8-d9e5-4cda-b00a-40ae1e0cc39f)
 - *Added the field `is_dynamic_mha_supported` to `SnippetsTokenization::Config` to adjust dynamic MHA tokenization for backends - now we check for dynamic shapes all tokenized operations in MHA pattern*
 - *Added unit test with pattern from the ticket*

### Tickets:
 - *143406*
