### PR TITLE
update build linux readme

### DIFF
--- a/docs/dev/build_linux.md
+++ b/docs/dev/build_linux.md
@@ -39,6 +39,9 @@ The software was validated on:
      mkdir build && cd build
    ```
 
+> **NOTE**: Disable oneAPI environment if has before this building process. 
+Please note that enabling the oneAPI environment during the compilation of OpenVINO from source code on Linux may cause the compilation to fail. It is recommended to disable the oneAPI environment during the build process to ensure successful compilation. Please proceed with caution and ensure to follow the build instructions accurately.  
+
 4. OpenVINO Runtime uses a CMake-based build system. In the created `build` directory, run `cmake` to fetch project dependencies and create Unix makefiles, then run `make` to build the project:
    ```sh
      cmake -DCMAKE_BUILD_TYPE=Release ..

--- a/docs/dev/build_linux.md
+++ b/docs/dev/build_linux.md
@@ -39,8 +39,7 @@ The software was validated on:
      mkdir build && cd build
    ```
 
-> **NOTE**: Disable oneAPI environment if has before this building process. 
-Please note that enabling the oneAPI environment during the compilation of OpenVINO from source code on Linux may cause the compilation to fail. It is recommended to disable the oneAPI environment during the build process to ensure successful compilation. Please proceed with caution and ensure to follow the build instructions accurately.  
+> **NOTE**: It is recommended to disable the oneAPI environment before compiling OpenVINO from source on Linux, as it may cause build failures. 
 
 4. OpenVINO Runtime uses a CMake-based build system. In the created `build` directory, run `cmake` to fetch project dependencies and create Unix makefiles, then run `make` to build the project:
    ```sh


### PR DESCRIPTION
### Details:
 - Identified an issue where enabling the oneAPI environment during the compilation of OpenVINO from source code on Linux causes the compilation to fail.
 - This issue seems to occur due to conflicts between the oneAPI environment and the OpenVINO build process.
 - To address this, I have added a warning in the building document advising users to disable the oneAPI environment during the build process.
 - This change will help users avoid compilation failures and ensure a smoother build process.
 - I have tested the build process with the oneAPI environment disabled and confirmed that the compilation completes successfully.