### PR TITLE
[NPU] Modifying the "HostMemAllocator" class such that it won't hold the last allocated buffer anymore

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -66,6 +66,8 @@ private:
     Logger _logger;
 
     ze_device_properties_t _properties = {};
+    std::shared_ptr<const zeroMemory::HostMemAllocator> _inputAllocator;
+    std::shared_ptr<const zeroMemory::HostMemAllocator> _outputAllocator;
 
     zeroProfiling::ProfilingPool _profilingPool;
     zeroProfiling::ProfilingQuery _profilingQuery;

--- a/src/plugins/intel_npu/src/backend/include/zero_memory.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_memory.hpp
@@ -71,6 +71,7 @@ public:
      * @return Handle to the allocated resource
      */
     void* allocate(const size_t bytes, const size_t alignment = STANDARD_PAGE_SIZE) noexcept;
+
     /**
      * @brief Releases handle and all associated memory resources which invalidates the handle.
      * @param handle Pointer to allocated data
@@ -84,7 +85,6 @@ private:
     const std::shared_ptr<ZeroInitStructsHolder> _initStructs;
 
     ze_host_mem_alloc_flag_t _flag;
-    void* _data = nullptr;
     static const std::size_t _alignment = STANDARD_PAGE_SIZE;
 };
 

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -193,7 +193,12 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
         return std::find(container.begin(), container.end(), value) != container.end();
     };
 
-    auto allocator = zeroMemory::HostMemAllocator(_initStructs);
+    _outputAllocator = std::make_shared<const zeroMemory::HostMemAllocator>(_initStructs);
+    _inputAllocator =
+        (_properties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED)
+            ? std::make_shared<const zeroMemory::HostMemAllocator>(_initStructs,
+                                                                   ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED)
+            : _outputAllocator;
 
     _logger.debug("ZeroInferRequest::ZeroInferRequest - performing I/O buffer allocation using Level Zero API");
     for (const std::string& inputName : _metadata.inputNames) {
@@ -234,14 +239,7 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
                                           executorInputDescriptors.at(shapeBufferName),
                                           shapeBufferName);
 
-            ov::Allocator inputAllocator;
-            if (_properties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) {
-                inputAllocator = zeroMemory::HostMemAllocator(_initStructs, ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED);
-            } else {
-                inputAllocator = zeroMemory::HostMemAllocator(_initStructs);
-            };
-
-            allocate_tensor(inputName, shapeDescriptor, TensorType::Shape, inputAllocator);
+            allocate_tensor(inputName, shapeDescriptor, TensorType::Shape, *_inputAllocator);
             _tensorsData[shapeBufferName] = TensorData{_copyAllTensors.at(shapeBufferName)->data(),
                                                        _copyAllTensors.at(shapeBufferName)->get_byte_size()};
         }
@@ -267,7 +265,7 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
                                               executorOutputDescriptors.at(shapeBufferName),
                                               shapeBufferName);
 
-                allocate_tensor(shapeNameMatch->second, shapeDescriptor, TensorType::Shape, allocator);
+                allocate_tensor(shapeNameMatch->second, shapeDescriptor, TensorType::Shape, *_outputAllocator);
                 _tensorsData[shapeBufferName] = TensorData{_copyAllTensors.at(shapeBufferName)->data(),
                                                            _copyAllTensors.at(shapeBufferName)->get_byte_size()};
             }
@@ -295,7 +293,7 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
 
         // Only one buffer per state variable is required, we'll use the "output" one since this one captures the latest
         // tensor value
-        allocate_tensor(stateName, stateDescriptor, TensorType::State, allocator);
+        allocate_tensor(stateName, stateDescriptor, TensorType::State, *_outputAllocator);
         _tensorsData[stateInputBufferName] = TensorData{_copyAllTensors.at(stateInputBufferName)->data(),
                                                         _copyAllTensors.at(stateInputBufferName)->get_byte_size()};
         _tensorsData[stateOutputBufferName] = TensorData{_copyAllTensors.at(stateOutputBufferName)->data(),
@@ -304,8 +302,6 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
 }
 
 void ZeroInferRequest::create_pipeline() {
-    auto allocator = zeroMemory::HostMemAllocator(_initStructs);
-
     for (const std::string& inputName : _metadata.inputNames) {
         if (_copyAllTensors.find(inputName) != _copyAllTensors.end()) {
             _logger.debug("ZeroInferRequest::create_pipeline - tensor %s was already allocated", inputName.c_str());
@@ -314,15 +310,8 @@ void ZeroInferRequest::create_pipeline() {
 
         IONodeDescriptor& parameterDescriptor = _metadata.parameters.at(inputName);
 
-        ov::Allocator inputAllocator;
-        if (_properties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) {
-            inputAllocator = zeroMemory::HostMemAllocator(_initStructs, ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED);
-        } else {
-            inputAllocator = zeroMemory::HostMemAllocator(_initStructs);
-        };
-
         _logger.debug("ZeroInferRequest::create_pipeline - Allocate new tensor");
-        allocate_tensor(inputName, parameterDescriptor, TensorType::InputOrOutput, inputAllocator);
+        allocate_tensor(inputName, parameterDescriptor, TensorType::InputOrOutput, *_inputAllocator);
         _tensorsData[inputName] =
             TensorData{_copyAllTensors.at(inputName)->data(), _copyAllTensors.at(inputName)->get_byte_size()};
     }
@@ -336,7 +325,7 @@ void ZeroInferRequest::create_pipeline() {
         IONodeDescriptor& resultDescriptor = _metadata.results.at(outputName);
 
         _logger.debug("ZeroInferRequest::create_pipeline - allocate new tensor");
-        allocate_tensor(outputName, resultDescriptor, TensorType::InputOrOutput, allocator);
+        allocate_tensor(outputName, resultDescriptor, TensorType::InputOrOutput, *_outputAllocator);
         _tensorsData[outputName] =
             TensorData{_copyAllTensors.at(outputName)->data(), _copyAllTensors.at(outputName)->get_byte_size()};
     }
@@ -378,21 +367,11 @@ void ZeroInferRequest::set_tensor_data(std::shared_ptr<ov::ITensor> tensor, cons
         // tensor
         if ((_tensorsData.find(name) != _tensorsData.end()) && !_tensorsData.at(name).levelZeroTensorCreatedLocally) {
             _logger.debug("ZeroInferRequest::set_tensor_data - create locally L0 tensor");
-            ov::Allocator allocator;
-            if (isParameter && (_properties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED)) {
-                allocator = zeroMemory::HostMemAllocator(_initStructs, ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED);
-            } else {
-                allocator = zeroMemory::HostMemAllocator(_initStructs);
-            };
 
-            IONodeDescriptor descriptor;
-            if (isParameter) {
-                descriptor = _metadata.parameters.at(name);
-            } else {
-                descriptor = _metadata.results.at(name);
-            }
-
-            allocate_tensor(name, descriptor, TensorType::InputOrOutput, allocator);
+            allocate_tensor(name,
+                            isParameter ? _metadata.parameters.at(name) : _metadata.results.at(name),
+                            TensorType::InputOrOutput,
+                            isParameter ? *_inputAllocator : *_outputAllocator);
 
             setTensorData = true;
             levelZeroTensorCreatedLocally = true;
@@ -450,33 +429,25 @@ void ZeroInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
 }
 
 ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::Node>& port) const {
-    if (_allTensors.find(port.get_node()->get_friendly_name()) != _allTensors.end()) {
+    const std::string& nodeFriendlyName = port.get_node()->get_friendly_name();
+
+    if (_allTensors.find(nodeFriendlyName) != _allTensors.end()) {
         _logger.debug("ZeroInferRequest::get_tensor - tensor allocated, get the tensor");
-        return _allTensors.at(port.get_node()->get_friendly_name());
+        return _allTensors.at(nodeFriendlyName);
     }
 
     _logger.debug("ZeroInferRequest::get_tensor - tensor is not allocated, create the tensor");
-    IONodeDescriptor nodeDescriptor;
-    ov::Allocator allocator;
-    if (ov::op::util::is_parameter(port.get_node())) {
-        nodeDescriptor = _metadata.parameters.at(port.get_node()->get_friendly_name());
 
-        if (_properties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) {
-            allocator = zeroMemory::HostMemAllocator(_initStructs, ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED);
-        } else {
-            allocator = zeroMemory::HostMemAllocator(_initStructs);
-        };
-    } else {
-        nodeDescriptor = _metadata.results.at(port.get_node()->get_friendly_name());
-        allocator = zeroMemory::HostMemAllocator(_initStructs);
-    }
+    const bool isParameter = ov::op::util::is_parameter(port.get_node());
+    allocate_tensor(nodeFriendlyName,
+                    isParameter ? _metadata.parameters.at(nodeFriendlyName) : _metadata.results.at(nodeFriendlyName),
+                    TensorType::InputOrOutput,
+                    isParameter ? *_inputAllocator : *_outputAllocator);
 
-    allocate_tensor(port.get_node()->get_friendly_name(), nodeDescriptor, TensorType::InputOrOutput, allocator);
-    _tensorsData[port.get_node()->get_friendly_name()] =
-        TensorData{_copyAllTensors.at(port.get_node()->get_friendly_name())->data(),
-                   _copyAllTensors.at(port.get_node()->get_friendly_name())->get_byte_size()};
+    _tensorsData[nodeFriendlyName] =
+        TensorData{_copyAllTensors.at(nodeFriendlyName)->data(), _copyAllTensors.at(nodeFriendlyName)->get_byte_size()};
 
-    return _allTensors.at(port.get_node()->get_friendly_name());
+    return _allTensors.at(nodeFriendlyName);
 }
 
 void ZeroInferRequest::infer() {

--- a/src/plugins/intel_npu/src/backend/src/zero_memory.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_memory.cpp
@@ -50,10 +50,11 @@ void* HostMemAllocator::allocate(const size_t bytes, const size_t /*alignment*/)
     ze_host_mem_alloc_desc_t desc = {ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC,
                                      nullptr,
                                      static_cast<ze_host_mem_alloc_flags_t>(_flag)};
-    ze_result_t res = zeMemAllocHost(_initStructs->getContext(), &desc, size, _alignment, &_data);
+    void* data = nullptr;
+    ze_result_t res = zeMemAllocHost(_initStructs->getContext(), &desc, size, _alignment, &data);
 
     if (res == ZE_RESULT_SUCCESS) {
-        return _data;
+        return data;
     } else {
         return nullptr;
     }
@@ -67,7 +68,7 @@ bool HostMemAllocator::deallocate(void* handle, const size_t /* bytes */, size_t
     return true;
 }
 bool HostMemAllocator::is_equal(const HostMemAllocator& other) const {
-    return other._data != nullptr && _data != nullptr && other._data == _data;
+    return (_initStructs == other._initStructs) && (_flag == other._flag);
 }
 
 void MemoryManagementUnit::appendArgument(const std::string& name, const std::size_t argSize) {


### PR DESCRIPTION
### Details:
 - From a design perspective, the allocator is meant to allocate a pool of tensors, not to represent a single allocated tensor. The current PR aims to change the NPU plugin's `HostMemAllocator` as to comply with this rule.
 - No real improvement is brought in terms of functionality/performance, except for reusing some allocators inside the `ZeroInferRequest` ctor.

### Tickets:
 - *EISW-130249*
