### PR TITLE
Single Image Test: Maintaining blob file name order in Single-Image-Test dump reference output

### DIFF
--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -1894,7 +1894,9 @@ static int runSingleImageTest() {
                 LayoutMap outputLayouts;  // Several metrics may require this
 
                 // Load the reference data
-                for (const auto& [tensorName, tensor] : outputTensors) {
+                for (const auto& out : compiledModel.outputs()) {
+                    const auto& tensorName = out.get_any_name();
+                    const auto& tensor = outputTensors.at(tensorName);
                     const ov::element::Type& precision = tensor.get_element_type();
                     const ov::Shape& shape = tensor.get_shape();
 
@@ -1930,7 +1932,8 @@ static int runSingleImageTest() {
                 outputInd = 0;
 
                 // Dump the outputs obtained upon prediction
-                for (const auto& tensorEntry : outputTensors) {
+                for (const auto& out : compiledModel.outputs()) {
+                    const auto& tensor = outputTensors.at(out.get_any_name());
                     std::ostringstream ostr;
                     ostr << netFileName << "_kmb_out_" << outputInd << "_case_" << numberOfTestCase << ".blob";
                     const auto blobFileName = ostr.str();
@@ -1938,7 +1941,7 @@ static int runSingleImageTest() {
                     std::cout << "Dump device output #" << outputInd << "_case_" << numberOfTestCase << " to "
                               << blobFileName << std::endl;
 
-                    dumpTensor(tensorEntry.second, blobFileName);
+                    dumpTensor(tensor, blobFileName);
                     ++outputInd;
                 }
 
@@ -2037,13 +2040,14 @@ static int runSingleImageTest() {
                 }
             } else {
                 size_t outputInd = 0;
-                for (const auto& tensorEntry : outputTensors) {
+                for (const auto& out : compiledModel.outputs()) {
+                    const auto& tensor = outputTensors.at(out.get_any_name());
                     std::ostringstream ostr;
                     ostr << netFileName << "_ref_out_" << outputInd << "_case_" << numberOfTestCase << ".blob";
                     const auto blobFileName = ostr.str();
 
                     std::cout << "Dump reference output #" << outputInd << " to " << blobFileName << std::endl;
-                    dumpTensor(tensorEntry.second, blobFileName);
+                    dumpTensor(tensor, blobFileName);
 
                     ++outputInd;
                 }


### PR DESCRIPTION
Cherrypicked changes from here PR: pull/11621.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
