### PR TITLE
[GPU] fixed to update dispatchData.blockWidth instead of jit constant

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_1x1.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_1x1.cpp
@@ -361,16 +361,16 @@ JitConstants ConvolutionKernel_b_fs_yx_fsv16_1x1::GetJitConstants(const convolut
     auto cldnnJit = GetJitConstants(newParams, dispatchData);
     for (size_t i = 0; i < num_kernels; i++) {
         if (params.is_shape_agnostic) {
-            cldnnJit.RemoveConstant("X_BLOCK_SIZE");
             if (i == 0) {
-                cldnnJit.AddConstant(MakeJitConstant("X_BLOCK_SIZE", "1"));
+                dispatchData.cldnnStyle.blockWidth = 1;
             } else if (i == 1) {
-                cldnnJit.AddConstant(MakeJitConstant("X_BLOCK_SIZE", "2"));
+                dispatchData.cldnnStyle.blockWidth = 2;
             } else if (i == 2) {
-                cldnnJit.AddConstant(MakeJitConstant("X_BLOCK_SIZE", "4"));
+                dispatchData.cldnnStyle.blockWidth = 4;
             } else if (i == 3) {
-                cldnnJit.AddConstant(MakeJitConstant("X_BLOCK_SIZE", "8"));
+                dispatchData.cldnnStyle.blockWidth = 8;
             }
+            cldnnJit = GetJitConstants(newParams, dispatchData);
         }
         auto entryPoint = GetEntryPoint(finalKernelName, newParams.layerID, params, i);
         auto jit = CreateJit(finalKernelName, cldnnJit, entryPoint);


### PR DESCRIPTION
### Details:
 - This PR fixed the `convolution_gpu_bfyx_f16_1x1` kernel to set the vector size of fused ops to updated `blockWidth`.