### PR TITLE
[GPU] Add TensorOffset support key in adaptive pooling ref kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/adaptive_pooling/adaptive_pooling_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/adaptive_pooling/adaptive_pooling_kernel_ref.cpp
@@ -24,6 +24,7 @@ ParamsKey AdaptivePoolingRef::GetSupportedKey() const {
     k.EnableAllOutputLayout();
     k.EnableBatching();
     k.EnableTensorPitches();
+    k.EnableTensorOffset();
 
     return k;
 }


### PR DESCRIPTION
### Details:
 - Add TensorOffset support key in adaptive pooling ref kernel as the kernel is using INPUT0_GET_INDEX() macro

### Tickets:
 - 144826
