### PR TITLE
[OV JS] Add readModel(model:str, weights: Tensor) sync&async

### DIFF
--- a/src/bindings/js/node/include/helper.hpp
+++ b/src/bindings/js/node/include/helper.hpp
@@ -105,6 +105,12 @@ Napi::Array cpp_to_js<ov::PartialShape, Napi::Array>(const Napi::CallbackInfo& i
 template <>
 Napi::Array cpp_to_js<ov::Dimension, Napi::Array>(const Napi::CallbackInfo& info, const ov::Dimension dim);
 
+/**
+ * @brief Creates JavaScript Model and wraps ov::Model inside of it.
+ * @return Javascript Model as Napi::Object. (Not ModelWrap object)
+ */
+Napi::Object cpp_to_js(const Napi::Env& env, std::shared_ptr<ov::Model> model);
+
 template <>
 Napi::Boolean cpp_to_js<bool, Napi::Boolean>(const Napi::CallbackInfo& info, const bool value);
 

--- a/src/bindings/js/node/include/model_wrap.hpp
+++ b/src/bindings/js/node/include/model_wrap.hpp
@@ -23,13 +23,6 @@ public:
     static Napi::Function get_class(Napi::Env env);
 
     void set_model(const std::shared_ptr<ov::Model>& model);
-    /**
-     * @brief Creates JavaScript Model object and wraps inside of it ov::Model object.
-     * @param env The environment in which to construct a JavaScript object.
-     * @param model a pointer to ov::Model to wrap.
-     * @return Javascript Model as Napi::Object. (Not ModelWrap object)
-     */
-    static Napi::Object wrap(Napi::Env env, std::shared_ptr<ov::Model> model);
 
     /** @return Napi::String containing a model name. */
     Napi::Value get_name(const Napi::CallbackInfo& info);
@@ -91,7 +84,7 @@ public:
      * @return number indicating the quantity of outputs for the model
      */
     Napi::Value get_output_size(const Napi::CallbackInfo& info);
-    
+
     /**
      * @brief Sets a friendly name for a model.
      * @param info Contains information about the environment and passed arguments

--- a/src/bindings/js/node/lib/addon.ts
+++ b/src/bindings/js/node/lib/addon.ts
@@ -151,7 +151,14 @@ interface Core {
    * For the TFLite format (*.tflite), the weights parameter is not used.
    */
   readModel(modelPath: string, weightsPath?: string): Promise<Model>;
-
+  /**
+   * It reads models from IR / ONNX / PDPD / TF and TFLite formats.
+   * @param model A string with model in IR / ONNX / PDPD / TF
+   * and TFLite format.
+   * @param weights Tensor with weights. Reading ONNX / PDPD / TF
+   * and TFLite models doesn’t support loading weights from weights tensors.
+   */
+  readModel(model: string, weights: Tensor): Promise<Model>;
   /**
    * It reads models from the IR / ONNX / PDPD / TF and TFLite formats.
    * @param modelBuffer Binary data with a model
@@ -165,6 +172,11 @@ interface Core {
    * It reads models from the IR / ONNX / PDPD / TF and TFLite formats.
    */
   readModelSync(modelPath: string, weightsPath?: string): Model;
+  /**
+   * A synchronous version of {@link Core.readModel}.
+   * It reads models from the IR / ONNX / PDPD / TF and TFLite formats.
+   */
+  readModelSync(model: string, weights: Tensor): Model;
   /**
    * A synchronous version of {@link Core.readModel}.
    * It reads models from the IR / ONNX / PDPD / TF and TFLite formats.

--- a/src/bindings/js/node/src/async_reader.cpp
+++ b/src/bindings/js/node/src/async_reader.cpp
@@ -13,14 +13,11 @@ void ReaderWorker::Execute() {
 }
 
 void ReaderWorker::OnOK() {
-    Napi::HandleScope scope(Env());
-    Napi::Object mw = ModelWrap::get_class(Env()).New({});
-    ModelWrap* m = Napi::ObjectWrap<ModelWrap>::Unwrap(mw);
-    m->set_model(_model);
+    auto model = cpp_to_js(Env(), _model);
 
     delete _args;
 
-    _deferred.Resolve(mw);
+    _deferred.Resolve(model);
 }
 
 void ReaderWorker::OnError(Napi::Error const& error) {

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -91,7 +91,7 @@ Napi::Value CoreWrap::read_model_sync(const Napi::CallbackInfo& info) {
             OPENVINO_THROW("'readModelSync'", ov::js::get_parameters_error_msg(info, allowed_signatures));
         }
 
-        return ModelWrap::wrap(info.Env(), model);
+        return cpp_to_js(info.Env(), model);
     } catch (std::runtime_error& err) {
         reportError(info.Env(), err.what());
 

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -85,6 +85,8 @@ Napi::Value CoreWrap::read_model_sync(const Napi::CallbackInfo& info) {
             model = _core.read_model(model_str, weight_tensor);
         } else if (ov::js::validate<Napi::String>(info, allowed_signatures)) {
             model = _core.read_model(info[0].ToString());
+        } else if (ov::js::validate<Napi::String, TensorWrap>(info, allowed_signatures)) {
+            model = _core.read_model(info[0].ToString(), cast_to_tensor(info, 1));
         } else {
             OPENVINO_THROW("'readModelSync'", ov::js::get_parameters_error_msg(info, allowed_signatures));
         }

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -251,6 +251,17 @@ Napi::Array cpp_to_js<ov::Dimension, Napi::Array>(const Napi::CallbackInfo& info
     return interval;
 }
 
+Napi::Object cpp_to_js(const Napi::Env& env, std::shared_ptr<ov::Model> model) {
+    const auto& prototype = env.GetInstanceData<AddonData>()->model;
+    if (!prototype) {
+        OPENVINO_THROW("Invalid pointer to Model prototype.");
+    }
+    const auto& model_js = prototype.New({});
+    const auto mw = Napi::ObjectWrap<ModelWrap>::Unwrap(model_js);
+    mw->set_model(model);
+    return model_js;
+}
+
 template <>
 Napi::Boolean cpp_to_js<bool, Napi::Boolean>(const Napi::CallbackInfo& info, const bool value) {
     return Napi::Boolean::New(info.Env(), value);

--- a/src/bindings/js/node/src/model_wrap.cpp
+++ b/src/bindings/js/node/src/model_wrap.cpp
@@ -33,18 +33,6 @@ void ModelWrap::set_model(const std::shared_ptr<ov::Model>& model) {
     _model = model;
 }
 
-Napi::Object ModelWrap::wrap(Napi::Env env, std::shared_ptr<ov::Model> model) {
-    Napi::HandleScope scope(env);
-    const auto& prototype = env.GetInstanceData<AddonData>()->model;
-    if (!prototype) {
-        OPENVINO_THROW("Invalid pointer to model prototype.");
-    }
-    const auto& model_js = prototype.New({});
-    const auto mw = Napi::ObjectWrap<ModelWrap>::Unwrap(model_js);
-    mw->set_model(model);
-    return model_js;
-}
-
 Napi::Value ModelWrap::get_name(const Napi::CallbackInfo& info) {
     if (_model->get_name() != "")
         return Napi::String::New(info.Env(), _model->get_name());

--- a/src/bindings/js/node/tests/read_model.test.js
+++ b/src/bindings/js/node/tests/read_model.test.js
@@ -34,7 +34,18 @@ describe('Core.readModeSync', () => {
     )
   });
 
-  it('readModeSync(modelUint8ArrayBuffer, weightsUint8ArrayBuffer) ', () => {
+  it('readModelSync(model string, weightsTensor) ', () => {
+    const model_str = fs.readFileSync(modelPath, 'utf8');
+    const weights = new ov.Tensor(ov.element.u8, [weightsFile.buffer.byteLength], new Uint8Array(weightsFile.buffer));
+    const model = core.readModelSync(
+      model_str,
+      weights,
+    );
+    assert.ok(model instanceof ov.Model);
+    assert.equal(model.inputs.length, 1);
+  });
+
+  it('readModelSync(modelUint8ArrayBuffer, weightsUint8ArrayBuffer) ', () => {
     const model = core.readModelSync(
       new Uint8Array(modelFile.buffer),
       new Uint8Array(weightsFile.buffer),
@@ -55,7 +66,7 @@ describe('Core.readModel', () => {
     assert.equal(model.inputs.length, 1);
   });
 
-  it('readMode(modelUint8ArrayBuffer, weightsUint8ArrayBuffer) ', async () => {
+  it('readModel(modelUint8ArrayBuffer, weightsUint8ArrayBuffer) ', async () => {
     const model = await core.readModel(
       new Uint8Array(modelFile.buffer),
       new Uint8Array(weightsFile.buffer),

--- a/src/bindings/js/node/tests/read_model.test.js
+++ b/src/bindings/js/node/tests/read_model.test.js
@@ -10,7 +10,9 @@ const { getModelPath } = require('./utils.js');
 
 const { xml: modelPath, bin: weightsPath } = getModelPath();
 const modelFile = fs.readFileSync(modelPath);
+const modelStr = fs.readFileSync(modelPath, 'utf8');
 const weightsFile = fs.readFileSync(weightsPath);
+const weightsTensor = new ov.Tensor(ov.element.u8, [weightsFile.buffer.byteLength], new Uint8Array(weightsFile.buffer));
 
 const core = new ov.Core();
 
@@ -35,11 +37,9 @@ describe('Core.readModeSync', () => {
   });
 
   it('readModelSync(model string, weightsTensor) ', () => {
-    const model_str = fs.readFileSync(modelPath, 'utf8');
-    const weights = new ov.Tensor(ov.element.u8, [weightsFile.buffer.byteLength], new Uint8Array(weightsFile.buffer));
     const model = core.readModelSync(
-      model_str,
-      weights,
+      modelStr,
+      weightsTensor,
     );
     assert.ok(model instanceof ov.Model);
     assert.equal(model.inputs.length, 1);
@@ -63,6 +63,15 @@ describe('Core.readModel', () => {
 
   it('readModel(xmlPath, weightsPath) ', async () => {
     const model = await core.readModel(modelPath, weightsPath);
+    assert.equal(model.inputs.length, 1);
+  });
+
+  it('readModel(model string, weightsTensor) ', async () => {
+    const model = await core.readModel(
+      modelStr,
+      weightsTensor,
+    );
+    // assert.ok(model instanceof ov.Model);
     assert.equal(model.inputs.length, 1);
   });
 

--- a/src/bindings/js/node/tests/read_model.test.js
+++ b/src/bindings/js/node/tests/read_model.test.js
@@ -36,7 +36,7 @@ describe('Core.readModeSync', () => {
     )
   });
 
-  it('readModelSync(model string, weightsTensor) ', () => {
+  it('readModelSync(modelString, weightsTensor) ', () => {
     const model = core.readModelSync(
       modelStr,
       weightsTensor,
@@ -66,7 +66,7 @@ describe('Core.readModel', () => {
     assert.equal(model.inputs.length, 1);
   });
 
-  it('readModel(model string, weightsTensor) ', async () => {
+  it('readModel(modelString, weightsTensor) ', async () => {
     const model = await core.readModel(
       modelStr,
       weightsTensor,

--- a/src/bindings/js/node/tests/read_model.test.js
+++ b/src/bindings/js/node/tests/read_model.test.js
@@ -71,7 +71,7 @@ describe('Core.readModel', () => {
       modelStr,
       weightsTensor,
     );
-    // assert.ok(model instanceof ov.Model);
+    assert.ok(model instanceof ov.Model);
     assert.equal(model.inputs.length, 1);
   });
 


### PR DESCRIPTION
### Details:
 - Add `readModel(model: string, weights: Tensor): Promise<Model>` and `readModelSync(model: string, weights: Tensor): Model`
 - Improve error reporting and parameter validation for readModel
 - Fix wrapping up Model in readModel(); on js side instanceof always operator gave false 
 - Change static ModelWrap::wrap method to function similar to other functions for conversion

### Tickets:
 - *CVS-134817*