### PR TITLE
[GPU] Reduce the number of set_arguments() and update_impl() calls

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -397,7 +397,7 @@ protected:
     void fill_shape_info_data(const layout& runtime_layout, const layout& node_layout, int32_t* shape_info_ptr, size_t& offset);
     bool use_async_compilation();
     // if primitive_inst doesn't replace impl to new impl(static impl with opt kerenl or dynamic impl), return false
-    bool update_impl();
+    bool update_impl(bool use_async_compilation);
     event::ptr realloc_if_needed();
 
     cldnn::network::ptr get_unfused_subgraph();

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -1470,7 +1470,7 @@ void network::allocate_primitive_instance(program_node const& node) {
                 return true;
             }
             if (dep_node->can_be_optimized()) {
-                if (is_mutable_input(*dep_node) || dep_node->is_dynamic()) {
+                if (is_mutable_input(*dep_node)) {
                     return true;
                 }
             }


### PR DESCRIPTION
### Details:
 - Previously, any node that had an `optimized_out` node in its dependencies, which in turn had an input `dynamic` node in their dependencies (something like: `dynamic_node -> optimized_out_node -> current_node`), could be marked as mutable due to the `is_mutable_input()` check in the `network::allocate_primitive_instance()` call. This forced `set_arguments()` call at every iteration (because of `has_mutable_input()`), despite the fact that the actual buffers remained the same. This change narrows the `is_mutable_input()` check to only actual mutable nodes, moving the optimized_out node dynamic dependencies check to runtime, thus allowing us to avoid unnecessary `set_arguments()` calls

 - Additionally, this change allows us to determine a little earlier whether `update_impl()` is really needed, reducing some code execution inside the `update_impl()` function in cases where `use_async_compilation()` returns false for the current primitive

### Tickets:

- [CVS-146255](https://jira.devtools.intel.com/browse/CVS-146255)