### PR TITLE
[CPU] Create dnnl stream once per graph

### DIFF
--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -253,6 +253,7 @@ private:
     std::vector<size_t> m_executableSyncNodesInds;
 
     GraphContext::CPtr context;
+    dnnl::stream m_stream;
 
     void EnforceInferencePrecision();
     void EnforceBF16();


### PR DESCRIPTION
to reduce infer overhead.

Even dnnl stream is very lightweight object, it is not actually
allocated on stack but performs dynamic memory allocation in constructor

### Tickets:
 - *ticket-id*