### PR TITLE
[CPU] Enforce inference precision for all nodes of inner graphs

### DIFF
--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -237,6 +237,10 @@ protected:
     friend std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph &graph);
 
 private:
+    void EnforceInferencePrecision();
+    void EnforceBF16();
+    void insertReorder(EdgePtr& edge, bool isOptimized, std::unordered_set<std::string>& uniqueLayerNames);
+
     // TODO: change std::map to std::unordered_map
     std::map<std::size_t, NodePtr> inputNodesMap;
     std::map<std::size_t, NodePtr> outputNodesMap;
@@ -250,10 +254,6 @@ private:
     std::vector<size_t> m_executableSyncNodesInds;
 
     GraphContext::CPtr context;
-
-    void EnforceInferencePrecision();
-    void EnforceBF16();
-    void insertReorder(EdgePtr& edge, bool isOptimized, std::unordered_set<std::string>& uniqueLayerNames);
 };
 
 using GraphPtr = std::shared_ptr<Graph>;


### PR DESCRIPTION
### Details:
 - Introduce local graph context with a nesting 'level'
 - Enforce inference precision for all nodes of a graph with nesting level more than 0

The previous GraphContext is now called GraphGlobalContext
The new GraphContext consists of GraphGlobalContext and GraphLocalContext (which currently has only a 'level' member variable)

The preferable solution would be to always pass GraphContext by value to avoid an additional level of indirection, considering the fact that it already stores GraphGlobalContext as shared ptr. The downsides are:
 - all the nodes will be "touched" by the PR
 - Currently plugin does not really use value semantics like this. Usually, shared ptrs are passed explicitly.

### Tickets:
 - *ticket-id*