### PR TITLE
[TF] Layer tests has a GPU mismatch

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_ApproximateEqual.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ApproximateEqual.py
@@ -40,7 +40,7 @@ class TestApproximateEqual(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_approximate_equal_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                      use_legacy_frontend):
-        if ie_device == 'GPU':
+        if ie_device == 'GPU' and precision == 'FP16':
             pytest.skip("Accuracy mismatch on GPU")
         self._test(*self.create_approximate_equal_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,

--- a/tests/layer_tests/tensorflow_tests/test_tf_ApproximateEqual.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ApproximateEqual.py
@@ -40,6 +40,8 @@ class TestApproximateEqual(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_approximate_equal_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                      use_legacy_frontend):
+        if ie_device == 'GPU':
+            pytest.skip("Accuracy mismatch on GPU")
         self._test(*self.create_approximate_equal_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
@@ -114,5 +114,7 @@ class TestBinaryOps(CommonTFLayerTest):
             pytest.skip("GPU does not support Bitwise ops. For Mod and Pow it has inference mismatch")
         if op_type in ['Mod', 'FloorDiv', 'FloorMod']:
             pytest.skip("Inference mismatch for Mod and FloorDiv")
+        if ie_device == 'GPU' and op_type in ['Equal', 'NotEqual', 'Greater', 'GreaterEqual', 'Less', 'LessEqual']:
+            pytest.skip("Accuracy mismatch on GPU")            
         self._test(*self.create_add_placeholder_const_net(x_shape=x_shape, y_shape=y_shape, op_type=op_type), ie_device,
                    precision, ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
@@ -114,7 +114,7 @@ class TestBinaryOps(CommonTFLayerTest):
             pytest.skip("GPU does not support Bitwise ops. For Mod and Pow it has inference mismatch")
         if op_type in ['Mod', 'FloorDiv', 'FloorMod']:
             pytest.skip("Inference mismatch for Mod and FloorDiv")
-        if ie_device == 'GPU' and op_type in ['Equal', 'NotEqual', 'Greater', 'GreaterEqual', 'Less', 'LessEqual']:
+        if ie_device == 'GPU' and precision == 'FP16' and op_type in ['Equal', 'NotEqual', 'Greater', 'GreaterEqual', 'Less', 'LessEqual']:
             pytest.skip("Accuracy mismatch on GPU")            
         self._test(*self.create_add_placeholder_const_net(x_shape=x_shape, y_shape=y_shape, op_type=op_type), ie_device,
                    precision, ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)


### PR DESCRIPTION
### Details:
 - Skipping test on GPU with FP16 precision due to sporadic misalignment in a results between original framework and OV

### Tickets:
 - 137495
