### PR TITLE
[CPU] Avoid Reorder->Reshape->Transpose fusion in case of non optimized Reorder

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -2471,6 +2471,15 @@ void GraphOptimizer::FusePerformedAsScaleShiftAndFakeQuantize(Graph &graph) {
     }
 }
 
+bool GraphOptimizer::canBeInplaced(const NodePtr& parentNode, const NodePtr& childNode) {
+    const auto parentInPlace = parentNode->getParentEdgeAt(0)->inPlace(Edge::LOOK_UP);
+    const auto& childEdges = childNode->getChildEdgesAtPort(0);
+    const auto childInPlace = std::any_of(childEdges.begin(), childEdges.end(), [](const EdgePtr& edge) {
+        return edge->inPlace(Edge::LOOK_DOWN);
+    });
+    return !(parentInPlace && childInPlace);
+}
+
 bool GraphOptimizer::checkAscendingFinalOrder(const VectorDims& transposeOrder,
                                               const VectorDims& layoutOrder,
                                               const VectorDims& reorderInOrder,
@@ -2534,21 +2543,14 @@ void GraphOptimizer::mergeTransposeReshapeReorder(Graph& graph,
     if (reshapeNode)
         graph.RemoveEdge(reshapeNode->getParentEdgeAt(1));
 
-    // to prevent inPlace conflict we must check that the memory reference is unidirectional or
-    // inPlace memory is not used
-    const auto parentInPlace = parentNode->getParentEdgeAt(0)->inPlace(Edge::LOOK_UP);
-    const auto& childEdges = childNode->getChildEdgesAtPort(0);
-
-    const auto childInPlace = std::any_of(childEdges.begin(), childEdges.end(), [](const EdgePtr& edge) {
-        return edge->inPlace(Edge::LOOK_DOWN);
-    });
-
+    // To prevent inPlace conflict, we must check that the memory reference is unidirectional
+    // or inPlace memory is not used
     // Note: this value must be computed before detaching nodes
-    bool isOptimized = !(parentInPlace && childInPlace);
+    bool isOptimized = canBeInplaced(parentNode, childNode);
 
     // hold references to all children before dropping reorder_node
     std::vector<std::pair<NodePtr, int>> reorderChildren;
-    for (auto ccEdge : childEdges)
+    for (auto ccEdge : childNode->getChildEdgesAtPort(0))
         reorderChildren.emplace_back(ccEdge->getChild(), ccEdge->getOutputNum());
 
     // detach nodes from graph by remove all of their edges
@@ -2900,17 +2902,10 @@ void GraphOptimizer::MergeReorderAndTranspose(Graph &graph) {
         auto& outOrder = outBlockedDesc->getOrder();
 
         if (checkAscendingFinalOrder(transposeOrder, layoutOrder, inOrder, outOrder)) {
-            const auto parentInPlace = parentNode->getParentEdgeAt(0)->inPlace(Edge::LOOK_UP);
-            const auto& childEdges = childNode->getChildEdgesAtPort(0);
-            const auto childInPlace = std::any_of(childEdges.begin(), childEdges.end(), [](const EdgePtr& edge) {
-                return edge->inPlace(Edge::LOOK_DOWN);
-            });
-            bool isOptimizedReorder = !(parentInPlace && childInPlace);
-            // In case of non optimized reorder OneDNN primitive is used,
-            // which doesn't support reordering in case of different ranks on input and output.
-            // So the fusion is skipped for such case.
-            if (!isOptimizedReorder &&
-                parentNode->getInputShapeAtPort(0).getRank() != childNode->getOutputShapeAtPort(0).getRank()) {
+            // Reorder node doesn't support (with rare exceptions) reordering in case of different ranks on input and output.
+            // So the merge can be performed only in the case when the fused reorder will be optimized.
+            if (parentNode->getInputShapeAtPort(0).getRank() != childNode->getOutputShapeAtPort(0).getRank() &&
+                !canBeInplaced(parentNode, childNode)) {
                 continue;
             }
             mergeTransposeReshapeReorder(graph, transposeNode, reshapeNode, reorderNode, true);

--- a/src/plugins/intel_cpu/src/graph_optimizer.h
+++ b/src/plugins/intel_cpu/src/graph_optimizer.h
@@ -53,6 +53,7 @@ private:
     void RemoveConvertMemoryOutput(Graph &graph);
     void MatchSdpaKvCache(Graph &graph);
 
+    bool canBeInplaced(const NodePtr& parentNode, const NodePtr& childNode);
     // Method checks that after the sequential execution of Transpose and Reorder nodes,
     // the order of the elements in the memory (physical layout) will not change.
     bool checkAscendingFinalOrder(const VectorDims& transposeOrder,

--- a/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
@@ -5,17 +5,17 @@
 
 #include <common_test_utils/test_common.hpp>
 
+#include "common_test_utils/node_builders/constant.hpp"
 #include "dummy_node.hpp"
 #include "graph.h"
 #include "nodes/input.h"
 #include "nodes/reorder.h"
+#include "nodes/reshape.h"
 #include "nodes/transpose.h"
-
-#include "openvino/op/transpose.hpp"
-#include "openvino/op/result.hpp"
 #include "openvino/op/parameter.hpp"
-
-#include "common_test_utils/node_builders/constant.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/transpose.hpp"
 
 using namespace ov::intel_cpu;
 using LOOK = Edge::LOOK;
@@ -37,6 +37,27 @@ struct MergeTransposeReorderTestParam {
 
 using MergeTransposeReorderTestParams = std::tuple<ov::Shape, MergeTransposeReorderTestParam>;
 
+/* graph topology
+    ┌───────┐
+    │ Input │
+    └───┬───┘
+        │
+    ┌───┴───┐
+    │ Dummy │      <*NOTE: fake node with firstNodeLayout, and firstNodeInplaceDirection*>
+    └───┬───┘
+        │
+   ┌────┴────┐
+   │Transpose│     <*NOTE: Reorder is inserted before/after Transpose depending on first/second node layouts.*>
+   └────┬────┘
+        │
+    ┌───┴───┐
+    │ Dummy │      <*NOTE: fake node with lastNodeLayout, and lastNodeInplaceDirection*>
+    └───┬───┘
+        │
+   ┌────┴───┐
+   │ Output │
+   └────────┘
+*/
 class MergeTransposeReorderCPUTest : public testing::WithParamInterface<MergeTransposeReorderTestParams>,
                                      public ov::test::TestsCommon {
 public:
@@ -50,49 +71,27 @@ protected:
     void SetUp() override {
         const auto& shape = std::get<0>(GetParam());
         const auto& params = std::get<1>(GetParam());
-        CreateGraph(shape,
-                    params.firstNodeLayout,
-                    params.firstNodeInplaceDirection,
-                    params.lastNodeLayout,
-                    params.lastNodeInplaceDirection,
-                    params.num_consumers);
+        OPENVINO_ASSERT(shape.size() == 4 || shape.size() == 3,
+                        "MergeTransposeReorderCPUTest doesn't support shape", shape,
+                        ". Only 4D and 3D shapes are supported");
+        m_context = std::make_shared<GraphContext>(Config(), nullptr, false);
+        const auto replication_result = CreateModelAndReplicate(shape,
+                                                                params.firstNodeLayout,
+                                                                params.firstNodeInplaceDirection,
+                                                                params.lastNodeLayout,
+                                                                params.lastNodeInplaceDirection,
+                                                                params.num_consumers);
+        m_graph = std::unique_ptr<Graph>(new Graph());
+        m_graph->CreateGraph(replication_result.first, replication_result.second, m_context, "fused_graph");
     }
 
-    /* graph topology
-        ┌───────┐
-        │ Input │
-        └───┬───┘
-            │
-        ┌───┴───┐
-        │ Dummy │      <*NOTE: fake node with firstNodeLayout, and firstNodeInplaceDirection*>
-        └───┬───┘
-            │
-       ┌────┴────┐
-       │Transpose│     <*NOTE: Reorder is inserted before/after Transpose depending on first/second node layouts.*>
-       └────┬────┘
-            │
-        ┌───┴───┐
-        │ Dummy │      <*NOTE: fake node with lastNodeLayout, and lastNodeInplaceDirection*>
-        └───┬───┘
-            │
-       ┌────┴───┐
-       │ Output │
-       └────────┘
-    */
-    void CreateGraph(const ov::Shape& testShape,
-                     LayoutType firstNodeLayout,
-                     LOOK firstNodeInplaceDirection,
-                     LayoutType lastNodeLayout,
-                     LOOK lastNodeInplaceDirection,
-                     size_t num_consumers) {
-        Config conf;
-        conf.rtCacheCapacity = 100;
-        auto context = std::make_shared<GraphContext>(conf, nullptr, false);
-        const dnnl::engine cpuEngine = context->getEngine();
-        m_graph = std::unique_ptr<Graph>(new Graph());
-
+    virtual std::pair<std::vector<NodePtr>, std::vector<EdgePtr>> CreateModelAndReplicate(const ov::Shape& testShape,
+                                                                                          LayoutType firstNodeLayout,
+                                                                                          LOOK firstNodeInplaceDirection,
+                                                                                          LayoutType lastNodeLayout,
+                                                                                          LOOK lastNodeInplaceDirection,
+                                                                                          size_t num_consumers) {
         const auto precision = ov::element::f32;
-        OPENVINO_ASSERT(testShape.size() == 4 || testShape.size() == 3, "Only 4D and 3D shapes are supported");
         // ov::Model with only a transpose node
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(precision, testShape)};
         auto order = testShape.size() == 4 ? std::vector<int32_t>{0, 3, 1, 2} : std::vector<int32_t>{0, 2, 1};
@@ -103,52 +102,46 @@ protected:
             results.push_back(std::make_shared<ov::op::v0::Result>(transpose));
 
         // Replicate
-        auto replicate = [&](std::vector<NodePtr> &nodes, std::vector<EdgePtr> &edges) -> void {
-            std::unordered_set<NodePtr> nodesSet;
+        std::vector<NodePtr> nodes;
+        std::vector<EdgePtr> edges;
+        std::unordered_set<NodePtr> nodesSet;
 
-            auto addEdge = [&](const NodePtr& parent, const NodePtr& child, size_t parentPort, size_t childPort) -> void {
-                auto edge = std::make_shared<Edge>(parent, child, parentPort, childPort);
-                Node::addEdge(edge);
-                edges.push_back(edge);
-                nodesSet.insert(parent);
-                nodesSet.insert(child);
-            };
-
-            auto inputNode = std::make_shared<node::Input>(params[0], context);
-
-            auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(
-                testShape, precision, "reshape", "DummyNode", context, firstNodeLayout, firstNodeInplaceDirection);
-
-            auto orderNode = std::make_shared<node::Input>(constOrder, context);
-            auto transposeNode = std::make_shared<node::Transpose>(transpose, context);
-            transposeNode->filterSupportedPrimitiveDescriptors();
-
-            addEdge(inputNode, dummyNode1, 0, 0);
-            addEdge(dummyNode1, transposeNode, 0, 0);
-            addEdge(orderNode, transposeNode, 0, 1);
-
-            const auto& transpose_shape = transpose->get_output_shape(0);
-            for (size_t i = 0; i < num_consumers; i++) {
-                auto dummyConsumer = std::make_shared<cpu_unit_test::DummyNode>(transpose_shape,
-                                                                                precision,
-                                                                                "multiply",
-                                                                                "DummyNode",
-                                                                                context,
-                                                                                lastNodeLayout,
-                                                                                lastNodeInplaceDirection);
-                auto outputNode = std::make_shared<node::Input>(results[i], context);
-                addEdge(transposeNode, dummyConsumer, 0, 0);
-                addEdge(dummyConsumer, outputNode, 0, 0);
-            }
-
-            for (auto &node : nodesSet) nodes.emplace_back(node);
+        auto addEdge = [&](const NodePtr& parent, const NodePtr& child, size_t parentPort, size_t childPort) -> void {
+            auto edge = std::make_shared<Edge>(parent, child, parentPort, childPort);
+            Node::addEdge(edge);
+            edges.push_back(edge);
+            nodesSet.insert(parent);
+            nodesSet.insert(child);
         };
 
-        std::vector<NodePtr> graphNodes;
-        std::vector<EdgePtr> graphEdges;
-        replicate(graphNodes, graphEdges);
+        auto inputNode = std::make_shared<node::Input>(params[0], m_context);
 
-        m_graph->CreateGraph(graphNodes, graphEdges, context, "fused_graph");
+        auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(
+            testShape, precision, "reshape", "DummyNode", m_context, firstNodeLayout, firstNodeInplaceDirection);
+
+        auto orderNode = std::make_shared<node::Input>(constOrder, m_context);
+        auto transposeNode = std::make_shared<node::Transpose>(transpose, m_context);
+        transposeNode->filterSupportedPrimitiveDescriptors();
+
+        addEdge(inputNode, dummyNode1, 0, 0);
+        addEdge(dummyNode1, transposeNode, 0, 0);
+        addEdge(orderNode, transposeNode, 0, 1);
+
+        const auto& transpose_shape = transpose->get_output_shape(0);
+        for (size_t i = 0; i < num_consumers; i++) {
+            auto dummyConsumer = std::make_shared<cpu_unit_test::DummyNode>(transpose_shape,
+                                                                            precision,
+                                                                            "multiply",
+                                                                            "DummyNode",
+                                                                            m_context,
+                                                                            lastNodeLayout,
+                                                                            lastNodeInplaceDirection);
+            auto outputNode = std::make_shared<node::Input>(results[i], m_context);
+            addEdge(transposeNode, dummyConsumer, 0, 0);
+            addEdge(dummyConsumer, outputNode, 0, 0);
+        }
+        for (auto &node : nodesSet) nodes.emplace_back(node);
+        return {nodes, edges};
     }
 
     void CheckTransposeCount(size_t ref_transpose_count) const {
@@ -176,14 +169,85 @@ protected:
         ASSERT_EQ(ref_not_optimized_reorder_count, not_optimized_count);
     }
 
-private:
+    std::shared_ptr<GraphContext> m_context;
     std::unique_ptr<Graph> m_graph;
 };  // class MergeTransposeReorderCPUTest
+
+class MergeTransposeReorderWithReshapeCPUTest : public MergeTransposeReorderCPUTest {
+    std::pair<std::vector<NodePtr>, std::vector<EdgePtr>> CreateModelAndReplicate(const ov::Shape& testShape,
+                                                                                  LayoutType firstNodeLayout,
+                                                                                  LOOK firstNodeInplaceDirection,
+                                                                                  LayoutType lastNodeLayout,
+                                                                                  LOOK lastNodeInplaceDirection,
+                                                                                  size_t num_consumers) override {
+        const auto precision = ov::element::f32;
+        const auto param = std::make_shared<ov::op::v0::Parameter>(precision, testShape);
+        auto reshape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int>{0, 0, -1});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(param, reshape_const, true);
+        auto order = std::vector<int32_t>{0, 2, 1};
+        auto transpose_order = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{order.size()}, order);
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(reshape, transpose_order);
+        ov::ResultVector results;
+        for (size_t i = 0; i < num_consumers; i++)
+            results.push_back(std::make_shared<ov::op::v0::Result>(transpose));
+
+        // Replicate
+        std::vector<NodePtr> nodes;
+        std::vector<EdgePtr> edges;
+        std::unordered_set<NodePtr> nodesSet;
+
+        auto addEdge = [&](const NodePtr& parent, const NodePtr& child, size_t parentPort, size_t childPort) -> void {
+            auto edge = std::make_shared<Edge>(parent, child, parentPort, childPort);
+            Node::addEdge(edge);
+            edges.push_back(edge);
+            nodesSet.insert(parent);
+            nodesSet.insert(child);
+        };
+
+        auto inputNode = std::make_shared<node::Input>(param, m_context);
+        auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(
+            testShape, precision, "before_reshape", "DummyNode", m_context, LayoutType::nspc, LOOK::LOOK_UP);
+
+        auto reshapeConstNode = std::make_shared<node::Input>(reshape_const, m_context);
+        auto reshapeNode = std::make_shared<node::Reshape>(reshape, m_context);
+
+        auto orderNode = std::make_shared<node::Input>(transpose_order, m_context);
+        auto transposeNode = std::make_shared<node::Transpose>(transpose, m_context);
+        transposeNode->filterSupportedPrimitiveDescriptors();
+
+        addEdge(inputNode, dummyNode1, 0, 0);
+        addEdge(dummyNode1, reshapeNode, 0, 0);
+        addEdge(reshapeNode, transposeNode, 0, 0);
+        addEdge(reshapeConstNode, reshapeNode, 0, 1);
+        addEdge(orderNode, transposeNode, 0, 1);
+
+        const auto& transpose_shape = transpose->get_output_shape(0);
+        for (size_t i = 0; i < num_consumers; i++) {
+            auto dummyConsumer = std::make_shared<cpu_unit_test::DummyNode>(transpose_shape,
+                                                                            precision,
+                                                                            "multiply",
+                                                                            "DummyNode",
+                                                                            m_context,
+                                                                            LayoutType::ncsp,
+                                                                            LOOK::LOOK_DOWN);
+            auto outputNode = std::make_shared<node::Input>(results[i], m_context);
+            addEdge(transposeNode, dummyConsumer, 0, 0);
+            addEdge(dummyConsumer, outputNode, 0, 0);
+        }
+        for (auto &node : nodesSet) nodes.emplace_back(node);
+        return {nodes, edges};
+    }
+};
 
 TEST_P(MergeTransposeReorderCPUTest, smoke_Run_MergeTransposeReorder) {
     Validate();
 }
 
+TEST_P(MergeTransposeReorderWithReshapeCPUTest, smoke_Run_MergeTransposeReorderWithReshape) {
+    Validate();
+}
+
+namespace {
 const std::vector<ov::Shape> input_shapes{{1, 3, 8, 16}, {3, 8, 16}};
 
 const std::vector<MergeTransposeReorderTestParam> test_params = {
@@ -201,3 +265,19 @@ const std::vector<MergeTransposeReorderTestParam> test_params = {
 INSTANTIATE_TEST_SUITE_P(smoke_Run_MergeTransposeReorder,
                          MergeTransposeReorderCPUTest,
                          ::testing::Combine(::testing::ValuesIn(input_shapes), ::testing::ValuesIn(test_params)));
+
+const std::vector<ov::Shape> input_shapes_with_reshape{{1, 64, 128, 128}};
+
+const std::vector<MergeTransposeReorderTestParam> test_params_with_reshape = {
+    // In case of non optimized reorder OneDNN primitive is used,
+    // which doesn't support reordering in case of different ranks on input and output.
+    // So the fusion is skipped for such case.
+    {LayoutType::nspc, LOOK::LOOK_UP, LayoutType::ncsp, LOOK::LOOK_DOWN, 1, Result{1, 0, 2}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Run_MergeTransposeReorderWithReshape,
+                         MergeTransposeReorderWithReshapeCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_with_reshape),
+                                            ::testing::ValuesIn(test_params_with_reshape)));
+
+}  // namespace

--- a/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
@@ -173,6 +173,31 @@ protected:
     std::unique_ptr<Graph> m_graph;
 };  // class MergeTransposeReorderCPUTest
 
+/*
+ ┌───────┐  
+ │ Input │  
+ └───┬───┘  
+     │      
+ ┌───┴───┐  
+ │ Dummy │  
+ └───┬───┘  
+     │      
+ ┌───┴───┐  
+ │Reshape│  
+ └───┬───┘  
+     │      
+┌────┴────┐ 
+│Transpose│ 
+└────┬────┘ 
+     │      
+ ┌───┴───┐  
+ │ Dummy │  
+ └───┬───┘  
+     │      
+┌────┴───┐  
+│ Output │  
+└────────┘  
+ */
 class MergeTransposeReorderWithReshapeCPUTest : public MergeTransposeReorderCPUTest {
     std::pair<std::vector<NodePtr>, std::vector<EdgePtr>> CreateModelAndReplicate(const ov::Shape& testShape,
                                                                                   LayoutType firstNodeLayout,


### PR DESCRIPTION
### Details:
MergeReorderAndTranspose fuses Reorder->Reshape->Transpose sequences into one Reorder, which can be optimized or not (depending on inplace characteristics of the nodes). In case of non optimized reorder OneDNN primitive is used, which doesn't support reordering in case of different ranks on input and output. This PR adds the corresponding logic which prevents reorder fusions in non optimized case and different ranks.

### Tickets:
 - *CVS-144935*
