### PR TITLE
[DOCS] Removing Ubuntu 24.04 from 24.2

### DIFF
--- a/docs/articles_en/get-started/configurations/configurations-intel-gpu.rst
+++ b/docs/articles_en/get-started/configurations/configurations-intel-gpu.rst
@@ -32,7 +32,7 @@ Below are the instructions on how to install the OpenCL packages on supported Li
 
 .. tab-set::
 
-   .. tab-item:: Ubuntu 22.04 LTS / Ubuntu 24.04 LTS
+   .. tab-item:: Ubuntu 22.04 LTS
       :sync: ubuntu-22
 
       Download and install the `deb` packages published `here <https://github.com/intel/compute-runtime/releases/latest>`__
@@ -123,7 +123,7 @@ Below are the required steps to make it work with OpenVINO:
      wsl --update
      wsl --shutdown
 
-- When booting Ubuntu 20.04, 22.04, or 24.04 install the same drivers as described above in the Linux section
+- When booting Ubuntu 20.04 or 22.04, install the same drivers as described above in the Linux section
 
 .. note::
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -117,16 +117,6 @@ Step 1: Download and Install the OpenVINO Core Components
 
          .. tab-set::
 
-            .. tab-item:: Ubuntu 24.04
-               :sync: ubuntu-24
-
-               .. code-block:: sh
-
-
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2024.2/linux/l_openvino_toolkit_ubuntu24_2024.2.0.15519.5c0f38f83f6_x86_64.tgz --output openvino_2024.2.0.tgz
-                  tar -xf openvino_2024.2.0.tgz
-                  sudo mv l_openvino_toolkit_ubuntu24_2024.2.0.15519.5c0f38f83f6_x86_64 /opt/intel/openvino_2024.2.0
-
             .. tab-item:: Ubuntu 22.04
                :sync: ubuntu-22
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-genai.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-genai.rst
@@ -40,14 +40,6 @@ Linux
 
       .. tab-set::
 
-         .. tab-item:: Ubuntu 24.04
-            :sync: ubuntu-24
-
-            .. code-block:: sh
-
-               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2024.2/linux/openvino_genai_ubuntu24_2024.2.0.0_x86_64.tar.gz --output openvino_genai_2024.2.0.0.tgz
-               tar -xf openvino_genai_2024.2.0.0.tgz
-
          .. tab-item:: Ubuntu 22.04
             :sync: ubuntu-22
 

--- a/docs/articles_en/openvino-workflow/deployment-locally.rst
+++ b/docs/articles_en/openvino-workflow/deployment-locally.rst
@@ -43,11 +43,11 @@ The table below shows which distribution type can be used for what target operat
    * - Distribution type
      - Operating systems
    * - Debian packages
-     - Ubuntu 18.04, 20.04, 22.04, 24.04 (64-bit)
+     - Ubuntu 18.04, 20.04, 22.04 (64-bit)
    * - RPM packages
      - Red Hat Enterprise Linux 8, 64-bit
    * - Docker images
-     - Ubuntu 20.04, 22.04, 24.04 (64-bit); Red Hat Enterprise Linux 8, 64-bit
+     - Ubuntu 20.04, 22.04 (64-bit); Red Hat Enterprise Linux 8, 64-bit
    * - PyPI (PIP package manager)
      - See https://pypi.org/project/openvino
    * - :doc:`Libraries for Local Distribution <deployment-locally/local-distribution-libraries>`


### PR DESCRIPTION
Removing mentions of Ubuntu 24.04 from 24.2.
24.2 doesn't support Ubuntu 24.04.