### PR TITLE
[GPU] fixed onednn_concat to save and load primitive_impl's info when it has no _prim

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -158,7 +158,8 @@ struct fully_connected : public primitive_base<fully_connected> {
 
         if (decompression_zero_point_scalar.has_value()) {
             ob << true;
-            ob << make_data(&decompression_zero_point_scalar.value(), sizeof(float));
+            float decompression_zero_point_value = decompression_zero_point_scalar.value();
+            ob << decompression_zero_point_value;
         } else {
             ob << false;
         }
@@ -178,7 +179,7 @@ struct fully_connected : public primitive_base<fully_connected> {
         ib >> has_value;
         if (has_value) {
             float decompression_zero_point_value = 0.f;
-            ib >> make_data(&decompression_zero_point_value, sizeof(float));
+            ib >> decompression_zero_point_value;
             decompression_zero_point_scalar = decompression_zero_point_value;
         } else {
             decompression_zero_point_scalar = optional_value<float>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -71,6 +71,7 @@ public:
 #ifdef ONEDNN_PRIMITIVE_SERIALIZATION
         if (_prim.get(true) == nullptr) {
             ob << false;
+            primitive_impl::save(ob);
             return;
         } else {
             ob << true;
@@ -93,8 +94,10 @@ public:
         bool has_prim;
         ib >> has_prim;
 
-        if (!has_prim)
+        if (!has_prim) {
+            primitive_impl::load(ib);
             return;
+        }
 
         parent::load(ib);
 


### PR DESCRIPTION
### Details:
 - `concatenation_onednn` may have no `_prim`. In this case, some class variables were not set properly with model caching.
 - This PR fixes this bug by calling `primitive_impl`'s `save()` and `load()` to set some variables, such as `cldnn::primitive_impl::_is_dynamic` and so on.

### Tickets:
 - 145734
 - 146050
