### PR TITLE
Skip new params for old driver compiler

### DIFF
--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -53,5 +53,13 @@ static constexpr ov::Property<uint64_t, ov::PropertyMutability::RO> device_total
  */
 static constexpr ov::Property<uint32_t, ov::PropertyMutability::RO> driver_version{"NPU_DRIVER_VERSION"};
 
+/**
+ * @brief [Only for NPU compiler]
+ * Type: std::string, default is empty.
+ * Sets various parameters supported by the NPU compiler.
+ * Available values: low-precision=true/low-precision=false
+ */
+static constexpr ov::Property<std::string> compilation_mode_params{"NPU_COMPILATION_MODE_PARAMS"};
+
 }  // namespace intel_npu
 }  // namespace ov

--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -55,9 +55,9 @@ static constexpr ov::Property<uint32_t, ov::PropertyMutability::RO> driver_versi
 
 /**
  * @brief [Only for NPU compiler]
- * Type: std::string, default is empty.
- * Sets various parameters supported by the NPU compiler.
- * Available values: low-precision=true/low-precision=false
+ * Type: std::string
+ * Set various parameters supported by the NPU compiler.
+ * @ingroup ov_runtime_npu_prop_cpp_api
  */
 static constexpr ov::Property<std::string> compilation_mode_params{"NPU_COMPILATION_MODE_PARAMS"};
 

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/compiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/compiler.hpp
@@ -156,7 +156,7 @@ struct COMPILATION_MODE_PARAMS final : OptionBase<COMPILATION_MODE_PARAMS, std::
     }
 
     static bool isPublic() {
-        return false;
+        return true;
     }
 };
 

--- a/src/plugins/intel_npu/src/al/include/npu_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/npu_private_properties.hpp
@@ -295,14 +295,6 @@ static constexpr ov::Property<CompilerType> compiler_type{"NPU_COMPILER_TYPE"};
 static constexpr ov::Property<std::string> compilation_mode{"NPU_COMPILATION_MODE"};
 
 /**
- * @brief [Only for NPU compiler]
- * Type: std::string, default is empty.
- * Sets various parameters supported by the NPU compiler.
- * Available values: low-precision=true/low-precision=false
- */
-static constexpr ov::Property<std::string> compilation_mode_params{"NPU_COMPILATION_MODE_PARAMS"};
-
-/**
  * @brief [Only for NPU Plugin]
  * Type: integer, default is None
  * Number of DPU groups

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -376,6 +376,7 @@ std::string LevelZeroCompilerInDriver<TableExtension>::serializeConfig(
     const Config& config,
     ze_graph_compiler_version_info_t& compilerVersion) const {
     std::string content = config.toString();
+    _logger.debug("Original content of config: %s", content.c_str());
 
     // Remove optimization-level and performance-hint-override for old driver which not support them
     if ((compilerVersion.major < 5) || (compilerVersion.major == 5 && compilerVersion.minor < 7)) {
@@ -391,7 +392,8 @@ std::string LevelZeroCompilerInDriver<TableExtension>::serializeConfig(
         content = std::regex_replace(content, std::regex(perfHintStr.str()), "");
 
         std::ostringstream compilationParamsStr;
-        compilationParamsStr << ov::intel_npu::compilation_mode_params.name() << KEY_VALUE_SEPARATOR << "";
+        compilationParamsStr << ov::intel_npu::compilation_mode_params.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER
+                             << "\\s*\"*";
         _logger.warning("Clear empty NPU_COMPILATION_MODE_PARAMS. Removing from parameters");
         content = std::regex_replace(content, std::regex(compilationParamsStr.str()), "");
     }

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -287,6 +287,14 @@ void CompiledModel::initialize_properties() {
               };
               return supportedProperty;
           }}},
+        // NPU Public
+        // =========
+        {ov::intel_npu::compilation_mode_params.name(),
+         {true,
+          ov::PropertyMutability::RO,
+          [](const Config& config) {
+              return config.get<COMPILATION_MODE_PARAMS>();
+          }}},
         // NPU Private
         // =========
         {ov::intel_npu::tiles.name(),

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -436,6 +436,12 @@ Plugin::Plugin()
           [&](const Config& config) {
               return _metrics->GetDriverVersion();
           }}},
+        {ov::intel_npu::compilation_mode_params.name(),
+         {true,
+          ov::PropertyMutability::RW,
+          [](const Config& config) {
+              return config.get<COMPILATION_MODE_PARAMS>();
+          }}},
         // NPU Private
         // =========
         {ov::intel_npu::dma_engines.name(),
@@ -473,12 +479,6 @@ Plugin::Plugin()
           ov::PropertyMutability::RW,
           [](const Config& config) {
               return config.get<COMPILATION_MODE>();
-          }}},
-        {ov::intel_npu::compilation_mode_params.name(),
-         {false,
-          ov::PropertyMutability::RW,
-          [](const Config& config) {
-              return config.get<COMPILATION_MODE_PARAMS>();
           }}},
         {ov::intel_npu::compiler_type.name(),
          {false,

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/properties_compatibility.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/properties_compatibility.cpp
@@ -58,6 +58,13 @@ TEST_P(DriverCompilerAdapterPropComTestNPU, TestNewPro) {
 }
 
 const std::vector<ov::AnyMap> configs = {
+    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)},
+    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
+     ov::intel_npu::compilation_mode_params("dummy-op-replacement=true")},
+    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
+     ov::intel_npu::compilation_mode_params("dummy-op-replacement=true optimization-level=1")},
+    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
+     ov::intel_npu::compilation_mode_params("optimization-level=1 dummy-op-replacement=true")},
     {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
      ov::intel_npu::compilation_mode_params("optimization-level=1")},
     {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/properties_compatibility.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/properties_compatibility.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "base/ov_behavior_test_utils.hpp"
+#include "common/npu_test_env_cfg.hpp"
+#include "intel_npu/al/config/common.hpp"
+#include "shared_test_classes/subgraph/split_conv_concat.hpp"
+
+using CompilationParams = std::tuple<std::string,  // Device name
+                                     ov::AnyMap    // Config
+                                     >;
+
+namespace ov::test::behavior {
+
+class DriverCompilerAdapterPropComTestNPU : public ov::test::behavior::OVPluginTestBase,
+                                            public testing::WithParamInterface<CompilationParams> {
+public:
+    void SetUp() override {
+        std::tie(target_device, configuration) = this->GetParam();
+        SKIP_IF_CURRENT_TEST_IS_DISABLED()
+        OVPluginTestBase::SetUp();
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<CompilationParams> obj) {
+        std::string targetDevice;
+        ov::AnyMap configuration;
+        std::tie(targetDevice, configuration) = obj.param;
+        std::replace(targetDevice.begin(), targetDevice.end(), ':', '.');
+
+        std::ostringstream result;
+        result << "targetDevice=" << targetDevice << "_";
+        result << "targetPlatform=" << ov::test::utils::getTestsPlatformFromEnvironmentOr(targetDevice) << "_";
+        if (!configuration.empty()) {
+            for (auto& configItem : configuration) {
+                result << "configItem=" << configItem.first << "_";
+                configItem.second.print(result);
+            }
+        }
+        return result.str();
+    }
+
+    void TearDown() override {
+        if (!configuration.empty()) {
+            utils::PluginCache::get().reset();
+        }
+        APIBaseTest::TearDown();
+    }
+
+protected:
+    ov::AnyMap configuration;
+};
+
+TEST_P(DriverCompilerAdapterPropComTestNPU, TestNewPro) {
+    auto simpleFunc = ov::test::utils::make_split_conv_concat();
+    ov::Core core;
+    EXPECT_NO_THROW(auto model = core.compile_model(simpleFunc, target_device, configuration));
+}
+
+const std::vector<ov::AnyMap> configs = {
+    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
+     ov::intel_npu::compilation_mode_params("optimization-level=1")},
+    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
+     ov::intel_npu::compilation_mode_params("optimization-level=1 performance-hint-override=latency")},
+    {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
+     ov::intel_npu::compilation_mode_params("performance-hint-override=latency")}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
+                         DriverCompilerAdapterPropComTestNPU,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configs)),
+                         DriverCompilerAdapterPropComTestNPU::getTestCaseName);
+}  // namespace ov::test::behavior

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
@@ -142,7 +142,6 @@ const std::vector<ov::AnyMap> CorrectPluginMutableProperties = {
     {{ov::intel_npu::dpu_groups.name(), 1}},
     {{ov::intel_npu::dma_engines.name(), 1}},
     {{ov::intel_npu::compilation_mode.name(), "DefaultHW"}},
-    {{ov::intel_npu::compilation_mode_params.name(), "dump-task-stats=false propagate-quant-dequant=0"}},
     {{ov::intel_npu::platform.name(),
       removeDeviceNameOnlyID(
           ov::test::utils::getTestsDeviceNameFromEnvironmentOr(std::string(ov::intel_npu::Platform::AUTO_DETECT)))}},
@@ -160,7 +159,6 @@ const std::vector<ov::AnyMap> IncorrectMutablePropertiesWrongValueTypes = {
     {{ov::intel_npu::profiling_type.name(), 10}},
     {{ov::intel_npu::tiles.name(), "none"}},
     {{ov::intel_npu::dma_engines.name(), false}},
-    {{ov::intel_npu::compilation_mode_params.name(), "not-a-param=true"}},
 };
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,


### PR DESCRIPTION
### Details:
 There are new added options for NPU_COMPILATION_MODE_PARAMS, need to skip for old driver compiler.

### Tickets:
 - *146197*
