### PR TITLE
[GPU] fix regression by group_norm_ref kernel

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/group_normalization.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/group_normalization.cpp
@@ -48,17 +48,8 @@ attach_group_normalization_impl::attach_group_normalization_impl() {
     auto types = {data_types::f16, data_types::f32};
     auto formats = {
             format::bfyx,
-            format::byxf,
-            format::yxfb,
             format::bfzyx,
-            format::b_fs_yx_fsv2,
-            format::b_fs_zyx_fsv2,
-            format::b_fs_yx_fsv4,
-            format::b_fs_zyx_fsv4,
             format::b_fs_yx_fsv16,
-            format::b_fs_yx_fsv32,
-            format::b_fs_zyx_fsv16,
-            format::b_fs_zyx_fsv32,
     };
 
     implementation_map<group_normalization>::add(impl_types::ocl, shape_types::static_shape,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/group_normalization_gpu_b_fs_yx_fsv16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/group_normalization_gpu_b_fs_yx_fsv16.cl
@@ -162,21 +162,22 @@ KERNEL(group_normalization_b_fs_yx_fsv16)(
     const uint yx = get_global_id(0) / FSV;
     const uint y = yx / OUTPUT_SIZE_X;
     const uint x = yx % OUTPUT_SIZE_X;
-    const uint data_index = OUTPUT_GET_INDEX(b, f, y, x);
+    const uint input_index = INPUT0_GET_INDEX(b, f, y, x);
+    const uint output_index = OUTPUT_GET_INDEX(b, f, y, x);
 
     if (f < OUTPUT_FEATURE_NUM) {
         ACTIVATION_TYPE mean = TO_ACTIVATION_TYPE(internal_mean[bf]);
         ACTIVATION_TYPE variance = TO_ACTIVATION_TYPE(internal_variance[bf]);
-        ACTIVATION_TYPE normalized = (TO_ACTIVATION_TYPE(input[data_index]) - mean) * variance;
+        ACTIVATION_TYPE normalized = (TO_ACTIVATION_TYPE(input[input_index]) - mean) * variance;
         normalized = normalized * TO_ACTIVATION_TYPE(scale[f]) + TO_ACTIVATION_TYPE(bias[f]);
         #if HAS_FUSED_OPS
             FUSED_OPS;
-            output[data_index] = FUSED_OPS_RESULT;
+            output[output_index] = FUSED_OPS_RESULT;
         #else
-            output[data_index] = TO_OUTPUT_TYPE(ACTIVATION(normalized, ACTIVATION_PARAMS));
+            output[output_index] = TO_OUTPUT_TYPE(ACTIVATION(normalized, ACTIVATION_PARAMS));
         #endif
     } else {
-        output[data_index] = OUTPUT_VAL_ZERO;
+        output[output_index] = OUTPUT_VAL_ZERO;
     }
 }
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_b_fs_yx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_b_fs_yx_fsv16.h
@@ -28,6 +28,7 @@ protected:
     MultiDispatchData SetDefault(const group_normalization_params& params) const;
     JitConstants GetJitConstants(const group_normalization_params& params, GroupNormalizationKernelBase::DispatchData dispatchData) const;
     void GetUpdateDispatchDataFunc(KernelData& kd) const override;
+    bool Validate(const Params& params) const override;
 };
 
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -150,7 +150,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(4),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_blocked_4d_formats),
-        ::testing::Values(padding())));
+        ::testing::ValuesIn({padding(), padding({0, 16, 0, 0})})));
 
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_blocked_layouts_support_5d, GroupNormalizationGPUTest,


### PR DESCRIPTION
### Details:
 - Currently, the `group_normalization_gpu_ref` kernel shows poor performance compared to other ones. So, it should not be selected if possible.
 - The purpose of this PR is to prevent the situation where the ref kernel is selected as much as possible by using a combination of reorder and opt kernels.