### PR TITLE
Align the behavior of CEIL_TORCH workaround subgraph with previous PT FE implementation

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
@@ -94,9 +94,6 @@ ov::pass::ConvertMaxPool14ToMaxPool8::ConvertMaxPool14ToMaxPool8() {
         std::shared_ptr<ov::op::v8::MaxPool> max_pool_v8;
         NodeRegistry node_registry;
         if (rounding_type_v14 == ov::op::RoundingType::CEIL_TORCH) {
-            if (max_pool_v14->is_dynamic()) {
-                return false;
-            }
             auto input = max_pool_v14->input_value(0);
             const auto strides = max_pool_v14->get_strides();
             const auto padding_begin = max_pool_v14->get_pads_begin();

--- a/src/common/transformations/tests/op_conversions/convert_maxpool_downgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_maxpool_downgrade_test.cpp
@@ -83,8 +83,10 @@ std::shared_ptr<ov::Model> create_ceil_torch_workaround_model(const ov::op::Roun
     using ov::op::v3::ShapeOf;
     using ov::op::v4::Range;
     using ov::op::v8::Gather;
-    const auto input_shape = dynamic_input ? ov::PartialShape{1, 3, ov::Dimension::dynamic(), ov::Dimension::dynamic()}
-                                           : ov::PartialShape{1, 3, 64, 64};
+    const auto input_shape =
+        dynamic_input
+            ? ov::PartialShape{ov::Dimension::dynamic(), 3, ov::Dimension::dynamic(), ov::Dimension::dynamic()}
+            : ov::PartialShape{1, 3, 64, 64};
     const auto input = std::make_shared<Parameter>(ov::element::f32, input_shape);
     const ov::Strides strides{2, 2}, dilations{1, 1};
     ov::Shape pads_begin{1, 1}, pads_end{1, 1}, kernel{2, 2};
@@ -180,8 +182,9 @@ TEST_F(TransformationTestsF, ConvertMaxPool14ToMaxPool8_ceil_torch_to_ceil) {
 }
 
 TEST_F(TransformationTestsF, ConvertMaxPool14ToMaxPool8_ceil_torch_to_ceil_dynamic) {
-    model = create_v14_model(ov::op::RoundingType::CEIL_TORCH,
-                             ov::PartialShape{1, 3, ov::Dimension::dynamic(), ov::Dimension::dynamic()});
+    model = create_v14_model(
+        ov::op::RoundingType::CEIL_TORCH,
+        ov::PartialShape{ov::Dimension::dynamic(), 3, ov::Dimension::dynamic(), ov::Dimension::dynamic()});
     model_ref = create_ceil_torch_workaround_model(ov::op::RoundingType::CEIL, true);
     manager.register_pass<ov::pass::ConvertMaxPool14ToMaxPool8>();
     comparator.disable(FunctionsComparator::CmpValues::ACCURACY);

--- a/src/common/transformations/tests/op_conversions/convert_maxpool_downgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_maxpool_downgrade_test.cpp
@@ -25,7 +25,7 @@
 
 namespace {
 
-std::shared_ptr<ov::Model> create_v14_model(const ov::op::RoundingType rounding_type, const ov::PartialShape input_shape) {
+std::shared_ptr<ov::Model> create_v14_model(const ov::op::RoundingType rounding_type, const ov::Shape input_shape) {
     const auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape);
     const ov::Strides strides{2, 2}, dilations{1, 1};
     const ov::Shape pads_begin{1, 1}, pads_end{1, 1}, kernel{2, 2};
@@ -169,15 +169,7 @@ TEST_F(TransformationTestsF, ConvertMaxPool8ToMaxPool1) {
 }
 
 TEST_F(TransformationTestsF, ConvertMaxPool14ToMaxPool8_ceil_torch_to_ceil) {
-    model = create_v14_model(ov::op::RoundingType::CEIL_TORCH, ov::PartialShape{1, 3, 64, 64});
-    model_ref = create_ceil_torch_workaround_model(ov::op::RoundingType::CEIL);
-    manager.register_pass<ov::pass::ConvertMaxPool14ToMaxPool8>();
-    comparator.disable(FunctionsComparator::CmpValues::ACCURACY);
-    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
-}
-
-TEST_F(TransformationTestsF, ConvertMaxPool14ToMaxPool8_ceil_torch_to_ceil_dynamic) {
-    model = create_v14_model(ov::op::RoundingType::CEIL_TORCH, ov::PartialShape{1, 3, ov::Dimension::dynamic(), ov::Dimension::dynamic()});
+    model = create_v14_model(ov::op::RoundingType::CEIL_TORCH, ov::Shape{1, 3, 64, 64});
     model_ref = create_ceil_torch_workaround_model(ov::op::RoundingType::CEIL);
     manager.register_pass<ov::pass::ConvertMaxPool14ToMaxPool8>();
     comparator.disable(FunctionsComparator::CmpValues::ACCURACY);
@@ -186,14 +178,14 @@ TEST_F(TransformationTestsF, ConvertMaxPool14ToMaxPool8_ceil_torch_to_ceil_dynam
 
 TEST_F(TransformationTestsF, ConvertMaxPool14ToMaxPool8_ceil_to_ceil) {
     manager.register_pass<ov::pass::ConvertMaxPool14ToMaxPool8>();
-    model = create_v14_model(ov::op::RoundingType::CEIL, ov::PartialShape{1, 3, 64, 64});
+    model = create_v14_model(ov::op::RoundingType::CEIL, ov::Shape{1, 3, 64, 64});
     model_ref = create_v8_model(ov::op::RoundingType::CEIL);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
 
 TEST_F(TransformationTestsF, ConvertMaxPool14ToMaxPool8_floor_to_floor) {
-    model = create_v14_model(ov::op::RoundingType::FLOOR, ov::PartialShape{1, 3, 64, 64});
+    model = create_v14_model(ov::op::RoundingType::FLOOR, ov::Shape{1, 3, 64, 64});
     manager.register_pass<ov::pass::ConvertMaxPool14ToMaxPool8>();
     model_ref = create_v8_model(ov::op::RoundingType::FLOOR);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/common/transformations/tests/op_conversions/convert_maxpool_downgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_maxpool_downgrade_test.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<ov::Model> create_ceil_torch_workaround_model(const ov::op::Roun
     using ov::op::v3::ShapeOf;
     using ov::op::v4::Range;
     using ov::op::v8::Gather;
-    const auto input_shape =
+    const auto& input_shape =
         dynamic_input
             ? ov::PartialShape{ov::Dimension::dynamic(), 3, ov::Dimension::dynamic(), ov::Dimension::dynamic()}
             : ov::PartialShape{1, 3, 64, 64};


### PR DESCRIPTION
### Details:
 - The workaround subgraph, which previously was in PT FE, was enabled for dynamic input shapes. When moving it to transformations it was decided it does not fully support dynamic shapes, but it broke some models. This PR fully aligns previous behavior of PT FE with the transformation.
 - The same workaround subgraph was applied for dynamic shapes as well, which can be seen in https://github.com/openvinotoolkit/openvino/pull/24846

### Tickets:
 - CVS-145719
