### PR TITLE
Remove redundant test

### DIFF
--- a/src/tests/functional/plugin/shared/CMakeLists.txt
+++ b/src/tests/functional/plugin/shared/CMakeLists.txt
@@ -74,12 +74,6 @@ ov_build_target_faster(${TARGET_NAME}
     PCH PRIVATE "src/precomp.hpp"
 )
 
-if (ENABLE_INTEL_CPU)
-    set_source_files_properties(
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/behavior/ov_executable_network/get_metric.cpp"
-        PROPERTIES COMPILE_DEFINITIONS ENABLE_INTEL_CPU=1)
-endif()
-
 # install & export
 
 ov_developer_package_export_targets(TARGET ${TARGET_NAME}

--- a/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/properties_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/properties_tests.hpp
@@ -92,17 +92,6 @@ TEST_P(InferRequestPropertiesTest, canSetExclusiveAsyncRequests) {
     }
 }
 
-TEST_P(InferRequestPropertiesTest, withoutExclusiveAsyncRequests) {
-    ASSERT_EQ(0ul, ov::threading::executor_manager()->get_executors_number());
-    OV_ASSERT_NO_THROW(createInferRequestWithConfig());
-    if (target_device.find(ov::test::utils::DEVICE_AUTO) == std::string::npos &&
-        target_device.find(ov::test::utils::DEVICE_MULTI) == std::string::npos &&
-        target_device.find(ov::test::utils::DEVICE_HETERO) == std::string::npos &&
-        target_device.find(ov::test::utils::DEVICE_BATCH) == std::string::npos) {
-        ASSERT_EQ(streamExecutorNumber, ov::threading::executor_manager()->get_executors_number());
-    }
-}
-
 TEST_P(InferRequestPropertiesTest, ReusableCPUStreamsExecutor) {
     ov::threading::executor_manager()->clear();
     ASSERT_EQ(0u, ov::threading::executor_manager()->get_executors_number());


### PR DESCRIPTION
### Details:
 - "canSetExclusiveAsyncRequests" & "withoutExclusiveAsyncRequests" do the same thing. Will remove one
 - Clean code used for API 1.0

### Tickets:
 - [29948](https://jira.devtools.intel.com/browse/CVS-129948)
