### PR TITLE
[CPU] Fix rounding and fusing with FQ issues for Reduce node

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
@@ -403,7 +403,7 @@ bool isSuitableChildForFusingSumActivation(const std::shared_ptr<const Node> &no
     return SupportsFusingWithConvolution_SumActivation(node);
 }
 bool isSuitableReduceChild(const std::shared_ptr<const Node> &node, const int channelAxis = DEFAULT_AXIS) {
-    return node->get_output_element_type(0) == ov::element::f32 && isSuitableChildForFusingSimple(node, channelAxis);
+    return isSuitableChildForFusingSimple(node, channelAxis);
 }
 bool isSuitableMatMulWithConstantPath(const std::shared_ptr<Node>& node) {
     return ov::is_type<ov::opset1::MatMul>(node) &&

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/reduce.cpp
@@ -134,7 +134,7 @@ const auto fusingFakeQuantizeTranspose = fusingSpecificParams{std::make_shared<p
         {[](postNodeConfig& cfg){
             auto localPrc = cfg.input->get_element_type();
             ov::Shape newShape(cfg.input->get_output_partial_shape(0).size(), 1);
-            const auto fakeQuantize = ov::test::utils::make_fake_quantize(cfg.input, localPrc, 256, newShape);
+            const auto fakeQuantize = ov::test::utils::make_fake_quantize(cfg.input, localPrc, 256, {}, {0}, {9}, {0}, {255});
             std::vector<size_t> order(newShape.size());
             std::iota(order.begin(), order.end(), 0);
             auto last = order[order.size() - 1];

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -604,9 +604,6 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(smoke_CompareWithRefs_4D.*/EltwiseLayerCPUTest.*Sub_secondary.*INFERENCE_PRECISION_HINT=f16.*FakeQuantize.*enforceSnippets=1.*)");
         retVector.emplace_back(R"(smoke_Reduce.*/ReduceCPULayerTest.*axes=\((0.1|1)\).*Prod_KeepDims.*INFERENCE_PRECISION_HINT=f16.*)");
         retVector.emplace_back(R"(smoke_ConvertRangeSubgraphCPUTest/ConvertRangeSubgraphCPUTest\.CompareWithRefs.*Prc=f16.*)");
-        // Issue: 142465
-        retVector.emplace_back(R"(smoke_Reduce_MultiAxis_4D_fusing_CPU/ReduceCPULayerTest.CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)");
-        retVector.emplace_back(R"(smoke_Reduce_MultiAxis_5D_fusing_CPU/ReduceCPULayerTest.CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)");
         // Issue: 143852
         retVector.emplace_back(R"((smoke|nightly)_FC_3D_FP16/.*_Fused=Multiply\(PerChannel\).*)");
         retVector.emplace_back(R"((smoke|nightly)_MM_Brgemm_Static_FP16.*TS=\(\(55\.12\)\).*_Fused=Multiply\(PerChannel\).*)");


### PR DESCRIPTION
### Details:
 - *Following the IEEE 754 standard for floating-point arithmetic, instructions that operate on floating-point numbers (e.g., vdivps and cvtps2dq) rounds to the nearest value by default. On the other hand, C++ standard requires the result of division round toward zero if both operands are integers. To comply with both standards, Reduce node will round the floating point result toward zero before storing, only when both input and output precisions are integers.*
 - *The patch for CVS-142465 is also included in this PR, because they share the same revised test suite. In this part, I exchange the order of the two logic blocks about revising output precision. Because output precision should be settled before the final precision check with post ops.*
 - *Regarding test cases, the arguments of ov::test::utils::make_fake_quantize is revised. Otherwise, both target and reference results tend to be all zeros, which can hardly tell potential issues for fusing with FQ. After this revision, both issues in CVS-146321 (before the reverting PR) and CVS-142465 can be reproduced beforehand by test suite smoke_Reduce_LowPrecision_fusing_CPU.*

### Tickets:
 - *[CVS-146321](https://jira.devtools.intel.com/browse/CVS-146321)*
 - *[CVS-142465](https://jira.devtools.intel.com/browse/CVS-142465)*
