### PR TITLE
[Op][Spec] Squeeze - additional notes for behavior clarification 

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/shape/squeeze-1.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/shape/squeeze-1.rst
@@ -20,7 +20,15 @@ Squeeze
 * With the second input provided, each value is an index of a dimension from the first tensor that is to be removed. Specified dimension should be equal to 1, otherwise it will be ignored and copied as is.
   Dimension indices can be specified directly, or by negative indices (counting dimensions from the end).
 
-Note: Updated behavior since 2024.3, request of squeezing dimension not equal to 1 is expected to be ignored instead of causing an error.
+.. note::
+
+    Behavior before 2024.3 OpenVINO release: Error is raised when dimension to squeeze is not compatible with 1.
+
+.. note::
+
+    - If index of the dimension to squeeze is provided as a constant input and it points to a dynamic dimension that might be `1`, then the dimension is considered as squeezable. Therefore the rank of the output shape will be reduced, but not dynamic.
+    - If the input with indices is empty or not provided, dynamic dimension compatible with `1` leads to dynamic rank of the output shape.
+
 
 **Attributes**: *Squeeze* operation doesn't have attributes.
 


### PR DESCRIPTION
### Details:
 - Updated note about 2024.3 changes (no throw on non-squeezable dims)
 - Additional note clarifying dynamic dimension cases, it describes behavior before and after the changes.
   It was implemented this way before the 2024.3 update, and is needed for backward compatibility.
 
 Related PR:
 - https://github.com/openvinotoolkit/openvino/pull/24715
 
### Tickets:
 - related to 142387