### PR TITLE
[TRANSFORMATIONS] Improve pattern matcher debug logs

### DIFF
--- a/src/core/include/openvino/pass/pattern/op/pattern.hpp
+++ b/src/core/include/openvino/pass/pattern/op/pattern.hpp
@@ -95,6 +95,9 @@ public:
 
     ValuePredicate get_predicate() const;
 
+    std::ostream& write_description(std::ostream& out, uint32_t depth) const override;
+    virtual std::ostream& write_type_description(std::ostream& out) const;
+
 protected:
     ValuePredicate m_predicate;
 };

--- a/src/core/include/openvino/pass/pattern/op/wrap_type.hpp
+++ b/src/core/include/openvino/pass/pattern/op/wrap_type.hpp
@@ -46,6 +46,7 @@ public:
     NodeTypeInfo get_wrapped_type() const;
 
     const std::vector<NodeTypeInfo>& get_wrapped_types() const;
+    std::ostream& write_type_description(std::ostream& out) const override;
 
 private:
     std::vector<NodeTypeInfo> m_wrapped_types;

--- a/src/core/src/pattern/matcher.cpp
+++ b/src/core/src/pattern/matcher.cpp
@@ -133,6 +133,11 @@ bool Matcher::match_value(const ov::Output<Node>& pattern_value, const ov::Outpu
 bool Matcher::match_permutation(const OutputVector& pattern_args, const OutputVector& args) {
     for (size_t i = 0; i < args.size(); i++) {
         if (!match_value(pattern_args.at(i), args.at(i))) {
+            OPENVINO_DEBUG("[MATCHER] Aborting. Argument ",
+                           i,
+                           " (",
+                           args.at(i).get_node()->get_friendly_name(),
+                           ") mismatch");
             return false;
         }
     }
@@ -140,13 +145,19 @@ bool Matcher::match_permutation(const OutputVector& pattern_args, const OutputVe
 }
 
 bool Matcher::match_arguments(Node* pattern_node, const std::shared_ptr<Node>& graph_node) {
-    OPENVINO_DEBUG("[MATCHER] Match arguments at ", *graph_node, " for pattern ", *pattern_node);
+    OPENVINO_DEBUG("[MATCHER] Match arguments at");
+    OPENVINO_DEBUG("\t", *graph_node);
+    OPENVINO_DEBUG("for pattern");
+    OPENVINO_DEBUG("\t", *pattern_node);
 
     auto args = graph_node->input_values();
     auto pattern_args = pattern_node->input_values();
 
     if (args.size() != pattern_args.size()) {
-        OPENVINO_DEBUG("[MATCHER] Aborting at ", *graph_node, " for pattern ", *pattern_node);
+        OPENVINO_DEBUG("[MATCHER] Aborting. Args count mismatch: candidate: ",
+                       args.size(),
+                       ";  pattern: ",
+                       pattern_args.size());
         return false;
     }
 
@@ -172,7 +183,7 @@ bool Matcher::match_arguments(Node* pattern_node, const std::shared_ptr<Node>& g
         return match_permutation(pattern_args, args);
     }
 
-    OPENVINO_DEBUG("[MATCHER] Aborting at ", *graph_node, " for pattern ", *pattern_node);
+    OPENVINO_DEBUG("[MATCHER] Aborting");
     return false;
 }
 

--- a/src/core/src/pattern/op/pattern.cpp
+++ b/src/core/src/pattern/op/pattern.cpp
@@ -41,6 +41,38 @@ ValuePredicate as_value_predicate(NodePredicate pred) {
         return node_value_true_predicate;
     }
 }
+
+std::ostream& Pattern::write_type_description(std::ostream& out) const {
+    auto version = get_type_info().version_id;
+    if (version)
+        out << version << "::" << get_type_info().name;
+    else
+        out << get_type_info().name;
+
+    return out;
+}
+
+std::ostream& Pattern::write_description(std::ostream& out, uint32_t depth) const {
+    write_type_description(out);
+
+    if (depth > 0) {
+        out << " (";
+        std::string sep = "";
+        for (const auto& arg : input_values()) {
+            out << sep << arg;
+            sep = ", ";
+        }
+        out << ") -> (";
+        sep = "";
+        for (size_t i = 0; i < get_output_size(); i++) {
+            out << sep << get_output_element_type(i) << get_output_partial_shape(i);
+            sep = ", ";
+        }
+        out << ")";
+    }
+    return out;
+}
+
 }  // namespace op
 
 PatternMap as_pattern_map(const PatternValueMap& pattern_value_map) {

--- a/src/core/src/pattern/op/wrap_type.cpp
+++ b/src/core/src/pattern/op/wrap_type.cpp
@@ -36,3 +36,18 @@ ov::NodeTypeInfo ov::pass::pattern::op::WrapType::get_wrapped_type() const {
 const std::vector<ov::NodeTypeInfo>& ov::pass::pattern::op::WrapType::get_wrapped_types() const {
     return m_wrapped_types;
 }
+
+std::ostream& ov::pass::pattern::op::WrapType::write_type_description(std::ostream& out) const {
+    bool first = true;
+    out << (m_wrapped_types.size() > 1 ? "<" : "");
+    for (const auto& type : m_wrapped_types) {
+        auto version = type.version_id;
+        if (version)
+            out << (first ? "" : ", ") << version << "::" << type.name;
+        else
+            out << (first ? "" : ", ") << type.name;
+        first = false;
+    }
+    out << (m_wrapped_types.size() > 1 ? ">" : "");
+    return out;
+}


### PR DESCRIPTION
### Details:
 - Make pattern matcher logs a little bit more readable. Example:
Before:
```
matcher.cpp 143	[MATCHER] Match arguments at opset1::MatMul MatMul_67 (opset1::Parameter in_matmul[0]:f16[1,32,1,30], opset1::Concat Convert_65[0]:f16[1,32,30,80]) -> (f16[1,32,1,80]) for pattern util::patternAnyType patternAnyType_27359 (util::patternLabel patternLabel_27357[0]:dynamic[...], util::patternAnyType patternAnyType_27358[0]:dynamic[...]) -> (dynamic[...])
matcher.cpp 143	[MATCHER] Match arguments at opset1::Reshape Transpose_63 (opset1::Parameter new_token_input[0]:f16[1,1,32,80], opset1::Constant Constant_27953[0]:i64[4]) -> (f16[1,32,1,80]) for pattern util::patternAnyType patternAnyType_27618 (util::patternAnyType patternAnyType_27615[0]:dynamic[...], util::patternLabel patternLabel_27617[0]:dynamic[...]) -> (dynamic[...])
matcher.cpp 143	[MATCHER] Match arguments at opset1::Concat Convert_65 (opset1::Parameter past_key_values[0]:f16[1,32,29,80], opset1::Reshape Transpose_63[0]:f16[1,32,1,80]) -> (f16[1,32,30,80]) for pattern util::patternAnyType patternAnyType_27969 (util::patternAnyType patternAnyType_27968[0]:dynamic[...], util::patternAnyType patternAnyType_27968[0]:dynamic[...], util::patternAnyType patternAnyType_27968[0]:dynamic[...]) -> (dynamic[...])
matcher.cpp 149	[MATCHER] Aborting at opset1::Concat Convert_65 (opset1::Parameter past_key_values[0]:f16[1,32,29,80], opset1::Reshape Transpose_63[0]:f16[1,32,1,80]) -> (f16[1,32,30,80]) for pattern util::patternAnyType patternAnyType_27969 (util::patternAnyType patternAnyType_27968[0]:dynamic[...], util::patternAnyType patternAnyType_27968[0]:dynamic[...], util::patternAnyType patternAnyType_27968[0]:dynamic[...]) -> (dynamic[...])
```
After:
```
matcher.cpp 144	[MATCHER] Match arguments at
matcher.cpp 145		opset1::MatMul MatMul_67 (opset1::Parameter in_matmul[0]:f16[1,32,1,30], opset1::Concat Convert_65[0]:f16[1,32,30,80]) -> (f16[1,32,1,80])
matcher.cpp 146	for pattern
matcher.cpp 147		opset1::MatMul (util::patternLabel[0]:dynamic[...], <opset1::Constant, opset1::FakeQuantize>[0]:dynamic[...]) -> (dynamic[...])
matcher.cpp 136	[MATCHER] Aborting. Argument 1 (Convert_65) mismatch
matcher.cpp 144	[MATCHER] Match arguments at
matcher.cpp 145		opset1::Reshape Transpose_63 (opset1::Parameter new_token_input[0]:f16[1,1,32,80], opset1::Constant Constant_27953[0]:i64[4]) -> (f16[1,32,1,80])
matcher.cpp 146	for pattern
matcher.cpp 147		opset1::Reshape (opset1::FakeQuantize[0]:dynamic[...], util::patternLabel[0]:dynamic[...]) -> (dynamic[...])
matcher.cpp 136	[MATCHER] Aborting. Argument 0 (new_token_input) mismatch
matcher.cpp 144	[MATCHER] Match arguments at
matcher.cpp 145		opset1::Concat Convert_65 (opset1::Parameter past_key_values[0]:f16[1,32,29,80], opset1::Reshape Transpose_63[0]:f16[1,32,1,80]) -> (f16[1,32,30,80])
matcher.cpp 146	for pattern
matcher.cpp 147		opset1::Concat (opset1::Split[0]:dynamic[...], opset1::Split[0]:dynamic[...], opset1::Split[0]:dynamic[...]) -> (dynamic[...])
matcher.cpp 153	[MATCHER] Aborting. Args count mismatch: candidate: 2;  pattern: 3
```
Key changes:
- Improved formatting
- Omit friendly names for pattern as those are autogenerated and meaningless
- Underlying types are printed for WrapType node instead of `patternAnyType`
- Add few extended messages about matcher abort reason
