### PR TITLE
[NPU] Linking libze_loader.so.1 instead of libze_loader.so on linux

### DIFF
--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
@@ -8,6 +8,10 @@
 
 #include <memory>
 
+#ifndef _WIN32
+#    define LIB_ZE_LOADER_SUFFIX ".1"
+#endif
+
 namespace intel_npu {
 
 // clang-format off

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_api.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_api.cpp
@@ -13,6 +13,10 @@ ZeroApi::ZeroApi() {
     const std::string baseName = "ze_loader";
     try {
         auto libpath = ov::util::make_plugin_library_name({}, baseName);
+#ifndef _WIN32
+        libpath = libpath + LIB_ZE_LOADER_SUFFIX;
+#endif
+
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
         this->lib = ov::util::load_shared_object(ov::util::string_to_wstring(libpath).c_str());
 #else


### PR DESCRIPTION
### Details:
 - Linking libze_loader.so.1 instead of libze_loader.so on linux

### Tickets:
 - CVS-146268