### PR TITLE
[CPU] WA for s4 weight-compression inner-product low-perf on ICX

### DIFF
--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -50,7 +50,7 @@ struct Config {
     std::string dumpToDot = {};
     std::string device_id = {};
     float fcSparseWeiDecompressionRate = 1.0f;
-    uint64_t fcDynamicQuantizationGroupSize = 32;
+    uint64_t fcDynamicQuantizationGroupSize = 0;
     ov::element::Type kvCachePrecision = ov::element::f16;
     bool fcDynamicQuantizationGroupSizeSetExplicitly = false;
 #if defined(OPENVINO_ARCH_X86_64)


### PR DESCRIPTION
### Details:
 So far we can confirm that on ICX `Intel(R) Xeon(R) Platinum 8358/8380`, when LLM models like `mistral-7b-v0.1` is being converted into OV IR using mixed INT4_SYM(i4 w/o zero-point)/INT8 weight-compression (ratio=0.9), performance regression would happen, and according to PMU counter we can also confirm that some `jit_brgemm_kernel_t` worker threads becomes slower due to unknown CPU stalls:

workaround provided in this PR just bring a useless `uni_vsubps(vmm_load, vmm_load, vmm_zero_points);` instruction back (since vmm_zero_points is always zero in INT4_SYM case), this actually make the weight-decompression process little slower(confirmed using PMU counter), but the strange CPU stalls is gone with this change.

### Tickets:
 - *CVS-146047*
 - *CVS-146312*
