### PR TITLE
Revert "[GPU] Disallow OneDNN usage of FP32 input with compressed weights on FC (#25232)"

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -936,10 +936,6 @@ static bool is_node_for_onednn(fully_connected_node const& node) {
                 (decompression_zp_dt != ov::element::Type_t::u8 && decompression_zp_dt != ov::element::Type_t::i8)) {
                 return false;
             }
-
-            auto input_dt = node.get_input_layout(0).data_type;
-            if (input_dt == data_types::f32)
-                return false;
         }
     }
 


### PR DESCRIPTION
This reverts commit 5cfbd06bd2dcda6db93e420ccc99f390cf940d1f.

Not needed anymore since missing functionality is now implemented in OneDNN

### Details:
 - Revert commit disallowing OneDNN usage of FP32 input with compressed weights on FC

### Tickets:
 - 138360