### PR TITLE
[CPU] only allow per-oc or per-tensor FQ fusing into FC 

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -25,6 +25,8 @@
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
 
+#include "fake_quantize.h"
+
 using namespace dnnl;
 using namespace ov::element;
 
@@ -94,6 +96,25 @@ bool FullyConnected::canFuse(const NodePtr& node) const {
 #if defined(OV_CPU_WITH_SHL)
     return false;
 #endif
+    if (node->getType() == Type::FakeQuantize) {
+        auto* fq = dynamic_cast<FakeQuantize*>(node.get());
+        if (fq->getBroadcastingPolicy() != FakeQuantize::BroadcastingPolicy::PerTensor) {
+            const auto& dstShape = getOutputShapeAtPort(0);
+            auto dataRanks = dstShape.getRank();
+            // only per-OC or per-Tensor fakequantize can be postOps
+            if (fq->getAxis() != dataRanks - 1) {
+                DEBUG_LOG("reject FakeQuantize ",
+                          fq->getName(),
+                          "(axis=",
+                          fq->getAxis(),
+                          ") from fusing into ",
+                          getName(),
+                          " with dst shape ",
+                          dstShape);
+                return false;
+            }
+        }
+    }
     return canFuseSimpleOperation(node);
 }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/matmul.cpp
@@ -1108,11 +1108,10 @@ INSTANTIATE_TEST_SUITE_P(
     testParamsDynamicFusingFullUndefShapes,
     MatMulLayerCPUTest::getTestCaseName);
 
-
 class FCNotFuseFQCPUTest : public MatMulLayerCPUTest {
     void SetUp() override {
         MatMulLayerCPUTest::SetUp();
-        isFused = false;
+        expectPostOpsToBeFused = false;
     }
 };
 
@@ -1135,17 +1134,16 @@ const std::vector<ShapeRelatedParams>& notFuseSmoke() {
     return params;
 }
 
-
 const auto notFuseTestParamsSmoke = ::testing::Combine(::testing::Combine(::testing::ValuesIn(notFuseSmoke()),
-                                                                ::testing::Values(ElementType::f32),
-                                                                ::testing::Values(ElementType::undefined),
-                                                                ::testing::Values(ElementType::undefined),
-                                                                ::testing::Values(utils::InputLayerType::CONSTANT),
-                                                                ::testing::Values(ov::test::utils::DEVICE_CPU),
-                                                                ::testing::Values(emptyAdditionalConfig())),
-                                             ::testing::Values(MatMulNodeType::FullyConnected),
-                                             ::testing::Values(notFusingFakeQuantizePerChannelOrPerTensor),
-                                             ::testing::ValuesIn(filterCPUInfo({CPUSpecificParams{{}, {}, {"gemm_mlas"}, "gemm_mlas"}})));
+                                                                          ::testing::Values(ElementType::f32),
+                                                                          ::testing::Values(ElementType::undefined),
+                                                                          ::testing::Values(ElementType::undefined),
+                                                                          ::testing::Values(utils::InputLayerType::CONSTANT),
+                                                                          ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                                                          ::testing::Values(emptyAdditionalConfig())),
+                                                       ::testing::Values(MatMulNodeType::FullyConnected),
+                                                       ::testing::ValuesIn({fusingFakeQuantizePerBatch, fusingFakeQuantizeFullTensor}),
+                                                       ::testing::ValuesIn({CPUSpecificParams{{}, {}, {""}, "any_type"}}));
 
 INSTANTIATE_TEST_SUITE_P(smoke_FC, FCNotFuseFQCPUTest, notFuseTestParamsSmoke, FCNotFuseFQCPUTest::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/matmul.cpp
@@ -1121,8 +1121,8 @@ TEST_P(FCNotFuseFQCPUTest, CompareWithRefs) {
     CheckPluginRelatedResults(compiledModel, cpuNodeType);
 }
 
-const std::vector<ShapeRelatedParams>& notFuse_smoke() {
-    static const std::vector<ShapeRelatedParams> NOFused_smoke = {
+const std::vector<ShapeRelatedParams>& notFuseSmoke() {
+    static const std::vector<ShapeRelatedParams> params = {
         {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {false, true}},
         {static_shapes_to_test_representation({{59, 1}, {1, 120}}), {true, true}},
 
@@ -1132,11 +1132,11 @@ const std::vector<ShapeRelatedParams>& notFuse_smoke() {
         {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {true, false}},
         {static_shapes_to_test_representation({{71, 128}, {128, 20}}), {false, true}},
     };
-    return NOFused_smoke;
+    return params;
 }
 
 
-const auto notFuseTestParams_smoke = ::testing::Combine(::testing::Combine(::testing::ValuesIn(notFuse_smoke()),
+const auto notFuseTestParamsSmoke = ::testing::Combine(::testing::Combine(::testing::ValuesIn(notFuseSmoke()),
                                                                 ::testing::Values(ElementType::f32),
                                                                 ::testing::Values(ElementType::undefined),
                                                                 ::testing::Values(ElementType::undefined),
@@ -1147,7 +1147,7 @@ const auto notFuseTestParams_smoke = ::testing::Combine(::testing::Combine(::tes
                                              ::testing::Values(notFusingFakeQuantizePerChannelOrPerTensor),
                                              ::testing::ValuesIn(filterCPUInfo({CPUSpecificParams{{}, {}, {"gemm_mlas"}, "gemm_mlas"}})));
 
-INSTANTIATE_TEST_SUITE_P(smoke_FC, FCNotFuseFQCPUTest, notFuseTestParams_smoke, FCNotFuseFQCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_FC, FCNotFuseFQCPUTest, notFuseTestParamsSmoke, FCNotFuseFQCPUTest::getTestCaseName);
 
 }  // namespace
 }  // namespace MatMul

--- a/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.cpp
@@ -58,7 +58,7 @@ void CpuTestWithFusing::CheckFusingResults(const std::shared_ptr<const ov::Model
             size_t pos = 0;
             for (const auto& fusedOp : fusedOps) {
                 pos = originalLayersNames.find(fusedOp, checkFusingPosition ? pos : 0);
-                if (isFused) {
+                if (expectPostOpsToBeFused) {
                     ASSERT_TRUE(pos != std::string::npos) << "Fused op " << fusedOp << " has not been found!";
                 } else {
                     ASSERT_TRUE(pos == std::string::npos) << "op" << fusedOp << " should not be fused!";

--- a/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.cpp
@@ -58,7 +58,11 @@ void CpuTestWithFusing::CheckFusingResults(const std::shared_ptr<const ov::Model
             size_t pos = 0;
             for (const auto& fusedOp : fusedOps) {
                 pos = originalLayersNames.find(fusedOp, checkFusingPosition ? pos : 0);
-                ASSERT_TRUE(pos != std::string::npos) << "Fused op " << fusedOp << " has not been found!";
+                if (isFused) {
+                    ASSERT_TRUE(pos != std::string::npos) << "Fused op " << fusedOp << " has not been found!";
+                } else {
+                    ASSERT_TRUE(pos == std::string::npos) << "op" << fusedOp << " should not be fused!";
+                }
             }
         }
     }

--- a/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.hpp
@@ -320,12 +320,12 @@ const auto notFusingFakeQuantizePerChannelOrPerTensor = fusingSpecificParams{std
                 std::mt19937 gen(rd());
                 std::uniform_int_distribution<> distrib(0, shapeSize - 1);
                 int axis = distrib(gen);
-                const int max_rand_count = 100;
-                int rand_count = 1;
+                const int maxRandomCount = 100;
+                int randomCount = 1;
                 while (axis == channelAxis || shape[axis].is_dynamic()) {
                     axis = distrib(gen);
-                    rand_count++;
-                    if (rand_count > max_rand_count) {
+                    randomCount++;
+                    if (randomCount > maxRandomCount) {
                         OPENVINO_THROW("the output shape is not suit for test");
                     }
                 }


### PR DESCRIPTION
### Details:
 - Add a check to reject non-supported FakeQuantize from fusing into FC node, so they can run in standalone mode w/o causing exceptions when composing oneDNN postOps.
 - port from https://github.com/openvinotoolkit/openvino/pull/23009
 - add test case

### Tickets:
 - *CVS-131890*
