### PR TITLE
Revert "OVCore to check for symlinks before opening files (#24781)"

### DIFF
--- a/src/common/util/CMakeLists.txt
+++ b/src/common/util/CMakeLists.txt
@@ -41,10 +41,6 @@ target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} PUBLIC openvino::p
 if (WIN32)
     target_link_libraries(${TARGET_NAME} PRIVATE Shlwapi)
 endif()
-
-if(LINUX)
-    target_link_libraries(${TARGET_NAME} PRIVATE stdc++fs)
-endif()
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${UTIL_INCLUDE_DIR}>)
 
 ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})

--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -12,20 +12,6 @@
 
 #include "openvino/util/util.hpp"
 
-#if !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
-#    if (__cplusplus >= 201703L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L) && (_MSC_VER >= 1913))
-#        if __has_include(<filesystem>)
-#            include <filesystem>
-namespace fs = std::filesystem;
-#        endif
-#    else
-#        define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
-#        define _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM
-#        include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#    endif
-#endif
-
 namespace ov {
 namespace util {
 

--- a/src/inference/src/model_reader.cpp
+++ b/src/inference/src/model_reader.cpp
@@ -118,10 +118,6 @@ std::shared_ptr<ov::Model> read_model(const std::string& modelPath,
     std::string model_path = modelPath;
 #endif
 
-#if !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
-    OPENVINO_ASSERT(!fs::is_symlink(model_path), "Cannot read model\"" + modelPath + "\". The path is a symlink!");
-#endif
-
     // Try to load with FrontEndManager
     ov::frontend::FrontEndManager manager;
     ov::frontend::FrontEnd::Ptr FE;

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -8,9 +8,6 @@
 
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/file_utils.hpp"
-#include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
-#include "openvino/pass/manager.hpp"
-#include "openvino/pass/serialize.hpp"
 #include "openvino/runtime/core.hpp"
 #include "openvino/util/file_util.hpp"
 
@@ -98,23 +95,4 @@ TEST(CoreBaseTest, LoadOVFolderOverCWPathPluginXML) {
     remove_plugin_xml(ov_file_path);
 }
 
-#    if !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
-TEST(CoreBaseTest, ReadModelwithSymlink) {
-    fs::create_directory("test_link");
-    std::string modelName = "test_link/test.xml";
-    std::string weightsName = "test_link/test.bin";
-    ov::pass::Manager manager;
-    manager.register_pass<ov::pass::Serialize>(modelName, weightsName);
-    manager.run_passes(ov::test::utils::make_conv_pool_relu({1, 3, 227, 227}, ov::element::Type_t::f32));
-
-    std::string modelNameSymlink = "test_link/test_symlink.xml";
-    fs::create_symlink(modelName, modelNameSymlink);
-    ov::Core core;
-    EXPECT_NO_THROW(core.read_model(modelName, weightsName));
-    EXPECT_THROW(core.read_model(modelNameSymlink, weightsName), std::runtime_error);
-
-    fs::remove_all("test_link");
-    ASSERT_FALSE(ov::util::directory_exists("test_link"));
-}
-#    endif
 #endif


### PR DESCRIPTION
### Details:
 - This reverts commit a904d9b94520ecc074a838ea23d69478d4e5b60f.
 - In the #24864, the FEs check if file can be opened at given path. If not possible then there is exception.
  
### Tickets:
 - CVS-146678
 - Relates to CVS-142055
