### PR TITLE
[IE TESTS] Change InputShapes ostream insertion op delimiter

### DIFF
--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -38,7 +38,9 @@ namespace ov {
 namespace test {
 
 std::ostream& operator <<(std::ostream& os, const InputShape& inputShape) {
-    os << ov::test::utils::partialShape2str({inputShape.first}) << "_" << ov::test::utils::vec2str(inputShape.second);
+    auto shape_str = ov::test::utils::vec2str(inputShape.second);
+    std::replace(shape_str.begin(), shape_str.end(), ',', '.');
+    os << ov::test::utils::partialShape2str({inputShape.first}) << "_" << shape_str;
     return os;
 }
 


### PR DESCRIPTION
### Details:
 - *Replace "," to "." in InputShapes ostream insertion op (<<)
 -  As a result, InputShapes will be printed in the tests output as []_([1.16.384.64]) instead of []_([1,16,384,64])*
 - *This is needed to improve developer experience, so the tests output will be displayed correctly in IDEs.*
 - *This is an example on how tests output is displayed now in Clion IDE:*
 ![before](https://github.com/user-attachments/assets/4c400c1f-b5fb-4ae2-8e16-3b68fb1fdc55)
 - *This is how tests output will be displayed after the proposed changes:*
 ![after](https://github.com/user-attachments/assets/98872b20-b8e9-43aa-8407-ee47b48c44cd)



### Tickets:
 - *-*
