### PR TITLE
[NPU] Adding support for the remote tensor feature - [Part II - leftovers]

### DIFF
--- a/src/plugins/intel_npu/src/al/include/npu.hpp
+++ b/src/plugins/intel_npu/src/al/include/npu.hpp
@@ -92,6 +92,11 @@ public:
         ov::intel_npu::MemType mem_type = ov::intel_npu::MemType::L0_INTERNAL_BUF,
         void* mem = nullptr);
 
+    virtual ov::SoPtr<ov::ITensor> createHostTensor(std::shared_ptr<ov::IRemoteContext> context,
+                                                    const ov::element::Type& element_type,
+                                                    const ov::Shape& shape,
+                                                    const Config& config);
+
 protected:
     virtual ~IDevice() = default;
 };

--- a/src/plugins/intel_npu/src/al/src/npu.cpp
+++ b/src/plugins/intel_npu/src/al/src/npu.cpp
@@ -81,4 +81,11 @@ ov::SoPtr<ov::IRemoteTensor> IDevice::createRemoteTensor(std::shared_ptr<ov::IRe
     OPENVINO_THROW("Create Remote Tensor is not supported");
 }
 
+ov::SoPtr<ov::ITensor> IDevice::createHostTensor(std::shared_ptr<ov::IRemoteContext>,
+                                                 const ov::element::Type&,
+                                                 const ov::Shape&,
+                                                 const Config&) {
+    OPENVINO_THROW("Create Host Tensor is not supported");
+}
+
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_device.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_device.hpp
@@ -47,6 +47,11 @@ public:
         ov::intel_npu::MemType mem_type = ov::intel_npu::MemType::L0_INTERNAL_BUF,
         void* mem = nullptr) override;
 
+    ov::SoPtr<ov::ITensor> createHostTensor(std::shared_ptr<ov::IRemoteContext> context,
+                                            const ov::element::Type& element_type,
+                                            const ov::Shape& shape,
+                                            const Config& config) override;
+
     ZeroDevice& operator=(const ZeroDevice&) = delete;
     ZeroDevice(const ZeroDevice&) = delete;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_host_tensor.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_host_tensor.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "intel_npu/al/config/config.hpp"
+#include "openvino/runtime/itensor.hpp"
+#include "zero_init.hpp"
+#include "zero_remote_tensor.hpp"
+
+namespace intel_npu {
+
+class ZeroHostTensor : public ov::ITensor {
+public:
+    ZeroHostTensor(std::shared_ptr<ov::IRemoteContext> context,
+                   std::shared_ptr<ZeroInitStructsHolder> init_structs,
+                   const ov::element::Type element_type,
+                   const ov::Shape& shape,
+                   const Config& config);
+
+    ~ZeroHostTensor() override = default;
+
+    void* data(const ov::element::Type& element_type) const override;
+    const ov::element::Type& get_element_type() const override;
+
+    const ov::Shape& get_shape() const override;
+
+    const ov::Strides& get_strides() const override;
+
+    void set_shape(ov::Shape new_shape) override;
+
+    std::shared_ptr<ZeroRemoteTensor> get_impl() const;
+
+private:
+    std::shared_ptr<ZeroRemoteTensor> m_impl;
+};
+
+}  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -53,8 +53,9 @@ private:
      * @brief Check the received remote tensor and copy it to the Level Zero tensor
      * @param tensor Reference to a tensor.
      * @param name Friendly name of the tensor.
+     * @param isParameter True if tensor is a parameter.
      */
-    void set_remote_tensor_data(std::shared_ptr<ZeroRemoteTensor> tensor, const std::string& name);
+    void set_remote_tensor_data(std::shared_ptr<ZeroRemoteTensor> tensor, const std::string& name, bool isParameter);
 
     void check_network_precision(const ov::element::Type_t precision) const override;
     void create_pipeline();
@@ -77,8 +78,7 @@ private:
     // specific operations on the plugin in this case.
     size_t _batchSize = DEFAULT_BATCH_SIZE;
 
-    bool _createPipeline = true;
-    bool _updateCommandList = false;
+    bool _pipelineIsCreated = false;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -16,7 +16,6 @@ struct TensorData {
     void* mem;
     size_t size;
     bool levelZeroTensorCreatedLocally = true;
-    bool changed = false;
 };
 
 struct Pipeline {
@@ -32,7 +31,7 @@ public:
     virtual void pull(size_t batch_index) = 0;
     virtual void reset(size_t batch_index) const = 0;
 
-    virtual void updateCommandList(std::unordered_map<std::string, TensorData>& tensors_data, size_t batch_size) = 0;
+    virtual void updateCommandList(const TensorData& tensors_data, uint32_t index, size_t batch_size) = 0;
 
 protected:
     zeroMemory::MemoryManagementUnit _deviceInputs;

--- a/src/plugins/intel_npu/src/backend/include/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_wrappers.hpp
@@ -87,7 +87,7 @@ public:
     void appendGraphInitialize(const ze_graph_handle_t& graph_handle) const;
     void appendGraphExecute(const ze_graph_handle_t& graph_handle,
                             const ze_graph_profiling_query_handle_t& profiling_query_handle) const;
-    void updateMutableCommandList(const void* pNext = nullptr) const;
+    void updateMutableCommandList(uint32_t arg_index, const void* arg_value) const;
     void appendNpuTimestamp(uint64_t* timestamp_buff) const;
     void appendBarrier() const;
     void close() const;
@@ -95,9 +95,6 @@ public:
 
     inline ze_command_list_handle_t handle() const {
         return _handle;
-    }
-    uint64_t getCommandListId() const {
-        return _command_id;
     }
 
 private:

--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -9,6 +9,7 @@
 #include "intel_npu/al/itt.hpp"
 #include "intel_npu/utils/zero/zero_api.hpp"
 #include "zero_executor.hpp"
+#include "zero_host_tensor.hpp"
 #include "zero_infer_request.hpp"
 #include "zero_remote_tensor.hpp"
 #include "zero_utils.hpp"
@@ -192,4 +193,11 @@ ov::SoPtr<ov::IRemoteTensor> ZeroDevice::createRemoteTensor(std::shared_ptr<ov::
                                                             void* mem) {
     return {std::make_shared<
         ZeroRemoteTensor>(context, _initStructs, element_type, shape, config, tensor_type, mem_type, mem)};
+};
+
+ov::SoPtr<ov::ITensor> ZeroDevice::createHostTensor(std::shared_ptr<ov::IRemoteContext> context,
+                                                    const ov::element::Type& element_type,
+                                                    const ov::Shape& shape,
+                                                    const Config& config) {
+    return {std::make_shared<ZeroHostTensor>(context, _initStructs, element_type, shape, config)};
 };

--- a/src/plugins/intel_npu/src/backend/src/zero_host_tensor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_host_tensor.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "zero_host_tensor.hpp"
+
+#include "openvino/runtime/intel_npu/remote_properties.hpp"
+
+namespace intel_npu {
+
+ZeroHostTensor::ZeroHostTensor(std::shared_ptr<ov::IRemoteContext> context,
+                               std::shared_ptr<ZeroInitStructsHolder> init_structs,
+                               const ov::element::Type element_type,
+                               const ov::Shape& shape,
+                               const Config& config)
+    : m_impl(std::make_shared<ZeroRemoteTensor>(context,
+                                                init_structs,
+                                                element_type,
+                                                shape,
+                                                config,
+                                                ov::intel_npu::TensorType::BINDED,
+                                                ov::intel_npu::MemType::L0_INTERNAL_BUF)) {}
+
+void* ZeroHostTensor::data(const ov::element::Type&) const {
+    return m_impl->get_properties().find(ov::intel_npu::mem_handle.name())->second.as<void*>();
+}
+
+const ov::element::Type& ZeroHostTensor::get_element_type() const {
+    return m_impl->get_element_type();
+}
+
+const ov::Shape& ZeroHostTensor::get_shape() const {
+    return m_impl->get_shape();
+}
+
+const ov::Strides& ZeroHostTensor::get_strides() const {
+    return m_impl->get_strides();
+}
+
+void ZeroHostTensor::set_shape(ov::Shape new_shape) {
+    m_impl->set_shape(new_shape);
+}
+
+std::shared_ptr<ZeroRemoteTensor> ZeroHostTensor::get_impl() const {
+    return m_impl;
+}
+
+}  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -275,59 +275,33 @@ public:
     };
 
     void updateCommandList(std::unordered_map<std::string, TensorData>& tensors_data, size_t batch_size) override {
-        std::vector<ze_mutable_graph_argument_exp_desc_t> mutable_argument_desc;
-        int32_t changed_tensors = 0;
-
-        for (const auto& desc : tensors_data) {
-            if (desc.second.changed == true) {
-                changed_tensors++;
-            }
-        }
-
-        mutable_argument_desc.reserve(changed_tensors);
-
-        auto set_mutable_desc =
-            [&](int32_t mutable_desc_index, uint64_t command_list_id, uint32_t arg_index, const void* arg_value) {
-                mutable_argument_desc.emplace_back(ze_mutable_graph_argument_exp_desc_t{
-                    ZE_STRUCTURE_TYPE_MUTABLE_GRAPH_ARGUMENT_EXP_DESC,
-                    mutable_desc_index ? &mutable_argument_desc.at(mutable_desc_index - 1) : nullptr,
-                    command_list_id,
-                    arg_index,
-                    arg_value});
-            };
-
         for (size_t i = 0; i < batch_size; i++) {
-            int32_t mutable_argument_desc_index = -1;
-
             for (const auto& desc : _executor->inputs_desc_map()) {
                 TensorData& inputTensorData = tensors_data.at(desc.first);
-
                 if (inputTensorData.changed == true) {
-                    set_mutable_desc(
-                        ++mutable_argument_desc_index,
-                        _command_lists.at(i)->getCommandListId(),
+                    _command_lists.at(i)->updateMutableCommandList(
                         desc.second.idx,
                         static_cast<unsigned char*>(inputTensorData.mem) + (i * inputTensorData.size) / batch_size);
 
-                    inputTensorData.changed = false;
+                    if (i == batch_size - 1) {
+                        inputTensorData.changed = false;
+                    }
                 }
             }
 
             for (const auto& desc : _executor->outputs_desc_map()) {
                 TensorData& outputTensorData = tensors_data.at(desc.first);
-
                 if (outputTensorData.changed == true) {
-                    set_mutable_desc(
-                        ++mutable_argument_desc_index,
-                        _command_lists.at(i)->getCommandListId(),
+                    _command_lists.at(i)->updateMutableCommandList(
                         desc.second.idx,
                         static_cast<unsigned char*>(outputTensorData.mem) + (i * outputTensorData.size) / batch_size);
 
-                    outputTensorData.changed = false;
+                    if (i == batch_size - 1) {
+                        outputTensorData.changed = false;
+                    }
                 }
             }
 
-            _command_lists.at(i)->updateMutableCommandList(&mutable_argument_desc.at(mutable_argument_desc_index));
             _command_lists.at(i)->close();
         }
     };

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -143,7 +143,7 @@ public:
         }
     };
 
-    void updateCommandList(std::unordered_map<std::string, TensorData>&, size_t) override{};
+    void updateCommandList(const TensorData&, uint32_t, size_t) override {}
 
 private:
     const Config _config;
@@ -274,34 +274,11 @@ public:
         _logger.debug("IntegratedPipeline - rest() completed");
     };
 
-    void updateCommandList(std::unordered_map<std::string, TensorData>& tensors_data, size_t batch_size) override {
+    void updateCommandList(const TensorData& tensors_data, uint32_t index, size_t batch_size) override {
         for (size_t i = 0; i < batch_size; i++) {
-            for (const auto& desc : _executor->inputs_desc_map()) {
-                TensorData& inputTensorData = tensors_data.at(desc.first);
-                if (inputTensorData.changed == true) {
-                    _command_lists.at(i)->updateMutableCommandList(
-                        desc.second.idx,
-                        static_cast<unsigned char*>(inputTensorData.mem) + (i * inputTensorData.size) / batch_size);
-
-                    if (i == batch_size - 1) {
-                        inputTensorData.changed = false;
-                    }
-                }
-            }
-
-            for (const auto& desc : _executor->outputs_desc_map()) {
-                TensorData& outputTensorData = tensors_data.at(desc.first);
-                if (outputTensorData.changed == true) {
-                    _command_lists.at(i)->updateMutableCommandList(
-                        desc.second.idx,
-                        static_cast<unsigned char*>(outputTensorData.mem) + (i * outputTensorData.size) / batch_size);
-
-                    if (i == batch_size - 1) {
-                        outputTensorData.changed = false;
-                    }
-                }
-            }
-
+            _command_lists.at(i)->updateMutableCommandList(
+                index,
+                static_cast<unsigned char*>(tensors_data.mem) + (i * tensors_data.size) / batch_size);
             _command_lists.at(i)->close();
         }
     };

--- a/src/plugins/intel_npu/src/backend/src/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_wrappers.cpp
@@ -115,10 +115,9 @@ CommandList::~CommandList() {
     }
 }
 void CommandList::updateMutableCommandList(const void* pNext) const {
-    ze_mutable_commands_exp_desc_t mutable_commands_exp_desc_t = {
-        static_cast<ze_structure_type_t>(ZE_MUTABLE_COMMAND_EXP_FLAG_GRAPH_ARGUMENT),
-        pNext,
-        0};
+    ze_mutable_commands_exp_desc_t mutable_commands_exp_desc_t = {ZE_STRUCTURE_TYPE_MUTABLE_COMMANDS_EXP_DESC,
+                                                                  pNext,
+                                                                  0};
 
     zeroUtils::throwOnFail("zeCommandListUpdateMutableCommandsExp",
                            zeCommandListUpdateMutableCommandsExp(_handle, &mutable_commands_exp_desc_t));

--- a/src/plugins/intel_npu/src/backend/src/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_wrappers.cpp
@@ -114,9 +114,15 @@ CommandList::~CommandList() {
         _log.error("zeCommandListDestroy failed %#X", uint64_t(result));
     }
 }
-void CommandList::updateMutableCommandList(const void* pNext) const {
+void CommandList::updateMutableCommandList(uint32_t arg_index, const void* arg_value) const {
+    ze_mutable_graph_argument_exp_desc_t desc = {ZE_STRUCTURE_TYPE_MUTABLE_GRAPH_ARGUMENT_EXP_DESC,
+                                                 nullptr,
+                                                 _command_id,
+                                                 arg_index,
+                                                 arg_value};
+
     ze_mutable_commands_exp_desc_t mutable_commands_exp_desc_t = {ZE_STRUCTURE_TYPE_MUTABLE_COMMANDS_EXP_DESC,
-                                                                  pNext,
+                                                                  &desc,
                                                                   0};
 
     zeroUtils::throwOnFail("zeCommandListUpdateMutableCommandsExp",

--- a/src/plugins/intel_npu/src/plugin/include/remote_context.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/remote_context.hpp
@@ -43,6 +43,14 @@ public:
                                                const ov::Shape& shape,
                                                const ov::AnyMap& params) override;
 
+    /**
+     * @brief This method is used to create a host tensor object friendly for the device in current context.
+     * @param type Tensor element type.
+     * @param shape Tensor shape.
+     * @return A tensor instance with device friendly memory.
+     */
+    ov::SoPtr<ov::ITensor> create_host_tensor(const ov::element::Type type, const ov::Shape& shape) override;
+
 private:
     std::shared_ptr<ov::IRemoteContext> get_this_shared_ptr();
 

--- a/src/plugins/intel_npu/src/plugin/src/remote_context.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/remote_context.cpp
@@ -84,6 +84,15 @@ ov::SoPtr<ov::IRemoteTensor> RemoteContextImpl::create_tensor(const ov::element:
                                       mem_handle_object);
 }
 
+ov::SoPtr<ov::ITensor> RemoteContextImpl::create_host_tensor(const ov::element::Type type, const ov::Shape& shape) {
+    auto device = _backends->getDevice(_config.get<DEVICE_ID>());
+    if (device == nullptr) {
+        OPENVINO_THROW("Device is not available");
+    }
+
+    return device->createHostTensor(get_this_shared_ptr(), type, shape, _config);
+}
+
 const std::string& RemoteContextImpl::get_device_name() const {
     return _device_name;
 }

--- a/src/plugins/intel_npu/tests/functional/behavior/remote_tensor_tests/remote_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/remote_tensor_tests/remote_run.hpp
@@ -318,6 +318,42 @@ TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensors3) {
     EXPECT_EQ(memcmp(first_output.data(), second_output, first_output.get_byte_size()), 0);
 }
 
+TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensorsHostTensor) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    ov::InferRequest inference_request;
+    ov::Tensor first_output;
+
+    auto context = core->get_default_context(target_device).as<ov::intel_npu::level_zero::ZeroContext>();
+
+    OV_ASSERT_NO_THROW(compiled_model = core->compile_model(ov_model, target_device, configuration));
+    OV_ASSERT_NO_THROW(inference_request = compiled_model.create_infer_request());
+    auto tensor = inference_request.get_input_tensor();
+    memset(tensor.data(), 99, tensor.get_byte_size());
+    OV_ASSERT_NO_THROW(inference_request.infer());
+    first_output = inference_request.get_output_tensor(0);
+
+    auto input_tensor = inference_request.get_input_tensor();
+    auto output_tensor = inference_request.get_output_tensor();
+    const auto byte_size = input_tensor.get_byte_size();
+    auto input_shape = input_tensor.get_shape();
+    auto output_shape = output_tensor.get_shape();
+    input_tensor = {};
+    output_tensor = {};
+
+    auto l0_host_input_tensor = context.create_host_tensor(ov::element::f32, input_shape);
+    auto l0_host_output_tensor = context.create_host_tensor(ov::element::f32, output_shape);
+
+    memset(l0_host_input_tensor.data(), 99, byte_size);
+    OV_ASSERT_NO_THROW(inference_request.set_input_tensor(l0_host_input_tensor));
+    OV_ASSERT_NO_THROW(inference_request.set_output_tensor(l0_host_output_tensor));
+    OV_ASSERT_NO_THROW(inference_request.infer());
+
+    EXPECT_NE(first_output.data(), l0_host_output_tensor.data());
+    EXPECT_EQ(memcmp(first_output.data(), l0_host_output_tensor.data(), first_output.get_byte_size()), 0);
+}
+
 }  // namespace behavior
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_npu/tests/functional/behavior/remote_tensor_tests/remote_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/remote_tensor_tests/remote_run.hpp
@@ -128,7 +128,7 @@ TEST_P(RemoteRunTests, CheckRemoteTensorInternalBufChangingTensors) {
 
     // set output remote tensor
     auto remote_output_tensor = inference_request.get_output_tensor();
-    auto output_remote_tensor = context.create_l0_host_tensor(ov::element::f32, remote_output_tensor.get_shape());
+    auto output_remote_tensor = context.create_tensor(ov::element::f32, remote_output_tensor.get_shape());
     remote_output_tensor = {};
 
     OV_ASSERT_NO_THROW(inference_request.set_output_tensor(output_remote_tensor));
@@ -202,8 +202,7 @@ TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensors1) {
 
         auto remote_input_tensor =
             context.create_l0_host_tensor(ov::element::f32, input_shape, ov::intel_npu::TensorType::INPUT);
-        remote_output_tensor = context.create_l0_host_tensor(ov::element::f32, output_shape)
-                                   .as<ov::intel_npu::level_zero::ZeroBufferTensor>();
+        remote_output_tensor = context.create_l0_host_tensor(ov::element::f32, output_shape);
 
         memset(remote_input_tensor.get(), 99, byte_size);
         OV_ASSERT_NO_THROW(inference_request.set_input_tensor(remote_input_tensor));
@@ -305,8 +304,7 @@ TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensors3) {
 
     auto remote_input_tensor =
         context.create_l0_host_tensor(ov::element::f32, input_shape, ov::intel_npu::TensorType::INPUT);
-    auto remote_output_tensor =
-        context.create_l0_host_tensor(ov::element::f32, output_shape).as<ov::intel_npu::level_zero::ZeroBufferTensor>();
+    auto remote_output_tensor = context.create_l0_host_tensor(ov::element::f32, output_shape);
 
     memset(remote_input_tensor.get(), 99, byte_size);
     OV_ASSERT_NO_THROW(inference_request.set_input_tensor(remote_input_tensor));

--- a/src/plugins/intel_npu/tests/functional/behavior/remote_tensor_tests/remote_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/remote_tensor_tests/remote_run.hpp
@@ -316,7 +316,7 @@ TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensors3) {
     EXPECT_EQ(memcmp(first_output.data(), second_output, first_output.get_byte_size()), 0);
 }
 
-TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensorsHostTensor) {
+TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensorsHostTensor1) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
@@ -330,8 +330,30 @@ TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensorsHostTensor) {
     auto tensor = inference_request.get_input_tensor();
     memset(tensor.data(), 99, tensor.get_byte_size());
     OV_ASSERT_NO_THROW(inference_request.infer());
-    first_output = inference_request.get_output_tensor(0);
+    first_output = inference_request.get_output_tensor();
 
+    auto l0_host_input_tensor = context.create_host_tensor(ov::element::f32, tensor.get_shape());
+    auto l0_host_output_tensor = context.create_host_tensor(ov::element::f32, first_output.get_shape());
+
+    memset(l0_host_input_tensor.data(), 99, tensor.get_byte_size());
+    OV_ASSERT_NO_THROW(inference_request.set_input_tensor(l0_host_input_tensor));
+    OV_ASSERT_NO_THROW(inference_request.set_output_tensor(l0_host_output_tensor));
+    OV_ASSERT_NO_THROW(inference_request.infer());
+
+    EXPECT_NE(first_output.data(), l0_host_output_tensor.data());
+    EXPECT_EQ(memcmp(first_output.data(), l0_host_output_tensor.data(), first_output.get_byte_size()), 0);
+}
+
+TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensorsHostTensor2) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    ov::InferRequest inference_request;
+
+    auto context = core->get_default_context(target_device).as<ov::intel_npu::level_zero::ZeroContext>();
+
+    OV_ASSERT_NO_THROW(compiled_model = core->compile_model(ov_model, target_device, configuration));
+    OV_ASSERT_NO_THROW(inference_request = compiled_model.create_infer_request());
     auto input_tensor = inference_request.get_input_tensor();
     auto output_tensor = inference_request.get_output_tensor();
     const auto byte_size = input_tensor.get_byte_size();
@@ -339,6 +361,15 @@ TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensorsHostTensor) {
     auto output_shape = output_tensor.get_shape();
     input_tensor = {};
     output_tensor = {};
+
+    auto remote_input_tensor =
+        context.create_l0_host_tensor(ov::element::f32, input_shape, ov::intel_npu::TensorType::INPUT);
+    auto remote_output_tensor =
+        context.create_l0_host_tensor(ov::element::f32, output_shape, ov::intel_npu::TensorType::INPUT);
+    memset(remote_input_tensor.get(), 1, byte_size);
+    OV_ASSERT_NO_THROW(inference_request.set_input_tensor(remote_input_tensor));
+    OV_ASSERT_NO_THROW(inference_request.set_output_tensor(remote_output_tensor));
+    OV_ASSERT_NO_THROW(inference_request.infer());
 
     auto l0_host_input_tensor = context.create_host_tensor(ov::element::f32, input_shape);
     auto l0_host_output_tensor = context.create_host_tensor(ov::element::f32, output_shape);
@@ -348,8 +379,9 @@ TEST_P(RemoteRunTests, CheckOutputDataFromTwoRunsInOutRemoteTensorsHostTensor) {
     OV_ASSERT_NO_THROW(inference_request.set_output_tensor(l0_host_output_tensor));
     OV_ASSERT_NO_THROW(inference_request.infer());
 
-    EXPECT_NE(first_output.data(), l0_host_output_tensor.data());
-    EXPECT_EQ(memcmp(first_output.data(), l0_host_output_tensor.data(), first_output.get_byte_size()), 0);
+    EXPECT_NE(remote_output_tensor.get(), l0_host_output_tensor.data());
+    EXPECT_NE(memcmp(remote_output_tensor.get(), l0_host_output_tensor.data(), remote_output_tensor.get_byte_size()),
+              0);
 }
 
 }  // namespace behavior


### PR DESCRIPTION
### Details:
 - *Allocate a Host L0 buffer when the create host tensor method is used*
 - *Do not chain the mutable descriptor, call the update mutable command list after each descriptor instead*
 - *Do not throw an error if using an older ze_loader only if the unsupported functions are going to be called*
 - *Call updateMutableCommandList after set_tensor method is used*
 - *Add extra test cases for batching flow using MCL*


### Tickets:
 - *EISW-131915*
