### PR TITLE
1. Align cpu execution order before/after ResolveComplexInplaceConfli…

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -343,6 +343,8 @@ void Graph::InitGraph(bool optimize) {
     optimizer.ShareReorders(*this);
     RemoveDroppedNodes();
 
+    SortTopologically();
+
     ResolveComplexInplaceConflicts();
 
     optimizer.ApplyImplSpecificGraphOptimizations(*this);

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1539,6 +1539,23 @@ void Graph::SortTopologically() {
     };
 
     graphNodes = sort(graphNodes);
+
+    // Sort in / out child edges by port index
+    // Make first N (N == port_num) edge indexes match with port index
+    for (auto &node : graphNodes) {
+        int port_num = node->outputShapes.size();
+        std::vector<EdgePtr> res(port_num);
+
+        for (size_t i = 0; i < node->childEdges.size(); i++) {
+            auto edge = node->getChildEdgeAt(i);
+            int port = edge->getInputNum();
+            if (port < port_num && !res[port])
+                res[port] = edge;
+            else
+                res.push_back(edge);
+        }
+        node->childEdges = {res.begin(), res.end()};
+    }
 }
 
 void Graph::GetPerfData(std::vector<ov::ProfilingInfo>& perfMap) const {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1476,37 +1476,58 @@ void Graph::Infer(SyncInferRequest* request) {
 void Graph::SortTopologically() {
     OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "Graph::SortTopologically");
 
+    for (auto &node : graphNodes) {
+        // Sort in / out Parent edges by port index
+        // Make first N (N == port_num) edge indexes match with port index
+        int port_num = node->inputShapes.size();
+        std::vector<EdgePtr> res(port_num);
+        for (size_t i = 0; i < node->parentEdges.size(); i++) {
+            auto edge = node->getParentEdgeAt(i);
+            int port = edge->getOutputNum();
+            if (port < port_num && !res[port])
+                res[port] = edge;
+            else
+                res.push_back(edge);
+        }
+        node->parentEdges = {res.begin(), res.end()};
+
+        // Set execIndex of all nodes to default invaild value
+        node->execIndex = -1;
+    }
+
     auto sort = [](const std::vector<NodePtr>& nodes) {
-        std::unordered_set<NodePtr> visited;
-        visited.reserve(nodes.size());
         std::vector<NodePtr> sorted;
         sorted.reserve(nodes.size());
 
+        int execIndexCnt = -1;
+
         std::function<void(const NodePtr)> visit;
-        visit = [&visited, &sorted, &visit](const NodePtr node) {
-            const bool inserted = visited.insert(node).second;
-            if (!inserted)
+        visit = [&execIndexCnt, &sorted, &visit](const NodePtr node) {
+            if (node->execIndex >= 0)
                 return; // already visited
 
             if (!node->parallelWith.empty()) {
                 for (auto& n : node->parallelWith) {
-                    for (size_t i = 0; i < n->getChildEdges().size(); i++) {
-                        visit(n->getChildEdgeAt(i)->getChild());
+                    for (size_t i = 0; i < n->getParentEdges().size(); i++) {
+                        visit(n->getParentEdgeAt(i)->getParent());
                     }
                 }
 
-                // make sure parallel nodes are always enqueue together
+                // parallel nodes has same execIndex
+                // so they can provide correct start/end time point for
+                // their input and output memory object
+                ++execIndexCnt;
                 for (auto& n : node->parallelWith) {
-                    if (std::find(sorted.begin(), sorted.end(), n) == sorted.end()) {
-                        sorted.push_back(n);
-                    }
+                    sorted.push_back(n);
+                    n->execIndex = execIndexCnt;
                 }
             } else {
-                for (size_t i = 0; i < node->getChildEdges().size(); i++) {
-                    visit(node->getChildEdgeAt(i)->getChild());
+                for (size_t i = 0; i < node->getParentEdges().size(); i++) {
+                    visit(node->getParentEdgeAt(i)->getParent());
                 }
 
                 sorted.push_back(node);
+                node->execIndex = ++execIndexCnt;
             }
         };
 
@@ -1517,42 +1538,7 @@ void Graph::SortTopologically() {
         return sorted;
     };
 
-    // as a first step sort in reversed topological order to avoid an insertion into the front of the vector
     graphNodes = sort(graphNodes);
-    // reverse to the actual topological order
-    std::reverse(graphNodes.begin(), graphNodes.end());
-    // number the nodes based on topological order
-    for (size_t i = 0; i < graphNodes.size(); i++) {
-        // parallel nodes has same execIndex
-        // so they can provide correct start/end time point for
-        // their input and output memory object
-        if (graphNodes[i]->parallelWith.size()) {
-            if (graphNodes[i]->parallelWith[0] == graphNodes[i]) {
-                for (auto& n : graphNodes[i]->parallelWith) {
-                    n->execIndex = static_cast<int>(i);
-                }
-            }
-            continue;
-        }
-        graphNodes[i]->execIndex = static_cast<int>(i);
-    }
-
-    // Sort in / out child edges by port index
-    // Make first N (N == port_num) edge indexes match with port index
-    for (auto &node : graphNodes) {
-        int port_num = node->outputShapes.size();
-        std::vector<EdgePtr> res(port_num);
-
-        for (size_t i = 0; i < node->childEdges.size(); i++) {
-            auto edge = node->getChildEdgeAt(i);
-            int port = edge->getInputNum();
-            if (port < port_num && !res[port])
-                res[port] = edge;
-            else
-                res.push_back(edge);
-        }
-        node->childEdges = {res.begin(), res.end()};
-    }
 }
 
 void Graph::GetPerfData(std::vector<ov::ProfilingInfo>& perfMap) const {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1476,17 +1476,8 @@ void Graph::Infer(SyncInferRequest* request) {
 void Graph::SortTopologically() {
     OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "Graph::SortTopologically");
 
+    // Set execIndex of all nodes to default invaild value
     for (auto &node : graphNodes) {
-        // Sort in / out Parent edges by port index
-        // Make first N (N == port_num) edge indexes match with port index
-       std::sort(node->parentEdges.begin(), node->parentEdges.end(), [](const EdgeWeakPtr& lhs, const EdgeWeakPtr& rhs) {
-           auto lhs_ptr = lhs.lock();
-           auto rhs_ptr = rhs.lock();
-           OPENVINO_ASSERT(lhs_ptr && rhs_ptr);
-           return lhs_ptr->getOutputNum() < rhs_ptr->getOutputNum();
-        });
-
-        // Set execIndex of all nodes to default invaild value
         node->execIndex = -1;
     }
 

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1479,17 +1479,12 @@ void Graph::SortTopologically() {
     for (auto &node : graphNodes) {
         // Sort in / out Parent edges by port index
         // Make first N (N == port_num) edge indexes match with port index
-        int port_num = node->inputShapes.size();
-        std::vector<EdgePtr> res(port_num);
-        for (size_t i = 0; i < node->parentEdges.size(); i++) {
-            auto edge = node->getParentEdgeAt(i);
-            int port = edge->getOutputNum();
-            if (port < port_num && !res[port])
-                res[port] = edge;
-            else
-                res.push_back(edge);
-        }
-        node->parentEdges = {res.begin(), res.end()};
+       std::sort(node->parentEdges.begin(), node->parentEdges.end(), [](const EdgeWeakPtr& lhs, const EdgeWeakPtr& rhs) {
+           auto lhs_ptr = lhs.lock();
+           auto rhs_ptr = rhs.lock();
+           OPENVINO_ASSERT(lhs_ptr && rhs_ptr);
+           return lhs_ptr->getOutputNum() < rhs_ptr->getOutputNum();
+        });
 
         // Set execIndex of all nodes to default invaild value
         node->execIndex = -1;

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1524,6 +1524,16 @@ void Graph::SortTopologically() {
         return sorted;
     };
 
+    // Insert nodes in outputNodesMap in front of graphNodes to make sure it always
+    // start tranverse from outputs
+    graphNodes.erase(std::remove_if(graphNodes.begin(), graphNodes.end(), [](const NodePtr node){
+        return node->getTypeStr().compare("Result") == 0;
+    }), graphNodes.end());
+
+    for (auto&& kvp : outputNodesMap) {
+        graphNodes.insert(graphNodes.begin(), kvp.second);
+    }
+
     graphNodes = sort(graphNodes);
 
     // Sort in / out child edges by port index

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1526,8 +1526,12 @@ void Graph::SortTopologically() {
 
     // Insert nodes in outputNodesMap in front of graphNodes to make sure it always
     // start tranverse from outputs
-    graphNodes.erase(std::remove_if(graphNodes.begin(), graphNodes.end(), [](const NodePtr node){
-        return node->getTypeStr().compare("Result") == 0;
+    graphNodes.erase(std::remove_if(graphNodes.begin(), graphNodes.end(), [&](const NodePtr node){
+        //return node->getTypeStr().compare("Result") == 0;
+        auto it = std::find_if(outputNodesMap.begin(), outputNodesMap.end(), [&](const std::pair<std::size_t, NodePtr>& kvp) {
+            return kvp.second == node;
+        });
+        return it != outputNodesMap.end();
     }), graphNodes.end());
 
     for (auto&& kvp : outputNodesMap) {
@@ -1540,6 +1544,7 @@ void Graph::SortTopologically() {
     // Make first N (N == port_num) edge indexes match with port index
     for (auto &node : graphNodes) {
         int port_num = node->outputShapes.size();
+
         std::vector<EdgePtr> res(port_num);
 
         for (size_t i = 0; i < node->childEdges.size(); i++) {

--- a/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
@@ -8,8 +8,13 @@
 #include "nodes/input.h"
 #include "nodes/concat.h"
 #include "openvino/op/concat.hpp"
+#include "openvino/opsets/opset.hpp"
+#include "openvino/op/shape_of.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/result.hpp"
+#include "openvino/op/reduce_prod.hpp"
+#include "openvino/op/scatter_nd_update.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov::intel_cpu;
 
@@ -85,4 +90,46 @@ TEST(ResolveEdgeConflictsCPUTest, smoke_Run_ResolveEdgeConflicts) {
     // Check whether reorder is inserted
     NodePtr expected_reorder = dummyNode2->getParentEdgeAt(0)->getParent();
     ASSERT_EQ(expected_reorder->getType(), Type::Reorder);
+}
+
+TEST(ResolveEdgeConflictsCPUTest2, smoke_Run_ResolveEdgeConflicts2) {
+    /*  create graph:
+                                                    Parameter
+                                                       |
+                                                    ShapeOf      Parameter
+        <*NOTE: Should insert reorder here>         /      \        /
+        <*NOTE: inplaced>               ScatterNDUpdate     ReduceProd
+                                           |                   |
+                                         Result              Result
+    */
+    Config conf;
+    conf.rtCacheCapacity = 100;
+    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+
+    std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
+
+    const ov::element::Type_t testPrec = ov::element::Type_t::f32;
+    const ov::Shape testShape{1, 384};
+    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(testPrec, testShape),
+                               std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::i32, ov::Shape{})};
+    auto org_ShapeOf_386 = std::make_shared<ov::op::v3::ShapeOf>(params[0], ov::element::Type_t::i32);
+
+    auto org_ReduceProd_423 = std::make_shared<ov::op::v1::ReduceProd>(org_ShapeOf_386, params[1]);
+
+    auto org_Constant_387 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1, 1}, std::vector<int64_t>{1});
+    auto org_Constant_1 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1}, std::vector<int64_t>{1});
+    auto org_ScatterNDUpdate_411 = std::make_shared<ov::op::v3::ScatterNDUpdate>(org_ShapeOf_386, org_Constant_387, org_Constant_1);
+
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(org_ReduceProd_423),
+                             std::make_shared<ov::op::v0::Result>(org_ScatterNDUpdate_411)};
+
+    const auto model = std::make_shared<const ov::Model>(results, params, "test_graph");
+    graph->CreateGraph(model, context);
+    for (auto node : graph->GetNodes()) {
+        if (node->getType() == Type::ScatterNDUpdate) {
+            NodePtr expected_reorder = node->getParentEdgeAt(0)->getParent();
+            ASSERT_EQ(expected_reorder->getType(), Type::Reorder);
+            break;
+        }
+    }
 }


### PR DESCRIPTION
### Details:
 - *Align cpu execution order before/after ResolveComplexInplaceConflicts()*
 - *Keep order information of Results and Parameters when dump CPU graph to ov::Model*

### Tickets:
 - *CVS-134638*
