### PR TITLE
[GPU] fixed group_normalization for large group sizes

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/group_normalization_gpu_b_fs_yx_fsv16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/group_normalization_gpu_b_fs_yx_fsv16.cl
@@ -64,11 +64,22 @@ KERNEL(calc_mean_per_group)(
     __global ACCUMULATOR_TYPE* internal_mean
 ) {
     const uint data_idx = get_global_id(0) + get_global_id(1) * get_global_size(0);
-    const uint group_size = get_local_size(0);
+    const uint num_workers = get_local_size(0);
+    const uint group_size = get_global_size(0) / NUM_GROUPS;
+    const uint items_num = group_size / num_workers;
 
-    ACCUMULATOR_TYPE mean = work_group_reduce_add(internal_mean[data_idx]);
-    mean /= TO_ACCUMULATOR_TYPE(group_size);
-    internal_mean[data_idx] = mean;
+    if ((data_idx % group_size) < num_workers) {
+        ACCUMULATOR_TYPE my_sum = ACCUMULATOR_VAL_ZERO;
+        for (uint i = 0; i < items_num; ++i) {
+            my_sum += internal_mean[data_idx + num_workers * i];
+        }
+
+        ACCUMULATOR_TYPE mean = work_group_reduce_add(my_sum);
+        mean /= TO_ACCUMULATOR_TYPE(group_size);
+        for (uint i = 0; i < items_num; ++i) {
+            internal_mean[data_idx + num_workers * i] = mean;
+        }
+    }
 }
 #elif GROUP_NORM_KERNEL_FEATURE_VAR
 REQD_SUB_GROUP_SIZE(SIMD)
@@ -135,12 +146,23 @@ KERNEL(calc_var_per_group)(
     __global ACCUMULATOR_TYPE* internal_variance
 ) {
     const uint data_idx = get_global_id(0) + get_global_id(1) * get_global_size(0);
-    const uint group_size = get_local_size(0);
+    const uint num_workers = get_local_size(0);
+    const uint group_size = get_global_size(0) / NUM_GROUPS;
+    const uint items_num = group_size / num_workers;
 
-    ACCUMULATOR_TYPE variance = work_group_reduce_add(internal_variance[data_idx]);
-    variance /= TO_ACCUMULATOR_TYPE(group_size);
-    variance = native_powr(variance + TO_ACCUMULATOR_TYPE(EPSILON), -0.5f);
-    internal_variance[data_idx] = variance;
+    if ((data_idx % group_size) < num_workers) {
+        ACCUMULATOR_TYPE my_variance = ACCUMULATOR_VAL_ZERO;
+        for (uint i = 0; i < items_num; ++i) {
+            my_variance += internal_variance[data_idx + num_workers * i];
+        }
+
+        ACCUMULATOR_TYPE variance = work_group_reduce_add(my_variance);
+        variance /= TO_ACCUMULATOR_TYPE(group_size);
+        variance = native_powr(variance + TO_ACCUMULATOR_TYPE(EPSILON), -0.5f);
+        for (uint i = 0; i < items_num; ++i) {
+            internal_variance[data_idx + num_workers * i] = variance;
+        }
+    }
 }
 #elif GROUP_NORM_KERNEL_FINAL
 REQD_SUB_GROUP_SIZE(SIMD)

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/group_normalization_gpu_b_fs_yx_fsv16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/group_normalization_gpu_b_fs_yx_fsv16.cl
@@ -14,11 +14,7 @@ KERNEL(calc_mean_per_feature)(
 ) {
     const uint data_set_idx = get_global_id(1);     // batch * feature split
     const uint in_data_set_idx = get_global_id(0);
-    #if IS_DYNAMIC
-        const uint workers_per_dataset = get_local_size(0) / FSV;    // 16 datasets are handled by one local workgroup
-    #else
-        const uint workers_per_dataset = WORKERS_PER_DATASET;
-    #endif
+    const uint workers_per_dataset = LWS0 / FSV;    // 16 datasets are handled by one local workgroup
     const uint data_set_size = INPUT0_SIZE_X * INPUT0_SIZE_Y;
     const uint items_num = data_set_size / workers_per_dataset;
     const uint leftovers = data_set_size - (items_num * workers_per_dataset);
@@ -42,7 +38,7 @@ KERNEL(calc_mean_per_feature)(
     }
 
     mean_per_feature[in_data_set_idx] = mean;
-    const uint num_local_workers = get_local_size(0);
+    const uint num_local_workers = LWS0;
     const uint worker_block_idx = in_data_set_idx / 16;
     uint reduce_add_level = 1;
     while ((SLM_SIZE / SIMD) > reduce_add_level) {
@@ -63,9 +59,9 @@ KERNEL(calc_mean_per_feature)(
 KERNEL(calc_mean_per_group)(
     __global ACCUMULATOR_TYPE* internal_mean
 ) {
-    const uint data_idx = get_global_id(0) + get_global_id(1) * get_global_size(0);
-    const uint num_workers = get_local_size(0);
-    const uint group_size = get_global_size(0) / NUM_GROUPS;
+    const uint data_idx = get_global_id(0) + get_global_id(1) * GWS0;
+    const uint num_workers = LWS0;
+    const uint group_size = GWS0 / NUM_GROUPS;
     const uint items_num = group_size / num_workers;
 
     if ((data_idx % group_size) < num_workers) {
@@ -86,16 +82,12 @@ REQD_SUB_GROUP_SIZE(SIMD)
 KERNEL(calc_var_per_feature)(
     OPTIONAL_SHAPE_INFO_ARG
     const __global INPUT0_TYPE* input,
-    __global ACCUMULATOR_TYPE* internal_mean,
+    const __global ACCUMULATOR_TYPE* internal_mean,
     __global ACCUMULATOR_TYPE* internal_variance
 ) {
     const uint data_set_idx = get_global_id(1);     // batch * feature split
     const uint in_data_set_idx = get_global_id(0);
-    #if IS_DYNAMIC
-        const uint workers_per_dataset = get_local_size(0) / FSV;    // 16 datasets are handled by one local workgroup
-    #else
-        const uint workers_per_dataset = WORKERS_PER_DATASET;
-    #endif
+    const uint workers_per_dataset = LWS0 / FSV;    // 16 datasets are handled by one local workgroup
     const uint data_set_size = INPUT0_SIZE_X * INPUT0_SIZE_Y;
     const uint items_num = data_set_size / workers_per_dataset;
     const uint leftovers = data_set_size - (items_num * workers_per_dataset);
@@ -126,11 +118,12 @@ KERNEL(calc_var_per_feature)(
     }
 
     var_per_feature[in_data_set_idx] = variance;
+    const uint num_local_workers = LWS0;
     const uint worker_block_idx = in_data_set_idx / 16;
     uint reduce_add_level = 1;
     while ((SLM_SIZE / SIMD) > reduce_add_level) {
         barrier(CLK_LOCAL_MEM_FENCE);
-        if (worker_block_idx % (reduce_add_level * 2) == 0) {
+        if (worker_block_idx % (reduce_add_level * 2) == 0 && (in_data_set_idx + SIMD * reduce_add_level) < num_local_workers) {
             var_per_feature[in_data_set_idx] += var_per_feature[in_data_set_idx + SIMD * reduce_add_level];
         }
         reduce_add_level *= 2;
@@ -145,9 +138,9 @@ KERNEL(calc_var_per_feature)(
 KERNEL(calc_var_per_group)(
     __global ACCUMULATOR_TYPE* internal_variance
 ) {
-    const uint data_idx = get_global_id(0) + get_global_id(1) * get_global_size(0);
-    const uint num_workers = get_local_size(0);
-    const uint group_size = get_global_size(0) / NUM_GROUPS;
+    const uint data_idx = get_global_id(0) + get_global_id(1) * GWS0;
+    const uint num_workers = LWS0;
+    const uint group_size = GWS0 / NUM_GROUPS;
     const uint items_num = group_size / num_workers;
 
     if ((data_idx % group_size) < num_workers) {
@@ -175,8 +168,8 @@ KERNEL(group_normalization_b_fs_yx_fsv16)(
 #if HAS_FUSED_OPS_DECLS
     FUSED_OPS_DECLS,
 #endif
-    __global ACCUMULATOR_TYPE* internal_mean,
-    __global ACCUMULATOR_TYPE* internal_variance
+    const __global ACCUMULATOR_TYPE* internal_mean,
+    const __global ACCUMULATOR_TYPE* internal_variance
 ) {
     const uint bf = get_global_id(1) * FSV + get_sub_group_local_id();
     const uint b = bf / OUTPUT_FEATURE_NUM;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_b_fs_yx_fsv16.cpp
@@ -105,8 +105,8 @@ JitConstants GroupNormalizationKernel_b_fs_yx_fsv16::GetJitConstants(const group
     auto jit = GroupNormalizationKernelBase::GetJitConstants(params);
 
     jit.AddConstants({
-        MakeJitConstant("SIMD", 16),
-        MakeJitConstant("FSV", 16),
+        MakeJitConstant("SIMD", simd),
+        MakeJitConstant("FSV", fsv),
     });
 
     if (params.has_dynamic_tensors()) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_b_fs_yx_fsv16.cpp
@@ -102,11 +102,14 @@ JitConstants GroupNormalizationKernel_b_fs_yx_fsv16::GetJitConstants(const group
 
     if (params.has_dynamic_tensors()) {
         jit.AddConstants({
+            MakeJitConstant("GWS0", "get_global_size(0)"),
+            MakeJitConstant("LWS0", "get_local_size(0)"),
             MakeJitConstant("SLM_SIZE", params.engineInfo.maxWorkGroupSize),
         });
     } else {
         jit.AddConstants({
-            MakeJitConstant("WORKERS_PER_DATASET", dispatchData.lws[0] / fsv),
+            MakeJitConstant("GWS0", dispatchData.gws[0]),
+            MakeJitConstant("LWS0", dispatchData.lws[0]),
             MakeJitConstant("SLM_SIZE", dispatchData.lws[0]),
         });
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_bfyx_opt.cpp
@@ -81,17 +81,24 @@ GroupNormalizationKernelBase::MultiDispatchData GroupNormalizationKernelBfyx::Se
         dispatchData.stage_final.gws[1] = input.Feature().v * input.Batch().v;
         dispatchData.stage_final.gws[2] = 1;
 
-        dispatchData.stage_final.lws[0] = 1;
-        dispatchData.stage_final.lws[1] = 1;
+        dispatchData.stage_final.lws[0] = input.X().v * input.Y().v;
+        dispatchData.stage_final.lws[1] = input.Feature().v * input.Batch().v;
         dispatchData.stage_final.lws[2] = 1;
 
-        while ((dispatchData.stage_final.lws[0] * 2) <= params.engineInfo.maxWorkGroupSize &&
-              (dispatchData.stage_final.lws[0] * 2) <= dispatchData.stage_final.gws[0]) {
-            if (dispatchData.stage_final.gws[0] % (dispatchData.stage_final.lws[0] * 2) == 0) {
-                dispatchData.stage_final.lws[0] *= 2;
-            } else {
-                break;
+        divisor = 2;
+        while (dispatchData.stage_final.lws[0] > params.engineInfo.maxWorkGroupSize) {
+            if (dispatchData.stage_final.gws[0] % divisor == 0) {
+                dispatchData.stage_final.lws[0] = dispatchData.stage_final.gws[0] / divisor;
             }
+            divisor += 1;
+        }
+
+        divisor = 2;
+        while ((dispatchData.stage_final.lws[0] * dispatchData.stage_final.lws[1]) > params.engineInfo.maxWorkGroupSize) {
+            if (dispatchData.stage_final.gws[1] % divisor == 0) {
+                dispatchData.stage_final.lws[1] = dispatchData.stage_final.gws[1] / divisor;
+            }
+            divisor += 1;
         }
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_bfyx_opt.cpp
@@ -69,6 +69,14 @@ GroupNormalizationKernelBase::MultiDispatchData GroupNormalizationKernelBfyx::Se
         dispatchData.stage_2.lws[1] = 1;
         dispatchData.stage_2.lws[2] = 1;
 
+        size_t divisor = 2;
+        while (dispatchData.stage_2.lws[0] > params.engineInfo.maxWorkGroupSize) {
+            if ((input.Feature().v / params.num_groups) % divisor == 0) {
+                dispatchData.stage_2.lws[0] = (input.Feature().v / params.num_groups) / divisor;
+            }
+            divisor += 1;
+        }
+
         dispatchData.stage_final.gws[0] = input.X().v * input.Y().v;
         dispatchData.stage_final.gws[1] = input.Feature().v * input.Batch().v;
         dispatchData.stage_final.gws[2] = 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_bfyx_opt.cpp
@@ -105,12 +105,16 @@ JitConstants GroupNormalizationKernelBfyx::GetJitConstants(const group_normaliza
     if (params.has_dynamic_tensors()) {
         jit.AddConstants({
             MakeJitConstant("SLM_SIZE", params.engineInfo.maxWorkGroupSize),
+            MakeJitConstant("GWS0", "get_global_size(0)"),
+            MakeJitConstant("LWS0", "get_local_size(0)"),
+            MakeJitConstant("LWS1", "get_local_size(1)"),
         });
     } else {
         jit.AddConstants({
             MakeJitConstant("SLM_SIZE", (dispatchData.lws[0] * dispatchData.lws[1])),
-            MakeJitConstant("Y_NUM_WORKERS", dispatchData.lws[1]),
-            MakeJitConstant("X_NUM_WORKERS", dispatchData.lws[0]),
+            MakeJitConstant("GWS0", dispatchData.gws[0]),
+            MakeJitConstant("LWS0", dispatchData.lws[0]),
+            MakeJitConstant("LWS1", dispatchData.lws[1]),
         });
     }
     auto activation_dt = GetActivationType(params);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -144,7 +144,7 @@ INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_blocked_layouts_support_4d, GroupNormalizationGPUTest,
     ::testing::Combine(
         ::testing::ValuesIn({std::vector<int32_t>{3, 64, 32, 64}, std::vector<int32_t>{3, 124, 97, 61}, std::vector<int32_t>{1, 1536, 151, 1}, std::vector<int32_t>{1, 12, 2175, 1}}),
-        ::testing::ValuesIn(std::vector<size_t>{1, 4}),
+        ::testing::ValuesIn(std::vector<size_t>{1, 2, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_blocked_4d_formats),
         ::testing::ValuesIn({padding(), padding({0, 16, 0, 0})})));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -121,10 +121,7 @@ const std::vector<cldnn::format> f_planar_4d_formats {
 };
 
 const std::vector<cldnn::format> f_blocked_4d_formats {
-    format::b_fs_yx_fsv2,
-    format::b_fs_yx_fsv4,
     format::b_fs_yx_fsv16,
-    format::b_fs_yx_fsv32,
 };
 
 const std::vector<cldnn::format> f_blocked_5d_formats {
@@ -137,8 +134,8 @@ const std::vector<cldnn::format> f_blocked_5d_formats {
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_planar_layouts_support_4d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::ValuesIn({std::vector<int32_t>{3, 64, 32, 64}, std::vector<int32_t>{3, 124, 97, 61}}),
-        ::testing::Values(4),
+        ::testing::ValuesIn({std::vector<int32_t>{3, 64, 32, 64}, std::vector<int32_t>{3, 124, 97, 61}, std::vector<int32_t>{1, 1536, 151, 1}, std::vector<int32_t>{1, 12, 2175, 1}}),
+        ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_planar_4d_formats),
         ::testing::ValuesIn({padding(), padding({0, 0, 1, 1})})));
@@ -146,8 +143,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_blocked_layouts_support_4d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::ValuesIn({std::vector<int32_t>{3, 64, 32, 64}, std::vector<int32_t>{3, 124, 97, 61}}),
-        ::testing::Values(4),
+        ::testing::ValuesIn({std::vector<int32_t>{3, 64, 32, 64}, std::vector<int32_t>{3, 124, 97, 61}, std::vector<int32_t>{1, 1536, 151, 1}, std::vector<int32_t>{1, 12, 2175, 1}}),
+        ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_blocked_4d_formats),
         ::testing::ValuesIn({padding(), padding({0, 16, 0, 0})})));


### PR DESCRIPTION
### Details:
 - This PR fixes a issue of `group_normalization` for group sizes larger than max local work group size (such as 1024 or 512).

### Tickets:
 - 138954
