### PR TITLE
[GPU] Improve kv cache memory allocation efficiency

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/shape_predictor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/shape_predictor.hpp
@@ -34,25 +34,31 @@ public:
         static_assert(_max_deque_size >= 2, "[GPU] Deque is supposed to contain at least 2 elements for prediction");
     }
 
-
-/// \brief Predicts the next possible shapes sizes based on history collected by previous
-///        predict_preallocation_shape() calls.
-///        This function works in two modes: by default it tries to predict shape for the next
-///        `_next_iters_preallocation_count` iterations, in case if per-iteration buffer size is less than
-///        `_max_per_iter_size` and difference between shapes is less than `_max_per_dim_diff`; the second
-///        operation mode is percentage preallocation - this mode can be configured with
-///        ov::intel_gpu::buffers_preallocation_ratio property, it increases buffer size by
-///        `_buffers_preallocation_ratio` value unconditionally.
-/// \param id Primitive id.
-/// \param layout Primitive's layout on current iteration.
-/// \param can_reuse_buffer Specifies if current memory buffer is enough to store data.
-/// \return The result of shape size prediction as std::pair<bool, ov::Shape>, where the first element
-///         says if shape is successfully predicted and can be preallocated, and the second element is ov::Shape itself.
+    /// \brief Predicts the next possible shapes sizes based on history collected by previous
+    ///        predict_preallocation_shape() calls.
+    ///        This function works in two modes: by default it tries to predict shape for the next
+    ///        `_next_iters_preallocation_count` iterations, in case if per-iteration buffer size is less than
+    ///        `_max_per_iter_size` and difference between shapes is less than `_max_per_dim_diff`; the second
+    ///        operation mode is percentage preallocation - this mode can be configured with
+    ///        ov::intel_gpu::buffers_preallocation_ratio property, it increases buffer size by
+    ///        `_buffers_preallocation_ratio` value unconditionally.
+    /// \param id Primitive id.
+    /// \param layout Primitive's layout on current iteration.
+    /// \param can_reuse_buffer Specifies if current memory buffer is enough to store data.
+    /// \param out_idx output index of multiple outputs
+    /// \param custom_next_iters_prealloc_couunt If it is specified, enforce prealloc size as the specified value
+    /// \param custom_prealloc_dim If both custom_next_iters_prealloc_count and custom_prealloc_dim are specified,
+    ///         increase custom_prealloc_dim with custom_next_iters_prealloc_count without checking shape history (e.g.,
+    ///         used for first inference of kv cache)
+    /// \return The result of shape size prediction as std::pair<bool, ov::Shape>, where
+    ///         the first element says if shape is successfully predicted and can be preallocated, and the second
+    ///         element is ov::Shape itself.
     std::pair<bool, ov::Shape> predict_preallocation_shape(const std::string& id,
                                                            const cldnn::layout& layout,
                                                            bool can_reuse_buffer,
                                                            const size_t out_idx = 0,
-                                                           int32_t next_iters_prealloc_count = -1);
+                                                           int32_t custom_next_iters_prealloc_count = -1,
+                                                           int32_t custom_prealloc_dim = -1);
 
     bool can_preallocate(size_t desired_buffer_size);
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -783,7 +783,7 @@ event::ptr primitive_inst::realloc_if_needed() {
                 GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable " << variable.get_name()
                                        << "'s layout with allocated kv cache output: " << present_layout.to_short_string()
                                        << " (is_set  = " << variable.is_set() << ") " << std::endl;
-                variable.set_layout(present_layout);
+                variable.set_memory(_outputs[0], present_layout);
             }
         } else {
             GPU_DEBUG_TRACE_DETAIL << id() << ": Update variable " << variable.get_name()

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -680,7 +680,7 @@ event::ptr primitive_inst::realloc_if_needed() {
             auto prealloc_shape = updated_layouts[i].get_shape();
             const auto shape_rank = prealloc_shape.size();
             auto seq_axis =
-                desc->concat_axis >= 0 ? desc->concat_axis : shape_rank + desc->concat_axis;
+                static_cast<int32_t>(desc->concat_axis >= 0 ? desc->concat_axis : shape_rank + desc->concat_axis);
             prealloc_shape[seq_axis] += tmp_prealloc_count;
             required_buffer_size = std::accumulate(prealloc_shape.begin(), prealloc_shape.end(), size_t(1), std::multiplies<size_t>());
         } else {
@@ -711,8 +711,8 @@ event::ptr primitive_inst::realloc_if_needed() {
             const auto& desc = _node->as<kv_cache>().get_primitive();
             auto shape_rank = updated_layouts[i].get_shape().size();
             auto seq_axis =
-                desc->concat_axis >= 0 ? desc->concat_axis : shape_rank + desc->concat_axis;
-            prealloc_info = sp.predict_preallocation_shape(id(), updated_layouts[i], can_reuse_buffer, i, tmp_prealloc_count, seq_axis);
+                static_cast<int32_t>(desc->concat_axis >= 0 ? desc->concat_axis : shape_rank + desc->concat_axis);
+            prealloc_info = sp.predict_preallocation_shape(id(), updated_layouts[i], false, i, tmp_prealloc_count, seq_axis);
         } else {
             prealloc_info = sp.predict_preallocation_shape(id(), updated_layouts[i], can_reuse_buffer, i, tmp_prealloc_count);
         }


### PR DESCRIPTION
### Details:
 - Fixed two issues 
 - 1) KV cache was allocating redundant memory when it requires new memory
 - 2) At a new inference, KV cache was setting a padding value as the one used in the previous execution (last token for the previous generation), which caused memory usage inefficiency. 
- After fixing above issues, in some cases, memory is more frequently allocated because 
- 1) switching shape 1024 => 32 : happens reclaiming (previously due to the wrong padding, it is not reclaimed.)
- 2) switching shape 32 => 1024 : new alloc needed at the first infer, but shape history is not tracked yet. So during 3 iteration, it is allocating new memory. 
- Additional fix to resolve above issues: 
- 1) For initial allocation of kv cache, enforce prealloc with custom prealloc count (known value of 128 + id%64) for sequence axis
- 2) For reclaiming kv cache : use prealloc size as the required memory size

Memalloc count with PR
![image](https://github.com/user-attachments/assets/c65b3335-c849-46f8-b9fe-140c3a0fbccb)

### Tickets:
 - 146930
