### PR TITLE
[TRANSFORMATIONS] Fix 'auto' Coverity hits

### DIFF
--- a/src/common/low_precision_transformations/src/convolution.cpp
+++ b/src/common/low_precision_transformations/src/convolution.cpp
@@ -57,7 +57,7 @@ bool ConvolutionTransformation::isQuantizedStatic(const std::shared_ptr<const No
 }
 
 size_t ConvolutionTransformation::getInputChannels(const std::shared_ptr<ov::Node> conv) const {
-    const auto channels = conv->get_input_partial_shape(1)[1];
+    const auto& channels = conv->get_input_partial_shape(1)[1];
     OPENVINO_ASSERT(channels.is_static());
     return channels.get_length();
 }
@@ -287,7 +287,7 @@ bool ConvolutionTransformation::transform(TransformationContext &context, ov::pa
             } else {
                 subtractFromWeights = ov::as_type_ptr<ov::opset1::Subtract>(optimizedSubtract);
 
-                const auto weightsPShape = subtractFromWeights->get_input_partial_shape(0);
+                const auto& weightsPShape = subtractFromWeights->get_input_partial_shape(0);
                 OPENVINO_ASSERT(weightsPShape.is_static());
 
                 const size_t weightsRankValue = weightsPShape.rank().get_length();

--- a/src/common/low_precision_transformations/src/convolution_backprop_data.cpp
+++ b/src/common/low_precision_transformations/src/convolution_backprop_data.cpp
@@ -69,7 +69,7 @@ bool ConvolutionBackpropDataTransformation::isQuantizedStatic(const std::shared_
 }
 
 size_t ConvolutionBackpropDataTransformation::getInputChannels(const std::shared_ptr<ov::Node> conv) const {
-    const auto channels = conv->get_input_partial_shape(1)[0];
+    const auto& channels = conv->get_input_partial_shape(1)[0];
     OPENVINO_ASSERT(channels.is_static());
     return channels.get_length();
 }
@@ -85,7 +85,7 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
                          NetworkHelper::getDequantization(reshapeFromWeights, defaultPrecisions);
         if (dequantization.empty()) {
             const auto fqOnWeights = getFakeQuantizeOnWeights(convolutionBackpropData);
-            auto constantShape = fqOnWeights->input(1).get_partial_shape();
+            const auto& constantShape = fqOnWeights->input(1).get_partial_shape();
             if (constantShape.is_dynamic() || constantShape.rank().is_dynamic()) {
                 return false;
             }
@@ -163,7 +163,7 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
         auto subtractFromWeights = ov::as_type_ptr<ov::opset1::Subtract>(multiplyFromWeights->get_input_node_shared_ptr(0));
 
         {
-            const auto newScalePShape = multiplyFromWeights->get_input_partial_shape(1);
+            const auto& newScalePShape = multiplyFromWeights->get_input_partial_shape(1);
             OPENVINO_ASSERT(newScalePShape.is_static());
             Shape newScaleShape = newScalePShape.to_shape();
 
@@ -194,7 +194,7 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
             } else {
                 subtractFromWeights = ov::as_type_ptr<ov::opset1::Subtract>(optimizedSubtract);
 
-                const auto weightsPShape = subtractFromWeights->get_input_partial_shape(0);
+                const auto& weightsPShape = subtractFromWeights->get_input_partial_shape(0);
                 OPENVINO_ASSERT(weightsPShape.is_static());
 
                 const size_t weightsRankValue = weightsPShape.rank().get_length();

--- a/src/common/low_precision_transformations/src/eliminate_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/eliminate_fake_quantize.cpp
@@ -73,9 +73,15 @@ bool check_interval(const std::shared_ptr<ov::opset1::FakeQuantize>& fq,
             fq->get_input_node_shared_ptr(2),
             fq->get_input_node_shared_ptr(3),
             fq->get_input_node_shared_ptr(4)}));
+        if (!tmp_fq) {
+            return false;
+        }
         auto result = NetworkHelper::fold_fake_quantize(tmp_fq, false);
+        if (!result) {
+            return false;
+        }
         const auto result_constant = as_type_ptr<ov::opset1::Constant>(result);
-        if (result_constant == nullptr) {
+        if (!result_constant) {
             return false;
         }
 

--- a/src/common/low_precision_transformations/src/fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize.cpp
@@ -137,8 +137,8 @@ bool FakeQuantizeTransformation::checkElementwise(const std::shared_ptr<Node>& e
 
     Shape shape = constant->get_shape();
     if (shape_size(shape) != 1ul) {
-        const auto eltwiseInputPShape = eltwise->get_input_partial_shape(0);
-        const auto eltwiseOutputPShape = eltwise->get_output_partial_shape(0);
+        const auto& eltwiseInputPShape = eltwise->get_input_partial_shape(0);
+        const auto& eltwiseOutputPShape = eltwise->get_output_partial_shape(0);
         if (eltwiseInputPShape != eltwiseOutputPShape || eltwiseInputPShape.rank().is_dynamic() || eltwiseOutputPShape.rank().is_dynamic()) {
             return false;
         }

--- a/src/common/low_precision_transformations/src/fake_quantize_decomposition.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize_decomposition.cpp
@@ -283,6 +283,9 @@ bool FakeQuantizeDecompositionTransformation::transform(TransformationContext& c
     }
 
     auto layer = NetworkHelper::fuseConvert(node);
+    if (!layer) {
+        return false;
+    }
     bool rewritten = layer.get() != node.get();
     if (rewritten) {
         register_new_node(layer);

--- a/src/common/low_precision_transformations/src/fake_quantize_dequantization.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize_dequantization.cpp
@@ -117,8 +117,8 @@ bool FakeQuantizeDequantization::checkShape(const std::shared_ptr<ov::Node>& ele
         return true;
     }
 
-    const auto inPShape = elementwise->get_input_partial_shape(branchIndex == 1 ? 0 : 1);
-    const auto outPShape = elementwise->get_output_partial_shape(0);
+    const auto& inPShape = elementwise->get_input_partial_shape(branchIndex == 1 ? 0 : 1);
+    const auto& outPShape = elementwise->get_output_partial_shape(0);
     if (inPShape.rank() != outPShape.rank()) {
         return false;
     }
@@ -154,14 +154,14 @@ bool FakeQuantizeDequantization::checkElementwise(const std::shared_ptr<ov::Node
         return true;
     }
 
-    const auto partialShape = dequantizationElementwise->get_output_partial_shape(0);
+    const auto& partialShape = dequantizationElementwise->get_output_partial_shape(0);
     if (partialShape.rank().is_dynamic()) {
         return false;
     }
 
     auto dimc = channelDimIndex;
 
-    const auto channelsDimension = partialShape[dimc];
+    const auto& channelsDimension = partialShape[dimc];
     if (channelsDimension.is_dynamic()) {
         return false;
     }

--- a/src/common/low_precision_transformations/src/fold_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fold_fake_quantize.cpp
@@ -43,7 +43,7 @@ bool FoldFakeQuantizeTransformation::transform(TransformationContext& context, o
         return false;
     }
 
-    const auto constantShape = fakeQuantize->input(1).get_partial_shape();
+    const auto& constantShape = fakeQuantize->input(1).get_partial_shape();
     if (constantShape.is_dynamic()) {
         return false;
     }

--- a/src/common/low_precision_transformations/src/gather.cpp
+++ b/src/common/low_precision_transformations/src/gather.cpp
@@ -181,7 +181,7 @@ bool GatherTransformation::canBeTransformed(const TransformationContext& context
             const auto indicesConstant = ov::as_type_ptr<opset1::Constant>(operation->get_input_node_shared_ptr(1));
             if (indicesConstant == nullptr)
                 return false;
-            const auto indicesShape = indicesConstant->get_shape();
+            const auto& indicesShape = indicesConstant->get_shape();
             if (indicesShape.size() != 0 && indicesShape.size() != 1) {
                 return false;
             }

--- a/src/common/low_precision_transformations/src/group_convolution.cpp
+++ b/src/common/low_precision_transformations/src/group_convolution.cpp
@@ -54,8 +54,8 @@ bool GroupConvolutionTransformation::isQuantizedStatic(const std::shared_ptr<con
 }
 
 size_t GroupConvolutionTransformation::getInputChannels(const std::shared_ptr<ov::Node> conv) const {
-    const auto groups = conv->get_input_partial_shape(1)[0];
-    const auto channels = conv->get_input_partial_shape(1)[2];
+    const auto& groups = conv->get_input_partial_shape(1)[0];
+    const auto& channels = conv->get_input_partial_shape(1)[2];
     assert(channels.is_static() && groups.is_static());
     return channels.get_length() * groups.get_length();
 }

--- a/src/common/low_precision_transformations/src/interpolate.cpp
+++ b/src/common/low_precision_transformations/src/interpolate.cpp
@@ -77,7 +77,7 @@ bool InterpolateTransformation::isPrecisionPreserved(std::shared_ptr<Node> layer
 
     std::shared_ptr<opset4::Interpolate> interpolate4 = ov::as_type_ptr<opset4::Interpolate>(layer);
     if (interpolate4) {
-        const auto attrs = interpolate4->get_attrs();
+        const auto& attrs = interpolate4->get_attrs();
         return attrs.mode == op::v4::Interpolate::InterpolateMode::NEAREST;
     }
 
@@ -98,7 +98,7 @@ bool InterpolateTransformation::canBeTransformed(const TransformationContext& co
 
     const auto interpolate1 = ov::as_type_ptr<opset1::Interpolate>(layer);
     if (interpolate1) {
-        const auto interpAttrs = interpolate1->get_attrs();
+        const auto& interpAttrs = interpolate1->get_attrs();
         if (interpAttrs.axes.count(0) || interpAttrs.axes.count(1)) {
             return false;
         }

--- a/src/common/low_precision_transformations/src/layer_transformation.cpp
+++ b/src/common/low_precision_transformations/src/layer_transformation.cpp
@@ -427,7 +427,7 @@ bool LayerTransformation::updateOutput(
     std::shared_ptr<ov::Node> lastNode,
     std::shared_ptr<ov::Node> originalNode) const {
     bool was_updated = false;
-    for (auto output : lastNode->outputs()) {
+    for (const auto& output : lastNode->outputs()) {
         for (auto input : output.get_target_inputs()) {
             if (ov::is_type<ov::opset1::Result>(input.get_node())) {
                 const std::string originalName = originalNode->get_friendly_name();

--- a/src/common/low_precision_transformations/src/markup_precisions.cpp
+++ b/src/common/low_precision_transformations/src/markup_precisions.cpp
@@ -173,7 +173,7 @@ bool ov::pass::low_precision::MarkupPrecisions::isPrecisionPreserved(const std::
     if (ov::is_type<opset1::Interpolate>(node)) {
         std::shared_ptr<opset1::Interpolate> interpolate1 = ov::as_type_ptr<opset1::Interpolate>(node);
         if (interpolate1) {
-            const auto attrs = interpolate1->get_attrs();
+            const auto& attrs = interpolate1->get_attrs();
             return attrs.mode == "nearest";
         }
 

--- a/src/common/low_precision_transformations/src/mat_mul.cpp
+++ b/src/common/low_precision_transformations/src/mat_mul.cpp
@@ -56,7 +56,7 @@ bool MatMulTransformation::transform(TransformationContext &context, ov::pass::p
             const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(fakeQuantize);
 
             const auto precisionsAttribute = getAttributeFromOutput<PrecisionsAttribute>(fakeQuantize);
-            const auto precisions = precisionsAttribute.empty() ?
+            const auto& precisions = precisionsAttribute.empty() ?
                 defaultPrecisions :
                 precisionsAttribute.as<PrecisionsAttribute>().value();
             const DataPrecision dataPrecision = getDataPrecision(fakeQuantize, quantizationDetails, precisions);
@@ -97,7 +97,7 @@ bool MatMulTransformation::transform(TransformationContext &context, ov::pass::p
             Shape(dequantization1.subtract->get_output_partial_shape(0).rank().get_length(), 1) :
             dequantization1.subtractConstant->get_shape();
 
-        const auto weightsPShape = newMatMul->get_input_partial_shape(1);
+        const auto& weightsPShape = newMatMul->get_input_partial_shape(1);
         assert(weightsPShape.is_static());
         const auto weightsShape = weightsPShape.to_shape();
 
@@ -145,7 +145,7 @@ bool MatMulTransformation::transform(TransformationContext &context, ov::pass::p
     if (NetworkHelper::isScalarLike(ov::as_type_ptr<ov::opset1::Constant>(mulConst2))) {
         mulConst2 = NetworkHelper::toScalar(ov::as_type_ptr<ov::opset1::Constant>(mulConst2));
     } else {
-        const auto constShape = mulConst2->get_shape();
+        const auto& constShape = mulConst2->get_shape();
         const size_t inputRank = matMul->get_input_partial_shape(0).rank().get_length();
 
         // unsqueeze from the left side to make both shapes of the same rank
@@ -203,8 +203,8 @@ bool MatMulTransformation::canBeTransformed(const TransformationContext& context
         }
 
         if (!NetworkHelper::isScalarLike(dequantization1.multiplyConstant)) {
-            const auto constantShape = dequantization1.multiplyConstant->get_shape();
-            const auto mulShape = dequantization1.multiply->get_output_partial_shape(0);
+            const auto& constantShape = dequantization1.multiplyConstant->get_shape();
+            const auto& mulShape = dequantization1.multiply->get_output_partial_shape(0);
             const size_t rank = mulShape.rank().get_length();
 
             const size_t columnsIdx = matMul->get_transpose_a() ? rank - 2 : rank - 1;
@@ -258,7 +258,7 @@ bool MatMulTransformation::canBeTransformed(const TransformationContext& context
         const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(fakeQuantize);
 
         const auto precisionsAttribute = getAttribute<PrecisionsAttribute>(matMul->input(1));
-        const auto precisions = precisionsAttribute.empty() ?
+        const auto& precisions = precisionsAttribute.empty() ?
             defaultPrecisions :
             precisionsAttribute.as<PrecisionsAttribute>().value();
 
@@ -267,9 +267,9 @@ bool MatMulTransformation::canBeTransformed(const TransformationContext& context
             return false;
         }
 
-        const auto outLowShape = fakeQuantize->get_input_node_shared_ptr(3)->get_shape();
-        const auto outHighShape = fakeQuantize->get_input_node_shared_ptr(4)->get_shape();
-        const auto fakeQuantizeShape = fakeQuantize->get_output_partial_shape(0);
+        const auto& outLowShape = fakeQuantize->get_input_node_shared_ptr(3)->get_shape();
+        const auto& outHighShape = fakeQuantize->get_input_node_shared_ptr(4)->get_shape();
+        const auto& fakeQuantizeShape = fakeQuantize->get_output_partial_shape(0);
         const size_t rank = fakeQuantizeShape.rank().get_length();
 
         const size_t rowsIdx = matMul->get_transpose_b() ? rank - 1 : rank - 2;

--- a/src/common/low_precision_transformations/src/multiply.cpp
+++ b/src/common/low_precision_transformations/src/multiply.cpp
@@ -138,7 +138,7 @@ bool MultiplyTransformation::transform(TransformationContext& context, ov::pass:
 }
 
 size_t MultiplyTransformation::getInputChannels(const std::shared_ptr<ov::Node> op) const {
-    const auto channels = op->get_input_partial_shape(1)[1];
+    const auto& channels = op->get_input_partial_shape(1)[1];
     assert(channels.is_static());
     return channels.get_length();
 }

--- a/src/common/low_precision_transformations/src/multiply_to_group_convolution.cpp
+++ b/src/common/low_precision_transformations/src/multiply_to_group_convolution.cpp
@@ -67,7 +67,7 @@ bool MultiplyToGroupConvolutionTransformation::transform(TransformationContext& 
         // if restrictions are absent precisions attribute is used
         if (weightsPrecision == element::undefined) {
             const auto precisionsAttribute = getAttribute<PrecisionsAttribute>(multiply->input(inputIndex == 0ul ? 1ul : 0ul));
-            const auto precisions = precisionsAttribute == nullptr ?
+            const auto& precisions = precisionsAttribute == nullptr ?
                 defaultPrecisions :
                 precisionsAttribute.as<PrecisionsAttribute>().value();
             weightsPrecision = precisions[0];
@@ -244,7 +244,7 @@ bool MultiplyToGroupConvolutionTransformation::isDynamicOrScalar(const std::shar
     }
 
     const Input<const Node> constantInput = node->input(constantIndex);
-    const auto shape = constantInput.get_partial_shape();
+    const auto& shape = constantInput.get_partial_shape();
     if (shape.is_dynamic() || shape.rank().is_dynamic()) {
         return true;
     }

--- a/src/common/low_precision_transformations/src/network_helper.cpp
+++ b/src/common/low_precision_transformations/src/network_helper.cpp
@@ -32,7 +32,7 @@ namespace low_precision {
 
 // Return true if `type` can be castable to at least one of `type`
 bool NetworkHelper::is_castable_to_one_of(NodeTypeInfo type, const std::unordered_set<NodeTypeInfo>& types) {
-    for (auto another : types) {
+    for (const auto& another : types) {
         if (type.is_castable(another)) {
             return true;
         }
@@ -223,11 +223,11 @@ std::shared_ptr<Node> NetworkHelper::swapMultiplyAndAdd(std::shared_ptr<ov::opse
     auto b = as_type_ptr<ov::opset1::Constant>(addAfterMultiply->get_input_node_shared_ptr(multiplyBranch == 0 ? 1 : 0));
     std::shared_ptr<ov::opset1::Constant> bDivA;
 
-    const auto aPShape = a->get_output_partial_shape(0);
+    const auto& aPShape = a->get_output_partial_shape(0);
     assert(aPShape.is_static());
     const auto aShape = aPShape.to_shape();
 
-    const auto bPShape = b->get_output_partial_shape(0);
+    const auto& bPShape = b->get_output_partial_shape(0);
     assert(bPShape.is_static());
     const auto bShape = bPShape.to_shape();
 
@@ -343,7 +343,7 @@ bool NetworkHelper::isScalarLike(std::shared_ptr<ov::opset1::Constant> constant)
     // ticket #48857
     // return constant->get_all_data_elements_bitwise_identical();
 
-    const auto shape = constant->output(0).get_shape();
+    const auto& shape = constant->output(0).get_shape();
     if (shape_size(shape) == 1ul) {
         return true;
     }
@@ -1320,7 +1320,7 @@ std::shared_ptr<ov::opset1::Constant> NetworkHelper::normalizeDequantizationShap
     const auto getConstWithNormalizeShape = [](
         const std::shared_ptr<Node>& eltwise,
         const std::shared_ptr<ov::opset1::Constant>& constant) {
-        const auto constantShape = constant->get_shape();
+        const auto& constantShape = constant->get_shape();
         if (constantShape.empty()) {
             return constant;
         }
@@ -1670,7 +1670,7 @@ std::vector<std::vector<std::shared_ptr<ov::opset1::Constant>>> NetworkHelper::s
     }
     for (size_t i = 0; i < currConstants.size(); ++i) {
         std::vector<std::shared_ptr<ov::opset1::Constant>> newConstant;
-        const auto const_shape = currConstants[i]->get_shape();
+        const auto& const_shape = currConstants[i]->get_shape();
         if (ov::shape_size(const_shape) == 1 || const_shape[concat_axis] == 1) {
             newConstant.push_back(currConstants[i]);
             newConstants[i] = newConstant;
@@ -1685,7 +1685,7 @@ std::vector<std::vector<std::shared_ptr<ov::opset1::Constant>>> NetworkHelper::s
             THROW_IE_LPT_EXCEPTION(*concat) << "error when splitting constants before concat " <<
                 concat->get_friendly_name();
         }
-        for (auto outputResult : outputResults) {
+        for (const auto& outputResult : outputResults) {
             auto constant = as_type_ptr<ov::opset1::Constant>(outputResult.get_node_shared_ptr());
             newConstant.push_back(constant);
         }

--- a/src/common/low_precision_transformations/src/normalize_l2.cpp
+++ b/src/common/low_precision_transformations/src/normalize_l2.cpp
@@ -84,7 +84,7 @@ bool NormalizeL2Transformation::canBeTransformed(const TransformationContext& co
     if (size != 1ul) {
         if (operation->get_output_partial_shape(0).size() < 2)
             return false;
-        const auto channelsInterval = operation->get_output_partial_shape(0)[1];
+        const auto& channelsInterval = operation->get_output_partial_shape(0)[1];
         if (channelsInterval.is_dynamic() || static_cast<size_t>(channelsInterval.get_length()) != size) {
             return false;
         }

--- a/src/common/low_precision_transformations/src/pad.cpp
+++ b/src/common/low_precision_transformations/src/pad.cpp
@@ -75,7 +75,7 @@ bool PadTransformation::transform(TransformationContext& context, ov::pass::patt
                 }
             }
 
-            const auto inputPShape = pad->get_input_partial_shape(0);
+            const auto& inputPShape = pad->get_input_partial_shape(0);
             assert(inputPShape[padIdx].is_static());
             assert(inputPShape.rank().is_static());
             auto bcastedShape = Shape(inputPShape.rank().get_length(), 1ul);
@@ -102,7 +102,7 @@ bool PadTransformation::transform(TransformationContext& context, ov::pass::patt
         const std::shared_ptr<ov::opset1::Constant>& constant,
         const std::shared_ptr<ov::op::util::PadBase>& pad,
         float padVal) {
-        const auto constantShape = constant->get_shape();
+        const auto& constantShape = constant->get_shape();
         if (shape_size(constantShape) == 1ul) {
             return NetworkHelper::toScalar(constant);
         }
@@ -234,7 +234,7 @@ bool PadTransformation::canBeTransformed(const TransformationContext& context, s
             }
 
             const size_t paddingDimension = beginNonZeroIdx != -1 ? beginNonZeroIdx : endNonZeroIdx;
-            const auto padInputPShape = pad->get_input_partial_shape(0);
+            const auto& padInputPShape = pad->get_input_partial_shape(0);
             const auto padInputRank = padInputPShape.rank();
             if (padInputRank.is_dynamic() || padInputPShape[paddingDimension].is_dynamic()) {
                 return false;

--- a/src/common/low_precision_transformations/src/pull_transpose_through_dequantization.cpp
+++ b/src/common/low_precision_transformations/src/pull_transpose_through_dequantization.cpp
@@ -30,8 +30,8 @@ std::shared_ptr<Node> moveThroughElementwise(const std::shared_ptr<Node>& transp
         elementwiseValuesConvert->get_input_node_shared_ptr(0ul);
     assert(ov::is_type<opset1::Constant>(elementwiseValues));
 
-    const auto transposeValuesShape = transposeValues->get_output_shape(0);
-    const auto elementwiseValuesShape = elementwiseValues->get_output_shape(0);
+    const auto& transposeValuesShape = transposeValues->get_output_shape(0);
+    const auto& elementwiseValuesShape = elementwiseValues->get_output_shape(0);
     if (elementwiseValuesShape.size() != shape_size(transposeValuesShape)) {
         if (shape_size(elementwiseValuesShape) != 1ul) {
             return nullptr;
@@ -110,7 +110,11 @@ ov::pass::low_precision::PullTransposeThroughDequantization::PullTransposeThroug
 
     ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher & m) -> bool {
         const auto& opsMap = m.get_pattern_value_map();
-        auto transpose = opsMap.find(matcherTranspose)->second.get_node()->shared_from_this();
+        auto it = opsMap.find(matcherTranspose);
+        if (it == opsMap.end()) {
+            return false;
+        }
+        auto transpose = it->second.get_node()->shared_from_this();
 
         while (transpose != nullptr) {
             const auto parent = transpose->get_input_node_shared_ptr(0);

--- a/src/common/low_precision_transformations/src/recurrent_cell.cpp
+++ b/src/common/low_precision_transformations/src/recurrent_cell.cpp
@@ -105,7 +105,7 @@ bool RecurrentCellTransformation::transform(TransformationContext& context, ov::
                 auto fq_node = as_type_ptr<ov::opset1::FakeQuantize>(lstm_parent);
                 const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(fq_node);
                 const auto precisionsAttribute = getAttributeFromOutput<PrecisionsAttribute>(lstm_parent);
-                const auto precisions = precisionsAttribute.empty()
+                const auto& precisions = precisionsAttribute.empty()
                                             ? defaultPrecisions
                                             : precisionsAttribute.as<PrecisionsAttribute>().value();
                 const DataPrecision dataPrecision = getDataPrecision(lstm_parent, quantizationDetails, precisions);

--- a/src/common/low_precision_transformations/src/reduce_base_transformation.cpp
+++ b/src/common/low_precision_transformations/src/reduce_base_transformation.cpp
@@ -56,7 +56,7 @@ bool ReduceBaseTransformation::canBeTransformed(const TransformationContext& con
     const std::vector<size_t> axes = ov::util::normalize_axes(reduce->get_friendly_name(), constData, inputRank);
 
     const auto deqByReducedConst = [&](const std::shared_ptr<Node>& eltwise) {
-        const auto constShape = eltwise->get_shape();
+        const auto& constShape = eltwise->get_shape();
 
         if (!constShape.empty()) {
             for (size_t i = 0; i < constShape.size(); ++i) {

--- a/src/common/low_precision_transformations/src/reduce_sum.cpp
+++ b/src/common/low_precision_transformations/src/reduce_sum.cpp
@@ -39,7 +39,7 @@ bool ReduceSumTransformation::canBeTransformed(const TransformationContext& cont
     const auto dequantization = NetworkHelper::getDequantization(reduce, defaultPrecisions);
     if (dequantization.subtract) {
         const auto reductionAxes = reduceSum->get_reduction_axes();
-        const auto inputPShape = dequantization.data.get_partial_shape();
+        const auto& inputPShape = dequantization.data.get_partial_shape();
 
         for (const auto& elem : reductionAxes) {
             if (inputPShape[elem].is_dynamic()) {
@@ -59,7 +59,7 @@ void ReduceSumTransformation::changeDequantizationValues(
     if (dequantization.subtract) {
         const auto reduceSum = ov::as_type_ptr<ov::opset1::ReduceSum>(reduce);
         const auto reductionAxes = reduceSum->get_reduction_axes();
-        const auto inputShape = reduceSum->get_input_partial_shape(0);
+        const auto& inputShape = reduceSum->get_input_partial_shape(0);
 
         // calculating the number of reduced elements
         size_t reductionSize = 1ul;

--- a/src/common/low_precision_transformations/src/reshape.cpp
+++ b/src/common/low_precision_transformations/src/reshape.cpp
@@ -83,7 +83,7 @@ void reshapeDequantizationConstant(const std::shared_ptr<ov::opset1::Reshape>& r
             }
         }
 
-        const auto reshapeOutputPShape = reshape->get_output_partial_shape(0);
+        const auto& reshapeOutputPShape = reshape->get_output_partial_shape(0);
         const auto reshapeOutputRank = reshapeOutputPShape.rank();
         assert(reshapeOutputRank.is_static());
         assert(reshapeOutputRank.get_length() >= 2);

--- a/src/common/low_precision_transformations/src/shuffle_channels.cpp
+++ b/src/common/low_precision_transformations/src/shuffle_channels.cpp
@@ -43,7 +43,7 @@ bool ShuffleChannelsTransformation::transform(TransformationContext& context, ov
 
     const auto shuffleDequantizationConstant = [&](const std::shared_ptr<Node>& eltwise) {
         const auto normalizedConst = NetworkHelper::normalizeDequantizationShape(eltwise, true);
-        const auto constShape = normalizedConst->get_shape();
+        const auto& constShape = normalizedConst->get_shape();
 
         if (shape_size(constShape) == 1ul) {
             return NetworkHelper::toScalar(normalizedConst);

--- a/src/common/low_precision_transformations/src/split.cpp
+++ b/src/common/low_precision_transformations/src/split.cpp
@@ -54,7 +54,7 @@ bool SplitTransformation::transform(TransformationContext& context, ov::pass::pa
     const auto splitConstant = [&](const std::shared_ptr<Node> operation) {
         // if batch is absent in constant shape - add batch
         const auto normalizedConstant = NetworkHelper::normalizeDequantizationShape(operation);
-        const auto constantShape = normalizedConstant->get_shape();
+        const auto& constantShape = normalizedConstant->get_shape();
 
         OutputVector results(outputSize);
         if ((shape_size(constantShape) == 1ul) || (constantShape[normalizedAxis] == 1ul)) {
@@ -139,8 +139,8 @@ void SplitTransformation::updateOutputs(
         const std::string originalName = originalNode->get_friendly_name();
         for (size_t i = 0; i < lastNodes.size(); ++i) {
             const auto lastNode = lastNodes[i];
-            for (auto output : lastNodes[i]->outputs()) {
-                for (auto input : output.get_target_inputs()) {
+            for (const auto& output : lastNodes[i]->outputs()) {
+                for (const auto& input : output.get_target_inputs()) {
                     if (ov::is_type<ov::opset1::Result>(input.get_node())) {
                         originalNode->set_friendly_name(originalName + LayerTransformation::originalLayerPostfix);
                         lastNode->set_friendly_name(originalName + "." + std::to_string(i));

--- a/src/common/low_precision_transformations/src/squeeze.cpp
+++ b/src/common/low_precision_transformations/src/squeeze.cpp
@@ -42,7 +42,7 @@ bool SqueezeTransformation::transform(TransformationContext& context, ov::pass::
                                 const std::shared_ptr<ov::opset1::Constant>& dequantizationOpConstant,
                                 const ov::PartialShape& inputShape) {
         const size_t inputRankValue = inputShape.rank().get_length();
-        const auto constantShape = dequantizationOpConstant->get_shape();
+        const auto& constantShape = dequantizationOpConstant->get_shape();
         if (shape_size(constantShape) == 1ul) {
             return NetworkHelper::toScalar(dequantizationOpConstant);
         }

--- a/src/common/low_precision_transformations/src/transpose.cpp
+++ b/src/common/low_precision_transformations/src/transpose.cpp
@@ -48,7 +48,7 @@ void transposeDequantizationConstant(std::shared_ptr<Node>& transpose, const std
         const std::shared_ptr<ov::opset1::Constant>& dequantizationConstant,
         const PartialShape& transposeOutputPShape,
         const std::shared_ptr<Node>& transposeConstant) -> std::shared_ptr<Node> {
-            const auto constantShape = dequantizationConstant->get_shape();
+            const auto& constantShape = dequantizationConstant->get_shape();
             if (shape_size(constantShape) == 1ul) {
                 return NetworkHelper::toScalar(dequantizationConstant);
             }
@@ -136,7 +136,7 @@ bool TransposeTransformation::canBeTransformed(const TransformationContext& cont
     }
 
     auto checkShape = [](const std::shared_ptr<ov::opset1::Constant>& dequantizationConstant, const PartialShape& transposeOutputShape) -> bool {
-        const auto dequantizationShape = dequantizationConstant->get_shape();
+        const auto& dequantizationShape = dequantizationConstant->get_shape();
         const auto rank = transposeOutputShape.rank();
         if (rank.is_dynamic()) {
             return false;

--- a/src/common/low_precision_transformations/src/weightable_layer_transformation.cpp
+++ b/src/common/low_precision_transformations/src/weightable_layer_transformation.cpp
@@ -192,14 +192,14 @@ bool WeightableLayerTransformation::canBeTransformed(const TransformationContext
             return false;
         }
 
-        const auto olPShape = fqFromWeights->get_input_partial_shape(3);
-        const auto ohPShape = fqFromWeights->get_input_partial_shape(4);
+        const auto& olPShape = fqFromWeights->get_input_partial_shape(3);
+        const auto& ohPShape = fqFromWeights->get_input_partial_shape(4);
         if (olPShape.is_dynamic() || ohPShape.is_dynamic() || olPShape != ohPShape) {
             return false;
         }
 
 
-        const auto fqOutPShape = fqFromWeights->get_output_partial_shape(0);
+        const auto& fqOutPShape = fqFromWeights->get_output_partial_shape(0);
         if (fqOutPShape.rank().is_dynamic()) {
             return false;
         }
@@ -351,7 +351,7 @@ std::tuple<bool, std::shared_ptr<Node>, std::shared_ptr<Node>> WeightableLayerTr
 
     const QuantizationDetails quantizationDetails = QuantizationDetails::getDetails(fq);
     const auto precisionsAttribute = getAttributeFromOutput<PrecisionsAttribute>(fq);
-    const auto precisions = precisionsAttribute.empty() ?
+    const auto& precisions = precisionsAttribute.empty() ?
         defaultPrecisions :
         precisionsAttribute.as<PrecisionsAttribute>().value();
 
@@ -425,7 +425,7 @@ DataPrecision WeightableLayerTransformation::getDataPrecisionOnWeights(
     }
 
     const auto precisionsAttribute = getAttributeFromOutput<PrecisionsAttribute>(fq);
-    const auto precisions = precisionsAttribute.empty() ?
+    const auto& precisions = precisionsAttribute.empty() ?
         defaultPrecisions :
         precisionsAttribute.as<PrecisionsAttribute>().value();
 
@@ -438,7 +438,7 @@ bool WeightableLayerTransformation::isAsymmetricOnWeights(
     const auto n = const_cast<ov::Node*>(node.get())->shared_from_this();
 
     const auto reshapeFromWeights = ov::as_type_ptr<ov::opset1::Reshape>(n->get_input_node_shared_ptr(1));
-    const auto dequantization = reshapeFromWeights == nullptr ?
+    const auto& dequantization = reshapeFromWeights == nullptr ?
         NetworkHelper::getDequantization(n, defaultPrecisions, 1ul) :
         NetworkHelper::getDequantization(reshapeFromWeights, defaultPrecisions);
 

--- a/src/common/transformations/include/ov_ops/nms_static_shape_ie.hpp
+++ b/src/common/transformations/include/ov_ops/nms_static_shape_ie.hpp
@@ -65,13 +65,13 @@ private:
 
 template <typename BaseNmsOp>
 void NmsStaticShapeIE<BaseNmsOp>::validate_and_infer_types() {
-    const auto boxes_ps = this->get_input_partial_shape(0);
-    const auto scores_ps = this->get_input_partial_shape(1);
+    const auto& boxes_ps = this->get_input_partial_shape(0);
+    const auto& scores_ps = this->get_input_partial_shape(1);
 
     auto first_dim_shape = Dimension::dynamic();
 
     if (boxes_ps.rank().is_static() && scores_ps.rank().is_static()) {
-        const auto num_boxes_boxes = boxes_ps[1];
+        const auto& num_boxes_boxes = boxes_ps[1];
         if (num_boxes_boxes.is_static() && scores_ps[0].is_static() && scores_ps[1].is_static()) {
             const auto num_boxes = num_boxes_boxes.get_length();
             auto num_classes = scores_ps[1].get_length();

--- a/src/common/transformations/include/ov_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ov_ops/type_relaxed.hpp
@@ -213,12 +213,12 @@ bool TypeRelaxed<BaseOp>::evaluate(ov::TensorVector& outputs, const ov::TensorVe
 
     ov::TensorVector original_outputs(BaseOp::get_output_size());
     for (size_t i = 0; i < BaseOp::get_output_size(); ++i) {
-        const auto expected_output_type = get_overridden_output_type(i);
+        const auto& expected_output_type = get_overridden_output_type(i);
         if (expected_output_type == element::undefined || expected_output_type == m_original_output_data_types[i]) {
             original_outputs[i] = outputs[i];
         } else {
-            auto partial_shape = BaseOp::get_output_partial_shape(i);
-            auto shape = partial_shape.is_dynamic() ? ov::Shape{0} : partial_shape.to_shape();
+            const auto& partial_shape = BaseOp::get_output_partial_shape(i);
+            const auto& shape = partial_shape.is_dynamic() ? ov::Shape{0} : partial_shape.to_shape();
             original_outputs[i] = ov::Tensor(m_original_output_data_types[i], shape);
         }
     }
@@ -228,7 +228,7 @@ bool TypeRelaxed<BaseOp>::evaluate(ov::TensorVector& outputs, const ov::TensorVe
     }
 
     for (size_t i = 0; i < BaseOp::get_output_size(); ++i) {
-        const auto expected_output_type = get_overridden_output_type(i);
+        const auto& expected_output_type = get_overridden_output_type(i);
 
         if (expected_output_type != element::undefined &&
             original_outputs[i].get_element_type() != expected_output_type) {

--- a/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_pooling.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_pooling.hpp
@@ -104,7 +104,7 @@ ov::matcher_pass_callback ConvertReduceBase::convert_reduce_to_pooling() {
         if (std::all_of(axes_vector.begin(), axes_vector.end(), [&input_shape](const int64_t& axis) {
                 return input_shape[axis] == 1;
             })) {
-            const auto reshape_shape = reduce->output(0).get_shape();
+            const auto& reshape_shape = reduce->output(0).get_shape();
             auto reshape = std::make_shared<ov::op::v1::Reshape>(
                 input,
                 ov::op::v0::Constant::create(ov::element::i64, ov::Shape{reshape_shape.size()}, reshape_shape),

--- a/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_reshape.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_reshape.hpp
@@ -104,12 +104,12 @@ ov::matcher_pass_callback CvtReduceBase::convert_reduce_to_reshape() {
             return false;
 
         auto input = reduce->input_value(0);
-        const auto input_shape = input.get_shape();
-        const auto reduce_shape = reduce->output(0).get_shape();
+        const auto& input_shape = input.get_shape();
+        const auto& reduce_shape = reduce->output(0).get_shape();
 
         // convert redundant reduce to reshape if the input shape is supported by reshape
         if (is_redundant(input_shape, reduce_shape) && input_shape.size() < 6) {
-            const auto reshape_shape = reduce->output(0).get_shape();
+            const auto& reshape_shape = reduce->output(0).get_shape();
             auto reshape = std::make_shared<ov::op::v1::Reshape>(
                 input,
                 ov::op::v0::Constant::create(ov::element::i64, ov::Shape{reshape_shape.size()}, reshape_shape),

--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -281,7 +281,7 @@ TRANSFORMATIONS_API bool is_on_constant_path(const ov::Output<ov::Node>& output)
 TRANSFORMATIONS_API bool process_subgraph(ov::pass::ModelPass& model_pass, const std::shared_ptr<Node>& node);
 
 template <typename T>
-ov::pass::pattern::op::ValuePredicate constant_predicate(std::function<bool(const std::vector<T>&)> predicate) {
+ov::pass::pattern::op::ValuePredicate constant_predicate(const std::function<bool(const std::vector<T>&)>& predicate) {
     return pass::pattern::op::as_value_predicate([=](std::shared_ptr<Node> n) -> bool {
         if (auto constant = as_type_ptr<v0::Constant>(n)) {
             auto values = constant->cast_vector<T>();

--- a/src/common/transformations/src/ov_ops/generate_proposals_ie_internal.cpp
+++ b/src/common/transformations/src/ov_ops/generate_proposals_ie_internal.cpp
@@ -37,8 +37,8 @@ void op::internal::GenerateProposalsIEInternal::validate_and_infer_types() {
     INTERNAL_OP_SCOPE(internal_GenerateProposalsIEInternal_validate_and_infer_types);
     Base::validate_and_infer_types();
 
-    const auto im_info_shape = get_input_partial_shape(0);
-    const auto num_batches = im_info_shape[0];
+    const auto& im_info_shape = get_input_partial_shape(0);
+    const auto& num_batches = im_info_shape[0];
     NODE_VALIDATION_CHECK(this, num_batches.is_static(), "Number of batches must be static");
 
     const Dimension post_nms_count{get_attrs().post_nms_count};

--- a/src/common/transformations/src/ov_ops/nms_ie_internal.cpp
+++ b/src/common/transformations/src/ov_ops/nms_ie_internal.cpp
@@ -113,15 +113,15 @@ int64_t op::internal::NonMaxSuppressionIEInternal::max_boxes_output_from_input()
 
 void op::internal::NonMaxSuppressionIEInternal::validate_and_infer_types() {
     INTERNAL_OP_SCOPE(internal_NonMaxSuppressionIEInternal_validate_and_infer_types);
-    const auto boxes_ps = get_input_partial_shape(boxes_port);
-    const auto scores_ps = get_input_partial_shape(scores_port);
+    const auto& boxes_ps = get_input_partial_shape(boxes_port);
+    const auto& scores_ps = get_input_partial_shape(scores_port);
 
     // NonMaxSuppression produces triplets
     // that have the following format: [batch_index, class_index, box_index]
     PartialShape out_shape = {Dimension::dynamic(), 3};
 
     if (boxes_ps.rank().is_static() && scores_ps.rank().is_static()) {
-        const auto num_boxes_boxes = boxes_ps[1];
+        const auto& num_boxes_boxes = boxes_ps[1];
         const auto max_output_boxes_per_class_node = input_value(max_output_boxes_per_class_port).get_node_shared_ptr();
         if (num_boxes_boxes.is_static() && scores_ps[0].is_static() && scores_ps[1].is_static() &&
             op::util::is_constant(max_output_boxes_per_class_node)) {

--- a/src/common/transformations/src/transformations/common_optimizations/concat_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/concat_fusion.cpp
@@ -21,7 +21,7 @@ ov::pass::ConcatFusion::ConcatFusion() {
         const auto& concat = std::dynamic_pointer_cast<v0::Concat>(output.get_node_shared_ptr());
         const auto axis = concat->get_axis();
         auto is_aplicable = false;
-        for (auto input : concat->input_values()) {
+        for (const auto& input : concat->input_values()) {
             const auto inp_concat = std::dynamic_pointer_cast<v0::Concat>(input.get_node_shared_ptr());
             if (inp_concat && inp_concat->get_axis() == axis && inp_concat->output(0).get_target_inputs().size() == 1) {
                 is_aplicable = true;
@@ -38,7 +38,7 @@ ov::pass::ConcatFusion::ConcatFusion() {
         const auto axis = concat->get_axis();
 
         OutputVector new_inputs;
-        for (auto input : concat->input_values()) {
+        for (const auto& input : concat->input_values()) {
             const auto inp_concat = std::dynamic_pointer_cast<v0::Concat>(input.get_node_shared_ptr());
             if (inp_concat && inp_concat->get_axis() == axis && inp_concat->output(0).get_target_inputs().size() == 1) {
                 const auto inp_concat_inps = inp_concat->input_values();

--- a/src/common/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
@@ -104,8 +104,8 @@ ov::pass::ConvertQuantizeDequantize::ConvertQuantizeDequantize() {
             return false;
         auto zero_point = pattern_map[zero_point_pattern];
         auto scale = pattern_map[scale_pattern];
-        auto convert1 = pattern_map[convert1_pattern];
-        auto convert2 = pattern_map[convert2_pattern];
+        const auto& convert1 = pattern_map[convert1_pattern];
+        const auto& convert2 = pattern_map[convert2_pattern];
         auto mul = pattern_map[mul_pattern].get_node_shared_ptr();
 
         // convert1 and convert2 should have only one input
@@ -158,13 +158,13 @@ ov::pass::ConvertQuantizeDequantize::ConvertQuantizeDequantize() {
                                                    scale);
 
         // check if new_out_low/high shapes are broadcastable to FQ's input
-        auto data_shape = data.get_partial_shape();
+        const auto& data_shape = data.get_partial_shape();
         if (data_shape.rank().is_dynamic())
             return false;
-        auto out_low_shape = new_out_low->get_output_partial_shape(0);
+        const auto& out_low_shape = new_out_low->get_output_partial_shape(0);
         if (out_low_shape.rank().is_dynamic() || out_low_shape.rank().get_length() > data_shape.rank().get_length())
             return false;
-        auto out_high_shape = new_out_high->get_output_partial_shape(0);
+        const auto& out_high_shape = new_out_high->get_output_partial_shape(0);
         if (out_high_shape.rank().is_dynamic() || out_high_shape.rank().get_length() > data_shape.rank().get_length())
             return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/depth_to_space_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/depth_to_space_fusion.cpp
@@ -146,10 +146,10 @@ ov::pass::DepthToSpaceFusion::DepthToSpaceFusion() {
             return false;
         }
 
-        auto p_shape_input = reshape_before->get_input_partial_shape(0);
-        auto p_shape_reshape_before = reshape_before->get_output_partial_shape(0);
-        auto p_shape_permute = permute->get_output_partial_shape(0);
-        auto p_shape_reshape_after = reshape_after->get_output_partial_shape(0);
+        const auto& p_shape_input = reshape_before->get_input_partial_shape(0);
+        const auto& p_shape_reshape_before = reshape_before->get_output_partial_shape(0);
+        const auto& p_shape_permute = permute->get_output_partial_shape(0);
+        const auto& p_shape_reshape_after = reshape_after->get_output_partial_shape(0);
 
         const auto input_rank = p_shape_input.rank();
         if (input_rank.is_dynamic() || p_shape_input.rank().get_length() < 3) {

--- a/src/common/transformations/src/transformations/common_optimizations/dimension_tracking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/dimension_tracking.cpp
@@ -36,7 +36,7 @@ void ov::batch_util::mark_batch(const std::shared_ptr<ov::op::v0::Parameter>& pa
     auto& shape = parameter->get_partial_shape();
     if (map.count(parameter)) {  // we already marked this parameter as having a batch
         std::unordered_set<std::shared_ptr<Symbol>> intersection_in_all_three_sources_of_batch;
-        auto mapped_batches = map[parameter];
+        const auto& mapped_batches = map[parameter];
         for (auto& dim : shape) {
             const auto& dim_symbol = dim.get_symbol();
             if (batches.count(dim_symbol) && mapped_batches.count(dim_symbol)) {
@@ -281,7 +281,7 @@ std::map<std::shared_ptr<ov::op::v0::Parameter>, ov::PartialShape> collect_origi
     const auto& parameters = m->get_parameters();
     std::map<std::shared_ptr<ov::op::v0::Parameter>, ov::PartialShape> parameter_to_shape;
     for (const auto& parameter : parameters) {
-        auto shape = parameter->get_partial_shape();
+        const auto& shape = parameter->get_partial_shape();
         if (shape.rank().is_dynamic())
             return {};
         parameter_to_shape[parameter] = shape;

--- a/src/common/transformations/src/transformations/common_optimizations/dropout_with_random_uniform_replacer.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/dropout_with_random_uniform_replacer.cpp
@@ -37,8 +37,8 @@ ov::pass::DropoutWithRandomUniformReplacer::DropoutWithRandomUniformReplacer() {
 
     ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
-        const auto random_uniform = pattern_map.at(random_uniform_pattern);
-        const auto shape_of = pattern_map.at(shape_pattern);
+        const auto& random_uniform = pattern_map.at(random_uniform_pattern);
+        const auto& shape_of = pattern_map.at(shape_pattern);
         const auto ru = std::dynamic_pointer_cast<ov::op::v8::RandomUniform>(random_uniform.get_node_shared_ptr());
         if (!ru)
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -660,8 +660,7 @@ ov::pass::RoPEFusionQwen::RoPEFusionQwen(int split_output_id) {
         if (pattern_map.count(reshape_special)) {
             // check reshape_special shape correctness
             auto reshape_special_node = pattern_map.at(reshape_special).get_node_shared_ptr();
-            auto data_shape = reshape_special_node->get_input_partial_shape(0);
-            auto reshape_shape = pattern_map.at(const_shape);
+            const auto& reshape_shape = pattern_map.at(const_shape);
             auto node = ov::as_type_ptr<opset1::Constant>(reshape_shape.get_node_shared_ptr());
             const auto& target = node->cast_vector<int32_t>();
             // ensure target_shape have correct rank

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -738,6 +738,7 @@ ov::pass::RoPEShareCosSin::RoPEShareCosSin() {
         if (it == pattern_map.end()) {
             return false;
         }
+
         auto cur_inv_freq = std::dynamic_pointer_cast<opset1::Constant>(it->second.get_node_shared_ptr());
         if (!cur_inv_freq) {
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/hswish_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/hswish_fusion.cpp
@@ -161,7 +161,7 @@ ov::pass::HSwishFusionWithClamp::HSwishFusionWithClamp() {
 
     ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        const auto x_output = pattern_to_output.at(input);
+        const auto& x_output = pattern_to_output.at(input);
         const auto add_const_value =
             std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_to_output.at(add_constant).get_node_shared_ptr());
         if (!op::util::has_constant_value(add_const_value, 3.0)) {

--- a/src/common/transformations/src/transformations/common_optimizations/leaky_relu_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/leaky_relu_fusion.cpp
@@ -42,7 +42,7 @@ ov::pass::LeakyReluFusion::LeakyReluFusion() {
             return false;
 
         auto leaky_relu = register_new_node<ov::op::v0::PRelu>(pattern_map.at(data_pattern), original_alpha_pattern);
-        auto maximum = pattern_map.at(max_pattern);
+        const auto& maximum = pattern_map.at(max_pattern);
         leaky_relu->set_friendly_name(maximum.get_node()->get_friendly_name());
 
         copy_runtime_info({pattern_map.at(multiply_pattern).get_node_shared_ptr(), maximum.get_node_shared_ptr()},

--- a/src/common/transformations/src/transformations/common_optimizations/nearest_neighbor_upsampling_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nearest_neighbor_upsampling_fusion.cpp
@@ -302,7 +302,7 @@ ov::pass::NearestNeighborUpsamplingFusion::NearestNeighborUpsamplingFusion() {
             return false;
 
         uint64_t input_rank = static_cast<uint64_t>(reshape_1_node->get_input_partial_shape(0).rank().get_length());
-        const auto mul_const_shape = mul_const_node->get_output_shape(0);
+        const auto& mul_const_shape = mul_const_node->get_output_shape(0);
         const auto scales = get_scales_from_mul_const_shape(mul_const_shape, input_rank);
         if (scales.empty() || std::all_of(scales.begin(), scales.end(), [](float s) {
                 return s == 1.0f;
@@ -322,7 +322,7 @@ ov::pass::NearestNeighborUpsamplingFusion::NearestNeighborUpsamplingFusion() {
         if (!concat_1_node)
             return false;
 
-        const auto input_shape = reshape_1_node->get_input_shape(0);
+        const auto& input_shape = reshape_1_node->get_input_shape(0);
         if (!check_concat_1(concat_1_node, input_shape))
             return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -256,7 +256,7 @@ static vector<int64_t> get_squeeze_axes(const PartialShape& data_shape, const Pa
 }
 
 static bool eliminate_unsqueeze(const shared_ptr<Node>& node) {
-    auto out_shape = node->get_output_partial_shape(0);
+    const auto& out_shape = node->get_output_partial_shape(0);
     // try to replace all squeeze/unsqueeze with reshape
     if (out_shape.rank().is_static() && out_shape.rank().get_length() != 0 && count_unknown_dims(out_shape) < 2) {
         return replace_squeeze_unsqueeze(node);
@@ -467,7 +467,7 @@ pass::EliminateSqueeze::EliminateSqueeze() {
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
         const auto node = m.get_match_root();
-        auto out_shape = node->get_output_partial_shape(0);
+        const auto& out_shape = node->get_output_partial_shape(0);
         // try to replace all unsqueeze/squeeze with reshape
         if (out_shape.rank().is_static() && out_shape.rank().get_length() != 0 && count_unknown_dims(out_shape) < 2) {
             return replace_squeeze_unsqueeze(node);
@@ -582,7 +582,7 @@ bool check_reshape(const shared_ptr<Node>& node) {
                 return false;
             }
             pattern_val.insert(pattern_val.begin() + 1, 1);
-            auto in_shape = reshape->input_value(0).get_partial_shape();
+            const auto& in_shape = reshape->input_value(0).get_partial_shape();
             // Current Reshape is a product of eliminate_reshape_v1 transformation.
             // Initial Unsqueeze operation had static input shape and thus was replaced.
             // This makes us eligible to assume input shape of Reshape that we are searching for is static

--- a/src/common/transformations/src/transformations/common_optimizations/normalize_l2_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/normalize_l2_fusion.cpp
@@ -52,7 +52,7 @@ ov::pass::NormalizeL2Fusion::NormalizeL2Fusion() {
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
 
-        const auto data_input = pattern_to_output.at(input);
+        const auto& data_input = pattern_to_output.at(input);
         const auto exp_input =
             std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_to_output.at(exp).get_node_shared_ptr());
         const auto axes_input =

--- a/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
@@ -118,7 +118,7 @@ bool ov::pass::GroupedStridedSliceOptimizer::run_on_model(const std::shared_ptr<
 
         bool valid_for_replacement = true;
 
-        auto root_plan = pair.second[0].plan;
+        const auto& root_plan = pair.second[0].plan;
         for (const auto& ss_plan : pair.second) {
             valid_for_replacement &= (ss_plan.plan.begins.size() == root_plan.begins.size());
             valid_for_replacement &=

--- a/src/common/transformations/src/transformations/common_optimizations/prelu_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/prelu_fusion.cpp
@@ -187,9 +187,9 @@ ov::pass::PReluFusionAbsSubMulMulAdd::PReluFusionAbsSubMulMulAdd() {
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        const auto input_output = pattern_to_output.at(input);
+        const auto& input_output = pattern_to_output.at(input);
         const auto add_node = pattern_to_output.at(add).get_node_shared_ptr();
-        const auto slope = pattern_to_output.at(mul_1_constant);
+        const auto& slope = pattern_to_output.at(mul_1_constant);
         const auto prelu = make_shared<ov::op::v0::PRelu>(input_output, slope);
 
         prelu->set_friendly_name(m.get_match_root()->get_friendly_name());
@@ -223,7 +223,7 @@ ov::pass::PReluFusionNegReluMulAdd::PReluFusionNegReluMulAdd() {
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        const auto input_output = pattern_to_output.at(input);
+        const auto& input_output = pattern_to_output.at(input);
         const auto add_node = pattern_to_output.at(add).get_node_shared_ptr();
         const auto slope = op::util::make_try_fold<ov::op::v0::Negative>(pattern_to_output.at(mul_constant));
         const auto prelu = make_shared<ov::op::v0::PRelu>(input_output, slope);

--- a/src/common/transformations/src/transformations/common_optimizations/pull_through_reduce.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/pull_through_reduce.cpp
@@ -119,7 +119,7 @@ ov::pass::PullUnsqueezeThroughReduce::PullUnsqueezeThroughReduce() {
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pattern_map = m.get_pattern_value_map();
-        const auto input_node = pattern_map.at(input);
+        const auto& input_node = pattern_map.at(input);
         const auto reduce_node =
             std::dynamic_pointer_cast<op::util::ReductionBase>(pattern_map.at(reduce).get_node_shared_ptr());
         const auto unsqueeze_node = pattern_map.at(unsqueeze).get_node_shared_ptr();
@@ -192,7 +192,7 @@ ov::pass::PullReshapeThroughReduce::PullReshapeThroughReduce() {
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pattern_map = m.get_pattern_value_map();
-        const auto input_node = pattern_map.at(input);
+        const auto& input_node = pattern_map.at(input);
         const auto reduce_node =
             std::dynamic_pointer_cast<op::util::ReductionBase>(pattern_map.at(reduce).get_node_shared_ptr());
         if (!reduce_node) {

--- a/src/common/transformations/src/transformations/common_optimizations/random_uniform_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/random_uniform_fusion.cpp
@@ -34,9 +34,9 @@ ov::pass::RandomUniformFusion::RandomUniformFusion() {
 
     ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
-        const auto data = pattern_map.at(data_pattern);
-        const auto random_uniform = pattern_map.at(random_uniform_pattern);
-        const auto constant = pattern_map.at(const_pattern);
+        const auto& data = pattern_map.at(data_pattern);
+        const auto& random_uniform = pattern_map.at(random_uniform_pattern);
+        const auto& constant = pattern_map.at(const_pattern);
         const auto ru = std::dynamic_pointer_cast<ov::op::v8::RandomUniform>(random_uniform.get_node_shared_ptr());
         if (!ru)
             return false;
@@ -49,7 +49,7 @@ ov::pass::RandomUniformFusion::RandomUniformFusion() {
         if (!old_const->get_element_type().is_real())
             return false;
 
-        auto const_shape = old_const->get_shape();
+        const auto& const_shape = old_const->get_shape();
         if (shape_size(const_shape) != 1)
             return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/relu_fake_quantize_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/relu_fake_quantize_fusion.cpp
@@ -28,9 +28,9 @@ ov::pass::ReluFakeQuantizeFusion::ReluFakeQuantizeFusion() {
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         auto pattern_map = m.get_pattern_value_map();
-        auto data = pattern_map[data_pattern];
-        auto relu = pattern_map[relu_pattern];
-        auto input_low = pattern_map[input_low_pattern];
+        const auto& data = pattern_map[data_pattern];
+        const auto& relu = pattern_map[relu_pattern];
+        const auto& input_low = pattern_map[input_low_pattern];
         auto input_low_const = std::dynamic_pointer_cast<ov::op::v0::Constant>(input_low.get_node_shared_ptr());
         if (!input_low_const)
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/reshape_prelu.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reshape_prelu.cpp
@@ -23,12 +23,12 @@ ReshapePRelu::ReshapePRelu() {
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
         const auto prelu = pattern_map.at(prelu_m).get_node_shared_ptr();
-        const auto input = pattern_map.at(input_m);
-        const auto slope = pattern_map.at(slope_m);
+        const auto& input = pattern_map.at(input_m);
+        const auto& slope = pattern_map.at(slope_m);
 
-        const auto prelu_pshape = prelu->get_input_partial_shape(0);
+        const auto& prelu_pshape = prelu->get_input_partial_shape(0);
         const auto prelu_rank = prelu_pshape.rank();
-        const auto slope_pshape = prelu->get_input_partial_shape(1);
+        const auto& slope_pshape = prelu->get_input_partial_shape(1);
         const auto slope_rank = slope_pshape.rank();
         if (prelu_rank.get_length() == 1 || slope_rank.get_length() != 1) {
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
@@ -79,8 +79,8 @@ ov::pass::ReshapeSequenceFusion::ReshapeSequenceFusion(bool use_shape_for_elimin
         auto input = pattern_map.at(reshape_input);
         auto reshape = m.get_match_root();
 
-        auto pattern_a = pattern_map.at(reshape_a_pattern);
-        auto pattern_b = pattern_map.at(reshape_b_pattern);
+        const auto& pattern_a = pattern_map.at(reshape_a_pattern);
+        const auto& pattern_b = pattern_map.at(reshape_b_pattern);
         // skip reshapes which patterns contain special numbers like -1 or 0
         if (!has_valid_pattern(pattern_a) || !has_valid_pattern(pattern_b)) {
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/reverse_shape_and_type_infer.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reverse_shape_and_type_infer.cpp
@@ -26,7 +26,7 @@
 bool ov::pass::ReverseShapeAndTypeInfer::inherit_output_shape(const std::shared_ptr<ov::Node>& node,
                                                               const std::vector<size_t>& input_idxs) {
     auto is_changed = false;
-    auto output_shape = node->get_output_partial_shape(0);
+    const auto& output_shape = node->get_output_partial_shape(0);
 
     for (auto idx : input_idxs) {
         if (idx < node->get_input_size() && node->get_input_partial_shape(idx).compatible(output_shape)) {
@@ -40,7 +40,7 @@ bool ov::pass::ReverseShapeAndTypeInfer::inherit_output_shape(const std::shared_
 bool ov::pass::ReverseShapeAndTypeInfer::inherit_output_rank(const std::shared_ptr<ov::Node>& node,
                                                              const std::vector<size_t>& input_idxs) {
     auto is_changed = false;
-    auto output_shape = node->get_output_partial_shape(0);
+    const auto& output_shape = node->get_output_partial_shape(0);
 
     for (auto idx : input_idxs) {
         if (idx < node->get_input_size() && node->get_input_partial_shape(idx).rank().is_dynamic()) {

--- a/src/common/transformations/src/transformations/common_optimizations/ric_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/ric_fusion.cpp
@@ -549,7 +549,7 @@ public:
 
         auto callback = [=](pattern::Matcher& m) {
             const auto& pattern_map = m.get_pattern_value_map();
-            auto input = pattern_map.at(input_p);
+            const auto& input = pattern_map.at(input_p);
             auto ric = ric_attr::get(input).propagate();
 
             auto order_node =
@@ -637,7 +637,7 @@ public:
         auto callback = [=](pattern::Matcher& m) {
             const auto& pattern_map = m.get_pattern_value_map();
             auto output = pattern_map.at(pattern_root);
-            auto input = pattern_map.at(input_p);
+            const auto& input = pattern_map.at(input_p);
             output.replace(input);
             return true;
         };
@@ -658,7 +658,7 @@ public:
         auto callback = [=](pattern::Matcher& m) {
             const auto& pattern_map = m.get_pattern_value_map();
             auto output = pattern_map.at(pattern_root);
-            auto input = pattern_map.at(input_p);
+            const auto& input = pattern_map.at(input_p);
             output.replace(input);
             return true;
         };

--- a/src/common/transformations/src/transformations/common_optimizations/select_with_one_value_condition.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/select_with_one_value_condition.cpp
@@ -37,7 +37,7 @@ ov::pass::SelectWithOneValueCondition::SelectWithOneValueCondition() {
             return false;
         }
 
-        auto condition_value = pattern_map.at(condition);
+        const auto& condition_value = pattern_map.at(condition);
         auto condition_const = std::dynamic_pointer_cast<ov::op::v0::Constant>(condition_value.get_node_shared_ptr());
         if (!condition_const) {
             return false;
@@ -66,7 +66,7 @@ ov::pass::SelectWithOneValueCondition::SelectWithOneValueCondition() {
         // based on the resulted shape and the shape of the skipped branch, perform further steps
         auto select_shape = select->get_output_partial_shape(0);
         auto branch_output = select->input_value(branch_index);
-        auto branch_output_shape = branch_output.get_partial_shape();
+        const auto& branch_output_shape = branch_output.get_partial_shape();
 
         if (select_shape.is_static() && branch_output_shape.same_scheme(select_shape)) {
             // Broadcast is not needed if the select shape is exactly the same as the selected branch

--- a/src/common/transformations/src/transformations/common_optimizations/shuffle_channels_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/shuffle_channels_fusion.cpp
@@ -131,9 +131,9 @@ ov::pass::ShuffleChannelsFusion::ShuffleChannelsFusion(const bool reshape_consta
             }
         }
 
-        auto pshape_input = reshape_before->get_input_partial_shape(0);
-        auto pshape_reshape_before = reshape_before->get_output_partial_shape(0);
-        auto pshape_reshape_after = reshape_after->get_output_partial_shape(0);
+        const auto& pshape_input = reshape_before->get_input_partial_shape(0);
+        const auto& pshape_reshape_before = reshape_before->get_output_partial_shape(0);
+        const auto& pshape_reshape_after = reshape_after->get_output_partial_shape(0);
 
         auto transpose_constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(
             pattern_map.at(transpose_const_pattern).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -286,7 +286,7 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
         bool gather_folded = false;
 
         auto update_expected_gather_location = [&](const Output<Node>& concat_input) {
-            const auto concat_input_shape = concat_input.get_shape();
+            const auto& concat_input_shape = concat_input.get_shape();
             OPENVINO_ASSERT(concat_input_shape.size() == 1,
                             "concat input rank is not valid for matched Concat with 1D output");
             gather_dims_expected_location += concat_input_shape[0];

--- a/src/common/transformations/src/transformations/common_optimizations/swish_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/swish_fusion.cpp
@@ -75,8 +75,8 @@ ov::pass::SwishFusionWithSigmoidWithBeta::SwishFusionWithSigmoidWithBeta() {
 
     ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
-        auto exp_input = pattern_to_output.at(input);
-        auto beta_input = pattern_to_output.at(beta);
+        const auto& exp_input = pattern_to_output.at(input);
+        const auto& beta_input = pattern_to_output.at(beta);
 
         auto beta_constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(beta_input.get_node_shared_ptr());
         Output<Node> new_beta;

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
@@ -87,7 +87,7 @@ bool check_transposes(const std::vector<int64_t>& before_order,
 bool check_input_reshape(const std::shared_ptr<ov::op::v1::Reshape>& reshape,
                          const std::vector<int64_t>& new_shape,
                          const bool transposed_b) {
-    const auto input_shape = reshape->get_input_shape(0);
+    const auto& input_shape = reshape->get_input_shape(0);
     const size_t input_rank = input_shape.size();
     const size_t output_rank = reshape->get_output_shape(0).size();
     if (input_rank < 3 || output_rank != 2)

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -89,7 +89,7 @@ ov::pass::TransposeEltwise::TransposeEltwise() {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto eltwise = pattern_to_output.at(eltwise_p).get_node_shared_ptr();
         auto eltwise_const_input = pattern_to_output.at(eltwise_const_input_p);
-        auto eltwise_data_input = pattern_to_output.at(eltwise_data_input_p);
+        const auto& eltwise_data_input = pattern_to_output.at(eltwise_data_input_p);
         auto transpose = pattern_to_output.at(transpose_p).get_node_shared_ptr();
 
         const auto& order_size = transpose->get_input_shape(1).at(0);

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_to_reshape.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_to_reshape.cpp
@@ -28,7 +28,7 @@ ov::pass::TransposeToReshape::TransposeToReshape() {
     ov::matcher_pass_callback matcher_pass_callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto transpose = m.get_match_root();
         auto data = transpose->input_value(0);
-        const auto input_shape = transpose->input(0).get_partial_shape();
+        const auto& input_shape = transpose->input(0).get_partial_shape();
 
         const size_t input_shape_rank = input_shape.rank().get_length();
 

--- a/src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
+++ b/src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
@@ -58,7 +58,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
                 // the corresponding Split output to the corresponding copy of the body.
                 // If the number of iterations is 1, then the Split is not needed.
 
-                auto in_data = sub_graph_op->input_values()[input_desc->m_input_index];
+                const auto& in_data = sub_graph_op->input_values()[input_desc->m_input_index];
                 const auto const_axis = ov::op::v0::Constant::create(element::i64, Shape{}, {input_desc->m_axis});
 
                 if (num_iter > 1) {
@@ -83,7 +83,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
             } else if (const auto& merged_desc =
                            std::dynamic_pointer_cast<ov::op::v0::TensorIterator::MergedInputDescription>(desc)) {
                 // Connect the input to the corresponding copy of the body.
-                auto in_data = sub_graph_op->input_values()[merged_desc->m_input_index];
+                const auto& in_data = sub_graph_op->input_values()[merged_desc->m_input_index];
                 const auto& param = body_functions[0]->get_parameters()[merged_desc->m_body_parameter_index];
                 for (auto& output : param->outputs()) {
                     output.replace(in_data);

--- a/src/common/transformations/src/transformations/fp16_compression/mark_decompression_convert_constant_folding.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_decompression_convert_constant_folding.cpp
@@ -129,8 +129,10 @@ pass::MarkCompressedFloatConstants::MarkCompressedFloatConstants() {
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& convert_node = as_type_ptr<ov::op::v0::Convert>(m.get_match_root());
+        if (!convert_node)
+            return false;
         const auto& const_node = convert_node->input_value(0).get_node_shared_ptr();
-        if (convert_node == nullptr || const_node == nullptr)
+        if (!const_node)
             return false;
         if (convert_node->get_destination_type() != element::f32)
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_avgpool_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_avgpool_downgrade.cpp
@@ -55,10 +55,10 @@ ov::pass::ConvertAvgPool14ToAvgPool1::ConvertAvgPool14ToAvgPool1() {
             const auto zero_i64 = node_registry.make<Constant>(element::i64, Shape{}, 0);
             const auto shape = node_registry.make<ShapeOf>(input, element::i64);
             const auto rank = node_registry.make<ShapeOf>(shape, element::i64);
-            const auto pads_begin_v14 = avg_pool_v14->get_pads_begin();
+            const auto& pads_begin_v14 = avg_pool_v14->get_pads_begin();
             const auto pads_begin_node =
                 node_registry.make<Constant>(element::i64, Shape{pads_begin_v14.size()}, pads_begin_v14);
-            const auto pads_end_v14 = avg_pool_v14->get_pads_end();
+            const auto& pads_end_v14 = avg_pool_v14->get_pads_end();
             const auto pads_end_node =
                 node_registry.make<Constant>(element::i64, Shape{pads_end_v14.size()}, pads_end_v14);
             const auto pads_len = node_registry.make<Constant>(element::i64, Shape{}, pads_begin_v14.size());

--- a/src/common/transformations/src/transformations/op_conversions/convert_convertpromotetypes.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_convertpromotetypes.cpp
@@ -24,7 +24,7 @@ ov::pass::ConvertConvertPromoteTypes::ConvertConvertPromoteTypes() {
             return false;
         }
         const element::Type& dest_type = convert_promote_types->get_output_element_type(0);
-        const auto friendly_name = convert_promote_types->get_friendly_name();
+        const auto& friendly_name = convert_promote_types->get_friendly_name();
         NodeRegistry node_registry;
         const auto out0 = node_registry.make<ov::op::v0::Convert>(convert_promote_types->input_value(0), dest_type);
         const auto out1 = node_registry.make<ov::op::v0::Convert>(convert_promote_types->input_value(1), dest_type);

--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_to_compressed.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_to_compressed.cpp
@@ -29,8 +29,8 @@ ov::pass::ConvertGatherToGatherCompressed::ConvertGatherToGatherCompressed() {
     };
 
     auto reshape_3d_to_2d = [](const ov::Output<ov::Node>& output) {
-        auto in_ps = output.get_node()->get_input_partial_shape(0);
-        auto out_ps = output.get_node()->get_output_partial_shape(0);
+        const auto& in_ps = output.get_node()->get_input_partial_shape(0);
+        const auto& out_ps = output.get_node()->get_output_partial_shape(0);
         return in_ps.rank().is_static() && out_ps.rank().is_static() && in_ps.size() == 3 && out_ps.size() == 2;
     };
 
@@ -134,7 +134,9 @@ ov::pass::ConvertGatherToGatherCompressed::ConvertGatherToGatherCompressed() {
                                                                                    gather_input_scale);
         }
 
-        transformation_callback(new_gather_node);
+        if (transformation_callback(new_gather_node)) {
+            return false;
+        }
 
         result_nodes.push_back(new_gather_node);
         new_gather_node->set_friendly_name(gather_node->get_friendly_name());

--- a/src/common/transformations/src/transformations/op_conversions/convert_interpolate1_to_interpolate4.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_interpolate1_to_interpolate4.cpp
@@ -27,7 +27,7 @@ ov::pass::ConvertInterpolate1ToInterpolate4::ConvertInterpolate1ToInterpolate4()
             return false;
         }
 
-        auto attrsV0 = interpolationV0->get_attrs();
+        const auto& attrsV0 = interpolationV0->get_attrs();
         std::vector<size_t> axes{attrsV0.axes.begin(), attrsV0.axes.end()};
         const auto& out_dims = std::make_shared<ov::op::v0::Convert>(interpolationV0->input_value(1), element::f32);
         const auto& in_dims = std::make_shared<ov::op::v0::Convert>(

--- a/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
@@ -95,11 +95,11 @@ ov::pass::ConvertMaxPool14ToMaxPool8::ConvertMaxPool14ToMaxPool8() {
         NodeRegistry node_registry;
         if (rounding_type_v14 == ov::op::RoundingType::CEIL_TORCH) {
             auto input = max_pool_v14->input_value(0);
-            const auto strides = max_pool_v14->get_strides();
-            const auto padding_begin = max_pool_v14->get_pads_begin();
+            const auto& strides = max_pool_v14->get_strides();
+            const auto& padding_begin = max_pool_v14->get_pads_begin();
             const auto padding_begin_node =
                 node_registry.make<Constant>(element::i64, Shape{padding_begin.size()}, padding_begin);
-            const auto padding_end = max_pool_v14->get_pads_end();
+            const auto& padding_end = max_pool_v14->get_pads_end();
             const auto padding_end_node =
                 node_registry.make<Constant>(element::i64, Shape{padding_end.size()}, padding_end);
             const auto zero = node_registry.make<Constant>(element::i64, Shape{}, 0);

--- a/src/common/transformations/src/transformations/op_conversions/convert_scatter_elements_to_scatter.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_scatter_elements_to_scatter.cpp
@@ -42,9 +42,9 @@ ov::pass::ConvertScatterElementsToScatter::ConvertScatterElementsToScatter() {
 
         auto indices_input = broadcast->input_value(0);
 
-        const auto data_pshape = scatter->input(0).get_partial_shape();
-        const auto indices_pshape = indices_input.get_partial_shape();
-        const auto updates_pshape = scatter->input(2).get_partial_shape();
+        const auto& data_pshape = scatter->input(0).get_partial_shape();
+        const auto& indices_pshape = indices_input.get_partial_shape();
+        const auto& updates_pshape = scatter->input(2).get_partial_shape();
 
         // Check that ScatterElementsUpdate and Broadcast inputs has static shapes
         if (data_pshape.rank().is_dynamic() || indices_pshape.rank().is_dynamic() ||

--- a/src/common/transformations/src/transformations/op_conversions/convert_sequences_to_tensor_iterator.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_sequences_to_tensor_iterator.cpp
@@ -87,7 +87,7 @@ bool convert_sequence_to_ti(const std::shared_ptr<ov::Node>& sequence,
                             const ov::Output<ov::Node>& R,
                             const ov::Output<ov::Node>& B,
                             const ov::op::RecurrentSequenceDirection& direction) {
-    auto X_pshape = X.get_partial_shape();
+    const auto& X_pshape = X.get_partial_shape();
     if (X_pshape.size() < 2) {
         return false;
     }

--- a/src/common/transformations/src/transformations/op_conversions/convert_shuffle_channels3.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_shuffle_channels3.cpp
@@ -95,7 +95,7 @@ ov::pass::ConvertShuffleChannels3::ConvertShuffleChannels3() {
             std::make_shared<ov::op::v1::Reshape>(transpose->output(0), original_shape->output(0), false);
 
         ::NodeVector new_ops = {original_shape, split_input_dimensions, transpose, reshape, reshape_back, new_shape};
-        for (auto output : new_dimensions)
+        for (const auto& output : new_dimensions)
             new_ops.insert(new_ops.begin(), output.get_node_shared_ptr());
         reshape_back->set_friendly_name(shuffle_channels->get_friendly_name());
         ::copy_runtime_info(shuffle_channels, new_ops);

--- a/src/common/transformations/src/transformations/op_conversions/einsum_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/einsum_decomposition.cpp
@@ -707,7 +707,7 @@ ov::pass::EinsumDecomposition::EinsumDecomposition() {
             return false;
         }
 
-        auto equation = einsum_node->get_equation();
+        const auto& equation = einsum_node->get_equation();
         std::vector<std::string> input_subscripts;
         std::string output_subscript;
         ov::op::v7::Einsum::parse_equation(equation, input_subscripts, output_subscript);

--- a/src/common/transformations/src/transformations/op_conversions/eye_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/eye_decomposition.cpp
@@ -137,10 +137,10 @@ EyeDecomposition::EyeDecomposition() {
         NodeRegistry copy_reg;
         const auto& pattern_to_output = m.get_pattern_value_map();
 
-        const auto dtype = m_eye->get_out_type();
-        const auto width = pattern_to_output.at(p_width);
-        const auto height = pattern_to_output.at(p_height);
-        const auto k = pattern_to_output.at(p_k);
+        const auto& dtype = m_eye->get_out_type();
+        const auto& width = pattern_to_output.at(p_width);
+        const auto& height = pattern_to_output.at(p_height);
+        const auto& k = pattern_to_output.at(p_k);
 
         auto eye = make_eye_model(copy_reg, height, width, k, dtype);
 

--- a/src/common/transformations/src/transformations/op_conversions/simplify_ctc_greedy_decoder_seq_len.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/simplify_ctc_greedy_decoder_seq_len.cpp
@@ -35,7 +35,7 @@ ov::pass::SimplifyCTCGreedyDecoderSeqLen::SimplifyCTCGreedyDecoderSeqLen() {
         }
 
         if (decoder_seq_len->get_input_size() > 2) {
-            const auto data_pshape = decoder_seq_len->get_input_partial_shape(0);
+            const auto& data_pshape = decoder_seq_len->get_input_partial_shape(0);
             auto blank_index =
                 std::dynamic_pointer_cast<ov::op::v0::Constant>(decoder_seq_len->input_value(2).get_node_shared_ptr());
             if (!blank_index || data_pshape.rank().is_dynamic() || data_pshape[2].is_dynamic()) {

--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/prev_sequence_length_pattern.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/prev_sequence_length_pattern.cpp
@@ -49,7 +49,7 @@ ov::pass::PrevSequenceLengthPattern::PrevSequenceLengthPattern(std::shared_ptr<o
         if (replacement->get_output_element_type(0) != target_type) {
             replacement = std::make_shared<v0::Convert>(replacement, target_type);
         }
-        auto required_shape = gather->get_output_partial_shape(0);
+        const auto& required_shape = gather->get_output_partial_shape(0);
         if (replacement->get_output_partial_shape(0) != required_shape && required_shape.rank().is_static()) {
             replacement = op::util::reshapeTo(replacement, Shape(required_shape.rank().get_length(), 1));
         }

--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
@@ -171,11 +171,11 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
             pattern_map.at(pattern_map.count(sdpa_with_4_inputs) ? sdpa_with_4_inputs : sdpa_with_5_inputs).get_node();
         // E and Ev are from the SDPA specification at
         // https://docs.openvino.ai/2024/documentation/openvino-ir-format/operation-sets/operation-specs/sequence/scaled-dot-product-attention.html
-        auto E = sdpa_node->get_input_tensor(1).get_partial_shape()[-1];
-        auto Ev = sdpa_node->get_input_tensor(2).get_partial_shape()[-1];  // in common case may not match E
+        const auto& E = sdpa_node->get_input_tensor(1).get_partial_shape()[-1];
+        const auto& Ev = sdpa_node->get_input_tensor(2).get_partial_shape()[-1];  // in common case may not match E
 
         auto extract_num_kv_heads = [=, &pattern_map](std::shared_ptr<Node> unsqueeze,
-                                                      const Dimension& default_heads_num) {
+                                                      const Dimension& default_heads_num) -> ov::Dimension {
             // Deduce number of k/v heads from Unsqueeze-Broadcast-Reshape (UBR pattern, if present)
             // pattern that appears in case of MQA/GQA.
             // In case if UBR pattern doesn't appear, the default number of heads is used passed as default_heads_num.
@@ -256,7 +256,7 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
             // it avoids complication in the pattern, but we don't really have many options
             auto take_4d = [=](const std::shared_ptr<Node>& option1,
                                const std::shared_ptr<Node>& option2,
-                               const std::shared_ptr<Node>& option3) {
+                               const std::shared_ptr<Node>& option3) -> ov::Output<Node> {
                 if (pattern_map.find(option1) != pattern_map.end() &&
                     pattern_map.at(option1).get_partial_shape().rank().get_length() == 4) {
                     return pattern_map.at(option1);

--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/total_sequence_length_pattern.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/total_sequence_length_pattern.cpp
@@ -34,7 +34,7 @@ ov::pass::TotalSequenceLengthPattern::TotalSequenceLengthPattern(
         if (replacement->get_output_element_type(0) != target_type) {
             replacement = std::make_shared<v0::Convert>(replacement, target_type);
         }
-        auto required_shape = gather->get_output_partial_shape(0);
+        const auto& required_shape = gather->get_output_partial_shape(0);
         if (replacement->get_output_partial_shape(0) != required_shape && required_shape.rank().is_static()) {
             replacement = op::util::reshapeTo(replacement, Shape(required_shape.rank().get_length(), 1));
         }

--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -47,9 +47,9 @@ bool relax_hc_reshape_followed_by_matmul(const ov::pass::pattern::PatternValueMa
     const auto in_C_2 = ov::op::v0::Constant::create(ov::element::i64, {}, {0});
     const auto C = std::make_shared<ov::op::v8::Gather>(in_C_0, in_C_1, in_C_2);
     const auto N = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
-    const auto& pattern_vector = reshape_is_A_input
-                                    ? (matmul->get_transpose_a() ? ov::OutputVector({C, N}) : ov::OutputVector({N, C}))
-                                    : (matmul->get_transpose_b() ? ov::OutputVector({N, C}) : ov::OutputVector({C, N}));
+    const auto& pattern_vector =
+        reshape_is_A_input ? (matmul->get_transpose_a() ? ov::OutputVector({C, N}) : ov::OutputVector({N, C}))
+                           : (matmul->get_transpose_b() ? ov::OutputVector({N, C}) : ov::OutputVector({C, N}));
     const auto new_reshape_pattern = std::make_shared<ov::op::v0::Concat>(pattern_vector, 0);
 
     auto reshape_pattern = pattern_to_output.at(reshape_pattern_label).get_node_shared_ptr();

--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -47,7 +47,7 @@ bool relax_hc_reshape_followed_by_matmul(const ov::pass::pattern::PatternValueMa
     const auto in_C_2 = ov::op::v0::Constant::create(ov::element::i64, {}, {0});
     const auto C = std::make_shared<ov::op::v8::Gather>(in_C_0, in_C_1, in_C_2);
     const auto N = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
-    const auto pattern_vector = reshape_is_A_input
+    const auto& pattern_vector = reshape_is_A_input
                                     ? (matmul->get_transpose_a() ? ov::OutputVector({C, N}) : ov::OutputVector({N, C}))
                                     : (matmul->get_transpose_b() ? ov::OutputVector({N, C}) : ov::OutputVector({C, N}));
     const auto new_reshape_pattern = std::make_shared<ov::op::v0::Concat>(pattern_vector, 0);

--- a/src/common/transformations/src/transformations/symbolic_transformations/chained_maximum.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/chained_maximum.cpp
@@ -23,7 +23,9 @@ ov::pass::ChainedMaximumOptimization::ChainedMaximumOptimization() {
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& vm = m.get_pattern_value_map();
 
-        const auto& A = vm.at(A_input), B = vm.at(B_input), C = vm.at(C_input);
+        const auto& A = vm.at(A_input);
+        const auto& B = vm.at(B_input);
+        const auto& C = vm.at(C_input);
         const auto& output_to_replace = vm.at(first_maximum);
 
         ov::TensorSymbol A_symbols, B_symbols, C_symbols;

--- a/src/common/transformations/src/transformations/symbolic_transformations/chained_maximum.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/chained_maximum.cpp
@@ -23,8 +23,8 @@ ov::pass::ChainedMaximumOptimization::ChainedMaximumOptimization() {
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& vm = m.get_pattern_value_map();
 
-        auto A = vm.at(A_input), B = vm.at(B_input), C = vm.at(C_input);
-        auto output_to_replace = vm.at(first_maximum);
+        const auto& A = vm.at(A_input), B = vm.at(B_input), C = vm.at(C_input);
+        const auto& output_to_replace = vm.at(first_maximum);
 
         ov::TensorSymbol A_symbols, B_symbols, C_symbols;
         bool A_read = get_symbols(A, A_symbols);

--- a/src/common/transformations/src/transformations/symbolic_transformations/dereshape_matmul.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/dereshape_matmul.cpp
@@ -23,7 +23,7 @@ using namespace ov::symbol::util;
 
 namespace {
 bool concat_predicate(ov::Output<ov::Node> output) {
-    auto output_pshape = output.get_partial_shape();
+    const auto& output_pshape = output.get_partial_shape();
     if (output_pshape.rank().is_dynamic() || output_pshape.size() <= 2)
         return false;
     const auto& concat = ov::as_type_ptr<ov::op::v0::Concat>(output.get_node_shared_ptr());
@@ -60,10 +60,10 @@ bool batches_are_equal(const ov::PartialShape& lhs, const ov::PartialShape& rhs,
 }
 
 bool batches_are_equal(const std::shared_ptr<ov::Node>& op_0, const std::shared_ptr<ov::Node>& op_1) {
-    auto input_0 = op_0->get_input_partial_shape(0);
-    auto input_1 = op_1->get_input_partial_shape(0);
-    auto output_0 = op_0->get_output_partial_shape(0);
-    auto output_1 = op_1->get_output_partial_shape(0);
+    const auto& input_0 = op_0->get_input_partial_shape(0);
+    const auto& input_1 = op_1->get_input_partial_shape(0);
+    const auto& output_0 = op_0->get_output_partial_shape(0);
+    const auto& output_1 = op_1->get_output_partial_shape(0);
     return batches_are_equal(input_0, input_1, true) && batches_are_equal(output_0, output_1);
 }
 
@@ -234,9 +234,9 @@ ov::pass::DeReshapeMatMul::DeReshapeMatMul() {
         [](ov::Output<Node> out) -> bool {
             if (!pattern::consumers_count(1)(out))
                 return false;
-            auto input_0_pshape = out.get_node_shared_ptr()->get_input_partial_shape(0);
-            auto input_1_pshape = out.get_node_shared_ptr()->get_input_partial_shape(1);
-            auto output_pshape = out.get_partial_shape();
+            const auto& input_0_pshape = out.get_node_shared_ptr()->get_input_partial_shape(0);
+            const auto& input_1_pshape = out.get_node_shared_ptr()->get_input_partial_shape(1);
+            const auto& output_pshape = out.get_partial_shape();
             ov::TensorSymbol output_symbols, input_0_symbols, input_1_symbols;
             if (get_symbols(input_0_pshape, input_0_symbols) && get_symbols(input_1_pshape, input_1_symbols) &&
                 get_symbols(output_pshape, output_symbols)) {

--- a/src/common/transformations/src/transformations/symbolic_transformations/nop_broadcast.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/nop_broadcast.cpp
@@ -45,8 +45,8 @@ ov::pass::NopBroadcast::NopBroadcast() {
 
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& vm = m.get_pattern_value_map();
-        auto data = vm.at(data_label);
-        auto shape = vm.at(shape_label);
+        const auto& data = vm.at(data_label);
+        const auto& shape = vm.at(shape_label);
 
         ov::TensorSymbol data_symbols, shape_symbols;
         if (!get_symbols(data.get_partial_shape(), data_symbols) || !get_symbols(shape, shape_symbols) ||

--- a/src/common/transformations/src/transformations/symbolic_transformations/symbol_optimization.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/symbol_optimization.cpp
@@ -204,7 +204,7 @@ void optimize_value_usage(ov::Output<ov::Node>& output, STS_map& symbol_shape_so
     auto symbol = value_symbols[0];
     if (symbol == nullptr)
         return;
-    auto pshape = output.get_partial_shape();
+    const auto& pshape = output.get_partial_shape();
     if (pshape.is_dynamic() || ov::shape_size(pshape.to_shape()) != 1)
         return;
 
@@ -342,7 +342,7 @@ void save_shape_sources(const std::shared_ptr<ov::Node>& op, STS_map& symbol_sha
         for (const auto& input : concat->input_values()) {
             if (input.get_partial_shape().rank().is_dynamic())
                 continue;
-            const auto dimension = input.get_partial_shape()[axis];
+            const auto& dimension = input.get_partial_shape()[axis];
             if (dimension.is_static())
                 continue;
             auto symbol = dimension.get_symbol();

--- a/src/common/transformations/src/transformations/symbolic_transformations/symbolic_optimizations.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/symbolic_optimizations.cpp
@@ -135,8 +135,8 @@ ov::pass::LabelResolvingThroughSelect::LabelResolvingThroughSelect() {
         if (!get_symbols(value_map.at(reshape).get_partial_shape(), reshape_symbols))
             return false;
         auto add_node = value_map.at(add).get_node_shared_ptr();
-        auto add_0_pshape = add_node->input_value(0).get_partial_shape();
-        auto add_1_pshape = add_node->input_value(1).get_partial_shape();
+        const auto& add_0_pshape = add_node->input_value(0).get_partial_shape();
+        const auto& add_1_pshape = add_node->input_value(1).get_partial_shape();
         if (!get_symbols(add_0_pshape, add_0_symbols) && !get_symbols(add_1_pshape, add_1_symbols))
             return false;
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
@@ -119,7 +119,7 @@ AxisVector ReverseTransposeOrder(const AxisVector& axis_order) {
 }
 
 void SwapOutputNames(Output<Node> output1, Output<Node> output2) {
-    const auto node2_output_names = output2.get_names();
+    const auto& node2_output_names = output2.get_names();
     output2.set_names(output1.get_names());
     output1.set_names(node2_output_names);
 

--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<ov::Node> activation(const std::string& activation_name, const o
 }
 
 bool is_seq_len_provided(const std::shared_ptr<Node>& X, const std::shared_ptr<Node>& seq_len_input) {
-    auto max_seq_dim = X->get_output_partial_shape(0)[1];
+    const auto& max_seq_dim = X->get_output_partial_shape(0)[1];
     if (max_seq_dim.is_dynamic()) {
         // if values in seq_len input are equal to max_seq_len dim in X input
         // then we don't need to insert Select operations
@@ -238,8 +238,8 @@ std::shared_ptr<Node> clone_try_fold(const std::shared_ptr<Node>& node, const Ou
 
 std::vector<Input<Node>> get_node_target_inputs(const std::shared_ptr<Node>& node) {
     std::vector<Input<Node>> result;
-    for (auto output : node->outputs()) {
-        for (auto input : output.get_target_inputs()) {
+    for (const auto& output : node->outputs()) {
+        for (auto& input : output.get_target_inputs()) {
             result.push_back(input);
         }
     }


### PR DESCRIPTION
[TRANSFORMATIONS] Fix 'auto' Coverity hits

Fix Coverity issues regarding the following topics:
* Use of auto that causes a copy
* Using invalid iterator
* Explicit null dereferenced

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>

Tickets:
	* CVS-121729