### PR TITLE
[GPU] Disabling fuse 'type conversion only' reorders for gather in decompression case

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -417,8 +417,9 @@ void remove_redundant_reorders::run(program& p) {
             bool allowed_dt_conversion_fuse =
                 (input.is_type<one_hot>() || input.is_type<permute>() || input.is_type<mvn>() ||
                  input.is_type<concatenation>() || input.is_type<depth_to_space>() || input.is_type<region_yolo>() ||
-                 input.is_type<detection_output>() || input.is_type<gather>() || input.is_type<broadcast>() ||
-                 input.is_type<select>() || input.is_type<eltwise>());
+                 input.is_type<detection_output>() || input.is_type<broadcast>() ||
+                 input.is_type<select>() || input.is_type<eltwise>()) ||
+                (input.is_type<gather>() && !input.as<gather>().get_primitive()->decompression_scale.is_valid());
             if (!same_data_type && !allowed_dt_conversion_fuse)
                 continue;
 


### PR DESCRIPTION
### Details:
 - *The accuracy of calculating Gather output if decompression is needed depends on the output data type. Changing the output data type due to reorder fusing led to a drop in accuracy.*

### Tickets:
 - *[146283](https://jira.devtools.intel.com/browse/CVS-146283)*
