### PR TITLE
[Core] move evaluate_* from ov to ov::util namespace

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
@@ -20,7 +20,7 @@ bool has_valid_pattern(const ov::Output<ov::Node>& node_out) {
     const auto const_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(node_out.get_node_shared_ptr());
     if (!const_node) {
         // Lower bound of the value
-        auto lb = ov::evaluate_lower_bound(node_out);
+        auto lb = ov::util::evaluate_lower_bound(node_out);
         if (!lb)
             return false;
         const auto lb_const_node =
@@ -36,7 +36,7 @@ bool has_valid_pattern(const ov::Output<ov::Node>& node_out) {
             return true;
 
         // Upper bound of the value
-        auto ub = ov::evaluate_upper_bound(node_out);
+        auto ub = ov::util::evaluate_upper_bound(node_out);
         if (!ub)
             return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -164,7 +164,7 @@ pass::AbsSinking::AbsSinking() {
             graph_got_changed = true;
         }
         for (const auto& abs : abs_ops) {
-            auto bounds = ov::evaluate_both_bounds(abs->input_value(0));
+            auto bounds = ov::util::evaluate_both_bounds(abs->input_value(0));
             if (ov::util::reduce_and(ov::util::greater_equal(bounds.first, 0))) {
                 replace_output_update_name(abs->output(0), abs->input_value(0));
                 graph_got_changed = true;

--- a/src/common/transformations/src/transformations/symbolic_transformations/symbol_optimization.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/symbol_optimization.cpp
@@ -215,7 +215,7 @@ void optimize_value_usage(ov::Output<ov::Node>& output, STS_map& symbol_shape_so
             get_alternative_source_from_value_or_shape_source(symbol_shape_source, symbol, output, symbol_value_source);
 
     if (alternative_source.get_node_shared_ptr() != nullptr) {
-        evaluate_both_bounds(alternative_source);
+        ov::util::evaluate_both_bounds(alternative_source);
         output.replace(alternative_source);
     } else {
         // in case we can not optimize it -- it is symbol which appeared just now on the value path

--- a/src/core/dev_api/openvino/core/bound_evaluation_util.hpp
+++ b/src/core/dev_api/openvino/core/bound_evaluation_util.hpp
@@ -14,6 +14,8 @@ namespace ov {
 /// \return True if bounds can be propagated for output and order vector has valid data, otherwise false.
 OPENVINO_API bool could_propagate(const Output<Node>& output, std::vector<Node*>& order);
 
+namespace util {
+
 /// \brief Evaluates lower value estimation of the output tensor. Traverses graph up to deduce
 /// estimation through it.
 /// \param Node output pointing to the tensor for estimation.
@@ -31,4 +33,5 @@ OPENVINO_API Tensor evaluate_upper_bound(const Output<Node>& output);
 /// \param output Node output pointing to the tensor for estimation.
 /// \return pair with Tensors for lower and upper value estimation.
 OPENVINO_API std::pair<Tensor, Tensor> evaluate_both_bounds(const Output<Node>& output);
+}
 }  // namespace ov

--- a/src/core/dev_api/openvino/core/bound_evaluation_util.hpp
+++ b/src/core/dev_api/openvino/core/bound_evaluation_util.hpp
@@ -33,5 +33,5 @@ OPENVINO_API Tensor evaluate_upper_bound(const Output<Node>& output);
 /// \param output Node output pointing to the tensor for estimation.
 /// \return pair with Tensors for lower and upper value estimation.
 OPENVINO_API std::pair<Tensor, Tensor> evaluate_both_bounds(const Output<Node>& output);
-}
+}  // namespace util
 }  // namespace ov

--- a/src/core/shape_inference/include/utils.hpp
+++ b/src/core/shape_inference/include/utils.hpp
@@ -366,7 +366,7 @@ ov::optional<TResult> get_input_bounds(const ov::Node* op, size_t port, const IT
         out->reserve(lowers.size());
         std::transform(lowers.cbegin(), lowers.cend(), lowers.cbegin(), std::back_inserter(*out), make_bound(et));
     } else if (port < op->get_input_size()) {
-        auto bounds = ov::evaluate_both_bounds(op->get_input_source_output(port));
+        auto bounds = ov::util::evaluate_both_bounds(op->get_input_source_output(port));
 
         if (bounds.first && bounds.second) {
             const auto& et = bounds.first.get_element_type();

--- a/src/core/src/bound_evaluate.cpp
+++ b/src/core/src/bound_evaluate.cpp
@@ -299,15 +299,15 @@ bool ov::could_propagate(const Output<Node>& output, std::vector<Node*>& result)
     return status;
 }
 
-ov::Tensor ov::evaluate_lower_bound(const Output<Node>& output) {
+ov::Tensor ov::util::evaluate_lower_bound(const Output<Node>& output) {
     return evaluate_bound(output, false);
 }
 
-ov::Tensor ov::evaluate_upper_bound(const Output<Node>& output) {
+ov::Tensor ov::util::evaluate_upper_bound(const Output<Node>& output) {
     return evaluate_bound(output, true);
 }
 
-std::pair<ov::Tensor, ov::Tensor> ov::evaluate_both_bounds(const Output<Node>& output) {
+std::pair<ov::Tensor, ov::Tensor> ov::util::evaluate_both_bounds(const Output<Node>& output) {
     const auto& output_tensor = output.get_tensor();
     if (output_tensor.get_lower_value() && output_tensor.get_upper_value())
         return {output_tensor.get_lower_value(), output_tensor.get_upper_value()};
@@ -381,10 +381,10 @@ bool ov::interval_bound_evaluator(const Node* node,
     OPENVINO_ASSERT(node->get_input_size() == 2);
 
     const auto num_of_outputs = node->get_output_size();
-    auto low_0 = ov::evaluate_lower_bound(node->get_input_source_output(0));
-    auto low_1 = ov::evaluate_lower_bound(node->get_input_source_output(1));
-    auto up_0 = ov::evaluate_upper_bound(node->get_input_source_output(0));
-    auto up_1 = ov::evaluate_upper_bound(node->get_input_source_output(1));
+    auto low_0 = ov::util::evaluate_lower_bound(node->get_input_source_output(0));
+    auto low_1 = ov::util::evaluate_lower_bound(node->get_input_source_output(1));
+    auto up_0 = ov::util::evaluate_upper_bound(node->get_input_source_output(0));
+    auto up_1 = ov::util::evaluate_upper_bound(node->get_input_source_output(1));
     if (!low_0 || !low_1 || !up_0 || !up_1)
         return false;
 
@@ -534,7 +534,7 @@ bool ov::has_and_set_equal_bounds(const Output<Node>& source) {
     if (op::util::is_constant(source.get_node_shared_ptr()))
         return true;
 
-    auto bounds = ov::evaluate_both_bounds(source);
+    auto bounds = ov::util::evaluate_both_bounds(source);
     return are_same_tensor(bounds.first, bounds.second);
 }
 

--- a/src/core/src/op/divide.cpp
+++ b/src/core/src/op/divide.cpp
@@ -80,16 +80,16 @@ bool evaluate_bound(const Node* node, TensorVector& output_values, bool is_upper
     OPENVINO_ASSERT(PartialShape::broadcast_merge_into(input_shape, input2.get_partial_shape(), node->get_autob()),
                     "Argument shapes in divide operation are inconsistent.");
 
-    const auto input1_low = ::ov::util::evaluate_lower_bound(input1);
+    const auto input1_low = ov::util::evaluate_lower_bound(input1);
     if (!input1_low)
         return false;
-    const auto input1_up = ::ov::util::evaluate_upper_bound(input1);
+    const auto input1_up = ov::util::evaluate_upper_bound(input1);
     if (!input1_up)
         return false;
-    const auto input2_low = ::ov::util::evaluate_lower_bound(input2);
+    const auto input2_low = ov::util::evaluate_lower_bound(input2);
     if (!input2_low)
         return false;
-    const auto input2_up = ::ov::util::evaluate_upper_bound(input2);
+    const auto input2_up = ov::util::evaluate_upper_bound(input2);
     if (!input2_up)
         return false;
 

--- a/src/core/src/op/divide.cpp
+++ b/src/core/src/op/divide.cpp
@@ -80,16 +80,16 @@ bool evaluate_bound(const Node* node, TensorVector& output_values, bool is_upper
     OPENVINO_ASSERT(PartialShape::broadcast_merge_into(input_shape, input2.get_partial_shape(), node->get_autob()),
                     "Argument shapes in divide operation are inconsistent.");
 
-    const auto input1_low = evaluate_lower_bound(input1);
+    const auto input1_low = ::ov::util::evaluate_lower_bound(input1);
     if (!input1_low)
         return false;
-    const auto input1_up = evaluate_upper_bound(input1);
+    const auto input1_up = ::ov::util::evaluate_upper_bound(input1);
     if (!input1_up)
         return false;
-    const auto input2_low = evaluate_lower_bound(input2);
+    const auto input2_low = ::ov::util::evaluate_lower_bound(input2);
     if (!input2_low)
         return false;
-    const auto input2_up = evaluate_upper_bound(input2);
+    const auto input2_up = ::ov::util::evaluate_upper_bound(input2);
     if (!input2_up)
         return false;
 

--- a/src/core/src/op/mod.cpp
+++ b/src/core/src/op/mod.cpp
@@ -78,8 +78,8 @@ namespace {
  * @return Vector with inputs bounds tensors.
  */
 TensorVector get_bounds(const Node* const op) {
-    auto&& v_bounds = ov::evaluate_both_bounds(op->input_value(0));
-    auto&& m_bounds = ov::evaluate_both_bounds(op->input_value(1));
+    auto&& v_bounds = ov::util::evaluate_both_bounds(op->input_value(0));
+    auto&& m_bounds = ov::util::evaluate_both_bounds(op->input_value(1));
     return {std::move(v_bounds.first),
             std::move(v_bounds.second),
             std::move(m_bounds.first),

--- a/src/core/tests/bound_evaluate.cpp
+++ b/src/core/tests/bound_evaluate.cpp
@@ -42,7 +42,7 @@ TEST_F(EvaluateBoundTest, no_exception_when_node_has_output_with_dynamic_rank) {
     fn_op->set_output_type(1, element::i32, PartialShape{{1, 4}});
     fn_op->validate_and_infer_types();
 
-    EXPECT_NO_THROW(evaluate_both_bounds(fn_op));
+    EXPECT_NO_THROW(ov::util::evaluate_both_bounds(fn_op));
 }
 
 TEST_F(EvaluateBoundTest, no_exception_when_node_has_output_with_dynamic_element_type) {
@@ -50,7 +50,7 @@ TEST_F(EvaluateBoundTest, no_exception_when_node_has_output_with_dynamic_element
     fn_op->set_output_type(1, element::dynamic, PartialShape{4});
     fn_op->validate_and_infer_types();
 
-    EXPECT_NO_THROW(evaluate_both_bounds(fn_op));
+    EXPECT_NO_THROW(ov::util::evaluate_both_bounds(fn_op));
 }
 
 using BoundEvaluatorTest = ::testing::Test;


### PR DESCRIPTION
### Details:
 -  Align approach -- some of evaluate_* functions already are under ov::util namespace.
### Tickets:
 - CVS-147171
