### PR TITLE
[GPU] Use get_output_pshape() in crop_in_place_optimization::match() to check user output dynamic shape

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -470,7 +470,7 @@ bool crop_in_place_optimization::match(const program_node& node,
     for (auto user : node.get_users()) {
         // If the user node's output shape is already static, the padding
         // w/ dyn pad mask will not be propagated properly at runtime
-        if (node.is_dynamic() && !user->get_output_layout().is_dynamic())
+        if (node.is_dynamic() && !user->get_output_pshape().is_dynamic())
             return false;
         // do not optimize when next node is concatenation which is not output
         if (user->is_type<concatenation>() && !user->is_output())


### PR DESCRIPTION
### Details:
 - Use get_output_pshape() in crop_in_place_optimization::match() to check user output dynamic shape because user would have valid_output_layouts=false

### Tickets:
 - 146725
