### PR TITLE
[Snippets][CPU] Added Kernel Executor table caching with binary code

### DIFF
--- a/src/common/snippets/include/snippets/generator.hpp
+++ b/src/common/snippets/include/snippets/generator.hpp
@@ -11,6 +11,7 @@
 #include "snippets_isa.hpp"
 
 #include "snippets/lowered/linear_ir.hpp"
+#include "snippets/kernel_executor_table.hpp"
 #include "snippets/shape_types.hpp"
 #include "target_machine.hpp"
 
@@ -32,7 +33,8 @@ class LoweringResult {
     std::vector<std::shared_ptr<Emitter>> m_saved_emitters{};
 
 public:
-    std::shared_ptr<CompiledSnippet> compiled_snippet = nullptr;
+    CompiledSnippetPtr compiled_snippet = nullptr;
+    KernelExecutorTablePtr kernel_executor_table = nullptr;
 };
 
 /**

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -284,6 +284,7 @@ private:
     size_t m_static_buffer_scratchpad_size = 0;
 };
 using LinearIRPtr = std::shared_ptr<LinearIR>;
+using LinearIRCPtr = std::shared_ptr<const LinearIR>;
 
 template<typename iterator>
 iterator LinearIR::find(iterator begin, iterator end, const ExpressionPtr& target) const {

--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -116,6 +116,7 @@ public:
 
     std::shared_ptr<Subgraph> clone() const;
 
+    const std::shared_ptr<RuntimeConfigurator>& get_runtime_configurator() const;
     const std::shared_ptr<RuntimeConfig>& update_runtime_config() const;
 
     static auto wrap_node_as_subgraph(const std::shared_ptr<ov::Node>& node) -> std::shared_ptr<Subgraph>;

--- a/src/common/snippets/include/snippets/runtime_configurator.hpp
+++ b/src/common/snippets/include/snippets/runtime_configurator.hpp
@@ -61,28 +61,36 @@ public:
      * @param linear_ir LinearIR
      * @return updated config
      */
-    const std::shared_ptr<RuntimeConfig>& get_updated_config(const lowered::LinearIRPtr& linear_ir);
-    /*** Returns pointer to KernelExecutorTable owned by the config */
+    const std::shared_ptr<RuntimeConfig>& get_updated_config(const lowered::LinearIRCPtr& linear_ir);
+    /**
+     * @brief Returns pointer to KernelExecutorTable owned by the config
+     * @return updated KernelExecutorTable
+     */
     const std::shared_ptr<KernelExecutorTable>& get_kernel_executor_table() const { return m_config->kernel_executor_table; }
+    /**
+     * @brief Set new KernelExecutorTable to the config
+     * @param table new KernelExecutorTable
+     */
+    void set_kernel_executor_table(std::shared_ptr<KernelExecutorTable> table) const;
 
 protected:
     /**
      * @brief Update RuntimeConfig based on LinearIR
      * @param linear_ir LinearIR
      */
-    virtual void update(const lowered::LinearIRPtr& linear_ir);
+    virtual void update(const lowered::LinearIRCPtr& linear_ir);
     /**
      * @brief Allocate and intialize fields in RuntimeConfig and RuntimeConfigurator
      * @param linear_ir LinearIR
      */
-    virtual void initialization(const lowered::LinearIRPtr& linear_ir);
+    virtual void initialization(const lowered::LinearIRCPtr& linear_ir);
 
     /**
      * @brief Initializes input and data information of LinearIR:
      *        descriptors (that contains shapes and layouts) and data_sizes
      * @param linear_ir LinearIR
      */
-    void init_data_info(const lowered::LinearIRPtr& linear_ir);
+    void init_data_info(const lowered::LinearIRCPtr& linear_ir);
     /**
      * @brief Initializes information of buffers:
      *        - static buffer_scratchpad_size
@@ -90,23 +98,23 @@ protected:
      *        - clusters with dynamic buffers (`m_dynamic_buffer_clusters`) for the quick access in `update()`
      * @param linear_ir LinearIR
      */
-    void init_buffer_info(const lowered::LinearIRPtr& linear_ir);
+    void init_buffer_info(const lowered::LinearIRCPtr& linear_ir);
     /**
      * @brief Initializes tensor rank of config
      * @param linear_ir LinearIR
      */
-    virtual void init_tensor_rank(const lowered::LinearIRPtr& linear_ir) const;
+    virtual void init_tensor_rank(const lowered::LinearIRCPtr& linear_ir) const;
     /**
      * @brief Update Loop informations in LinearIR: Unified and ExpandedLoopInfo
      * @param linear_ir LinearIR
      */
-    void update_loop_info(const lowered::LinearIRPtr& linear_ir) const;
+    void update_loop_info(const lowered::LinearIRCPtr& linear_ir) const;
     /**
      * @brief Update Buffer scratchpad size and offsets if needed
      *        Note: `update_loop_info` must be called before
      * @param linear_ir LinearIR
      */
-    void update_buffer_scratchpad_size(const lowered::LinearIRPtr& linear_ir) const;
+    void update_buffer_scratchpad_size(const lowered::LinearIRCPtr& linear_ir) const;
     /**
      * @brief Calculate data offsets of LinearIR and update these values in RuntimeConfig
      */

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -5,6 +5,7 @@
 #include "snippets/generator.hpp"
 
 #include "snippets/itt.hpp"
+#include "snippets/runtime_configurator.hpp"
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/lowered/expression.hpp"
 #include "snippets/op/kernel.hpp"
@@ -46,6 +47,7 @@ LoweringResult Generator::generate(lowered::LinearIR& linear_ir, const void* com
             result.m_saved_emitters.emplace_back(emitter);
     }
     result.compiled_snippet = target->get_snippet();
+    result.kernel_executor_table = target->get_runtime_configurator()->get_kernel_executor_table();
 
     return result;
 }

--- a/src/common/snippets/src/kernel_executor_table.cpp
+++ b/src/common/snippets/src/kernel_executor_table.cpp
@@ -7,21 +7,13 @@
 namespace ov {
 namespace snippets {
 
-void KernelExecutorTable::replace_key_expression(const snippets::lowered::ExpressionPtr& from, const snippets::lowered::ExpressionPtr& to) {
-    const auto& found = m_table.find(from);
-    if (found != m_table.end()) {
-        OPENVINO_ASSERT(m_table.count(to) == 0, "Attempt to replace a value that is already in the KernelExecutorTable");
-        m_table.insert({to, found->second});
-        m_table.erase(found);
-    }
-}
-
 void KernelExecutorTable::reset_state(const ExecTableState& state) {
     OPENVINO_ASSERT(state.size() == m_table.size(), "Invalid state in restore_state: size mismatch");
     auto state_it = state.begin();
     for (const auto& table_record : m_table) {
         const auto& state_record = *state_it++;
-        OPENVINO_ASSERT(table_record.first == state_record.first, "Invalid state in restore_state: expressions mismatch");
+        OPENVINO_ASSERT(table_record.first == state_record.first,
+                        "Invalid state in restore_state: expression execution numbers mismatched");
         table_record.second->update_by_config(*state_record.second);
     }
 }

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -544,22 +544,21 @@ snippets::Schedule Subgraph::generate(const void* compile_params) const {
     }
 
     auto lowering_result = m_generator->generate(linear_ir, compile_params);
-
-    // Note: Since the code emission is performed on a copy of LIR, but RuntimeConfigurator works with the initial instance,
-    //  we need to replace cloned expression pointers to original ones in the KernelExecutorTable. Ticket: 129772
-    const auto& exec_table = m_generator->get_target_machine()->get_runtime_configurator()->get_kernel_executor_table();
-    for (const auto& expr : *m_linear_ir)
-        exec_table->replace_key_expression(expression_map.at(expr.get()), expr);
     // Some kernel executors might've been registered during code emission.
     //  We need to update them, so appropriate kernels will be compiled.
+    const auto& exec_table = m_generator->get_target_machine()->get_runtime_configurator()->get_kernel_executor_table();
     exec_table->update_state(m_linear_ir);
     return {std::move(lowering_result)};
 }
 
-const std::shared_ptr<RuntimeConfig>& Subgraph::update_runtime_config() const {
+const std::shared_ptr<RuntimeConfigurator>& Subgraph::get_runtime_configurator() const {
     OPENVINO_ASSERT(m_generator, "Generator has not been inited!");
+    return m_generator->get_target_machine()->get_runtime_configurator();
+}
+
+const std::shared_ptr<RuntimeConfig>& Subgraph::update_runtime_config() const {
     OPENVINO_ASSERT(m_linear_ir, "LoweredLinearIR has not been inited!");
-    return m_generator->get_target_machine()->get_runtime_configurator()->get_updated_config(m_linear_ir);
+    return get_runtime_configurator()->get_updated_config(m_linear_ir);
 }
 
 void Subgraph::print() const {

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -546,7 +546,7 @@ snippets::Schedule Subgraph::generate(const void* compile_params) const {
     auto lowering_result = m_generator->generate(linear_ir, compile_params);
     // Some kernel executors might've been registered during code emission.
     //  We need to update them, so appropriate kernels will be compiled.
-    const auto& exec_table = m_generator->get_target_machine()->get_runtime_configurator()->get_kernel_executor_table();
+    const auto& exec_table = get_runtime_configurator()->get_kernel_executor_table();
     exec_table->update_state(m_linear_ir);
     return {std::move(lowering_result)};
 }

--- a/src/common/snippets/src/runtime_configurator.cpp
+++ b/src/common/snippets/src/runtime_configurator.cpp
@@ -35,7 +35,7 @@ RuntimeConfigurator::RuntimeConfigurator(std::shared_ptr<RuntimeConfig> c) :
     OPENVINO_ASSERT(m_config, "Runtime config is nullptr!");
 }
 
-const std::shared_ptr<RuntimeConfig>& RuntimeConfigurator::get_updated_config(const lowered::LinearIRPtr& linear_ir) {
+const std::shared_ptr<RuntimeConfig>& RuntimeConfigurator::get_updated_config(const lowered::LinearIRCPtr& linear_ir) {
     // First initialization
     if (m_io_num == 0)
         initialization(linear_ir);
@@ -44,7 +44,7 @@ const std::shared_ptr<RuntimeConfig>& RuntimeConfigurator::get_updated_config(co
     return m_config;
 }
 
-void RuntimeConfigurator::initialization(const lowered::LinearIRPtr& linear_ir) {
+void RuntimeConfigurator::initialization(const lowered::LinearIRCPtr& linear_ir) {
     init_data_info(linear_ir);
     init_tensor_rank(linear_ir);
     init_buffer_info(linear_ir);
@@ -55,7 +55,7 @@ void RuntimeConfigurator::initialization(const lowered::LinearIRPtr& linear_ir) 
     m_config->tile_rank = linear_ir->get_config().m_loop_depth;
 }
 
-void RuntimeConfigurator::update(const lowered::LinearIRPtr& linear_ir) {
+void RuntimeConfigurator::update(const lowered::LinearIRCPtr& linear_ir) {
     if (linear_ir->is_dynamic()) {
         update_loop_info(linear_ir);
         update_buffer_scratchpad_size(linear_ir);
@@ -67,11 +67,11 @@ void RuntimeConfigurator::update(const lowered::LinearIRPtr& linear_ir) {
     update_latest_shapes();
 }
 
-void RuntimeConfigurator::init_tensor_rank(const lowered::LinearIRPtr& linear_ir) const {
+void RuntimeConfigurator::init_tensor_rank(const lowered::LinearIRCPtr& linear_ir) const {
     m_config->tensor_rank = linear_ir->get_master_shape().size();
 }
 
-void RuntimeConfigurator::init_data_info(const lowered::LinearIRPtr& linear_ir) {
+void RuntimeConfigurator::init_data_info(const lowered::LinearIRCPtr& linear_ir) {
     const auto& parameters = linear_ir->get_parameters();
     const auto& results = linear_ir->get_results();
     m_in_num = parameters.size();
@@ -113,7 +113,7 @@ void RuntimeConfigurator::init_data_info(const lowered::LinearIRPtr& linear_ir) 
     }
 }
 
-void RuntimeConfigurator::init_buffer_info(const lowered::LinearIRPtr& linear_ir) {
+void RuntimeConfigurator::init_buffer_info(const lowered::LinearIRCPtr& linear_ir) {
     std::map<size_t, std::set<lowered::ExpressionPtr>> dynamic_buffer_clusters, static_buffer_clusters;
 
     // All needed checks are in Validate pass
@@ -143,7 +143,7 @@ void RuntimeConfigurator::init_buffer_info(const lowered::LinearIRPtr& linear_ir
     m_dynamic_buffer_clusters = std::move(dynamic_buffer_clusters);
 }
 
-void RuntimeConfigurator::update_loop_info(const lowered::LinearIRPtr& linear_ir) const {
+void RuntimeConfigurator::update_loop_info(const lowered::LinearIRCPtr& linear_ir) const {
     // Initialized UnifiedLoopInfo
     struct CurrentUnifiedLoopInfo {
         size_t current_work_amount = 0;
@@ -202,7 +202,7 @@ void RuntimeConfigurator::update_loop_info(const lowered::LinearIRPtr& linear_ir
     }
 }
 
-void RuntimeConfigurator::update_buffer_scratchpad_size(const lowered::LinearIRPtr& linear_ir) const {
+void RuntimeConfigurator::update_buffer_scratchpad_size(const lowered::LinearIRCPtr& linear_ir) const {
     const auto& loop_manager = linear_ir->get_loop_manager();
     m_config->buffer_scratchpad_size = linear_ir->get_static_buffer_scratchpad_size();
 
@@ -276,6 +276,11 @@ void RuntimeConfigurator::update_latest_shapes() {
     for (size_t i = 0; i < m_io_num; ++i) {
         m_latest_shapes[i] = m_io_descs[i]->get_shape();
     }
+}
+
+void RuntimeConfigurator::set_kernel_executor_table(std::shared_ptr<KernelExecutorTable> table) const {
+    OPENVINO_ASSERT(table, "Failed to update Kernel Executo Table: passed table is missed");
+    m_config->kernel_executor_table = std::move(table);
 }
 
 } // namespace snippets

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.cpp
@@ -14,7 +14,7 @@ namespace intel_cpu {
 CPURuntimeConfigurator::CPURuntimeConfigurator() : ov::snippets::RuntimeConfigurator(std::make_shared<CPURuntimeConfig>()) {
 }
 
-void CPURuntimeConfigurator::update(const ov::snippets::lowered::LinearIRPtr& linear_ir) {
+void CPURuntimeConfigurator::update(const ov::snippets::lowered::LinearIRCPtr& linear_ir) {
     if (linear_ir->is_dynamic()) {
         update_loop_info(linear_ir);
         update_loop_args(linear_ir);
@@ -30,11 +30,11 @@ void CPURuntimeConfigurator::update(const ov::snippets::lowered::LinearIRPtr& li
     update_latest_shapes();
 }
 
-void CPURuntimeConfigurator::init_tensor_rank(const ov::snippets::lowered::LinearIRPtr& linear_ir) const {
+void CPURuntimeConfigurator::init_tensor_rank(const ov::snippets::lowered::LinearIRCPtr& linear_ir) const {
     m_config->tensor_rank = std::max(linear_ir->get_master_shape().size(), rank6D);
 }
 
-void CPURuntimeConfigurator::update_loop_args(const ov::snippets::lowered::LinearIRPtr& linear_ir) const {
+void CPURuntimeConfigurator::update_loop_args(const ov::snippets::lowered::LinearIRCPtr& linear_ir) const {
     const auto& cpu_config = ov::as_type_ptr<CPURuntimeConfig>(m_config);
     OPENVINO_ASSERT(cpu_config, "CPURuntimeConfigurator expects CPURuntimeConfig");
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
@@ -29,17 +29,17 @@ protected:
      * @brief Update RuntimeConfig based on LinearIR
      * @param linear_ir LinearIR
      */
-    void update(const ov::snippets::lowered::LinearIRPtr& linear_ir) override;
+    void update(const ov::snippets::lowered::LinearIRCPtr& linear_ir) override;
     /**
      * @brief Initializes tensor rank of config
      * @param linear_ir LinearIR
      */
-    void init_tensor_rank(const ov::snippets::lowered::LinearIRPtr& linear_ir) const override;
+    void init_tensor_rank(const ov::snippets::lowered::LinearIRCPtr& linear_ir) const override;
     /**
      * @brief Calculate Loop parameters of Loop emitters and update these values in CPURuntimeConfig
      * @param linear_ir LinearIR
      */
-    void update_loop_args(const ov::snippets::lowered::LinearIRPtr& linear_ir) const;
+    void update_loop_args(const ov::snippets::lowered::LinearIRCPtr& linear_ir) const;
 
     const size_t rank6D = 6;
 };

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.cpp
@@ -184,7 +184,7 @@ float BrgemmKernelExecutor::get_beta(const ov::snippets::lowered::LoopManagerPtr
     return 0;
 }
 void BrgemmKernelExecutor::update_config(const ov::snippets::lowered::ExpressionPtr& expr,
-                                         const ov::snippets::lowered::LinearIRPtr& linear_ir,
+                                         const ov::snippets::lowered::LinearIRCPtr& linear_ir,
                                          BrgemmKernelConfig& config) const {
     const auto& input_pds = expr->get_input_port_descriptors();
     const auto& output_pds = expr->get_output_port_descriptors();

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
@@ -100,7 +100,7 @@ public:
 protected:
     std::shared_ptr<BrgemmCompiledKernel> compile_kernel(const BrgemmKernelConfig& c) const override;
     void update_config(const ov::snippets::lowered::ExpressionPtr& expr,
-                       const ov::snippets::lowered::LinearIRPtr& linear_ir,
+                       const ov::snippets::lowered::LinearIRCPtr& linear_ir,
                        BrgemmKernelConfig& config) const override;
 
     static float get_beta(const ov::snippets::lowered::LoopManagerPtr& loop_manager, int loop_id,

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -752,7 +752,7 @@ void Subgraph::prepareParams() {
             // 1. Generate JIT code if needed
             // 2. Update runtime config with dynamic values
             //    If JIT code has been taken from cache, need to set cached kernel executor table for the configuration
-            // 3. Create SubgraphDynamicSpecializedExecutor<CPURuntimeConfig>(snippet->update_runtime_config());
+            // 3. Create SubgraphDynamicSpecializedExecutor
             const auto code_gen_result = cache->getOrCreate(SubgraphCodeGeneratorKey(subgraph_attrs, getBroadcastingMask(in_shapes)),
                                                             [](const SubgraphCodeGeneratorKey& key) -> std::shared_ptr<SubgraphCodeGenerator> {
                                                                 return std::make_shared<SubgraphCodeGenerator>(key.attrs, std::make_shared<CPURuntimeConfig>());

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -746,15 +746,34 @@ void Subgraph::prepareParams() {
     const auto cache = context->getParamsCache();
 
     auto builder = [this, cache](const SubgraphKey& key) -> std::shared_ptr<SubgraphExecutor> {
-        const auto& snippet_config = ov::as_type_ptr<CPURuntimeConfig>(subgraph_attrs->snippet->update_runtime_config());
-        // Firstly, find the schedule in the cache
-        const auto code_gen_result = cache->getOrCreate(SubgraphCodeGeneratorKey(subgraph_attrs, getBroadcastingMask(in_shapes)),
-                                                        [&snippet_config](const SubgraphCodeGeneratorKey& key) -> std::shared_ptr<SubgraphCodeGenerator> {
-                                                            return std::make_shared<SubgraphCodeGenerator>(key.attrs, snippet_config);
-                                                        });
+        const auto& snippet = subgraph_attrs->snippet;
         if (is_dynamic) {
-            return std::make_shared<SubgraphDynamicSpecializedExecutor>(key.attrs, code_gen_result.first, start_offset_in, start_offset_out, snippet_config);
+            // Dynamic case:
+            // 1. Generate JIT code if needed
+            // 2. Update runtime config with dynamic values
+            //    If JIT code has been taken from cache, need to set cached kernel executor table for the configuration
+            // 3. Create SubgraphDynamicSpecializedExecutor<CPURuntimeConfig>(snippet->update_runtime_config());
+            const auto code_gen_result = cache->getOrCreate(SubgraphCodeGeneratorKey(subgraph_attrs, getBroadcastingMask(in_shapes)),
+                                                            [](const SubgraphCodeGeneratorKey& key) -> std::shared_ptr<SubgraphCodeGenerator> {
+                                                                return std::make_shared<SubgraphCodeGenerator>(key.attrs, std::make_shared<CPURuntimeConfig>());
+                                                            });
+            const auto& code_gen = code_gen_result.first;
+            // [148644] : Update Kernel table from SubgraphCodeGenerator when JIT code was already generated with specific Kernel table
+            if (code_gen_result.second == CacheEntryBase::LookUpStatus::Hit) {
+                snippet->get_runtime_configurator()->set_kernel_executor_table(code_gen->get()->lowering_result.kernel_executor_table);
+            }
+            const auto& snippet_config = ov::as_type_ptr<CPURuntimeConfig>(snippet->update_runtime_config());
+            return std::make_shared<SubgraphDynamicSpecializedExecutor>(key.attrs, code_gen, start_offset_in, start_offset_out, snippet_config);
         } else {
+            // Static case:
+            // 1. Update runtime config to get static scheduling data (io data offsets, parallel domain) which will be compiled in JIT code
+            // 2. Generate JIT code with this static data if needed
+            // 3. Create SubgraphStaticExecutor
+            const auto& snippet_config = ov::as_type_ptr<CPURuntimeConfig>(snippet->update_runtime_config());
+            const auto code_gen_result = cache->getOrCreate(SubgraphCodeGeneratorKey(subgraph_attrs, getBroadcastingMask(in_shapes)),
+                                                            [&snippet_config](const SubgraphCodeGeneratorKey& key) -> std::shared_ptr<SubgraphCodeGenerator> {
+                                                                return std::make_shared<SubgraphCodeGenerator>(key.attrs, snippet_config);
+                                                            });
             return std::make_shared<SubgraphStaticExecutor>(key.attrs, code_gen_result.first, start_offset_in, start_offset_out, snippet_config);
         }
     };

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/subgraph_caching.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/subgraph_caching.cpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Motivation:
+// In a dynamic scenario, depending on the input shapes for the current node,
+//   -  we can either generate a new jit kernel or get an existing one from the cache
+//   -  we can either make shape inference or get existing output shapes from the cache
+// But the current single layer tests do not allow checking the case when the same kernel can be used for different nodes.
+// We check 2 Subgraphs with MatMuls inside to validate Kernel Executor table also
+
+//  -----------              -----------    -----------              -----------
+//  |input 0.0|              |input 0.1|    |input 1.0|              |input 1.1|
+//  -----------              -----------    -----------              -----------
+//       |                        |              |                        |
+//  ------------------------------------    ------------------------------------
+//  |            MatMul 0              |    |            Matmul 1              |
+//  ------------------------------------    ------------------------------------
+//                   |                                       |
+//  ------------------------------------    ------------------------------------
+//  |              Add 0               |    |              Add 1               |
+//  ------------------------------------    ------------------------------------
+//                   |                                       |
+//  ----------------------------------------------------------------------------
+//  |                                 concat                                   |
+//  ----------------------------------------------------------------------------
+//                                       |
+//                                   --------
+//                                   |output|
+//                                   --------
+
+#include "snippets/op/subgraph.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "common_test_utils/node_builders/eltwise.hpp"
+#include "common_test_utils/node_builders/constant.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "utils/cpu_test_utils.hpp"
+#include "internal_properties.hpp"
+
+
+using namespace CPUTestUtils;
+
+namespace ov {
+namespace test {
+using namespace ov::test::utils;
+
+typedef std::tuple<
+        std::vector<InputShape>, // Input Shapes
+        std::vector<ElementType> // Input precisions
+> SubgraphCacheTestParams;
+
+class SubgraphCacheTest : public testing::WithParamInterface<SubgraphCacheTestParams>,
+                          virtual public SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<SubgraphCacheTestParams> &obj) {
+        std::vector<InputShape> inputShapes;
+        std::vector<ElementType> inputPrecisions;
+        std::tie(inputShapes, inputPrecisions) = obj.param;
+
+        std::ostringstream results;
+
+         for (size_t i = 0; i < inputShapes.size(); i++) {
+            results << "IS[" << i << "]=" << inputShapes[i];
+        }
+
+        for (size_t i = 0; i < inputPrecisions.size(); i++) {
+            results << "InPRC" << std::to_string(i) << "=" << inputPrecisions[i] << "_";
+        }
+
+        return results.str();
+    }
+
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_CPU;
+
+        std::vector<InputShape> inputShapes;
+        std::vector<ElementType> inputPrecisions;
+        std::tie(inputShapes, inputPrecisions) = this->GetParam();
+
+        init_input_shapes(inputShapes);
+
+        // Enable Snippets
+        configuration.insert(ov::intel_cpu::snippets_mode(ov::intel_cpu::SnippetsMode::IGNORE_CALLBACK));
+
+        ov::ParameterVector paramVec;
+        for (size_t i = 0; i < inputDynamicShapes.size(); i++) {
+            paramVec.push_back(std::make_shared<ov::op::v0::Parameter>(inputPrecisions[i], inputDynamicShapes[i]));
+        }
+
+        auto matmul0 = std::make_shared<ov::op::v0::MatMul>(paramVec[0], paramVec[1]);
+        auto matmul1 = std::make_shared<ov::op::v0::MatMul>(paramVec[2], paramVec[3]);
+
+        auto const0 = utils::make_constant(matmul0->get_output_element_type(0), ov::Shape{1});
+        auto const1 = utils::make_constant(matmul1->get_output_element_type(0), ov::Shape{1});
+
+        auto add0 = std::make_shared<ov::op::v1::Add>(matmul0, const0);
+        auto add1 = std::make_shared<ov::op::v1::Add>(matmul1, const1);
+
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::NodeVector{add0, add1}, -1);
+        function = std::make_shared<ov::Model>(concat, paramVec, "Subgraph");
+    }
+
+    void validate_result() const {
+        const std::set<std::string> types = { "Input", "Output", "Subgraph", "Concatenation" };
+        const auto function = compiledModel.get_runtime_model();
+        for (const auto& op : function->get_ordered_ops()) {
+            const auto& rtInfo = op->get_rt_info();
+            auto it = rtInfo.find(ov::exec_model_info::LAYER_TYPE);
+            OPENVINO_ASSERT(rtInfo.end() != it);
+            const auto node_type = it->second.as<std::string>();
+            ASSERT_TRUE(types.count(node_type)) << "The execution node is unexpected : " << node_type;
+        }
+    }
+};
+
+TEST_P(SubgraphCacheTest, CompareWithRefs) {
+    run();
+    validate_result();
+}
+
+namespace {
+
+std::vector<ElementType> inputPrecisions {
+    ElementType::f32, ElementType::f32, ElementType::f32, ElementType::f32
+};
+
+std::vector<InputShape> inputShapes {
+    {{1, 2, -1, -1}, {{1, 2, 10, 3}, {1, 2, 10, 3}, {1, 2, 10, 8}, {1, 2, 10, 3}}},
+    {{1, 2, -1, -1}, {{1, 2, 3, 12}, {1, 2, 3, 12}, {1, 2, 8,  9}, {1, 2, 3, 12}}},
+    {{1, 2, -1, -1}, {{1, 2, 10, 8}, {1, 2, 10, 3}, {1, 2, 10, 3}, {1, 2, 10, 8}}},
+    {{1, 2, -1, -1}, {{1, 2, 8,  9}, {1, 2, 3, 12}, {1, 2, 3, 12}, {1, 2, 8,  9}}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_SubgraphCache, SubgraphCacheTest,
+                        ::testing::Combine(
+                                ::testing::Values(inputShapes),
+                                ::testing::Values(inputPrecisions)),
+                        SubgraphCacheTest::getTestCaseName);
+
+}  // namespace
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - *The Kernel Executor table maps on Expression execution numbers instead of Expressions to avoid dependency between `LinearIR` and binary code*
 - *Added Kernel Executor table to `SubgraphCodeGenerator` to be cached with binary code*
 - *Added Subgraph caching test*

### Tickets:
 - *N/A*
 
 ### Prerequisites:
- [x] https://github.com/openvinotoolkit/openvino/pull/25623
- [x] https://github.com/openvinotoolkit/openvino/pull/25378
