### PR TITLE
[GPU] Fix accumulate issue in FC

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
@@ -304,9 +304,7 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
         // NOTE: Manually unrolling multiplication loop leads to lower register pressure and allows for bigger block sizes,
         //       but significantly degrades readability and generality of code.
         //       It doesn't also show noticable performance improvement on tested configurations.
-        #if DECOMPRESSION_SCALE_POST_OP
-            ACCUMULATOR_VEC_TYPE acc_tmp[TILE_B] = { };
-        #endif
+        ACCUMULATOR_VEC_TYPE acc_tmp[TILE_B] = { };
 
         #if USE_SLM && COMPRESSED_WEIGHTS_INT4
             #if TILE_OFM != 2
@@ -469,9 +467,9 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
                     #endif
 #else
                     #if TILE_OFM > 1
-                        ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += in_val * ((ACCUMULATOR_TYPE*)(&wei))[W_IDX];
+                        ((ACCUMULATOR_TYPE*)(&acc_tmp[bi]))[fi] += in_val * ((ACCUMULATOR_TYPE*)(&wei))[W_IDX];
                     #else
-                        acc[bi] += in_val * ((ACCUMULATOR_TYPE*)(&wei))[W_IDX];
+                        acc_tmp[bi] += in_val * ((ACCUMULATOR_TYPE*)(&wei))[W_IDX];
                     #endif
 #endif
                     }
@@ -523,6 +521,18 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
                 ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += ((ACCUMULATOR_TYPE*)(&acc_tmp[bi]))[fi] * ds;
                 #else
                 acc[bi] += acc_tmp[bi] * ds;
+                #endif
+            }
+        }
+#endif
+
+#if !DECOMPRESSION_SCALE_POST_OP
+        unroll_for (uint bi = 0; bi < TILE_B; ++bi) {
+            unroll_for(uint fi = 0; fi < TILE_OFM; ++fi) {
+                #if TILE_OFM > 1
+                ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += ((ACCUMULATOR_TYPE*)(&acc_tmp[bi]))[fi];
+                #else
+                acc[bi] += acc_tmp[bi];
                 #endif
             }
         }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1474,6 +1474,66 @@ public:
             ASSERT_NEAR(output_ptr_ref[i], output_ptr[i], 9.0) << "i = " << i;
     }
 
+    void test_compressed_int4_accumulation(bool is_caching_test, bool is_dynamic, long int batch_num) {
+        auto& engine = get_test_engine();
+
+        long int ifm_num = 4096;
+        long int ofm_num = 4;
+
+        auto input_mem      = engine.allocate_memory({ { batch_num, ifm_num}, data_types::f16, format::bfyx });
+        auto weights_mem    = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u4, format::bfyx });
+        auto scale_mem      = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::f16, format::bfyx });
+
+        auto input_data = std::vector<ov::float16>(input_mem->count());
+        std::fill(input_data.begin(), input_data.end(), 1);
+        set_values(input_mem, input_data);
+
+        auto weigths_data = std::vector<uint8_t>(weights_mem->count() / 2);
+        std::fill(weigths_data.begin(), weigths_data.end(), 0x11);
+        set_values(weights_mem, weigths_data);
+
+        auto scale_data = std::vector<ov::float16>(scale_mem->count());
+        std::fill(scale_data.begin(), scale_data.end(), 1);
+        set_values(scale_mem, scale_data);
+
+        auto in_layout = is_dynamic ? layout{ {-1, ifm_num}, data_types::f16, format::bfyx }
+                                    : layout{ {batch_num, ifm_num}, data_types::f16, format::bfyx };
+        primitive_id empty_id = "";
+
+        auto fc_prim = fully_connected("fc_prim", input_info("input"), "weights", empty_id, "scale", empty_id, data_types::f16);
+
+        topology topology(
+            input_layout("input", in_layout),
+            data("weights", weights_mem),
+            data("scale", scale_mem),
+            fc_prim
+        );
+
+        auto config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
+
+        // Impl is selected only when it is running from cldnn
+        if (is_dynamic && !engine.get_device_info().supports_immad) {
+            auto inst = network->get_primitive("fc_prim");
+            auto impl = inst->get_impl();
+            ASSERT_TRUE(impl != NULL);
+            ASSERT_EQ(impl->get_kernels().size(), 1);
+        }
+
+        network->set_input_data("input", input_mem);
+
+        auto outputs = network->execute();
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "fc_prim");
+
+        auto output_mem = outputs.begin()->second.get_memory();
+        cldnn::mem_lock<ov::float16> output_ptr (output_mem, get_test_stream());
+        for (size_t i = 0; i < output_ptr.size(); i++)
+            ASSERT_NEAR(ov::float16(ifm_num), output_ptr[i], 9.0) << "i = " << i;
+    }
+
     void test_compressed_int4_scale_reuse(bool is_caching_test, bool is_dynamic, long int batch_num, long int scales_group_size = 128) {
         tests::random_generator rg(GET_SUITE_NAME);
         auto& engine = get_test_engine();
@@ -3271,6 +3331,10 @@ TEST_F(fully_connected_gpu_tests, compressed_int4_scale_cached) {
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic) {
     this->test_compressed_int4_scale(false, true, 260);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_dynamic_acc) {
+    this->test_compressed_int4_accumulation(false, true, 512);
 }
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dynamic_cached) {


### PR DESCRIPTION
### Details:
- *Previously there was an issue in accumulator with half precision in SLM kernel of fc_tiled_opt kernel.: It was accumulating fp16 value in the innermost loop, however, when the accumulated value becomes bigger but newly added values are still small, the small added values are being ignored. Fixed this issue by accumulating for more values to be added.*

### Tickets:
 - *138438*

