### PR TITLE
[Snippets] Dynamic SplitDimensionM via runtime configurator

### DIFF
--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -24,7 +24,13 @@ public:
     InitLoops() = default;
     bool run(LinearIR& linear_ir) override;
 
+    /**
+     * @brief Updates ptr_increments and finalization offsets of the provided "loop_info" based on current work amount
+     */
     static void update_data_pointer_shifts(const UnifiedLoopInfoPtr& loop_info);
+    /**
+     * @brief Updates work amount and updates data pointer shifts of the provided "loop_info"
+     */
     static void update_runtime_parameters(const UnifiedLoopInfoPtr& loop_info);
 
 private:

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -24,7 +24,7 @@ public:
     InitLoops() = default;
     bool run(LinearIR& linear_ir) override;
 
-    static void init_loop_info(const UnifiedLoopInfoPtr& loop_info, size_t loop_id, bool only_runtime_args = false);
+    static void update_runtime_parameters(const UnifiedLoopInfoPtr& loop_info, bool update_work_amount = true);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -24,7 +24,11 @@ public:
     InitLoops() = default;
     bool run(LinearIR& linear_ir) override;
 
-    static void update_runtime_parameters(const UnifiedLoopInfoPtr& loop_info, bool update_work_amount = true);
+    static void update_data_pointer_shifts(const UnifiedLoopInfoPtr& loop_info);
+    static void update_runtime_parameters(const UnifiedLoopInfoPtr& loop_info);
+
+private:
+    static void update_compile_parameters(const UnifiedLoopInfoPtr& loop_info, size_t loop_id);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
+++ b/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
@@ -27,18 +27,27 @@ public:
     static bool is_supported_matmul(const std::shared_ptr<const ov::Node>& node);
     // Returns True if parallelism work amount (concurrency) can be increased by this optimization
     static bool can_be_optimized(const std::shared_ptr<const ov::Node>& node, size_t concurrency);
+    static bool split(const ov::Shape& shape, size_t optimal_parallelism_work_amount, size_t& batch_m_dim, size_t& new_m_dim);
+
+    /**
+     * @brief Splits m dimension in order
+     * @param order Original order
+     * @param m_index M dimension index
+     * @return updated order with the split M dimension
+     */
+    static std::vector<size_t> get_updated_order(const std::vector<size_t>& order, size_t m_index);
+
+    static ov::snippets::VectorDims reshape_m_dim(const ov::snippets::VectorDims& shape, size_t m_index, size_t batch_m_dim, size_t new_m_dim);
+    static ov::snippets::VectorDims unsqueeze_m_dim(const ov::snippets::VectorDims& shape, size_t m_index);
 
 private:
     static std::shared_ptr<ov::op::v0::MatMul> get_matmul(const std::shared_ptr<op::Subgraph>& subgraph);
     static std::pair<size_t, size_t> get_splited_dimensions(size_t batch_dim, size_t m_dim, size_t optimal_parallelism_work_amount);
-    static bool split(const ov::Shape& shape, size_t optimal_parallelism_work_amount, size_t& batch_m_dim, size_t& new_m_dim);
 
     void reshape_subgraph(const std::shared_ptr<op::Subgraph>& subgraph, const ov::Shape& shape, size_t batch_m_dim, size_t new_m_dim);
 
     size_t m_concurrency;
 };
-
-
 } // namespace pass
 } // namespace snippets
 } // namespace ov

--- a/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
+++ b/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
@@ -14,6 +14,9 @@ namespace pass {
  * @interface SplitDimensionM
  * @brief Inserts Reshape nodes before inputs and after outputs of Subgraphs with MatMul inside
  *        to split dimension M for MatMuls. It allows to increase work amount for parallelism
+ * @attention This pass works only for MHA with static shapes.
+ * For dynamic shapes, parallel work amount is optimized in RuntimeConfigurator.
+ * @todo Ticket 148805: Move static cases handling in RuntimeConfigurator as well.
  * @ingroup snippets
  */
 class SplitDimensionM: public CommonOptimizations::SubgraphPass {
@@ -27,6 +30,15 @@ public:
     static bool is_supported_matmul(const std::shared_ptr<const ov::Node>& node);
     // Returns True if parallelism work amount (concurrency) can be increased by this optimization
     static bool can_be_optimized(const std::shared_ptr<const ov::Node>& node, size_t concurrency);
+
+    /**
+     * @brief Tries to split M dimension in "shape" in accordance to optimal parallel work amount
+     * @param shape Original shape
+     * @param optimal_parallelism_work_amount Optimal work amount
+     * @param batch_m_dim reference on batch's part of the split M
+     * @param new_m_dim reference on new M dim after the split
+     * @return true if split was successfull, otherwise false
+     */
     static bool split(const ov::Shape& shape, size_t optimal_parallelism_work_amount, size_t& batch_m_dim, size_t& new_m_dim);
 
     /**
@@ -36,9 +48,22 @@ public:
      * @return updated order with the split M dimension
      */
     static std::vector<size_t> get_updated_order(const std::vector<size_t>& order, size_t m_index);
-
-    static ov::snippets::VectorDims reshape_m_dim(const ov::snippets::VectorDims& shape, size_t m_index, size_t batch_m_dim, size_t new_m_dim);
-    static ov::snippets::VectorDims unsqueeze_m_dim(const ov::snippets::VectorDims& shape, size_t m_index);
+    /**
+     * @brief Reshapes m dimension in "shape": separates M in two parts: "batch_m_dim" and "new_m_dim"
+     * @param shape Shape to split
+     * @param m_index M dimension index
+     * @param batch_m_dim batch's part of the split M
+     * @param new_m_dim new M dim after the split
+     * @return the updated shape
+     */
+    static ov::snippets::VectorDims reshape_m_dim(ov::snippets::VectorDims shape, size_t m_index, size_t batch_m_dim, size_t new_m_dim);
+    /**
+     * @brief Unsqueezes m dimension in "shape" (inserts "1" before the dimension)
+     * @param shape Shape to split
+     * @param m_index M dimension index
+     * @return the updated shape
+     */
+    static ov::snippets::VectorDims unsqueeze_m_dim(ov::snippets::VectorDims shape, size_t m_index);
 
 private:
     static std::shared_ptr<ov::op::v0::MatMul> get_matmul(const std::shared_ptr<op::Subgraph>& subgraph);

--- a/src/common/snippets/include/snippets/runtime_configurator.hpp
+++ b/src/common/snippets/include/snippets/runtime_configurator.hpp
@@ -117,7 +117,6 @@ protected:
         std::vector<int64_t> finalization_offsets;
     };
     static UnifiedLoopInfoRtParams compute_runtime_params(const lowered::UnifiedLoopInfoPtr& unified_loop_info);
-
     using LoopInfoRuntimeParamsMap = std::unordered_map<lowered::UnifiedLoopInfoPtr, UnifiedLoopInfoRtParams>;
     /**
      * @brief Update Loop informations in LinearIR: Unified and ExpandedLoopInfo
@@ -134,13 +133,70 @@ protected:
     void update_buffer_scratchpad_size(const lowered::LinearIRCPtr& linear_ir) const;
     /**
      * @brief Calculate data offsets of LinearIR and update these values in RuntimeConfig
+     * @param shapes shapes used in offsets computation
+     * @param layouts layouts used in offsets computation
      */
-    void update_data_offsets(const std::vector<ov::snippets::VectorDims>& shapes = {},
-                             const std::vector<std::vector<size_t>>& layouts = {}) const;
+    void update_data_offsets(const std::vector<ov::snippets::VectorDims>& shapes,
+                             const std::vector<std::vector<size_t>>& layouts) const;
     /**
-     * @brief Update latest input shapes
+     * @brief Extract shapes from m_io_descs
      */
-    void update_latest_shapes();
+    std::vector<ov::snippets::VectorDims> extract_shapes();
+    /**
+     * @brief Extract layouts from m_io_descs
+     */
+    std::vector<std::vector<size_t>> extract_layouts();
+
+    class ParallelWAOptimizer {
+    public:
+        /**
+         * @brief Inits ParallelWAOptimizer: computes optimizer parameters which should be set at compilation stage
+         * @param linear_ir LinearIR
+         */
+        void init(const ov::snippets::lowered::LinearIRCPtr& linear_ir,
+                  const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
+                  size_t in_num);
+        /**
+         * @brief Defines if the optimizer should be applied
+         * @attention It also computes "batch_m" and "new_m" runtime parameters
+         * @param master_shape Master shape
+         */
+        bool need_optimize(const ov::snippets::VectorDims& master_shape);
+        /**
+         * @brief Updates all the necessary runtime information
+         * @param map Loop info -> Runtime params map which will be passed in "update_loop_info"
+         * the map is filled with updated loops_to_split loops: "new_m" work amount is set for them, and runtime params are updated correspondingly
+         * @param shapes Vector which is filled with the split shapes
+         * @param layouts Vector which is filled with the split layouts
+         * @param config Config which should be updated: tile rank and master shape is updated
+         * @attention It also computes "batch_m" and "new_m" runtime parameters
+         * @param master_shape Master shape
+         */
+        void update(ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap& map,
+                    std::vector<ov::snippets::VectorDims>& shapes,
+                    std::vector<std::vector<size_t>>& layouts,
+                    const std::shared_ptr<ov::snippets::RuntimeConfig>& config,
+                    size_t in_num);
+
+    private:
+        void update_split_loops_info(ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap& map);
+        void update_shapes(std::vector<ov::snippets::VectorDims>& shapes);
+        void update_layouts(std::vector<std::vector<size_t>>& layouts);
+        void update_config(const std::shared_ptr<ov::snippets::RuntimeConfig>& config);
+
+        static std::unordered_set<snippets::lowered::ExpressionPtr> find_applicable_brgemms(const ov::snippets::lowered::LinearIRCPtr& linear_ir);
+        void init_non_m_related_params(const ov::snippets::lowered::LinearIRCPtr& linear_ir,
+                                       const std::unordered_set<snippets::lowered::ExpressionPtr>& brgemms);
+        void init_loops_to_split(const ov::snippets::lowered::LinearIRCPtr& linear_ir);
+
+        std::unordered_set<ov::snippets::lowered::UnifiedLoopInfoPtr> loops_to_split{};
+        std::unordered_set<size_t> not_m_related_params{};
+        std::vector<std::vector<size_t>> split_layouts{};
+        std::vector<size_t> m_dim_idces{};
+        size_t concurrency = 0;
+        size_t batch_m = 0;
+        size_t new_m = 0;
+    } m_optimizer;
 
     std::shared_ptr<RuntimeConfig> m_config = nullptr;
 

--- a/src/common/snippets/include/snippets/runtime_configurator.hpp
+++ b/src/common/snippets/include/snippets/runtime_configurator.hpp
@@ -165,6 +165,12 @@ protected:
                   const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
                   size_t in_num);
         /**
+         * @brief Checks if optimizer is enabled
+         * @todo Ticket 148891: when RuntimeConfigurator::update will be rewritten on PassPipeline, this method should be removed
+         * We will not just register ParallelWAOptimizer in case if it is not needed
+         */
+        bool enabled();
+        /**
          * @brief Checks if the current master shape can be optimized, and if yes, updates all the necessary runtime information
          * @param master_shape Master shape
          * @param map Loop info -> Runtime params map which will be passed in "update_loop_info"
@@ -174,7 +180,7 @@ protected:
          * @param in_num Number of inputs. It is needed to distinguish input and output shapes/layouts
          * @return status if the optimization is applied
          */
-        bool optimize(ov::snippets::VectorDims& master_shape,
+        void optimize(ov::snippets::VectorDims& master_shape,
                       ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap& map,
                       std::vector<ov::snippets::VectorDims>& shapes,
                       std::vector<std::vector<size_t>>& layouts,

--- a/src/common/snippets/include/snippets/utils/utils.hpp
+++ b/src/common/snippets/include/snippets/utils/utils.hpp
@@ -275,6 +275,19 @@ std::shared_ptr<ov::Node> get_leaf_node_of_first_parent_shape_infer_seq(const st
 
 int64_t get_dim_stride(const lowered::ExpressionPort& expr_port, size_t idx = 1);
 
+/**
+ * @brief Traverses path starting from "expr", and calls "func" for each expression.
+ * Traversal direction is defined by "visit_parent_path"
+ * @param expr The expr from which path is started.
+ * @param visited Set of expressions which were visited.
+ * @param func The function which is called for each visited node.
+ * @param visit_parent_path if true, parent nodes are visited. Otherwise, consumers are visited.
+ */
+void visit_path(const lowered::ExpressionPtr& expr,
+                std::unordered_set<lowered::ExpressionPtr>& visited,
+                std::function<void(lowered::ExpressionPtr)> func,
+                bool visit_parent_path);
+
 } // namespace utils
 } // namespace snippets
 } // namespace ov

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -120,32 +120,21 @@ inline void init_work_amount(const LoopInfoPtr& loop_info) {
 }
 }  // namespace
 
-void InitLoops::init_loop_info(const UnifiedLoopInfoPtr& loop_info, const size_t loop_id, bool only_runtime_args) {
+void InitLoops::update_runtime_parameters(const UnifiedLoopInfoPtr& loop_info, bool update_work_amount) {
     OPENVINO_ASSERT(loop_info != nullptr, "UnifiedLoopInfo is nullptr, nothing to initialize");
-    if (!loop_info->is_work_amount_const())
+    if (update_work_amount && !loop_info->is_work_amount_const())
         init_work_amount(loop_info);
 
     const auto work_amount = loop_info->get_work_amount();
     const auto input_count = loop_info->get_input_count();
     const auto output_count = loop_info->get_output_count();
 
-    auto init_runtime_parameters = [&work_amount, &input_count, &output_count](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
+    auto update_runtime_parameters = [&work_amount, &input_count, &output_count](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
         ptr_shifts_params.ptr_increment = get_ptr_increment(loop_port, work_amount,
                                                             loop_port.expr_port->get_type() == ExpressionPort::Input ? input_count : output_count);
         ptr_shifts_params.finalization_offset = get_finalization_offset(work_amount, ptr_shifts_params.ptr_increment);
     };
-
-    auto init_all_parameters = [loop_id, &init_runtime_parameters](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
-        init_is_incremented(loop_port, loop_id);
-        ptr_shifts_params.data_size = get_data_size(loop_port);
-        init_runtime_parameters(loop_port, ptr_shifts_params);
-    };
-
-    if (only_runtime_args) {
-        loop_info->iterate_through_infos(init_runtime_parameters);
-    } else {
-        loop_info->iterate_through_infos(init_all_parameters);
-    }
+    loop_info->iterate_through_infos(update_runtime_parameters);
 }
 
 bool InitLoops::run(LinearIR& linear_ir) {
@@ -156,7 +145,14 @@ bool InitLoops::run(LinearIR& linear_ir) {
     const auto& loop_manager = linear_ir.get_loop_manager();
     const auto& loops = loop_manager->get_map();
     for (const auto& loop : loops) {
-        init_loop_info(ov::as_type_ptr<UnifiedLoopInfo>(loop.second), loop.first);
+        const auto& loop_id = loop.first;
+        const auto& loop_info = ov::as_type_ptr<UnifiedLoopInfo>(loop.second);
+        loop_info->iterate_through_infos(
+            [loop_id](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
+                init_is_incremented(loop_port, loop_id);
+                ptr_shifts_params.data_size = get_data_size(loop_port);
+            });
+        update_runtime_parameters(loop_info);
     }
 
     return true;

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -120,21 +120,34 @@ inline void init_work_amount(const LoopInfoPtr& loop_info) {
 }
 }  // namespace
 
-void InitLoops::update_runtime_parameters(const UnifiedLoopInfoPtr& loop_info, bool update_work_amount) {
-    OPENVINO_ASSERT(loop_info != nullptr, "UnifiedLoopInfo is nullptr, nothing to initialize");
-    if (update_work_amount && !loop_info->is_work_amount_const())
-        init_work_amount(loop_info);
+void InitLoops::update_compile_parameters(const UnifiedLoopInfoPtr& loop_info, size_t loop_id) {
+    OPENVINO_ASSERT(loop_info != nullptr, "UnifiedLoopInfo is nullptr, nothing to update");
+    loop_info->iterate_through_infos(
+        [loop_id](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
+            init_is_incremented(loop_port, loop_id);
+            ptr_shifts_params.data_size = get_data_size(loop_port);
+        });
+}
 
+void InitLoops::update_data_pointer_shifts(const UnifiedLoopInfoPtr& loop_info) {
+    OPENVINO_ASSERT(loop_info != nullptr, "UnifiedLoopInfo is nullptr, nothing to update");
     const auto work_amount = loop_info->get_work_amount();
     const auto input_count = loop_info->get_input_count();
     const auto output_count = loop_info->get_output_count();
 
-    auto update_runtime_parameters = [&work_amount, &input_count, &output_count](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
+    auto update_shifts = [&work_amount, &input_count, &output_count](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
         ptr_shifts_params.ptr_increment = get_ptr_increment(loop_port, work_amount,
                                                             loop_port.expr_port->get_type() == ExpressionPort::Input ? input_count : output_count);
         ptr_shifts_params.finalization_offset = get_finalization_offset(work_amount, ptr_shifts_params.ptr_increment);
     };
-    loop_info->iterate_through_infos(update_runtime_parameters);
+    loop_info->iterate_through_infos(update_shifts);
+}
+
+void InitLoops::update_runtime_parameters(const UnifiedLoopInfoPtr& loop_info) {
+    OPENVINO_ASSERT(loop_info != nullptr, "UnifiedLoopInfo is nullptr, nothing to update");
+    if (!loop_info->is_work_amount_const())
+        init_work_amount(loop_info);
+    update_data_pointer_shifts(loop_info);
 }
 
 bool InitLoops::run(LinearIR& linear_ir) {
@@ -147,11 +160,7 @@ bool InitLoops::run(LinearIR& linear_ir) {
     for (const auto& loop : loops) {
         const auto& loop_id = loop.first;
         const auto& loop_info = ov::as_type_ptr<UnifiedLoopInfo>(loop.second);
-        loop_info->iterate_through_infos(
-            [loop_id](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
-                init_is_incremented(loop_port, loop_id);
-                ptr_shifts_params.data_size = get_data_size(loop_port);
-            });
+        update_compile_parameters(loop_info, loop_id);
         update_runtime_parameters(loop_info);
     }
 

--- a/src/common/snippets/src/pass/split_dimension_m.cpp
+++ b/src/common/snippets/src/pass/split_dimension_m.cpp
@@ -78,18 +78,16 @@ std::vector<size_t> SplitDimensionM::get_updated_order(const std::vector<size_t>
     return new_order;
 }
 
-ov::snippets::VectorDims SplitDimensionM::reshape_m_dim(const ov::snippets::VectorDims& shape, size_t m_index, size_t batch_m_dim, size_t new_m_dim) {
+ov::snippets::VectorDims SplitDimensionM::reshape_m_dim(ov::snippets::VectorDims shape, size_t m_index, size_t batch_m_dim, size_t new_m_dim) {
     if (shape[m_index] == 1)
-        return unsqueeze_m_dim(shape, m_index);
-    auto new_shape = shape;
-    new_shape[m_index] = new_m_dim;
-    new_shape.insert(new_shape.begin() + m_index, batch_m_dim);
-    return new_shape;
+        return unsqueeze_m_dim(std::move(shape), m_index);
+    shape[m_index] = new_m_dim;
+    shape.insert(shape.begin() + m_index, batch_m_dim);
+    return shape;
 }
-ov::snippets::VectorDims SplitDimensionM::unsqueeze_m_dim(const ov::snippets::VectorDims& shape, size_t m_index) {
-    auto new_shape = shape;
-    new_shape.insert(new_shape.begin() + m_index, 1);
-    return new_shape;
+ov::snippets::VectorDims SplitDimensionM::unsqueeze_m_dim(ov::snippets::VectorDims shape, size_t m_index) {
+    shape.insert(shape.begin() + m_index, 1);
+    return shape;
 }
 
 std::shared_ptr<ov::op::v0::MatMul> SplitDimensionM::get_matmul(const std::shared_ptr<op::Subgraph>& subgraph) {

--- a/src/common/snippets/src/pass/split_dimension_m.cpp
+++ b/src/common/snippets/src/pass/split_dimension_m.cpp
@@ -23,13 +23,15 @@ bool is_prime_number(size_t value) {
 }
 }  // namespace
 
-bool ov::snippets::pass::SplitDimensionM::is_supported_matmul(const std::shared_ptr<const ov::Node>& node) {
+namespace ov {
+namespace snippets {
+namespace pass {
+bool SplitDimensionM::is_supported_matmul(const std::shared_ptr<const ov::Node>& node) {
     const auto matmul = ov::as_type_ptr<const ov::op::v0::MatMul>(node);
     return matmul && !matmul->get_transpose_a() && !matmul->is_dynamic();
 }
 
-std::pair<size_t, size_t> ov::snippets::pass::SplitDimensionM::get_splited_dimensions(size_t batch_dim, size_t m_dim,
-                                                                                      size_t optimal_parallelism_work_amount) {
+std::pair<size_t, size_t> SplitDimensionM::get_splited_dimensions(size_t batch_dim, size_t m_dim, size_t optimal_parallelism_work_amount) {
     std::pair<size_t, size_t> splited = { 1, m_dim };
 
     const size_t lower_bound = optimal_parallelism_work_amount / batch_dim;
@@ -53,14 +55,44 @@ std::pair<size_t, size_t> ov::snippets::pass::SplitDimensionM::get_splited_dimen
     return splited;
 }
 
-bool ov::snippets::pass::SplitDimensionM::can_be_optimized(const std::shared_ptr<const ov::Node>& node, size_t concurrency) {
+bool SplitDimensionM::can_be_optimized(const std::shared_ptr<const ov::Node>& node, size_t concurrency) {
     if (!is_supported_matmul(node))
         return false;
     size_t batch_m_dim, new_m_dim;
     return split(node->get_shape(), concurrency, batch_m_dim, new_m_dim);
 }
 
-std::shared_ptr<ov::op::v0::MatMul> ov::snippets::pass::SplitDimensionM::get_matmul(const std::shared_ptr<op::Subgraph>& subgraph) {
+std::vector<size_t> SplitDimensionM::get_updated_order(const std::vector<size_t>& order, size_t m_index) {
+    std::vector<size_t> new_order(order.size() + 1, 0);
+    size_t shift_idx = 0;
+    for (size_t i = 0; i < order.size(); ++i) {
+        if (order[i] < m_index) {
+            new_order[i + shift_idx] = order[i];
+        } else if (order[i] == m_index) {
+            new_order[i + shift_idx++] = order[i];
+            new_order[i + shift_idx] = order[i] + 1;
+        } else {
+            new_order[i + shift_idx] = order[i] + 1;
+        }
+    }
+    return new_order;
+}
+
+ov::snippets::VectorDims SplitDimensionM::reshape_m_dim(const ov::snippets::VectorDims& shape, size_t m_index, size_t batch_m_dim, size_t new_m_dim) {
+    if (shape[m_index] == 1)
+        return unsqueeze_m_dim(shape, m_index);
+    auto new_shape = shape;
+    new_shape[m_index] = new_m_dim;
+    new_shape.insert(new_shape.begin() + m_index, batch_m_dim);
+    return new_shape;
+}
+ov::snippets::VectorDims SplitDimensionM::unsqueeze_m_dim(const ov::snippets::VectorDims& shape, size_t m_index) {
+    auto new_shape = shape;
+    new_shape.insert(new_shape.begin() + m_index, 1);
+    return new_shape;
+}
+
+std::shared_ptr<ov::op::v0::MatMul> SplitDimensionM::get_matmul(const std::shared_ptr<op::Subgraph>& subgraph) {
     const auto& body = subgraph->body_ptr();
     const auto& parameters = body->get_parameters();
     // [107806]: If count of Parameters isn't equal to Subgraph inputs (it's possible case in general),
@@ -79,7 +111,7 @@ std::shared_ptr<ov::op::v0::MatMul> ov::snippets::pass::SplitDimensionM::get_mat
     return is_supported_matmul(matmul0) ? ov::as_type_ptr<ov::op::v0::MatMul>(matmul0) : nullptr;
 }
 
-bool ov::snippets::pass::SplitDimensionM::split(const ov::Shape& shape, size_t optimal_parallelism_work_amount, size_t& batch_m_dim, size_t& new_m_dim) {
+bool SplitDimensionM::split(const ov::Shape& shape, size_t optimal_parallelism_work_amount, size_t& batch_m_dim, size_t& new_m_dim) {
     const auto batch_dim =
         std::accumulate(shape.rbegin() + 2, shape.rend(), size_t(1), std::multiplies<size_t>());  // B (batch)
     const auto m_dim = get_dim_M(shape);  // M
@@ -98,8 +130,7 @@ bool ov::snippets::pass::SplitDimensionM::split(const ov::Shape& shape, size_t o
     return is_optimized(batch_dim * batch_m_dim);
 }
 
-void ov::snippets::pass::SplitDimensionM::reshape_subgraph(const std::shared_ptr<op::Subgraph>& subgraph,
-                                                           const ov::Shape& shape, size_t batch_m_dim, size_t new_m_dim) {
+void SplitDimensionM::reshape_subgraph(const std::shared_ptr<op::Subgraph>& subgraph, const ov::Shape& shape, size_t batch_m_dim, size_t new_m_dim) {
     const auto& body = subgraph->body_ptr();
     const auto& parameters = body->get_parameters();
     const auto& results = body->get_results();
@@ -121,42 +152,20 @@ void ov::snippets::pass::SplitDimensionM::reshape_subgraph(const std::shared_ptr
         reshaped_params.insert(param);
     };
 
-    auto get_updated_shape = [&](const ov::Shape& shape, size_t m_index, bool split_m_dim) {
+    auto get_updated_shape = [&](const ov::snippets::VectorDims& shape, size_t m_index, bool split_m_dim) {
         const auto current_m_dim = shape[m_index];
         OPENVINO_ASSERT(!split_m_dim || current_m_dim == 1 || current_m_dim == m_dim, "Incorrect shape for splitting!");
-        ov::Shape new_shape = shape;
-        if ((split_m_dim && current_m_dim == 1) || !split_m_dim) {
-            new_shape.insert(new_shape.begin() + m_index, 1);
-        } else {
-            new_shape[m_index] = new_m_dim;
-            new_shape.insert(new_shape.begin() + m_index, batch_m_dim);
-        }
+        const auto new_shape = split_m_dim ? reshape_m_dim(shape, m_index, batch_m_dim, new_m_dim) : unsqueeze_m_dim(shape, m_index);
         OPENVINO_ASSERT(ov::shape_size(new_shape) == ov::shape_size(shape), "Incorrect shape splitting!");
         return new_shape;
-    };
-
-    auto get_updated_order = [](const std::vector<int32_t>& order, int m_index) {
-        std::vector<int32_t> new_order(order.size() + 1, 0);
-        size_t shift_idx = 0;
-        for (size_t i = 0; i < order.size(); ++i) {
-            if (order[i] < m_index) {
-                new_order[i + shift_idx] = order[i];
-            } else if (order[i] == m_index) {
-                new_order[i + shift_idx++] = order[i];
-                new_order[i + shift_idx] = order[i] + 1;
-            } else {
-                new_order[i + shift_idx] = order[i] + 1;
-            }
-        }
-        return new_order;
     };
 
     auto reshape_transpose = [&](const std::shared_ptr<ov::Node>& transpose, bool is_input) -> size_t {
         const auto order_constant = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
         OPENVINO_ASSERT(order_constant != nullptr, "Transpose must have Constant order");
-        const auto order = order_constant->cast_vector<int32_t>();
+        const auto order = order_constant->cast_vector<size_t>();
         const auto m_index = is_input ? order[order.size() - 2] : order.size() - 2;  // Index of M dimension in the previous order
-        const auto new_order = get_updated_order(order, static_cast<int>(m_index));
+        const auto new_order = get_updated_order(order, m_index);
         transpose->set_argument(1, std::make_shared<ov::op::v0::Constant>(order_constant->get_element_type(), ov::Shape{new_order.size()}, new_order));
         return m_index;
     };
@@ -201,9 +210,10 @@ void ov::snippets::pass::SplitDimensionM::reshape_subgraph(const std::shared_ptr
             softmax_v1->set_axis(softmax_v1->get_output_partial_shape(0).size()); // since new_shape.size() = old_shape.size() + 1
         } else if (const auto broadcast = ov::as_type_ptr<ov::op::v1::Broadcast>(op)) {
             // Broadcast is tokenized only between MatMuls -> Split M dimension
-            const auto shape_const = ov::as_type_ptr<ov::op::v0::Constant>(broadcast->input_value(1).get_node_shared_ptr());
+            const auto shape_const = ov::as_type_ptr<ov::op::v0::Constant>(broadcast->get_input_node_shared_ptr(1));
             OPENVINO_ASSERT(shape_const, "SplitDimensionM expects Broadcast with Constant output shape");
-            const auto new_shape = get_updated_shape(shape_const->cast_vector<size_t>(), broadcast->get_output_shape(0).size() - 2, true);
+            const auto m_dim_idx = broadcast->get_output_partial_shape(0).size() - 2;
+            const auto new_shape = get_updated_shape(shape_const->cast_vector<size_t>(), m_dim_idx, true);
             broadcast->set_argument(1, std::make_shared<ov::op::v0::Constant>(shape_const->get_element_type(), ov::Shape{new_shape.size()}, new_shape));
         }
     }
@@ -251,7 +261,7 @@ void ov::snippets::pass::SplitDimensionM::reshape_subgraph(const std::shared_ptr
     subgraph->validate_and_infer_types();
 }
 
-bool ov::snippets::pass::SplitDimensionM::run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) {
+bool SplitDimensionM::run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::SplitDimensionM");
     // To increase parallelism work in MHA pattern,
     // we split 1st dimension (starting from 0th) into 2 new dimensions to get 4D Shapes where
@@ -273,3 +283,6 @@ bool ov::snippets::pass::SplitDimensionM::run_on_subgraph(const std::shared_ptr<
     }
     return false;
 }
+} // namespace pass
+} // namespace snippets
+} // namespace ov

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.cpp
@@ -4,19 +4,38 @@
 
 #include "emitters/snippets/cpu_runtime_configurator.hpp"
 
-#include "snippets/utils/utils.hpp"
 #include "snippets/lowered/loop_manager.hpp"
-
+#include "snippets/lowered/pass/init_loops.hpp"
+#include "snippets/pass/split_dimension_m.hpp"
+#include "snippets/utils/utils.hpp"
 
 namespace ov {
 namespace intel_cpu {
+
+using namespace ov::snippets::lowered;
+using namespace ov::snippets::pass;
+
+const size_t CPURuntimeConfigurator::rank6D = 6;
 
 CPURuntimeConfigurator::CPURuntimeConfigurator() : ov::snippets::RuntimeConfigurator(std::make_shared<CPURuntimeConfig>()) {
 }
 
 void CPURuntimeConfigurator::update(const ov::snippets::lowered::LinearIRCPtr& linear_ir) {
+    m_config->master_shape = linear_ir->get_master_shape();
+
+    ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap initialized_info;
+    std::vector<ov::snippets::VectorDims> updated_shapes;
+    std::vector<std::vector<size_t>> updated_layouts;
+    bool optimize_work_amount = m_optimizer.need_optimize(m_config->master_shape);
+    if (optimize_work_amount) {
+        m_optimizer.update_split_loops_info(initialized_info);
+        m_optimizer.update_shapes(m_io_descs, updated_shapes, m_in_num);
+        m_optimizer.update_layouts(m_io_descs, updated_layouts, m_in_num);
+        m_optimizer.update_config(m_config);
+    }
+
     if (linear_ir->is_dynamic()) {
-        update_loop_info(linear_ir);
+        update_loop_info(linear_ir, initialized_info);
         update_loop_args(linear_ir);
         // Update KernelExecutor Table should be before `update_buffer_scratchpad_size`
         // because `ComputeAllocationSize` depends on subtensors which are updated in the table
@@ -24,10 +43,18 @@ void CPURuntimeConfigurator::update(const ov::snippets::lowered::LinearIRCPtr& l
         update_buffer_scratchpad_size(linear_ir);
     }
 
-    m_config->master_shape = linear_ir->get_master_shape();
+    update_data_offsets(updated_shapes, updated_layouts);
+    // TODO: unify this logic somehow?
+    if (!optimize_work_amount) {
+        update_latest_shapes();
+    } else {
+        m_latest_shapes = std::move(updated_shapes);
+    }
+}
 
-    update_data_offsets();
-    update_latest_shapes();
+void CPURuntimeConfigurator::initialization(const ov::snippets::lowered::LinearIRPtr& linear_ir) {
+    RuntimeConfigurator::initialization(linear_ir);
+    m_optimizer.init(linear_ir);
 }
 
 void CPURuntimeConfigurator::init_tensor_rank(const ov::snippets::lowered::LinearIRCPtr& linear_ir) const {
@@ -54,6 +81,153 @@ void CPURuntimeConfigurator::update_loop_args(const ov::snippets::lowered::Linea
             loop_arg.m_ptr_increments[i] *= (increment * data_sizes[i]);
             loop_arg.m_finalization_offsets[i] *= data_sizes[i];
         }
+    }
+}
+
+std::unordered_set<size_t> CPURuntimeConfigurator::ParallelWAOptimizer::find_not_m_related_params(
+    const ov::snippets::lowered::LinearIRPtr& linear_ir) {
+    using namespace ov::snippets::lowered;
+    auto is_brgemm = [](const ExpressionPtr& expr) {
+        return ov::is_type<ov::snippets::op::Brgemm>(expr->get_node());
+    };
+    std::unordered_set<ExpressionPtr> brgemms;
+    auto brgemm_it = std::find_if(linear_ir->begin(), linear_ir->end(), is_brgemm);
+    while (brgemm_it != linear_ir->end()) {
+        brgemms.insert(*brgemm_it);
+        brgemm_it = std::find_if(std::next(brgemm_it), linear_ir->end(), is_brgemm);
+    }
+
+    std::unordered_set<ExpressionPtr> visited;
+    std::unordered_set<size_t> res;
+    const auto& params = linear_ir->get_parameters();
+    for (const auto& brgemm : brgemms) {
+        // Find all parameters which are placed on B Brgemm inputs: these params must be skipped
+        std::deque<ExpressionPtr> exprs{brgemm->get_input_port_connector(1)->get_source().get_expr()};
+        while (!exprs.empty()) {
+            auto curr_expr = exprs.front();
+            exprs.pop_front();
+            if (ov::is_type<ov::op::v0::Parameter>(curr_expr->get_node())) {
+                auto found_param = std::find(params.begin(), params.end(), curr_expr);
+                OPENVINO_ASSERT(found_param != params.end(), "find_param didn't found parameter for expr");
+                res.insert(std::distance(params.begin(), found_param));
+            }
+
+            for (const auto& input_connector : curr_expr->get_input_port_connectors()) {
+                const auto& input_expr = input_connector->get_source().get_expr();
+                if (visited.count(input_expr))
+                    continue;
+                exprs.push_front(input_expr);
+                visited.insert(input_expr);
+            }
+        }
+    }
+    return res;
+}
+
+std::unordered_set<UnifiedLoopInfoPtr> CPURuntimeConfigurator::ParallelWAOptimizer::find_loops_to_split(
+    const ov::snippets::lowered::LinearIRPtr& linear_ir,
+    const std::unordered_set<size_t>& params_to_skip) {
+    std::unordered_set<UnifiedLoopInfoPtr> loops_to_split;
+    const auto& loop_manager = linear_ir->get_loop_manager();
+    // The idea is to traverse LIR down from the M dimension related parameters
+    // and find all the outermost loops: these loops will be split in runtime
+    std::unordered_set<ExpressionPtr> visited;
+    size_t i = 0;
+    for (const auto& param : linear_ir->get_parameters()) {
+        // Ops after non related params mustn't be traversed
+        if (params_to_skip.count(i++))
+            continue;
+
+        std::deque<ExpressionPtr> exprs{param};
+        while (!exprs.empty()) {
+            auto curr_expr = exprs.front();
+            exprs.pop_front();
+            const auto& loop_ids = curr_expr->get_loop_ids();
+            if (!loop_ids.empty()) {
+                const auto outermost_loop_idx = loop_ids[0];
+                const auto loop_info_to_add = loop_manager->get_loop_info<ExpandedLoopInfo>(outermost_loop_idx);
+                loops_to_split.insert(loop_info_to_add->get_unified_loop_info());
+            }
+
+            for (const auto& output_connector : curr_expr->get_output_port_connectors()) {
+                for (const auto& consumer : output_connector->get_consumers()) {
+                    const auto& consumer_expr = consumer.get_expr();
+                    if (visited.count(consumer_expr))
+                        continue;
+                    exprs.push_front(consumer_expr);
+                    visited.insert(consumer_expr);
+                }
+            }
+        }
+    }
+    return loops_to_split;
+}
+
+bool CPURuntimeConfigurator::ParallelWAOptimizer::check_brgemms(const ov::snippets::lowered::LinearIRPtr& linear_ir) {
+    auto found_it = std::find_if(linear_ir->begin(), linear_ir->end(), [](const ExpressionPtr& expr) {
+        return ov::is_type<ov::snippets::op::Brgemm>(expr->get_node());
+    });
+    if (found_it == linear_ir->end())
+        return false;
+    const auto& brgemm = *found_it;
+    const auto planar_shape = ov::snippets::utils::get_planar_vdims(brgemm->get_input_port(0));
+    return ov::snippets::utils::is_dynamic_value(*++planar_shape.rbegin());
+}
+
+void CPURuntimeConfigurator::ParallelWAOptimizer::init(const ov::snippets::lowered::LinearIRPtr& linear_ir) {
+    if (linear_ir->get_config().m_enable_domain_optimization || !linear_ir->is_dynamic() || !check_brgemms(linear_ir))
+        return;
+    not_m_related_params = find_not_m_related_params(linear_ir);
+    loops_to_split = find_loops_to_split(linear_ir, not_m_related_params);
+    concurrency = linear_ir->get_config().m_min_parallel_work_amount;
+}
+
+bool CPURuntimeConfigurator::ParallelWAOptimizer::need_optimize(const ov::snippets::VectorDims& master_shape) {
+    return !loops_to_split.empty() && SplitDimensionM::split(master_shape, concurrency, batch_m, new_m);
+}
+
+void CPURuntimeConfigurator::ParallelWAOptimizer::update_split_loops_info(
+    ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap& initialized_info) {
+    for (const auto& loop : loops_to_split) {
+        if (initialized_info.count(loop) == 0) {
+            loop->set_work_amount(new_m);
+            ov::snippets::lowered::pass::InitLoops::update_runtime_parameters(loop, false);
+            initialized_info[loop] = compute_runtime_params(loop);
+        }
+    }
+}
+
+void CPURuntimeConfigurator::ParallelWAOptimizer::update_config(const std::shared_ptr<ov::snippets::RuntimeConfig>& config) {
+    *++config->master_shape.rbegin() = new_m;
+    config->master_shape.insert(config->master_shape.cbegin() + config->master_shape.size() - 2, batch_m);
+    config->tensor_rank = std::max(config->master_shape.size(), CPURuntimeConfigurator::rank6D);
+}
+
+void CPURuntimeConfigurator::ParallelWAOptimizer::update_shapes(
+    const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
+    std::vector<ov::snippets::VectorDims>& shapes,
+    size_t in_num) {
+    shapes.resize(io_descs.size());
+    for (size_t i = 0; i < io_descs.size(); ++i) {
+        const auto& desc = io_descs[i];
+        const auto dim_idx = i < in_num ? ov::snippets::utils::get_input_dim_idx(desc->get_layout(), 1)
+                                        : ov::snippets::utils::get_output_dim_idx(desc->get_layout(), 1);
+        shapes[i] = not_m_related_params.count(i)
+                        ? SplitDimensionM::unsqueeze_m_dim(desc->get_shape(), dim_idx)
+                        : SplitDimensionM::reshape_m_dim(desc->get_shape(), dim_idx, batch_m, new_m);
+    }
+}
+
+void CPURuntimeConfigurator::ParallelWAOptimizer::update_layouts(
+    const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
+    std::vector<std::vector<size_t>>& layouts,
+    size_t in_num) {
+    layouts.resize(io_descs.size());
+    for (size_t i = 0; i < io_descs.size(); ++i) {
+        const auto& original_layout = io_descs[i]->get_layout();
+        const auto dim_idx =
+            i < in_num ? ov::snippets::utils::get_input_dim_idx(original_layout, 1) : original_layout.size() - 2;
+        layouts[i] = SplitDimensionM::get_updated_order(original_layout, dim_idx);
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.cpp
@@ -6,14 +6,10 @@
 
 #include "snippets/lowered/loop_manager.hpp"
 #include "snippets/lowered/pass/init_loops.hpp"
-#include "snippets/pass/split_dimension_m.hpp"
 #include "snippets/utils/utils.hpp"
 
 namespace ov {
 namespace intel_cpu {
-
-using namespace ov::snippets::lowered;
-using namespace ov::snippets::pass;
 
 const size_t CPURuntimeConfigurator::rank6D = 6;
 
@@ -24,14 +20,12 @@ void CPURuntimeConfigurator::update(const ov::snippets::lowered::LinearIRCPtr& l
     m_config->master_shape = linear_ir->get_master_shape();
 
     ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap initialized_info;
-    std::vector<ov::snippets::VectorDims> updated_shapes;
-    std::vector<std::vector<size_t>> updated_layouts;
-    bool optimize_work_amount = m_optimizer.need_optimize(m_config->master_shape);
-    if (optimize_work_amount) {
-        m_optimizer.update_split_loops_info(initialized_info);
-        m_optimizer.update_shapes(m_io_descs, updated_shapes, m_in_num);
-        m_optimizer.update_layouts(m_io_descs, updated_layouts, m_in_num);
-        m_optimizer.update_config(m_config);
+    auto shapes = extract_shapes();
+    auto layouts = extract_layouts();
+    if (m_optimizer.need_optimize(m_config->master_shape)) {
+        m_optimizer.update(initialized_info, shapes, layouts, m_config, m_in_num);
+        // Note: since tensor_rank was changed by optimizer, need to adjust the updated rank accordingly to CPU specific
+        m_config->tensor_rank = std::max(m_config->tensor_rank, rank6D);
     }
 
     if (linear_ir->is_dynamic()) {
@@ -43,18 +37,8 @@ void CPURuntimeConfigurator::update(const ov::snippets::lowered::LinearIRCPtr& l
         update_buffer_scratchpad_size(linear_ir);
     }
 
-    update_data_offsets(updated_shapes, updated_layouts);
-    // TODO: unify this logic somehow?
-    if (!optimize_work_amount) {
-        update_latest_shapes();
-    } else {
-        m_latest_shapes = std::move(updated_shapes);
-    }
-}
-
-void CPURuntimeConfigurator::initialization(const ov::snippets::lowered::LinearIRPtr& linear_ir) {
-    RuntimeConfigurator::initialization(linear_ir);
-    m_optimizer.init(linear_ir);
+    update_data_offsets(shapes, layouts);
+    m_latest_shapes = std::move(shapes);
 }
 
 void CPURuntimeConfigurator::init_tensor_rank(const ov::snippets::lowered::LinearIRCPtr& linear_ir) const {
@@ -81,147 +65,6 @@ void CPURuntimeConfigurator::update_loop_args(const ov::snippets::lowered::Linea
             loop_arg.m_ptr_increments[i] *= (increment * data_sizes[i]);
             loop_arg.m_finalization_offsets[i] *= data_sizes[i];
         }
-    }
-}
-
-void CPURuntimeConfigurator::ParallelWAOptimizer::init(const ov::snippets::lowered::LinearIRPtr& linear_ir) {
-    if (linear_ir->get_config().m_enable_domain_optimization || !linear_ir->is_dynamic())
-        return;
-    concurrency = linear_ir->get_config().m_min_parallel_work_amount;
-
-    const auto brgemms = find_applicable_brgemms(linear_ir);
-    // Parallel WA optimization is Brgemm related
-    if (brgemms.empty())
-        return;
-
-    init_non_m_related_params(linear_ir, brgemms);
-    OPENVINO_ASSERT(!not_m_related_params.empty(), "not_m_related_params mustn't be empty after initialization");
-    init_loops_to_split(linear_ir);
-}
-
-bool CPURuntimeConfigurator::ParallelWAOptimizer::need_optimize(const ov::snippets::VectorDims& master_shape) {
-    return !loops_to_split.empty() && SplitDimensionM::split(master_shape, concurrency, batch_m, new_m);
-}
-
-void CPURuntimeConfigurator::ParallelWAOptimizer::update_split_loops_info(
-    ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap& initialized_info) {
-    for (const auto& loop : loops_to_split) {
-        if (initialized_info.count(loop) == 0) {
-            loop->set_work_amount(new_m);
-            ov::snippets::lowered::pass::InitLoops::update_runtime_parameters(loop, false);
-            initialized_info[loop] = compute_runtime_params(loop);
-        }
-    }
-}
-
-void CPURuntimeConfigurator::ParallelWAOptimizer::update_shapes(
-    const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
-    std::vector<ov::snippets::VectorDims>& shapes,
-    size_t in_num) {
-    shapes.resize(io_descs.size());
-    for (size_t i = 0; i < io_descs.size(); ++i) {
-        const auto& desc = io_descs[i];
-        const auto dim_idx = i < in_num ? ov::snippets::utils::get_input_dim_idx(desc->get_layout(), 1)
-                                        : ov::snippets::utils::get_output_dim_idx(desc->get_layout(), 1);
-        shapes[i] = not_m_related_params.count(i)
-                        ? SplitDimensionM::unsqueeze_m_dim(desc->get_shape(), dim_idx)
-                        : SplitDimensionM::reshape_m_dim(desc->get_shape(), dim_idx, batch_m, new_m);
-    }
-}
-
-void CPURuntimeConfigurator::ParallelWAOptimizer::update_layouts(
-    const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
-    std::vector<std::vector<size_t>>& layouts,
-    size_t in_num) {
-    layouts.resize(io_descs.size());
-    for (size_t i = 0; i < io_descs.size(); ++i) {
-        const auto& original_layout = io_descs[i]->get_layout();
-        const auto dim_idx =
-            i < in_num ? ov::snippets::utils::get_input_dim_idx(original_layout, 1) : original_layout.size() - 2;
-        layouts[i] = SplitDimensionM::get_updated_order(original_layout, dim_idx);
-    }
-}
-
-void CPURuntimeConfigurator::ParallelWAOptimizer::update_config(const std::shared_ptr<ov::snippets::RuntimeConfig>& config) {
-    *++config->master_shape.rbegin() = new_m;
-    config->master_shape.insert(config->master_shape.cbegin() + config->master_shape.size() - 2, batch_m);
-    config->tensor_rank = std::max(config->master_shape.size(), CPURuntimeConfigurator::rank6D);
-}
-
-std::unordered_set<snippets::lowered::ExpressionPtr> CPURuntimeConfigurator::ParallelWAOptimizer::find_applicable_brgemms(
-    const ov::snippets::lowered::LinearIRPtr& linear_ir) {
-    auto is_brgemm = [](const ExpressionPtr& expr) {
-        return ov::is_type<ov::snippets::op::Brgemm>(expr->get_node());
-    };
-    auto brgemm_it = std::find_if(linear_ir->begin(), linear_ir->end(), is_brgemm);
-    std::unordered_set<ExpressionPtr> brgemms;
-    while (brgemm_it != linear_ir->end()) {
-        brgemms.insert(*brgemm_it);
-        brgemm_it = std::find_if(std::next(brgemm_it), linear_ir->end(), is_brgemm);
-    }
-    const auto& loop_manager = linear_ir->get_loop_manager();
-    auto applicable_brgemm = [&loop_manager](const ExpressionPtr& expr) {
-        const auto& loop_idces = expr->get_loop_ids();
-        if (loop_idces.empty())
-            return false;
-        const auto& outermost_loop = loop_manager->get_loop_info(loop_idces[0]);
-        // WA: the feature doesn't work in static case
-        if (!ov::snippets::utils::is_dynamic_value(outermost_loop->get_work_amount()))
-            return false;
-        bool loop_by_m = true;
-        outermost_loop->iterate_through_ports([&loop_by_m](const LoopPort& port) {
-            if (port.is_incremented && port.dim_idx != 1)
-                loop_by_m = false;
-        });
-        return loop_by_m;
-    };
-    if (std::all_of(brgemms.begin(), brgemms.end(), applicable_brgemm))
-        return brgemms;
-    else
-        return {};
-}
-
-void CPURuntimeConfigurator::ParallelWAOptimizer::init_non_m_related_params(
-    const ov::snippets::lowered::LinearIRPtr& linear_ir,
-    const std::unordered_set<snippets::lowered::ExpressionPtr>& brgemms) {
-    const auto& params = linear_ir->get_parameters();
-    auto add_param = [&params, this](const ExpressionPtr& expr) {
-        if (ov::is_type<ov::op::v0::Parameter>(expr->get_node())) {
-            auto found_param = std::find(params.begin(), params.end(), expr);
-            OPENVINO_ASSERT(found_param != params.end(), "find_param didn't found parameter for expr");
-            not_m_related_params.insert(std::distance(params.begin(), found_param));
-        }
-    };
-
-    std::unordered_set<ExpressionPtr> visited;
-    for (const auto& brgemm : brgemms) {
-        const auto& brgemm_b_input = brgemm->get_input_port_connector(1)->get_source().get_expr();
-        ov::snippets::utils::visit_path(brgemm_b_input, visited, add_param, true);
-    }
-}
-
-void CPURuntimeConfigurator::ParallelWAOptimizer::init_loops_to_split(
-    const ov::snippets::lowered::LinearIRPtr& linear_ir) {
-    const auto loop_manager = linear_ir->get_loop_manager();
-
-    auto add_loops_to_split = [&loop_manager, this](const ExpressionPtr& expr) {
-        const auto& loop_ids = expr->get_loop_ids();
-        if (!loop_ids.empty()) {
-            const auto outermost_loop_idx = loop_ids[0];
-            const auto loop_info_to_add = loop_manager->get_loop_info<ExpandedLoopInfo>(outermost_loop_idx);
-            loops_to_split.insert(loop_info_to_add->get_unified_loop_info());
-        }
-    };
-
-    size_t i = 0;
-    std::unordered_set<ExpressionPtr> visited;
-    // The idea is to traverse LIR down from the M dimension related parameters
-    // and find all the outermost loops: these loops will be split in runtime
-    for (const auto& param : linear_ir->get_parameters()) {
-        // Ops after non related params mustn't be traversed
-        if (not_m_related_params.count(i++))
-            continue;
-        ov::snippets::utils::visit_path(param, visited, add_loops_to_split, false);
     }
 }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include "emitters/snippets/jit_snippets_call_args.hpp"
-#include "snippets/lowered/loop_info.hpp"
-#include "snippets/lowered/port_descriptor.hpp"
 #include "snippets/runtime_configurator.hpp"
+
+#include "snippets/lowered/port_descriptor.hpp"
+#include "emitters/snippets/jit_snippets_call_args.hpp"
 
 namespace ov {
 namespace intel_cpu {
@@ -31,11 +31,6 @@ protected:
      */
     void update(const ov::snippets::lowered::LinearIRCPtr& linear_ir) override;
     /**
-     * @brief Allocate and intialize fields in RuntimeConfig and RuntimeConfigurator
-     * @param linear_ir LinearIR
-     */
-    void initialization(const ov::snippets::lowered::LinearIRPtr& linear_ir) override;
-    /**
      * @brief Initializes tensor rank of config
      * @param linear_ir LinearIR
      */
@@ -47,61 +42,6 @@ protected:
     void update_loop_args(const ov::snippets::lowered::LinearIRCPtr& linear_ir) const;
 
     static const size_t rank6D;
-
-    class ParallelWAOptimizer {
-    public:
-        /**
-         * @brief Inits ParallelWAOptimizer: computes optimizer parameters which should be set at compilation stage
-         * @param linear_ir LinearIR
-         */
-        void init(const ov::snippets::lowered::LinearIRPtr& linear_ir);
-        /**
-         * @brief Defines if the optimizer should be applied
-         * @attention It also computes "batch_m" and "new_m" runtime parameters
-         * @param master_shape Master shape
-         */
-        bool need_optimize(const ov::snippets::VectorDims& master_shape);
-        /**
-         * @brief Updates loops_to_split loop info: sets "new_m" work amount, and correspondingly updates runtime params
-         * @param map Loop info -> Runtime params map which will be passed in "update_loop_info"
-         */
-        void update_split_loops_info(ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap& map);
-        /**
-         * @brief Splits m dimension in shapes
-         * @param io_descs Descriptors which contain original shapes
-         * @param shapes Vector which is filled with the split shapes
-         * @param in_num Number of inputs
-         */
-        void update_shapes(const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
-                           std::vector<ov::snippets::VectorDims>& shapes,
-                           size_t in_num);
-        /**
-         * @brief Splits m dimension in layouts
-         * @param io_descs Descriptors which contain original layouts
-         * @param shapes Vector which is filled with the split layouts
-         * @param in_num Number of inputs
-         */
-        void update_layouts(const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
-                            std::vector<std::vector<size_t>>& layouts,
-                            size_t in_num);
-        /**
-         * @brief Updates runtime config: tile rank and master shape
-         * @param config Config which should be updated
-         */
-        void update_config(const std::shared_ptr<ov::snippets::RuntimeConfig>& config);
-
-    private:
-        static std::unordered_set<snippets::lowered::ExpressionPtr> find_applicable_brgemms(const ov::snippets::lowered::LinearIRPtr& linear_ir);
-        void init_non_m_related_params(const ov::snippets::lowered::LinearIRPtr& linear_ir,
-                                       const std::unordered_set<snippets::lowered::ExpressionPtr>& brgemms);
-        void init_loops_to_split(const ov::snippets::lowered::LinearIRPtr& linear_ir);
-
-        std::unordered_set<ov::snippets::lowered::UnifiedLoopInfoPtr> loops_to_split{};
-        std::unordered_set<size_t> not_m_related_params{};
-        size_t concurrency = 0;
-        size_t batch_m = 0;
-        size_t new_m = 0;
-    } m_optimizer;
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
@@ -31,6 +31,11 @@ protected:
      */
     void update(const ov::snippets::lowered::LinearIRCPtr& linear_ir) override;
     /**
+     * @brief Update tensor rank based on master shape
+     * @param master_shape Master shape
+     */
+    void update_tensor_rank(const ov::snippets::VectorDims& master_shape) override;
+    /**
      * @brief Initializes tensor rank of config
      * @param linear_ir LinearIR
      */

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
@@ -50,16 +50,44 @@ protected:
 
     class ParallelWAOptimizer {
     public:
+        /**
+         * @brief Inits ParallelWAOptimizer: computes optimizer parameters which should be set at compilation stage
+         * @param linear_ir LinearIR
+         */
         void init(const ov::snippets::lowered::LinearIRPtr& linear_ir);
+        /**
+         * @brief Defines if the optimizer should be applied
+         * @attention It also computes "batch_m" and "new_m" runtime parameters
+         * @param master_shape Master shape
+         */
         bool need_optimize(const ov::snippets::VectorDims& master_shape);
-
+        /**
+         * @brief Updates loops_to_split loop info: sets "new_m" work amount, and correspondingly updates runtime params
+         * @param map Loop info -> Runtime params map which will be passed in "update_loop_info"
+         */
         void update_split_loops_info(ov::snippets::RuntimeConfigurator::LoopInfoRuntimeParamsMap& map);
+        /**
+         * @brief Splits m dimension in shapes
+         * @param io_descs Descriptors which contain original shapes
+         * @param shapes Vector which is filled with the split shapes
+         * @param in_num Number of inputs
+         */
         void update_shapes(const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
                            std::vector<ov::snippets::VectorDims>& shapes,
                            size_t in_num);
+        /**
+         * @brief Splits m dimension in layouts
+         * @param io_descs Descriptors which contain original layouts
+         * @param shapes Vector which is filled with the split layouts
+         * @param in_num Number of inputs
+         */
         void update_layouts(const std::vector<snippets::lowered::PortDescriptorPtr>& io_descs,
                             std::vector<std::vector<size_t>>& layouts,
                             size_t in_num);
+        /**
+         * @brief Updates runtime config: tile rank and master shape
+         * @param config Config which should be updated
+         */
         void update_config(const std::shared_ptr<ov::snippets::RuntimeConfig>& config);
 
     private:

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
@@ -63,11 +63,10 @@ protected:
         void update_config(const std::shared_ptr<ov::snippets::RuntimeConfig>& config);
 
     private:
-        bool check_brgemms(const ov::snippets::lowered::LinearIRPtr& linear_ir);
-        static std::unordered_set<size_t> find_not_m_related_params(const ov::snippets::lowered::LinearIRPtr& linear_ir);
-        static std::unordered_set<ov::snippets::lowered::UnifiedLoopInfoPtr> find_loops_to_split(
-            const ov::snippets::lowered::LinearIRPtr& linear_ir,
-            const std::unordered_set<size_t>& params_to_skip);
+        static std::unordered_set<snippets::lowered::ExpressionPtr> find_applicable_brgemms(const ov::snippets::lowered::LinearIRPtr& linear_ir);
+        void init_non_m_related_params(const ov::snippets::lowered::LinearIRPtr& linear_ir,
+                                       const std::unordered_set<snippets::lowered::ExpressionPtr>& brgemms);
+        void init_loops_to_split(const ov::snippets::lowered::LinearIRPtr& linear_ir);
 
         std::unordered_set<ov::snippets::lowered::UnifiedLoopInfoPtr> loops_to_split{};
         std::unordered_set<size_t> not_m_related_params{};

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -176,7 +176,7 @@ std::vector<std::string> disabledTestPatterns() {
         // Need to generate sequence exactly in the i64 data type. Enable in scope of i64 enabling.
         R"(.*RandomUniformLayerTestCPU.*OutPrc=i64.*)",
         // Issue: 123815 (Tests are sensintive to available thread count on testing machines)
-        R"(.*smoke_Snippets_MHA_.?D_SplitDimensionM.*)",
+        R"(.*smoke_Snippets_MHA_.?D_SplitDimensionM_static.*)",
         // Issue: 122356
         R"(.*NmsRotatedOpTest.*(SortDesc=True|Clockwise=False).*)",
         // Issue: 126095

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -183,6 +183,12 @@ std::vector<std::vector<ov::test::InputShape>> splitm_dynamic_shapes_3d = {
         {PartialShape{-1, -1, -1}, {{1, 1, 128}, {1, 1, 17}, {1, 1, 128}}},
         {PartialShape{-1, -1, -1}, {{128, 2, 64}, {17, 2, 64}, {128, 2, 64}}},
     },
+    {
+        {PartialShape{-1, 2, 64}, {{128, 2, 64}, {64, 2, 64}, {128, 2, 64}}},
+        {PartialShape{-1, 2, 64}, {{128, 2, 64}, {64, 2, 64}, {128, 2, 64}}},
+        {PartialShape{1, 1, -1}, {{1, 1, 128}, {1, 1, 64}, {1, 1, 128}}},
+        {PartialShape{-1, 2, 64}, {{128, 2, 64}, {64, 2, 64}, {128, 2, 64}}},
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -104,10 +104,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_3D,
                                             ::testing::Values(CPUTestUtils::empty_plugin_config)),
                          MHA::getTestCaseName);
 
+const auto& splitm_static_shapes = STATIC_SHAPES({{1, 128, 2, 64}, {1, 128, 2, 64}, {1, 1, 1, 1}, {1, 128, 2, 64}});
+
 INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHA_4D_SplitDimensionM,
+    smoke_Snippets_MHA_4D_SplitDimensionM_static,
     MHA,
-    ::testing::Combine(::testing::ValuesIn(STATIC_SHAPES({{1, 128, 2, 64}, {1, 128, 2, 64}, {1, 1, 1, 1}, {1, 128, 2, 64}})),
+    ::testing::Combine(::testing::ValuesIn(splitm_static_shapes),
                        ::testing::ValuesIn(precision_f32(4)),
                        ::testing::Values(ov::element::f32),
                        ::testing::Values(true),
@@ -119,7 +121,7 @@ INSTANTIATE_TEST_SUITE_P(
     MHA::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHA_3D_SplitDimensionM,
+    smoke_Snippets_MHA_3D_SplitDimensionM_static,
     MHA,
     ::testing::Combine(
         ::testing::ValuesIn(STATIC_SHAPES({{384, 2, 64}, {384, 2, 64}, {1, 384, 384}, {384, 2, 64}})),
@@ -131,6 +133,58 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(1),   // MHA
         ::testing::Values(ov::test::utils::DEVICE_CPU),
         ::testing::Values(enable_callback())),
+    MHA::getTestCaseName);
+
+std::vector<std::vector<ov::test::InputShape>> splitm_dynamic_shapes_4d = {
+    {
+        {PartialShape{-1, -1, -1, -1}, {{1, 128, 2, 64}, {1, 17, 2, 64}, {1, 128, 2, 64}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 128, 2, 64}, {1, 17, 2, 64}, {1, 128, 2, 64}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 1, 1, 128}, {1, 1, 1, 17}, {1, 1, 1, 128}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 128, 2, 64}, {1, 17, 2, 64}, {1, 128, 2, 64}}},
+    },
+    {
+        {PartialShape{-1, -1, -1, -1}, {{1, 32, 2, 64}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 64}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 1, 32, 16}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 32}}},
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHA_4D_SplitDimensionM_dynamic,
+    MHA,
+    ::testing::Combine(::testing::ValuesIn(splitm_dynamic_shapes_4d),
+                       ::testing::ValuesIn(precision_f32(4)),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(false),
+                       ::testing::Values(4),  // 4 Threads
+                       ::testing::Values(1),
+                       ::testing::Values(1),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+std::vector<std::vector<ov::test::InputShape>> splitm_dynamic_shapes_3d = {
+    {
+        {PartialShape{-1, -1, -1}, {{128, 2, 64}, {17, 2, 64}, {128, 2, 64}}},
+        {PartialShape{-1, -1, -1}, {{128, 2, 64}, {17, 2, 64}, {128, 2, 64}}},
+        {PartialShape{-1, -1, -1}, {{1, 1, 128}, {1, 1, 17}, {1, 1, 128}}},
+        {PartialShape{-1, -1, -1}, {{128, 2, 64}, {17, 2, 64}, {128, 2, 64}}},
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHA_3D_SplitDimensionM_dynamic,
+    MHA,
+    ::testing::Combine(::testing::ValuesIn(splitm_dynamic_shapes_3d),
+                       ::testing::ValuesIn(precision_f32(4)),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(false),
+                       ::testing::Values(4),  // 4 Threads
+                       ::testing::Values(5),  // Subgraph + 4 Transpose
+                       ::testing::Values(2),  // MHA + one of the transposes is executed via Subgraph (because callback is disabled)
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
     MHA::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHABF16_4D,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -143,9 +143,21 @@ std::vector<std::vector<ov::test::InputShape>> splitm_dynamic_shapes_4d = {
         {PartialShape{-1, -1, -1, -1}, {{1, 128, 2, 64}, {1, 17, 2, 64}, {1, 128, 2, 64}}},
     },
     {
-        {PartialShape{-1, -1, -1, -1}, {{1, 32, 2, 64}}},
+        {PartialShape{-1, 128, -1, -1}, {{1, 128, 2, 64}}},
         {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 64}}},
-        {PartialShape{-1, -1, -1, -1}, {{1, 1, 32, 16}}},
+        {PartialShape{-1, -1, 128, -1}, {{1, 1, 128, 16}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 32}}},
+    },
+    {
+        {PartialShape{-1, 32, -1, -1}, {{1, 32, 2, 64}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 64}}},
+        {PartialShape{-1, -1, 32, -1}, {{1, 1, 32, 16}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 32}}},
+    },
+    {
+        {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 64}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 64}}},
+        {PartialShape{-1, -1, 16, -1}, {{1, 1, 16, 16}}},
         {PartialShape{-1, -1, -1, -1}, {{1, 16, 2, 32}}},
     },
 };


### PR DESCRIPTION
### Details:
 - *Introduced `ParallelWAOptimizer` class, which is used in RuntimeConfigurator to split M dimension of LIR with brgemms in order to optimize parallel work amount*

### Tickets:
 - *147834*
