### PR TITLE
NPU CMakeLists.txt: Build NPU internal tools only if tests are enabled

### DIFF
--- a/src/plugins/intel_npu/CMakeLists.txt
+++ b/src/plugins/intel_npu/CMakeLists.txt
@@ -30,8 +30,8 @@ add_subdirectory(src)
 
 if(ENABLE_TESTS)
     add_subdirectory(tests)
+    add_subdirectory(tools)
 endif()
 
-add_subdirectory(tools)
 
 ov_cpack_add_component(${NPU_INTERNAL_COMPONENT} HIDDEN)


### PR DESCRIPTION
### Details:
 - Build NPU internal tools only if tests are enabled

