### PR TITLE
[GPU] group_normalization for bfzyx

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/group_normalization.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/group_normalization.cpp
@@ -21,6 +21,15 @@ struct group_normalization_impl : typed_primitive_impl_ocl<group_normalization> 
         return make_unique<group_normalization_impl>(*this);
     }
 
+    void load(BinaryInputBuffer& ib) override {
+        parent::load(ib);
+        if (is_dynamic()) {
+            auto& kernel_selector = kernel_selector_t::Instance();
+            auto kernel_impl = kernel_selector.GetImplementation(_kernel_data.kernelName);
+            kernel_impl->GetUpdateDispatchDataFunc(_kernel_data);
+        }
+    }
+
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, bool is_shape_agnostic = false) {
         const auto& primitive = impl_param.typed_desc<group_normalization>();
         auto params = get_default_params<kernel_selector::group_normalization_params>(impl_param, is_shape_agnostic);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/group_normalization_gpu_bfyx_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/group_normalization_gpu_bfyx_opt.cl
@@ -11,11 +11,23 @@ KERNEL(calc_mean_per_feature)(
     const __global INPUT0_TYPE* input,
     __global ACCUMULATOR_TYPE* internal_mean
 ) {
-    const uint bf = get_global_id(2);     // batch * feature
+    #if INPUT0_DIMS == 5
+        const uint bf = get_global_id(2) / LWS2;     // batch * feature
+    #else
+        const uint bf = get_global_id(2);     // batch * feature
+    #endif
     const uint b = bf / INPUT0_FEATURE_NUM;
     const uint f = bf % INPUT0_FEATURE_NUM;
+    #if INPUT0_DIMS == 5
+        const uint z_num_workers = LWS2;
+    #endif
     const uint y_num_workers = LWS1;
     const uint x_num_workers = LWS0;
+    #if INPUT0_DIMS == 5
+        const uint z_block_size = INPUT0_SIZE_Z / z_num_workers;
+        const uint z_base = get_local_id(2) * z_block_size;
+        const uint z_leftover = INPUT0_SIZE_Z - z_num_workers * z_block_size;
+    #endif
     const uint y_block_size = INPUT0_SIZE_Y / y_num_workers;
     const uint y_base = get_local_id(1) * y_block_size;
     const uint y_leftover = INPUT0_SIZE_Y - y_num_workers * y_block_size;
@@ -24,39 +36,89 @@ KERNEL(calc_mean_per_feature)(
     const uint x_base = get_local_id(0);
     const uint x_leftover = INPUT0_SIZE_X - x_num_workers * x_block_size;
 
-    const uint num_local_workers = y_num_workers * x_num_workers;
-    const uint worker_idx = get_local_linear_id();
-
     __local ACCUMULATOR_TYPE mean_per_feature[SLM_SIZE];
 
     ACCUMULATOR_TYPE mean = ACCUMULATOR_VAL_ZERO;
 
-    for (uint y = y_base; y < (y_base + y_block_size); ++y) {
-        uint my_data_offset = INPUT0_GET_INDEX(b, f, y, x_base);
-        for (uint i = 0; i < x_block_size; ++i) {
-            mean += TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
+    #if INPUT0_DIMS == 5
+        for (uint z = z_base; z < (z_base + z_block_size); ++z) {
+    #endif
+            for (uint y = y_base; y < (y_base + y_block_size); ++y) {
+                #if INPUT0_DIMS == 5
+                    uint my_data_offset = INPUT0_GET_INDEX(b, f, z, y, x_base);
+                #else
+                    uint my_data_offset = INPUT0_GET_INDEX(b, f, y, x_base);
+                #endif
+                for (uint i = 0; i < x_block_size; ++i) {
+                    mean += TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
+                }
+            }
+    #if INPUT0_DIMS == 5
         }
-    }
+    #endif
+
+    #if INPUT0_DIMS == 5
+        if (get_local_id(2) < z_leftover) {
+            for (uint y = y_base; y < (y_base + y_block_size); ++y) {
+                uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(2) + z_num_workers * z_block_size), y, x_base);
+                for (uint i = 0; i < x_block_size; ++i) {
+                    mean += TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
+                }
+            }
+        }
+    #endif
 
     if (get_local_id(1) < y_leftover) {
-        uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(1) + y_num_workers * y_block_size), x_base);
-        for (uint i = 0; i < x_block_size; ++i) {
-            mean += TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
-        }
+        #if INPUT0_DIMS == 5
+            for (uint z = z_base; z < (z_base + z_block_size); ++z) {
+                uint my_data_offset = INPUT0_GET_INDEX(b, f, z, (get_local_id(1) + y_num_workers * y_block_size), x_base);
+        #else
+                uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(1) + y_num_workers * y_block_size), x_base);
+        #endif
+                for (uint i = 0; i < x_block_size; ++i) {
+                    mean += TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
+                }
+        #if INPUT0_DIMS == 5
+            }
+        #endif
     }
 
     if (get_local_id(0) < x_leftover) {
-        for (uint y = y_base; y < (y_base + y_block_size); ++y) {
-            uint my_data_offset = INPUT0_GET_INDEX(b, f, y, (get_local_id(0) + x_num_workers * x_block_size));
-            mean += TO_ACCUMULATOR_TYPE(input[my_data_offset]);
-        }
+        #if INPUT0_DIMS == 5
+            for (uint z = z_base; z < (z_base + z_block_size); ++z) {
+        #endif
+                for (uint y = y_base; y < (y_base + y_block_size); ++y) {
+                    #if INPUT0_DIMS == 5
+                        uint my_data_offset = INPUT0_GET_INDEX(b, f, z, y, (get_local_id(0) + x_num_workers * x_block_size));
+                    #else
+                        uint my_data_offset = INPUT0_GET_INDEX(b, f, y, (get_local_id(0) + x_num_workers * x_block_size));
+                    #endif
+                    mean += TO_ACCUMULATOR_TYPE(input[my_data_offset]);
+                }
+        #if INPUT0_DIMS == 5
+            }
+        #endif
     }
 
-    if (get_local_id(1) < y_leftover && get_local_id(0) < x_leftover) {
-        uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(1) + y_num_workers * y_block_size),
-                                                     (get_local_id(0) + x_num_workers * x_block_size));
-        mean += TO_ACCUMULATOR_TYPE(input[my_data_offset]);
-    }
+    #if INPUT0_DIMS == 5
+        if (get_local_id(2) < z_leftover && get_local_id(1) < y_leftover && get_local_id(0) < x_leftover) {
+            uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(2) + z_num_workers * z_block_size),
+                                                         (get_local_id(1) + y_num_workers * y_block_size),
+                                                         (get_local_id(0) + x_num_workers * x_block_size));
+    #else
+        if (get_local_id(1) < y_leftover && get_local_id(0) < x_leftover) {
+            uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(1) + y_num_workers * y_block_size),
+                                                         (get_local_id(0) + x_num_workers * x_block_size));
+    #endif
+            mean += TO_ACCUMULATOR_TYPE(input[my_data_offset]);
+        }
+
+    #if INPUT0_DIMS == 5
+        const uint num_local_workers = z_num_workers * y_num_workers * x_num_workers;
+    #else
+        const uint num_local_workers = y_num_workers * x_num_workers;
+    #endif
+    const uint worker_idx = get_local_linear_id();
 
     mean_per_feature[worker_idx] = mean;
     uint reduce_add_level = 1;
@@ -69,7 +131,7 @@ KERNEL(calc_mean_per_feature)(
     }
 
     if (worker_idx == 0) {
-        mean = mean_per_feature[0] / TO_ACCUMULATOR_TYPE(INPUT0_SIZE_Y * INPUT0_SIZE_X);
+        mean = mean_per_feature[0] / TO_ACCUMULATOR_TYPE(INPUT0_SIZE_Z * INPUT0_SIZE_Y * INPUT0_SIZE_X);
         internal_mean[bf] = mean;
     }
 }
@@ -102,11 +164,23 @@ KERNEL(calc_var_per_feature)(
     const __global ACCUMULATOR_TYPE* internal_mean,
     __global ACCUMULATOR_TYPE* internal_variance
 ) {
-    const uint bf = get_global_id(2);     // batch * feature
+    #if INPUT0_DIMS == 5
+        const uint bf = get_global_id(2) / LWS2;     // batch * feature
+    #else
+        const uint bf = get_global_id(2);     // batch * feature
+    #endif
     const uint b = bf / INPUT0_FEATURE_NUM;
     const uint f = bf % INPUT0_FEATURE_NUM;
+    #if INPUT0_DIMS == 5
+        const uint z_num_workers = LWS2;
+    #endif
     const uint y_num_workers = LWS1;
     const uint x_num_workers = LWS0;
+    #if INPUT0_DIMS == 5
+        const uint z_block_size = INPUT0_SIZE_Z / z_num_workers;
+        const uint z_base = get_local_id(2) * z_block_size;
+        const uint z_leftover = INPUT0_SIZE_Z - z_num_workers * z_block_size;
+    #endif
     const uint y_block_size = INPUT0_SIZE_Y / y_num_workers;
     const uint y_base = get_local_id(1) * y_block_size;
     const uint y_leftover = INPUT0_SIZE_Y - y_num_workers * y_block_size;
@@ -120,42 +194,94 @@ KERNEL(calc_var_per_feature)(
     const ACCUMULATOR_TYPE mean = internal_mean[bf];
     ACCUMULATOR_TYPE variance = ACCUMULATOR_VAL_ZERO;
 
-    for (uint y = y_base; y < (y_base + y_block_size); ++y) {
-        uint my_data_offset = INPUT0_GET_INDEX(b, f, y, x_base);
-        for (uint i = 0; i < x_block_size; ++i) {
-            ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
-            tmp -= mean;
-            variance = fma(tmp, tmp, variance);
+    #if INPUT0_DIMS == 5
+        for (uint z = z_base; z < (z_base + z_block_size); ++z) {
+    #endif
+            for (uint y = y_base; y < (y_base + y_block_size); ++y) {
+                #if INPUT0_DIMS == 5
+                    uint my_data_offset = INPUT0_GET_INDEX(b, f, z, y, x_base);
+                #else
+                    uint my_data_offset = INPUT0_GET_INDEX(b, f, y, x_base);
+                #endif
+                for (uint i = 0; i < x_block_size; ++i) {
+                    ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
+                    tmp -= mean;
+                    variance = fma(tmp, tmp, variance);
+                }
+            }
+    #if INPUT0_DIMS == 5
         }
-    }
+    #endif
+
+    #if INPUT0_DIMS == 5
+        if (get_local_id(2) < z_leftover) {
+            for (uint y = y_base; y < (y_base + y_block_size); ++y) {
+                uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(2) + z_num_workers * z_block_size), y, x_base);
+                for (uint i = 0; i < x_block_size; ++i) {
+                    ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
+                    tmp -= mean;
+                    variance = fma(tmp, tmp, variance);
+                }
+            }
+        }
+    #endif
 
     if (get_local_id(1) < y_leftover) {
-        uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(1) + y_num_workers * y_block_size), x_base);
-        for (uint i = 0; i < x_block_size; ++i) {
-            ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
-            tmp -= mean;
-            variance = fma(tmp, tmp, variance);
-        }
+        #if INPUT0_DIMS == 5
+            for (uint z = z_base; z < (z_base + z_block_size); ++z) {
+                uint my_data_offset = INPUT0_GET_INDEX(b, f, z, (get_local_id(1) + y_num_workers * y_block_size), x_base);
+        #else
+                uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(1) + y_num_workers * y_block_size), x_base);
+        #endif
+                for (uint i = 0; i < x_block_size; ++i) {
+                    ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[my_data_offset + i * x_num_workers]);
+                    tmp -= mean;
+                    variance = fma(tmp, tmp, variance);
+                }
+        #if INPUT0_DIMS == 5
+            }
+        #endif
     }
 
     if (get_local_id(0) < x_leftover) {
-        for (uint y = y_base; y < (y_base + y_block_size); ++y) {
-            uint my_data_offset = INPUT0_GET_INDEX(b, f, y, (get_local_id(0) + x_num_workers * x_block_size));
+        #if INPUT0_DIMS == 5
+            for (uint z = z_base; z < (z_base + z_block_size); ++z) {
+        #endif
+                for (uint y = y_base; y < (y_base + y_block_size); ++y) {
+                    #if INPUT0_DIMS == 5
+                        uint my_data_offset = INPUT0_GET_INDEX(b, f, z, y, (get_local_id(0) + x_num_workers * x_block_size));
+                    #else
+                        uint my_data_offset = INPUT0_GET_INDEX(b, f, y, (get_local_id(0) + x_num_workers * x_block_size));
+                    #endif
+                    ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[my_data_offset]);
+                    tmp -= mean;
+                    variance = fma(tmp, tmp, variance);
+                }
+        #if INPUT0_DIMS == 5
+            }
+        #endif
+    }
+
+    #if INPUT0_DIMS == 5
+        if (get_local_id(2) < z_leftover && get_local_id(1) < y_leftover && get_local_id(0) < x_leftover) {
+            uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(2) + z_num_workers * z_block_size),
+                                                         (get_local_id(1) + y_num_workers * y_block_size),
+                                                         (get_local_id(0) + x_num_workers * x_block_size));
+    #else
+        if (get_local_id(1) < y_leftover && get_local_id(0) < x_leftover) {
+            uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(1) + y_num_workers * y_block_size),
+                                                         (get_local_id(0) + x_num_workers * x_block_size));
+    #endif
             ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[my_data_offset]);
             tmp -= mean;
             variance = fma(tmp, tmp, variance);
         }
-    }
 
-    if (get_local_id(1) < y_leftover && get_local_id(0) < x_leftover) {
-        uint my_data_offset = INPUT0_GET_INDEX(b, f, (get_local_id(1) + y_num_workers * y_block_size),
-                                                     (get_local_id(0) + x_num_workers * x_block_size));
-        ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[my_data_offset]);
-        tmp -= mean;
-        variance = fma(tmp, tmp, variance);
-    }
-
-    const uint num_local_workers = y_num_workers * x_num_workers;
+    #if INPUT0_DIMS == 5
+        const uint num_local_workers = z_num_workers * y_num_workers * x_num_workers;
+    #else
+        const uint num_local_workers = y_num_workers * x_num_workers;
+    #endif
     const uint worker_idx = get_local_linear_id();
 
     var_per_feature[worker_idx] = variance;
@@ -169,7 +295,7 @@ KERNEL(calc_var_per_feature)(
     }
 
     if (worker_idx == 0) {
-        variance = var_per_feature[0] / TO_ACCUMULATOR_TYPE(INPUT0_SIZE_Y * INPUT0_SIZE_X);
+        variance = var_per_feature[0] / TO_ACCUMULATOR_TYPE(INPUT0_SIZE_Z * INPUT0_SIZE_Y * INPUT0_SIZE_X);
         internal_variance[bf] = variance;
     }
 }
@@ -212,18 +338,32 @@ KERNEL(group_normalization_b_fs_yx_fsv16)(
     const uint bf = get_global_id(1);
     const uint b = bf / OUTPUT_FEATURE_NUM;
     const uint f = bf % OUTPUT_FEATURE_NUM;
-    const uint yx = get_global_id(0);
+    #if INPUT0_DIMS == 5
+        const uint zyx = get_global_id(0);
+        const uint z = zyx / (OUTPUT_SIZE_Y * OUTPUT_SIZE_X);
+        const uint yx = zyx % (OUTPUT_SIZE_Y * OUTPUT_SIZE_X);
+    #else
+        const uint yx = get_global_id(0);
+    #endif
     const uint y = yx / OUTPUT_SIZE_X;
     const uint x = yx % OUTPUT_SIZE_X;
 
-    const uint input_data_index = INPUT0_GET_INDEX(b, f, y, x);
+    #if INPUT0_DIMS == 5
+        const uint input_data_index = INPUT0_GET_INDEX(b, f, z, y, x);
+    #else
+        const uint input_data_index = INPUT0_GET_INDEX(b, f, y, x);
+    #endif
 
     ACTIVATION_TYPE mean = TO_ACTIVATION_TYPE(internal_mean[bf]);
     ACTIVATION_TYPE variance = TO_ACTIVATION_TYPE(internal_variance[bf]);
     ACTIVATION_TYPE normalized = (TO_ACTIVATION_TYPE(input[input_data_index]) - mean) * variance;
     normalized = normalized * TO_ACTIVATION_TYPE(scale[f]) + TO_ACTIVATION_TYPE(bias[f]);
 
-    const uint output_data_index = OUTPUT_GET_INDEX(b, f, y, x);
+    #if INPUT0_DIMS == 5
+        const uint output_data_index = OUTPUT_GET_INDEX(b, f, z, y, x);
+    #else
+        const uint output_data_index = OUTPUT_GET_INDEX(b, f, y, x);
+    #endif
     #if HAS_FUSED_OPS
         FUSED_OPS;
         output[output_data_index] = FUSED_OPS_RESULT;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_b_fs_yx_fsv16.cpp
@@ -181,13 +181,12 @@ bool GroupNormalizationKernel_b_fs_yx_fsv16::Validate(const Params& params) cons
         return true;
 
     // no support for spatial paddings
-    if (prim_params.inputs[0].X().pad.Total() > 0 || prim_params.inputs[0].Y().pad.Total() > 0 ||
-        prim_params.outputs[0].X().pad.Total() > 0 || prim_params.outputs[0].Y().pad.Total() > 0) {
+    if (prim_params.inputs[0].X().pad.Total() > 0 || prim_params.inputs[0].Y().pad.Total() > 0) {
         return false;
     }
 
     // feature paddings should be multiples of fsv.
-    if (prim_params.inputs[0].Feature().pad.before % fsv != 0 || prim_params.outputs[0].Feature().pad.before % fsv != 0) {
+    if (prim_params.inputs[0].Feature().pad.before % fsv != 0) {
         return false;
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_selector.cpp
@@ -9,7 +9,7 @@
 namespace kernel_selector {
 
 group_normalization_kernel_selector::group_normalization_kernel_selector() {
-    // Attach<GroupNormalizationKernelRef>();
+    Attach<GroupNormalizationKernelRef>();
     Attach<GroupNormalizationKernelBfyx>();
     Attach<GroupNormalizationKernel_b_fs_yx_fsv16>();
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_selector.cpp
@@ -9,7 +9,7 @@
 namespace kernel_selector {
 
 group_normalization_kernel_selector::group_normalization_kernel_selector() {
-    Attach<GroupNormalizationKernelRef>();
+    // Attach<GroupNormalizationKernelRef>();
     Attach<GroupNormalizationKernelBfyx>();
     Attach<GroupNormalizationKernel_b_fs_yx_fsv16>();
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -124,11 +124,8 @@ const std::vector<cldnn::format> f_blocked_4d_formats {
     format::b_fs_yx_fsv16,
 };
 
-const std::vector<cldnn::format> f_blocked_5d_formats {
-    format::b_fs_zyx_fsv2,
-    format::b_fs_zyx_fsv4,
-    format::b_fs_zyx_fsv16,
-    format::b_fs_zyx_fsv32,
+const std::vector<cldnn::format> f_planar_5d_formats {
+    format::bfzyx,
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -150,12 +147,12 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn({padding(), padding({0, 16, 0, 0})})));
 
 INSTANTIATE_TEST_SUITE_P(
-    GroupNormalizationGPUTest_blocked_layouts_support_5d, GroupNormalizationGPUTest,
+    GroupNormalizationGPUTest_planar_layouts_support_5d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::Values(std::vector<int32_t>{3, 64, 28, 32, 12}),
-        ::testing::Values(4),
+        ::testing::ValuesIn({std::vector<int32_t>{3, 64, 28, 32, 12}, std::vector<int32_t>{3, 124, 10, 97, 61}, std::vector<int32_t>{1, 1536, 9, 151, 1}, std::vector<int32_t>{1, 12, 8, 2175, 1}}),
+        ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
-        ::testing::ValuesIn(f_blocked_5d_formats),
-        ::testing::Values(padding())));
+        ::testing::ValuesIn(f_planar_5d_formats),
+        ::testing::ValuesIn({padding(), padding({0, 0, 1, 1})})));
 
 } // anonymous namespace


### PR DESCRIPTION
### Details:
 - This PR updates the `group_normalization_bfyx` kernel to support bfzyx format.
 - Additionally, this PR fixes the output feature calculation logic of the group_norm_fsv16 kernel and a model caching related logic for dynamic model.

### Tickets:
 - 147841
