### PR TITLE
[GPU] Add an ability to reuse single kernel between multiple implementations

### DIFF
--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -123,6 +123,15 @@ static constexpr Property<int64_t> available_device_mem{"AVAILABLE_DEVICE_MEM_SI
  * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
  */
 static constexpr Property<bool> enable_sdpa_optimization{"GPU_ENABLE_SDPA_OPTIMIZATION"};
+
+/**
+ * @brief Turning on this property enables kernels reuse between implementations, resulting in a lower memory footprint.
+ * However, as a drawback, OpenCL set_arguments() call will be made more often, resulting in higher host pressure
+ * and slower execution in some host-bottleneck cases.
+ * This property is available only for single-stream scenarios and will be ignored in other cases.
+ * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
+ */
+static constexpr Property<bool> enable_kernels_reuse{"GPU_ENABLE_KERNELS_REUSE"};
 }  // namespace hint
 
 /**

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/kernel.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/kernel.hpp
@@ -17,7 +17,7 @@ using kernel_id = std::string;
 class kernel {
 public:
     using ptr = std::shared_ptr<kernel>;
-    virtual std::shared_ptr<kernel> clone() const = 0;
+    virtual std::shared_ptr<kernel> clone(bool reuse_kernel_handle = false) const = 0;
     virtual ~kernel() = default;
     virtual std::string get_id() const { return ""; }
 };

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -40,7 +40,7 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
     : cl_kernel(other.cl_kernel)
     , _kernels({}) {
         for (const auto& kernel : other._kernels) {
-            _kernels.emplace_back(kernel->clone());
+            _kernels.emplace_back(kernel->clone(other.can_share_kernels));
         }
     }
 
@@ -59,10 +59,12 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
         _kernels.clear();
         auto compiled_kernels = kernels_cache.get_kernels(params);
         _kernels.insert(_kernels.begin(), compiled_kernels.begin(), compiled_kernels.end());
+        this->can_share_kernels = kernels_cache.get_kernels_reuse();
     }
 
     void init_by_cached_kernels(const kernels_cache& kernels_cache, std::vector<std::string>& cached_kernel_ids) override {
         _kernels.emplace_back(kernels_cache.get_kernel_from_cached_kernels(cached_kernel_ids[0]));
+        this->can_share_kernels = kernels_cache.get_kernels_reuse();
     }
 
     std::vector<std::string> get_cached_kernel_ids(const kernels_cache& kernels_cache) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
@@ -49,9 +49,10 @@ struct multi_stage_primitive : public typed_primitive_impl<PType> {
         , _kernels({}) {
         _kernels.reserve(other._kernels.size());
         for (size_t k = 0; k < other._kernels.size(); ++k) {
-            _kernels.emplace_back(other._kernels[k]->clone());
+            _kernels.emplace_back(other._kernels[k]->clone(other.can_share_kernels));
         }
         this->can_reuse_memory = other.can_reuse_memory;
+        this->can_share_kernels = other.can_share_kernels;
         this->_kernel_name = other._kernel_name;
         this->_is_dynamic = other._is_dynamic;
     }
@@ -132,6 +133,7 @@ protected:
             for (size_t i = 1; i < _kernels_data[0].kernels.size(); ++i)
                 kernel_dump_info.second += " " + _kernels_data[0].kernels[i].code.kernelString->entry_point;
         }
+        this->can_share_kernels = kernels_cache.get_kernels_reuse();
     }
 
     void init_by_cached_kernels(const kernels_cache& kernels_cache, std::vector<std::string>& cached_kernel_ids) override {
@@ -141,6 +143,7 @@ protected:
         for (size_t k = 0; k < cached_kernel_ids.size(); ++k) {
             _kernels.emplace_back(kernels_cache.get_kernel_from_cached_kernels(cached_kernel_ids[k]));
         }
+        this->can_share_kernels = kernels_cache.get_kernels_reuse();
     }
 
     std::vector<std::string> get_cached_kernel_ids(const kernels_cache& kernels_cache) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -50,9 +50,10 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
     , _kernels({}) {
         _kernels.reserve(other._kernels.size());
         for (size_t k = 0; k < other._kernels.size(); ++k) {
-            _kernels.emplace_back(other._kernels[k]->clone());
+            _kernels.emplace_back(other._kernels[k]->clone(other.can_share_kernels));
         }
         this->can_reuse_memory = _kernel_data.can_reuse_memory;
+        this->can_share_kernels = other.can_share_kernels;
     }
 
     typed_primitive_impl_ocl(const kernel_selector::kernel_data& kd)
@@ -159,6 +160,7 @@ protected:
             for (size_t i = 1; i < _kernel_data.kernels.size(); ++i)
                 kernel_dump_info.second += " " + _kernel_data.kernels[i].code.kernelString->entry_point;
         }
+        this->can_share_kernels = kernels_cache.get_kernels_reuse();
     }
 
     void init_by_cached_kernels(const kernels_cache& kernels_cache, std::vector<std::string>& cached_kernel_ids) override {
@@ -171,6 +173,7 @@ protected:
         for (size_t k = 0; k < cached_kernel_ids.size(); ++k) {
             _kernels.emplace_back(kernels_cache.get_kernel_from_cached_kernels(cached_kernel_ids[k]));
         }
+        this->can_share_kernels = kernels_cache.get_kernels_reuse();
     }
 
     std::vector<std::string> get_cached_kernel_ids(const kernels_cache& kernels_cache) override {

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -99,6 +99,7 @@ struct primitive_impl {
 
     // If this flag is set as false, the memory allocated for this primitive is not allowed to be reused
     bool can_reuse_memory = true;
+    bool can_share_kernels = false;
 
     void set_dynamic(bool val) { _is_dynamic = val; }
     bool is_dynamic() const { return _is_dynamic; }

--- a/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
@@ -47,6 +47,7 @@ struct primitive_type_base : primitive_type {
             auto factory = implementation_map<PType>::get(runtime_params, node.get_preferred_impl_type(), get_shape_type(runtime_params));
             auto impl = factory(node, runtime_params);
             impl->set_dynamic(get_shape_type(runtime_params) == shape_types::dynamic_shape);
+            impl->can_share_kernels = node.get_program().get_config().get_property(ov::intel_gpu::hint::enable_kernels_reuse);
             return impl;
         } catch (std::exception& e) {
             std::stringstream ss;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1650,8 +1650,10 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
         return false;
     };
 
+    bool use_shared_kernels = _node->get_program().get_config().get_property(ov::intel_gpu::hint::enable_kernels_reuse);
+
     // Output buffer may be changed under the following conditions, so we need to set args to kernel on each iteration
-    if ((is_dynamic() && need_args_update) || has_mutable_input() || is_output() || has_dynamic_dependencies_insts(this)) {
+    if ((is_dynamic() && need_args_update) || has_mutable_input() || is_output() || has_dynamic_dependencies_insts(this) || use_shared_kernels) {
         set_arguments();
     }
     on_execute();
@@ -2010,6 +2012,7 @@ event::ptr primitive_inst::update_weights() {
                     auto kernels = kernels_cache.compile(*reorder_kernel_params, reorder_impl->get_kernels_source());
                     OPENVINO_ASSERT(kernels.size() == 1, "[GPU] Expected number of compiled kernels is 1, but got ", kernels.size());
                     reorder_impl->set_kernels(kernels);
+                    reorder_impl->can_share_kernels = _node->get_program().get_config().get_property(ov::intel_gpu::hint::enable_kernels_reuse);
                 }
 
                 reorder_inst->set_impl(reorder_impl->clone());

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -225,6 +225,8 @@ void program::init_program() {
     _kernels_cache = std::unique_ptr<kernels_cache>(new kernels_cache(_engine, _config, prog_id, _task_executor,
                                                                       kernel_selector::KernelBase::get_db().get_batch_headers()));
 
+    _kernels_cache->set_kernels_reuse(get_config().get_property(ov::intel_gpu::hint::enable_kernels_reuse));
+
     if (!_compilation_context)
         _compilation_context = program::make_compilation_context(_config);
 

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -58,6 +58,7 @@ void ExecutionConfig::set_default() {
         std::make_tuple(ov::internal::query_model_ratio, 1.0f),
         std::make_tuple(ov::cache_mode, ov::CacheMode::OPTIMIZE_SPEED),
         std::make_tuple(ov::hint::dynamic_quantization_group_size, 0),
+        std::make_tuple(ov::intel_gpu::hint::enable_kernels_reuse, false),
 
         // Legacy API properties
         std::make_tuple(ov::intel_gpu::nv12_two_inputs, false),
@@ -163,6 +164,13 @@ void ExecutionConfig::apply_performance_hints(const cldnn::device_info& info) {
 
     if (get_property(ov::internal::exclusive_async_requests)) {
         set_property(ov::num_streams(1));
+    }
+
+    // Allow kernels reuse only for single-stream scenarios
+    if (get_property(ov::intel_gpu::hint::enable_kernels_reuse)) {
+        if (get_property(ov::num_streams) != 1) {
+            set_property(ov::intel_gpu::hint::enable_kernels_reuse(false));
+        }
     }
 }
 

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -433,7 +433,8 @@ void kernels_cache::build_batch(const engine& build_engine, const batch_program&
 kernel::ptr kernels_cache::get_kernel_from_cached_kernels(std::string id) const {
     auto res = _cached_kernels.find(id);
     OPENVINO_ASSERT(_cached_kernels.end() != res, "[GPU] Kernel " + id + " not found in the cached kernel cache!");
-    return res->second->clone();
+
+    return res->second->clone(_reuse_kernels);
 }
 
 std::vector<kernel::ptr> kernels_cache::get_kernels(kernel_impl_params params) const {
@@ -451,7 +452,7 @@ std::vector<kernel::ptr> kernels_cache::get_kernels(kernel_impl_params params) c
     for (auto& k : res->second) {
         auto& kernel_ptr = k.first;
         auto kernel_part_idx = k.second;
-        kernels[kernel_part_idx] = kernel_ptr->clone();
+        kernels[kernel_part_idx] = kernel_ptr->clone(_reuse_kernels);
     }
     return kernels;
 }

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
@@ -107,6 +107,8 @@ private:
     bool is_cache_enabled() const;
     size_t get_max_kernels_per_batch() const;
 
+    bool _reuse_kernels = false;
+
 public:
     explicit kernels_cache(engine& engine,
                            const ExecutionConfig& config,
@@ -115,6 +117,9 @@ public:
                            const std::map<std::string, std::string>& batch_headers = {});
     kernel::ptr get_kernel_from_cached_kernels(std::string id) const;
     std::vector<kernel::ptr> get_kernels(kernel_impl_params params) const;
+
+    void set_kernels_reuse(bool reuse_kernels) { _reuse_kernels = reuse_kernels; }
+    bool get_kernels_reuse() const { return _reuse_kernels; }
 
     bool validate_simple_kernel_execution(kernel::ptr kernel);
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel.hpp
@@ -27,7 +27,12 @@ public:
     std::string get_id() const override { return _kernel_id; }
     const ocl_kernel_type& get_handle() const { return _compiled_kernel; }
     ocl_kernel_type& get_handle() { return _compiled_kernel; }
-    std::shared_ptr<kernel> clone() const override { return std::make_shared<ocl_kernel>(get_handle().clone(), _kernel_id); }
+    std::shared_ptr<kernel> clone(bool reuse_kernel_handle = false) const override {
+        if (reuse_kernel_handle)
+            return std::make_shared<ocl_kernel>(get_handle(), _kernel_id);
+
+        return std::make_shared<ocl_kernel>(get_handle().clone(), _kernel_id);
+    }
 };
 
 }  // namespace ocl

--- a/src/plugins/intel_gpu/tests/unit/passes/kernels_cache_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/kernels_cache_test.cpp
@@ -4,9 +4,11 @@
 
 #include "test_utils.h"
 
+#include "runtime/ocl/ocl_kernel.hpp"
 #include "intel_gpu/runtime/engine.hpp"
-
 #include "intel_gpu/graph/program.hpp"
+#include "intel_gpu/graph/network.hpp"
+
 #include "data_inst.h"
 #include "eltwise_inst.h"
 #include "reshape_inst.h"
@@ -14,13 +16,12 @@
 #include "fully_connected_inst.h"
 #include "permute_inst.h"
 #include "reduce_inst.h"
-#include "intel_gpu/graph/network.hpp"
-#include "pass_manager.h"
 #include "to_string_utils.h"
-#include <regex>
 #include "program_wrapper.h"
+#include "pass_manager.h"
 
 #include <memory>
+#include <regex>
 
 using namespace cldnn;
 using namespace ::tests;
@@ -125,5 +126,83 @@ TEST(kernels_cache, sub_kernel_ordering_test) {
     ASSERT_EQ(entry_point_list.size(), _out_kernels.size());
     for (size_t i = 0; i < entry_point_list.size(); i++) {
         ASSERT_EQ(entry_point_list[i], _out_kernels[i]->get_id());
+    }
+}
+
+
+TEST(kernels_cache, reuse_kernels_property) {
+    auto& engine = get_test_engine();
+
+    auto input0 = engine.allocate_memory({{1, 1, 4, 5}, data_types::f16, format::bfyx});
+    auto input1 = engine.allocate_memory({{1, 1, 4, 5}, data_types::f16, format::bfyx});
+    auto input2 = engine.allocate_memory({{1, 1, 4, 5}, data_types::f16, format::bfyx});
+    auto input3 = engine.allocate_memory({{1, 1, 4, 5}, data_types::f16, format::bfyx});
+    auto input4 = engine.allocate_memory({{1, 1, 4, 5}, data_types::f16, format::bfyx});
+    auto input5 = engine.allocate_memory({{1, 1, 4, 5}, data_types::f16, format::bfyx});
+    auto weights1 = engine.allocate_memory({{1, 3, 2, 3 }, data_types::f16, format::bfyx});
+    auto weights2 = engine.allocate_memory({{1, 3, 2, 3 }, data_types::f16, format::bfyx});
+
+    topology topology(input_layout("input0", input0->get_layout()),
+                      input_layout("input1", input1->get_layout()),
+                      input_layout("input2", input2->get_layout()),
+                      input_layout("input3", input3->get_layout()),
+                      input_layout("input4", input4->get_layout()),
+                      input_layout("input5", input5->get_layout()),
+                      data("weights1", weights1),
+                      data("weights2", weights2),
+                      concatenation("concat1",
+                                    { input_info("input0"), input_info("input1"), input_info("input2") },
+                                    1,
+                                    data_types::f16),
+                      convolution("conv1", input_info("concat1"), "weights1", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false),
+                      concatenation("concat2",
+                                    { input_info("input3"), input_info("input4"), input_info("input5") },
+                                    1,
+                                    data_types::f16),
+                      convolution("conv2", input_info("concat2"), "weights2", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false),
+                      eltwise("sum", {input_info("concat1"), input_info("concat2")}, eltwise_mode::sum),
+                      reorder("output", input_info("sum"), {{3, 2}, data_types::f16, format::bfyx}));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::hint::enable_kernels_reuse(true));
+    auto prog = program::build_program(engine, topology, config, false, false);
+    auto& cache = prog->get_kernels_cache();
+    auto& conv1_node = prog->get_node("conv1");
+    auto& conv2_node = prog->get_node("conv2");
+    auto conv1_kernels = conv1_node.get_selected_impl()->get_kernels();
+    cache.add_to_cached_kernels(conv1_kernels);
+    auto conv2_kernels = conv2_node.get_selected_impl()->get_kernels();
+    cache.add_to_cached_kernels(conv2_kernels);
+    ASSERT_EQ(conv1_kernels.size(), conv2_kernels.size());
+    for (size_t idx = 0; idx < conv1_kernels.size(); idx++) {
+        auto conv1_kern = cache.get_cached_kernel_id(conv1_kernels[idx]);
+        auto conv2_kern = cache.get_cached_kernel_id(conv2_kernels[idx]);
+        ASSERT_EQ(conv1_kern, conv2_kern);
+
+        auto conv1_ocl_kernel = std::dynamic_pointer_cast<ocl::ocl_kernel>(conv1_kernels[idx]);
+        auto conv2_ocl_kernel = std::dynamic_pointer_cast<ocl::ocl_kernel>(conv2_kernels[idx]);
+        if (conv1_ocl_kernel && conv2_ocl_kernel) {
+            ASSERT_EQ(conv1_ocl_kernel->get_handle().get(), conv2_ocl_kernel->get_handle().get());
+        }
+    }
+
+    auto& concat1_node = prog->get_node("concat1");
+    auto& concat2_node = prog->get_node("concat2");
+    auto concat1_kernels = concat1_node.get_selected_impl()->get_kernels();
+    cache.add_to_cached_kernels(concat1_kernels);
+    auto concat2_kernels = concat2_node.get_selected_impl()->get_kernels();
+    cache.add_to_cached_kernels(concat2_kernels);
+    ASSERT_EQ(concat1_kernels.size(), concat2_kernels.size());
+    for (size_t idx = 0; idx < concat1_kernels.size(); idx++) {
+        auto concat1_kern = cache.get_cached_kernel_id(concat1_kernels[idx]);
+        auto concat2_kern = cache.get_cached_kernel_id(concat2_kernels[idx]);
+        ASSERT_EQ(concat1_kern, concat2_kern);
+
+        auto concat1_ocl_kernel = std::dynamic_pointer_cast<ocl::ocl_kernel>(concat1_kernels[idx]);
+        auto concat2_ocl_kernel = std::dynamic_pointer_cast<ocl::ocl_kernel>(concat2_kernels[idx]);
+        if (concat1_ocl_kernel && concat2_ocl_kernel) {
+            ASSERT_EQ(concat1_ocl_kernel->get_handle().get(), concat2_ocl_kernel->get_handle().get());
+        }
     }
 }


### PR DESCRIPTION
### Details:
 - This PR adds an ability to reuse single kernel between multiple implementations, resulting in much lower memory pressure in some cases. It can be enabled with `ov::intel_gpu::hint::enable_kernels_reuse(true)` property
 
 ### Tickets:
 - [CVS-145296](https://jira.devtools.intel.com/browse/CVS-145296)
