### PR TITLE
[GPU] Fixed fc tile size for better perf for small N size (4096) kernels 

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -310,7 +310,7 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
         if (!params.is_shape_agnostic && batch == 1) {
             // Tuning for Meteor Lake
             size_t min_num_threads = params.engineInfo.computeUnitsCount * simd;
-            if (output_f / 2 < min_num_threads && params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
+            if (output_f / 2 <= min_num_threads && params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
                 GPU_DEBUG_TRACE_DETAIL << "FC bf tiled: Set ofm_tile 1. (output_f : " << output_f
                     << ", computeUnitsCount : " << params.engineInfo.computeUnitsCount
                     << " min_num_threads : " << min_num_threads << ")" << std::endl;


### PR DESCRIPTION
### Details:
 - [GPU] Fixed fc tile size for better perf for small N size (4096) kernels in MTL
 - To get 3-5% gain on 2nd token latency on MTL
 
![image](https://github.com/user-attachments/assets/9da816ab-b104-4dcb-b8d2-e816068589fb)



### Tickets:
 - *ticket-id*
