### PR TITLE
[OV JS] Expose Model.clone to Node.js Api

### DIFF
--- a/src/bindings/js/node/include/model_wrap.hpp
+++ b/src/bindings/js/node/include/model_wrap.hpp
@@ -116,6 +116,13 @@ public:
      */
     Napi::Value get_output_element_type(const Napi::CallbackInfo& info);
 
+    /**
+     * @brief Returns a cloned model for the current model
+     * @param info Contains information about the environment and passed arguments
+     * @return Napi::Value Cloned model returned from the API
+     */
+    Napi::Value clone(const Napi::CallbackInfo& info);
+
 private:
     std::shared_ptr<ov::Model> _model;
     ov::Core _core;

--- a/src/bindings/js/node/lib/addon.ts
+++ b/src/bindings/js/node/lib/addon.ts
@@ -215,6 +215,10 @@ interface CoreConstructor {
  */
 interface Model {
   /**
+   * It returns a cloned model.
+   */
+  clone(): Model;
+  /**
    * It gets the friendly name for a model. If a friendly name is not set
    * via {@link Model.setFriendlyName}, a unique model name is returned.
    * @returns A string with a friendly name of the model.

--- a/src/bindings/js/node/src/model_wrap.cpp
+++ b/src/bindings/js/node/src/model_wrap.cpp
@@ -27,6 +27,7 @@ Napi::Function ModelWrap::get_class(Napi::Env env) {
                         InstanceMethod("getFriendlyName", &ModelWrap::get_friendly_name),
                         InstanceMethod("getOutputShape", &ModelWrap::get_output_shape),
                         InstanceMethod("getOutputElementType", &ModelWrap::get_output_element_type),
+                        InstanceMethod("clone", &ModelWrap::clone),
                         InstanceAccessor<&ModelWrap::get_inputs>("inputs"),
                         InstanceAccessor<&ModelWrap::get_outputs>("outputs")});
 }
@@ -188,4 +189,13 @@ Napi::Value ModelWrap::get_output_element_type(const Napi::CallbackInfo& info) {
         reportError(info.Env(), e.what());
         return info.Env().Undefined();
     }
+}
+
+Napi::Value ModelWrap::clone(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() > 0) {
+        reportError(env, "clone() does not accept any arguments.");
+        return env.Undefined();
+    }
+    return cpp_to_js(env, _model->clone());
 }

--- a/src/bindings/js/node/src/model_wrap.cpp
+++ b/src/bindings/js/node/src/model_wrap.cpp
@@ -192,10 +192,15 @@ Napi::Value ModelWrap::get_output_element_type(const Napi::CallbackInfo& info) {
 }
 
 Napi::Value ModelWrap::clone(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-    if (info.Length() > 0) {
-        reportError(env, "clone() does not accept any arguments.");
-        return env.Undefined();
+    std::vector<std::string> allowed_signatures;
+    try {
+        if (ov::js::validate(info, allowed_signatures)) {
+            return cpp_to_js(info.Env(), _model->clone());
+        } else {
+            OPENVINO_THROW("'clone'", ov::js::get_parameters_error_msg(info, allowed_signatures));
+        }
+    } catch (const std::exception& e) {
+        reportError(info.Env(), e.what());
+        return info.Env().Undefined();
     }
-    return cpp_to_js(env, _model->clone());
 }

--- a/src/bindings/js/node/tests/unit/model.test.js
+++ b/src/bindings/js/node/tests/unit/model.test.js
@@ -9,6 +9,7 @@ const { getModelPath } = require('./utils.js');
 const testXml = getModelPath().xml;
 const core = new ov.Core();
 const model = core.readModelSync(testXml);
+const clonedModel = model.clone();
 
 describe('Node.js Model.isDynamic()', () => {
   it('should return a boolean value indicating if the model is dynamic', () => {
@@ -155,5 +156,21 @@ describe('Model.getOutputElementType()', () => {
       /^Error: /,
       'Should throw for out-of-range index'
     );
+  });
+});
+
+describe('Model.clone()', () => {
+  it('should return an object of type model', () => {
+    assert.ok(clonedModel instanceof ov.Model, 'clone() should return a model');
+  });
+
+  it('should return a model that is a clone of the calling model', () => {
+    assert.deepStrictEqual(clonedModel, model, "Cloned Model should be exactly equal to the calling model");
+  });
+  
+  it('should not accept any arguments', () => {
+    assert.throws(() => {
+      model.clone('unexpected argument');
+    }, /^Error: clone\(\) does not accept any arguments\.$/, 'Expected clone to throw an error when called with arguments');
   });
 });

--- a/src/bindings/js/node/tests/unit/model.test.js
+++ b/src/bindings/js/node/tests/unit/model.test.js
@@ -169,8 +169,9 @@ describe('Model.clone()', () => {
   });
   
   it('should not accept any arguments', () => {
-    assert.throws(() => {
-      model.clone('unexpected argument');
-    }, /^Error: clone\(\) does not accept any arguments\.$/, 'Expected clone to throw an error when called with arguments');
+    assert.throws(
+      () => model.clone("Unexpected argument").then(),
+      /'clone' method called with incorrect parameters./
+    );
   });
 });


### PR DESCRIPTION
### Details:

Changes as part of this PR include:
* Add a ModelWrap::clone function: Calls the underlying Model.clone function
* Add a ModelWrap::Wrap function to return the cloned model as a Napi::Value
* Update the addon.ts file with the clone method
* Add unit tests for the clone Api

resolves #25402 

### Tickets:
 - #25402 