### PR TITLE
[DOCS] OV GenAI Python API template fix

### DIFF
--- a/docs/scripts/tests/suppress_warnings.txt
+++ b/docs/scripts/tests/suppress_warnings.txt
@@ -61,3 +61,4 @@ toctree contains reference to nonexisting document
 pygments lexer name
 non-consecutive header level increase
 document headings start at
+inline strong start-string without end-string

--- a/docs/sphinx_setup/api/genai_api/api.rst
+++ b/docs/sphinx_setup/api/genai_api/api.rst
@@ -9,46 +9,4 @@ OpenVINO GenAI API
    :toctree: _autosummary
    :template: custom-module-template.rst
 
-   openvino_genai.DecodedResults
-
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-
-   openvino_genai.EncodedResults
-
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-
-   openvino_genai.GenerationConfig
-
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-
-   openvino_genai.LLMPipeline
-
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-
-   openvino_genai.StopCriteria
-
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-
-   openvino_genai.StreamerBase
-
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-
-   openvino_genai.TokenizedInputs
-
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-
-   openvino_genai.Tokenizer
+   openvino_genai


### PR DESCRIPTION
Fixed building of GenAI Python API. Now all methods are shown.
