### PR TITLE
Md/fix sit standalone master

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -51,6 +51,7 @@ else()
 endif()
 
 ov_dependent_option (ENABLE_INTEL_NPU "NPU plugin for OpenVINO runtime" ${ENABLE_INTEL_NPU_DEFAULT} "X86 OR X86_64;NOT APPLE" OFF)
+ov_dependent_option (ENABLE_INTEL_NPU_INTERNAL "NPU plugin internal components for OpenVINO runtime" ON "ENABLE_INTEL_NPU" OFF)
 
 ov_option (ENABLE_DEBUG_CAPS "enable OpenVINO debug capabilities at runtime" OFF)
 ov_dependent_option (ENABLE_NPU_DEBUG_CAPS "enable NPU debug capabilities at runtime" ON "ENABLE_DEBUG_CAPS;ENABLE_INTEL_NPU" OFF)

--- a/src/plugins/intel_npu/CMakeLists.txt
+++ b/src/plugins/intel_npu/CMakeLists.txt
@@ -30,8 +30,10 @@ add_subdirectory(src)
 
 if(ENABLE_TESTS)
     add_subdirectory(tests)
-    add_subdirectory(tools)
 endif()
 
+if(ENABLE_INTEL_NPU_INTERNAL)
+    add_subdirectory(tools)
 
-ov_cpack_add_component(${NPU_INTERNAL_COMPONENT} HIDDEN)
+    ov_cpack_add_component(${NPU_INTERNAL_COMPONENT} HIDDEN)
+endif()

--- a/src/plugins/intel_npu/tools/common/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/common/CMakeLists.txt
@@ -5,24 +5,16 @@
 
 set(TARGET_NAME "npu_tools_utils")
 
-#
-# Define the target
-#
+file(GLOB_RECURSE SOURCES "*.cpp" "*.hpp")
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCES})
 
-ov_add_target(ADD_CPPLINT
-              TYPE STATIC
-              NAME ${TARGET_NAME}
-              ROOT ${CMAKE_CURRENT_SOURCE_DIR}
-              INCLUDES
-                  PUBLIC
-                      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-              LINK_LIBRARIES
-                  PRIVATE
-                      openvino::runtime)
-
+add_library(${TARGET_NAME} STATIC EXCLUDE_FROM_ALL ${SOURCES})
 set_target_properties(${TARGET_NAME} PROPERTIES
                           FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
                           CXX_STANDARD 17)
+
+target_include_directories(${TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime)
 
 if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(${TARGET_NAME} PRIVATE -Wall)

--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
@@ -30,10 +30,6 @@ set_target_properties(${TARGET_NAME} PROPERTIES
                           FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
                           CXX_STANDARD 17)
 
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(${TARGET_NAME} PRIVATE -Wall)
-endif()
-
 # TODO: fix warnings and remove this exception
 if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)
     ov_add_compiler_flags(-Wno-missing-declarations)

--- a/src/plugins/intel_npu/tools/compile_tool/cmake/standalone.cmake
+++ b/src/plugins/intel_npu/tools/compile_tool/cmake/standalone.cmake
@@ -33,14 +33,14 @@ set(DEPENDENCIES
         openvino::runtime
 )
 
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(${TARGET_NAME} PRIVATE -Wall)
-endif()
-
 file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
 add_executable(${TARGET_NAME} ${SOURCES})
 target_link_libraries(${TARGET_NAME} ${DEPENDENCIES})
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+    target_compile_options(${TARGET_NAME} PRIVATE -Wall)
+endif()
 
 install(TARGETS ${TARGET_NAME}
         DESTINATION "tools/${TARGET_NAME}"

--- a/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
@@ -41,12 +41,13 @@ ov_add_target(ADD_CPPLINT
               LINK_LIBRARIES
                   PRIVATE
                       openvino::runtime
-                      TBB::tbb
                       opencv_core
                       opencv_imgproc
                       opencv_imgcodecs
                       npu_tools_utils
                       gflags)
+
+ov_set_threading_interface_for(${TARGET_NAME})
 
 set_target_properties(${TARGET_NAME} PROPERTIES
                           FOLDER ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
@@ -53,10 +53,6 @@ set_target_properties(${TARGET_NAME} PROPERTIES
                           FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
                           CXX_STANDARD 17)
 
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(${TARGET_NAME} PRIVATE -Wall)
-endif()
-
 # TODO: fix warnings and remove this exception
 if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)
     ov_add_compiler_flags(-Wno-missing-declarations)

--- a/src/plugins/intel_npu/tools/single-image-test/cmake/standalone.cmake
+++ b/src/plugins/intel_npu/tools/single-image-test/cmake/standalone.cmake
@@ -44,14 +44,13 @@ set(DEPENDENCIES
         npu_tools_utils
 )
 
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(${TARGET_NAME} PRIVATE -Wall)
-endif()
-
 file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
 add_executable(${TARGET_NAME} ${SOURCES})
 target_link_libraries(${TARGET_NAME} PRIVATE ${DEPENDENCIES})
+if (CMAKE_COMPILER_IS_GNUCXX)
+    target_compile_options(${TARGET_NAME} PRIVATE -Wall)
+endif()
 
 install(TARGETS ${TARGET_NAME}
         DESTINATION "tools/${TARGET_NAME}"

--- a/src/plugins/intel_npu/tools/single-image-test/cmake/standalone.cmake
+++ b/src/plugins/intel_npu/tools/single-image-test/cmake/standalone.cmake
@@ -18,7 +18,7 @@ endif()
 
 find_package(Threads REQUIRED)
 find_package(OpenVINO REQUIRED COMPONENTS Runtime)
-find_package(TBB REQUIRED)
+find_package(TBB QUIET)
 find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs)
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../common" common EXCLUDE_FROM_ALL)
@@ -37,12 +37,20 @@ set(DEPENDENCIES
         Threads::Threads
         gflags
         openvino::runtime
-        TBB::tbb
         opencv_core
         opencv_imgproc
         opencv_imgcodecs
         npu_tools_utils
 )
+
+if (TBB_FOUND)
+    list(APPEND DEPENDENCIES TBB::tbb)
+else()
+    message(WARNING
+        "TBB not found. We will try to build SIT without TBB. "
+        "If OpenVINO was built with TBB, you'll likely get a linking error. "
+        "Make sure you have called setupvars or have specified TBB_DIR.")
+endif()
 
 file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 


### PR DESCRIPTION
### Details:
 - clone of https://github.com/openvinotoolkit/openvino/pull/25752 
 - Fix sing-image-test and compile_tool standalone build when OpenVINO project and ov_add_target is not reachable
 - Fix TBB search for single-image-test
 - Adding new INTEL_NPU_INTERNAL cmake option to avoid issues with building the tools in Conda build

### Tickets:
 - E-132977
